### PR TITLE
feat(desktop): add clipboard copy options

### DIFF
--- a/__tests__/clipboard.test.ts
+++ b/__tests__/clipboard.test.ts
@@ -1,0 +1,124 @@
+import type { ClipboardResult } from '../utils/clipboard';
+
+describe('clipboard utilities', () => {
+  const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    'clipboard',
+  );
+  const originalWorker = global.Worker;
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor);
+    } else {
+      delete (navigator as any).clipboard;
+    }
+    global.Worker = originalWorker as any;
+  });
+
+  const setupClipboard = (overrides: Partial<Clipboard> = {}) => {
+    const clipboardMock: Clipboard = {
+      writeText: jest.fn(() => Promise.resolve()),
+      readText: jest.fn(),
+      write: jest.fn(() => Promise.resolve()),
+      read: jest.fn(),
+      ...overrides,
+    } as unknown as Clipboard;
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: clipboardMock,
+    });
+    return clipboardMock;
+  };
+
+  const createWorkerStub = () => {
+    class MockWorker {
+      onmessage: ((event: MessageEvent<any>) => void) | null = null;
+      onerror: ((event: ErrorEvent) => void) | null = null;
+      constructor() {}
+      postMessage(data: { id: number; format: 'original' | 'png' }) {
+        const { id, format } = data;
+        setTimeout(() => {
+          const type = format === 'png' ? 'image/png' : 'image/svg+xml';
+          const blob = new Blob(['icon'], { type });
+          this.onmessage?.({
+            data: { id, success: true, blob },
+          } as MessageEvent<{ id: number; success: boolean; blob: Blob }>);
+        }, 0);
+      }
+      terminate() {}
+      addEventListener() {}
+      removeEventListener() {}
+    }
+    global.Worker = MockWorker as any;
+  };
+
+  beforeAll(() => {
+    class MockClipboardItem {
+      types: string[];
+      data: Record<string, Blob>;
+      constructor(items: Record<string, Blob>) {
+        this.types = Object.keys(items);
+        this.data = items;
+      }
+    }
+    (global as any).ClipboardItem = MockClipboardItem;
+  });
+
+  afterAll(() => {
+    (global as any).ClipboardItem = undefined;
+  });
+
+  it('copies text using the Clipboard API', async () => {
+    const clipboard = setupClipboard({
+      writeText: jest.fn(() => Promise.resolve()),
+    });
+    const { copyTextDetailed } = await import('../utils/clipboard');
+    const result = await copyTextDetailed('hello world');
+    expect(clipboard.writeText).toHaveBeenCalledWith('hello world');
+    expect(result.success).toBe(true);
+  });
+
+  it('reports permission errors from writeText', async () => {
+    const error = new DOMException('Denied', 'NotAllowedError');
+    setupClipboard({
+      writeText: jest.fn(() => Promise.reject(error)),
+    });
+    const { copyTextDetailed } = await import('../utils/clipboard');
+    const result = (await copyTextDetailed('denied')) as ClipboardResult;
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('permission-denied');
+  });
+
+  it('copies icon blobs through the worker pipeline', async () => {
+    const clipboard = setupClipboard({
+      write: jest.fn(() => Promise.resolve()),
+    });
+    createWorkerStub();
+    const { copyIconsToClipboard } = await import('../utils/clipboard');
+    const result = await copyIconsToClipboard(['/icon.svg']);
+    expect(result.success).toBe(true);
+    expect(clipboard.write).toHaveBeenCalledTimes(1);
+    const items = clipboard.write.mock.calls[0][0];
+    expect(items).toHaveLength(1);
+    const item = items[0] as any;
+    expect(item.types).toContain('image/svg+xml');
+  });
+
+  it('propagates permission errors when copying icons as PNG', async () => {
+    const error = new DOMException('Denied', 'NotAllowedError');
+    const clipboard = setupClipboard({
+      write: jest.fn(() => Promise.reject(error)),
+    });
+    createWorkerStub();
+    const { copyIconsAsPng } = await import('../utils/clipboard');
+    const result = await copyIconsAsPng(['/icon.svg']);
+    expect(clipboard.write).toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('permission-denied');
+  });
+});

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -15,6 +15,22 @@ export class UbuntuApp extends Component {
         this.setState({ dragging: false });
     }
 
+    handleMouseDown = (event) => {
+        if (this.props.disabled) return;
+        if (typeof this.props.onSelect === 'function') {
+            this.props.onSelect(this.props.id, {
+                additive: event.ctrlKey || event.metaKey,
+            });
+        }
+    }
+
+    handleFocus = () => {
+        if (this.props.disabled) return;
+        if (typeof this.props.onSelect === 'function') {
+            this.props.onSelect(this.props.id);
+        }
+    }
+
     openApp = () => {
         if (this.props.disabled) return;
         this.setState({ launching: true }, () => {
@@ -31,24 +47,30 @@ export class UbuntuApp extends Component {
     }
 
     render() {
+        const selectedClass = this.props.selected
+            ? ' bg-white bg-opacity-20 border-yellow-500 border-opacity-70 '
+            : '';
         return (
             <div
                 role="button"
                 aria-label={this.props.name}
                 aria-disabled={this.props.disabled}
+                aria-pressed={this.props.selected}
                 data-context="app"
                 data-app-id={this.props.id}
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
+                onMouseDown={this.handleMouseDown}
                 className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
+                    selectedClass +
                     " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
                 tabIndex={this.props.disabled ? -1 : 0}
                 onMouseEnter={this.handlePrefetch}
-                onFocus={this.handlePrefetch}
+                onFocus={() => { this.handlePrefetch(); this.handleFocus(); }}
             >
                 <Image
                     width={40}

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -28,6 +28,7 @@ function AppMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
+            data-preserve-selection="true"
             className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
         >
             <button

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -20,6 +20,7 @@ function DefaultMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
+            data-preserve-selection="true"
             className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
         >
 

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -43,11 +43,19 @@ function DesktopMenu(props) {
         }
     }
 
+    const copyDisabled = !props.canCopySelection
+
+    const makeCopyHandler = (handler) => () => {
+        if (copyDisabled) return
+        handler && handler()
+    }
+
     return (
         <div
             id="desktop-menu"
             role="menu"
             aria-label="Desktop context menu"
+            data-preserve-selection="true"
             className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
         >
             <button
@@ -67,6 +75,42 @@ function DesktopMenu(props) {
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
                 <span className="ml-5">Create Shortcut...</span>
+            </button>
+            <button
+                type="button"
+                onClick={makeCopyHandler(props.onCopyPaths)}
+                role="menuitem"
+                aria-label="Copy path"
+                aria-disabled={copyDisabled}
+                aria-keyshortcuts="Ctrl+C"
+                disabled={copyDisabled}
+                className={(copyDisabled ? " text-gray-400 cursor-default " : " hover:bg-ub-warm-grey hover:bg-opacity-20 ") + " w-full text-left py-0.5 mb-1.5"}
+            >
+                <span className="ml-5">Copy path</span>
+            </button>
+            <button
+                type="button"
+                onClick={makeCopyHandler(props.onCopyIcon)}
+                role="menuitem"
+                aria-label="Copy icon"
+                aria-disabled={copyDisabled}
+                aria-keyshortcuts="Ctrl+Shift+C"
+                disabled={copyDisabled}
+                className={(copyDisabled ? " text-gray-400 cursor-default " : " hover:bg-ub-warm-grey hover:bg-opacity-20 ") + " w-full text-left py-0.5 mb-1.5"}
+            >
+                <span className="ml-5">Copy icon</span>
+            </button>
+            <button
+                type="button"
+                onClick={makeCopyHandler(props.onCopyAsPng)}
+                role="menuitem"
+                aria-label="Copy icon as PNG"
+                aria-disabled={copyDisabled}
+                aria-keyshortcuts="Ctrl+Alt+C"
+                disabled={copyDisabled}
+                className={(copyDisabled ? " text-gray-400 cursor-default " : " hover:bg-ub-warm-grey hover:bg-opacity-20 ") + " w-full text-left py-0.5 mb-1.5"}
+            >
+                <span className="ml-5">Copy as PNG</span>
             </button>
             <Devider />
             <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -30,6 +30,7 @@ function TaskbarMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
+            data-preserve-selection="true"
             className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
         >
             <button

--- a/utils/clipboard.ts
+++ b/utils/clipboard.ts
@@ -1,22 +1,268 @@
-export const copyToClipboard = async (text: string): Promise<boolean> => {
-  try {
-    if (navigator?.clipboard?.writeText) {
-      await navigator.clipboard.writeText(text);
-    } else {
-      const textarea = document.createElement('textarea');
-      textarea.value = text;
-      textarea.style.position = 'fixed';
-      textarea.style.opacity = '0';
-      document.body.appendChild(textarea);
-      textarea.focus();
-      textarea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textarea);
-    }
-    return true;
-  } catch {
-    return false;
+export type ClipboardFailureReason =
+  | 'unsupported'
+  | 'permission-denied'
+  | 'unknown';
+
+export type ClipboardResult =
+  | { success: true }
+  | { success: false; reason: ClipboardFailureReason; error?: Error };
+
+type IconFormat = 'original' | 'png';
+
+interface IconRequestMessage {
+  id: number;
+  url: string;
+  format: IconFormat;
+}
+
+interface IconResponseMessage {
+  id: number;
+  success: boolean;
+  error?: string;
+  blob?: Blob;
+}
+
+const isPermissionError = (error: unknown): error is DOMException => {
+  if (!(error instanceof DOMException)) return false;
+  return error.name === 'NotAllowedError' || error.name === 'SecurityError';
+};
+
+const createSuccess = (): ClipboardResult => ({ success: true });
+
+const createFailure = (
+  reason: ClipboardFailureReason,
+  error?: Error,
+): ClipboardResult => ({ success: false, reason, error });
+
+const copyUsingTextarea = (text: string): ClipboardResult => {
+  if (typeof document === 'undefined') {
+    return createFailure('unsupported');
   }
+
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', 'true');
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const successful = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return successful ? createSuccess() : createFailure('unknown');
+  } catch (error) {
+    return createFailure('unknown', error as Error);
+  }
+};
+
+export const copyTextDetailed = async (text: string): Promise<ClipboardResult> => {
+  if (typeof navigator === 'undefined') {
+    return createFailure('unsupported');
+  }
+
+  const clipboard = navigator.clipboard;
+
+  if (clipboard?.writeText) {
+    try {
+      await clipboard.writeText(text);
+      return createSuccess();
+    } catch (error) {
+      if (isPermissionError(error)) {
+        return createFailure('permission-denied', error as Error);
+      }
+      return createFailure('unknown', error as Error);
+    }
+  }
+
+  return copyUsingTextarea(text);
+};
+
+type PendingRequest = {
+  resolve: (blob: Blob) => void;
+  reject: (error: Error) => void;
+};
+
+let iconWorker: Worker | null = null;
+let nextRequestId = 1;
+const pendingRequests = new Map<number, PendingRequest>();
+
+const resolveUrl = (input: string): string => {
+  try {
+    const base = typeof location !== 'undefined' ? location.href : 'http://localhost/';
+    return new URL(input, base).toString();
+  } catch {
+    return input;
+  }
+};
+
+const ensureIconWorker = (): Worker | null => {
+  if (iconWorker || typeof window === 'undefined') return iconWorker;
+  if (typeof Worker !== 'function') return null;
+
+  try {
+    iconWorker = new Worker(
+      new URL('../workers/iconClipboard.worker.ts', import.meta.url),
+    );
+    iconWorker.onmessage = (event: MessageEvent<IconResponseMessage>) => {
+      const { id, success, blob, error } = event.data;
+      const pending = pendingRequests.get(id);
+      if (!pending) return;
+      pendingRequests.delete(id);
+      if (success && blob) {
+        pending.resolve(blob);
+      } else {
+        pending.reject(new Error(error || 'Icon worker failed'));
+      }
+    };
+    iconWorker.onerror = (event) => {
+      pendingRequests.forEach(({ reject }) => {
+        reject(new Error(event.message || 'Icon worker encountered an error'));
+      });
+      pendingRequests.clear();
+    };
+  } catch {
+    iconWorker = null;
+  }
+
+  return iconWorker;
+};
+
+const fetchIconOnMainThread = async (
+  url: string,
+  format: IconFormat,
+): Promise<Blob> => {
+  if (typeof fetch !== 'function') {
+    throw new Error('Fetch API is not available');
+  }
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to load icon: ${response.status}`);
+  }
+
+  const blob = await response.blob();
+  if (format === 'original') {
+    return blob;
+  }
+
+  if (typeof document === 'undefined') {
+    return blob;
+  }
+
+  const imageUrl = URL.createObjectURL(blob);
+  return new Promise<Blob>((resolve, reject) => {
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.onload = () => {
+      URL.revokeObjectURL(imageUrl);
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = image.width || 1;
+        canvas.height = image.height || 1;
+        const context = canvas.getContext('2d');
+        if (!context) {
+          reject(new Error('Canvas context unavailable'));
+          return;
+        }
+        context.drawImage(image, 0, 0);
+        const toBlob = (canvas as any).toBlob?.bind(canvas);
+        if (typeof toBlob === 'function') {
+          toBlob((png: Blob | null) => {
+            if (png) resolve(png);
+            else reject(new Error('Failed to convert icon to PNG'));
+          }, 'image/png');
+        } else if (typeof (canvas as any).convertToBlob === 'function') {
+          (canvas as any)
+            .convertToBlob({ type: 'image/png' })
+            .then((png: Blob) => resolve(png))
+            .catch((error: Error) => reject(error));
+        } else {
+          reject(new Error('Canvas toBlob not supported'));
+        }
+      } catch (error) {
+        reject(error as Error);
+      }
+    };
+    image.onerror = () => {
+      URL.revokeObjectURL(imageUrl);
+      reject(new Error('Unable to load icon for conversion'));
+    };
+    image.src = imageUrl;
+  });
+};
+
+const requestIconBlob = async (url: string, format: IconFormat): Promise<Blob> => {
+  const absoluteUrl = resolveUrl(url);
+  const worker = ensureIconWorker();
+
+  if (!worker) {
+    return fetchIconOnMainThread(absoluteUrl, format);
+  }
+
+  const id = nextRequestId++;
+
+  return new Promise<Blob>((resolve, reject) => {
+    pendingRequests.set(id, { resolve, reject });
+    worker.postMessage({ id, url: absoluteUrl, format } as IconRequestMessage);
+  });
+};
+
+const copyImageBlobs = async (
+  urls: string[],
+  format: IconFormat,
+): Promise<ClipboardResult> => {
+  if (!urls.length) {
+    return createSuccess();
+  }
+
+  if (typeof navigator === 'undefined') {
+    return createFailure('unsupported');
+  }
+
+  const clipboard = navigator.clipboard as
+    | (Clipboard & { write?: (items: ClipboardItem[]) => Promise<void> })
+    | undefined;
+
+  if (!clipboard || typeof clipboard.write !== 'function') {
+    return createFailure('unsupported');
+  }
+
+  if (typeof ClipboardItem === 'undefined') {
+    return createFailure('unsupported');
+  }
+
+  try {
+    const blobs = await Promise.all(urls.map((url) => requestIconBlob(url, format)));
+    const items = blobs.map((blob) => {
+      const type = format === 'png' ? 'image/png' : blob.type || 'image/png';
+      return new ClipboardItem({ [type]: blob });
+    });
+    await clipboard.write(items);
+    return createSuccess();
+  } catch (error) {
+    if (isPermissionError(error)) {
+      return createFailure('permission-denied', error as Error);
+    }
+    return createFailure('unknown', error as Error);
+  }
+};
+
+export const copyPathsToClipboard = async (
+  paths: string[],
+): Promise<ClipboardResult> => copyTextDetailed(paths.join('\n'));
+
+export const copyIconsToClipboard = async (
+  urls: string[],
+): Promise<ClipboardResult> => copyImageBlobs(urls, 'original');
+
+export const copyIconsAsPng = async (
+  urls: string[],
+): Promise<ClipboardResult> => copyImageBlobs(urls, 'png');
+
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+  const result = await copyTextDetailed(text);
+  return result.success;
 };
 
 export default copyToClipboard;

--- a/workers/iconClipboard.worker.ts
+++ b/workers/iconClipboard.worker.ts
@@ -1,0 +1,86 @@
+interface IconRequestMessage {
+  id: number;
+  url: string;
+  format: 'original' | 'png';
+}
+
+interface IconResponseMessage {
+  id: number;
+  success: boolean;
+  error?: string;
+  blob?: Blob;
+}
+
+const toBlob = (canvas: OffscreenCanvas): Promise<Blob> => {
+  const anyCanvas = canvas as OffscreenCanvas & {
+    toBlob?: (callback: BlobCallback, type?: string, quality?: number) => void;
+  };
+
+  if (typeof anyCanvas.toBlob !== 'function' && 'convertToBlob' in canvas) {
+    anyCanvas.toBlob = (callback: BlobCallback, type?: string, quality?: number) => {
+      canvas
+        .convertToBlob({ type, quality })
+        .then((blob) => callback(blob))
+        .catch(() => callback(null));
+    };
+  }
+
+  return new Promise<Blob>((resolve, reject) => {
+    if (typeof anyCanvas.toBlob !== 'function') {
+      reject(new Error('toBlob not supported in worker'));
+      return;
+    }
+    anyCanvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error('Failed to create blob'));
+    }, 'image/png');
+  });
+};
+
+const resolveUrl = (input: string): string => {
+  try {
+    return new URL(input, self.location.origin).toString();
+  } catch {
+    return input;
+  }
+};
+
+self.onmessage = async ({ data }: MessageEvent<IconRequestMessage>) => {
+  const { id, url, format } = data;
+  try {
+    const response = await fetch(resolveUrl(url));
+    if (!response.ok) {
+      throw new Error(`Failed to fetch icon: ${response.status}`);
+    }
+
+    const blob = await response.blob();
+    if (format === 'original') {
+      (self as any).postMessage(
+        { id, success: true, blob } as IconResponseMessage,
+        [blob],
+      );
+      return;
+    }
+
+    const bitmap = await createImageBitmap(blob);
+    const canvas = new OffscreenCanvas(bitmap.width || 1, bitmap.height || 1);
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Canvas context unavailable');
+    }
+    context.drawImage(bitmap, 0, 0);
+    const pngBlob = await toBlob(canvas);
+    (self as any).postMessage(
+      { id, success: true, blob: pngBlob } as IconResponseMessage,
+      [pngBlob],
+    );
+  } catch (error) {
+    (self as any).postMessage({
+      id,
+      success: false,
+      error: (error as Error).message,
+    } as IconResponseMessage);
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- add clipboard helpers and worker-based icon conversion to support copying paths, icons, and PNG variants
- integrate desktop selection, context menu commands, keyboard shortcuts, and permission messaging with the new helpers
- add Jest coverage that mocks the Clipboard API and worker pipeline

## Testing
- yarn test __tests__/clipboard.test.ts
- npx eslint components/screen/desktop.js components/base/ubuntu_app.js components/context-menus/desktop-menu.js components/context-menus/app-menu.js components/context-menus/default.js components/context-menus/taskbar-menu.js utils/clipboard.ts workers/iconClipboard.worker.ts __tests__/clipboard.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68cc6d06c82083288d4553dde43b3bdf