### PR TITLE
[settings] Add accessible accent picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,10 @@ Browse all apps, games, and security tool demos at `/apps`, which presents a sea
 
 > The VS Code app now embeds a StackBlitz IDE via iframe instead of the local Monaco editor.
 
+### Personalization
+
+The **Settings** app centralizes themes, wallpapers, and accessibility options. Accent colors come from an accessible palette or a custom picker that enforces WCAG contrast: 4.5:1 for text placed on the accent surface and 3:1 against the desktop background for focus rings and outlines. Every saved accent updates the global design tokens (`--color-ub-orange`, `--color-focus-ring`, `--color-on-accent`, etc.), so buttons, toggles, and selection highlights refresh immediately without reloading. Accent choices persist independently of theme and wallpaper selections—switching between Default, Dark, Neon, or Matrix keeps your chosen accent while wallpapers continue to rotate or stay pinned according to your selection. Resetting the desktop (or importing an older settings file) restores the defaults.
+
 The Spotify app lets you customize a mood-to-playlist mapping. Use the in-app form to
 add, reorder, or delete moods; selections persist in the browser's Origin Private File
 System so your choices restore on load. The last mood played is remembered, and

--- a/__tests__/accentSettings.test.tsx
+++ b/__tests__/accentSettings.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, fireEvent, waitFor, renderHook, act } from '@testing-library/react';
+import { del } from 'idb-keyval';
+import type { ReactNode } from 'react';
+import Settings from '../apps/settings';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+import { getPreferredTextColor } from '../utils/color';
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <SettingsProvider>{children}</SettingsProvider>
+);
+
+beforeEach(async () => {
+  window.localStorage.clear();
+  document.documentElement.style.cssText = '';
+  await del('accent');
+});
+
+describe('accent customization', () => {
+  test('prevents saving accents with insufficient focus contrast', async () => {
+    const { unmount } = render(
+      <SettingsProvider>
+        <Settings />
+      </SettingsProvider>
+    );
+
+    const input = await screen.findByLabelText(/custom accent/i);
+    await waitFor(() =>
+      expect(document.documentElement.style.getPropertyValue('--color-ub-orange')).toBe('#1793d1')
+    );
+
+    fireEvent.change(input, { target: { value: '#10161a' } });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/focus contrast [0-9.]+:1 is below the 3:1 non-text requirement/i),
+      ).toBeInTheDocument(),
+    );
+
+    expect(document.documentElement.style.getPropertyValue('--color-ub-orange')).toBe('#1793d1');
+
+    unmount();
+  });
+
+  test('persists accessible custom accent selections', async () => {
+    const { result, unmount } = renderHook(() => useSettings(), { wrapper });
+
+    await waitFor(() => expect(result.current.accent).toBeDefined());
+
+    const customAccent = '#ff4f7a';
+    act(() => result.current.setAccent(customAccent));
+
+    await waitFor(() => expect(result.current.accent).toBe(customAccent));
+
+    await waitFor(() =>
+      expect(document.documentElement.style.getPropertyValue('--color-ub-orange')).toBe(customAccent),
+    );
+
+    const expectedTextColor = getPreferredTextColor(customAccent).text;
+    await waitFor(() =>
+      expect(document.documentElement.style.getPropertyValue('--color-on-accent')).toBe(
+        expectedTextColor,
+      ),
+    );
+
+    unmount();
+
+    const rerender = renderHook(() => useSettings(), { wrapper });
+    await waitFor(() => expect(rerender.result.current.accent).toBe(customAccent));
+
+    await waitFor(() =>
+      expect(document.documentElement.style.getPropertyValue('--color-ub-orange')).toBe(customAccent),
+    );
+
+    rerender.unmount();
+  });
+});

--- a/apps/autopsy/components/ReportExport.tsx
+++ b/apps/autopsy/components/ReportExport.tsx
@@ -60,7 +60,7 @@ const ReportExport: React.FC<ReportExportProps> = ({ caseName = 'case', artifact
       </button>
       <button
         onClick={exportReport}
-        className="bg-ub-orange px-3 py-1 rounded text-sm text-black"
+        className="bg-ub-orange px-3 py-1 rounded text-sm"
       >
         Download HTML Report
       </button>

--- a/apps/autopsy/index.tsx
+++ b/apps/autopsy/index.tsx
@@ -32,7 +32,7 @@ const AutopsyPage: React.FC = () => {
       <div className="flex space-x-2">
         <button
           className={`px-2 py-1 rounded ${
-            view === 'autopsy' ? 'bg-ub-grey text-white' : 'bg-ub-orange text-black'
+            view === 'autopsy' ? 'bg-ub-grey text-white' : 'bg-ub-orange'
           }`}
           onClick={() => setView('autopsy')}
         >
@@ -40,7 +40,7 @@ const AutopsyPage: React.FC = () => {
         </button>
         <button
           className={`px-2 py-1 rounded ${
-            view === 'keywords' ? 'bg-ub-grey text-white' : 'bg-ub-orange text-black'
+            view === 'keywords' ? 'bg-ub-grey text-white' : 'bg-ub-orange'
           }`}
           onClick={() => setView('keywords')}
         >

--- a/apps/settings/components/KeymapOverlay.tsx
+++ b/apps/settings/components/KeymapOverlay.tsx
@@ -83,7 +83,7 @@ export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
               <button
                 type="button"
                 onClick={() => setRebinding(s.description)}
-                className="px-2 py-1 bg-ub-orange text-white rounded text-sm"
+                className="px-2 py-1 bg-ub-orange rounded text-sm"
               >
                 {rebinding === s.description ? 'Press keys...' : 'Rebind'}
               </button>

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -29,7 +29,7 @@ export default function Tabs<T extends string>({
           tabIndex={active === t.id ? 0 : -1}
           onClick={() => onChange(t.id)}
           className={`px-4 py-2 focus:outline-none ${
-            active === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
+            active === t.id ? "bg-ub-orange" : "text-ubt-grey"
           }`}
         >
           {t.label}

--- a/components/apps/autopsy/KeywordSearchPanel.js
+++ b/components/apps/autopsy/KeywordSearchPanel.js
@@ -53,7 +53,7 @@ function KeywordSearchPanel({ keyword, setKeyword, artifacts, onSelect }) {
         />
         <button
           onClick={exportHits}
-          className="bg-ub-orange px-2 py-1 rounded text-sm text-black"
+          className="bg-ub-orange px-2 py-1 rounded text-sm"
         >
           Export Hits
         </button>

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -245,14 +245,14 @@ function Timeline({ events, onSelect }) {
       <div className="flex space-x-2 mb-1">
         <button
           onClick={() => setZoom((z) => Math.min(z * 2, MAX_ZOOM))}
-          className="bg-ub-orange text-black px-2 py-1 rounded"
+          className="bg-ub-orange px-2 py-1 rounded"
           aria-label="Zoom in"
         >
           +
         </button>
         <button
           onClick={() => setZoom((z) => Math.max(z / 2, MIN_ZOOM))}
-          className="bg-ub-orange text-black px-2 py-1 rounded"
+          className="bg-ub-orange px-2 py-1 rounded"
           aria-label="Zoom out"
         >
           -
@@ -732,7 +732,7 @@ function Autopsy({ initialArtifacts = null }) {
                     <button
                       className={`${
                         previewTab === 'hex'
-                          ? 'bg-ub-orange text-black'
+                          ? 'bg-ub-orange'
                           : 'bg-ub-cool-grey'
                       } px-2 py-1 rounded`}
                       onClick={() => setPreviewTab('hex')}
@@ -742,7 +742,7 @@ function Autopsy({ initialArtifacts = null }) {
                     <button
                       className={`${
                         previewTab === 'text'
-                          ? 'bg-ub-orange text-black'
+                          ? 'bg-ub-orange'
                           : 'bg-ub-cool-grey'
                       } px-2 py-1 rounded`}
                       onClick={() => setPreviewTab('text')}
@@ -753,7 +753,7 @@ function Autopsy({ initialArtifacts = null }) {
                       <button
                         className={`${
                           previewTab === 'image'
-                            ? 'bg-ub-orange text-black'
+                            ? 'bg-ub-orange'
                             : 'bg-ub-cool-grey'
                         } px-2 py-1 rounded`}
                         onClick={() => setPreviewTab('image')}

--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -500,7 +500,7 @@ const Hangman = () => {
         <button
           onClick={handleHint}
           disabled={hintCoins <= 0 || paused}
-          className="px-2 py-0.5 bg-ub-orange text-black rounded-full text-xs shadow" 
+          className="px-2 py-0.5 bg-ub-orange rounded-full text-xs shadow"
         >
           Hint ({hintCoins})
         </button>

--- a/components/apps/metasploit/metasploit.jsx
+++ b/components/apps/metasploit/metasploit.jsx
@@ -461,7 +461,7 @@ const MetasploitApp = ({
           <div className="mt-4">
             <button
               onClick={startReplay}
-              className="px-2 py-1 bg-ub-orange rounded text-black"
+              className="px-2 py-1 bg-ub-orange rounded"
             >
               Replay Mock Exploit
             </button>

--- a/components/apps/pinball.js
+++ b/components/apps/pinball.js
@@ -436,14 +436,14 @@ const Pinball = () => {
             </option>
           ))}
         </select>
-        <button className="px-2 bg-ub-orange text-black" onClick={() => setEditing(!editing)}>
+        <button className="px-2 bg-ub-orange" onClick={() => setEditing(!editing)}>
           {editing ? 'Play' : 'Edit'}
         </button>
-        <button className="px-2 bg-ub-orange text-black" onClick={saveShare}>
+        <button className="px-2 bg-ub-orange" onClick={saveShare}>
           Save/Share
         </button>
         <button
-          className="px-2 bg-ub-orange text-black"
+          className="px-2 bg-ub-orange"
           onClick={() => setLightsEnabled(!lightsEnabled)}
           aria-pressed={lightsEnabled}
         >

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -231,13 +231,13 @@ export function Settings() {
                         a.click();
                         URL.revokeObjectURL(url);
                     }}
-                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                    className="px-4 py-2 rounded bg-ub-orange"
                 >
                     Export Settings
                 </button>
                 <button
                     onClick={() => fileInput.current && fileInput.current.click()}
-                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                    className="px-4 py-2 rounded bg-ub-orange"
                 >
                     Import Settings
                 </button>
@@ -253,7 +253,7 @@ export function Settings() {
                         setHighContrast(defaults.highContrast);
                         setTheme('default');
                     }}
-                    className="px-4 py-2 rounded bg-ub-orange text-white"
+                    className="px-4 py-2 rounded bg-ub-orange"
                 >
                     Reset Desktop
                 </button>

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -71,7 +71,7 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
           {filtered.map((w, i) => (
             <li
               key={w.id}
-              className={`px-2 py-1 rounded ${i === selected ? 'bg-ub-orange text-black' : ''}`}
+              className={`px-2 py-1 rounded ${i === selected ? 'bg-ub-orange' : ''}`}
             >
               {w.title}
             </li>

--- a/docs/TASKS_UI_POLISH.md
+++ b/docs/TASKS_UI_POLISH.md
@@ -107,7 +107,7 @@ This document tracks UI polish tasks for the Kali/Ubuntu inspired desktop experi
     - **Where:** CSS tokens.
 
 25. **Accent color setting**
-    - **Accept:** Choose from 6 accents; applies to focus, selection, controls; stored persistently.
+    - **Accept:** Palette plus custom picker with WCAG 4.5:1 text and 3:1 focus contrast validation; updates focus, selection, controls, and `--color-on-accent`; persists across themes/wallpapers.
     - **Where:** Settings app + CSS variables.
 
 26. **Wallpaper fit and blur**

--- a/pages/module-workspace.tsx
+++ b/pages/module-workspace.tsx
@@ -114,7 +114,7 @@ const ModuleWorkspace: React.FC = () => {
           />
           <button
             onClick={addWorkspace}
-            className="px-2 py-1 bg-ub-orange rounded text-black"
+            className="px-2 py-1 bg-ub-orange rounded"
           >
             Create
           </button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,6 +9,7 @@
   --color-primary: #1793d1; /* kali blue accent */
   --color-secondary: #1a1f26; /* complementary dark */
   --color-accent: #1793d1; /* accent matches primary */
+  --color-on-accent: #000000; /* default accessible foreground on accent */
   /* Utility colors */
   --color-muted: #2a2e36; /* muted surfaces */
   --color-surface: #1a1f26; /* panel surfaces */
@@ -76,4 +77,8 @@ html[data-theme='matrix'] {
 *:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
+}
+
+.text-on-accent {
+  color: var(--color-on-accent);
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -516,6 +516,10 @@ textarea:focus-visible {
     outline-offset: 2px;
 }
 
+.bg-ub-orange {
+    color: var(--color-on-accent, #000000);
+}
+
 /* Enable scroll snapping for gallery containers */
 .gallery-container {
     scroll-snap-type: x mandatory;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -22,6 +22,7 @@
   --color-ubt-gedit-blue: #50B6C6;
   --color-ubt-gedit-dark: #003B70;
   --color-ub-border-orange: #1793d1;
+  --color-on-accent: #000000;
   --color-ub-dark-grey: #2a2e36;
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
@@ -73,6 +74,7 @@
   --color-ub-orange: #ffff00;
   --color-ub-lite-abrgn: #00ffff;
   --color-ub-border-orange: #ffff00;
+  --color-on-accent: #000000;
   --game-color-secondary: #ffff00;
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;

--- a/utils/color.ts
+++ b/utils/color.ts
@@ -1,0 +1,70 @@
+const HEX_REGEX = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+const expandShortHex = (value: string): string =>
+  value
+    .split('')
+    .map((char) => char + char)
+    .join('');
+
+export const normalizeHex = (value: string): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!HEX_REGEX.test(trimmed)) return null;
+  const normalized = trimmed.startsWith('#') ? trimmed.slice(1) : trimmed;
+  const hex = normalized.length === 3 ? expandShortHex(normalized) : normalized;
+  return `#${hex.toLowerCase()}`;
+};
+
+type RGB = { r: number; g: number; b: number };
+
+const hexToRgb = (hex: string): RGB | null => {
+  const normalized = normalizeHex(hex);
+  if (!normalized) return null;
+  const value = parseInt(normalized.slice(1), 16);
+  return {
+    r: (value >> 16) & 0xff,
+    g: (value >> 8) & 0xff,
+    b: value & 0xff,
+  };
+};
+
+const relativeLuminance = (hex: string): number => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return 0;
+  const toLinear = (component: number) => {
+    const channel = component / 255;
+    return channel <= 0.03928
+      ? channel / 12.92
+      : Math.pow((channel + 0.055) / 1.055, 2.4);
+  };
+  const { r, g, b } = rgb;
+  const [lr, lg, lb] = [r, g, b].map(toLinear);
+  return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+};
+
+export const contrastRatio = (foreground: string, background: string): number => {
+  const l1 = relativeLuminance(foreground);
+  const l2 = relativeLuminance(background);
+  if (l1 === 0 && l2 === 0) return 1;
+  const [light, dark] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (light + 0.05) / (dark + 0.05);
+};
+
+export const getPreferredTextColor = (
+  background: string,
+): { text: '#000000' | '#ffffff'; contrast: number } => {
+  const normalized = normalizeHex(background);
+  if (!normalized) return { text: '#ffffff', contrast: 1 };
+  const blackContrast = contrastRatio('#000000', normalized);
+  const whiteContrast = contrastRatio('#ffffff', normalized);
+  return blackContrast >= whiteContrast
+    ? { text: '#000000', contrast: blackContrast }
+    : { text: '#ffffff', contrast: whiteContrast };
+};
+
+export const meetsContrastRequirement = (background: string, minRatio = 4.5): boolean => {
+  const { contrast } = getPreferredTextColor(background);
+  return contrast >= minRatio;
+};
+
+export const MIN_ACCENT_CONTRAST = 4.5;


### PR DESCRIPTION
## Summary
- add a reusable color utility and expose MIN_ACCENT_CONTRAST for settings validation
- normalize/persist custom accents in the settings provider and update accent token consumers
- refresh the settings UI with palette + custom picker, contrast feedback, docs, and tests

## Testing
- yarn test __tests__/accentSettings.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc6fc6ac548328b6bced8923661fcf