### PR TITLE
[context-menu] add nested menu keyboard navigation

### DIFF
--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -1,10 +1,13 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';
 
 export interface MenuItem {
   label: React.ReactNode;
-  onSelect: () => void;
+  onSelect?: () => void;
+  disabled?: boolean;
+  accelerator?: string;
+  submenu?: MenuItem[];
 }
 
 interface ContextMenuProps {
@@ -13,6 +16,174 @@ interface ContextMenuProps {
   /** Menu items to render */
   items: MenuItem[];
 }
+
+interface MenuListProps {
+  items: MenuItem[];
+  depth: number;
+  parentPath: number[];
+  open: boolean;
+  openPath: number[];
+  registerItem: (path: number[], node: HTMLButtonElement | null) => void;
+  setOpenPath: React.Dispatch<React.SetStateAction<number[]>>;
+  setPendingFocus: React.Dispatch<React.SetStateAction<number[] | null>>;
+  setActivePath: React.Dispatch<React.SetStateAction<number[]>>;
+  closeMenu: () => void;
+}
+
+const pathKey = (path: number[]) => path.join('-');
+
+const isPathOpen = (openPath: number[], path: number[]) => {
+  if (path.length === 0) return true;
+  if (openPath.length < path.length) return false;
+  return path.every((segment, index) => openPath[index] === segment);
+};
+
+const MenuList: React.FC<MenuListProps> = ({
+  items,
+  depth,
+  parentPath,
+  open,
+  openPath,
+  registerItem,
+  setOpenPath,
+  setPendingFocus,
+  setActivePath,
+  closeMenu,
+}) => {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useRovingTabIndex(listRef as React.RefObject<HTMLElement>, open, 'vertical');
+
+  const containerClasses =
+    'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm';
+
+  return (
+    <div
+      role="menu"
+      ref={listRef}
+      aria-hidden={!open}
+      className={
+        (open ? 'block ' : 'hidden ') +
+        (depth === 0 ? containerClasses : `${containerClasses} left-full top-0 ml-1`)
+      }
+    >
+      {items.map((item, index) => {
+        const path = [...parentPath, index];
+        const key = pathKey(path);
+        const hasSubmenu = Boolean(item.submenu && item.submenu.length);
+        const submenuItems = item.submenu ?? [];
+        const submenuOpen = hasSubmenu && isPathOpen(openPath, path);
+        const disabled = Boolean(item.disabled);
+
+        const focusPath = () => {
+          setActivePath(path);
+          setOpenPath(prev => prev.slice(0, path.length));
+        };
+
+        const openSubmenu = () => {
+          if (!hasSubmenu) return;
+          setOpenPath(path);
+          setPendingFocus([...path, 0]);
+        };
+
+        const closeSubmenu = () => {
+          if (path.length === 0) return;
+          setOpenPath(prev => {
+            if (prev.length === 0) return prev;
+            if (prev.length >= path.length) {
+              return prev.slice(0, path.length - 1);
+            }
+            return prev.slice(0, prev.length - 1);
+          });
+          const targetPath = path.length > 1 ? path.slice(0, -1) : path;
+          setPendingFocus(targetPath);
+        };
+
+        const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+          if (disabled) return;
+          if (event.key === 'ArrowRight' || (event.key === 'Enter' && hasSubmenu)) {
+            if (hasSubmenu) {
+              event.preventDefault();
+              openSubmenu();
+            }
+          } else if (event.key === 'ArrowLeft') {
+            if (path.length > 0) {
+              event.preventDefault();
+              closeSubmenu();
+            }
+          }
+        };
+
+        const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+          if (disabled) {
+            event.preventDefault();
+            return;
+          }
+          if (hasSubmenu) {
+            event.preventDefault();
+            openSubmenu();
+            return;
+          }
+          item.onSelect?.();
+          closeMenu();
+        };
+
+        const handleMouseEnter = () => {
+          if (disabled) return;
+          setActivePath(path);
+          if (hasSubmenu) {
+            setOpenPath(path);
+          } else {
+            setOpenPath(prev => prev.slice(0, path.length));
+          }
+        };
+
+        return (
+          <div key={key} className="relative">
+            <button
+              type="button"
+              data-path={key}
+              ref={node => registerItem(path, node)}
+              role="menuitem"
+              tabIndex={-1}
+              aria-disabled={disabled || undefined}
+              disabled={disabled}
+              aria-haspopup={hasSubmenu ? 'true' : undefined}
+              aria-expanded={hasSubmenu ? (submenuOpen ? 'true' : 'false') : undefined}
+              onFocus={focusPath}
+              onMouseEnter={handleMouseEnter}
+              onKeyDown={handleKeyDown}
+              onClick={handleClick}
+              className={`w-full flex items-center justify-between px-3 py-1.5 text-left cursor-default hover:bg-gray-700 ${
+                disabled ? 'text-gray-400 cursor-not-allowed' : ''
+              }`}
+            >
+              <span className="flex-1 mr-3 truncate">{item.label}</span>
+              <span className="flex items-center gap-2 ml-auto text-xs text-gray-300">
+                {item.accelerator && <span>{item.accelerator}</span>}
+                {hasSubmenu && <span aria-hidden="true">›</span>}
+              </span>
+            </button>
+            {hasSubmenu && submenuOpen && (
+              <MenuList
+                items={submenuItems}
+                depth={depth + 1}
+                parentPath={path}
+                open
+                openPath={openPath}
+                registerItem={registerItem}
+                setOpenPath={setOpenPath}
+                setPendingFocus={setPendingFocus}
+                setActivePath={setActivePath}
+                closeMenu={closeMenu}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
 
 /**
  * Accessible context menu that supports right click and Shift+F10
@@ -23,14 +194,22 @@ interface ContextMenuProps {
 const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
   const [open, setOpen] = useState(false);
   const [pos, setPos] = useState({ x: 0, y: 0 });
+  const [openPath, setOpenPath] = useState<number[]>([]);
+  const [, setActivePath] = useState<number[]>([]);
+  const [pendingFocus, setPendingFocus] = useState<number[] | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef(new Map<string, HTMLButtonElement>());
 
   useFocusTrap(menuRef as React.RefObject<HTMLElement>, open);
-  useRovingTabIndex(
-    menuRef as React.RefObject<HTMLElement>,
-    open,
-    'vertical',
-  );
+
+  const registerItem = (path: number[], node: HTMLButtonElement | null) => {
+    const key = pathKey(path);
+    if (node) {
+      itemRefs.current.set(key, node);
+    } else {
+      itemRefs.current.delete(key);
+    }
+  };
 
   useEffect(() => {
     const node = targetRef.current;
@@ -92,29 +271,47 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
     };
   }, [open]);
 
+  useEffect(() => {
+    if (!open) {
+      setOpenPath([]);
+      setActivePath([]);
+      return;
+    }
+    setPendingFocus([0]);
+  }, [open]);
+
+  useEffect(() => {
+    if (!pendingFocus) return;
+    const key = pathKey(pendingFocus);
+    const node = itemRefs.current.get(key);
+    if (node) {
+      node.focus();
+    }
+    setPendingFocus(null);
+  }, [pendingFocus]);
+
+  const closeMenu = () => setOpen(false);
+
+  const rootItems = useMemo(() => items ?? [], [items]);
+
   return (
     <div
-      role="menu"
       ref={menuRef}
-      aria-hidden={!open}
       style={{ left: pos.x, top: pos.y }}
-      className={(open ? 'block ' : 'hidden ') +
-        'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+      className={(open ? 'block ' : 'hidden ') + 'absolute'}
     >
-      {items.map((item, i) => (
-        <button
-          key={i}
-          role="menuitem"
-          tabIndex={-1}
-          onClick={() => {
-            item.onSelect();
-            setOpen(false);
-          }}
-          className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
-        >
-          {item.label}
-        </button>
-      ))}
+      <MenuList
+        items={rootItems}
+        depth={0}
+        parentPath={[]}
+        open={open}
+        openPath={openPath}
+        registerItem={registerItem}
+        setOpenPath={setOpenPath}
+        setPendingFocus={setPendingFocus}
+        setActivePath={setActivePath}
+        closeMenu={closeMenu}
+      />
     </div>
   );
 };

--- a/components/common/menuDefinitions.ts
+++ b/components/common/menuDefinitions.ts
@@ -1,0 +1,94 @@
+import type { MenuItem } from './ContextMenu';
+
+export interface MenuDefinition {
+  id: string;
+  label: string;
+  accelerator?: string;
+  children?: MenuDefinition[];
+}
+
+export const nestedContextMenu: MenuDefinition[] = [
+  {
+    id: 'open',
+    label: 'Open',
+    accelerator: 'Enter',
+  },
+  {
+    id: 'share',
+    label: 'Share',
+    accelerator: 'Ctrl+Shift+S',
+    children: [
+      {
+        id: 'share-email',
+        label: 'Email Link…',
+        accelerator: 'Ctrl+E',
+      },
+      {
+        id: 'share-export',
+        label: 'Export',
+        accelerator: 'Ctrl+Shift+X',
+        children: [
+          {
+            id: 'share-export-png',
+            label: 'Export as PNG',
+            accelerator: 'Ctrl+Shift+P',
+          },
+          {
+            id: 'share-export-pdf',
+            label: 'Export as PDF',
+            accelerator: 'Ctrl+Shift+F',
+          },
+        ],
+      },
+      {
+        id: 'share-copy',
+        label: 'Copy Link',
+        accelerator: 'Ctrl+C',
+      },
+    ],
+  },
+  {
+    id: 'recent',
+    label: 'Open Recent',
+    accelerator: 'Ctrl+R',
+    children: [
+      {
+        id: 'recent-report',
+        label: 'Quarterly Report.odt',
+        accelerator: 'Ctrl+1',
+      },
+      {
+        id: 'recent-charts',
+        label: 'Charts.graffle',
+        accelerator: 'Ctrl+2',
+      },
+      {
+        id: 'recent-clear',
+        label: 'Clear Menu',
+        accelerator: 'Ctrl+Backspace',
+      },
+    ],
+  },
+  {
+    id: 'preferences',
+    label: 'Preferences…',
+    accelerator: 'Ctrl+,',
+  },
+  {
+    id: 'quit',
+    label: 'Quit',
+    accelerator: 'Ctrl+Q',
+  },
+];
+
+export const toMenuItems = (
+  definitions: MenuDefinition[],
+  onSelect: (id: string) => void,
+): MenuItem[] =>
+  definitions.map(def => ({
+    label: def.label,
+    accelerator: def.accelerator,
+    submenu: def.children ? toMenuItems(def.children, onSelect) : undefined,
+    onSelect: def.children ? undefined : () => onSelect(def.id),
+  }));
+

--- a/pages/apps/menu-demo.tsx
+++ b/pages/apps/menu-demo.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useMemo, useRef, useState } from 'react';
+import ContextMenu, { type MenuItem } from '../../components/common/ContextMenu';
+import {
+  nestedContextMenu,
+  toMenuItems,
+  type MenuDefinition,
+} from '../../components/common/menuDefinitions';
+
+const MenuDemo = () => {
+  const targetRef = useRef<HTMLButtonElement>(null);
+  const [selection, setSelection] = useState<string>('None');
+
+  const items: MenuItem[] = useMemo(() => {
+    const findLabel = (defs: MenuDefinition[], search: string): string | null => {
+      for (const entry of defs) {
+        if (entry.id === search) {
+          return entry.label;
+        }
+        if (entry.children) {
+          const child = findLabel(entry.children, search);
+          if (child) return child;
+        }
+      }
+      return null;
+    };
+
+    return toMenuItems(nestedContextMenu, id => {
+      setSelection(findLabel(nestedContextMenu, id) ?? id);
+    });
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-ub-dark text-white p-8">
+      <div className="max-w-xl mx-auto space-y-6">
+        <header>
+          <h1 className="text-2xl font-semibold">Nested menu demo</h1>
+          <p className="mt-2 text-sm text-gray-300">
+            Focus the button below and press <kbd className="mx-1 rounded bg-gray-700 px-1">Shift</kbd>
+            +<kbd className="mx-1 rounded bg-gray-700 px-1">F10</kbd> to open the menu using keyboard only.
+          </p>
+        </header>
+        <div className="space-y-4">
+          <button
+            ref={targetRef}
+            type="button"
+            data-testid="menu-target"
+            className="px-4 py-2 bg-ub-gedit-light text-black font-semibold rounded focus:outline-none focus:ring-2 focus:ring-ub-orange"
+          >
+            Document actions
+          </button>
+          <p data-testid="selection" className="text-sm text-gray-200">
+            Selected action: <span className="font-semibold">{selection}</span>
+          </p>
+        </div>
+      </div>
+      <ContextMenu targetRef={targetRef} items={items} />
+    </main>
+  );
+};
+
+export default MenuDemo;
+

--- a/playwright/menu-navigation.spec.ts
+++ b/playwright/menu-navigation.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Nested context menu keyboard navigation', () => {
+  test('opens, traverses and selects submenu items with keyboard only', async ({ page }) => {
+    await page.goto('/apps/menu-demo');
+
+    const target = page.getByTestId('menu-target');
+    await target.focus();
+
+    await page.keyboard.press('Shift+F10');
+
+    const rootMenu = page.locator('[role="menu"]').first();
+    await expect(rootMenu).toBeVisible();
+
+    // Move to "Share" which has a submenu
+    await page.keyboard.press('ArrowDown');
+    const shareItem = page.locator('[data-path="1"]');
+    await expect(shareItem).toBeFocused();
+
+    // Open the submenu with ArrowRight and ensure the first child gains focus
+    await page.keyboard.press('ArrowRight');
+    const emailItem = page.locator('[data-path="1-0"]');
+    await expect(emailItem).toBeFocused();
+
+    // Move to the nested "Export" item and open its submenu
+    await page.keyboard.press('ArrowDown');
+    const exportItem = page.locator('[data-path="1-1"]');
+    await expect(exportItem).toBeFocused();
+    await page.keyboard.press('ArrowRight');
+    const exportPngItem = page.locator('[data-path="1-1-0"]');
+    await expect(exportPngItem).toBeFocused();
+
+    // Go back to the parent submenu using ArrowLeft
+    await page.keyboard.press('ArrowLeft');
+    await expect(exportItem).toBeFocused();
+
+    // Open the nested submenu again and activate an option
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowDown');
+    const exportPdfItem = page.locator('[data-path="1-1-1"]');
+    await expect(exportPdfItem).toBeFocused();
+    await page.keyboard.press('Enter');
+
+    // Menu should close and the selection text should update
+    await expect(rootMenu).toBeHidden();
+    await expect(page.getByTestId('selection')).toContainText('Export as PDF');
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend the shared `ContextMenu` to recursively render nested submenus, expose accelerators, and keep focus when moving between levels
- add shared menu metadata plus a `/apps/menu-demo` page that wires the nested menu into the desktop shell for manual verification
- add a Playwright spec that opens the nested menu and exercises keyboard-only traversal and selection

## Testing
- `yarn lint` *(fails: longstanding jsx-a11y and no-top-level-window errors in legacy apps)*
- `yarn test` *(fails: existing suites such as `__tests__/window.test.tsx`, `__tests__/nmapNse.test.tsx`, and settings store tests)*
- `npx playwright test` *(fails: browsers not installed in container; Playwright suggests running `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6fd359dc83288f023bf742a03400