### PR TITLE
[ui] centralize tooltip handling

### DIFF
--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Taskbar from '../components/screen/taskbar';
+import { TooltipProvider } from '../components/ui/TooltipProvider';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 
@@ -11,14 +12,16 @@ describe('Taskbar', () => {
     const openApp = jest.fn();
     const minimize = jest.fn();
     render(
-      <Taskbar
-        apps={apps}
-        closed_windows={{ app1: false }}
-        minimized_windows={{ app1: false }}
-        focused_windows={{ app1: true }}
-        openApp={openApp}
-        minimize={minimize}
-      />
+      <TooltipProvider>
+        <Taskbar
+          apps={apps}
+          closed_windows={{ app1: false }}
+          minimized_windows={{ app1: false }}
+          focused_windows={{ app1: true }}
+          openApp={openApp}
+          minimize={minimize}
+        />
+      </TooltipProvider>
     );
     const button = screen.getByRole('button', { name: /app one/i });
     fireEvent.click(button);
@@ -30,14 +33,16 @@ describe('Taskbar', () => {
     const openApp = jest.fn();
     const minimize = jest.fn();
     render(
-      <Taskbar
-        apps={apps}
-        closed_windows={{ app1: false }}
-        minimized_windows={{ app1: true }}
-        focused_windows={{ app1: false }}
-        openApp={openApp}
-        minimize={minimize}
-      />
+      <TooltipProvider>
+        <Taskbar
+          apps={apps}
+          closed_windows={{ app1: false }}
+          minimized_windows={{ app1: true }}
+          focused_windows={{ app1: false }}
+          openApp={openApp}
+          minimize={minimize}
+        />
+      </TooltipProvider>
     );
     const button = screen.getByRole('button', { name: /app one/i });
     fireEvent.click(button);

--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -36,13 +36,16 @@ import React, { createRef, act } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import Terminal from '../apps/terminal';
 import TerminalTabs from '../apps/terminal/tabs';
+import { TooltipProvider } from '../components/ui/TooltipProvider';
+
+const renderWithTooltip = (ui: React.ReactElement) => render(<TooltipProvider>{ui}</TooltipProvider>);
 
 describe('Terminal component', () => {
   const openApp = jest.fn();
 
   it('renders container and exposes runCommand', async () => {
     const ref = createRef<any>();
-    render(<Terminal ref={ref} openApp={openApp} />);
+    renderWithTooltip(<Terminal ref={ref} openApp={openApp} />);
     await act(async () => {});
     expect(ref.current).toBeTruthy();
     act(() => {
@@ -53,7 +56,7 @@ describe('Terminal component', () => {
 
   it('invokes openApp for open command', async () => {
     const ref = createRef<any>();
-    render(<Terminal ref={ref} openApp={openApp} />);
+    renderWithTooltip(<Terminal ref={ref} openApp={openApp} />);
     await act(async () => {});
     act(() => {
       ref.current.runCommand('open calculator');
@@ -62,7 +65,7 @@ describe('Terminal component', () => {
   });
 
   it('supports tab management shortcuts', async () => {
-    const { container } = render(<TerminalTabs openApp={openApp} />);
+    const { container } = renderWithTooltip(<TerminalTabs openApp={openApp} />);
     await act(async () => {});
     const root = container.firstChild as HTMLElement;
     root.focus();

--- a/__tests__/tooltipProvider.test.tsx
+++ b/__tests__/tooltipProvider.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { Tooltip, TooltipProvider } from '../components/ui/TooltipProvider';
+
+describe('TooltipProvider focus interactions', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('shows tooltip on focus after the configured delay', () => {
+    render(
+      <TooltipProvider>
+        <Tooltip content="Hello tooltip">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      </TooltipProvider>
+    );
+
+    const trigger = screen.getByRole('button', { name: /trigger/i });
+    fireEvent.focus(trigger);
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Hello tooltip');
+  });
+
+  it('hides tooltip on blur', () => {
+    render(
+      <TooltipProvider>
+        <Tooltip content="Hello tooltip">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      </TooltipProvider>
+    );
+
+    const trigger = screen.getByRole('button', { name: /trigger/i });
+    fireEvent.focus(trigger);
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    fireEvent.blur(trigger);
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('suppresses focus tooltips when the last input was touch', () => {
+    render(
+      <TooltipProvider>
+        <Tooltip content="Hello tooltip">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      </TooltipProvider>
+    );
+
+    const trigger = screen.getByRole('button', { name: /trigger/i });
+    const pointerDown = new Event('pointerdown') as PointerEvent;
+    (pointerDown as any).pointerType = 'touch';
+    window.dispatchEvent(pointerDown);
+
+    fireEvent.focus(trigger);
+
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+});

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -1,6 +1,7 @@
 import React, { act } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Window from '../components/base/window';
+import { TooltipProvider } from '../components/ui/TooltipProvider';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 jest.mock('react-draggable', () => ({
@@ -9,13 +10,18 @@ jest.mock('react-draggable', () => ({
 }));
 jest.mock('../components/apps/terminal', () => ({ displayTerminal: jest.fn() }));
 
+const renderWithTooltip = (
+  ui: React.ReactElement,
+  options?: Parameters<typeof render>[1]
+) => render(<TooltipProvider>{ui}</TooltipProvider>, options);
+
 describe('Window lifecycle', () => {
   it('invokes callbacks on close', () => {
     jest.useFakeTimers();
     const closed = jest.fn();
     const hideSideBar = jest.fn();
 
-    render(
+    renderWithTooltip(
       <Window
         id="test-window"
         title="Test"
@@ -45,7 +51,7 @@ describe('Window lifecycle', () => {
 describe('Window snapping preview', () => {
   it('shows preview when dragged near left edge', () => {
     const ref = React.createRef<Window>();
-    render(
+    renderWithTooltip(
       <Window
         id="test-window"
         title="Test"
@@ -82,7 +88,7 @@ describe('Window snapping preview', () => {
 
   it('hides preview when away from edge', () => {
     const ref = React.createRef<Window>();
-    render(
+    renderWithTooltip(
       <Window
         id="test-window"
         title="Test"
@@ -121,7 +127,7 @@ describe('Window snapping preview', () => {
 describe('Window snapping finalize and release', () => {
   it('snaps window on drag stop near left edge', () => {
     const ref = React.createRef<Window>();
-    render(
+    renderWithTooltip(
       <Window
         id="test-window"
         title="Test"
@@ -162,7 +168,7 @@ describe('Window snapping finalize and release', () => {
 
   it('releases snap with Alt+ArrowDown restoring size', () => {
     const ref = React.createRef<Window>();
-    render(
+    renderWithTooltip(
       <Window
         id="test-window"
         title="Test"
@@ -199,7 +205,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: () => {},
+        stopPropagation: () => {},
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();
@@ -209,7 +220,7 @@ describe('Window snapping finalize and release', () => {
 
   it('releases snap when starting drag', () => {
     const ref = React.createRef<Window>();
-    render(
+    renderWithTooltip(
       <Window
         id="test-window"
         title="Test"
@@ -257,7 +268,7 @@ describe('Window snapping finalize and release', () => {
 
 describe('Window keyboard dragging', () => {
   it('moves window using arrow keys with grabbed state', () => {
-    render(
+    renderWithTooltip(
       <Window
         id="test-window"
         title="Test"
@@ -287,7 +298,7 @@ describe('Window keyboard dragging', () => {
 describe('Edge resistance', () => {
   it('clamps drag movement near boundaries', () => {
     const ref = React.createRef<Window>();
-    render(
+    renderWithTooltip(
       <Window
         id="test-window"
         title="Test"
@@ -333,7 +344,7 @@ describe('Window overlay inert behaviour', () => {
     document.body.appendChild(opener);
     opener.focus();
 
-    render(
+    renderWithTooltip(
       <Window
         id="test-window"
         title="Test"
@@ -374,7 +385,7 @@ describe('Window overlay inert behaviour', () => {
     document.body.appendChild(opener);
     opener.focus();
 
-    render(
+    renderWithTooltip(
       <Window
         id="test-window"
         title="Test"

--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -1,13 +1,14 @@
 import React, { Component } from "react";
 import Image from 'next/image';
 import { toCanvas } from 'html-to-image';
+import { Tooltip } from '../ui/TooltipProvider';
 
 export class SideBarApp extends Component {
     constructor() {
         super();
         this.id = null;
         this.state = {
-            showTitle: false,
+            showPreview: false,
             scaleImage: false,
             thumbnail: null,
         };
@@ -57,7 +58,7 @@ export class SideBarApp extends Component {
             this.scaleImage();
         }
         this.props.openApp(this.id);
-        this.setState({ showTitle: false, thumbnail: null });
+        this.setState({ showPreview: false, thumbnail: null });
     };
 
     captureThumbnail = async () => {
@@ -87,73 +88,71 @@ export class SideBarApp extends Component {
 
     render() {
         return (
-            <button
-                type="button"
-                aria-label={this.props.title}
-                data-context="app"
-                data-app-id={this.props.id}
-                onClick={this.openApp}
-                onMouseEnter={() => {
-                    this.captureThumbnail();
-                    this.setState({ showTitle: true });
-                }}
-                onMouseLeave={() => {
-                    this.setState({ showTitle: false, thumbnail: null });
-                }}
-                className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
-                    " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
-                id={"sidebar-" + this.props.id}
+            <Tooltip
+                content={this.props.title}
+                placement={["right", "left", "top"]}
+                id={`tooltip-${this.props.id}`}
             >
-                <Image
-                    width={28}
-                    height={28}
-                    className="w-7"
-                    src={this.props.icon.replace('./', '/')}
-                    alt="Ubuntu App Icon"
-                    sizes="28px"
-                />
-                <Image
-                    width={28}
-                    height={28}
-                    className={(this.state.scaleImage ? " scale " : "") + " scalable-app-icon w-7 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"}
-                    src={this.props.icon.replace('./', '/')}
-                    alt=""
-                    sizes="28px"
-                />
-                {
-                    (
-                        this.props.isClose[this.id] === false
-                            ? <div className=" w-2 h-1 absolute bottom-0 left-1/2 transform -translate-x-1/2 bg-white rounded-md"></div>
-                            : null
-                    )
-                }
-                {this.state.thumbnail && (
-                    <div
-                        className={
-                            (this.state.showTitle ? " visible " : " invisible ") +
-                            " pointer-events-none absolute bottom-full mb-2 left-1/2 transform -translate-x-1/2" +
-                            " rounded border border-gray-400 border-opacity-40 shadow-lg overflow-hidden bg-black bg-opacity-50"
-                        }
-                    >
-                        <Image
-                            width={128}
-                            height={80}
-                            src={this.state.thumbnail}
-                            alt={`Preview of ${this.props.title}`}
-                            className="w-32 h-20 object-cover"
-                            sizes="128px"
-                        />
-                    </div>
-                )}
-                <div
-                    className={
-                        (this.state.showTitle ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1.5 left-full ml-3 m-1 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
-                    }
+                <button
+                    type="button"
+                    aria-label={this.props.title}
+                    data-context="app"
+                    data-app-id={this.props.id}
+                    onClick={this.openApp}
+                    onPointerEnter={() => {
+                        this.captureThumbnail();
+                        this.setState({ showPreview: true });
+                    }}
+                    onPointerLeave={() => {
+                        this.setState({ showPreview: false, thumbnail: null });
+                    }}
+                    className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
+                        " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
+                    id={"sidebar-" + this.props.id}
                 >
-                    {this.props.title}
-                </div>
-            </button>
+                    <Image
+                        width={28}
+                        height={28}
+                        className="w-7"
+                        src={this.props.icon.replace('./', '/')}
+                        alt="Ubuntu App Icon"
+                        sizes="28px"
+                    />
+                    <Image
+                        width={28}
+                        height={28}
+                        className={(this.state.scaleImage ? " scale " : "") + " scalable-app-icon w-7 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"}
+                        src={this.props.icon.replace('./', '/')}
+                        alt=""
+                        sizes="28px"
+                    />
+                    {
+                        (
+                            this.props.isClose[this.id] === false
+                                ? <div className=" w-2 h-1 absolute bottom-0 left-1/2 transform -translate-x-1/2 bg-white rounded-md"></div>
+                                : null
+                        )
+                    }
+                    {this.state.thumbnail && (
+                        <div
+                            className={
+                                (this.state.showPreview ? " visible " : " invisible " ) +
+                                " pointer-events-none absolute bottom-full mb-2 left-1/2 transform -translate-x-1/2" +
+                                " rounded border border-gray-400 border-opacity-40 shadow-lg overflow-hidden bg-black bg-opacity-50"
+                            }
+                        >
+                            <Image
+                                width={128}
+                                height={80}
+                                src={this.state.thumbnail}
+                                alt={`Preview of ${this.props.title}`}
+                                className="w-32 h-20 object-cover"
+                                sizes="128px"
+                            />
+                        </div>
+                    )}
+                </button>
+            </Tooltip>
         );
     }
 }

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -7,6 +7,7 @@ import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
 import styles from './window.module.css';
+import { Tooltip } from '../ui/TooltipProvider';
 
 export class Window extends Component {
     constructor(props) {
@@ -736,89 +737,99 @@ export function WindowEditButtons(props) {
     return (
         <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center h-11 min-w-[8.25rem]">
             {pipSupported && props.pip && (
+                <Tooltip content="Pin Window" placement={["bottom", "top"]}>
+                    <button
+                        type="button"
+                        aria-label="Window pin"
+                        className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                        onClick={togglePin}
+                    >
+                        <NextImage
+                            src="/themes/Yaru/window/window-pin-symbolic.svg"
+                            alt="Kali window pin"
+                            className="h-4 w-4 inline"
+                            width={16}
+                            height={16}
+                            sizes="16px"
+                        />
+                    </button>
+                </Tooltip>
+            )}
+            <Tooltip content="Minimize" placement={["bottom", "top"]}>
                 <button
                     type="button"
-                    aria-label="Window pin"
+                    aria-label="Window minimize"
                     className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                    onClick={togglePin}
+                    onClick={props.minimize}
                 >
                     <NextImage
-                        src="/themes/Yaru/window/window-pin-symbolic.svg"
-                        alt="Kali window pin"
+                        src="/themes/Yaru/window/window-minimize-symbolic.svg"
+                        alt="Kali window minimize"
                         className="h-4 w-4 inline"
                         width={16}
                         height={16}
                         sizes="16px"
                     />
                 </button>
-            )}
-            <button
-                type="button"
-                aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                onClick={props.minimize}
-            >
-                <NextImage
-                    src="/themes/Yaru/window/window-minimize-symbolic.svg"
-                    alt="Kali window minimize"
-                    className="h-4 w-4 inline"
-                    width={16}
-                    height={16}
-                    sizes="16px"
-                />
-            </button>
+            </Tooltip>
             {props.allowMaximize && (
                 props.isMaximised
                     ? (
-                        <button
-                            type="button"
-                            aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                            onClick={props.maximize}
-                        >
-                            <NextImage
-                                src="/themes/Yaru/window/window-restore-symbolic.svg"
-                                alt="Kali window restore"
-                                className="h-4 w-4 inline"
-                                width={16}
-                                height={16}
-                                sizes="16px"
-                            />
-                        </button>
+                        <Tooltip content="Restore" placement={["bottom", "top"]}>
+                            <button
+                                type="button"
+                                aria-label="Window restore"
+                                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                                onClick={props.maximize}
+                            >
+                                <NextImage
+                                    src="/themes/Yaru/window/window-restore-symbolic.svg"
+                                    alt="Kali window restore"
+                                    className="h-4 w-4 inline"
+                                    width={16}
+                                    height={16}
+                                    sizes="16px"
+                                />
+                            </button>
+                        </Tooltip>
                     ) : (
-                        <button
-                            type="button"
-                            aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                            onClick={props.maximize}
-                        >
-                            <NextImage
-                                src="/themes/Yaru/window/window-maximize-symbolic.svg"
-                                alt="Kali window maximize"
-                                className="h-4 w-4 inline"
-                                width={16}
-                                height={16}
-                                sizes="16px"
-                            />
-                        </button>
+                        <Tooltip content="Maximize" placement={["bottom", "top"]}>
+                            <button
+                                type="button"
+                                aria-label="Window maximize"
+                                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                                onClick={props.maximize}
+                            >
+                                <NextImage
+                                    src="/themes/Yaru/window/window-maximize-symbolic.svg"
+                                    alt="Kali window maximize"
+                                    className="h-4 w-4 inline"
+                                    width={16}
+                                    height={16}
+                                    sizes="16px"
+                                />
+                            </button>
+                        </Tooltip>
                     )
             )}
-            <button
-                type="button"
-                id={`close-${props.id}`}
-                aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
-                onClick={props.close}
-            >
-                <NextImage
-                    src="/themes/Yaru/window/window-close-symbolic.svg"
-                    alt="Kali window close"
-                    className="h-4 w-4 inline"
-                    width={16}
-                    height={16}
-                    sizes="16px"
-                />
-            </button>
+            <Tooltip content="Close" placement={["bottom", "top"]}>
+                <button
+                    type="button"
+                    id={`close-${props.id}`}
+                    aria-label="Window close"
+                    className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                    onClick={props.close}
+                >
+                    <NextImage
+                        src="/themes/Yaru/window/window-close-symbolic.svg"
+                        alt="Kali window close"
+                        className="h-4 w-4 inline"
+                        width={16}
+                        height={16}
+                        sizes="16px"
+                    />
+                </button>
+            </Tooltip>
         </div>
     )
 }

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,6 +1,7 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
+import { Tooltip } from '../ui/TooltipProvider';
 
 let renderApps = (props) => {
     let sideBarAppsJsx = [];
@@ -47,22 +48,15 @@ export default function SideBar(props) {
 }
 
 export function AllApps(props) {
-
-    const [title, setTitle] = useState(false);
-
     return (
-        <div
-            className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
-            style={{ marginTop: 'auto' }}
-            onMouseEnter={() => {
-                setTitle(true);
-            }}
-            onMouseLeave={() => {
-                setTitle(false);
-            }}
-            onClick={props.showApps}
-        >
-            <div className="relative">
+        <Tooltip content="Show Applications" placement={["right", "left", "top"]}>
+            <button
+                type="button"
+                aria-label="Show Applications"
+                className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
+                style={{ marginTop: 'auto' }}
+                onClick={props.showApps}
+            >
                 <Image
                     width={28}
                     height={28}
@@ -71,15 +65,7 @@ export function AllApps(props) {
                     alt="Ubuntu view app"
                     sizes="28px"
                 />
-                <div
-                    className={
-                        (title ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1 left-full ml-5 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
-                    }
-                >
-                    Show Applications
-                </div>
-            </div>
-        </div>
+            </button>
+        </Tooltip>
     );
 }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
+import { Tooltip } from '../ui/TooltipProvider';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
@@ -18,29 +19,30 @@ export default function Taskbar(props) {
     return (
         <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
             {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
+                <Tooltip key={app.id} content={app.title} placement={["top", "bottom"]}>
+                    <button
+                        type="button"
+                        aria-label={app.title}
+                        data-context="taskbar"
+                        data-app-id={app.id}
+                        onClick={() => handleClick(app)}
+                        className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
+                            'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                        {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
+                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
+                        )}
+                    </button>
+                </Tooltip>
             ))}
         </div>
     );

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState, createContext, useContext } from 'react';
+import { Tooltip } from './TooltipProvider';
 
 function middleEllipsis(text: string, max = 30) {
   if (text.length <= max) return text;
@@ -170,40 +171,45 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
     >
       <div className="flex flex-shrink-0 bg-gray-800 text-white text-sm overflow-x-auto">
         {tabs.map((t, i) => (
-          <div
-            key={t.id}
-            className={`flex items-center gap-1.5 px-3 py-1 cursor-pointer select-none ${
-              t.id === activeId ? 'bg-gray-700' : 'bg-gray-800'
-            }`}
-            draggable
-            onDragStart={handleDragStart(i)}
-            onDragOver={handleDragOver(i)}
-            onDrop={handleDrop(i)}
-            onClick={() => setActive(t.id)}
-          >
-            <span className="max-w-[150px]">{middleEllipsis(t.title)}</span>
-            {t.closable !== false && tabs.length > 1 && (
-              <button
-                className="p-0.5"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  closeTab(t.id);
-                }}
-                aria-label="Close Tab"
-              >
-                ×
-              </button>
-            )}
-          </div>
+          <Tooltip key={t.id} content={t.title} placement={["bottom", "top"]}>
+            <div
+              className={`flex items-center gap-1.5 px-3 py-1 cursor-pointer select-none ${
+                t.id === activeId ? 'bg-gray-700' : 'bg-gray-800'
+              }`}
+              draggable
+              onDragStart={handleDragStart(i)}
+              onDragOver={handleDragOver(i)}
+              onDrop={handleDrop(i)}
+              onClick={() => setActive(t.id)}
+            >
+              <span className="max-w-[150px]">{middleEllipsis(t.title)}</span>
+              {t.closable !== false && tabs.length > 1 && (
+                <Tooltip content="Close Tab" placement={["bottom", "top"]}>
+                  <button
+                    className="p-0.5"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      closeTab(t.id);
+                    }}
+                    aria-label="Close Tab"
+                  >
+                    ×
+                  </button>
+                </Tooltip>
+              )}
+            </div>
+          </Tooltip>
         ))}
         {onNewTab && (
-          <button
-            className="px-2 py-1 bg-gray-800 hover:bg-gray-700"
-            onClick={addTab}
-            aria-label="New Tab"
-          >
-            +
-          </button>
+          <Tooltip content="New Tab" placement={["bottom", "top"]}>
+            <button
+              className="px-2 py-1 bg-gray-800 hover:bg-gray-700"
+              onClick={addTab}
+              aria-label="New Tab"
+            >
+              +
+            </button>
+          </Tooltip>
         )}
       </div>
       <div className="flex-grow relative overflow-hidden">

--- a/components/ui/TooltipProvider.tsx
+++ b/components/ui/TooltipProvider.tsx
@@ -1,0 +1,508 @@
+"use client";
+
+import React, {
+  CSSProperties,
+  MutableRefObject,
+  ReactElement,
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+const DEFAULT_DELAY = 300;
+const OFFSET = 8;
+const DEFAULT_PLACEMENTS: TooltipPlacement[] = ["top", "bottom", "right", "left"];
+
+type InputMode = "mouse" | "touch" | "pen" | "keyboard" | "unknown";
+
+export type TooltipPlacement = "top" | "bottom" | "left" | "right";
+
+type TriggerType = "focus" | "hover";
+
+interface ShowTooltipOptions {
+  id: string;
+  content: ReactNode;
+  target: HTMLElement | null;
+  trigger: TriggerType;
+  preferredPlacements?: TooltipPlacement[];
+  delay?: number;
+}
+
+interface TooltipContextValue {
+  showTooltip: (options: ShowTooltipOptions) => void;
+  hideTooltip: (id?: string) => void;
+  isVisible: (id: string) => boolean;
+}
+
+interface TooltipState {
+  id: string | null;
+  content: ReactNode;
+  target: HTMLElement | null;
+  targetRect: DOMRect | null;
+  visible: boolean;
+  preferredPlacements: TooltipPlacement[];
+}
+
+const initialState: TooltipState = {
+  id: null,
+  content: null,
+  target: null,
+  targetRect: null,
+  visible: false,
+  preferredPlacements: DEFAULT_PLACEMENTS,
+};
+
+const TooltipContext = createContext<TooltipContextValue | null>(null);
+
+function useTooltipContext(): TooltipContextValue {
+  const ctx = useContext(TooltipContext);
+  if (!ctx) {
+    throw new Error("Tooltip components must be used within a <TooltipProvider>.");
+  }
+  return ctx;
+}
+
+type TooltipCoordinates = {
+  top: number;
+  left: number;
+  placement: TooltipPlacement;
+};
+
+const clamp = (value: number, min: number, max: number) => {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+};
+
+const mergeRefs = <T,>(...refs: (React.Ref<T> | undefined)[]): React.RefCallback<T> => {
+  return (node: T) => {
+    refs.forEach((ref) => {
+      if (!ref) return;
+      if (typeof ref === "function") {
+        ref(node);
+      } else {
+        try {
+          (ref as MutableRefObject<T | null>).current = node;
+        } catch {
+          /* noop */
+        }
+      }
+    });
+  };
+};
+
+function composeEventHandlers<E extends { defaultPrevented: boolean }>(
+  theirs: ((event: E) => void) | undefined,
+  ours: (event: E) => void,
+) {
+  return (event: E) => {
+    theirs?.(event);
+    if (!event.defaultPrevented) {
+      ours(event);
+    }
+  };
+}
+
+export const TooltipProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [state, setState] = useState<TooltipState>(initialState);
+  const [mounted, setMounted] = useState(false);
+  const [tooltipSize, setTooltipSize] = useState({ width: 0, height: 0 });
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const showTimer = useRef<number | null>(null);
+  const hideTimer = useRef<number | null>(null);
+  const [canHover, setCanHover] = useState(true);
+  const lastInputRef = useRef<InputMode>("unknown");
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const finePointer = window.matchMedia("(hover: hover) and (pointer: fine)");
+    const updatePointerState = () => {
+      setCanHover(finePointer.matches);
+      if (!finePointer.matches && lastInputRef.current === "mouse") {
+        lastInputRef.current = "unknown";
+      }
+    };
+    updatePointerState();
+
+    const handlePointerChange = (event: MediaQueryListEvent) => {
+      setCanHover(event.matches);
+    };
+
+    finePointer.addEventListener("change", handlePointerChange);
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (event.pointerType === "mouse") {
+        lastInputRef.current = "mouse";
+      } else if (event.pointerType === "touch") {
+        lastInputRef.current = "touch";
+      } else {
+        lastInputRef.current = "pen";
+      }
+    };
+
+    const handleKeyDown = () => {
+      lastInputRef.current = "keyboard";
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown, { passive: true });
+    window.addEventListener("keydown", handleKeyDown, { passive: true });
+
+    return () => {
+      finePointer.removeEventListener("change", handlePointerChange);
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!state.visible || !state.target) return;
+
+    const updateRect = () => {
+      setState((prev) => {
+        if (!prev.visible || !prev.target) return prev;
+        return {
+          ...prev,
+          targetRect: prev.target.getBoundingClientRect(),
+        };
+      });
+    };
+
+    updateRect();
+    window.addEventListener("scroll", updateRect, true);
+    window.addEventListener("resize", updateRect);
+
+    return () => {
+      window.removeEventListener("scroll", updateRect, true);
+      window.removeEventListener("resize", updateRect);
+    };
+  }, [state.visible, state.target]);
+
+  useEffect(() => {
+    if (!state.visible) return;
+    const node = tooltipRef.current;
+    if (!node) return;
+
+    const measure = () => {
+      const rect = node.getBoundingClientRect();
+      setTooltipSize((prev) => {
+        if (prev.width === rect.width && prev.height === rect.height) {
+          return prev;
+        }
+        return { width: rect.width, height: rect.height };
+      });
+    };
+
+    measure();
+
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(() => measure());
+      observer.observe(node);
+      return () => observer.disconnect();
+    }
+
+    return undefined;
+  }, [state.visible, state.content]);
+
+  const cancelTimers = () => {
+    if (showTimer.current) {
+      window.clearTimeout(showTimer.current);
+      showTimer.current = null;
+    }
+    if (hideTimer.current) {
+      window.clearTimeout(hideTimer.current);
+      hideTimer.current = null;
+    }
+  };
+
+  const hideTooltip = useCallback((id?: string) => {
+    if (typeof window === "undefined") return;
+    cancelTimers();
+    hideTimer.current = window.setTimeout(() => {
+      setState((prev) => {
+        if (id && prev.id && prev.id !== id) {
+          return prev;
+        }
+        return initialState;
+      });
+    }, 0);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!state.visible) return;
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        hideTooltip();
+      }
+    };
+
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [state.visible, hideTooltip]);
+
+  const showTooltip = useCallback(
+    ({ id, content, target, trigger, preferredPlacements, delay }: ShowTooltipOptions) => {
+      if (typeof window === "undefined") return;
+      if (!target) return;
+
+      const isTouchLike =
+        lastInputRef.current === "touch" ||
+        (!canHover && lastInputRef.current === "pen");
+
+      if (trigger === "hover" && (!canHover || isTouchLike)) {
+        return;
+      }
+
+      if (trigger === "focus" && isTouchLike && lastInputRef.current !== "keyboard") {
+        return;
+      }
+
+      cancelTimers();
+      const placements = preferredPlacements?.length
+        ? preferredPlacements
+        : DEFAULT_PLACEMENTS;
+      const nextRect = target.getBoundingClientRect();
+      showTimer.current = window.setTimeout(() => {
+        setTooltipSize({ width: 0, height: 0 });
+        setState({
+          id,
+          content,
+          target,
+          targetRect: nextRect,
+          visible: true,
+          preferredPlacements: placements,
+        });
+      }, delay ?? DEFAULT_DELAY);
+    },
+    [canHover],
+  );
+
+  const coordinates: TooltipCoordinates | null = useMemo(() => {
+    if (typeof window === "undefined") return null;
+    if (!state.visible || !state.targetRect) return null;
+
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const { targetRect } = state;
+
+    const placements = state.preferredPlacements.length
+      ? state.preferredPlacements
+      : DEFAULT_PLACEMENTS;
+
+    const getCoords = (placement: TooltipPlacement) => {
+      const { top, bottom, left, right, width, height } = targetRect;
+      const tooltipWidth = tooltipSize.width;
+      const tooltipHeight = tooltipSize.height;
+
+      switch (placement) {
+        case "top":
+          return {
+            top: top - tooltipHeight - OFFSET,
+            left: left + width / 2 - tooltipWidth / 2,
+          };
+        case "bottom":
+          return {
+            top: bottom + OFFSET,
+            left: left + width / 2 - tooltipWidth / 2,
+          };
+        case "left":
+          return {
+            top: top + height / 2 - tooltipHeight / 2,
+            left: left - tooltipWidth - OFFSET,
+          };
+        case "right":
+        default:
+          return {
+            top: top + height / 2 - tooltipHeight / 2,
+            left: right + OFFSET,
+          };
+      }
+    };
+
+    const fitsViewport = (placement: TooltipPlacement) => {
+      const coords = getCoords(placement);
+      const tooltipWidth = tooltipSize.width;
+      const tooltipHeight = tooltipSize.height;
+      const clampedTop = clamp(coords.top, OFFSET, viewportHeight - tooltipHeight - OFFSET);
+      const clampedLeft = clamp(coords.left, OFFSET, viewportWidth - tooltipWidth - OFFSET);
+      const fitsVertically = coords.top >= OFFSET && coords.top + tooltipHeight <= viewportHeight - OFFSET;
+      const fitsHorizontally = coords.left >= OFFSET && coords.left + tooltipWidth <= viewportWidth - OFFSET;
+      return fitsVertically && fitsHorizontally
+        ? { top: coords.top, left: coords.left }
+        : { top: clampedTop, left: clampedLeft };
+    };
+
+    let chosenPlacement = placements[0] ?? "top";
+    for (const placement of placements) {
+      const coords = getCoords(placement);
+      const tooltipWidth = tooltipSize.width;
+      const tooltipHeight = tooltipSize.height;
+      const fullyVisible =
+        coords.top >= OFFSET &&
+        coords.left >= OFFSET &&
+        coords.top + tooltipHeight <= viewportHeight - OFFSET &&
+        coords.left + tooltipWidth <= viewportWidth - OFFSET;
+      if (fullyVisible) {
+        chosenPlacement = placement;
+        break;
+      }
+    }
+
+    const finalCoords = fitsViewport(chosenPlacement);
+
+    return {
+      top: finalCoords.top,
+      left: finalCoords.left,
+      placement: chosenPlacement,
+    };
+  }, [state, tooltipSize]);
+
+  const contextValue = useMemo<TooltipContextValue>(
+    () => ({
+      showTooltip,
+      hideTooltip,
+      isVisible: (id: string) => state.visible && state.id === id,
+    }),
+    [showTooltip, hideTooltip, state.visible, state.id],
+  );
+
+  const tooltipStyle: CSSProperties | undefined = coordinates
+    ? {
+        top: Math.round(coordinates.top),
+        left: Math.round(coordinates.left),
+        background: "var(--tooltip-bg)",
+        color: "var(--tooltip-text)",
+        borderColor: "var(--tooltip-border)",
+        boxShadow: "var(--tooltip-shadow)",
+      }
+    : undefined;
+
+  return (
+    <TooltipContext.Provider value={contextValue}>
+      {children}
+      {mounted && state.visible && state.id && coordinates &&
+        createPortal(
+          <div
+            ref={tooltipRef}
+            role="tooltip"
+            id={state.id}
+            data-placement={coordinates.placement}
+            className="pointer-events-none fixed z-[2147483646] max-w-xs rounded-md border px-2 py-1 text-xs leading-snug transition-opacity duration-150"
+            style={{
+              ...tooltipStyle,
+              opacity: state.visible ? 1 : 0,
+              visibility: state.visible ? "visible" : "hidden",
+              willChange: "transform, opacity",
+            }}
+          >
+            {state.content}
+          </div>,
+          document.body,
+        )}
+    </TooltipContext.Provider>
+  );
+};
+
+interface TooltipProps {
+  content: ReactNode;
+  children: ReactElement;
+  id?: string;
+  placement?: TooltipPlacement | TooltipPlacement[];
+  delay?: number;
+  disabled?: boolean;
+}
+
+export const Tooltip: React.FC<TooltipProps> = ({
+  content,
+  children,
+  id,
+  placement,
+  delay,
+  disabled = false,
+}) => {
+  const { showTooltip, hideTooltip, isVisible } = useTooltipContext();
+  const generatedId = useId();
+  const tooltipId = id ?? generatedId;
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const placements = useMemo(() => {
+    if (!placement) return undefined;
+    return Array.isArray(placement) ? placement : [placement];
+  }, [placement]);
+
+  const setRef = useCallback((node: HTMLElement | null) => {
+    triggerRef.current = node;
+  }, []);
+
+  const handleFocus = useCallback(
+    (event: React.FocusEvent<HTMLElement>) => {
+      if (disabled) return;
+      const target = triggerRef.current ?? (event.currentTarget as HTMLElement | null);
+      showTooltip({
+        id: tooltipId,
+        content,
+        target,
+        trigger: "focus",
+        preferredPlacements: placements,
+        delay,
+      });
+    },
+    [disabled, showTooltip, tooltipId, content, placements, delay],
+  );
+
+  const handleBlur = useCallback(() => {
+    hideTooltip(tooltipId);
+  }, [hideTooltip, tooltipId]);
+
+  const handlePointerEnter = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      if (disabled) return;
+      const target = triggerRef.current ?? (event.currentTarget as HTMLElement | null);
+      showTooltip({
+        id: tooltipId,
+        content,
+        target,
+        trigger: "hover",
+        preferredPlacements: placements,
+        delay,
+      });
+    },
+    [disabled, showTooltip, tooltipId, content, placements, delay],
+  );
+
+  const handlePointerLeave = useCallback(() => {
+    hideTooltip(tooltipId);
+  }, [hideTooltip, tooltipId]);
+
+  const handlePointerDown = useCallback(() => {
+    hideTooltip(tooltipId);
+  }, [hideTooltip, tooltipId]);
+
+  const childProps = children.props as Record<string, unknown>;
+  const describedBy = [childProps["aria-describedby"], isVisible(tooltipId) ? tooltipId : undefined]
+    .filter(Boolean)
+    .join(" ");
+
+  const cloned = React.cloneElement(children, {
+    ref: mergeRefs((children as unknown as { ref?: React.Ref<HTMLElement> }).ref, setRef),
+    onFocus: composeEventHandlers(children.props.onFocus, handleFocus),
+    onBlur: composeEventHandlers(children.props.onBlur, handleBlur),
+    onPointerEnter: composeEventHandlers(children.props.onPointerEnter, handlePointerEnter),
+    onPointerLeave: composeEventHandlers(children.props.onPointerLeave, handlePointerLeave),
+    onPointerDown: composeEventHandlers(children.props.onPointerDown, handlePointerDown),
+    "aria-describedby": describedBy || undefined,
+  });
+
+  return cloned;
+};
+
+export const useTooltip = useTooltipContext;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { TooltipProvider } from '../components/ui/TooltipProvider';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -157,7 +158,8 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
+          <TooltipProvider>
+            <PipPortalProvider>
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
             <ShortcutOverlay />
@@ -171,7 +173,8 @@ function MyApp(props) {
             />
 
             {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+            </PipPortalProvider>
+          </TooltipProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -26,6 +26,10 @@
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
   --kali-bg: rgba(15, 19, 23, 0.85);
+  --tooltip-bg: color-mix(in srgb, var(--color-bg), black 25%);
+  --tooltip-text: var(--color-text);
+  --tooltip-border: color-mix(in srgb, var(--color-text), transparent 65%);
+  --tooltip-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
@@ -73,6 +77,10 @@
   --color-ub-orange: #ffff00;
   --color-ub-lite-abrgn: #00ffff;
   --color-ub-border-orange: #ffff00;
+  --tooltip-bg: #000000;
+  --tooltip-text: #ffffff;
+  --tooltip-border: #ffffff;
+  --tooltip-shadow: 0 0 0 1px #ffffff;
   --game-color-secondary: #ffff00;
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
@@ -116,5 +124,9 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --tooltip-bg: #000000;
+    --tooltip-text: #ffffff;
+    --tooltip-border: #ffffff;
+    --tooltip-shadow: 0 0 0 1px #ffffff;
   }
 }


### PR DESCRIPTION
## Summary
- add a TooltipProvider with smart placement, pointer awareness, and themed tokens
- migrate taskbar buttons, tabbed windows, and window controls to the shared Tooltip component
- expand unit tests to cover tooltip focus/blur behaviour and wrap UI tests in the provider

## Testing
- yarn lint *(fails: existing accessibility violations in unrelated apps)*
- yarn test --watch=false *(fails: existing suites unrelated to tooltip changes)*
- yarn test --watch=false taskbar.test.tsx window.test.tsx terminal.test.tsx tooltipProvider.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc6fd1850c8328a69bceee21290d48