### PR TITLE
[a11y] reinforce focus styling for sticky notes and window controls

### DIFF
--- a/apps/sticky_notes/index.tsx
+++ b/apps/sticky_notes/index.tsx
@@ -10,7 +10,9 @@ export default function StickyNotes() {
 
   return (
     <div>
-      <button id="add-note">Add Note</button>
+      <button id="add-note" type="button" className="focus-visible-ring">
+        Add Note
+      </button>
       <div id="notes" />
     </div>
   );

--- a/apps/sticky_notes/main.js
+++ b/apps/sticky_notes/main.js
@@ -73,6 +73,8 @@ function createNoteElement(note) {
   const colorInput = document.createElement('input');
   colorInput.type = 'color';
   colorInput.value = note.color;
+  colorInput.classList.add('focus-visible-ring');
+  colorInput.setAttribute('aria-label', 'Sticky note color');
   colorInput.addEventListener('input', (e) => {
     note.color = e.target.value;
     el.style.backgroundColor = note.color;
@@ -81,7 +83,8 @@ function createNoteElement(note) {
 
   const deleteBtn = document.createElement('button');
   deleteBtn.textContent = 'Delete';
-  deleteBtn.className = 'delete-note';
+  deleteBtn.className = 'delete-note focus-visible-ring';
+  deleteBtn.type = 'button';
   deleteBtn.addEventListener('click', () => {
     notes = notes.filter((n) => n.id !== note.id);
     el.remove();
@@ -94,6 +97,8 @@ function createNoteElement(note) {
 
   const textarea = document.createElement('textarea');
   textarea.value = note.content;
+  textarea.classList.add('focus-visible-ring');
+  textarea.setAttribute('aria-label', 'Sticky note text');
   textarea.addEventListener('input', (e) => {
     note.content = e.target.value;
     void saveNotes();

--- a/apps/sticky_notes/styles.css
+++ b/apps/sticky_notes/styles.css
@@ -39,7 +39,6 @@ body {
   border: none;
   background: transparent;
   resize: none;
-  outline: none;
 }
 
 .note .controls {

--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -91,12 +91,12 @@ export default function AppGrid({ openApp }) {
   return (
     <div className="flex flex-col items-center h-full">
       <input
-        className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+        className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus-visible-ring"
         placeholder="Search"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
       />
-      <div className="w-full flex-1 h-[70vh] outline-none" onKeyDown={handleKeyDown}>
+      <div className="w-full flex-1 h-[70vh]" onKeyDown={handleKeyDown}>
         <AutoSizer>
           {({ height, width }) => {
             const columnCount = getColumnCount(width);

--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -101,7 +101,7 @@ export class SideBarApp extends Component {
                     this.setState({ showTitle: false, thumbnail: null });
                 }}
                 className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
-                    " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
+                    " w-auto p-2 focus-visible-ring relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
                 id={"sidebar-" + this.props.id}
             >
                 <Image

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -42,7 +42,7 @@ export class UbuntuApp extends Component {
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
                 className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent focus-visible-ring rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -739,7 +739,7 @@ export function WindowEditButtons(props) {
                 <button
                     type="button"
                     aria-label="Window pin"
-                    className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                    className="mx-1 focus-visible-ring bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                     onClick={togglePin}
                 >
                     <NextImage
@@ -755,7 +755,7 @@ export function WindowEditButtons(props) {
             <button
                 type="button"
                 aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                className="mx-1 focus-visible-ring bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                 onClick={props.minimize}
             >
                 <NextImage
@@ -773,7 +773,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className="mx-1 focus-visible-ring bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -789,7 +789,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className="mx-1 focus-visible-ring bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -807,7 +807,7 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                className="mx-1 focus-visible-ring cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
                 onClick={props.close}
             >
                 <NextImage

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -120,7 +120,7 @@ const WhiskerMenu: React.FC = () => {
         ref={buttonRef}
         type="button"
         onClick={() => setOpen(o => !o)}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className="pl-3 pr-3 focus-visible-ring transition duration-100 ease-in-out border-b-2 border-transparent py-1"
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"
@@ -146,7 +146,7 @@ const WhiskerMenu: React.FC = () => {
             {CATEGORIES.map(cat => (
               <button
                 key={cat.id}
-                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
+                className={`text-left px-2 py-1 rounded mb-1 focus-visible-ring ${category === cat.id ? 'bg-gray-700' : ''}`}
                 onClick={() => setCategory(cat.id)}
               >
                 {cat.label}
@@ -155,7 +155,7 @@ const WhiskerMenu: React.FC = () => {
           </div>
           <div className="p-3">
             <input
-              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus-visible-ring"
               placeholder="Search"
               value={query}
               onChange={e => setQuery(e.target.value)}

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -57,7 +57,7 @@ class AllApplications extends React.Component {
         return (
             <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
                 <input
-                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus-visible-ring"
                     placeholder="Search"
                     value={this.state.query}
                     onChange={this.handleChange}

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -3,6 +3,12 @@ import Image from 'next/image'
 
 function BootingScreen(props) {
 
+    const handleActivate = () => {
+        if (typeof props.turnOn === 'function') {
+            props.turnOn();
+        }
+    };
+
     return (
         <div
             style={{
@@ -19,7 +25,19 @@ function BootingScreen(props) {
                 sizes="(max-width: 768px) 50vw, 25vw"
                 priority
             />
-            <div className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer" onClick={props.turnOn} >
+            <div
+                className="w-10 h-10 flex justify-center items-center rounded-full focus-visible-ring cursor-pointer"
+                role="button"
+                tabIndex={0}
+                aria-label={props.isShutDown ? 'Power on desktop' : 'Boot sequence status'}
+                onClick={handleActivate}
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        handleActivate();
+                    }
+                }}
+            >
                 {(props.isShutDown
                     ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><Image width={32} height={32} className="w-8" src="/themes/Yaru/status/power-button.svg" alt="Power Button" sizes="32px" priority/></div>
                     : <Image width={40} height={40} className={" w-10 " + (props.visible ? " animate-spin " : "")} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" sizes="40px" priority/>)}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -22,7 +22,7 @@ export default class Navbar extends Component {
                                 <WhiskerMenu />
                                 <div
                                         className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                'pl-2 pr-2 text-xs md:text-sm transition duration-100 ease-in-out border-b-2 border-transparent py-1'
                                         }
                                 >
                                         <Clock />
@@ -35,7 +35,7 @@ export default class Navbar extends Component {
                                                 this.setState({ status_card: !this.state.status_card });
                                         }}
                                         className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                                'relative pr-3 pl-3 focus-visible-ring transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
                                         }
                                 >
                                         <Status />

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -57,7 +57,7 @@ class ShortcutSelector extends React.Component {
         return (
             <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
                 <input
-                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus-visible-ring"
                     placeholder="Search"
                     value={this.state.query}
                     onChange={this.handleChange}
@@ -66,7 +66,7 @@ class ShortcutSelector extends React.Component {
                     {this.renderApps()}
                 </div>
                 <button
-                    className="mb-8 px-4 py-2 rounded bg-black bg-opacity-20 text-white"
+                    className="mb-8 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus-visible-ring"
                     onClick={this.props.onClose}
                 >
                     Cancel

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -4,6 +4,14 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(0);
   const inputRef = useRef(null);
+  const commitSelection = (id) => {
+    if (!id) return;
+    if (typeof onSelect === 'function') {
+      onSelect(id);
+    } else if (typeof onClose === 'function') {
+      onClose();
+    }
+  };
 
   const filtered = windows.filter((w) =>
     w.title.toLowerCase().includes(query.toLowerCase())
@@ -64,14 +72,25 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
           value={query}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+          className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus-visible-ring"
           placeholder="Search windows"
         />
-        <ul>
+        <ul role="listbox" aria-label="Open windows">
           {filtered.map((w, i) => (
             <li
               key={w.id}
-              className={`px-2 py-1 rounded ${i === selected ? 'bg-ub-orange text-black' : ''}`}
+              role="option"
+              tabIndex={0}
+              aria-selected={i === selected}
+              onFocus={() => setSelected(i)}
+              onClick={() => commitSelection(w.id)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  commitSelection(w.id);
+                }
+              }}
+              className={`px-2 py-1 rounded focus-visible-ring ${i === selected ? 'bg-ub-orange text-black' : ''}`}
             >
               {w.title}
             </li>

--- a/docs/keyboard-only-test-plan.md
+++ b/docs/keyboard-only-test-plan.md
@@ -21,3 +21,8 @@
 1. After resizing or snapping, press **Tab** to move focus inside the window.
 2. Continue pressing **Tab** to confirm focus can leave the window and is not trapped.
 3. Shift+Tab moves focus backward as expected.
+
+## Focus indicators and exceptions
+- All taskbar icons, launcher tiles, and global menus now share the accent-colored focus ring token. Verify the outline appears on focus-visible states in both default and high-contrast themes.
+- The boot screen power control supports **Enter** and **Space**. Focus it with **Tab** to confirm the blue/yellow ring renders before activating the desktop.
+- The window switcher exposes its results list as a focusable listbox. After the search field, press **Tab** to step through window thumbnails and use **Enter**/**Space** to activate the highlighted entry. Arrow keys continue to work for cycling without moving focus.

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,7 +16,7 @@
   --color-border: #2a2e36; /* subtle borders */
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
-  --color-focus-ring: var(--color-accent);
+  --color-focus-ring: var(--focus-ring-color);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   accent-color: var(--color-control-accent);
@@ -74,6 +74,8 @@ html[data-theme='matrix'] {
 }
 
 *:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-shadow);
+  transition: var(--focus-ring-transition);
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -17,9 +17,22 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 }
 
 a:focus-visible,
-button:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
-    outline-offset: 2px;
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+[role="button"]:focus-visible,
+[tabindex]:focus-visible {
+    outline: var(--focus-ring-width) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
+    box-shadow: var(--focus-ring-shadow);
+    transition: var(--focus-ring-transition);
+}
+
+.focus-visible-ring:focus-visible {
+    outline: var(--focus-ring-width) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
+    box-shadow: var(--focus-ring-shadow);
+    transition: var(--focus-ring-transition);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -64,7 +77,6 @@ button:focus-visible {
 }
 
 input[type=range].ubuntu-slider {
-    outline: none;
     -webkit-appearance: none;
     background: linear-gradient(
         to right,

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -57,9 +57,18 @@
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;
-  /* Focus outline */
-  --focus-outline-color: var(--color-ubt-blue);
-  --focus-outline-width: 2px;
+  /* Focus ring tokens */
+  --focus-ring-color: var(--color-ub-orange);
+  --focus-ring-width: 2px;
+  --focus-ring-offset: 3px;
+  --focus-ring-shadow: 0 0 0 calc(var(--focus-ring-width) + 2px)
+    color-mix(in srgb, var(--focus-ring-color), transparent 65%);
+  --focus-ring-transition: box-shadow var(--motion-fast) ease,
+    outline-color var(--motion-fast) ease;
+  /* Legacy aliases */
+  --focus-outline-color: var(--focus-ring-color);
+  --focus-outline-width: var(--focus-ring-width);
+  --focus-outline-offset: var(--focus-ring-offset);
 }
 
 /* High contrast theme */
@@ -77,6 +86,11 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --focus-ring-color: var(--color-ub-orange);
+  --focus-ring-width: 3px;
+  --focus-ring-offset: 4px;
+  --focus-ring-shadow: 0 0 0 calc(var(--focus-ring-width) + 4px)
+    color-mix(in srgb, var(--color-text), transparent 70%);
 }
 
 /* Dyslexia-friendly fonts */
@@ -116,5 +130,10 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --focus-ring-color: var(--color-ub-orange);
+    --focus-ring-width: 3px;
+    --focus-ring-offset: 4px;
+    --focus-ring-shadow: 0 0 0 calc(var(--focus-ring-width) + 4px)
+      color-mix(in srgb, var(--color-text), transparent 70%);
   }
 }


### PR DESCRIPTION
## Summary
- give the sticky notes launcher and controls the shared focus-visible helper and remove outline overrides
- add focus rings to the window chrome buttons so minimize/maximize/pin share the same accent outline
- stop removing the outline from the shared ubuntu slider token so the new focus styles appear

## Testing
- yarn lint *(fails: existing unlabeled control warnings across many apps)*
- yarn test *(fails: pre-existing suites such as window resize, nmap results, settings store, etc.)*
- node tmp-axe-check.js *(temporary Playwright + axe check, no violations)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6d1688508328a67674de298dbefd