### PR TITLE
[ui] centralize motion presets

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -1,6 +1,7 @@
 import React, { act } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Window from '../components/base/window';
+import { motionDurations } from '../utils/motion';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 jest.mock('react-draggable', () => ({
@@ -34,7 +35,7 @@ describe('Window lifecycle', () => {
     expect(hideSideBar).toHaveBeenCalledWith('test-window', false);
 
     act(() => {
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(motionDurations.fade);
     });
 
     expect(closed).toHaveBeenCalledWith('test-window');
@@ -199,7 +200,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: () => {},
+        stopPropagation: () => {},
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();

--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -20,12 +20,12 @@ export default function ToggleSwitch({
       aria-checked={checked}
       aria-label={ariaLabel}
       onClick={() => onChange(!checked)}
-      className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
+      className={`relative inline-flex w-10 h-5 rounded-full transition-colors motion-duration-fade motion-ease-fade focus:outline-none ${
         checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
       } ${className}`.trim()}
     >
       <span
-        className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-ub-cool-grey transition-transform duration-200 ${
+        className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-ub-cool-grey transition-transform motion-duration-spring motion-ease-spring ${
           checked ? "translate-x-5" : "translate-x-0"
         }`}
       />

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -310,7 +310,7 @@ const ContactApp: React.FC = () => {
           />
           <label
             htmlFor="contact-name"
-            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-blue-400"
+            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all motion-duration-fade motion-ease-fade peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-blue-400"
           >
             Name
           </label>
@@ -329,7 +329,7 @@ const ContactApp: React.FC = () => {
           />
           <label
             htmlFor="contact-email"
-            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-blue-400"
+            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all motion-duration-fade motion-ease-fade peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-blue-400"
           >
             Email
           </label>
@@ -353,7 +353,7 @@ const ContactApp: React.FC = () => {
           />
           <label
             htmlFor="contact-message"
-            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-blue-400"
+            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all motion-duration-fade motion-ease-fade peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-blue-400"
           >
             Message
           </label>

--- a/components/apps/john/index.js
+++ b/components/apps/john/index.js
@@ -8,6 +8,7 @@ import {
 } from './utils';
 import FormError from '../../ui/FormError';
 import StatsChart from '../../StatsChart';
+import { fade, transitionString } from '../../../utils/motion';
 
 // Enhanced John the Ripper interface that supports rule uploads,
 // basic hash analysis and mock distribution of cracking tasks.
@@ -449,7 +450,9 @@ const JohnApp = () => {
                       : 'repeating-linear-gradient(45deg,#1e3a8a,#1e3a8a 10px,#065f46 10px,#065f46 20px)',
                   backgroundSize: '20px 20px',
                   backgroundPosition: `${phase === 'wordlist' ? animOffset : -animOffset}px 0`,
-                  transition: prefersReducedMotion ? 'none' : 'width 0.2s ease-out',
+                  transition: prefersReducedMotion
+                    ? 'none'
+                    : transitionString('width', fade({ reducedMotion: prefersReducedMotion })),
                 }}
                 role="progressbar"
                 aria-valuenow={Math.round(progress)}

--- a/components/apps/memory.js
+++ b/components/apps/memory.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import GameLayout from './GameLayout';
 import { createDeck, PATTERN_THEMES, fisherYatesShuffle } from './memory_utils';
+import { spring, transitionString } from '../../utils/motion';
 
 const DEFAULT_TIME = { 2: 30, 4: 60, 6: 120 };
 
@@ -290,7 +291,7 @@ const MemoryBoard = ({ player, themePacks, onWin }) => {
         style={{
           width: `${size * 120}px`,
           transform: nudge ? 'translateX(2px)' : 'none',
-          transition: 'transform 150ms',
+          transition: transitionString('transform', spring({ reducedMotion: reduceMotion.current })),
         }}
       >
         <div className="grid gap-4" style={{ gridTemplateColumns: `repeat(${size}, minmax(0,1fr))` }}>
@@ -312,13 +313,17 @@ const MemoryBoard = ({ player, themePacks, onWin }) => {
                 className={`relative w-full aspect-square [perspective:600px] rounded transform ${
                   isHighlighted ? 'ring-4 ring-green-600' : ''
                 } ${
-                  reduceMotion.current ? '' : 'transition-transform duration-200'
+                  reduceMotion.current
+                    ? ''
+                    : 'transition-transform motion-duration-spring motion-ease-spring'
                 } ${isHighlighted && !reduceMotion.current ? 'scale-105' : ''}`}
               >
                 <div
                   data-testid="card-inner"
                   className={`w-full h-full transition-transform ${
-                    reduceMotion.current ? '' : 'duration-500'
+                    reduceMotion.current
+                      ? ''
+                      : 'motion-duration-spring motion-ease-spring'
                   } [transform-style:preserve-3d]`}
                   style={{ transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)' }}
                 >
@@ -326,7 +331,11 @@ const MemoryBoard = ({ player, themePacks, onWin }) => {
                   <div
                     className={`absolute inset-0 rounded flex items-center justify-center [transform:rotateY(180deg)] [backface-visibility:hidden] ${
                       isHighlighted ? 'bg-green-500 text-black' : 'bg-white text-black'
-                    } ${reduceMotion.current ? '' : 'transition-colors duration-300'}`}
+                    } ${
+                      reduceMotion.current
+                        ? ''
+                        : 'transition-colors motion-duration-fade motion-ease-fade'
+                    }`}
                   >
                     {card.image ? (
                       <img src={card.image} alt="" className="w-3/4 h-3/4 object-contain" />

--- a/components/apps/mimikatz/CredentialLocator.js
+++ b/components/apps/mimikatz/CredentialLocator.js
@@ -1,5 +1,6 @@
 // Simulator: displays sample credential artifacts. For educational use only.
 import React, { useState, useEffect } from 'react';
+import { fade, transitionString } from '../../../utils/motion';
 
 const artifacts = [
   { label: 'SAM Database (sample)', found: true },
@@ -61,7 +62,9 @@ const CredentialArtifactLocator = () => {
           className="bg-blue-500 h-4"
           style={{
             width: `${progress}%`,
-            transition: prefersReducedMotion ? 'none' : 'width 0.2s',
+            transition: prefersReducedMotion
+              ? 'none'
+              : transitionString('width', fade({ reducedMotion: prefersReducedMotion })),
           }}
           role="progressbar"
           aria-label="scan progress"

--- a/components/apps/nessus/HostBubbleChart.js
+++ b/components/apps/nessus/HostBubbleChart.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { spring, transitionString } from '../../../utils/motion';
 
 const severityLevels = ['All', 'Critical', 'High', 'Medium', 'Low'];
 const severityColors = {
@@ -92,7 +93,9 @@ const HostBubbleChart = ({ hosts = sampleHosts }) => {
                 fill={severityColors[host.severity]}
                 aria-label={`${host.host} severity ${host.severity} CVSS ${host.cvss}`}
                 style={{
-                  transition: prefersReducedMotion ? 'none' : 'all 0.3s ease',
+                  transition: prefersReducedMotion
+                    ? 'none'
+                    : transitionString('all', spring({ reducedMotion: prefersReducedMotion })),
                 }}
               />
               <text

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -40,7 +40,7 @@ type AnimatedCard = Card & {
 };
 
 const renderCard = (card: Card) => (
-  <div className="w-16 h-24 min-w-[24px] min-h-[24px] rounded border border-black bg-white flex items-center justify-center transition-transform duration-300 shadow-[0_1px_0_rgba(0,0,0,0.5)]">
+  <div className="w-16 h-24 min-w-[24px] min-h-[24px] rounded border border-black bg-white flex items-center justify-center transition-transform motion-duration-spring motion-ease-spring shadow-[0_1px_0_rgba(0,0,0,0.5)]">
     <span className={card.color === 'red' ? 'text-red-600' : ''}>
       {valueToString(card.value)}{card.suit}
     </span>
@@ -681,7 +681,7 @@ const Solitaire = () => {
       {flying.map((c, i) => (
         <div
           key={`fly-${i}`}
-          className="absolute transition-transform duration-300"
+          className="absolute transition-transform motion-duration-spring motion-ease-spring"
           style={{ transform: `translate(${c.x}px, ${c.y}px)` }}
         >
           {renderCard(c)}
@@ -691,7 +691,7 @@ const Solitaire = () => {
         cascade.map((c, i) => (
           <div
             key={i}
-            className="absolute transition-transform duration-1000 ease-[cubic-bezier(0.22,1,0.36,1)]"
+            className="absolute transition-transform motion-duration-spring motion-ease-spring"
             style={{
               transform: `translate(${c.x}px, ${c.y}px) rotate(${c.angle}deg)`,
               boxShadow: '0 8px 16px rgba(0,0,0,0.3)',
@@ -848,7 +848,7 @@ const Solitaire = () => {
               <div
                 key={idx}
                 className={`absolute ${
-                  !prefersReducedMotion ? 'transition-transform duration-300' : ''
+                  !prefersReducedMotion ? 'transition-transform motion-duration-spring motion-ease-spring' : ''
                 } ${
                   drag &&
                   drag.source === 'tableau' &&

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -7,6 +7,7 @@ import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
 import styles from './window.module.css';
+import { fade, spring } from '../../utils/motion';
 
 export class Window extends Component {
     constructor(props) {
@@ -400,9 +401,12 @@ export class Window extends Component {
         }
 
         const startTransform = node.style.transform;
+        const timing = spring({ reducedMotion: prefersReducedMotion });
+        const options = { duration: timing.duration, easing: timing.easing, fill: 'forwards' };
+        if (timing.delay) options.delay = timing.delay;
         this._dockAnimation = node.animate(
             [{ transform: startTransform }, { transform: endTransform }],
-            { duration: 300, easing: 'ease-in-out', fill: 'forwards' }
+            options
         );
         this._dockAnimation.onfinish = () => {
             node.style.transform = endTransform;
@@ -437,9 +441,12 @@ export class Window extends Component {
             };
             this._dockAnimation.reverse();
         } else {
+            const timing = spring({ reducedMotion: prefersReducedMotion });
+            const options = { duration: timing.duration, easing: timing.easing, fill: 'forwards' };
+            if (timing.delay) options.delay = timing.delay;
             this._dockAnimation = node.animate(
                 [{ transform: startTransform }, { transform: endTransform }],
-                { duration: 300, easing: 'ease-in-out', fill: 'forwards' }
+                options
             );
             this._dockAnimation.onfinish = () => {
                 node.style.transform = endTransform;
@@ -471,9 +478,10 @@ export class Window extends Component {
         this.setState({ closed: true }, () => {
             this.deactivateOverlay();
             this.props.hideSideBar(this.id, false);
+            const { duration } = fade();
             setTimeout(() => {
                 this.props.closed(this.id)
-            }, 300) // after 300ms this window will be unmounted from parent (Desktop)
+            }, duration); // sync with close animation timing
         });
     }
 

--- a/components/ui/ProgressBar.tsx
+++ b/components/ui/ProgressBar.tsx
@@ -16,7 +16,7 @@ export default function ProgressBar({ progress, className = '' }: ProgressBarPro
       aria-valuemax={100}
     >
       <div
-        className="h-full bg-blue-500 transition-all duration-200"
+        className="h-full bg-blue-500 transition-all motion-duration-fade motion-ease-fade"
         style={{ width: `${clamped}%` }}
       />
     </div>

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -32,7 +32,7 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform motion-duration-spring motion-ease-spring ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
       <span>{message}</span>
       {onAction && actionLabel && (

--- a/docs/motion-guidelines.md
+++ b/docs/motion-guidelines.md
@@ -1,0 +1,43 @@
+# Motion Guidelines
+
+This project standardizes UI motion so that interactive feedback feels consistent and remains accessible for users who prefer reduced effects. Use the helpers described below whenever you introduce transitions or animations.
+
+## JavaScript presets
+
+Use the utilities in [`utils/motion.ts`](../utils/motion.ts) instead of hard-coding animation timings.
+
+```ts
+import { fade, spring, transitionString } from '../utils/motion';
+
+const widthTransition = transitionString('width', fade());
+const { duration, easing } = spring();
+```
+
+* `spring()` and `fade()` enforce a 450&nbsp;ms timing cap and automatically fall back to zero-duration linear transitions when the user (or quick settings) enables reduced motion.
+* Pass `{ reducedMotion: boolean }` if you already computed the preference for the current component.
+* `transitionString(property, timing)` returns a `transition` value that you can drop into inline styles or Web Animations options.
+* The exported `motionDurations` and `motionEasings` objects surface the default values for tests or other tooling.
+
+## CSS custom properties and helper classes
+
+The design tokens in [`styles/tokens.css`](../styles/tokens.css) expose reusable motion variables:
+
+* `--motion-duration-spring` / `--motion-duration-fade`
+* `--motion-ease-spring` / `--motion-ease-fade`
+
+The global stylesheet defines utility classes that work with Tailwind’s `transition-*` helpers:
+
+```html
+<div class="transition-transform motion-duration-spring motion-ease-spring">…</div>
+<div class="transition-all motion-duration-fade motion-ease-fade">…</div>
+```
+
+Use these classes (or the `.motion-fade` / `.motion-spring` shorthands) to keep timing consistent across JSX and static CSS. They automatically resolve to `0ms` when `prefers-reduced-motion` or the in-app quick setting is enabled.
+
+## Reduced-motion behaviour
+
+* The Quick Settings panel toggles the `reduce-motion`/`reduced-motion` classes on `<html>`. The motion helpers respect both, so you do not need to add extra guards.
+* Avoid duplicating `matchMedia('(prefers-reduced-motion: reduce)')` checks unless a component must react immediately to the user preference. In most cases the motion utilities and CSS tokens provide the correct fallback automatically.
+* If you add bespoke keyframe animations, reference `var(--motion-duration-fade)` or `var(--motion-duration-spring)` and set a sensible easing (`var(--motion-ease-*)`).
+
+Keeping all animation primitives in one place makes it easier to tune the experience, run audits, and deliver accessible motion defaults.

--- a/styles/index.css
+++ b/styles/index.css
@@ -38,6 +38,30 @@ button:focus-visible {
     scroll-behavior: auto !important;
 }
 
+.motion-duration-spring {
+    transition-duration: var(--motion-duration-spring);
+}
+
+.motion-duration-fade {
+    transition-duration: var(--motion-duration-fade);
+}
+
+.motion-ease-spring {
+    transition-timing-function: var(--motion-ease-spring);
+}
+
+.motion-ease-fade {
+    transition-timing-function: var(--motion-ease-fade);
+}
+
+.motion-spring {
+    transition: transform var(--motion-duration-spring) var(--motion-ease-spring);
+}
+
+.motion-fade {
+    transition: opacity var(--motion-duration-fade) var(--motion-ease-fade);
+}
+
 /* Top NavBar styling */
 
 .top-arrow-up {
@@ -48,7 +72,8 @@ button:focus-visible {
 
 
 .animateShow {
-    animation: transformDownShow 200ms 1 forwards;
+    animation: transformDownShow var(--motion-duration-fade) 1 forwards;
+    animation-timing-function: var(--motion-ease-fade);
 }
 
 @keyframes transformDownShow {
@@ -111,7 +136,8 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .closed-window {
-    animation: closeWindow 200ms 1 forwards;
+    animation: closeWindow var(--motion-duration-fade) 1 forwards;
+    animation-timing-function: var(--motion-ease-spring);
 }
 
 @keyframes closeWindow {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -51,6 +51,11 @@
   --motion-fast: 150ms;
   --motion-medium: 300ms;
   --motion-slow: 500ms;
+  --motion-duration-cap: 450ms;
+  --motion-duration-spring: min(var(--motion-slow), 320ms);
+  --motion-duration-fade: min(var(--motion-medium), 200ms);
+  --motion-ease-spring: cubic-bezier(0.16, 1, 0.3, 1);
+  --motion-ease-fade: cubic-bezier(0.4, 0, 0.2, 1);
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
@@ -94,6 +99,9 @@
   --motion-fast: 0ms;
   --motion-medium: 0ms;
   --motion-slow: 0ms;
+  --motion-duration-cap: 0ms;
+  --motion-duration-spring: 0ms;
+  --motion-duration-fade: 0ms;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -101,6 +109,9 @@
     --motion-fast: 0ms;
     --motion-medium: 0ms;
     --motion-slow: 0ms;
+    --motion-duration-cap: 0ms;
+    --motion-duration-spring: 0ms;
+    --motion-duration-fade: 0ms;
   }
 }
 

--- a/utils/motion.ts
+++ b/utils/motion.ts
@@ -1,0 +1,87 @@
+import { isBrowser } from './isBrowser';
+
+export const MOTION_DURATION_CAP = 450;
+const SPRING_DEFAULT_DURATION = 320;
+const FADE_DEFAULT_DURATION = 200;
+const SPRING_EASING = 'cubic-bezier(0.16, 1, 0.3, 1)';
+const FADE_EASING = 'cubic-bezier(0.4, 0, 0.2, 1)';
+
+type MotionOptions = {
+  duration?: number;
+  delay?: number;
+  reducedMotion?: boolean;
+};
+
+export type MotionTiming = {
+  duration: number;
+  delay: number;
+  easing: string;
+};
+
+function clampDuration(value: number) {
+  return Math.min(value, MOTION_DURATION_CAP);
+}
+
+function prefersReducedMotion(explicit?: boolean): boolean {
+  if (typeof explicit === 'boolean') {
+    return explicit;
+  }
+
+  if (!isBrowser) return false;
+
+  const doc = document.documentElement;
+  if (doc?.classList.contains('reduced-motion') || doc?.classList.contains('reduce-motion')) {
+    return true;
+  }
+
+  if (typeof window.matchMedia === 'function') {
+    try {
+      return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+function resolveTiming(
+  defaults: { duration: number; easing: string },
+  options: MotionOptions
+): MotionTiming {
+  if (prefersReducedMotion(options.reducedMotion)) {
+    return { duration: 0, delay: 0, easing: 'linear' };
+  }
+
+  const duration = clampDuration(options.duration ?? defaults.duration);
+  const delay = Math.max(0, options.delay ?? 0);
+
+  return {
+    duration,
+    delay,
+    easing: defaults.easing,
+  };
+}
+
+export function spring(options: MotionOptions = {}): MotionTiming {
+  return resolveTiming({ duration: SPRING_DEFAULT_DURATION, easing: SPRING_EASING }, options);
+}
+
+export function fade(options: MotionOptions = {}): MotionTiming {
+  return resolveTiming({ duration: FADE_DEFAULT_DURATION, easing: FADE_EASING }, options);
+}
+
+export function transitionString(property: string, timing: MotionTiming) {
+  const delayPart = timing.delay ? ` ${timing.delay}ms` : '';
+  return `${property} ${timing.duration}ms ${timing.easing}${delayPart}`;
+}
+
+export const motionEasings = {
+  spring: SPRING_EASING,
+  fade: FADE_EASING,
+};
+
+export const motionDurations = {
+  spring: SPRING_DEFAULT_DURATION,
+  fade: FADE_DEFAULT_DURATION,
+};


### PR DESCRIPTION
## Summary
- add a reusable motion helper module with spring/fade presets, reduced-motion fallback logic, and exported timing constants
- expose motion CSS tokens/utilities and update UI components to consume the shared presets
- document the motion system for contributors and align window tests with the shared timing helpers

## Testing
- yarn lint *(fails: existing accessibility label and no-top-level-window violations in legacy apps)*
- yarn test --watch=false *(fails: legacy suites depending on Supabase/localStorage, not introduced here)*
- yarn test __tests__/window.test.tsx --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cc6d04e5e88328bbf1dc8d6977aa3b