### PR TITLE
[tests] add menu regression coverage

### DIFF
--- a/docs/qa-menu-checklist.md
+++ b/docs/qa-menu-checklist.md
@@ -1,0 +1,25 @@
+# Menu QA Checklist
+
+This checklist covers manual validation steps for the desktop, taskbar, and app context menus when automated tests do not fully exercise pointer-driven flows. Run it after substantial menu or tooltip changes and before shipping major UI revisions.
+
+## Context menu sweeps
+
+- [ ] Start a production build (`yarn build && yarn start`) and open the desktop at `http://localhost:3000`.
+- [ ] With a pointing device, right-click five different empty spots on the desktop to confirm the desktop menu positions itself fully within the viewport and closes on Escape, click-away, and after launching an action (e.g., **Open in Terminal**).
+- [ ] Open app context menus for at least five distinct desktop icons via right-click. Verify Pin/Unpin toggles update the dock immediately and close the menu without leaving windows `inert`.
+- [ ] Exercise taskbar menu interactions for every running window: right-click, choose **Minimize**, re-open the menu, and choose **Close**. Ensure minimized windows can still be restored from the dock and that closed windows disappear from the taskbar.
+- [ ] Trigger each menu near screen edges (bottom-right corner, lower-left, etc.) and confirm the menu auto-repositions on-screen with no overflow scrollbars.
+
+## Keyboard and focus spot-checks
+
+- [ ] From the desktop, use `Shift+F10` to open each context menu type (desktop background, desktop icon, taskbar button). Tab through the entries to confirm focus loops and Escape returns focus to the original control.
+- [ ] While a menu is open, verify no background window retains the `inert` attribute in the Elements panel, and that `document.activeElement` resides within the menu.
+- [ ] After closing the menu with Escape, ensure the previously focused element regains focus and can be activated with Enter or Space.
+
+## Tooltip behaviour
+
+- [ ] Hover over each dock shortcut and confirm the preview thumbnail and label appear with `visible` class, then disappear (`invisible`) after moving the pointer away or shifting keyboard focus.
+- [ ] Focus the dock shortcut and the status area with the keyboard (Tab/Shift+Tab) to verify no tooltip remains visible while navigating with keys.
+- [ ] Confirm tooltips never overlap or obscure an open context menu, especially when both are triggered rapidly.
+
+Document the date, browser, and any anomalies in `test-log.md` for future regressions.

--- a/playwright/menu.gate.spec.ts
+++ b/playwright/menu.gate.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+async function exerciseMenu(
+  page: Page,
+  menu: Locator,
+  options: {
+    open: () => Promise<void>;
+    trigger?: Locator;
+    expectedFocusReturn?: 'trigger' | 'body';
+  },
+) {
+  await options.open();
+  await expect(menu).toBeVisible();
+  await expect(menu).toHaveCSS('z-index', '50');
+  await expect(page.locator('[role="menu"]:visible')).toHaveCount(1);
+
+  const items = menu.locator('[role="menuitem"]');
+  await expect(items.first()).toBeVisible();
+
+  const focusInside = await menu.evaluate((el) => el.contains(document.activeElement));
+  if (!focusInside) {
+    await page.keyboard.press('Tab');
+  }
+  await expect(items.first()).toBeFocused();
+
+  const itemCount = await items.count();
+  if (itemCount > 1) {
+    await page.keyboard.press('ArrowDown');
+    await expect(items.nth(1)).toBeFocused();
+    await page.keyboard.press('ArrowUp');
+  } else {
+    await page.keyboard.press('ArrowDown');
+  }
+  await expect(items.first()).toBeFocused();
+
+  await page.keyboard.press('Shift+Tab');
+  if (itemCount > 1) {
+    await expect(items.nth(itemCount - 1)).toBeFocused();
+    await page.keyboard.press('Tab');
+  }
+  await expect(items.first()).toBeFocused();
+
+  await page.keyboard.press('Escape');
+  await expect(menu).toBeHidden();
+  await expect(page.locator('[role="menu"]:visible')).toHaveCount(0);
+  await expect(page.locator('.opened-window[inert]')).toHaveCount(0);
+
+  if (options.expectedFocusReturn === 'trigger' && options.trigger) {
+    await expect(options.trigger).toBeFocused();
+  } else if (options.expectedFocusReturn === 'body') {
+    await expect.poll(() => page.evaluate(() => document.activeElement === document.body)).toBeTruthy();
+  }
+}
+
+test.describe('Menu regressions', () => {
+  test('context menus stay accessible and do not leak focus', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('#desktop-menu');
+
+    const desktopMenu = page.locator('#desktop-menu');
+    const appMenu = page.locator('#app-menu');
+    const taskbarMenu = page.locator('#taskbar-menu');
+
+    const desktopIcon = page.locator('[id^="app-"]').first();
+    await expect(desktopIcon).toBeVisible();
+
+    const taskbarButton = page.locator('[data-context="taskbar"]').first();
+    await expect(taskbarButton).toBeVisible();
+
+    let openCount = 0;
+
+    for (let i = 0; i < 20; i += 1) {
+      await exerciseMenu(page, desktopMenu, {
+        open: async () => {
+          await page.evaluate(() => {
+            const area = document.querySelector<HTMLElement>('#window-area');
+            if (!area) {
+              throw new Error('Desktop area missing');
+            }
+            const event = new KeyboardEvent('keydown', {
+              key: 'F10',
+              shiftKey: true,
+              bubbles: true,
+            });
+            area.dispatchEvent(event);
+          });
+        },
+        expectedFocusReturn: 'body',
+      });
+      openCount += 1;
+    }
+
+    for (let i = 0; i < 15; i += 1) {
+      await exerciseMenu(page, appMenu, {
+        open: async () => {
+          await desktopIcon.focus();
+          await desktopIcon.press('Shift+F10');
+        },
+        trigger: desktopIcon,
+        expectedFocusReturn: 'trigger',
+      });
+      openCount += 1;
+    }
+
+    for (let i = 0; i < 15; i += 1) {
+      await exerciseMenu(page, taskbarMenu, {
+        open: async () => {
+          await taskbarButton.focus();
+          await taskbarButton.press('Shift+F10');
+        },
+        trigger: taskbarButton,
+        expectedFocusReturn: 'trigger',
+      });
+      openCount += 1;
+    }
+
+    expect(openCount).toBe(50);
+
+    const dockIcon = page.locator('[id^="sidebar-"]').first();
+    if (await dockIcon.count()) {
+      const label = (await dockIcon.getAttribute('aria-label'))?.trim() || (await dockIcon.textContent())?.trim();
+      if (label) {
+        const tooltip = dockIcon.locator(`div:has-text("${label}")`).first();
+        if (await tooltip.count()) {
+          await page.mouse.move(0, 0);
+          await expect(tooltip).toHaveClass(/invisible/);
+
+          await dockIcon.hover();
+          await expect(tooltip).toHaveClass(/visible/);
+
+          await page.mouse.move(0, 0);
+          await expect.poll(() => tooltip.evaluate((node) => node.classList.contains('invisible'))).toBeTruthy();
+
+          await dockIcon.focus();
+          await expect(tooltip).toHaveClass(/invisible/);
+
+          await desktopIcon.focus();
+          await expect(tooltip).toHaveClass(/invisible/);
+        }
+      }
+    }
+
+    const statusTooltip = page.locator('#status-bar [title]');
+    if (await statusTooltip.count()) {
+      const titleValue = (await statusTooltip.first().getAttribute('title')) || '';
+      await page.locator('#status-bar').focus();
+      await expect(statusTooltip.first()).toHaveAttribute('title', titleValue);
+      await desktopIcon.focus();
+      await expect(statusTooltip.first()).toHaveAttribute('title', titleValue);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a Playwright regression suite that opens 50 desktop/taskbar/app context menus with keyboard navigation, checks focus recovery, and validates tooltip behaviour
- document manual QA steps for menu and tooltip verification when automated coverage is insufficient

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in unrelated apps)*
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cc6fce075c832891e2b555aa671798