### PR TITLE
[apps] Add XSS playground harness

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -111,6 +111,7 @@ const SecurityToolsApp = createDynamicApp('security-tools', 'Security Tools');
 const SSHApp = createDynamicApp('ssh', 'SSH Command Builder');
 const HTTPApp = createDynamicApp('http', 'HTTP Request Builder');
 const HtmlRewriteApp = createDynamicApp('html-rewriter', 'HTML Rewriter');
+const XssPlaygroundApp = createDynamicApp('xss-playground', 'XSS Playground');
 const ContactApp = createDynamicApp('contact', 'Contact');
 
 
@@ -196,6 +197,7 @@ const displaySecurityTools = createDisplay(SecurityToolsApp);
 const displaySSH = createDisplay(SSHApp);
 const displayHTTP = createDisplay(HTTPApp);
 const displayHtmlRewrite = createDisplay(HtmlRewriteApp);
+const displayXssPlayground = createDisplay(XssPlaygroundApp);
 const displayContact = createDisplay(ContactApp);
 
 const displayHashcat = createDisplay(HashcatApp);
@@ -906,6 +908,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayHtmlRewrite,
+  },
+  {
+    id: 'xss-playground',
+    title: 'XSS Playground',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayXssPlayground,
   },
   {
     id: 'contact',

--- a/apps/xss-playground/index.tsx
+++ b/apps/xss-playground/index.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+
+import LabHarness from '../../components/apps/xss-playground/LabHarness';
+
+const XssPlaygroundApp: React.FC = () => {
+  return (
+    <div className="flex h-full w-full flex-col bg-ub-cool-grey text-white">
+      <header className="flex items-center justify-between border-b border-black/40 bg-black/30 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Image src="/themes/Yaru/apps/project-gallery.svg" alt="XSS Playground" width={40} height={40} />
+          <div>
+            <h1 className="text-xl font-semibold">XSS Playground</h1>
+            <p className="text-xs text-gray-300">Explore reflected, stored, and DOM-based payload behavior safely.</p>
+          </div>
+        </div>
+        <div className="flex gap-2 opacity-80">
+          <img
+            src="/themes/Yaru/window/window-minimize-symbolic.svg"
+            alt="minimize"
+            className="h-5 w-5"
+          />
+          <img src="/themes/Yaru/window/window-close-symbolic.svg" alt="close" className="h-5 w-5" />
+        </div>
+      </header>
+      <div className="flex-1 overflow-hidden">
+        <LabHarness />
+      </div>
+    </div>
+  );
+};
+
+export default XssPlaygroundApp;

--- a/components/apps/xss-playground/LabHarness.tsx
+++ b/components/apps/xss-playground/LabHarness.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const SANDBOX_FLAGS = ['allow-forms', 'allow-same-origin'];
+
+const FALLBACKS = {
+  reflected: 'No payload submitted.',
+  stored: 'No entries stored yet.',
+  dom: 'Template is waiting for DOM content.',
+};
+
+interface BuildState {
+  reflected: string;
+  dom: string;
+  storedEntries: string[];
+}
+
+const buildMarkup = (base: string, state: BuildState) => {
+  if (typeof window === 'undefined' || typeof DOMParser === 'undefined') {
+    return base;
+  }
+
+  try {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(base, 'text/html');
+
+    const reflectedValue = state.reflected.trim();
+    const reflectedSafe = reflectedValue || FALLBACKS.reflected;
+
+    const reflectedSafeNode = doc.querySelector('[data-slot="reflected-safe"]');
+    if (reflectedSafeNode) {
+      reflectedSafeNode.textContent = reflectedSafe;
+    }
+
+    const reflectedRawNode = doc.querySelector('[data-slot="reflected-raw"]');
+    if (reflectedRawNode) {
+      reflectedRawNode.innerHTML = reflectedValue || FALLBACKS.reflected;
+    }
+
+    const safeFeed = doc.querySelector('[data-feed="safe"]');
+    if (safeFeed) {
+      safeFeed.innerHTML = '';
+      if (state.storedEntries.length === 0) {
+        const placeholder = doc.createElement('li');
+        placeholder.classList.add('placeholder');
+        placeholder.textContent = FALLBACKS.stored;
+        safeFeed.appendChild(placeholder);
+      } else {
+        state.storedEntries.forEach((entry, index) => {
+          const item = doc.createElement('li');
+          item.textContent = entry;
+          item.setAttribute('data-entry-index', index.toString());
+          safeFeed.appendChild(item);
+        });
+      }
+    }
+
+    const rawFeed = doc.querySelector('[data-feed="raw"]');
+    if (rawFeed) {
+      if (state.storedEntries.length === 0) {
+        rawFeed.innerHTML = `<li class="placeholder">${FALLBACKS.stored}</li>`;
+      } else {
+        rawFeed.innerHTML = state.storedEntries
+          .map((entry, index) => `<li data-entry-index="${index}">${entry}</li>`)
+          .join('');
+      }
+    }
+
+    const domValue = state.dom.trim() || FALLBACKS.dom;
+    const domSafeNode = doc.querySelector('[data-slot="dom-safe"]');
+    if (domSafeNode) {
+      domSafeNode.textContent = domValue;
+    }
+
+    const domRawNode = doc.querySelector('[data-slot="dom-raw"]');
+    if (domRawNode instanceof HTMLElement) {
+      domRawNode.innerHTML = domValue;
+      domRawNode.setAttribute('data-user-fragment', domValue);
+    }
+
+    return `<!DOCTYPE html>\n${doc.documentElement.outerHTML}`;
+  } catch (error) {
+    console.warn('Failed to build iframe markup', error);
+    return base;
+  }
+};
+
+const LabHarness: React.FC = () => {
+  const pristineMarkupRef = useRef<string | null>(null);
+  const skipNextUpdateRef = useRef(false);
+  const [iframeMarkup, setIframeMarkup] = useState('');
+  const [iframeKey, setIframeKey] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [reflectedPayload, setReflectedPayload] = useState('');
+  const [storedDraft, setStoredDraft] = useState('');
+  const [storedEntries, setStoredEntries] = useState<string[]>([]);
+  const [domPayload, setDomPayload] = useState('');
+
+  const fetchPristine = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetch('/demo-data/xss/base.html');
+      if (!response.ok) {
+        throw new Error(`Failed to load demo markup (status ${response.status})`);
+      }
+      const html = await response.text();
+      pristineMarkupRef.current = html;
+      skipNextUpdateRef.current = true;
+      setIframeMarkup(html);
+      setIframeKey((key) => key + 1);
+    } catch (err) {
+      console.error(err);
+      setError('Unable to load the sandboxed demo page.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchPristine();
+  }, [fetchPristine]);
+
+  useEffect(() => {
+    if (!pristineMarkupRef.current) {
+      return;
+    }
+
+    if (skipNextUpdateRef.current) {
+      skipNextUpdateRef.current = false;
+      return;
+    }
+
+    const nextMarkup = buildMarkup(pristineMarkupRef.current, {
+      reflected: reflectedPayload,
+      dom: domPayload,
+      storedEntries,
+    });
+    setIframeMarkup(nextMarkup);
+  }, [reflectedPayload, domPayload, storedEntries]);
+
+  const handleReset = () => {
+    if (!pristineMarkupRef.current) {
+      return;
+    }
+    skipNextUpdateRef.current = true;
+    setIframeMarkup(pristineMarkupRef.current);
+    setIframeKey((key) => key + 1);
+  };
+
+  const handleClear = () => {
+    setReflectedPayload('');
+    setStoredDraft('');
+    setStoredEntries([]);
+    setDomPayload('');
+  };
+
+  const commitStoredPayload = () => {
+    const value = storedDraft.trim();
+    if (!value) {
+      setStoredDraft('');
+      return;
+    }
+    setStoredEntries((entries) => [...entries, value]);
+    setStoredDraft('');
+  };
+
+  const sandboxAttribute = useMemo(() => SANDBOX_FLAGS.join(' '), []);
+
+  return (
+    <div className="flex h-full w-full flex-col bg-ub-cool-grey text-white">
+      <div className="border-b border-black/40 bg-black/30 px-4 py-3">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">Sandbox Controls</h2>
+            <p className="text-xs text-gray-300">
+              Payloads render inside a locked iframe with strict CSP. Reset reloads the document, while Clear wipes your inputs.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={handleReset}
+              className="rounded bg-sky-600 px-3 py-1 text-sm font-medium text-white transition hover:bg-sky-500"
+            >
+              Reset iframe
+            </button>
+            <button
+              type="button"
+              onClick={handleClear}
+              className="rounded bg-red-600 px-3 py-1 text-sm font-medium hover:bg-red-500"
+            >
+              Clear payloads
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-1 flex-col overflow-hidden md:flex-row">
+        <aside className="w-full max-w-full border-b border-black/40 bg-black/20 p-4 text-sm md:w-80 md:flex-shrink-0 md:border-b-0 md:border-r md:overflow-y-auto">
+          <section className="space-y-2">
+            <header>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">Reflected input</h3>
+              <p className="text-xs text-gray-400">Simulates a query parameter echoed back to the page.</p>
+            </header>
+            <input
+              type="text"
+              value={reflectedPayload}
+              onChange={(event) => setReflectedPayload(event.target.value)}
+              placeholder="<script>alert('xss')</script>"
+              className="w-full rounded border border-white/10 bg-black/40 px-2 py-1 text-sm text-white placeholder-gray-500 focus:border-sky-400 focus:outline-none"
+            />
+          </section>
+
+          <section className="mt-6 space-y-2">
+            <header>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">Stored payload</h3>
+              <p className="text-xs text-gray-400">
+                Add a comment that persists across reloads. The vulnerable feed renders the HTML directly.
+              </p>
+            </header>
+            <textarea
+              value={storedDraft}
+              onChange={(event) => setStoredDraft(event.target.value)}
+              placeholder="<img src=x onerror=alert('stored') />"
+              rows={3}
+              className="w-full resize-none rounded border border-white/10 bg-black/40 px-2 py-1 text-sm text-white placeholder-gray-500 focus:border-sky-400 focus:outline-none"
+            />
+            <div className="flex items-center justify-between gap-2">
+              <button
+                type="button"
+                onClick={commitStoredPayload}
+                className="rounded bg-amber-400 px-3 py-1 text-sm font-medium text-black transition hover:bg-amber-300"
+              >
+                Store payload
+              </button>
+              <span className="text-xs text-gray-400">{storedEntries.length} stored</span>
+            </div>
+            {storedEntries.length > 0 ? (
+              <ol className="space-y-1 rounded border border-white/10 bg-black/40 p-2 text-xs text-gray-300">
+                {storedEntries.map((entry, index) => (
+                  <li key={index} className="break-words">
+                    {entry}
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <p className="text-xs italic text-gray-500">No stored payloads yet.</p>
+            )}
+          </section>
+
+          <section className="mt-6 space-y-2">
+            <header>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">DOM fragment</h3>
+              <p className="text-xs text-gray-400">
+                Represents a snippet a script injects into the DOM after load.
+              </p>
+            </header>
+            <textarea
+              value={domPayload}
+              onChange={(event) => setDomPayload(event.target.value)}
+              placeholder="<marquee>owned</marquee>"
+              rows={3}
+              className="w-full resize-none rounded border border-white/10 bg-black/40 px-2 py-1 text-sm text-white placeholder-gray-500 focus:border-sky-400 focus:outline-none"
+            />
+          </section>
+        </aside>
+
+        <section className="flex-1 bg-[#0b1120]">
+          {loading ? (
+            <div className="flex h-full items-center justify-center text-sm text-gray-300">Loading demo site…</div>
+          ) : error ? (
+            <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-red-300">
+              <p>{error}</p>
+              <button
+                type="button"
+                onClick={() => {
+                  void fetchPristine();
+                }}
+                className="rounded bg-sky-600 px-3 py-1 text-sm font-medium text-white transition hover:bg-sky-500"
+              >
+                Retry load
+              </button>
+            </div>
+          ) : (
+            <iframe
+              key={iframeKey}
+              title="XSS playground sandbox"
+              className="h-full w-full border-0"
+              sandbox={sandboxAttribute}
+              srcDoc={iframeMarkup}
+            />
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default LabHarness;

--- a/pages/apps/xss-playground.jsx
+++ b/pages/apps/xss-playground.jsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const XssPlayground = dynamic(() => import('../../apps/xss-playground'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function XssPlaygroundPage() {
+  return <XssPlayground />;
+}

--- a/public/demo-data/xss/base.html
+++ b/public/demo-data/xss/base.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>XSS Playground Demo Site</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta
+    http-equiv="Content-Security-Policy"
+    content="default-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'none'; font-src 'none'; script-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
+  />
+  <style>
+    :root {
+      color-scheme: dark;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Segoe UI', 'Ubuntu', system-ui, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      line-height: 1.5;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header,
+    footer {
+      background: rgba(15, 23, 42, 0.9);
+      padding: 1.25rem 1.5rem;
+    }
+
+    header {
+      border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+    }
+
+    footer {
+      border-top: 1px solid rgba(148, 163, 184, 0.2);
+      font-size: 0.75rem;
+      color: rgba(148, 163, 184, 0.8);
+      text-align: center;
+    }
+
+    main {
+      flex: 1;
+      padding: 1.5rem;
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    .card {
+      background: rgba(30, 41, 59, 0.85);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 0.75rem;
+      padding: 1.25rem;
+      display: grid;
+      gap: 1rem;
+      box-shadow: 0 18px 35px rgba(8, 15, 31, 0.45);
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 1.5rem;
+    }
+
+    h2 {
+      margin: 0;
+      font-size: 1.25rem;
+    }
+
+    h3 {
+      margin: 0;
+      font-size: 1rem;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.25rem 0.6rem;
+      border-radius: 999px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      background: rgba(34, 197, 94, 0.15);
+      color: #4ade80;
+    }
+
+    .badge.warning {
+      background: rgba(248, 113, 113, 0.15);
+      color: #fca5a5;
+    }
+
+    .warning-text {
+      color: #fca5a5;
+      font-size: 0.9rem;
+    }
+
+    .note {
+      font-size: 0.85rem;
+      color: rgba(148, 163, 184, 0.95);
+    }
+
+    .feed-title {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: rgba(148, 163, 184, 0.9);
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }
+
+    .feed {
+      list-style: none;
+      padding: 0.75rem 0.85rem;
+      margin: 0;
+      border-radius: 0.6rem;
+      background: rgba(15, 23, 42, 0.75);
+      border: 1px dashed rgba(148, 163, 184, 0.25);
+      display: grid;
+      gap: 0.5rem;
+      font-size: 0.85rem;
+    }
+
+    .feed.feed--vulnerable {
+      background: rgba(67, 20, 7, 0.6);
+      border-color: rgba(248, 113, 113, 0.4);
+    }
+
+    .feed li {
+      padding: 0.35rem 0.5rem;
+      border-radius: 0.45rem;
+      background: rgba(148, 163, 184, 0.1);
+    }
+
+    .feed li.placeholder {
+      font-style: italic;
+      color: rgba(148, 163, 184, 0.7);
+      background: transparent;
+    }
+
+    .dom-grid {
+      display: grid;
+      gap: 1rem;
+    }
+
+    @media (min-width: 640px) {
+      .dom-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    .panel {
+      border-radius: 0.75rem;
+      padding: 1rem;
+      background: rgba(15, 23, 42, 0.65);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .panel.warning {
+      background: rgba(67, 20, 7, 0.5);
+      border-color: rgba(248, 113, 113, 0.4);
+    }
+
+    .canvas {
+      min-height: 4.5rem;
+      border-radius: 0.6rem;
+      border: 1px dashed rgba(148, 163, 184, 0.35);
+      padding: 0.75rem;
+      background: rgba(15, 23, 42, 0.5);
+      font-size: 0.9rem;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>XSS Playground Demo Portal</h1>
+    <p class="note">This page lives in an isolated iframe. Every payload you submit is reflected here for educational purposes only.</p>
+  </header>
+  <main>
+    <section class="card">
+      <h2>Reflected Search Results</h2>
+      <p class="note">Safe template escaping renders attacker data as plain text.</p>
+      <p>
+        <span class="badge" aria-label="sanitized payload badge">Sanitized</span>
+        <span data-slot="reflected-safe">No payload submitted.</span>
+      </p>
+      <p class="warning-text">
+        <span class="badge warning" aria-label="vulnerable payload badge">Vulnerable</span>
+        <span data-slot="reflected-raw">No payload submitted.</span>
+      </p>
+      <p class="note">The vulnerable path injects the payload via <code>innerHTML</code> without any escaping logic.</p>
+    </section>
+
+    <section class="card">
+      <h2>Stored Comment Feed</h2>
+      <p class="note">Persisted content appears on every render. The sanitized feed escapes user messages while the vulnerable feed trusts raw HTML.</p>
+      <p class="feed-title">Sanitized timeline</p>
+      <ul class="feed" data-feed="safe" aria-label="Sanitized comments">
+        <li class="placeholder" data-placeholder="safe">No entries stored yet.</li>
+      </ul>
+      <p class="feed-title warning-text">Vulnerable timeline</p>
+      <ul class="feed feed--vulnerable" data-feed="raw" aria-label="Unsafe comments">
+        <li class="placeholder" data-placeholder="raw">No entries stored yet.</li>
+      </ul>
+    </section>
+
+    <section class="card">
+      <h2>DOM-Based Widget</h2>
+      <p class="note">Client-side scripts often stitch together fragments. When the fragment is trusted HTML, it executes within the widget.</p>
+      <div class="dom-grid">
+        <div class="panel">
+          <h3>Safe widget</h3>
+          <div class="canvas" data-slot="dom-safe">Template is waiting for DOM content.</div>
+        </div>
+        <div class="panel warning">
+          <h3>Vulnerable widget</h3>
+          <div
+            class="canvas"
+            data-slot="dom-raw"
+            data-user-fragment="Template is waiting for DOM content."
+          >
+            Template is waiting for DOM content.
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer>
+    Cross-site scripting payloads entered here stay inside this sandbox. Practice safe injection testing.
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a sandboxed XSS lab harness with iframe controls, reset/clear flows, and stored payload management
- register the XSS Playground desktop app, dynamic page, and static demo markup for the new experience

## Testing
- yarn lint *(fails: pre-existing accessibility and window/document lint violations in unrelated files)*
- yarn test *(fails: existing unit test failures around window keyboard handling, clipboard alerts, and modal focus state)*

------
https://chatgpt.com/codex/tasks/task_e_68cc47611f3c8328bd1bd8c25ff14124