### PR TITLE
[desktop] Add drag-and-drop zone overlays

### DIFF
--- a/__tests__/desktopDragDrop.test.tsx
+++ b/__tests__/desktopDragDrop.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Desktop } from '../components/screen/desktop';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+
+const createMatchMedia = () =>
+  jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
+
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: createMatchMedia(),
+  });
+}
+
+describe('Desktop drag and drop actions', () => {
+  beforeEach(() => {
+    document.documentElement.style.setProperty('--motion-fast', '150ms');
+  });
+
+  const mountlessDesktop = () => {
+    const desktop = new Desktop({});
+    desktop.setState = (updater) => {
+      const update =
+        typeof updater === 'function' ? updater(desktop.state, desktop.props) : updater;
+      desktop.state = { ...desktop.state, ...update };
+    };
+    return desktop;
+  };
+
+  it('pins app when dropped on taskbar zone', () => {
+    const desktop = mountlessDesktop();
+    const pinSpy = jest.spyOn(desktop, 'pinApp').mockImplementation(() => {});
+
+    const result = desktop.performDropAction(
+      {
+        zone: { id: 'taskbar', label: 'Pin to taskbar', effect: 'copy', accepts: ['app-shortcut'] },
+        element: document.createElement('div'),
+        data: {},
+      } as any,
+      { id: 'terminal', type: 'app-shortcut' } as any,
+    );
+
+    expect(result).toBe(true);
+    expect(pinSpy).toHaveBeenCalledWith('terminal');
+  });
+
+  it('opens app and focuses window when dropped on window zone', () => {
+    const desktop = mountlessDesktop();
+    const openSpy = jest.spyOn(desktop, 'openApp').mockImplementation(() => {});
+    const focusSpy = jest.spyOn(desktop, 'focus').mockImplementation(() => {});
+
+    const result = desktop.performDropAction(
+      {
+        zone: { id: 'window', label: 'Open with', effect: 'link', accepts: ['app-shortcut'] },
+        element: document.createElement('div'),
+        data: { targetId: 'about-alex' },
+      } as any,
+      { id: 'calculator', type: 'app-shortcut' } as any,
+    );
+
+    expect(result).toBe(true);
+    expect(openSpy).toHaveBeenCalledWith('calculator');
+    expect(focusSpy).toHaveBeenCalledWith('about-alex');
+  });
+
+  it('returns false for unknown drop zone', () => {
+    const desktop = mountlessDesktop();
+    const result = desktop.performDropAction(
+      {
+        zone: { id: 'unknown', label: 'Unknown', effect: 'none', accepts: [] },
+        element: document.createElement('div'),
+      } as any,
+      { id: 'terminal', type: 'app-shortcut' } as any,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('restores focus and clears drag state after invalid drop', () => {
+    jest.useFakeTimers();
+    const desktop = mountlessDesktop();
+    const source = document.createElement('button');
+    const focusSpy = jest.fn();
+    (source as any).focus = focusSpy;
+    (window.matchMedia as any) = createMatchMedia();
+
+    desktop.state.dragItem = { id: 'terminal', type: 'app-shortcut' } as any;
+    desktop._dragSource = source as any;
+    desktop.state.invalidDrop = false;
+
+    desktop.triggerInvalidDrop();
+
+    expect(focusSpy).toHaveBeenCalled();
+    expect(desktop.state.invalidDrop).toBe(true);
+
+    jest.advanceTimersByTime(200);
+    expect(desktop.state.dragItem).toBeNull();
+    jest.useRealTimers();
+  });
+
+  it('renders overlay labels', () => {
+    const desktop = mountlessDesktop();
+    desktop.state.dragItem = { id: 'terminal', type: 'app-shortcut' } as any;
+    desktop.state.dropVisuals = [
+      {
+        key: 'desktop:main',
+        zoneId: 'desktop',
+        label: 'Move',
+        effect: 'move',
+        rect: { left: 5, top: 10, width: 100, height: 60 },
+      },
+    ];
+
+    const { getByText, getByTestId } = render(<>{desktop.renderDropOverlays()}</>);
+    expect(getByText('Move')).toBeInTheDocument();
+    expect(getByTestId('drop-overlay-layer')).toHaveClass('drop-overlay-layer');
+  });
+});

--- a/__tests__/dragContext.test.ts
+++ b/__tests__/dragContext.test.ts
@@ -1,0 +1,59 @@
+import { resolveDropZones } from '../modules/dragContext';
+
+describe('dragContext drop zone metadata', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <main id="desktop">
+        <div id="window-area">
+          <div class="opened-window" id="window-terminal"></div>
+        </div>
+        <div id="taskbar"></div>
+      </main>
+    `;
+
+    const baseRect = {
+      left: 10,
+      top: 20,
+      right: 210,
+      bottom: 120,
+      width: 200,
+      height: 100,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    } as DOMRect;
+
+    const withOffset = (offset: number) => ({
+      ...baseRect,
+      top: baseRect.top + offset,
+      bottom: baseRect.bottom + offset,
+      y: baseRect.y + offset,
+    });
+
+    const desktop = document.getElementById('desktop') as HTMLElement;
+    const taskbar = document.getElementById('taskbar') as HTMLElement;
+    const windowEl = document.getElementById('window-terminal') as HTMLElement;
+
+    if (desktop) {
+      desktop.getBoundingClientRect = () => withOffset(0);
+    }
+    if (taskbar) {
+      taskbar.getBoundingClientRect = () => withOffset(140);
+    }
+    if (windowEl) {
+      windowEl.getBoundingClientRect = () => withOffset(70);
+    }
+  });
+
+  it('resolves desktop, taskbar, and window zones with labels', () => {
+    const zones = resolveDropZones('app-shortcut');
+    const labels = zones.map((zone) => zone.zone.label);
+    expect(labels).toContain('Move');
+    expect(labels).toContain('Pin to taskbar');
+    expect(labels).toContain('Open with');
+
+    const windowTargets = zones.filter((zone) => zone.zone.id === 'window');
+    expect(windowTargets).toHaveLength(1);
+    expect(windowTargets[0].data?.targetId).toBe('window-terminal');
+  });
+});

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -7,12 +7,18 @@ export class UbuntuApp extends Component {
         this.state = { launching: false, dragging: false, prefetched: false };
     }
 
-    handleDragStart = () => {
+    handleDragStart = (event) => {
         this.setState({ dragging: true });
+        if (typeof this.props.onDragStart === 'function') {
+            this.props.onDragStart(event);
+        }
     }
 
-    handleDragEnd = () => {
+    handleDragEnd = (event) => {
         this.setState({ dragging: false });
+        if (typeof this.props.onDragEnd === 'function') {
+            this.props.onDragEnd(event);
+        }
     }
 
     openApp = () => {

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -16,7 +16,11 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div
+            id="taskbar"
+            className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40"
+            role="toolbar"
+        >
             {runningApps.map(app => (
                 <button
                     key={app.id}

--- a/modules/dragContext.ts
+++ b/modules/dragContext.ts
@@ -1,0 +1,87 @@
+export type DragItemType = 'app-shortcut' | 'taskbar-entry' | 'window-tab';
+export type DropZoneId = 'desktop' | 'taskbar' | 'window';
+
+export interface DropZoneMeta {
+  id: DropZoneId;
+  label: string;
+  effect: DataTransfer['dropEffect'];
+  accepts: DragItemType[];
+  getTargets: () => DropZoneTargetInit[];
+}
+
+export interface DropZoneTargetInit {
+  element: HTMLElement;
+  data?: Record<string, string>;
+}
+
+export interface DropZoneTarget extends DropZoneTargetInit {
+  zone: DropZoneMeta;
+}
+
+const getDocument = () => {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  return document;
+};
+
+const desktopZone: DropZoneMeta = {
+  id: 'desktop',
+  label: 'Move',
+  effect: 'move',
+  accepts: ['app-shortcut', 'taskbar-entry'],
+  getTargets: () => {
+    const doc = getDocument();
+    if (!doc) return [];
+    const element = doc.getElementById('desktop');
+    if (!element) return [];
+    return [{ element }];
+  },
+};
+
+const taskbarZone: DropZoneMeta = {
+  id: 'taskbar',
+  label: 'Pin to taskbar',
+  effect: 'copy',
+  accepts: ['app-shortcut'],
+  getTargets: () => {
+    const doc = getDocument();
+    if (!doc) return [];
+    const element = doc.getElementById('taskbar');
+    if (!element) return [];
+    return [{ element }];
+  },
+};
+
+const windowZone: DropZoneMeta = {
+  id: 'window',
+  label: 'Open with',
+  effect: 'link',
+  accepts: ['app-shortcut', 'window-tab'],
+  getTargets: () => {
+    const doc = getDocument();
+    if (!doc) return [];
+    const nodes = Array.from(doc.querySelectorAll('.opened-window'));
+    return nodes
+      .filter((node): node is HTMLElement => node instanceof HTMLElement)
+      .map((element) => ({ element, data: element.id ? { targetId: element.id } : undefined }));
+  },
+};
+
+const ZONES: DropZoneMeta[] = [desktopZone, taskbarZone, windowZone];
+
+export const getDropZoneMetadata = (): DropZoneMeta[] => [...ZONES];
+
+export const resolveDropZones = (type: DragItemType): DropZoneTarget[] => {
+  const doc = getDocument();
+  if (!doc) return [];
+  const zones = ZONES.filter((zone) => zone.accepts.includes(type));
+  const results: DropZoneTarget[] = [];
+  zones.forEach((zone) => {
+    zone.getTargets().forEach((target) => {
+      if (!target.element) return;
+      results.push({ ...target, zone });
+    });
+  });
+  return results;
+};

--- a/styles/index.css
+++ b/styles/index.css
@@ -197,8 +197,61 @@ dialog {
     100% { opacity: 1; }
 }
 
+.drop-overlay-layer {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 70;
+    display: block;
+}
+
+.drop-overlay {
+    position: absolute;
+    pointer-events: auto;
+    border: 2px dashed color-mix(in srgb, var(--color-ubt-grey), transparent 45%);
+    background: color-mix(in srgb, var(--color-ub-grey), transparent 55%);
+    color: var(--color-ubt-grey);
+    border-radius: var(--radius-lg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    transition: transform var(--motion-fast) ease, opacity var(--motion-fast) ease;
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-ubt-grey), transparent 60%);
+}
+
+.drop-overlay--active {
+    background: color-mix(in srgb, var(--color-ubt-blue), transparent 60%);
+    border-color: color-mix(in srgb, var(--color-ubt-blue), transparent 25%);
+    color: var(--color-text);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-ubt-blue), transparent 45%);
+}
+
+.drop-overlay__label {
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--color-ub-lite-abrgn), transparent 35%);
+    backdrop-filter: blur(8px);
+}
+
+.drop-overlay-layer--invalid .drop-overlay {
+    animation: drop-invalid-shake var(--motion-fast) ease;
+}
+
+@keyframes drop-invalid-shake {
+    0%, 100% { transform: translate3d(0, 0, 0); }
+    25% { transform: translate3d(-6px, 0, 0); }
+    75% { transform: translate3d(6px, 0, 0); }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .xterm .xterm-cursor {
+        animation: none;
+    }
+    .drop-overlay-layer--invalid .drop-overlay {
         animation: none;
     }
 }


### PR DESCRIPTION
## Summary
- add a dragContext module that describes desktop, taskbar, and window drop zones
- surface desktop overlays that highlight valid targets, reject invalid drops, and restore focus
- style the new indicators with token-based CSS and cover the flows with unit tests

## Testing
- npx jest __tests__/dragContext.test.ts --runInBand
- npx jest __tests__/desktopDragDrop.test.tsx --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cc6d07c5648328a49ac074effb6bae