### PR TITLE
[desktop] add ui scaling controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,13 @@ play/pause and track controls include keyboard hotkeys.
 - **`components/apps/radare2`** - dual hex/disassembly panes with seek/find/xref; graph mode from JSON fixtures; per-file notes and bookmarks.
 - **`components/common/PipPortal.tsx`** - renders arbitrary UI inside a Document Picture-in-Picture window. See [`docs/pip-portal.md`](./docs/pip-portal.md).
 
+## UI Scaling & Theming
+
+- Global preferences now expose a **UI scale** slider (100–200%) via `useSettings`. The provider persists the value and publishes it through the `--ui-scale` CSS variable so that typography, spacing tokens, hit targets, and window chrome expand together.
+- Theme accents and high-contrast modes continue to flow through CSS custom properties. Because scaling is handled with the same variables, switching themes or toggling high contrast automatically recalculates the larger layout without color clashes.
+- Canvas-based apps listen for UI scale changes through a custom `ui-scale-change` event, ensuring their drawing surfaces resize crisply alongside the rest of the desktop.
+- Text-specific adjustments still use the `fontScale` preference. Combine both controls to balance dense themes with larger typography while keeping wallpapers and accent colors intact.
+
 ---
 
 ## Adding a New App

--- a/__tests__/uiScale.test.tsx
+++ b/__tests__/uiScale.test.tsx
@@ -1,0 +1,97 @@
+import { act, render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
+import useCanvasResize from '../hooks/useCanvasResize';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+
+describe('UI scale settings', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.style.setProperty('--ui-scale', '1');
+  });
+
+  test('persists scale changes and updates css variables', () => {
+    const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+    act(() => result.current.setUiScale(1.5));
+    expect(document.documentElement.style.getPropertyValue('--ui-scale')).toBe('1.5');
+    expect(window.localStorage.getItem('ui-scale')).toBe('1.5');
+  });
+
+  test('notifies canvas hooks to avoid clipping', () => {
+    const originalResizeObserver = (window as any).ResizeObserver;
+    const observe = jest.fn();
+    const disconnect = jest.fn();
+    class ResizeObserverMock {
+      callback: ResizeObserverCallback;
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+      }
+      observe = observe;
+      disconnect = disconnect;
+    }
+    (window as any).ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+    const setTransform = jest.fn();
+    const getContextSpy = jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(() =>
+        ({
+          setTransform,
+          clearRect: jest.fn(),
+          fillRect: jest.fn(),
+          beginPath: jest.fn(),
+        } as unknown as CanvasRenderingContext2D),
+      );
+
+    const CanvasHarness = ({ width, height }: { width: number; height: number }) => {
+      const canvasRef = useCanvasResize(100, 100);
+      const containerRef = useRef<HTMLDivElement | null>(null);
+
+      useLayoutEffect(() => {
+        if (!containerRef.current) return;
+        Object.defineProperty(containerRef.current, 'clientWidth', {
+          configurable: true,
+          get: () => width,
+        });
+        Object.defineProperty(containerRef.current, 'clientHeight', {
+          configurable: true,
+          get: () => height,
+        });
+      }, [width, height]);
+
+      return (
+        <div ref={containerRef}>
+          <canvas ref={canvasRef} />
+        </div>
+      );
+    };
+
+    let updateScale: ((value: number) => void) | null = null;
+    const Controller = () => {
+      const { setUiScale } = useSettings();
+      useEffect(() => {
+        updateScale = setUiScale;
+      }, [setUiScale]);
+      return null;
+    };
+
+    render(
+      <SettingsProvider>
+        <Controller />
+        <CanvasHarness width={200} height={200} />
+      </SettingsProvider>,
+    );
+
+    expect(setTransform).toHaveBeenCalled();
+    setTransform.mockClear();
+
+    act(() => {
+      updateScale?.(1.6);
+    });
+
+    expect(setTransform).toHaveBeenCalled();
+
+    getContextSpy.mockRestore();
+    (window as any).ResizeObserver = originalResizeObserver;
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -216,7 +216,7 @@ const utilityList = [
   {
     id: 'ascii-art',
     title: 'ASCII Art',
-    icon: '/themes/Yaru/apps/gedit.png',
+    icon: '/themes/Yaru/apps/gedit.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -225,7 +225,7 @@ const utilityList = [
   {
     id: 'clipboard-manager',
     title: 'Clipboard Manager',
-    icon: '/themes/Yaru/apps/gedit.png',
+    icon: '/themes/Yaru/apps/gedit.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -234,7 +234,7 @@ const utilityList = [
   {
     id: 'figlet',
     title: 'Figlet',
-    icon: '/themes/Yaru/apps/gedit.png',
+    icon: '/themes/Yaru/apps/gedit.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -598,7 +598,7 @@ const apps = [
   {
     id: 'chrome',
     title: 'Google Chrome',
-    icon: '/themes/Yaru/apps/chrome.png',
+    icon: '/themes/Yaru/apps/chrome.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: true,
@@ -607,7 +607,7 @@ const apps = [
   {
     id: 'calculator',
     title: 'Calculator',
-    icon: '/themes/Yaru/apps/calc.png',
+    icon: '/themes/Yaru/apps/calc.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -620,7 +620,7 @@ const apps = [
   {
     id: 'terminal',
     title: 'Terminal',
-    icon: '/themes/Yaru/apps/bash.png',
+    icon: '/themes/Yaru/apps/bash.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -630,7 +630,7 @@ const apps = [
     // VSCode app uses a Stack iframe, so no editor dependencies are required
     id: 'vscode',
     title: 'Visual Studio Code',
-    icon: '/themes/Yaru/apps/vscode.png',
+    icon: '/themes/Yaru/apps/vscode.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -641,7 +641,7 @@ const apps = [
   {
     id: 'x',
     title: 'X',
-    icon: '/themes/Yaru/apps/x.png',
+    icon: '/themes/Yaru/apps/x.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -677,7 +677,7 @@ const apps = [
   {
     id: 'about',
     title: 'About Alex',
-    icon: '/themes/Yaru/system/user-home.png',
+    icon: '/themes/Yaru/system/user-home.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: true,
@@ -686,7 +686,7 @@ const apps = [
   {
     id: 'settings',
     title: 'Settings',
-    icon: '/themes/Yaru/apps/gnome-control-center.png',
+    icon: '/themes/Yaru/apps/gnome-control-center.svg',
     disabled: false,
     favourite: true,
     desktop_shortcut: false,
@@ -695,7 +695,7 @@ const apps = [
   {
     id: 'files',
     title: 'Files',
-    icon: '/themes/Yaru/system/folder.png',
+    icon: '/themes/Yaru/system/folder.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -758,7 +758,7 @@ const apps = [
   {
     id: 'todoist',
     title: 'Todoist',
-    icon: '/themes/Yaru/apps/todoist.png',
+    icon: '/themes/Yaru/apps/todoist.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -767,7 +767,7 @@ const apps = [
   {
     id: 'sticky_notes',
     title: 'Sticky Notes',
-    icon: '/themes/Yaru/apps/gedit.png',
+    icon: '/themes/Yaru/apps/gedit.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -785,7 +785,7 @@ const apps = [
   {
     id: 'gedit',
     title: 'Contact Me',
-    icon: '/themes/Yaru/apps/gedit.png',
+    icon: '/themes/Yaru/apps/gedit.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: true,
@@ -794,7 +794,7 @@ const apps = [
   {
     id: 'converter',
     title: 'Converter',
-    icon: '/themes/Yaru/apps/calc.png',
+    icon: '/themes/Yaru/apps/calc.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,
@@ -955,7 +955,7 @@ const apps = [
   {
     id: 'serial-terminal',
     title: 'Serial Terminal',
-    icon: '/themes/Yaru/apps/bash.png',
+    icon: '/themes/Yaru/apps/bash.svg',
     disabled: false,
     favourite: false,
     desktop_shortcut: false,

--- a/apps/autopsy/data/case.json
+++ b/apps/autopsy/data/case.json
@@ -3,7 +3,7 @@
     {
       "timestamp": "2023-08-01T10:00:00Z",
       "event": "resume.docx created on desktop",
-      "thumbnail": "/themes/Yaru/apps/gedit.png"
+      "thumbnail": "/themes/Yaru/apps/gedit.svg"
     },
     {
       "timestamp": "2023-08-01T12:30:00Z",
@@ -34,7 +34,7 @@
         "children": [
           {
             "name": "resume.docx",
-            "thumbnail": "/themes/Yaru/apps/gedit.png"
+            "thumbnail": "/themes/Yaru/apps/gedit.svg"
           }
         ]
       },

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -25,6 +25,8 @@ export default function Settings() {
     setReducedMotion,
     fontScale,
     setFontScale,
+    uiScale,
+    setUiScale,
     highContrast,
     setHighContrast,
     haptics,
@@ -77,6 +79,7 @@ export default function Settings() {
       if (parsed.reducedMotion !== undefined)
         setReducedMotion(parsed.reducedMotion);
       if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
+      if (parsed.uiScale !== undefined) setUiScale(parsed.uiScale);
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
@@ -99,6 +102,7 @@ export default function Settings() {
     setDensity(defaults.density as any);
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
+    setUiScale(defaults.uiScale);
     setHighContrast(defaults.highContrast);
     setTheme("default");
   };
@@ -211,6 +215,26 @@ export default function Settings() {
       )}
       {activeTab === "accessibility" && (
         <>
+          <div className="flex justify-center my-4 items-center">
+            <label htmlFor="ui-scale" className="mr-2 text-ubt-grey">
+              UI Scale:
+            </label>
+            <input
+              id="ui-scale"
+              type="range"
+              min="100"
+              max="200"
+              step="10"
+              value={Math.round(uiScale * 100)}
+              onChange={(e) => setUiScale(parseInt(e.target.value, 10) / 100)}
+              className="ubuntu-slider"
+              aria-valuemin={100}
+              aria-valuemax={200}
+              aria-valuenow={Math.round(uiScale * 100)}
+              aria-valuetext={`${Math.round(uiScale * 100)} percent`}
+            />
+            <span className="ml-2 text-ubt-grey">{Math.round(uiScale * 100)}%</span>
+          </div>
           <div className="flex justify-center my-4">
             <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
             <input

--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import useTrashState from './state';
 import HistoryList from './components/HistoryList';
 
-const DEFAULT_ICON = '/themes/Yaru/system/folder.png';
+const DEFAULT_ICON = '/themes/Yaru/system/folder.svg';
 const EMPTY_ICON = '/themes/Yaru/status/user-trash-symbolic.svg';
 const FULL_ICON = '/themes/Yaru/status/user-trash-full-symbolic.svg';
 

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,7 +3,7 @@ import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, uiScale, setUiScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -87,6 +87,20 @@ export function Settings() {
                         />
                     ))}
                 </div>
+            </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey">UI Scale:</label>
+                <input
+                    type="range"
+                    min="100"
+                    max="200"
+                    step="10"
+                    value={Math.round(uiScale * 100)}
+                    onChange={(e) => setUiScale(parseInt(e.target.value, 10) / 100)}
+                    className="ubuntu-slider"
+                    aria-label="UI scale"
+                />
+                <span className="ml-2 text-ubt-grey">{Math.round(uiScale * 100)}%</span>
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Density:</label>
@@ -250,6 +264,7 @@ export function Settings() {
                         setReducedMotion(defaults.reducedMotion);
                         setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
+                        setUiScale(defaults.uiScale);
                         setHighContrast(defaults.highContrast);
                         setTheme('default');
                     }}
@@ -273,6 +288,8 @@ export function Settings() {
                         if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
                         if (parsed.density !== undefined) setDensity(parsed.density);
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
+                        if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
+                        if (parsed.uiScale !== undefined) setUiScale(parsed.uiScale);
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
                         if (parsed.theme !== undefined) { setTheme(parsed.theme); }

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -110,7 +110,7 @@ export class Desktop extends Component {
                 apps.push({
                     id: `new-folder-${folder.id}`,
                     title: folder.name,
-                    icon: '/themes/Yaru/system/folder.png',
+                    icon: '/themes/Yaru/system/folder.svg',
                     disabled: true,
                     favourite: false,
                     desktop_shortcut: true,
@@ -808,7 +808,7 @@ export class Desktop extends Component {
         apps.push({
             id: `new-folder-${folder_id}`,
             title: folder_name,
-            icon: '/themes/Yaru/system/folder.png',
+            icon: '/themes/Yaru/system/folder.svg',
             disabled: true,
             favourite: false,
             desktop_shortcut: true,

--- a/hooks/useCanvasResize.ts
+++ b/hooks/useCanvasResize.ts
@@ -10,22 +10,35 @@ export default function useCanvasResize(baseWidth: number, baseHeight: number) {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
+    const readUiScale = () => {
+      const raw = getComputedStyle(document.documentElement).getPropertyValue('--ui-scale');
+      const parsed = parseFloat(raw.trim());
+      if (Number.isFinite(parsed) && parsed > 0) return parsed;
+      return 1;
+    };
+
     const resize = () => {
       const parent = canvas.parentElement;
       if (!parent) return;
       const { clientWidth, clientHeight } = parent;
+      const uiScale = readUiScale();
+      const targetWidth = baseWidth * uiScale;
+      const targetHeight = baseHeight * uiScale;
+      const widthRatio = targetWidth > 0 ? clientWidth / targetWidth : 1;
+      const heightRatio = targetHeight > 0 ? clientHeight / targetHeight : 1;
       const scale = Math.min(
-        clientWidth / baseWidth,
-        clientHeight / baseHeight,
+        Number.isFinite(widthRatio) && widthRatio > 0 ? widthRatio : 1,
+        Number.isFinite(heightRatio) && heightRatio > 0 ? heightRatio : 1,
       );
-      const width = baseWidth * scale;
-      const height = baseHeight * scale;
+      const width = targetWidth * scale;
+      const height = targetHeight * scale;
       const dpr = window.devicePixelRatio || 1;
       canvas.style.width = `${width}px`;
       canvas.style.height = `${height}px`;
       canvas.width = Math.floor(width * dpr);
       canvas.height = Math.floor(height * dpr);
-      ctx.setTransform(dpr * scale, 0, 0, dpr * scale, 0, 0);
+      const transformScale = dpr * scale * uiScale;
+      ctx.setTransform(transformScale, 0, 0, transformScale, 0, 0);
     };
 
     resize();
@@ -33,8 +46,11 @@ export default function useCanvasResize(baseWidth: number, baseHeight: number) {
     const parent = canvas.parentElement;
     if (parent) ro.observe(parent);
     window.addEventListener('resize', resize);
+    const handleUiScale: EventListener = () => resize();
+    window.addEventListener('ui-scale-change', handleUiScale);
     return () => {
       window.removeEventListener('resize', resize);
+      window.removeEventListener('ui-scale-change', handleUiScale);
       ro.disconnect();
     };
   }, [baseWidth, baseHeight]);

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -10,6 +10,8 @@ import {
   setReducedMotion as saveReducedMotion,
   getFontScale as loadFontScale,
   setFontScale as saveFontScale,
+  getUiScale as loadUiScale,
+  setUiScale as saveUiScale,
   getHighContrast as loadHighContrast,
   setHighContrast as saveHighContrast,
   getLargeHitAreas as loadLargeHitAreas,
@@ -57,6 +59,7 @@ interface SettingsContextValue {
   density: Density;
   reducedMotion: boolean;
   fontScale: number;
+  uiScale: number;
   highContrast: boolean;
   largeHitAreas: boolean;
   pongSpin: boolean;
@@ -68,6 +71,7 @@ interface SettingsContextValue {
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
   setFontScale: (value: number) => void;
+  setUiScale: (value: number) => void;
   setHighContrast: (value: boolean) => void;
   setLargeHitAreas: (value: boolean) => void;
   setPongSpin: (value: boolean) => void;
@@ -82,6 +86,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
+  uiScale: defaults.uiScale,
   highContrast: defaults.highContrast,
   largeHitAreas: defaults.largeHitAreas,
   pongSpin: defaults.pongSpin,
@@ -93,6 +98,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setDensity: () => {},
   setReducedMotion: () => {},
   setFontScale: () => {},
+  setUiScale: () => {},
   setHighContrast: () => {},
   setLargeHitAreas: () => {},
   setPongSpin: () => {},
@@ -107,6 +113,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
+  const [uiScale, setUiScale] = useState<number>(defaults.uiScale);
   const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
   const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
@@ -122,6 +129,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
+      setUiScale(await loadUiScale());
       setHighContrast(await loadHighContrast());
       setLargeHitAreas(await loadLargeHitAreas());
       setPongSpin(await loadPongSpin());
@@ -157,27 +165,30 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [wallpaper]);
 
   useEffect(() => {
-    const spacing: Record<Density, Record<string, string>> = {
+    const spacing: Record<Density, Record<string, number>> = {
       regular: {
-        '--space-1': '0.25rem',
-        '--space-2': '0.5rem',
-        '--space-3': '0.75rem',
-        '--space-4': '1rem',
-        '--space-5': '1.5rem',
-        '--space-6': '2rem',
+        '--space-1': 4,
+        '--space-2': 8,
+        '--space-3': 12,
+        '--space-4': 16,
+        '--space-5': 24,
+        '--space-6': 32,
       },
       compact: {
-        '--space-1': '0.125rem',
-        '--space-2': '0.25rem',
-        '--space-3': '0.5rem',
-        '--space-4': '0.75rem',
-        '--space-5': '1rem',
-        '--space-6': '1.5rem',
+        '--space-1': 2,
+        '--space-2': 4,
+        '--space-3': 8,
+        '--space-4': 12,
+        '--space-5': 16,
+        '--space-6': 24,
       },
     };
     const vars = spacing[density];
     Object.entries(vars).forEach(([key, value]) => {
-      document.documentElement.style.setProperty(key, value);
+      document.documentElement.style.setProperty(
+        key,
+        `calc(${value}px * var(--ui-scale))`,
+      );
     });
     saveDensity(density);
   }, [density]);
@@ -191,6 +202,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     document.documentElement.style.setProperty('--font-multiplier', fontScale.toString());
     saveFontScale(fontScale);
   }, [fontScale]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--ui-scale', uiScale.toString());
+    saveUiScale(uiScale);
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('ui-scale-change', { detail: uiScale }));
+    }
+  }, [uiScale]);
 
   useEffect(() => {
     document.documentElement.classList.toggle('high-contrast', highContrast);
@@ -244,6 +263,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         density,
         reducedMotion,
         fontScale,
+        uiScale,
         highContrast,
         largeHitAreas,
         pongSpin,
@@ -255,6 +275,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setDensity,
         setReducedMotion,
         setFontScale,
+        setUiScale,
         setHighContrast,
         setLargeHitAreas,
         setPongSpin,

--- a/public/themes/Yaru/apps/bash.svg
+++ b/public/themes/Yaru/apps/bash.svg
@@ -1,0 +1,11 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Terminal icon</title>
+  <desc id="desc">Dark terminal window with a green command prompt caret</desc>
+  <rect x="10" y="18" width="108" height="92" rx="16" fill="#0b1120" stroke="#1f2937" stroke-width="4" />
+  <rect x="18" y="26" width="92" height="12" rx="6" fill="#1e293b" />
+  <circle cx="28" cy="32" r="4" fill="#f87171" />
+  <circle cx="40" cy="32" r="4" fill="#facc15" />
+  <circle cx="52" cy="32" r="4" fill="#34d399" />
+  <path d="M34 60 50 68 34 76" stroke="#34d399" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M58 80h30" stroke="#38bdf8" stroke-width="6" stroke-linecap="round" />
+</svg>

--- a/public/themes/Yaru/apps/calc.svg
+++ b/public/themes/Yaru/apps/calc.svg
@@ -1,0 +1,24 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Calculator icon</title>
+  <desc id="desc">Dark calculator keypad with highlighted operation buttons</desc>
+  <rect x="12" y="12" width="104" height="104" rx="20" fill="#111827" />
+  <rect x="26" y="22" width="76" height="28" rx="8" fill="#1f2937" stroke="#0ea5e9" stroke-width="4" />
+  <g fill="#0ea5e9">
+    <rect x="26" y="58" width="20" height="20" rx="5" />
+    <rect x="52" y="58" width="20" height="20" rx="5" />
+    <rect x="78" y="58" width="20" height="20" rx="5" />
+  </g>
+  <g fill="#334155">
+    <rect x="26" y="84" width="20" height="20" rx="5" />
+    <rect x="52" y="84" width="20" height="20" rx="5" />
+    <rect x="78" y="84" width="20" height="20" rx="5" />
+  </g>
+  <rect x="78" y="58" width="20" height="46" rx="5" fill="#f97316" />
+  <path d="M36 68h10" stroke="#f8fafc" stroke-width="4" stroke-linecap="round" />
+  <path d="M36 94h10" stroke="#f8fafc" stroke-width="4" stroke-linecap="round" />
+  <path d="M62 68h10" stroke="#f8fafc" stroke-width="4" stroke-linecap="round" />
+  <path d="M62 94h10" stroke="#f8fafc" stroke-width="4" stroke-linecap="round" />
+  <path d="M88 68v34" stroke="#111827" stroke-width="6" stroke-linecap="round" opacity="0.4" />
+  <path d="M88 68h0" stroke="#f8fafc" stroke-width="4" stroke-linecap="round" />
+  <path d="M88 92h0" stroke="#f8fafc" stroke-width="4" stroke-linecap="round" />
+</svg>

--- a/public/themes/Yaru/apps/chrome.svg
+++ b/public/themes/Yaru/apps/chrome.svg
@@ -1,0 +1,12 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Chromium style browser icon</title>
+  <desc id="desc">Tri-colour circular icon inspired by the Chromium browser logo</desc>
+  <circle cx="64" cy="64" r="56" fill="#0f172a" />
+  <g transform="translate(64 64)">
+    <path d="M0-48A48 48 0 0 1 43.2-24L24 8H-4.5Z" fill="#f87171" />
+    <path d="M24 8 43.2-24A48 48 0 0 1 8 47.5H-24Z" fill="#22c55e" />
+    <path d="M8 47.5H-40A48 48 0 0 1-4.5-48L-4.4-11Z" fill="#38bdf8" />
+  </g>
+  <circle cx="64" cy="64" r="24" fill="#0ea5e9" stroke="#f8fafc" stroke-width="6" />
+  <circle cx="64" cy="64" r="12" fill="#f8fafc" />
+</svg>

--- a/public/themes/Yaru/apps/gedit.svg
+++ b/public/themes/Yaru/apps/gedit.svg
@@ -1,0 +1,23 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Text editor icon</title>
+  <desc id="desc">Stylised sheet of paper with an orange pencil to suggest editing</desc>
+  <defs>
+    <linearGradient id="gedit-bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#1e293b" />
+    </linearGradient>
+    <linearGradient id="gedit-pencil" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#fb923c" />
+      <stop offset="1" stop-color="#f97316" />
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="112" height="112" rx="24" fill="url(#gedit-bg)" />
+  <rect x="28" y="22" width="60" height="84" rx="10" fill="#f8fafc" />
+  <path d="M36 40h44" stroke="#cbd5f5" stroke-width="6" stroke-linecap="round" />
+  <path d="M36 58h44" stroke="#cbd5f5" stroke-width="6" stroke-linecap="round" />
+  <path d="M36 76h36" stroke="#cbd5f5" stroke-width="6" stroke-linecap="round" />
+  <path d="M36 94h28" stroke="#cbd5f5" stroke-width="6" stroke-linecap="round" />
+  <path d="M58 96l32-32 12 12-32 32-16 4z" fill="url(#gedit-pencil)" />
+  <path d="M102 76l-4 4-12-12 4-4a6 6 0 0 1 8.5 0l3.5 3.5a6 6 0 0 1 0 8.5z" fill="#facc15" />
+  <path d="M60 102l14-3.5-10.5-10.5z" fill="#1f2937" opacity="0.35" />
+</svg>

--- a/public/themes/Yaru/apps/gnome-control-center.svg
+++ b/public/themes/Yaru/apps/gnome-control-center.svg
@@ -1,0 +1,22 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">System settings icon</title>
+  <desc id="desc">Circular gear symbol representing system controls</desc>
+  <defs>
+    <radialGradient id="gear-bg" cx="0.5" cy="0.4" r="0.75">
+      <stop offset="0" stop-color="#38bdf8" />
+      <stop offset="1" stop-color="#0f172a" />
+    </radialGradient>
+  </defs>
+  <circle cx="64" cy="64" r="56" fill="url(#gear-bg)" />
+  <g fill="none" stroke="#f8fafc" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="64" cy="64" r="20" />
+    <path d="M64 32v10" />
+    <path d="M64 86v10" />
+    <path d="M96 64h-10" />
+    <path d="M32 64h10" />
+    <path d="M88 40l-7 7" />
+    <path d="M40 88l7-7" />
+    <path d="M88 88l-7-7" />
+    <path d="M40 40l7 7" />
+  </g>
+</svg>

--- a/public/themes/Yaru/apps/todoist.svg
+++ b/public/themes/Yaru/apps/todoist.svg
@@ -1,0 +1,8 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Task list icon</title>
+  <desc id="desc">Rounded red square with stacked check marks</desc>
+  <rect x="12" y="12" width="104" height="104" rx="28" fill="#dc2626" />
+  <path d="M32 48 52 64 92 32" stroke="#f8fafc" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M32 70 52 86 92 54" stroke="#fde68a" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" opacity="0.75" />
+  <path d="M32 92 52 108 92 76" stroke="#fee2e2" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" opacity="0.6" />
+</svg>

--- a/public/themes/Yaru/apps/vscode.svg
+++ b/public/themes/Yaru/apps/vscode.svg
@@ -1,0 +1,14 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Code editor icon</title>
+  <desc id="desc">Blue lozenge with angular brackets evoking a code editor</desc>
+  <defs>
+    <linearGradient id="vscode-bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#1d4ed8" />
+      <stop offset="1" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect x="12" y="20" width="104" height="88" rx="24" fill="url(#vscode-bg)" />
+  <path d="M52 44 36 64l16 20" fill="none" stroke="#e0f2fe" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M76 44 92 64 76 84" fill="none" stroke="#e0f2fe" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
+  <rect x="60" y="48" width="8" height="32" rx="4" fill="#f8fafc" opacity="0.8" />
+</svg>

--- a/public/themes/Yaru/apps/x.svg
+++ b/public/themes/Yaru/apps/x.svg
@@ -1,0 +1,6 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Social app icon</title>
+  <desc id="desc">Minimal dark square with a stylised white X</desc>
+  <rect x="12" y="12" width="104" height="104" rx="24" fill="#111827" />
+  <path d="M40 36h16l16 22 20-22h16l-26 30 26 30h-16l-18-22-18 22H40l26-30z" fill="#f8fafc" />
+</svg>

--- a/public/themes/Yaru/system/folder.svg
+++ b/public/themes/Yaru/system/folder.svg
@@ -1,0 +1,7 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Folder icon</title>
+  <desc id="desc">Stylised teal folder used in the desktop</desc>
+  <rect x="12" y="28" width="104" height="80" rx="20" fill="#0f172a" />
+  <path d="M28 44h26l10 12h36a10 10 0 0 1 10 10v30a10 10 0 0 1-10 10H28a10 10 0 0 1-10-10V54a10 10 0 0 1 10-10z" fill="#0ea5e9" />
+  <path d="M28 44h26l10 12h36c5.5 0 10 4.5 10 10v4H18v-6a20 20 0 0 1 10-20z" fill="#38bdf8" opacity="0.6" />
+</svg>

--- a/public/themes/Yaru/system/user-home.svg
+++ b/public/themes/Yaru/system/user-home.svg
@@ -1,0 +1,13 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Home folder icon</title>
+  <desc id="desc">Blue house silhouette representing the user's home directory</desc>
+  <defs>
+    <linearGradient id="home-bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#1d4ed8" />
+      <stop offset="1" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <rect x="10" y="22" width="108" height="92" rx="24" fill="#0b1120" />
+  <path d="M32 76v28h64V76h12L64 32 20 76z" fill="url(#home-bg)" stroke="#38bdf8" stroke-width="4" stroke-linejoin="round" />
+  <rect x="56" y="84" width="16" height="20" rx="4" fill="#f8fafc" opacity="0.85" />
+</svg>

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,7 +1,11 @@
 @import './globals.css';
 
 html {
-    font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
+    font-size: clamp(
+        calc(12px * var(--ui-scale)),
+        calc(16px * var(--font-multiplier) * var(--ui-scale)),
+        calc(24px * var(--ui-scale))
+    );
 }
 
 body{

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -34,12 +34,12 @@
   --game-color-danger: #b91c1c;
 
   /* Spacing scale */
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.5rem;
-  --space-6: 2rem;
+  --space-1: calc(4px * var(--ui-scale));
+  --space-2: calc(8px * var(--ui-scale));
+  --space-3: calc(12px * var(--ui-scale));
+  --space-4: calc(16px * var(--ui-scale));
+  --space-5: calc(24px * var(--ui-scale));
+  --space-6: calc(32px * var(--ui-scale));
 
   /* Radius */
   --radius-sm: 2px;
@@ -55,8 +55,9 @@
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
   --font-multiplier: 1;
+  --ui-scale: 1;
   /* Minimum interactive target size */
-  --hit-area: 32px;
+  --hit-area: calc(32px * var(--ui-scale));
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
@@ -86,7 +87,7 @@
 
 /* Larger hit areas */
 .large-hit-area {
-  --hit-area: 48px;
+  --hit-area: calc(48px * var(--ui-scale));
 }
 
 /* Reduced motion */

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -9,6 +9,7 @@ const DEFAULT_SETTINGS = {
   density: 'regular',
   reducedMotion: false,
   fontScale: 1,
+  uiScale: 1,
   highContrast: false,
   largeHitAreas: false,
   pongSpin: true,
@@ -69,6 +70,17 @@ export async function getFontScale() {
 export async function setFontScale(scale) {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('font-scale', String(scale));
+}
+
+export async function getUiScale() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.uiScale;
+  const stored = window.localStorage.getItem('ui-scale');
+  return stored ? parseFloat(stored) : DEFAULT_SETTINGS.uiScale;
+}
+
+export async function setUiScale(scale) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('ui-scale', String(scale));
 }
 
 export async function getHighContrast() {
@@ -132,6 +144,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
   window.localStorage.removeItem('font-scale');
+  window.localStorage.removeItem('ui-scale');
   window.localStorage.removeItem('high-contrast');
   window.localStorage.removeItem('large-hit-areas');
   window.localStorage.removeItem('pong-spin');
@@ -146,6 +159,7 @@ export async function exportSettings() {
     density,
     reducedMotion,
     fontScale,
+    uiScale,
     highContrast,
     largeHitAreas,
     pongSpin,
@@ -157,6 +171,7 @@ export async function exportSettings() {
     getDensity(),
     getReducedMotion(),
     getFontScale(),
+    getUiScale(),
     getHighContrast(),
     getLargeHitAreas(),
     getPongSpin(),
@@ -170,6 +185,7 @@ export async function exportSettings() {
     density,
     reducedMotion,
     fontScale,
+    uiScale,
     highContrast,
     largeHitAreas,
     pongSpin,
@@ -194,6 +210,7 @@ export async function importSettings(json) {
     density,
     reducedMotion,
     fontScale,
+    uiScale,
     highContrast,
     largeHitAreas,
     pongSpin,
@@ -206,6 +223,7 @@ export async function importSettings(json) {
   if (density !== undefined) await setDensity(density);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
   if (fontScale !== undefined) await setFontScale(fontScale);
+  if (uiScale !== undefined) await setUiScale(uiScale);
   if (highContrast !== undefined) await setHighContrast(highContrast);
   if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
   if (pongSpin !== undefined) await setPongSpin(pongSpin);


### PR DESCRIPTION
## Summary
- add a persisted UI scale preference to the global settings context and propagate it via CSS variables and canvas resize hooks
- expose the new control in both settings experiences, update documentation, and ship crisp SVG icon replacements
- add regression coverage verifying CSS variable updates and canvas responses to ui-scale-change events

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label and no-top-level-window violations across legacy apps)*
- yarn test --runInBand *(fails: existing window.handleKeyDown event mock missing preventDefault and Nmap NSE clipboard alert expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6d0d0f5083289041e90f3ee1aa0e