### PR TITLE
screen: add task preview hover

### DIFF
--- a/components/screen/task-preview.tsx
+++ b/components/screen/task-preview.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Image from 'next/image';
+import { toCanvas } from 'html-to-image';
+import { useSettings } from '../../hooks/useSettings';
+
+const MAX_WIDTH = 280;
+const MAX_HEIGHT = 180;
+const DEFAULT_WIDTH = 220;
+const DEFAULT_HEIGHT = 140;
+const VIEWPORT_PADDING = 12;
+const HEADER_HEIGHT = 40;
+
+type AnchorRect = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+type TaskPreviewProps = {
+  app: { id: string; title: string; icon: string } | null;
+  anchor: AnchorRect | null;
+  minimized: boolean;
+  visible: boolean;
+  onClose: (id: string) => void;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+};
+
+type FrameSize = {
+  width: number;
+  height: number;
+  scaledWidth: number;
+  scaledHeight: number;
+};
+
+type Status = 'idle' | 'loading' | 'ready' | 'minimized' | 'missing' | 'error';
+
+const defaultFrame: FrameSize = {
+  width: DEFAULT_WIDTH,
+  height: DEFAULT_HEIGHT,
+  scaledWidth: DEFAULT_WIDTH,
+  scaledHeight: DEFAULT_HEIGHT,
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const TaskPreview: React.FC<TaskPreviewProps> = ({
+  app,
+  anchor,
+  minimized,
+  visible,
+  onClose,
+  onMouseEnter,
+  onMouseLeave,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const frameRef = useRef<number>();
+  const [frameSize, setFrameSize] = useState<FrameSize>(defaultFrame);
+  const [status, setStatus] = useState<Status>('idle');
+  const { reducedMotion } = useSettings();
+
+  const captureFrame = useCallback(async () => {
+    if (!app || !canvasRef.current) {
+      setStatus((prev) => (prev === 'missing' ? prev : 'missing'));
+      return;
+    }
+
+    const node = document.getElementById(app.id);
+    if (!node) {
+      setStatus((prev) => (prev === 'missing' ? prev : 'missing'));
+      return;
+    }
+
+    const computed = window.getComputedStyle(node);
+    const rect = node.getBoundingClientRect();
+    const hidden =
+      computed.visibility === 'hidden' ||
+      computed.display === 'none' ||
+      rect.width === 0 ||
+      rect.height === 0;
+
+    if (minimized || hidden) {
+      setStatus((prev) => (prev === 'ready' ? prev : 'minimized'));
+      return;
+    }
+
+    try {
+      const offscreen = await toCanvas(node, { cacheBust: false });
+      const canvas = canvasRef.current;
+      const context = canvas?.getContext('2d');
+      if (!canvas || !context) {
+        setStatus('error');
+        return;
+      }
+
+      canvas.width = offscreen.width;
+      canvas.height = offscreen.height;
+      context.clearRect(0, 0, canvas.width, canvas.height);
+      context.drawImage(offscreen, 0, 0);
+
+      const scale = Math.min(MAX_WIDTH / offscreen.width, MAX_HEIGHT / offscreen.height, 1);
+      const scaledWidth = Math.max(Math.round(offscreen.width * scale), 120);
+      const scaledHeight = Math.max(Math.round(offscreen.height * scale), 80);
+
+      setFrameSize({
+        width: offscreen.width,
+        height: offscreen.height,
+        scaledWidth,
+        scaledHeight,
+      });
+      setStatus('ready');
+    } catch (error) {
+      setStatus('error');
+    }
+  }, [app, minimized]);
+
+  useEffect(() => {
+    if (!visible) {
+      if (frameRef.current) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = undefined;
+      }
+      return;
+    }
+
+    setStatus('loading');
+    let cancelled = false;
+
+    const loop = async () => {
+      if (cancelled) return;
+      await captureFrame();
+      if (!cancelled && !reducedMotion) {
+        frameRef.current = requestAnimationFrame(loop);
+      }
+    };
+
+    loop();
+
+    return () => {
+      cancelled = true;
+      if (frameRef.current) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = undefined;
+      }
+    };
+  }, [captureFrame, reducedMotion, visible]);
+
+  useEffect(() => {
+    if (!visible) {
+      setStatus('idle');
+      setFrameSize(defaultFrame);
+    }
+  }, [visible]);
+
+  const style = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return {
+        left: '50%',
+        top: `calc(100% - ${defaultFrame.scaledHeight + HEADER_HEIGHT + VIEWPORT_PADDING}px)`,
+        width: defaultFrame.scaledWidth,
+      } as React.CSSProperties;
+    }
+
+    const width = frameSize.scaledWidth;
+    const height = frameSize.scaledHeight + HEADER_HEIGHT;
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    let left = anchor
+      ? anchor.left + anchor.width / 2 - width / 2
+      : viewportWidth / 2 - width / 2;
+    left = clamp(left, VIEWPORT_PADDING, viewportWidth - width - VIEWPORT_PADDING);
+
+    let top = anchor
+      ? anchor.top - frameSize.scaledHeight - HEADER_HEIGHT - VIEWPORT_PADDING
+      : viewportHeight - height - VIEWPORT_PADDING;
+
+    if (top < VIEWPORT_PADDING && anchor) {
+      top = anchor.top + anchor.height + VIEWPORT_PADDING;
+    }
+
+    if (top + height > viewportHeight - VIEWPORT_PADDING) {
+      top = viewportHeight - height - VIEWPORT_PADDING;
+    }
+
+    return {
+      left,
+      top,
+      width,
+    } as React.CSSProperties;
+  }, [anchor, frameSize]);
+
+  if (!visible || !app) {
+    return null;
+  }
+
+  const statusMessage = (() => {
+    switch (status) {
+      case 'loading':
+        return 'Loading preview…';
+      case 'minimized':
+        return 'Window is minimized';
+      case 'missing':
+        return 'Preview unavailable';
+      case 'error':
+        return 'Unable to render preview';
+      default:
+        return null;
+    }
+  })();
+
+  const handleClose = () => {
+    onClose(app.id);
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label={`${app.title} preview`}
+      className="fixed z-50 rounded-lg shadow-lg bg-ub-dark-surface border border-black border-opacity-50 text-white"
+      style={style}
+      data-testid="task-preview"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <div className="flex items-center justify-between px-3" style={{ height: HEADER_HEIGHT }}>
+        <div className="flex items-center gap-2">
+          <Image
+            src={app.icon.replace('./', '/')}
+            alt=""
+            width={24}
+            height={24}
+            className="w-5 h-5"
+            sizes="24px"
+          />
+          <span className="text-sm font-medium">{app.title}</span>
+        </div>
+        <button
+          type="button"
+          className="rounded px-2 py-1 text-xs bg-red-600 hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-300"
+          onClick={handleClose}
+          aria-label={`Close ${app.title}`}
+          data-testid="task-preview-close"
+        >
+          Close
+        </button>
+      </div>
+      <div
+        className="relative bg-black bg-opacity-80 rounded-b-lg overflow-hidden"
+        style={{ width: frameSize.scaledWidth, height: frameSize.scaledHeight }}
+      >
+        <canvas ref={canvasRef} className="w-full h-full" />
+        {statusMessage && (
+          <div className="absolute inset-0 flex items-center justify-center text-xs bg-black bg-opacity-60">
+            {statusMessage}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TaskPreview;

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -2,7 +2,31 @@ import React from 'react';
 import Image from 'next/image';
 
 export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const runningApps = React.useMemo(
+        () => props.apps.filter(app => props.closed_windows[app.id] === false),
+        [props.apps, props.closed_windows]
+    );
+    const buttonRefs = React.useRef({});
+
+    React.useEffect(() => {
+        const activeIds = new Set(runningApps.map(app => app.id));
+        Object.keys(buttonRefs.current).forEach((key) => {
+            if (!activeIds.has(key)) {
+                delete buttonRefs.current[key];
+            }
+        });
+    }, [runningApps]);
+
+    React.useEffect(() => {
+        if (!props.pendingFocusId) return;
+        const target = buttonRefs.current[props.pendingFocusId];
+        if (target && typeof target.focus === 'function') {
+            target.focus();
+        }
+        if (props.onPendingFocusHandled) {
+            props.onPendingFocusHandled();
+        }
+    }, [props.pendingFocusId, props.onPendingFocusHandled]);
 
     const handleClick = (app) => {
         const id = app.id;
@@ -15,6 +39,38 @@ export default function Taskbar(props) {
         }
     };
 
+    const assignRef = React.useCallback((id) => (node) => {
+        if (node) {
+            buttonRefs.current[id] = node;
+        } else {
+            delete buttonRefs.current[id];
+        }
+    }, []);
+
+    const showPreview = (event, app) => {
+        if (props.onPreviewStart) {
+            const rect = event.currentTarget.getBoundingClientRect();
+            props.onPreviewStart(app.id, {
+                left: rect.left,
+                top: rect.top,
+                width: rect.width,
+                height: rect.height,
+            });
+        }
+    };
+
+    const hidePreview = () => {
+        if (props.onPreviewEnd) {
+            props.onPreviewEnd();
+        }
+    };
+
+    const clearPreview = () => {
+        if (props.onPreviewClear) {
+            props.onPreviewClear();
+        }
+    };
+
     return (
         <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
             {runningApps.map(app => (
@@ -24,7 +80,15 @@ export default function Taskbar(props) {
                     aria-label={app.title}
                     data-context="taskbar"
                     data-app-id={app.id}
-                    onClick={() => handleClick(app)}
+                    ref={assignRef(app.id)}
+                    onClick={() => {
+                        handleClick(app);
+                        clearPreview();
+                    }}
+                    onMouseEnter={(event) => showPreview(event, app)}
+                    onMouseLeave={hidePreview}
+                    onFocus={(event) => showPreview(event, app)}
+                    onBlur={hidePreview}
                     className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
                         'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
                 >

--- a/tests/task-preview.spec.ts
+++ b/tests/task-preview.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test, Page } from '@playwright/test';
+
+async function openApp(page: Page, appId: string) {
+  await page.evaluate((id) => {
+    window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
+  }, appId);
+  await page.locator(`button[data-app-id="${appId}"]`).first().waitFor();
+}
+
+test.describe('task previews', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('#desktop');
+  });
+
+  test('shows a live preview when hovering a running app', async ({ page }) => {
+    await openApp(page, 'terminal');
+
+    const taskButton = page.locator('button[data-app-id="terminal"]').first();
+    await taskButton.hover();
+
+    const preview = page.locator('[data-testid="task-preview"]');
+    await expect(preview).toBeVisible();
+    await expect(preview.locator('text=Terminal')).toBeVisible();
+
+    await page.mouse.move(10, 10);
+    await expect(preview).toHaveCount(0);
+  });
+
+  test('closing from the preview focuses the next window', async ({ page }) => {
+    await openApp(page, 'terminal');
+    await openApp(page, 'calculator');
+
+    const terminalButton = page.locator('button[data-app-id="terminal"]').first();
+    const calculatorButton = page.locator('button[data-app-id="calculator"]').first();
+
+    await terminalButton.hover();
+    const preview = page.locator('[data-testid="task-preview"]');
+    await expect(preview).toBeVisible();
+
+    await preview.locator('[data-testid="task-preview-close"]').click();
+
+    await expect(terminalButton).toHaveCount(0);
+    await expect(calculatorButton).toBeFocused();
+  });
+});


### PR DESCRIPTION
## Summary
- add a TaskPreview canvas component that streams window frames and honours reduced motion
- wire Desktop and Taskbar to manage preview visibility, focus handoff, and close actions from hover cards
- add Playwright coverage for hovering previews and closing via the preview controls

## Testing
- yarn lint *(fails: existing accessibility and lint errors in unrelated files)*
- yarn test *(fails: pre-existing unit and API tests require additional environment configuration)*
- npx playwright test *(fails: Playwright browsers not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc77e2f05883289900a7f3571097e7