### PR TITLE
desktop: add DND scheduling and accessibility labels

### DIFF
--- a/__tests__/dnd.test.tsx
+++ b/__tests__/dnd.test.tsx
@@ -1,0 +1,99 @@
+import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import { renderHook, act, render, waitFor, screen } from '@testing-library/react';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+import { NotificationCenter } from '../components/common/NotificationCenter';
+import Toast from '../components/ui/Toast';
+
+describe('Do Not Disturb integration', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('toggleDnd updates override state', () => {
+    const { result } = renderHook(() => useSettings(), {
+      wrapper: SettingsProvider,
+    });
+
+    expect(result.current.dndActive).toBe(false);
+    expect(result.current.dndOverride).toBeNull();
+
+    act(() => {
+      result.current.toggleDnd();
+    });
+    expect(result.current.dndActive).toBe(true);
+    expect(result.current.dndOverride).toBe('on');
+
+    act(() => {
+      result.current.toggleDnd();
+    });
+    expect(result.current.dndActive).toBe(false);
+    expect(result.current.dndOverride).toBe('off');
+
+    act(() => {
+      result.current.clearDndOverride();
+    });
+    expect(result.current.dndOverride).toBeNull();
+  });
+
+  test('suppresses toast but logs notification when DND active', async () => {
+    const Harness = forwardRef<
+      {
+        enableDnd: () => void;
+        showToast: (message: string) => void;
+      }
+    >((_, ref) => {
+      const { setDndOverride } = useSettings();
+      const [toast, setToast] = useState('');
+
+      useImperativeHandle(
+        ref,
+        () => ({
+          enableDnd: () => setDndOverride('on'),
+          showToast: (message: string) => setToast(message),
+        }),
+        [setDndOverride]
+      );
+
+      if (!toast) return null;
+
+      return (
+        <Toast
+          appId="Unit Test"
+          message={toast}
+          onClose={() => setToast('')}
+        />
+      );
+    });
+    Harness.displayName = 'Harness';
+
+    const ref = React.createRef<{
+      enableDnd: () => void;
+      showToast: (message: string) => void;
+    }>();
+
+    render(
+      <SettingsProvider>
+        <NotificationCenter>
+          <Harness ref={ref} />
+        </NotificationCenter>
+      </SettingsProvider>
+    );
+
+    await waitFor(() => expect(ref.current).toBeDefined());
+
+    act(() => {
+      ref.current!.enableDnd();
+    });
+
+    act(() => {
+      ref.current!.showToast('Suppressed toast');
+    });
+
+    expect(screen.queryByRole('status')).toBeNull();
+
+    await waitFor(() => {
+      expect(screen.getByText('Unit Test')).toBeInTheDocument();
+      expect(screen.getByText('Suppressed toast')).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -82,7 +82,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -199,7 +199,12 @@ describe('Window snapping finalize and release', () => {
     expect(ref.current!.state.snapped).toBe('left');
 
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown({
+        key: 'ArrowDown',
+        altKey: true,
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+      } as any);
     });
 
     expect(ref.current!.state.snapped).toBeNull();

--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -151,6 +151,7 @@ const ContactApp: React.FC = () => {
               value={name}
               onChange={(e) => setName(e.target.value)}
               required
+              aria-label="Name"
             />
             <svg
               className="pointer-events-none absolute left-3 top-1/2 h-6 w-6 -translate-y-1/2 text-gray-400"
@@ -182,6 +183,7 @@ const ContactApp: React.FC = () => {
               required
               aria-invalid={!!emailError}
               aria-describedby={emailError ? "contact-email-error" : undefined}
+              aria-label="Email"
             />
             <svg
               className="pointer-events-none absolute left-3 top-1/2 h-6 w-6 -translate-y-1/2 text-gray-400"
@@ -218,6 +220,7 @@ const ContactApp: React.FC = () => {
               required
               aria-invalid={!!messageError}
               aria-describedby={messageError ? "contact-message-error" : undefined}
+              aria-label="Message"
             />
             <svg
               className="pointer-events-none absolute left-3 top-3 h-6 w-6 text-gray-400"
@@ -247,6 +250,7 @@ const ContactApp: React.FC = () => {
           className="hidden"
           tabIndex={-1}
           autoComplete="off"
+          aria-label="Leave this field empty"
         />
         {error && <FormError>{error}</FormError>}
         <button
@@ -261,7 +265,7 @@ const ContactApp: React.FC = () => {
           )}
         </button>
       </form>
-      {toast && <Toast message={toast} onClose={() => setToast("")} />}
+      {toast && <Toast appId="Contact" message={toast} onClose={() => setToast("")} />}
     </div>
   );
 };

--- a/apps/metasploit/index.tsx
+++ b/apps/metasploit/index.tsx
@@ -140,6 +140,7 @@ const MetasploitPage: React.FC = () => {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           className="w-full p-1 mb-2 border rounded"
+          aria-label="Search modules"
         />
         <div className="flex flex-wrap gap-1 mb-2">
           <button
@@ -199,6 +200,7 @@ const MetasploitPage: React.FC = () => {
               type="text"
               placeholder="Payload options..."
               className="border p-1 w-full"
+              aria-label="Payload options"
             />
             <button
               onClick={handleGenerate}
@@ -209,7 +211,7 @@ const MetasploitPage: React.FC = () => {
           </div>
         </div>
       </div>
-      {toast && <Toast message={toast} onClose={() => setToast('')} />}
+      {toast && <Toast appId="Metasploit" message={toast} onClose={() => setToast('')} />}
     </div>
   );
 };

--- a/components/apps/Games/common/Overlay.tsx
+++ b/components/apps/Games/common/Overlay.tsx
@@ -10,11 +10,13 @@ export default function Overlay({
   onResume,
   muted: externalMuted,
   onToggleSound,
+  appId = 'Games',
 }: {
   onPause?: () => void;
   onResume?: () => void;
   muted?: boolean;
   onToggleSound?: (muted: boolean) => void;
+  appId?: string;
 }) {
   const [paused, setPaused] = useState(false);
   const [muted, setMuted] = useState(externalMuted ?? false);
@@ -98,6 +100,7 @@ export default function Overlay({
       </div>
       {toast && (
         <Toast
+          appId={appId}
           message={toast}
           onClose={() => setToast('')}
           duration={1000000}

--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -204,6 +204,7 @@ const NmapNSEApp = () => {
             value={target}
             onChange={(e) => setTarget(e.target.value)}
             className="w-full p-2 text-black"
+            aria-label="Target"
           />
         </div>
         <div className="mb-4">
@@ -216,42 +217,55 @@ const NmapNSEApp = () => {
             onChange={(e) => setScriptQuery(e.target.value)}
             placeholder="Search scripts"
             className="w-full p-2 text-black mb-2"
+            aria-label="Script search"
           />
           <div className="max-h-64 overflow-y-auto grid grid-cols-1 sm:grid-cols-2 gap-2">
-            {filteredScripts.map((s) => (
-              <div key={s.name} className="bg-white text-black p-2 rounded">
-                <label className="flex items-center space-x-2">
-                  <input
-                    type="checkbox"
-                    checked={selectedScripts.includes(s.name)}
-                    onChange={() => toggleScript(s.name)}
-                  />
-                  <span className="font-mono">{s.name}</span>
-                </label>
-                <p className="text-xs mb-1">{s.description}</p>
-                <div className="flex flex-wrap gap-1 mb-1">
-                  {s.tags.map((t) => (
-                    <span key={t} className="px-1 text-xs bg-gray-200 rounded">
-                      {t}
+            {filteredScripts.map((s) => {
+              const slug = s.name.replace(/[^a-z0-9-]/gi, '-');
+              const checkboxId = `script-${slug}`;
+              const checkboxLabelId = `${checkboxId}-label`;
+              const optionsId = `script-${slug}-options`;
+              return (
+                <div key={s.name} className="bg-white text-black p-2 rounded">
+                  <label className="flex items-center space-x-2" htmlFor={checkboxId}>
+                    <span id={checkboxLabelId} className="font-mono">
+                      {s.name}
                     </span>
-                  ))}
+                    <input
+                      id={checkboxId}
+                      type="checkbox"
+                      aria-labelledby={checkboxLabelId}
+                      checked={selectedScripts.includes(s.name)}
+                      onChange={() => toggleScript(s.name)}
+                    />
+                  </label>
+                  <p className="text-xs mb-1">{s.description}</p>
+                  <div className="flex flex-wrap gap-1 mb-1">
+                    {s.tags.map((t) => (
+                      <span key={t} className="px-1 text-xs bg-gray-200 rounded">
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+                  {selectedScripts.includes(s.name) && (
+                    <input
+                      id={optionsId}
+                      type="text"
+                      aria-label={`Options for ${s.name}`}
+                      value={scriptOptions[s.name] || ''}
+                      onChange={(e) =>
+                        setScriptOptions((prev) => ({
+                          ...prev,
+                          [s.name]: e.target.value,
+                        }))
+                      }
+                      placeholder="arg=value"
+                      className="w-full p-1 border rounded text-black"
+                    />
+                  )}
                 </div>
-                {selectedScripts.includes(s.name) && (
-                  <input
-                    type="text"
-                    value={scriptOptions[s.name] || ''}
-                    onChange={(e) =>
-                      setScriptOptions((prev) => ({
-                        ...prev,
-                        [s.name]: e.target.value,
-                      }))
-                    }
-                    placeholder="arg=value"
-                    className="w-full p-1 border rounded text-black"
-                  />
-                )}
-              </div>
-            ))}
+              );
+            })}
             {filteredScripts.length === 0 && (
               <p className="text-sm">No scripts found.</p>
             )}
@@ -435,7 +449,7 @@ const NmapNSEApp = () => {
           </button>
         </div>
       </div>
-      {toast && <Toast message={toast} onClose={() => setToast('')} />}
+      {toast && <Toast appId="Nmap NSE" message={toast} onClose={() => setToast('')} />}
     </div>
   );
 };

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,4 +1,6 @@
 import React, { createContext, useCallback, useEffect, useState } from 'react';
+import type { DndSchedule } from '../../hooks/useSettings';
+import { useSettings } from '../../hooks/useSettings';
 
 export interface AppNotification {
   id: string;
@@ -14,8 +16,30 @@ interface NotificationsContextValue {
 
 export const NotificationsContext = createContext<NotificationsContextValue | null>(null);
 
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+const formatDays = (days: number[]) => {
+  if (!days || days.length === 0) return 'Every day';
+  const normalized = Array.from(new Set(days)).map((day) => ((day % 7) + 7) % 7).sort((a, b) => a - b);
+  if (normalized.length === 7) return 'Every day';
+  if (normalized.length === 5 && normalized.every((day, index) => day === index + 1)) return 'Weekdays';
+  if (normalized.length === 2 && normalized[0] === 0 && normalized[1] === 6) return 'Weekends';
+  return normalized.map((day) => DAY_NAMES[day]).join(', ');
+};
+
+const isValidTimeValue = (value: string) => /^([01]\d|2[0-3]):([0-5]\d)$/.test(value);
+
 export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
+  const {
+    dndActive,
+    dndOverride,
+    dndScheduleActive,
+    dndSchedules,
+    toggleDnd,
+    clearDndOverride,
+    updateDndSchedule,
+  } = useSettings();
 
   const pushNotification = useCallback((appId: string, message: string) => {
     setNotifications(prev => {
@@ -49,6 +73,32 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
     0
   );
 
+  const handleScheduleToggle = useCallback(
+    (id: string, enabled: boolean) => {
+      updateDndSchedule(id, { enabled });
+    },
+    [updateDndSchedule]
+  );
+
+  const handleTimeChange = (
+    id: string,
+    field: 'start' | 'end'
+  ) => (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    if (!isValidTimeValue(value)) return;
+    updateDndSchedule(id, { [field]: value } as Partial<Omit<DndSchedule, 'id'>>);
+  };
+
+  const dndStatusLabel = (() => {
+    if (dndOverride === 'on') return 'Active (manual)';
+    if (dndOverride === 'off') return 'Off (manual override)';
+    if (dndScheduleActive) return 'Active (scheduled)';
+    return 'Off';
+  })();
+
+  const toggleLabel = dndActive ? 'Turn off now' : 'Turn on now';
+  const showScheduleResume = dndOverride !== null;
+
   useEffect(() => {
     const nav: any = navigator;
     if (nav && nav.setAppBadge) {
@@ -62,17 +112,124 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
       value={{ notifications, pushNotification, clearNotifications }}
     >
       {children}
-      <div className="notification-center">
-        {Object.entries(notifications).map(([appId, list]) => (
-          <section key={appId} className="notification-group">
-            <h3>{appId}</h3>
-            <ul>
-              {list.map(n => (
-                <li key={n.id}>{n.message}</li>
-              ))}
-            </ul>
-          </section>
-        ))}
+      <div className="notification-center space-y-4">
+        <section className="notification-group rounded-md border border-white/10 bg-black/60 p-4 text-sm text-white space-y-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h3 className="text-base font-semibold">Do Not Disturb</h3>
+              <p className="text-xs text-white/70">{dndStatusLabel}</p>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={toggleDnd}
+                className="rounded border border-white/20 px-3 py-1 text-xs font-medium uppercase tracking-wide hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
+              >
+                {toggleLabel}
+              </button>
+              {showScheduleResume && (
+                <button
+                  type="button"
+                  onClick={clearDndOverride}
+                  className="rounded border border-white/20 px-3 py-1 text-xs font-medium uppercase tracking-wide hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
+                >
+                  Use schedules
+                </button>
+              )}
+            </div>
+          </div>
+          <div className="space-y-3">
+            {dndSchedules.map((schedule) => {
+              const toggleId = `${schedule.id}-toggle`;
+              const toggleLabelId = `${toggleId}-label`;
+              const startId = `${schedule.id}-start`;
+              const endId = `${schedule.id}-end`;
+              const startLabelId = `${startId}-label`;
+              const endLabelId = `${endId}-label`;
+              return (
+                <div
+                  key={schedule.id}
+                  className="rounded border border-white/10 bg-black/40 p-3"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="font-medium">{schedule.label}</p>
+                      {schedule.description && (
+                        <p className="text-xs text-white/60">{schedule.description}</p>
+                      )}
+                      <p className="mt-1 text-xs text-white/60">{formatDays(schedule.days)}</p>
+                    </div>
+                    <label htmlFor={toggleId} className="flex items-center gap-2 text-sm">
+                      <span id={toggleLabelId} className="sr-only">
+                        {`Enable ${schedule.label}`}
+                      </span>
+                      <span aria-hidden>{schedule.enabled ? 'On' : 'Off'}</span>
+                      <input
+                        id={toggleId}
+                        type="checkbox"
+                        aria-labelledby={toggleLabelId}
+                        checked={schedule.enabled}
+                        onChange={(event) =>
+                          handleScheduleToggle(schedule.id, event.target.checked)
+                        }
+                      />
+                    </label>
+                  </div>
+                  <div className="mt-3 grid grid-cols-2 gap-3 text-sm">
+                    <label className="flex flex-col gap-1" htmlFor={startId}>
+                      <span
+                        id={startLabelId}
+                        className="text-xs text-white/60 uppercase tracking-wide"
+                      >
+                        Start
+                      </span>
+                      <input
+                        id={startId}
+                        type="time"
+                        aria-labelledby={startLabelId}
+                        value={schedule.start}
+                        onChange={handleTimeChange(schedule.id, 'start')}
+                        className="rounded border border-white/20 bg-black/60 px-2 py-1 text-white focus:outline-none focus:ring-2 focus:ring-white/40"
+                        step="60"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1" htmlFor={endId}>
+                      <span
+                        id={endLabelId}
+                        className="text-xs text-white/60 uppercase tracking-wide"
+                      >
+                        End
+                      </span>
+                      <input
+                        id={endId}
+                        type="time"
+                        aria-labelledby={endLabelId}
+                        value={schedule.end}
+                        onChange={handleTimeChange(schedule.id, 'end')}
+                        className="rounded border border-white/20 bg-black/60 px-2 py-1 text-white focus:outline-none focus:ring-2 focus:ring-white/40"
+                        step="60"
+                      />
+                    </label>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+        {Object.entries(notifications).length === 0 ? (
+          <p className="text-sm text-white/60">No notifications yet.</p>
+        ) : (
+          Object.entries(notifications).map(([appId, list]) => (
+            <section key={appId} className="notification-group">
+              <h3>{appId}</h3>
+              <ul>
+                {list.map((n) => (
+                  <li key={n.id}>{n.message}</li>
+                ))}
+              </ul>
+            </section>
+          ))
+        )}
       </div>
     </NotificationsContext.Provider>
   );

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { useEffect, useId } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import { useSettings } from '../../hooks/useSettings';
 
 interface Props {
   open: boolean;
@@ -12,6 +13,23 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const { dndActive, dndScheduleActive, dndOverride, toggleDnd } = useSettings();
+  const dndLabelId = useId();
+  const dndControlId = useId();
+  const dndStatusId = useId();
+  const soundLabelId = useId();
+  const soundControlId = useId();
+  const networkLabelId = useId();
+  const networkControlId = useId();
+  const reduceMotionLabelId = useId();
+  const reduceMotionControlId = useId();
+
+  const dndStatus = (() => {
+    if (dndOverride === 'on') return 'Manual';
+    if (dndOverride === 'off') return 'Override off';
+    if (dndScheduleActive) return 'Scheduled';
+    return 'Off';
+  })();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -27,6 +45,25 @@ const QuickSettings = ({ open }: Props) => {
         open ? '' : 'hidden'
       }`}
     >
+      <label
+        htmlFor={dndControlId}
+        className="px-4 pb-2 flex justify-between items-center gap-4 cursor-pointer"
+      >
+        <span className="flex flex-col">
+          <span id={dndLabelId}>Do Not Disturb</span>
+          <span id={dndStatusId} className="text-xs text-white/70">
+            {dndStatus}
+          </span>
+        </span>
+        <input
+          id={dndControlId}
+          type="checkbox"
+          aria-labelledby={dndLabelId}
+          aria-describedby={dndStatusId}
+          checked={dndActive}
+          onChange={() => toggleDnd()}
+        />
+      </label>
       <div className="px-4 pb-2">
         <button
           className="w-full flex justify-between"
@@ -36,22 +73,45 @@ const QuickSettings = ({ open }: Props) => {
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
+      <label
+        htmlFor={soundControlId}
+        className="px-4 pb-2 flex justify-between items-center cursor-pointer"
+      >
+        <span id={soundLabelId}>Sound</span>
         <input
+          id={soundControlId}
           type="checkbox"
+          aria-labelledby={soundLabelId}
+          checked={sound}
+          onChange={() => setSound(!sound)}
+        />
+      </label>
+      <label
+        htmlFor={networkControlId}
+        className="px-4 pb-2 flex justify-between items-center cursor-pointer"
+      >
+        <span id={networkLabelId}>Network</span>
+        <input
+          id={networkControlId}
+          type="checkbox"
+          aria-labelledby={networkLabelId}
+          checked={online}
+          onChange={() => setOnline(!online)}
+        />
+      </label>
+      <label
+        htmlFor={reduceMotionControlId}
+        className="px-4 flex justify-between items-center cursor-pointer"
+      >
+        <span id={reduceMotionLabelId}>Reduced motion</span>
+        <input
+          id={reduceMotionControlId}
+          type="checkbox"
+          aria-labelledby={reduceMotionLabelId}
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
         />
-      </div>
+      </label>
     </div>
   );
 };

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -3,6 +3,58 @@
 import { get, set, del } from 'idb-keyval';
 import { getTheme, setTheme } from './theme';
 
+let localStorageWarningIssued = false;
+
+const memoryStorage = (() => {
+  const store = new Map();
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => {
+      store.set(key, String(value));
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+})();
+
+const getLocalStorage = () => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch (error) {
+    if (!localStorageWarningIssued && process.env.NODE_ENV !== 'test') {
+      console.warn('localStorage unavailable; using in-memory fallback', error);
+      localStorageWarningIssued = true;
+    }
+    return memoryStorage;
+  }
+};
+
+const DEFAULT_DND_SCHEDULES = [
+  {
+    id: 'work-hours',
+    label: 'Work hours',
+    description: 'Weekdays 09:00 – 17:00',
+    start: '09:00',
+    end: '17:00',
+    days: [1, 2, 3, 4, 5],
+    enabled: false,
+  },
+  {
+    id: 'quiet-nights',
+    label: 'Quiet nights',
+    description: 'Every day 22:00 – 07:00',
+    start: '22:00',
+    end: '07:00',
+    days: [0, 1, 2, 3, 4, 5, 6],
+    enabled: false,
+  },
+];
+
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
   wallpaper: 'wall-2',
@@ -14,7 +66,112 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  dnd: getDefaultDndSettings(),
 };
+
+function cloneSchedule(schedule) {
+  return {
+    ...schedule,
+    days: Array.isArray(schedule.days) ? [...schedule.days] : [],
+  };
+}
+
+export function getDefaultDndSchedules() {
+  return DEFAULT_DND_SCHEDULES.map((schedule) => cloneSchedule(schedule));
+}
+
+export function getDefaultDndSettings() {
+  return {
+    override: null,
+    schedules: getDefaultDndSchedules(),
+  };
+}
+
+function sanitizeTime(value, fallback) {
+  if (typeof value !== 'string') return fallback;
+  const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(value.trim());
+  if (!match) return fallback;
+  return `${match[1]}:${match[2]}`;
+}
+
+function sanitizeDays(days, fallback) {
+  if (!Array.isArray(days)) return [...fallback];
+  const normalized = days
+    .map((day) => (typeof day === 'number' ? day : parseInt(day, 10)))
+    .filter((day) => Number.isInteger(day) && day >= 0 && day <= 6);
+  if (!normalized.length) return [...fallback];
+  return Array.from(new Set(normalized)).sort((a, b) => a - b);
+}
+
+export async function getDndSettings() {
+  const storage = getLocalStorage();
+  if (!storage) return getDefaultDndSettings();
+  let raw = null;
+  try {
+    raw = storage.getItem('dnd-settings');
+  } catch (error) {
+    if (!localStorageWarningIssued && process.env.NODE_ENV !== 'test') {
+      console.warn('localStorage unavailable; falling back to defaults', error);
+      localStorageWarningIssued = true;
+    }
+    return getDefaultDndSettings();
+  }
+  if (!raw) return getDefaultDndSettings();
+  try {
+    const parsed = JSON.parse(raw);
+    const defaults = getDefaultDndSettings();
+    const schedules = defaults.schedules.map((defaultSchedule) => {
+      if (!parsed?.schedules) return cloneSchedule(defaultSchedule);
+      const stored = parsed.schedules.find((item) => item.id === defaultSchedule.id);
+      if (!stored) return cloneSchedule(defaultSchedule);
+      return {
+        ...defaultSchedule,
+        start: sanitizeTime(stored.start, defaultSchedule.start),
+        end: sanitizeTime(stored.end, defaultSchedule.end),
+        days: sanitizeDays(stored.days, defaultSchedule.days),
+        enabled: Boolean(stored.enabled),
+      };
+    });
+    const override = parsed.override === 'on' || parsed.override === 'off' ? parsed.override : null;
+    return {
+      override,
+      schedules,
+    };
+  } catch (error) {
+    console.warn('Invalid DND settings detected, using defaults', error);
+    return getDefaultDndSettings();
+  }
+}
+
+export async function setDndSettings(value) {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  const defaults = getDefaultDndSettings();
+  const byId = new Map(defaults.schedules.map((schedule) => [schedule.id, schedule]));
+  const schedules = (value?.schedules || defaults.schedules).map((schedule) => {
+    const fallback = byId.get(schedule.id) || defaults.schedules[0];
+    return {
+      ...fallback,
+      start: sanitizeTime(schedule.start, fallback.start),
+      end: sanitizeTime(schedule.end, fallback.end),
+      days: sanitizeDays(schedule.days, fallback.days),
+      enabled: Boolean(schedule.enabled),
+    };
+  });
+  const override = value?.override === 'on' || value?.override === 'off' ? value.override : null;
+  const payload = {
+    override,
+    schedules,
+  };
+  try {
+    storage.setItem('dnd-settings', JSON.stringify(payload));
+  } catch (error) {
+    if (!localStorageWarningIssued && process.env.NODE_ENV !== 'test') {
+      console.warn('localStorage unavailable; falling back to defaults', error);
+      localStorageWarningIssued = true;
+    }
+  }
+}
 
 export async function getAccent() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
@@ -37,90 +194,110 @@ export async function setWallpaper(wallpaper) {
 }
 
 export async function getDensity() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.density;
+  return storage.getItem('density') || DEFAULT_SETTINGS.density;
 }
 
 export async function setDensity(density) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('density', density);
 }
 
 export async function getReducedMotion() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  const stored = window.localStorage.getItem('reduced-motion');
-  if (stored !== null) {
-    return stored === 'true';
+  const storage = getLocalStorage();
+  if (storage) {
+    const stored = storage.getItem('reduced-motion');
+    if (stored !== null) {
+      return stored === 'true';
+    }
   }
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
+  return DEFAULT_SETTINGS.reducedMotion;
 }
 
 export async function setReducedMotion(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.fontScale;
+  const stored = storage.getItem('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('font-scale', String(scale));
 }
 
 export async function getHighContrast() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.highContrast;
+  return storage.getItem('high-contrast') === 'true';
 }
 
 export async function setHighContrast(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('high-contrast', value ? 'true' : 'false');
 }
 
 export async function getLargeHitAreas() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.largeHitAreas;
+  return storage.getItem('large-hit-areas') === 'true';
 }
 
 export async function setLargeHitAreas(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
 export async function getHaptics() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
-  const val = window.localStorage.getItem('haptics');
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.haptics;
+  const val = storage.getItem('haptics');
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
 export async function setHaptics(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('haptics', value ? 'true' : 'false');
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('haptics', value ? 'true' : 'false');
 }
 
 export async function getPongSpin() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.pongSpin;
+  const val = storage.getItem('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
 export async function setPongSpin(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('pong-spin', value ? 'true' : 'false');
 }
 
 export async function getAllowNetwork() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
+  const storage = getLocalStorage();
+  if (!storage) return DEFAULT_SETTINGS.allowNetwork;
+  return storage.getItem('allow-network') === 'true';
 }
 
 export async function setAllowNetwork(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem('allow-network', value ? 'true' : 'false');
 }
 
 export async function resetSettings() {
@@ -129,14 +306,17 @@ export async function resetSettings() {
     del('accent'),
     del('bg-image'),
   ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.removeItem('density');
+  storage.removeItem('reduced-motion');
+  storage.removeItem('font-scale');
+  storage.removeItem('high-contrast');
+  storage.removeItem('large-hit-areas');
+  storage.removeItem('pong-spin');
+  storage.removeItem('allow-network');
+  storage.removeItem('haptics');
+  storage.removeItem('dnd-settings');
 }
 
 export async function exportSettings() {
@@ -151,6 +331,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    dnd,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +343,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getDndSettings(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -176,6 +358,7 @@ export async function exportSettings() {
     allowNetwork,
     haptics,
     theme,
+    dnd,
   });
 }
 
@@ -200,6 +383,7 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    dnd,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -212,6 +396,7 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (dnd !== undefined) await setDndSettings(dnd);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- implement Do Not Disturb scheduling, overrides, and persistence with notification center integration
- surface DND controls in the quick settings tray, suppress toasts while active, and attribute notifications by app
- add accessible labels for DND toggles and toast callers to satisfy lint rules

## Testing
- `npx eslint hooks/useSettings.tsx components/ui/QuickSettings.tsx components/common/NotificationCenter.tsx components/ui/Toast.tsx apps/contact/index.tsx apps/metasploit/index.tsx components/apps/nmap-nse/index.js components/apps/Games/common/Overlay.tsx __tests__/dnd.test.tsx`
- `yarn test __tests__/dnd.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68cc6fd980148328950243f9f8eb6722