### PR TITLE
[tests] Add launcher gate spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,8 @@
     "@axe-core/playwright": "^4.10.2",
     "@eslint/eslintrc": "^3.3.1",
     "@next/bundle-analyzer": "15.5.2",
+    "@percy/playwright": "^1.0.9",
+    "@percy/sdk-utils": "^1.30.9",
     "@playwright/test": "^1.55.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.4",

--- a/playwright/launcher.gate.spec.ts
+++ b/playwright/launcher.gate.spec.ts
@@ -1,0 +1,275 @@
+import { expect, test, type CDPSession, type Page, type TestInfo } from '@playwright/test';
+import { percySnapshot } from '@percy/playwright';
+import { gzipSync } from 'node:zlib';
+
+const SEARCH_QUERIES = [
+  'Terminal',
+  'Calculator',
+  'Converter',
+  'Tic Tac Toe',
+  'Chess',
+  'Connect Four',
+  'Hangman',
+  'Frogger',
+  'Flappy Bird',
+  '2048',
+  'Snake',
+  'Memory',
+  'Minesweeper',
+  'Pong',
+  'Pacman',
+  'Car Racer',
+  'Lane Runner',
+  'Platformer',
+  'Battleship',
+  'Checkers',
+  'Reversi',
+  'Simon',
+  'Sokoban',
+  'Solitaire',
+  'Tower Defense',
+  'Word Search',
+  'Wordle',
+  'Blackjack',
+  'Breakout',
+  'Asteroids',
+] as const;
+
+const COMMAND_TARGETS = [
+  { id: 'terminal', title: 'Terminal' },
+  { id: 'calculator', title: 'Calculator' },
+  { id: 'weather', title: 'Weather' },
+  { id: 'wireshark', title: 'Wireshark' },
+  { id: 'hashcat', title: 'Hashcat' },
+  { id: 'hydra', title: 'Hydra' },
+  { id: 'radare2', title: 'Radare2' },
+  { id: 'metasploit', title: 'Metasploit' },
+  { id: 'openvas', title: 'OpenVAS' },
+  { id: 'project-gallery', title: 'Project Gallery' },
+] as const;
+
+const PIN_TARGETS = [
+  { id: 'chrome', title: 'Chrome' },
+  { id: 'spotify', title: 'Spotify' },
+  { id: 'youtube', title: 'YouTube' },
+] as const;
+
+type MemoryMetrics = {
+  jsHeapUsed: number;
+  jsHeapTotal: number;
+  documents: number;
+  nodes: number;
+  jsEventListeners: number;
+};
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeForSelector(value: string): string {
+  return value.replace(/([!"#$%&'()*+,./:;<=>?@[\\\\]^`{|}~])/g, '\\$1');
+}
+
+async function ensureDesktopReady(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForSelector('#desktop', { state: 'visible' });
+}
+
+async function ensureLauncherOpen(page: Page) {
+  const overlay = page.locator('.all-apps-anim');
+  if (!(await overlay.isVisible())) {
+    const launcherButton = page.locator('nav[aria-label="Dock"] img[alt="Ubuntu view app"]').first();
+    await launcherButton.click();
+    await overlay.waitFor({ state: 'visible' });
+  }
+  const searchInput = overlay.locator('input[placeholder="Search"]');
+  await expect(searchInput).toBeVisible();
+  const results = overlay.locator('[data-context="app"]');
+  return { overlay, searchInput, results };
+}
+
+async function captureMemoryMetrics(session: CDPSession): Promise<MemoryMetrics> {
+  const { metrics } = await session.send('Performance.getMetrics');
+  const jsHeapUsed = metrics.find((entry) => entry.name === 'JSHeapUsedSize')?.value ?? 0;
+  const jsHeapTotal = metrics.find((entry) => entry.name === 'JSHeapTotalSize')?.value ?? 0;
+  const domCounters = await session.send('Memory.getDOMCounters');
+  return {
+    jsHeapUsed,
+    jsHeapTotal,
+    documents: domCounters.documents,
+    nodes: domCounters.nodes,
+    jsEventListeners: domCounters.jsEventListeners,
+  };
+}
+
+async function takeHeapSnapshot(session: CDPSession): Promise<Buffer> {
+  const chunks: string[] = [];
+  const handleChunk = (params: { chunk: string }) => {
+    chunks.push(params.chunk);
+  };
+  session.on('HeapProfiler.addHeapSnapshotChunk', handleChunk);
+  try {
+    await session.send('HeapProfiler.takeHeapSnapshot', { reportProgress: false });
+  } finally {
+    if (typeof session.off === 'function') {
+      session.off('HeapProfiler.addHeapSnapshotChunk', handleChunk);
+    } else {
+      // @ts-expect-error - removeListener exists at runtime
+      session.removeListener('HeapProfiler.addHeapSnapshotChunk', handleChunk);
+    }
+  }
+  const snapshot = chunks.join('');
+  return gzipSync(snapshot);
+}
+
+async function attachJson(testInfo: TestInfo, name: string, payload: unknown) {
+  const body = Buffer.from(JSON.stringify(payload, null, 2), 'utf-8');
+  await testInfo.attach(name, { body, contentType: 'application/json' });
+}
+
+async function runVisualSnapshot(page: Page, testInfo: TestInfo, name: string) {
+  if (process.env.PERCY_SERVER_ADDRESS || process.env.PERCY_TOKEN) {
+    try {
+      await percySnapshot(page, name);
+      testInfo.annotations.push({ type: 'info', description: `Percy snapshot captured: ${name}` });
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      testInfo.annotations.push({ type: 'warning', description: `Percy snapshot failed: ${message}` });
+    }
+  }
+
+  if (process.env.CHROMATIC_PROJECT_TOKEN) {
+    try {
+      const chromatic = await import('@chromatic-com/playwright');
+      if (chromatic && typeof chromatic.chromaticSnapshot === 'function') {
+        await chromatic.chromaticSnapshot(page, { name });
+        testInfo.annotations.push({ type: 'info', description: `Chromatic snapshot captured: ${name}` });
+        return;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      testInfo.annotations.push({ type: 'warning', description: `Chromatic snapshot failed: ${message}` });
+    }
+  }
+
+  const screenshot = await page.screenshot({ fullPage: true });
+  await testInfo.attach(`${name}.png`, {
+    body: screenshot,
+    contentType: 'image/png',
+  });
+}
+
+test.describe('Launcher gate workflow', () => {
+  test('handles heavy search, command, and pin flows without memory leaks', async ({ page }, testInfo) => {
+    await ensureDesktopReady(page);
+
+    const session = await page.context().newCDPSession(page);
+    await session.send('Performance.enable');
+    await session.send('HeapProfiler.enable');
+    await session.send('HeapProfiler.startTrackingHeapObjects', { trackAllocations: true });
+
+    try {
+      const baselineMemory = await captureMemoryMetrics(session);
+      await attachJson(testInfo, 'memory-baseline.json', baselineMemory);
+      const baselineSnapshot = await takeHeapSnapshot(session);
+      await testInfo.attach('heap-before.heapsnapshot.gz', {
+        body: baselineSnapshot,
+        contentType: 'application/gzip',
+      });
+
+      await runVisualSnapshot(page, testInfo, 'Launcher gate - desktop baseline');
+
+      await test.step('execute 30 launcher searches', async () => {
+        const { searchInput, results } = await ensureLauncherOpen(page);
+        expect(SEARCH_QUERIES).toHaveLength(30);
+        for (const query of SEARCH_QUERIES) {
+          await searchInput.fill(query);
+          await expect(searchInput).toHaveValue(query);
+          const regex = new RegExp(escapeRegExp(query), 'i');
+          await expect(results.filter({ hasText: regex })).not.toHaveCount(0);
+        }
+      });
+
+      const afterSearchMemory = await captureMemoryMetrics(session);
+      await attachJson(testInfo, 'memory-after-searches.json', afterSearchMemory);
+
+      await test.step('pin key apps from search results', async () => {
+        for (const target of PIN_TARGETS) {
+          const { searchInput: pinSearch, results: pinResults } = await ensureLauncherOpen(page);
+          const dockItem = page.locator(`nav[aria-label="Dock"] [data-app-id="${target.id}"]`);
+          await pinSearch.fill(target.title);
+          const candidate = pinResults.locator(`[data-app-id="${target.id}"]`).first();
+          await expect(candidate).toBeVisible();
+
+          if (await dockItem.isVisible()) {
+            await candidate.click({ button: 'right' });
+            const unpinButton = page.getByRole('menuitem', { name: 'Unpin from Favorites' });
+            if (await unpinButton.isVisible()) {
+              await unpinButton.click();
+              await expect(page.locator('#app-menu')).toBeHidden();
+              await expect(dockItem).toBeHidden();
+            }
+            await candidate.click({ button: 'right' });
+          } else {
+            await candidate.click({ button: 'right' });
+          }
+
+          await expect(page.locator('#app-menu')).toBeVisible();
+          const pinButton = page.getByRole('menuitem', { name: 'Pin to Favorites' });
+          await pinButton.click();
+          await expect(page.locator('#app-menu')).toBeHidden();
+          await expect(dockItem).toBeVisible();
+        }
+      });
+
+      const afterPinMemory = await captureMemoryMetrics(session);
+      await attachJson(testInfo, 'memory-after-pins.json', afterPinMemory);
+
+      await test.step('execute 10 application launch commands', async () => {
+        for (const target of COMMAND_TARGETS) {
+          const { searchInput: commandSearch, results: commandResults } = await ensureLauncherOpen(page);
+          await commandSearch.fill(target.title);
+          const appTile = commandResults.locator(`[data-app-id="${target.id}"]`).first();
+          await expect(appTile).toBeVisible();
+          await appTile.dblclick();
+
+          const windowSelector = `#${escapeForSelector(target.id)}`;
+          const appWindow = page.locator(windowSelector);
+          await expect(appWindow).toBeVisible();
+
+          const closeButton = page.locator(`#close-${escapeForSelector(target.id)}`);
+          await expect(closeButton).toBeVisible();
+          await closeButton.click();
+          await appWindow.waitFor({ state: 'detached' });
+        }
+      });
+
+      const finalMemory = await captureMemoryMetrics(session);
+      await attachJson(testInfo, 'memory-after-commands.json', finalMemory);
+
+      const finalSnapshot = await takeHeapSnapshot(session);
+      await testInfo.attach('heap-after.heapsnapshot.gz', {
+        body: finalSnapshot,
+        contentType: 'application/gzip',
+      });
+
+      await runVisualSnapshot(page, testInfo, 'Launcher gate - post interactions');
+
+      const allowedHeapGrowth = 60 * 1024 * 1024; // 60 MB
+      const heapGrowth = Math.max(finalMemory.jsHeapUsed - baselineMemory.jsHeapUsed, 0);
+      expect(heapGrowth).toBeLessThan(allowedHeapGrowth);
+
+      const nodeGrowth = Math.max(finalMemory.nodes - baselineMemory.nodes, 0);
+      expect(nodeGrowth).toBeLessThan(6000);
+
+      const listenerGrowth = Math.max(finalMemory.jsEventListeners - baselineMemory.jsEventListeners, 0);
+      expect(listenerGrowth).toBeLessThan(200);
+    } finally {
+      await session.send('HeapProfiler.stopTrackingHeapObjects').catch(() => {});
+      await session.send('HeapProfiler.disable').catch(() => {});
+      await session.send('Performance.disable').catch(() => {});
+    }
+  });
+});

--- a/types/chromatic-playwright.d.ts
+++ b/types/chromatic-playwright.d.ts
@@ -1,0 +1,5 @@
+declare module '@chromatic-com/playwright' {
+  import type { Page } from '@playwright/test';
+
+  export function chromaticSnapshot(page: Page, options: { name: string }): Promise<void>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2630,6 +2630,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@percy/playwright@npm:^1.0.9":
+  version: 1.0.9
+  resolution: "@percy/playwright@npm:1.0.9"
+  peerDependencies:
+    playwright-core: ">=1"
+  checksum: 10c0/dccbf80fed9c03709ec79bc6ad717816badd1bf7096a4db25302fb554dc74770167658956a439f2e71d1dab2ae97b19d9e93f4ac0e4a98ed51743efe22547cf6
+  languageName: node
+  linkType: hard
+
+"@percy/sdk-utils@npm:^1.30.9":
+  version: 1.31.2
+  resolution: "@percy/sdk-utils@npm:1.31.2"
+  checksum: 10c0/4f0baaf3033c62abbcd342404ba04c55e7684177842bcfec3883f997dab0a47c3988e5e546ea6e91e546d9f0097165b45f68d2ca3e9776520e70fb25c5399602
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -13860,6 +13876,8 @@ __metadata:
     "@monaco-editor/react": "npm:^4.7.0"
     "@mozilla/readability": "npm:^0.6.0"
     "@next/bundle-analyzer": "npm:15.5.2"
+    "@percy/playwright": "npm:^1.0.9"
+    "@percy/sdk-utils": "npm:^1.30.9"
     "@playwright/test": "npm:^1.55.0"
     "@supabase/ssr": "npm:^0.7.0"
     "@supabase/supabase-js": "npm:^2.56.1"


### PR DESCRIPTION
## Summary
- add a launcher gate Playwright spec that drives search, pinning, and app commands while capturing CDP memory metrics and heap snapshots
- include optional Percy/Chromatic visual snapshot handling with gzip attachments for heap dumps
- add Chromatic Playwright type declarations and Percy tooling dependencies needed by the new spec

## Testing
- yarn lint *(fails: repo has 571 pre-existing lint errors)*
- CI=1 yarn build
- yarn test *(fails: multiple existing Jest suites break in current main)*
- npx playwright test playwright/launcher.gate.spec.ts -c playwright *(fails: missing system libraries for Chromium in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6fd4ba708328a16805c0d29f41d9