### PR TITLE
[menu] add launcher onboarding hints

### DIFF
--- a/__tests__/whiskerMenu.test.tsx
+++ b/__tests__/whiskerMenu.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import WhiskerMenu from '../components/menu/WhiskerMenu';
+
+const originalAnalyticsFlag = process.env.NEXT_PUBLIC_ENABLE_ANALYTICS;
+
+afterAll(() => {
+  if (originalAnalyticsFlag === undefined) {
+    delete process.env.NEXT_PUBLIC_ENABLE_ANALYTICS;
+  } else {
+    process.env.NEXT_PUBLIC_ENABLE_ANALYTICS = originalAnalyticsFlag;
+  }
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  process.env.NEXT_PUBLIC_ENABLE_ANALYTICS = 'false';
+});
+
+test('shows launcher hints on first open and hides after acknowledging', async () => {
+  const user = userEvent.setup();
+  render(<WhiskerMenu />);
+
+  const launcherButton = screen.getByRole('button', { name: /applications/i });
+  await user.click(launcherButton);
+
+  const dialog = await screen.findByRole('dialog', { name: /launcher tips/i });
+  expect(dialog).toBeInTheDocument();
+
+  const gotIt = screen.getByRole('button', { name: /got it/i });
+  await user.click(gotIt);
+
+  await waitFor(() =>
+    expect(screen.queryByRole('dialog', { name: /launcher tips/i })).not.toBeInTheDocument(),
+  );
+  expect(localStorage.getItem('launcher-hints-seen')).toBe('true');
+
+  await user.click(launcherButton);
+  await user.click(launcherButton);
+
+  await waitFor(() =>
+    expect(screen.queryByRole('dialog', { name: /launcher tips/i })).not.toBeInTheDocument(),
+  );
+});
+
+test('persists never show again preference across sessions', async () => {
+  const user = userEvent.setup();
+  const { unmount } = render(<WhiskerMenu />);
+
+  const launcherButton = screen.getByRole('button', { name: /applications/i });
+  await user.click(launcherButton);
+
+  await screen.findByRole('dialog', { name: /launcher tips/i });
+
+  const neverShow = screen.getByRole('button', { name: /never show again/i });
+  await user.click(neverShow);
+
+  await waitFor(() =>
+    expect(screen.queryByRole('dialog', { name: /launcher tips/i })).not.toBeInTheDocument(),
+  );
+  expect(localStorage.getItem('launcher-hints-opt-out')).toBe('true');
+
+  await user.click(launcherButton);
+  await user.click(launcherButton);
+
+  await waitFor(() =>
+    expect(screen.queryByRole('dialog', { name: /launcher tips/i })).not.toBeInTheDocument(),
+  );
+
+  unmount();
+  render(<WhiskerMenu />);
+
+  const reopenedButton = screen.getByRole('button', { name: /applications/i });
+  await user.click(reopenedButton);
+
+  await waitFor(() =>
+    expect(screen.queryByRole('dialog', { name: /launcher tips/i })).not.toBeInTheDocument(),
+  );
+});

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { trackEvent } from '@/lib/analytics-client';
 
 type AppMeta = {
   id: string;
@@ -20,6 +21,9 @@ const CATEGORIES = [
   { id: 'games', label: 'Games' }
 ];
 
+const HINTS_SEEN_KEY = 'launcher-hints-seen';
+const HINTS_OPT_OUT_KEY = 'launcher-hints-opt-out';
+
 const WhiskerMenu: React.FC = () => {
   const [open, setOpen] = useState(false);
   const [category, setCategory] = useState('all');
@@ -27,6 +31,13 @@ const WhiskerMenu: React.FC = () => {
   const [highlight, setHighlight] = useState(0);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [storageReady, setStorageReady] = useState(false);
+  const [hintsSeen, setHintsSeen] = useState(false);
+  const [optedOut, setOptedOut] = useState(false);
+  const [sessionAcknowledged, setSessionAcknowledged] = useState(false);
+  const [hintsVisible, setHintsVisible] = useState(false);
 
   const allApps: AppMeta[] = apps as any;
   const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
@@ -71,6 +82,20 @@ const WhiskerMenu: React.FC = () => {
     setHighlight(0);
   }, [open, category, query]);
 
+  useEffect(() => {
+    try {
+      const seen = safeLocalStorage?.getItem(HINTS_SEEN_KEY) === 'true';
+      const optOut = safeLocalStorage?.getItem(HINTS_OPT_OUT_KEY) === 'true';
+      setHintsSeen(seen);
+      setOptedOut(optOut);
+    } catch {
+      setHintsSeen(false);
+      setOptedOut(false);
+    } finally {
+      setStorageReady(true);
+    }
+  }, []);
+
   const openSelectedApp = (id: string) => {
     window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
     setOpen(false);
@@ -103,6 +128,17 @@ const WhiskerMenu: React.FC = () => {
   }, [open, currentApps, highlight]);
 
   useEffect(() => {
+    if (!open) {
+      setHintsVisible(false);
+      return;
+    }
+    if (!storageReady || optedOut || sessionAcknowledged) return;
+    if (!hintsSeen) {
+      setHintsVisible(true);
+    }
+  }, [open, storageReady, optedOut, sessionAcknowledged, hintsSeen]);
+
+  useEffect(() => {
     const handleClick = (e: MouseEvent) => {
       if (!open) return;
       const target = e.target as Node;
@@ -113,6 +149,75 @@ const WhiskerMenu: React.FC = () => {
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
   }, [open]);
+
+  useEffect(() => {
+    if (!hintsVisible) return;
+    const overlay = overlayRef.current;
+    const selectors =
+      'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
+    const focusables = overlay
+      ? Array.from(overlay.querySelectorAll<HTMLElement>(selectors))
+      : [];
+    focusables[0]?.focus();
+    const handleTab = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab' || focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    overlay?.addEventListener('keydown', handleTab);
+    return () => overlay?.removeEventListener('keydown', handleTab);
+  }, [hintsVisible]);
+
+  const handleCloseHints = useCallback(() => {
+    setSessionAcknowledged(true);
+    setHintsVisible(false);
+    try {
+      safeLocalStorage?.setItem(HINTS_SEEN_KEY, 'true');
+      setHintsSeen(true);
+    } catch {
+      setHintsSeen(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!hintsVisible) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleCloseHints();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [hintsVisible, handleCloseHints]);
+
+  useEffect(() => {
+    if (!hintsVisible && open) {
+      searchInputRef.current?.focus();
+    }
+  }, [hintsVisible, open]);
+
+  const handleNeverShowAgain = useCallback(() => {
+    handleCloseHints();
+    try {
+      safeLocalStorage?.setItem(HINTS_OPT_OUT_KEY, 'true');
+      setOptedOut(true);
+    } catch {
+      setOptedOut(true);
+    }
+    if (process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true') {
+      trackEvent('launcher_hint_dismiss', { method: 'never_show' });
+    }
+  }, [handleCloseHints]);
 
   return (
     <div className="relative">
@@ -134,7 +239,7 @@ const WhiskerMenu: React.FC = () => {
       {open && (
         <div
           ref={menuRef}
-          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg relative"
           tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {
@@ -142,7 +247,7 @@ const WhiskerMenu: React.FC = () => {
             }
           }}
         >
-          <div className="flex flex-col bg-gray-800 p-2">
+          <div className="flex flex-col bg-gray-800 p-2" aria-hidden={hintsVisible}>
             {CATEGORIES.map(cat => (
               <button
                 key={cat.id}
@@ -153,8 +258,9 @@ const WhiskerMenu: React.FC = () => {
               </button>
             ))}
           </div>
-          <div className="p-3">
+          <div className="p-3" aria-hidden={hintsVisible}>
             <input
+              ref={searchInputRef}
               className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
               placeholder="Search"
               value={query}
@@ -175,6 +281,49 @@ const WhiskerMenu: React.FC = () => {
               ))}
             </div>
           </div>
+          {hintsVisible && (
+            <div
+              ref={overlayRef}
+              className="absolute inset-0 z-10 flex items-center justify-center bg-black/80 p-4"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="launcher-hints-title"
+              aria-describedby="launcher-hints-description"
+            >
+              <div className="max-w-sm w-full space-y-3 rounded-lg bg-gray-900/95 p-4 text-sm shadow-lg">
+                <h2 id="launcher-hints-title" className="text-lg font-semibold">
+                  Launcher tips
+                </h2>
+                <p id="launcher-hints-description" className="text-sm">
+                  Start typing to filter applications instantly and keep your hands on the keyboard with quick commands.
+                </p>
+                <ul className="list-disc space-y-2 pl-5">
+                  <li>
+                    <span className="font-semibold">Search:</span> Use the search box or begin typing to narrow the app grid without leaving the launcher.
+                  </li>
+                  <li>
+                    <span className="font-semibold">Commands:</span> Press <span className="rounded border border-gray-600 px-1 py-0.5 font-mono">Meta</span>, then use ↑/↓ and Enter to launch the highlighted app.
+                  </li>
+                </ul>
+                <div className="flex flex-wrap justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={handleCloseHints}
+                    className="rounded bg-gray-700 px-3 py-1 text-sm hover:bg-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-ubb-orange"
+                  >
+                    Got it
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleNeverShowAgain}
+                    className="rounded border border-gray-500 px-3 py-1 text-sm hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-ubb-orange"
+                  >
+                    Never show again
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/lib/analytics-client.ts
+++ b/lib/analytics-client.ts
@@ -4,7 +4,8 @@ export type EventName =
   | 'contact_submit'
   | 'contact_submit_error'
   | 'outbound_link_click'
-  | 'download_click';
+  | 'download_click'
+  | 'launcher_hint_dismiss';
 
 export function trackEvent(
   name: EventName,


### PR DESCRIPTION
## Summary
- add a first-run launcher hint overlay backed by safeLocalStorage flags and keyboard-accessible controls
- gate analytics tracking for “never show again” dismissals behind the existing environment flag
- cover the hint lifecycle with new WhiskerMenu tests

## Testing
- yarn lint *(fails: existing repo-wide accessibility lint errors unrelated to this change)*
- yarn test __tests__/whiskerMenu.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc6fd57970832899a50aa5c9e2ad82