### PR TITLE
[screen] add taskbar drag hover focus support

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -9,10 +9,16 @@ export class UbuntuApp extends Component {
 
     handleDragStart = () => {
         this.setState({ dragging: true });
+        if (typeof this.props.onDragStart === 'function') {
+            this.props.onDragStart(this.props.id);
+        }
     }
 
     handleDragEnd = () => {
         this.setState({ dragging: false });
+        if (typeof this.props.onDragEnd === 'function') {
+            this.props.onDragEnd(this.props.id);
+        }
     }
 
     openApp = () => {

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -17,31 +17,50 @@ export default function Taskbar(props) {
 
     return (
         <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
+            {runningApps.map(app => {
+                const isDragActive = props.dragActive;
+                const isRaised = props.dragRaisedWindowId === app.id;
+                let dragDescription;
+                if (isDragActive) {
+                    if (props.prefersReducedMotion) {
+                        dragDescription = `Drag and click to focus ${app.title}. Auto-raise is disabled by reduced motion settings.`;
+                    } else if (isRaised) {
+                        dragDescription = `${app.title} window raised while dragging. Move to the window to drop items.`;
+                    } else {
+                        dragDescription = `Drag over and hold to focus ${app.title}.`;
+                    }
+                }
+
+                return (
+                    <button
+                        key={app.id}
+                        type="button"
+                        aria-label={app.title}
+                        aria-description={dragDescription}
+                        data-context="taskbar"
+                        data-app-id={app.id}
+                        onClick={() => handleClick(app)}
+                        onDragEnter={(event) => props.onDragHover?.(app.id, event)}
+                        onDragOver={(event) => props.onDragHover?.(app.id, event)}
+                        onDragLeave={(event) => props.onDragLeave?.(app.id, event)}
+                        className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
+                            'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                        {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
+                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
+                        )}
+                    </button>
+                );
+            })}
         </div>
     );
 }

--- a/tests/taskbar-drag.spec.ts
+++ b/tests/taskbar-drag.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, Page } from '@playwright/test';
+
+async function dispatchDragEvent(page: Page, selector: string, type: 'dragstart' | 'dragenter' | 'dragleave' | 'dragend', options: { relatedSelector?: string } = {}) {
+  await page.evaluate(({ targetSelector, eventType, relatedSelector }) => {
+    const target = document.querySelector(targetSelector);
+    if (!target) {
+      throw new Error(`Element not found for selector: ${targetSelector}`);
+    }
+    const dataTransfer = new DataTransfer();
+    const eventInit: DragEventInit = {
+      bubbles: true,
+      cancelable: true,
+      dataTransfer,
+    };
+    if (relatedSelector) {
+      const relatedTarget = document.querySelector(relatedSelector) ?? null;
+      if (relatedTarget) {
+        eventInit.relatedTarget = relatedTarget as EventTarget;
+      }
+    }
+    const dragEvent = new DragEvent(eventType, eventInit);
+    target.dispatchEvent(dragEvent);
+  }, { targetSelector: selector, eventType: type, relatedSelector: options.relatedSelector });
+}
+
+async function prepareDesktop(page: Page) {
+  await page.goto('/');
+  await page.waitForSelector('#desktop');
+  const terminalIcon = page.locator('#app-terminal');
+  await terminalIcon.waitFor();
+  await terminalIcon.dblclick();
+  await page.locator('#terminal').waitFor();
+  await page.locator('#terminal').click();
+  await expect(page.locator('#terminal')).toHaveClass(/z-30/);
+  await expect(page.locator('#about-alex')).not.toHaveClass(/z-30/);
+}
+
+test.describe('taskbar drag hover focus', () => {
+  test('focuses hovered window after delay and restores origin when leaving', async ({ page }) => {
+    await prepareDesktop(page);
+    const taskbarButton = page.locator('button[data-app-id="about-alex"]');
+    await taskbarButton.waitFor();
+
+    await dispatchDragEvent(page, '#app-terminal', 'dragstart');
+    await dispatchDragEvent(page, 'button[data-app-id="about-alex"]', 'dragenter');
+
+    await page.waitForTimeout(400);
+
+    await expect(page.locator('#about-alex')).toHaveClass(/z-30/);
+    await expect(page.locator('#terminal')).not.toHaveClass(/z-30/);
+    await expect(taskbarButton).toHaveAttribute('aria-description', /window raised while dragging/i);
+
+    await dispatchDragEvent(page, 'button[data-app-id="about-alex"]', 'dragleave', { relatedSelector: '#desktop' });
+
+    await expect(page.locator('#terminal')).toHaveClass(/z-30/);
+    await expect(taskbarButton).toHaveAttribute('aria-description', /drag over and hold/i);
+
+    await dispatchDragEvent(page, '#app-terminal', 'dragend');
+  });
+
+  test('does not raise windows when reduced motion is preferred', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await prepareDesktop(page);
+    const taskbarButton = page.locator('button[data-app-id="about-alex"]');
+    await taskbarButton.waitFor();
+
+    await dispatchDragEvent(page, '#app-terminal', 'dragstart');
+    await dispatchDragEvent(page, 'button[data-app-id="about-alex"]', 'dragenter');
+
+    await page.waitForTimeout(400);
+
+    await expect(page.locator('#about-alex')).not.toHaveClass(/z-30/);
+    await expect(page.locator('#terminal')).toHaveClass(/z-30/);
+    await expect(taskbarButton).toHaveAttribute('aria-description', /auto-raise is disabled/i);
+
+    await dispatchDragEvent(page, 'button[data-app-id="about-alex"]', 'dragleave', { relatedSelector: '#desktop' });
+    await dispatchDragEvent(page, '#app-terminal', 'dragend');
+  });
+});


### PR DESCRIPTION
## Summary
- track desktop drag hover state, announce raised windows, and respect reduced-motion preferences
- wire drag lifecycle callbacks to taskbar buttons with contextual aria descriptions
- add Playwright coverage for drag-hover focus timing and reduced-motion opt out

## Testing
- `npx eslint . --max-warnings=0` *(fails: existing accessibility violations)*
- `CI=1 yarn test --watch=false` *(fails: existing unit test issues)*
- `BASE_URL=http://localhost:3001 npx playwright test tests/taskbar-drag.spec.ts --config=playwright.config.ts --retries=0 --timeout=60000 --grep-invert=@smoke --reporter=list --workers=1 --global-timeout=0 --trace=off --output=test-results` *(fails: timed out waiting for #desktop)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6d08801083288663b12e9ff63c43