### PR TITLE
[apps] Add subnet calculator utility

### DIFF
--- a/__tests__/modules/subnet.test.ts
+++ b/__tests__/modules/subnet.test.ts
@@ -1,0 +1,57 @@
+import {
+  calculateSubnetInfo,
+  getBroadcastAddress,
+  getHostRange,
+  getNetworkAddress,
+  getUsableHostCount,
+} from '../../modules/networking/subnet';
+
+describe('modules/networking/subnet', () => {
+  it('derives network and broadcast addresses for typical prefixes', () => {
+    expect(getNetworkAddress('192.168.1.42', 26)).toBe('192.168.1.0');
+    expect(getBroadcastAddress('192.168.1.42', 26)).toBe('192.168.1.63');
+
+    expect(getNetworkAddress('10.0.12.200', 20)).toBe('10.0.0.0');
+    expect(getBroadcastAddress('10.0.12.200', 20)).toBe('10.0.15.255');
+  });
+
+  it('calculates host range and usable hosts for standard networks', () => {
+    const hostRange = getHostRange('172.16.5.10', 24);
+    expect(hostRange).toEqual({
+      firstHost: '172.16.5.1',
+      lastHost: '172.16.5.254',
+    });
+
+    expect(getUsableHostCount(24)).toBe(254);
+    expect(getUsableHostCount(0)).toBe(4294967294);
+  });
+
+  it('returns no usable host range for /31 and /32 networks', () => {
+    expect(getHostRange('192.0.2.1', 31)).toEqual({ firstHost: null, lastHost: null });
+    expect(getHostRange('192.0.2.1', 32)).toEqual({ firstHost: null, lastHost: null });
+
+    expect(getUsableHostCount(31)).toBe(0);
+    expect(getUsableHostCount(32)).toBe(0);
+  });
+
+  it('aggregates subnet info with calculateSubnetInfo', () => {
+    const info = calculateSubnetInfo('203.0.113.9', 27);
+    expect(info).toEqual({
+      network: '203.0.113.0',
+      broadcast: '203.0.113.31',
+      hostRange: {
+        firstHost: '203.0.113.1',
+        lastHost: '203.0.113.30',
+      },
+      usableHosts: 30,
+      cidr: 27,
+    });
+  });
+
+  it('validates IPv4 addresses and CIDR prefixes', () => {
+    expect(() => getNetworkAddress('300.1.1.1', 24)).toThrow('Invalid IPv4 address');
+    expect(() => getBroadcastAddress('1.1.1', 24)).toThrow('Invalid IPv4 address');
+    expect(() => getHostRange('192.168.0.1', 40)).toThrow('Invalid CIDR prefix');
+    expect(() => getUsableHostCount(-1)).toThrow('Invalid CIDR prefix');
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -72,6 +72,7 @@ const QuoteApp = createDynamicApp('quote', 'Quote');
 const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery');
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
+const SubnetCalculatorApp = createDynamicApp('subnet-calculator', 'Subnet Calculator');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
@@ -165,6 +166,7 @@ const displayStickyNotes = createDisplay(StickyNotesApp);
 const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
+const displaySubnetCalculator = createDisplay(SubnetCalculatorApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -266,6 +268,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'subnet-calculator',
+    title: 'Subnet Calculator',
+    icon: '/themes/Yaru/apps/subnet-calculator.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displaySubnetCalculator,
   },
 ];
 

--- a/apps/subnet-calculator/index.tsx
+++ b/apps/subnet-calculator/index.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { HostRange } from '../../modules/networking/subnet';
+import { calculateSubnetInfo } from '../../modules/networking/subnet';
+
+const formatHostRange = (range: HostRange) => {
+  if (!range.firstHost || !range.lastHost) {
+    return 'No usable host addresses';
+  }
+  if (range.firstHost === range.lastHost) {
+    return range.firstHost;
+  }
+  return `${range.firstHost} – ${range.lastHost}`;
+};
+
+interface StatProps {
+  label: string;
+  value: string | number;
+}
+
+const Stat = ({ label, value }: StatProps) => (
+  <div className="bg-black/30 rounded-md p-4">
+    <dt className="text-sm uppercase tracking-wide text-slate-300">{label}</dt>
+    <dd className="mt-1 font-mono text-lg text-white break-words">{value}</dd>
+  </div>
+);
+
+const SubnetCalculator = () => {
+  const [ipAddress, setIpAddress] = useState('192.168.1.10');
+  const [cidrInput, setCidrInput] = useState('24');
+
+  const result = useMemo(() => {
+    const trimmedIp = ipAddress.trim();
+    const trimmedCidr = cidrInput.trim();
+
+    if (!trimmedIp) {
+      return { error: 'An IPv4 address is required.' } as const;
+    }
+
+    if (!trimmedCidr) {
+      return { error: 'A CIDR prefix between 0 and 32 is required.' } as const;
+    }
+
+    const cidr = Number(trimmedCidr);
+
+    if (!Number.isInteger(cidr)) {
+      return { error: 'CIDR prefix must be a whole number.' } as const;
+    }
+
+    try {
+      const info = calculateSubnetInfo(trimmedIp, cidr);
+      const totalAddresses = 2 ** (32 - info.cidr);
+      return { data: { ...info, totalAddresses } } as const;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to calculate subnet information.';
+      return { error: message } as const;
+    }
+  }, [ipAddress, cidrInput]);
+
+  return (
+    <div className="h-full w-full overflow-auto bg-ub-cool-grey text-white">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-6">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-semibold">Subnet Calculator</h1>
+          <p className="text-sm text-slate-200">
+            Explore IPv4 subnets by entering an address and prefix length. The calculator derives the network and broadcast
+            addresses, usable host range, and capacity in real time.
+          </p>
+        </header>
+
+        <form
+          className="grid gap-4 rounded-md bg-black/30 p-4 sm:grid-cols-2"
+          onSubmit={(event) => event.preventDefault()}
+        >
+          <label
+            className="flex flex-col gap-2"
+            htmlFor="subnet-calculator-ipv4-address"
+          >
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">IPv4 address</span>
+            <input
+              id="subnet-calculator-ipv4-address"
+              className="rounded-md border border-slate-600 bg-black/40 px-3 py-2 font-mono text-white focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500"
+              aria-label="IPv4 address"
+              inputMode="numeric"
+              placeholder="e.g. 10.0.0.42"
+              value={ipAddress}
+              onChange={(event) => setIpAddress(event.target.value)}
+            />
+          </label>
+
+          <label
+            className="flex flex-col gap-2"
+            htmlFor="subnet-calculator-cidr-prefix"
+          >
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">CIDR prefix</span>
+            <input
+              id="subnet-calculator-cidr-prefix"
+              className="rounded-md border border-slate-600 bg-black/40 px-3 py-2 font-mono text-white focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500"
+              aria-label="CIDR prefix"
+              type="number"
+              min={0}
+              max={32}
+              value={cidrInput}
+              onChange={(event) => setCidrInput(event.target.value)}
+            />
+          </label>
+        </form>
+
+        {'error' in result ? (
+          <div
+            role="alert"
+            className="rounded-md border border-red-500/60 bg-red-900/40 px-4 py-3 text-sm text-red-100"
+          >
+            {result.error}
+          </div>
+        ) : result.data ? (
+          <section className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-4">
+              <h2 className="text-lg font-semibold text-white">Address summary</h2>
+              <dl className="grid gap-4">
+                <Stat label="CIDR notation" value={`${ipAddress.trim()}/${result.data.cidr}`} />
+                <Stat label="Network address" value={result.data.network} />
+                <Stat label="Broadcast address" value={result.data.broadcast} />
+              </dl>
+            </div>
+
+            <div className="space-y-4">
+              <h2 className="text-lg font-semibold text-white">Host availability</h2>
+              <dl className="grid gap-4">
+                <Stat label="Usable host range" value={formatHostRange(result.data.hostRange)} />
+                <Stat label="Usable host count" value={result.data.usableHosts} />
+                <Stat label="Total addresses" value={result.data.totalAddresses} />
+              </dl>
+            </div>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default SubnetCalculator;

--- a/components/apps/subnet-calculator.tsx
+++ b/components/apps/subnet-calculator.tsx
@@ -1,0 +1,12 @@
+import dynamic from 'next/dynamic';
+
+const SubnetCalculator = dynamic(() => import('../../apps/subnet-calculator'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full w-full items-center justify-center bg-ub-cool-grey text-white">
+      Loading Subnet Calculator...
+    </div>
+  ),
+});
+
+export default SubnetCalculator;

--- a/modules/networking/subnet.ts
+++ b/modules/networking/subnet.ts
@@ -1,0 +1,110 @@
+export interface HostRange {
+  firstHost: string | null;
+  lastHost: string | null;
+}
+
+const IPV4_OCTET_COUNT = 4;
+const IPV4_BIT_LENGTH = 32;
+
+const parseIPv4 = (address: string): number => {
+  if (typeof address !== 'string') {
+    throw new Error('Invalid IPv4 address');
+  }
+
+  const parts = address.trim().split('.');
+  if (parts.length !== IPV4_OCTET_COUNT) {
+    throw new Error('Invalid IPv4 address');
+  }
+
+  return parts.reduce((acc, part) => {
+    if (part.trim() === '') {
+      throw new Error('Invalid IPv4 address');
+    }
+
+    const value = Number(part);
+    if (!Number.isInteger(value) || value < 0 || value > 255) {
+      throw new Error('Invalid IPv4 address');
+    }
+
+    return ((acc << 8) | value) >>> 0;
+  }, 0);
+};
+
+const validateCidr = (cidr: number): number => {
+  if (!Number.isInteger(cidr) || cidr < 0 || cidr > IPV4_BIT_LENGTH) {
+    throw new Error('Invalid CIDR prefix');
+  }
+
+  return cidr;
+};
+
+const toIPv4 = (value: number): string =>
+  [24, 16, 8, 0].map((shift) => ((value >>> shift) & 0xff).toString()).join('.');
+
+const getMask = (cidr: number): number => {
+  if (cidr === 0) {
+    return 0;
+  }
+
+  return (-1 << (IPV4_BIT_LENGTH - cidr)) >>> 0;
+};
+
+const getBounds = (ip: string, cidr: number) => {
+  const prefix = validateCidr(cidr);
+  const address = parseIPv4(ip);
+  const mask = getMask(prefix);
+  const network = (address & mask) >>> 0;
+  const broadcast = (network | (~mask >>> 0)) >>> 0;
+
+  return { network, broadcast };
+};
+
+export const getNetworkAddress = (ip: string, cidr: number): string => {
+  const { network } = getBounds(ip, cidr);
+  return toIPv4(network);
+};
+
+export const getBroadcastAddress = (ip: string, cidr: number): string => {
+  const { broadcast } = getBounds(ip, cidr);
+  return toIPv4(broadcast);
+};
+
+export const getHostRange = (ip: string, cidr: number): HostRange => {
+  const prefix = validateCidr(cidr);
+  const { network, broadcast } = getBounds(ip, prefix);
+
+  if (prefix >= IPV4_BIT_LENGTH - 1) {
+    return { firstHost: null, lastHost: null };
+  }
+
+  return {
+    firstHost: toIPv4((network + 1) >>> 0),
+    lastHost: toIPv4((broadcast - 1) >>> 0),
+  };
+};
+
+export const getUsableHostCount = (cidr: number): number => {
+  const prefix = validateCidr(cidr);
+  if (prefix >= IPV4_BIT_LENGTH - 1) {
+    return 0;
+  }
+
+  const totalHosts = 2 ** (IPV4_BIT_LENGTH - prefix);
+  return totalHosts - 2;
+};
+
+export const calculateSubnetInfo = (ip: string, cidr: number) => {
+  const prefix = validateCidr(cidr);
+  const network = getNetworkAddress(ip, prefix);
+  const broadcast = getBroadcastAddress(ip, prefix);
+  const hostRange = getHostRange(ip, prefix);
+  const usableHosts = getUsableHostCount(prefix);
+
+  return {
+    network,
+    broadcast,
+    hostRange,
+    usableHosts,
+    cidr: prefix,
+  };
+};

--- a/pages/apps/subnet-calculator.jsx
+++ b/pages/apps/subnet-calculator.jsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const SubnetCalculator = dynamic(() => import('../../apps/subnet-calculator'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function SubnetCalculatorPage() {
+  return <SubnetCalculator />;
+}

--- a/public/apps/subnet-calculator/icon.svg
+++ b/public/apps/subnet-calculator/icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#111827" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="18" fill="url(#bg)" />
+  <rect x="18" y="26" width="92" height="76" rx="14" fill="#1f2937" stroke="#38bdf8" stroke-width="4" />
+  <path
+    d="M34 54h60M34 74h60M64 26v18M64 102V88"
+    stroke="#38bdf8"
+    stroke-width="4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    opacity="0.6"
+  />
+  <circle cx="40" cy="46" r="8" fill="#1d4ed8" />
+  <circle cx="88" cy="46" r="8" fill="#1d4ed8" />
+  <circle cx="40" cy="86" r="8" fill="#22d3ee" />
+  <circle cx="88" cy="86" r="8" fill="#22d3ee" />
+  <circle cx="64" cy="66" r="10" fill="#0ea5e9" stroke="#38bdf8" stroke-width="4" />
+</svg>

--- a/public/apps/subnet-calculator/metadata.json
+++ b/public/apps/subnet-calculator/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "subnet-calculator",
+  "name": "Subnet Calculator",
+  "category": "Utilities",
+  "description": "Interactive IPv4 calculator that derives network, broadcast, host range, and usable address counts for any CIDR prefix.",
+  "icon": "/apps/subnet-calculator/icon.svg",
+  "tags": ["networking", "ipv4", "calculator"],
+  "screens": [],
+  "source": "https://github.com/Alex-Unnippillil/kali-linux-portfolio"
+}

--- a/public/themes/Yaru/apps/subnet-calculator.svg
+++ b/public/themes/Yaru/apps/subnet-calculator.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#111827" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="18" fill="url(#bg)" />
+  <rect x="18" y="26" width="92" height="76" rx="14" fill="#1f2937" stroke="#38bdf8" stroke-width="4" />
+  <path
+    d="M34 54h60M34 74h60M64 26v18M64 102V88"
+    stroke="#38bdf8"
+    stroke-width="4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    opacity="0.6"
+  />
+  <circle cx="40" cy="46" r="8" fill="#1d4ed8" />
+  <circle cx="88" cy="46" r="8" fill="#1d4ed8" />
+  <circle cx="40" cy="86" r="8" fill="#22d3ee" />
+  <circle cx="88" cy="86" r="8" fill="#22d3ee" />
+  <circle cx="64" cy="66" r="10" fill="#0ea5e9" stroke="#38bdf8" stroke-width="4" />
+</svg>


### PR DESCRIPTION
## Summary
- add IPv4 subnet helpers with coverage for network, broadcast, host range, and usable counts
- build the subnet calculator UI, desktop wrapper, and direct page route
- register launcher metadata and icons for the new utility

## Testing
- yarn test --watch=false --runInBand __tests__/modules/subnet.test.ts
- yarn eslint apps/subnet-calculator/index.tsx pages/apps/subnet-calculator.jsx components/apps/subnet-calculator.tsx modules/networking/subnet.ts __tests__/modules/subnet.test.ts
- CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cc38f6ceb48328a89ac5ae709a7e5b