### PR TITLE
desktop: support multi-display window transitions

### DIFF
--- a/__tests__/displayManager.test.ts
+++ b/__tests__/displayManager.test.ts
@@ -1,0 +1,96 @@
+import {
+  clampRectToDisplay,
+  findDisplayForRect,
+  getDisplayLayout,
+  getWorkspaceRect,
+  scaleSizeBetweenDisplays,
+  setDisplayLayoutOverride,
+  type DisplayDefinition,
+  type Rect,
+} from '../utils/displayManager';
+
+const makeDisplay = (overrides: Partial<DisplayDefinition> = {}): DisplayDefinition => ({
+  id: overrides.id ?? 'display-0',
+  x: overrides.x ?? 0,
+  y: overrides.y ?? 0,
+  width: overrides.width ?? 1920,
+  height: overrides.height ?? 1080,
+  scale: overrides.scale ?? 1,
+});
+
+const makeRect = (overrides: Partial<Rect> = {}): Rect => ({
+  x: overrides.x ?? 0,
+  y: overrides.y ?? 0,
+  width: overrides.width ?? 200,
+  height: overrides.height ?? 150,
+});
+
+describe('displayManager geometry helpers', () => {
+  afterEach(() => {
+    setDisplayLayoutOverride(null);
+  });
+
+  it('clamps rects to stay fully inside a display', () => {
+    const display = makeDisplay({ id: 'primary', x: 100, y: 50, width: 500, height: 400 });
+    const rect = makeRect({ x: 40, y: -10, width: 250, height: 100 });
+
+    const clamped = clampRectToDisplay(rect, display);
+
+    expect(clamped).toEqual({
+      x: 100,
+      y: 50,
+      width: 250,
+      height: 100,
+    });
+  });
+
+  it('prefers displays that contain the rect centre', () => {
+    const displays = [
+      makeDisplay({ id: 'left', x: 0, width: 500 }),
+      makeDisplay({ id: 'right', x: 500, width: 600 }),
+    ];
+    setDisplayLayoutOverride(displays);
+
+    const rect = makeRect({ x: 620, y: 20, width: 180, height: 180 });
+    const target = findDisplayForRect(rect, displays);
+
+    expect(target?.id).toBe('right');
+  });
+
+  it('falls back to the display with the largest overlap', () => {
+    const displays = [
+      makeDisplay({ id: 'left', x: 0, width: 300 }),
+      makeDisplay({ id: 'right', x: 500, width: 400 }),
+    ];
+    setDisplayLayoutOverride(displays);
+
+    const rect = makeRect({ x: 280, width: 100 });
+    const target = findDisplayForRect(rect, displays);
+
+    expect(target?.id).toBe('left');
+  });
+
+  it('scales window sizes between displays using density ratio bounds', () => {
+    const from = makeDisplay({ id: 'hidpi', width: 1440, height: 900, scale: 2 });
+    const to = makeDisplay({ id: 'standard', width: 1280, height: 800, scale: 1 });
+
+    const { width, height } = scaleSizeBetweenDisplays(400, 300, from, to);
+
+    expect(width).toBeCloseTo(800, 5);
+    expect(height).toBeCloseTo(600, 5);
+    expect(width).toBeLessThanOrEqual(to.width);
+  });
+
+  it('computes the combined workspace bounding box', () => {
+    const displays = [
+      makeDisplay({ id: 'left', x: -1920, y: 0, width: 1920, height: 1080 }),
+      makeDisplay({ id: 'centre', x: 0, y: 0, width: 1920, height: 1080 }),
+      makeDisplay({ id: 'right', x: 1920, y: -200, width: 1600, height: 1200 }),
+    ];
+    setDisplayLayoutOverride(displays);
+
+    const workspace = getWorkspaceRect(getDisplayLayout());
+
+    expect(workspace).toEqual({ x: -1920, y: -200, width: 5440, height: 1280 });
+  });
+});

--- a/docs/multi-display-qa.md
+++ b/docs/multi-display-qa.md
@@ -1,0 +1,58 @@
+# Multi-display window QA checklist
+
+These notes outline how the desktop shell should behave when more than one
+virtual display is configured. Use them when validating regressions or setting
+up exploratory tests.
+
+## Display layout overrides
+
+* Tests and debug sessions can provide a virtual layout by assigning an array of
+  display descriptors to `window.__KALI_DISPLAY_OVERRIDE__` before the desktop
+  renders.
+* Each descriptor accepts `id`, `x`, `y`, `width`, `height`, and `scale`. The
+  coordinate space matches the browser viewport (positive `x` moves windows to
+  the right, positive `y` moves them down).
+* Call `window.__kaliResetDisplayLayout()` in the console to return to a single
+  display using the current viewport dimensions.
+
+## Expected window behaviour
+
+* Window dragging respects the active display bounds. When a window crosses a
+  display boundary its target display is detected using the window's centre
+  point. If the centre lies between displays, the one with the greatest overlap
+  area wins.
+* After a display change the window resizes based on the destination scale
+  factor. Size changes are clamped to the destination's workspace, with a 20%
+  minimum to keep content usable.
+* Transitions between displays animate over ~220 ms. Windows should remain fully
+  visible during the animation. Motion is disabled for users that prefer reduced
+  motion.
+* Snapping, maximising, and keyboard nudges keep windows inside their assigned
+  display.
+* Session persistence records the most recent `{ x, y, displayId }` tuple for
+  each open window. Reloading restores windows on their previous displays.
+
+## Manual test passes
+
+1. Configure two displays with different scale factors (for example 1280×800 @1x
+   and 1600×900 @1.5x) using the override helper.
+2. Drag the default `about-alex` window between displays. Verify that the window
+   resizes smoothly and the final dimensions match expectations for the target
+   density.
+3. Reload the page. Ensure the window reappears on the last display visited and
+   that its size matches the stored scale.
+4. Snap the window to each edge on both displays and confirm it never escapes
+   the visible workspace.
+5. Repeat with a triple-display layout that includes an off-axis monitor (for
+   example, one display positioned higher or with a negative `x`). Verify clamping
+   respects the composite workspace bounds.
+
+## Automated coverage
+
+* `__tests__/displayManager.test.ts` exercises layout clamping, overlap detection,
+  and scaling helpers.
+* `tests/multi-display.spec.ts` drives Playwright to drag windows between displays
+  with different density ratios and validates persisted display IDs.
+
+Always run `yarn lint`, `yarn test`, and `npx playwright test` before shipping
+multi-display changes.

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -5,6 +5,7 @@ export interface SessionWindow {
   id: string;
   x: number;
   y: number;
+  displayId?: string;
 }
 
 export interface DesktopSession {
@@ -19,11 +20,23 @@ const initialSession: DesktopSession = {
   dock: [],
 };
 
+function isSessionWindow(value: unknown): value is SessionWindow {
+  if (!value || typeof value !== 'object') return false;
+  const w = value as SessionWindow;
+  return (
+    typeof w.id === 'string' &&
+    typeof w.x === 'number' &&
+    typeof w.y === 'number' &&
+    (w.displayId === undefined || typeof w.displayId === 'string')
+  );
+}
+
 function isSession(value: unknown): value is DesktopSession {
   if (!value || typeof value !== 'object') return false;
   const s = value as DesktopSession;
   return (
     Array.isArray(s.windows) &&
+    s.windows.every(isSessionWindow) &&
     typeof s.wallpaper === 'string' &&
     Array.isArray(s.dock)
   );

--- a/tests/multi-display.spec.ts
+++ b/tests/multi-display.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from '@playwright/test';
+
+type DisplayConfig = {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  scale: number;
+};
+
+const getWindowRect = async (selector: string, page: import('@playwright/test').Page) => {
+  return page.locator(selector).evaluate((el) => {
+    const rect = el.getBoundingClientRect();
+    return { left: rect.x, top: rect.y, width: rect.width, height: rect.height };
+  });
+};
+
+const dragWindow = async (
+  page: import('@playwright/test').Page,
+  selector: string,
+  targetX: number,
+  targetY: number,
+) => {
+  const handle = page.locator(`${selector} .bg-ub-window-title`);
+  await handle.waitFor({ state: 'visible' });
+  const box = await handle.boundingBox();
+  if (!box) throw new Error('Window title bar not found');
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(targetX, targetY, { steps: 20 });
+  await page.mouse.up();
+};
+
+const waitForWindowWithinDisplay = async (
+  page: import('@playwright/test').Page,
+  selector: string,
+  display: DisplayConfig,
+) => {
+  await expect
+    .poll(async () => {
+      const rect = await getWindowRect(selector, page);
+      return rect.left;
+    })
+    .toBeGreaterThanOrEqual(display.x - 2);
+  await expect
+    .poll(async () => {
+      const rect = await getWindowRect(selector, page);
+      return rect.left + rect.width;
+    })
+    .toBeLessThanOrEqual(display.x + display.width + 2);
+  await expect
+    .poll(async () => {
+      const rect = await getWindowRect(selector, page);
+      return rect.top;
+    })
+    .toBeGreaterThanOrEqual(display.y - 2);
+  await expect
+    .poll(async () => {
+      const rect = await getWindowRect(selector, page);
+      return rect.top + rect.height;
+    })
+    .toBeLessThanOrEqual(display.y + display.height + 2);
+};
+
+const clearAndStubDisplays = async (page: import('@playwright/test').Page, layout: DisplayConfig[]) => {
+  await page.addInitScript((config: DisplayConfig[]) => {
+    window.localStorage.clear();
+    window.__KALI_DISPLAY_OVERRIDE__ = config;
+  }, layout);
+};
+
+test.describe('multi-display window dragging', () => {
+  test('rescales window when moving to a higher density display', async ({ page }) => {
+    const displays: DisplayConfig[] = [
+      { id: 'primary', x: 0, y: 0, width: 1280, height: 800, scale: 1 },
+      { id: 'secondary', x: 1280, y: 0, width: 1600, height: 900, scale: 1.5 },
+    ];
+    await clearAndStubDisplays(page, displays);
+    await page.goto('/');
+    const aboutSelector = '#about-alex';
+    await page.locator(aboutSelector).waitFor({ state: 'visible' });
+    const initialRect = await getWindowRect(aboutSelector, page);
+
+    const targetX = displays[1].x + displays[1].width / 2;
+    const targetY = displays[1].y + 150;
+    await dragWindow(page, aboutSelector, targetX, targetY);
+    await waitForWindowWithinDisplay(page, aboutSelector, displays[1]);
+
+    const finalRect = await getWindowRect(aboutSelector, page);
+    const rawExpectedWidth = initialRect.width * (displays[0].scale / displays[1].scale);
+    const minWidth = displays[1].width * 0.2;
+    const maxWidth = displays[1].width;
+    const expectedWidth = Math.min(Math.max(rawExpectedWidth, minWidth), maxWidth);
+    expect(Math.abs(finalRect.width - expectedWidth)).toBeLessThan(6);
+
+    const session = await page.evaluate(() => {
+      const raw = window.localStorage.getItem('desktop-session');
+      return raw ? JSON.parse(raw) : null;
+    });
+    expect(session).not.toBeNull();
+    const aboutSession = session.windows.find((w: any) => w.id === 'about-alex');
+    expect(aboutSession?.displayId).toBe('secondary');
+  });
+
+  test('expands window when moving to a lower density display', async ({ page }) => {
+    const displays: DisplayConfig[] = [
+      { id: 'hidpi', x: 0, y: 0, width: 1600, height: 900, scale: 1.5 },
+      { id: 'standard', x: 1600, y: 0, width: 1280, height: 800, scale: 1 },
+    ];
+    await clearAndStubDisplays(page, displays);
+    await page.goto('/');
+    const aboutSelector = '#about-alex';
+    await page.locator(aboutSelector).waitFor({ state: 'visible' });
+    const initialRect = await getWindowRect(aboutSelector, page);
+
+    const targetX = displays[1].x + displays[1].width / 2;
+    const targetY = displays[1].y + 160;
+    await dragWindow(page, aboutSelector, targetX, targetY);
+    await waitForWindowWithinDisplay(page, aboutSelector, displays[1]);
+
+    const finalRect = await getWindowRect(aboutSelector, page);
+    const rawExpectedWidth = initialRect.width * (displays[0].scale / displays[1].scale);
+    const minWidth = displays[1].width * 0.2;
+    const maxWidth = displays[1].width;
+    const expectedWidth = Math.min(Math.max(rawExpectedWidth, minWidth), maxWidth);
+    expect(Math.abs(finalRect.width - expectedWidth)).toBeLessThan(6);
+    expect(finalRect.width).toBeLessThanOrEqual(displays[1].width + 2);
+
+    const session = await page.evaluate(() => {
+      const raw = window.localStorage.getItem('desktop-session');
+      return raw ? JSON.parse(raw) : null;
+    });
+    expect(session).not.toBeNull();
+    const aboutSession = session.windows.find((w: any) => w.id === 'about-alex');
+    expect(aboutSession?.displayId).toBe('standard');
+  });
+});

--- a/utils/displayManager.ts
+++ b/utils/displayManager.ts
@@ -1,0 +1,187 @@
+export interface DisplayDefinition {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  scale: number;
+}
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+type DisplayInput = Partial<DisplayDefinition> & { id: string };
+
+const DEFAULT_DISPLAY: DisplayDefinition = {
+  id: 'display-0',
+  x: 0,
+  y: 0,
+  width: 1920,
+  height: 1080,
+  scale: 1,
+};
+
+let overrideDisplays: DisplayDefinition[] | null = null;
+
+const parseNumber = (value: unknown, fallback: number) =>
+  typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+
+const normalizeDisplay = (display: DisplayInput): DisplayDefinition => {
+  return {
+    id: display.id,
+    x: parseNumber(display.x, 0),
+    y: parseNumber(display.y, 0),
+    width: Math.max(1, parseNumber(display.width, DEFAULT_DISPLAY.width)),
+    height: Math.max(1, parseNumber(display.height, DEFAULT_DISPLAY.height)),
+    scale: Math.max(0.1, parseNumber(display.scale, 1)),
+  };
+};
+
+const notifyLayoutChange = () => {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('kali-display-change'));
+  }
+};
+
+export const setDisplayLayoutOverride = (layout: DisplayInput[] | null) => {
+  overrideDisplays = layout ? layout.map(normalizeDisplay) : null;
+  notifyLayoutChange();
+};
+
+export const getDisplayLayout = (): DisplayDefinition[] => {
+  if (overrideDisplays && overrideDisplays.length) {
+    return overrideDisplays;
+  }
+  if (typeof window === 'undefined') {
+    return [DEFAULT_DISPLAY];
+  }
+  const width = window.innerWidth || DEFAULT_DISPLAY.width;
+  const height = window.innerHeight || DEFAULT_DISPLAY.height;
+  const scale = window.devicePixelRatio || 1;
+  return [
+    {
+      id: DEFAULT_DISPLAY.id,
+      x: 0,
+      y: 0,
+      width,
+      height,
+      scale,
+    },
+  ];
+};
+
+export const getDisplayById = (id: string | null | undefined, displays = getDisplayLayout()) => {
+  if (!id) return displays[0];
+  return displays.find((display) => display.id === id) ?? displays[0];
+};
+
+export const getWorkspaceRect = (displays = getDisplayLayout()): Rect => {
+  const minX = Math.min(...displays.map((d) => d.x));
+  const minY = Math.min(...displays.map((d) => d.y));
+  const maxX = Math.max(...displays.map((d) => d.x + d.width));
+  const maxY = Math.max(...displays.map((d) => d.y + d.height));
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+};
+
+export const findDisplayForRect = (rect: Rect | null | undefined, displays = getDisplayLayout()) => {
+  if (!rect) return displays[0];
+  const centerX = rect.x + rect.width / 2;
+  const centerY = rect.y + rect.height / 2;
+  const containing = displays.find(
+    (display) =>
+      centerX >= display.x &&
+      centerX <= display.x + display.width &&
+      centerY >= display.y &&
+      centerY <= display.y + display.height,
+  );
+  if (containing) return containing;
+  // Fallback: choose display with greatest overlap area
+  let best: DisplayDefinition | null = null;
+  let bestArea = -1;
+  for (const display of displays) {
+    const overlapX = Math.max(0, Math.min(rect.x + rect.width, display.x + display.width) - Math.max(rect.x, display.x));
+    const overlapY = Math.max(0, Math.min(rect.y + rect.height, display.y + display.height) - Math.max(rect.y, display.y));
+    const area = overlapX * overlapY;
+    if (area > bestArea) {
+      best = display;
+      bestArea = area;
+    }
+  }
+  return best ?? displays[0];
+};
+
+export const clampRectToDisplay = (rect: Rect, display: DisplayDefinition): Rect => {
+  const maxX = display.x + display.width - rect.width;
+  const maxY = display.y + display.height - rect.height;
+  return {
+    x: Math.min(Math.max(rect.x, display.x), Math.max(display.x, maxX)),
+    y: Math.min(Math.max(rect.y, display.y), Math.max(display.y, maxY)),
+    width: rect.width,
+    height: rect.height,
+  };
+};
+
+export const scaleSizeBetweenDisplays = (
+  width: number,
+  height: number,
+  fromDisplay: DisplayDefinition | null | undefined,
+  toDisplay: DisplayDefinition,
+): { width: number; height: number } => {
+  if (!fromDisplay) {
+    return {
+      width: Math.min(width, toDisplay.width),
+      height: Math.min(height, toDisplay.height),
+    };
+  }
+  const ratio = fromDisplay.scale / toDisplay.scale;
+  const nextWidth = Math.min(Math.max(width * ratio, toDisplay.width * 0.2), toDisplay.width);
+  const nextHeight = Math.min(Math.max(height * ratio, toDisplay.height * 0.2), toDisplay.height);
+  return {
+    width: nextWidth,
+    height: nextHeight,
+  };
+};
+
+declare global {
+  interface Window {
+    __KALI_DISPLAY_OVERRIDE__?: DisplayInput[];
+    __kaliSetDisplayLayout?: (layout: DisplayInput[]) => void;
+    __kaliResetDisplayLayout?: () => void;
+  }
+}
+
+const getGlobalWindow = () => {
+  if (typeof globalThis === 'undefined') return undefined;
+  if (!('window' in globalThis)) return undefined;
+  const candidate = (globalThis as typeof globalThis & { window?: unknown }).window;
+  return candidate && typeof candidate === 'object' ? (candidate as Window & typeof globalThis) : undefined;
+};
+
+const bootstrapWindowBindings = () => {
+  const globalWindow = getGlobalWindow();
+  if (!globalWindow) return;
+  if (Array.isArray(globalWindow.__KALI_DISPLAY_OVERRIDE__)) {
+    setDisplayLayoutOverride(globalWindow.__KALI_DISPLAY_OVERRIDE__);
+  }
+  globalWindow.__kaliSetDisplayLayout = (layout: DisplayInput[]) => {
+    setDisplayLayoutOverride(layout);
+  };
+  globalWindow.__kaliResetDisplayLayout = () => {
+    setDisplayLayoutOverride(null);
+  };
+};
+
+bootstrapWindowBindings();
+
+export const DEFAULT_DISPLAY_ID = DEFAULT_DISPLAY.id;
+
+export default getDisplayLayout;


### PR DESCRIPTION
## Summary
- add a display manager utility that can normalise overrides, clamp rects and scale windows between displays
- update the window shell and desktop manager to track active displays, animate cross-display transitions and persist display IDs
- extend session typing, end-to-end coverage and QA docs for multi-display behaviour

## Testing
- ⚠️ `yarn lint` *(fails: repository-wide jsx-a11y/no-top-level-window violations in untouched apps)*
- ✅ `npx eslint utils/displayManager.ts components/base/window.js components/screen/desktop.js hooks/useSession.ts tests/multi-display.spec.ts __tests__/displayManager.test.ts`
- ✅ `yarn test __tests__/window.test.tsx --runInBand`
- ✅ `yarn test __tests__/displayManager.test.ts --runInBand`
- ⚠️ `npx playwright test tests/multi-display.spec.ts` *(fails: Playwright browser binaries not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6d0af1088328a94c19e23807a62b