### PR TITLE
[desktop] Add inline rename UI for desktop icons

### DIFF
--- a/__tests__/desktopRename.test.ts
+++ b/__tests__/desktopRename.test.ts
@@ -1,0 +1,121 @@
+import apps from '../apps.config';
+import { Desktop } from '../components/screen/desktop';
+
+const TARGET_ID = 'about';
+
+function getTargetApp() {
+  const app = apps.find((candidate) => candidate.id === TARGET_ID);
+  if (!app) {
+    throw new Error('Expected target app to exist');
+  }
+  return app;
+}
+
+function createDesktop(): Desktop {
+  const desktop = new Desktop();
+  // @ts-expect-error allow tests to provide props manually
+  desktop.props = desktop.props || {};
+  desktop.setState = function (update: any, callback?: () => void) {
+    const prevState = this.state;
+    const nextState = typeof update === 'function' ? update(prevState, this.props) : update;
+    if (nextState) {
+      this.state = { ...prevState, ...nextState };
+    }
+    if (typeof callback === 'function') {
+      callback();
+    }
+  };
+  desktop.applyRenamedTitles();
+  return desktop;
+}
+
+describe('Desktop rename flows', () => {
+  let desktop: Desktop;
+  let originalTitle: string;
+  let originalStored: string | undefined;
+
+  beforeEach(() => {
+    localStorage.clear();
+    desktop = createDesktop();
+    const app = getTargetApp();
+    originalTitle = app.title;
+    originalStored = app.originalTitle;
+  });
+
+  afterEach(() => {
+    const app = getTargetApp();
+    app.title = originalTitle;
+    if (originalStored !== undefined) {
+      app.originalTitle = originalStored;
+    } else {
+      delete app.originalTitle;
+    }
+    localStorage.clear();
+  });
+
+  test('committing a rename updates title and persistence', () => {
+    desktop.startRename(TARGET_ID);
+    desktop.handleRenameChange('Renamed App');
+    desktop.commitRename();
+
+    expect(getTargetApp().title).toBe('Renamed App');
+    const stored = JSON.parse(localStorage.getItem('app_renames') || '{}');
+    expect(stored[TARGET_ID]).toBe('Renamed App');
+    expect(desktop.state.rename).toBeNull();
+  });
+
+  test('canceling a rename restores the original title', () => {
+    desktop.startRename(TARGET_ID);
+    desktop.handleRenameChange('Another Name');
+    desktop.cancelRename();
+
+    expect(getTargetApp().title).toBe(originalTitle);
+    expect(desktop.state.rename).toBeNull();
+    expect(localStorage.getItem('app_renames')).toBeNull();
+  });
+
+  test('renaming preserves file extensions', () => {
+    const fileApp = {
+      id: 'unit-test-file',
+      title: 'Sample.txt',
+      originalTitle: 'Sample.txt',
+      icon: '',
+      disabled: false,
+      favourite: false,
+      desktop_shortcut: true,
+      screen: () => {},
+    };
+    apps.push(fileApp);
+    try {
+      desktop.startRename(fileApp.id);
+      expect(desktop.state.rename).not.toBeNull();
+      expect(desktop.state.rename?.extension).toBe('.txt');
+      desktop.handleRenameChange('Example');
+      desktop.commitRename();
+
+      expect(fileApp.title).toBe('Example.txt');
+      const stored = JSON.parse(localStorage.getItem('app_renames') || '{}');
+      expect(stored[fileApp.id]).toBe('Example.txt');
+    } finally {
+      const index = apps.indexOf(fileApp);
+      if (index !== -1) {
+        apps.splice(index, 1);
+      }
+      localStorage.removeItem('app_renames');
+    }
+  });
+
+  test('invalid characters show inline errors and block commit', () => {
+    desktop.startRename(TARGET_ID);
+    desktop.handleRenameChange('Bad/Name');
+    desktop.commitRename();
+
+    expect(desktop.state.rename).not.toBeNull();
+    expect(desktop.state.rename?.error).toBeTruthy();
+    expect(getTargetApp().title).toBe(originalTitle);
+    expect(localStorage.getItem('app_renames')).toBeNull();
+
+    desktop.cancelRename();
+  });
+});
+

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -5,6 +5,7 @@ export class UbuntuApp extends Component {
     constructor() {
         super();
         this.state = { launching: false, dragging: false, prefetched: false };
+        this.renameInputRef = React.createRef();
     }
 
     handleDragStart = () => {
@@ -30,7 +31,16 @@ export class UbuntuApp extends Component {
         }
     }
 
+    componentDidUpdate(prevProps) {
+        if (!prevProps.isRenaming && this.props.isRenaming && this.renameInputRef.current) {
+            this.renameInputRef.current.focus();
+            this.renameInputRef.current.select();
+        }
+    }
+
     render() {
+        const isRenaming = !!this.props.isRenaming;
+        const errorId = isRenaming ? `rename-error-${this.props.id}` : undefined;
         return (
             <div
                 role="button"
@@ -38,14 +48,23 @@ export class UbuntuApp extends Component {
                 aria-disabled={this.props.disabled}
                 data-context="app"
                 data-app-id={this.props.id}
-                draggable
+                draggable={!isRenaming}
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
                 className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
                     " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}
-                onDoubleClick={this.openApp}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
+                onDoubleClick={isRenaming ? undefined : this.openApp}
+                onKeyDown={(e) => {
+                    if (isRenaming) return;
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        this.openApp();
+                    } else if (e.key === 'F2') {
+                        e.preventDefault();
+                        this.props.onStartRename && this.props.onStartRename();
+                    }
+                }}
                 tabIndex={this.props.disabled ? -1 : 0}
                 onMouseEnter={this.handlePrefetch}
                 onFocus={this.handlePrefetch}
@@ -58,7 +77,45 @@ export class UbuntuApp extends Component {
                     alt={"Kali " + this.props.name}
                     sizes="40px"
                 />
-                {this.props.displayName || this.props.name}
+                {isRenaming ? (
+                    <div className="mt-1 w-full">
+                        <div className="flex items-center justify-center w-full rounded bg-black bg-opacity-70 px-1 py-0.5">
+                            <input
+                                ref={this.renameInputRef}
+                                type="text"
+                                value={typeof this.props.renameValue === 'string' ? this.props.renameValue : ''}
+                                onChange={(e) => this.props.onRenameChange && this.props.onRenameChange(e.target.value)}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter') {
+                                        e.preventDefault();
+                                        this.props.onRenameCommit && this.props.onRenameCommit();
+                                    } else if (e.key === 'Escape') {
+                                        e.preventDefault();
+                                        this.props.onRenameCancel && this.props.onRenameCancel();
+                                    }
+                                }}
+                                onBlur={() => this.props.onRenameCommit && this.props.onRenameCommit()}
+                                aria-label={`Rename ${this.props.name}`}
+                                aria-invalid={this.props.renameError ? 'true' : 'false'}
+                                aria-describedby={this.props.renameError ? errorId : undefined}
+                                spellCheck={false}
+                                autoComplete="off"
+                                className="w-full bg-transparent text-white outline-none"
+                                data-rename-input={this.props.id}
+                            />
+                            {this.props.renameExtension ? (
+                                <span className="ml-1 select-none" aria-hidden="true">{this.props.renameExtension}</span>
+                            ) : null}
+                        </div>
+                        {this.props.renameError ? (
+                            <p id={errorId} className="mt-1 text-[0.65rem] leading-tight text-red-300">
+                                {this.props.renameError}
+                            </p>
+                        ) : null}
+                    </div>
+                ) : (
+                    this.props.displayName || this.props.name
+                )}
 
             </div>
         )

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -21,6 +21,12 @@ function AppMenu(props) {
         }
     }
 
+    const handleRename = () => {
+        if (props.onRename) {
+            props.onRename()
+        }
+    }
+
     return (
         <div
             id="app-menu"
@@ -30,6 +36,15 @@ function AppMenu(props) {
             onKeyDown={handleKeyDown}
             className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
         >
+            <button
+                type="button"
+                onClick={handleRename}
+                role="menuitem"
+                aria-label="Rename"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Rename</span>
+            </button>
             <button
                 type="button"
                 onClick={handlePin}


### PR DESCRIPTION
**Summary**
* Implemented inline rename UI for desktop icons with keyboard focus management and validation, including rename overlay in `components/base/ubuntu_app.js`.
* Added “Rename” action to the app context menu in `components/context-menus/app-menu.js`.
* Introduced rename persistence, validation, and helper utilities within the desktop manager plus integration with icons/context menus in `components/screen/desktop.js`, and corrected the default About app id to match the registry.
* Created unit tests covering rename commit, cancel, extension preservation, and invalid-character handling in `__tests__/desktopRename.test.ts`.

**Testing**
* ✅ `yarn test desktopRename`
* ❌ `yarn lint`
* ❌ `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68cc6d069ed4832890fe98f50f155622