### PR TITLE
[desktop] multi-display workspace persistence

### DIFF
--- a/__tests__/desktopDisplays.test.tsx
+++ b/__tests__/desktopDisplays.test.tsx
@@ -1,0 +1,66 @@
+import { Desktop } from '../components/screen/desktop';
+
+describe('Desktop multi-display workspace management', () => {
+  const createInstance = () => {
+    const desktop = new Desktop({ session: {}, setSession: jest.fn(), clearSession: jest.fn() });
+    desktop.setState = (updater, callback) => {
+      const prevState = desktop.state;
+      const partial = typeof updater === 'function' ? updater(prevState, desktop.props) : updater;
+      if (!partial) return;
+      desktop.state = { ...prevState, ...partial };
+      if (callback) callback();
+    };
+    return desktop;
+  };
+
+  it('switchDisplay swaps active workspace state and taskbar windows', () => {
+    const desktop = createInstance();
+    const baseWorkspace = desktop.snapshotActiveWorkspace();
+    const ids = Object.keys(baseWorkspace.closed_windows);
+    const firstApp = ids[0];
+    const secondApp = ids.find((id) => id !== firstApp) || firstApp;
+
+    const workspaceOne = JSON.parse(JSON.stringify(baseWorkspace));
+    workspaceOne.closed_windows[firstApp] = false;
+    workspaceOne.focused_windows[firstApp] = true;
+    workspaceOne.app_stack = [firstApp];
+
+    const workspaceTwo = JSON.parse(JSON.stringify(baseWorkspace));
+    workspaceTwo.closed_windows[firstApp] = true;
+    workspaceTwo.closed_windows[secondApp] = false;
+    workspaceTwo.focused_windows[secondApp] = true;
+    workspaceTwo.app_stack = [secondApp];
+
+    desktop.state = {
+      ...desktop.state,
+      activeDisplayId: 'display-1',
+      displayOrder: ['display-1', 'display-2'],
+      displayMeta: {
+        'display-1': { name: 'Primary Display' },
+        'display-2': { name: 'Display 2' },
+      },
+      displayWorkspaces: {
+        'display-1': workspaceOne,
+        'display-2': workspaceTwo,
+      },
+      focused_windows: workspaceOne.focused_windows,
+      closed_windows: workspaceOne.closed_windows,
+      minimized_windows: workspaceOne.minimized_windows,
+      overlapped_windows: workspaceOne.overlapped_windows,
+      window_positions: workspaceOne.window_positions,
+    };
+    desktop.app_stack = [...workspaceOne.app_stack];
+    desktop.hideSideBar = jest.fn();
+    desktop.saveSession = jest.fn();
+
+    desktop.switchDisplay('display-2');
+
+    expect(desktop.state.activeDisplayId).toBe('display-2');
+    expect(desktop.state.focused_windows[secondApp]).toBe(true);
+    expect(desktop.state.closed_windows[firstApp]).toBe(true);
+    expect(desktop.app_stack).toEqual([secondApp]);
+    expect(desktop.state.displayWorkspaces['display-1'].focused_windows[firstApp]).toBe(true);
+    expect(desktop.hideSideBar).toHaveBeenCalledWith(null, false);
+    expect(desktop.saveSession).toHaveBeenCalled();
+  });
+});

--- a/__tests__/displayState.test.ts
+++ b/__tests__/displayState.test.ts
@@ -1,0 +1,42 @@
+import {
+  DISPLAY_STORAGE_KEY,
+  ensureDisplayConfig,
+  generateDisplayId,
+  loadDisplayConfig,
+  saveDisplayConfig,
+} from '../utils/displayState';
+
+describe('displayState helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('ensureDisplayConfig seeds defaults when no config exists', () => {
+    expect(localStorage.getItem(DISPLAY_STORAGE_KEY)).toBeNull();
+    const config = ensureDisplayConfig();
+    expect(config).toEqual([{ id: 'display-1', name: 'Primary Display' }]);
+    const stored = JSON.parse(localStorage.getItem(DISPLAY_STORAGE_KEY) ?? '[]');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe('display-1');
+  });
+
+  it('generateDisplayId avoids collisions even with gaps', () => {
+    const nextId = generateDisplayId([
+      { id: 'display-1', name: 'One' },
+      { id: 'display-3', name: 'Three' },
+    ]);
+    expect(nextId).toBe('display-4');
+  });
+
+  it('saveDisplayConfig stores sanitized display definitions', () => {
+    saveDisplayConfig([
+      { id: 'display-1', name: null as unknown as string },
+      { id: 'display-2', name: 'Workspace' },
+    ]);
+    const stored = loadDisplayConfig();
+    expect(stored).toEqual([
+      { id: 'display-1', name: '' },
+      { id: 'display-2', name: 'Workspace' },
+    ]);
+  });
+});

--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -10,14 +10,18 @@ describe('Taskbar', () => {
   it('minimizes focused window on click', () => {
     const openApp = jest.fn();
     const minimize = jest.fn();
+    const workspace = {
+      closed_windows: { app1: false },
+      minimized_windows: { app1: false },
+      focused_windows: { app1: true },
+    };
     render(
       <Taskbar
         apps={apps}
-        closed_windows={{ app1: false }}
-        minimized_windows={{ app1: false }}
-        focused_windows={{ app1: true }}
+        workspace={workspace}
         openApp={openApp}
         minimize={minimize}
+        displayId="display-1"
       />
     );
     const button = screen.getByRole('button', { name: /app one/i });
@@ -29,14 +33,18 @@ describe('Taskbar', () => {
   it('restores minimized window on click', () => {
     const openApp = jest.fn();
     const minimize = jest.fn();
+    const workspace = {
+      closed_windows: { app1: false },
+      minimized_windows: { app1: true },
+      focused_windows: { app1: false },
+    };
     render(
       <Taskbar
         apps={apps}
-        closed_windows={{ app1: false }}
-        minimized_windows={{ app1: true }}
-        focused_windows={{ app1: false }}
+        workspace={workspace}
         openApp={openApp}
         minimize={minimize}
+        displayId="display-1"
       />
     );
     const button = screen.getByRole('button', { name: /app one/i });

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -3,11 +3,26 @@ import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
 
 let renderApps = (props) => {
+    const workspace = props.workspace || {};
+    const closed_windows = workspace.closed_windows || {};
+    const focused_windows = workspace.focused_windows || {};
+    const minimized_windows = workspace.minimized_windows || {};
+
     let sideBarAppsJsx = [];
-    props.apps.forEach((app, index) => {
+    props.apps.forEach((app) => {
         if (props.favourite_apps[app.id] === false) return;
         sideBarAppsJsx.push(
-            <SideBarApp key={app.id} id={app.id} title={app.title} icon={app.icon} isClose={props.closed_windows} isFocus={props.focused_windows} openApp={props.openAppByAppId} isMinimized={props.isMinimized} openFromMinimised={props.openFromMinimised} />
+            <SideBarApp
+                key={app.id}
+                id={app.id}
+                title={app.title}
+                icon={app.icon}
+                isClose={closed_windows}
+                isFocus={focused_windows}
+                openApp={props.openAppByAppId}
+                isMinimized={minimized_windows}
+                openFromMinimised={props.openFromMinimised}
+            />
         );
     });
     return sideBarAppsJsx;
@@ -34,7 +49,7 @@ export default function SideBar(props) {
             >
                 {
                     (
-                        Object.keys(props.closed_windows).length !== 0
+                        Object.keys((props.workspace && props.workspace.closed_windows) || {}).length !== 0
                             ? renderApps(props)
                             : null
                     )

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,22 +1,38 @@
 import React from 'react';
 import Image from 'next/image';
 
-export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+export default function Taskbar({
+    apps,
+    workspace,
+    openApp,
+    minimize,
+    displayId,
+    displayIndex = 0,
+}) {
+    const closed_windows = workspace?.closed_windows || {};
+    const minimized_windows = workspace?.minimized_windows || {};
+    const focused_windows = workspace?.focused_windows || {};
+
+    const runningApps = apps.filter(app => closed_windows[app.id] === false);
 
     const handleClick = (app) => {
         const id = app.id;
-        if (props.minimized_windows[id]) {
-            props.openApp(id);
-        } else if (props.focused_windows[id]) {
-            props.minimize(id);
+        if (minimized_windows[id]) {
+            openApp(id);
+        } else if (focused_windows[id]) {
+            minimize(id);
         } else {
-            props.openApp(id);
+            openApp(id);
         }
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div
+            className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40 transition-transform"
+            role="toolbar"
+            data-display={displayId}
+            style={{ transform: `translateX(${displayIndex * 100}%)` }}
+        >
             {runningApps.map(app => (
                 <button
                     key={app.id}
@@ -25,7 +41,7 @@ export default function Taskbar(props) {
                     data-context="taskbar"
                     data-app-id={app.id}
                     onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
+                    className={(focused_windows[app.id] && !minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
                         'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
                 >
                     <Image
@@ -37,7 +53,7 @@ export default function Taskbar(props) {
                         sizes="24px"
                     />
                     <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
+                    {!focused_windows[app.id] && !minimized_windows[app.id] && (
                         <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
                     )}
                 </button>

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -5,28 +5,63 @@ export interface SessionWindow {
   id: string;
   x: number;
   y: number;
+  minimized?: boolean;
+}
+
+export interface DisplaySession {
+  id: string;
+  name: string;
+  windows: SessionWindow[];
 }
 
 export interface DesktopSession {
   windows: SessionWindow[];
   wallpaper: string;
   dock: string[];
+  displays?: DisplaySession[];
+  activeDisplay?: string;
 }
 
 const initialSession: DesktopSession = {
   windows: [],
   wallpaper: defaults.wallpaper,
   dock: [],
+  displays: [],
+  activeDisplay: 'display-1',
+};
+
+const isSessionWindow = (value: unknown): value is SessionWindow => {
+  if (!value || typeof value !== 'object') return false;
+  const w = value as SessionWindow;
+  return (
+    typeof w.id === 'string' &&
+    typeof w.x === 'number' &&
+    typeof w.y === 'number'
+  );
+};
+
+const isDisplaySession = (value: unknown): value is DisplaySession => {
+  if (!value || typeof value !== 'object') return false;
+  const d = value as DisplaySession;
+  return (
+    typeof d.id === 'string' &&
+    typeof d.name === 'string' &&
+    Array.isArray(d.windows) &&
+    d.windows.every(isSessionWindow)
+  );
 };
 
 function isSession(value: unknown): value is DesktopSession {
   if (!value || typeof value !== 'object') return false;
   const s = value as DesktopSession;
-  return (
-    Array.isArray(s.windows) &&
-    typeof s.wallpaper === 'string' &&
-    Array.isArray(s.dock)
-  );
+  if (!Array.isArray(s.windows) || typeof s.wallpaper !== 'string' || !Array.isArray(s.dock)) {
+    return false;
+  }
+  if (!s.windows.every(isSessionWindow)) return false;
+  if (s.displays !== undefined && !Array.isArray(s.displays)) return false;
+  if (Array.isArray(s.displays) && !s.displays.every(isDisplaySession)) return false;
+  if (s.activeDisplay !== undefined && typeof s.activeDisplay !== 'string') return false;
+  return true;
 }
 
 export default function useSession() {

--- a/utils/displayState.js
+++ b/utils/displayState.js
@@ -1,0 +1,55 @@
+import { safeLocalStorage } from './safeStorage';
+
+export const DISPLAY_STORAGE_KEY = 'desktop-displays';
+
+const normalizeDisplays = (displays) => {
+  if (!Array.isArray(displays)) return [];
+  return displays
+    .filter((display) => display && typeof display.id === 'string')
+    .map((display) => ({
+      id: display.id,
+      name: typeof display.name === 'string' ? display.name : '',
+    }));
+};
+
+export const loadDisplayConfig = () => {
+  if (!safeLocalStorage) return [];
+  try {
+    const stored = safeLocalStorage.getItem(DISPLAY_STORAGE_KEY);
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    return normalizeDisplays(parsed);
+  } catch {
+    return [];
+  }
+};
+
+export const saveDisplayConfig = (displays) => {
+  if (!safeLocalStorage) return;
+  try {
+    const normalized = normalizeDisplays(displays);
+    safeLocalStorage.setItem(DISPLAY_STORAGE_KEY, JSON.stringify(normalized));
+  } catch {
+    // ignore write errors
+  }
+};
+
+export const ensureDisplayConfig = () => {
+  const existing = loadDisplayConfig();
+  if (existing.length) return existing;
+  const defaults = [{ id: 'display-1', name: 'Primary Display' }];
+  saveDisplayConfig(defaults);
+  return defaults;
+};
+
+export const generateDisplayId = (displays) => {
+  const normalized = normalizeDisplays(displays);
+  const used = new Set(normalized.map((display) => display.id));
+  let index = normalized.length + 1;
+  let candidate = '';
+  do {
+    candidate = `display-${index}`;
+    index += 1;
+  } while (used.has(candidate));
+  return candidate;
+};


### PR DESCRIPTION
## Summary
- persist per-display workspaces in the desktop manager and swap them when the primary display changes
- surface the active workspace snapshot through the taskbar/sidebar and add a settings panel to manage displays
- store display metadata locally and cover the helpers, taskbar behaviour, and display switching with unit tests

## Testing
- yarn test -- __tests__/taskbar.test.tsx __tests__/desktopDisplays.test.tsx __tests__/displayState.test.ts
- yarn test *(fails: Modal.test.tsx, nmapNse.test.tsx and other pre-existing suites that require DOM APIs unavailable in jsdom)*
- yarn lint *(fails: long-standing accessibility and no-top-level-window violations across legacy apps)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6d0a539083289ec3f288b8aedb3e