### PR TITLE
[desktop] add per-display workspace management

### DIFF
--- a/__tests__/desktopDisplays.test.tsx
+++ b/__tests__/desktopDisplays.test.tsx
@@ -1,0 +1,90 @@
+import { Desktop } from '../components/screen/desktop';
+
+describe('Desktop multi-display workspaces', () => {
+  const baseDisplayConfig = {
+    displays: [
+      { id: 'display-1', name: 'Internal Display' },
+      { id: 'display-2', name: 'Projector' },
+    ],
+    primary: 'display-1',
+  };
+
+  const baseSession = {
+    windows: [],
+    wallpaper: 'wall-2',
+    dock: [],
+    workspaces: {
+      'display-1': {
+        windows: [{ id: 'terminal', x: 120, y: 80 }],
+        minimized: [],
+        focused: 'terminal',
+        order: ['terminal'],
+      },
+      'display-2': {
+        windows: [{ id: 'browser', x: 300, y: 160 }],
+        minimized: ['browser'],
+        focused: null,
+        order: ['browser'],
+      },
+    },
+    activeDisplay: 'display-1',
+    displays: ['display-1', 'display-2'],
+  };
+
+  const setupDesktop = () => {
+    const setSession = jest.fn();
+    const props = {
+      displayConfig: baseDisplayConfig,
+      session: baseSession,
+      setSession,
+      clearSession: jest.fn(),
+    } as any;
+    const desktop = new Desktop(props);
+    desktop.setState = (update: any, callback?: () => void) => {
+      const partial =
+        typeof update === 'function' ? update(desktop.state, desktop.props) : update;
+      desktop.state = { ...desktop.state, ...partial };
+      if (typeof callback === 'function') callback();
+    };
+    desktop.initFavourite = { terminal: false, browser: false };
+    desktop.state = {
+      ...desktop.state,
+      focused_windows: { terminal: false, browser: false },
+      closed_windows: { terminal: true, browser: true },
+      overlapped_windows: { terminal: false, browser: false },
+      minimized_windows: { terminal: false, browser: false },
+      window_positions: {},
+    };
+    desktop.initialWorkspaceSnapshot = desktop.createWorkspaceSnapshotFromState();
+    return { desktop, setSession };
+  };
+
+  it('switches workspace state when the primary display changes', () => {
+    const { desktop, setSession } = setupDesktop();
+
+    desktop.initializeWorkspaces(baseSession);
+    expect(desktop.state.activeDisplay).toBe('display-1');
+    expect(desktop.state.closed_windows.terminal).toBe(false);
+    expect(desktop.state.closed_windows.browser).toBe(true);
+
+    setSession.mockClear();
+
+    desktop.handlePrimaryDisplayChange('display-2');
+
+    expect(desktop.state.activeDisplay).toBe('display-2');
+    expect(desktop.state.closed_windows.browser).toBe(false);
+    expect(desktop.state.minimized_windows.browser).toBe(true);
+    expect(desktop.workspaceStates['display-1'].closed_windows.terminal).toBe(false);
+
+    expect(setSession).toHaveBeenCalledTimes(1);
+    const payload = setSession.mock.calls[0][0];
+    expect(payload.activeDisplay).toBe('display-2');
+    expect(payload.workspaces['display-1'].windows).toEqual([
+      { id: 'terminal', x: 120, y: 80 },
+    ]);
+    expect(payload.workspaces['display-2'].windows).toEqual([
+      { id: 'browser', x: 300, y: 160 },
+    ]);
+    expect(payload.workspaces['display-2'].minimized).toEqual(['browser']);
+  });
+});

--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -18,6 +18,8 @@ describe('Taskbar', () => {
         focused_windows={{ app1: true }}
         openApp={openApp}
         minimize={minimize}
+        activeDisplay="display-1"
+        displayName="Internal Display"
       />
     );
     const button = screen.getByRole('button', { name: /app one/i });
@@ -37,10 +39,29 @@ describe('Taskbar', () => {
         focused_windows={{ app1: false }}
         openApp={openApp}
         minimize={minimize}
+        activeDisplay="display-2"
+        displayName="Projector"
       />
     );
     const button = screen.getByRole('button', { name: /app one/i });
     fireEvent.click(button);
     expect(openApp).toHaveBeenCalledWith('app1');
+  });
+
+  it('annotates toolbar with active display metadata', () => {
+    render(
+      <Taskbar
+        apps={apps}
+        closed_windows={{ app1: false }}
+        minimized_windows={{ app1: false }}
+        focused_windows={{ app1: false }}
+        openApp={jest.fn()}
+        minimize={jest.fn()}
+        activeDisplay="display-3"
+        displayName="External Monitor"
+      />
+    );
+    const toolbar = screen.getByRole('toolbar', { name: /external monitor/i });
+    expect(toolbar).toHaveAttribute('data-display-id', 'display-3');
   });
 });

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -3,6 +3,8 @@ import Image from 'next/image';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const displayId = props.activeDisplay || 'display-1';
+    const displayName = props.displayName || 'Primary Display';
 
     const handleClick = (app) => {
         const id = app.id;
@@ -16,32 +18,43 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
+        <div
+            className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40"
+            role="toolbar"
+            aria-label={`Taskbar for ${displayName}`}
+            data-display-id={displayId}
+        >
+            <div className="flex items-center h-full px-3 border-r border-white border-opacity-10 text-xs uppercase tracking-wide text-white text-opacity-80">
+                <span className="sr-only">Active display</span>
+                <span aria-hidden="true">{displayName}</span>
+            </div>
+            <div className="flex-1 flex items-center overflow-x-auto">
+                {runningApps.map(app => (
+                    <button
+                        key={app.id}
+                        type="button"
+                        aria-label={app.title}
+                        data-context="taskbar"
+                        data-app-id={app.id}
+                        onClick={() => handleClick(app)}
+                        className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
+                            'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                        {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
+                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
+                        )}
+                    </button>
+                ))}
+            </div>
         </div>
     );
 }

--- a/hooks/useDisplayConfig.ts
+++ b/hooks/useDisplayConfig.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import usePersistentState from './usePersistentState';
+
+export interface DisplayWorkspaceDefinition {
+  id: string;
+  name: string;
+}
+
+export interface DisplayWorkspaceConfig {
+  displays: DisplayWorkspaceDefinition[];
+  primary: string;
+}
+
+export const DEFAULT_DISPLAY_CONFIG: DisplayWorkspaceConfig = {
+  displays: [{ id: 'display-1', name: 'Primary Workspace' }],
+  primary: 'display-1',
+};
+
+function isDisplayWorkspaceDefinition(value: unknown): value is DisplayWorkspaceDefinition {
+  if (!value || typeof value !== 'object') return false;
+  const entry = value as DisplayWorkspaceDefinition;
+  return typeof entry.id === 'string' && typeof entry.name === 'string';
+}
+
+function isDisplayWorkspaceConfig(value: unknown): value is DisplayWorkspaceConfig {
+  if (!value || typeof value !== 'object') return false;
+  const config = value as DisplayWorkspaceConfig;
+  if (!Array.isArray(config.displays) || typeof config.primary !== 'string') {
+    return false;
+  }
+  return config.displays.every(isDisplayWorkspaceDefinition);
+}
+
+export default function useDisplayConfig() {
+  return usePersistentState<DisplayWorkspaceConfig>(
+    'display-config',
+    DEFAULT_DISPLAY_CONFIG,
+    isDisplayWorkspaceConfig,
+  );
+}

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -1,32 +1,80 @@
 import usePersistentState from './usePersistentState';
 import { defaults } from '../utils/settingsStore';
 
+const DEFAULT_DISPLAY_ID = 'display-1';
+
 export interface SessionWindow {
   id: string;
   x: number;
   y: number;
 }
 
+export interface WorkspaceSession {
+  windows: SessionWindow[];
+  minimized: string[];
+  focused: string | null;
+  order: string[];
+}
+
 export interface DesktopSession {
   windows: SessionWindow[];
   wallpaper: string;
   dock: string[];
+  workspaces?: Record<string, WorkspaceSession>;
+  activeDisplay?: string;
+  displays?: string[];
 }
 
 const initialSession: DesktopSession = {
   windows: [],
   wallpaper: defaults.wallpaper,
   dock: [],
+  workspaces: {
+    [DEFAULT_DISPLAY_ID]: { windows: [], minimized: [], focused: null, order: [] },
+  },
+  activeDisplay: DEFAULT_DISPLAY_ID,
+  displays: [DEFAULT_DISPLAY_ID],
 };
+
+function isSessionWindow(value: unknown): value is SessionWindow {
+  if (!value || typeof value !== 'object') return false;
+  const win = value as SessionWindow;
+  return (
+    typeof win.id === 'string' &&
+    typeof win.x === 'number' &&
+    typeof win.y === 'number'
+  );
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isWorkspaceSession(value: unknown): value is WorkspaceSession {
+  if (!value || typeof value !== 'object') return false;
+  const ws = value as WorkspaceSession;
+  return (
+    Array.isArray(ws.windows) &&
+    ws.windows.every(isSessionWindow) &&
+    isStringArray(ws.minimized) &&
+    (typeof ws.focused === 'string' || ws.focused === null) &&
+    isStringArray(ws.order)
+  );
+}
 
 function isSession(value: unknown): value is DesktopSession {
   if (!value || typeof value !== 'object') return false;
   const s = value as DesktopSession;
-  return (
-    Array.isArray(s.windows) &&
-    typeof s.wallpaper === 'string' &&
-    Array.isArray(s.dock)
-  );
+  if (!Array.isArray(s.windows) || !s.windows.every(isSessionWindow)) return false;
+  if (typeof s.wallpaper !== 'string') return false;
+  if (!isStringArray(s.dock)) return false;
+  if (s.workspaces) {
+    if (typeof s.workspaces !== 'object' || Array.isArray(s.workspaces)) return false;
+    if (!Object.values(s.workspaces).every(isWorkspaceSession)) return false;
+  }
+  if (s.activeDisplay !== undefined && typeof s.activeDisplay !== 'string') return false;
+  if (s.displays && !isStringArray(s.displays)) return false;
+  return true;
 }
 
 export default function useSession() {


### PR DESCRIPTION
## Summary
- add per-display workspace snapshots/state swapping to the Desktop manager and persist active display metadata in the session
- surface the active display on the taskbar, broadcast persistent state changes, and extend session/display hooks for multi-display support
- expose a Desktop tab in Settings for managing displays/workspaces and add regression tests covering display switches

## Testing
- yarn lint *(fails: existing accessibility issues in legacy app forms and static games)*
- yarn test *(fails: pre-existing unit test regressions around window controls, jsdom localStorage, and nmap demo fetches)*
- yarn test __tests__/desktopDisplays.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc6fc1ff348328a4d94559299defb4