### PR TITLE
[desktop] add virtual display manager for multi-display simulation

### DIFF
--- a/__tests__/desktopDisplayBounds.test.ts
+++ b/__tests__/desktopDisplayBounds.test.ts
@@ -1,0 +1,91 @@
+import { Desktop } from '../components/screen/desktop';
+import displayManager, { type DisplayInfo } from '../modules/displayManager';
+
+describe('Desktop display bounds', () => {
+  const primaryDisplay: DisplayInfo = {
+    id: 'primary',
+    label: 'Test Primary',
+    isPrimary: true,
+    scaleFactor: 1,
+    bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+  };
+
+  const secondaryDisplay: DisplayInfo = {
+    id: 'secondary',
+    label: 'Test Secondary',
+    isPrimary: false,
+    scaleFactor: 1,
+    bounds: { x: 0, y: 0, width: 1600, height: 900 },
+  };
+
+  beforeEach(() => {
+    displayManager.setVirtualDisplays([primaryDisplay, secondaryDisplay], 'primary');
+  });
+
+  afterEach(() => {
+    displayManager.setVirtualDisplays([primaryDisplay, secondaryDisplay], 'primary');
+  });
+
+  const attachSetState = (desktop: Desktop) => {
+    desktop.setState = ((updater: any, callback?: () => void) => {
+      const nextState =
+        typeof updater === 'function' ? updater(desktop.state, desktop.props) : updater;
+      if (nextState && typeof nextState === 'object') {
+        desktop.state = { ...desktop.state, ...nextState };
+      }
+      if (callback) callback();
+    }) as any;
+  };
+
+  it('clamps existing windows inside the active display when bounds shrink', () => {
+    const desktop = new Desktop();
+    desktop.props = { activeDisplayId: 'primary', snapEnabled: false } as any;
+    attachSetState(desktop);
+    desktop.state.window_positions = {
+      'app-1': { x: 2600, y: -120 },
+      'app-2': { x: -320, y: 1500 },
+    } as any;
+
+    const smallerDisplay: DisplayInfo = {
+      id: 'primary',
+      label: 'Shrunk Display',
+      isPrimary: true,
+      scaleFactor: 1,
+      bounds: { x: 0, y: 0, width: 1024, height: 640 },
+    };
+
+    displayManager.setVirtualDisplays([smallerDisplay], 'primary');
+    desktop.realignWindowsToDisplay('primary');
+
+    const active = displayManager.getDisplay('primary');
+    expect(active).toBeDefined();
+    const bounds = active!.bounds;
+    Object.values(desktop.state.window_positions).forEach((position: any) => {
+      expect(position.x).toBeGreaterThanOrEqual(bounds.x);
+      expect(position.x).toBeLessThanOrEqual(bounds.x + bounds.width);
+      expect(position.y).toBeGreaterThanOrEqual(bounds.y);
+      expect(position.y).toBeLessThanOrEqual(bounds.y + bounds.height);
+    });
+  });
+
+  it('respects the selected display when realigning windows', () => {
+    const desktop = new Desktop();
+    desktop.props = { activeDisplayId: 'secondary', snapEnabled: false } as any;
+    attachSetState(desktop);
+    desktop.state.window_positions = {
+      'app-secondary': { x: 2000, y: 1200 },
+    } as any;
+
+    displayManager.setVirtualDisplays([primaryDisplay, secondaryDisplay], 'secondary');
+    desktop.realignWindowsToDisplay('secondary');
+
+    const active = displayManager.getDisplay('secondary');
+    expect(active).toBeDefined();
+    const bounds = active!.bounds;
+    const position = desktop.state.window_positions['app-secondary'];
+    expect(position.x).toBeGreaterThanOrEqual(bounds.x);
+    expect(position.x).toBeLessThanOrEqual(bounds.x + bounds.width);
+    expect(position.y).toBeGreaterThanOrEqual(bounds.y);
+    expect(position.y).toBeLessThanOrEqual(bounds.y + bounds.height);
+  });
+});

--- a/docs/multi-display.md
+++ b/docs/multi-display.md
@@ -1,0 +1,53 @@
+# Multi-display Support
+
+The desktop UI now exposes a virtual multi-display model so windows can target a
+specific monitor and stay on-screen when geometry changes. Browsers cannot
+enumerate real monitors, so the implementation simulates a *primary* and
+*secondary* display with widths derived from the current viewport and device
+pixel ratio.
+
+## Display manager
+
+`modules/displayManager.ts` provides a singleton that tracks the available
+monitors, the active display, and helper methods for positioning windows.
+
+- Each `DisplayInfo` entry exposes bounds, a label, `isPrimary`, and the scale
+  factor.
+- `clampPosition` and `clampWindowMap` coerce window coordinates back inside the
+  active display using a 48 px safety margin to avoid clipping window chrome.
+- `getCascadePosition` produces staggered offsets so new windows fan out instead
+  of stacking.
+- Consumers can subscribe to display updates (resize, active-display changes, or
+  virtual layouts set during tests) to recalculate positions.
+
+## Desktop behaviour
+
+`components/screen/desktop.js` now receives the active display id from the
+settings context. Whenever the active monitor or viewport changes, the desktop:
+
+1. Clamps stored window coordinates with `displayManager.clampPosition`.
+2. Applies cascaded defaults for newly opened apps on the selected display.
+3. Persists the realigned coordinates so sessions never reopen off-screen.
+
+Tests in `__tests__/desktopDisplayBounds.test.ts` verify that shrinking the
+active display or switching to another monitor always keeps window origins
+within the display bounds.
+
+## Settings UI
+
+The Settings app includes a **Display** tab that lists the simulated monitors.
+Users can pick the active display, view its resolution and scale factor, and
+read a brief note explaining the clamping behaviour. The selection is stored in
+localStorage (`active-display`) and restored on boot.
+
+## Assumptions and limitations
+
+- The browser sandbox only exposes the current viewport, so secondary displays
+  are virtual (scaled versions of the primary display).
+- Coordinates are relative to the viewport origin; switching to a secondary
+  display does not move the DOM outside the current tab.
+- The safety margin trades a small inset for the guarantee that window title
+  bars remain accessible even on very small displays.
+
+This model is meant for the portfolio simulation and does not interact with real
+multi-monitor hardware.

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,9 +20,12 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getActiveDisplay as loadActiveDisplay,
+  setActiveDisplay as saveActiveDisplay,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import displayManager from '../modules/displayManager';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -63,6 +66,7 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  activeDisplayId: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +78,7 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setActiveDisplayId: (value: string) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +93,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  activeDisplayId: defaults.activeDisplay,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +105,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setActiveDisplayId: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -113,6 +120,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [activeDisplayId, setActiveDisplayId] = useState<string>(defaults.activeDisplay);
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -128,12 +136,18 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
       setTheme(loadTheme());
+      setActiveDisplayId(await loadActiveDisplay());
     })();
   }, []);
 
   useEffect(() => {
     saveTheme(theme);
   }, [theme]);
+
+  useEffect(() => {
+    displayManager.setActiveDisplay(activeDisplayId);
+    saveActiveDisplay(activeDisplayId);
+  }, [activeDisplayId]);
 
   useEffect(() => {
     const border = shadeColor(accent, -0.2);
@@ -250,6 +264,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        activeDisplayId,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +276,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setActiveDisplayId,
       }}
     >
       {children}

--- a/modules/displayManager.ts
+++ b/modules/displayManager.ts
@@ -1,0 +1,213 @@
+export interface DisplayBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DisplayInfo {
+  id: string;
+  label: string;
+  isPrimary: boolean;
+  scaleFactor: number;
+  bounds: DisplayBounds;
+}
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+interface DisplaySnapshot {
+  displays: DisplayInfo[];
+  activeDisplayId: string;
+}
+
+type DisplayListener = (snapshot: DisplaySnapshot) => void;
+
+const DEFAULT_PRIMARY: DisplayInfo = {
+  id: 'primary',
+  label: 'Primary Display',
+  isPrimary: true,
+  scaleFactor: 1,
+  bounds: { x: 0, y: 0, width: 1440, height: 900 },
+};
+
+const DEFAULT_SECONDARY: DisplayInfo = {
+  id: 'secondary',
+  label: 'External Display',
+  isPrimary: false,
+  scaleFactor: 1,
+  bounds: { x: 0, y: 0, width: 1280, height: 800 },
+};
+
+const SAFE_MARGIN = 48;
+
+const cloneDisplay = (display: DisplayInfo): DisplayInfo => ({
+  ...display,
+  bounds: { ...display.bounds },
+});
+
+class DisplayManager {
+  private displays: DisplayInfo[] = [cloneDisplay(DEFAULT_PRIMARY), cloneDisplay(DEFAULT_SECONDARY)];
+  private activeDisplayId: string = 'primary';
+  private listeners: Set<DisplayListener> = new Set();
+
+  constructor() {
+    this.displays = this.detectDisplays();
+    this.activeDisplayId =
+      this.displays.find((display) => display.isPrimary)?.id || this.displays[0]?.id || 'primary';
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', this.handleResize);
+    }
+  }
+
+  private handleResize = () => {
+    this.displays = this.detectDisplays();
+    if (!this.displays.some((display) => display.id === this.activeDisplayId)) {
+      this.activeDisplayId = this.displays[0]?.id || 'primary';
+    }
+    this.notify();
+  };
+
+  private detectDisplays(): DisplayInfo[] {
+    if (typeof window === 'undefined') {
+      return [cloneDisplay(DEFAULT_PRIMARY), cloneDisplay(DEFAULT_SECONDARY)];
+    }
+
+    const screenWidth = window.screen?.width ?? 0;
+    const screenHeight = window.screen?.height ?? 0;
+    const width = Math.max(window.innerWidth, screenWidth, DEFAULT_PRIMARY.bounds.width);
+    const height = Math.max(window.innerHeight, screenHeight, DEFAULT_PRIMARY.bounds.height);
+    const scaleFactor = window.devicePixelRatio || 1;
+
+    const secondaryWidth = Math.max(Math.round(width * 0.75), 960);
+    const secondaryHeight = Math.max(Math.round(height * 0.75), 720);
+
+    return [
+      {
+        id: 'primary',
+        label: 'Primary Display',
+        isPrimary: true,
+        scaleFactor,
+        bounds: { x: 0, y: 0, width, height },
+      },
+      {
+        id: 'secondary',
+        label: 'External Display',
+        isPrimary: false,
+        scaleFactor,
+        bounds: { x: 0, y: 0, width: secondaryWidth, height: secondaryHeight },
+      },
+    ];
+  }
+
+  private notify() {
+    const snapshot = this.getSnapshot();
+    this.listeners.forEach((listener) => listener(snapshot));
+  }
+
+  private getSnapshot(): DisplaySnapshot {
+    return {
+      activeDisplayId: this.activeDisplayId,
+      displays: this.displays.map(cloneDisplay),
+    };
+  }
+
+  getDisplays(): DisplayInfo[] {
+    return this.displays.map(cloneDisplay);
+  }
+
+  getActiveDisplayId(): string {
+    return this.activeDisplayId;
+  }
+
+  getDisplay(id?: string): DisplayInfo | undefined {
+    const targetId = id ?? this.activeDisplayId;
+    const display = this.displays.find((item) => item.id === targetId);
+    return display ? cloneDisplay(display) : undefined;
+  }
+
+  setActiveDisplay(id: string): void {
+    if (id === this.activeDisplayId) return;
+    if (!this.displays.some((display) => display.id === id)) return;
+    this.activeDisplayId = id;
+    this.notify();
+  }
+
+  subscribe(listener: DisplayListener): () => void {
+    this.listeners.add(listener);
+    listener(this.getSnapshot());
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  clampPosition(position: Position, options: { displayId?: string; margin?: number } = {}): Position {
+    const display = this.getDisplay(options.displayId) ?? cloneDisplay(DEFAULT_PRIMARY);
+    const margin = Math.max(0, options.margin ?? SAFE_MARGIN);
+    const { x: originX, y: originY, width, height } = display.bounds;
+
+    const effectiveMarginX = Math.min(margin, width / 2);
+    const effectiveMarginY = Math.min(margin, height / 2);
+
+    const minX = originX + effectiveMarginX;
+    const maxX = originX + width - effectiveMarginX;
+    const minY = originY + effectiveMarginY;
+    const maxY = originY + height - effectiveMarginY;
+
+    const nextX =
+      width <= effectiveMarginX * 2
+        ? originX + width / 2
+        : Math.min(Math.max(position.x, minX), maxX);
+    const nextY =
+      height <= effectiveMarginY * 2
+        ? originY + height / 2
+        : Math.min(Math.max(position.y, minY), maxY);
+
+    return { x: nextX, y: nextY };
+  }
+
+  clampWindowMap(
+    positions: Record<string, Position | undefined>,
+    options: { displayId?: string; margin?: number } = {}
+  ): Record<string, Position> {
+    const result: Record<string, Position> = {};
+    Object.entries(positions || {}).forEach(([id, value]) => {
+      if (!value) return;
+      result[id] = this.clampPosition(value, options);
+    });
+    return result;
+  }
+
+  getCascadePosition(index: number, options: { displayId?: string; margin?: number } = {}): Position {
+    const display = this.getDisplay(options.displayId) ?? cloneDisplay(DEFAULT_PRIMARY);
+    const margin = Math.max(0, options.margin ?? SAFE_MARGIN);
+    const step = 32;
+    const x = display.bounds.x + margin + index * step;
+    const y = display.bounds.y + margin + index * step;
+    return this.clampPosition({ x, y }, { displayId: display.id, margin });
+  }
+
+  setVirtualDisplays(displays: DisplayInfo[], activeId?: string): void {
+    if (!displays.length) {
+      this.displays = [cloneDisplay(DEFAULT_PRIMARY)];
+      this.activeDisplayId = 'primary';
+      this.notify();
+      return;
+    }
+    this.displays = displays.map(cloneDisplay);
+    if (activeId && this.displays.some((display) => display.id === activeId)) {
+      this.activeDisplayId = activeId;
+    } else if (!this.displays.some((display) => display.id === this.activeDisplayId)) {
+      this.activeDisplayId = this.displays[0].id;
+    }
+    this.notify();
+  }
+}
+
+const displayManager = new DisplayManager();
+
+export default displayManager;
+export { SAFE_MARGIN };

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  activeDisplay: 'primary',
 };
 
 export async function getAccent() {
@@ -123,6 +124,16 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getActiveDisplay() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.activeDisplay;
+  return window.localStorage.getItem('active-display') || DEFAULT_SETTINGS.activeDisplay;
+}
+
+export async function setActiveDisplay(id) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('active-display', id);
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +148,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('active-display');
 }
 
 export async function exportSettings() {
@@ -151,6 +163,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    activeDisplay,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +175,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getActiveDisplay(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +189,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    activeDisplay,
     theme,
   });
 }
@@ -200,6 +215,7 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    activeDisplay,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -211,6 +227,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (activeDisplay !== undefined) await setActiveDisplay(activeDisplay);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add a reusable display manager abstraction that exposes virtual primary/secondary monitor bounds and clamping helpers
- teach the desktop window manager to respect the active display when restoring, cascading, and persisting window positions
- surface an active-display selector in Settings, persist the choice, document the feature, and cover clamping with unit tests

## Testing
- yarn lint *(fails: longstanding jsx-a11y label issues across existing apps)*
- yarn test --watch=false *(fails: pre-existing Window keyboard handler test, Nmap NSE alert expectation, jsdom localStorage crash in Modal tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6d0dd08c8328a79adb9663963cb1