### PR TITLE
[tiling] add ctrl+drag tiling overlay

### DIFF
--- a/components/screen/tiling-overlay.tsx
+++ b/components/screen/tiling-overlay.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export type TilingTemplateOption = {
+  id: string;
+  label: string;
+  rows: number;
+  cols: number;
+};
+
+const TEMPLATE_OPTIONS: TilingTemplateOption[] = [
+  { id: '2x2', label: '2 × 2', rows: 2, cols: 2 },
+  { id: '1x3', label: '1 × 3', rows: 1, cols: 3 },
+  { id: '2x3', label: '2 × 3', rows: 2, cols: 3 },
+];
+
+export interface TilingOverlayProps {
+  visible: boolean;
+  onSelect(option: TilingTemplateOption): void;
+  onCancel(): void;
+  activeTemplateId?: string | null;
+}
+
+const previewCellClass =
+  'border border-white border-opacity-30 bg-white bg-opacity-10 rounded-sm';
+
+const TilingOverlay: React.FC<TilingOverlayProps> = ({
+  visible,
+  onSelect,
+  onCancel,
+  activeTemplateId,
+}) => {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!visible) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [visible, onCancel]);
+
+  const options = useMemo(() => TEMPLATE_OPTIONS, []);
+
+  if (!mounted || !visible) {
+    return null;
+  }
+
+  const content = (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onCancel();
+        }
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Choose window tiling layout"
+        className="w-full max-w-md rounded-lg border border-white border-opacity-20 bg-gray-900 bg-opacity-95 p-6 text-white shadow-xl"
+      >
+        <div className="mb-4">
+          <h2 className="text-lg font-semibold">Tiling layouts</h2>
+          <p className="text-sm text-gray-200 text-opacity-80">
+            Pick a grid to place the active window. The layout will be reused for
+            the next window you tile.
+          </p>
+        </div>
+        <div className="grid gap-4">
+          {options.map((option) => {
+            const isActive = option.id === activeTemplateId;
+            return (
+              <button
+                key={option.id}
+                type="button"
+                data-template={option.id}
+                className={`flex w-full items-center justify-between rounded-md border px-4 py-3 text-left transition focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-900 ${
+                  isActive
+                    ? 'border-blue-400 bg-blue-500 bg-opacity-20'
+                    : 'border-white border-opacity-20 hover:border-blue-300 hover:bg-white hover:bg-opacity-10'
+                }`}
+                onClick={() => onSelect(option)}
+              >
+                <div>
+                  <div className="text-base font-medium">{option.label}</div>
+                  <div className="text-xs text-gray-300">
+                    {option.rows} row{option.rows > 1 ? 's' : ''} × {option.cols}
+                    {' '}
+                    column{option.cols > 1 ? 's' : ''}
+                  </div>
+                </div>
+                <div
+                  className="ml-4 grid gap-1"
+                  style={{ gridTemplateRows: `repeat(${option.rows}, minmax(0, 1fr))`, gridTemplateColumns: `repeat(${option.cols}, minmax(0, 1fr))`, width: '4.5rem', height: '3rem' }}
+                  aria-hidden="true"
+                >
+                  {Array.from({ length: option.rows * option.cols }).map((_, index) => (
+                    <div key={index} className={previewCellClass} />
+                  ))}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+        <div className="mt-6 flex justify-end">
+          <button
+            type="button"
+            className="rounded-md border border-white border-opacity-20 px-4 py-2 text-sm hover:border-blue-300 hover:bg-white hover:bg-opacity-10 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-900"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(content, document.body);
+};
+
+export default TilingOverlay;

--- a/tests/window-tiling.spec.ts
+++ b/tests/window-tiling.spec.ts
@@ -1,0 +1,189 @@
+import { test, expect, Page } from '@playwright/test';
+
+type TemplateConfig = {
+  id: string;
+  rows: number;
+  cols: number;
+};
+
+const templates: TemplateConfig[] = [
+  { id: '2x2', rows: 2, cols: 2 },
+  { id: '1x3', rows: 1, cols: 3 },
+  { id: '2x3', rows: 2, cols: 3 },
+];
+
+const TILING_DIALOG_LABEL = 'Choose window tiling layout';
+
+async function openTilingOverlay(page: Page, windowName: string) {
+  const titleBar = page.getByRole('button', { name: windowName }).first();
+  await expect(titleBar).toBeVisible();
+  const box = await titleBar.boundingBox();
+  if (!box) throw new Error(`Unable to measure title bar for ${windowName}`);
+
+  const centerX = box.x + box.width / 2;
+  const centerY = box.y + box.height / 2;
+
+  await page.mouse.move(centerX, centerY);
+  await page.keyboard.down('Control');
+  await page.mouse.down();
+  await page.mouse.move(centerX + 20, centerY, { steps: 5 });
+  await page.mouse.up();
+  await page.keyboard.up('Control');
+
+  const overlay = page.getByRole('dialog', { name: TILING_DIALOG_LABEL });
+  await expect(overlay).toBeVisible();
+  return overlay;
+}
+
+async function computeExpectedRect(
+  page: Page,
+  template: TemplateConfig,
+  cellIndex: number,
+) {
+  return page.evaluate(
+    ({ template, cellIndex }) => {
+      let snapEnabled = true;
+      try {
+        const stored = window.localStorage.getItem('snap-enabled');
+        if (stored !== null) {
+          snapEnabled = JSON.parse(stored);
+        }
+      } catch (e) {
+        snapEnabled = true;
+      }
+      const gridSize = snapEnabled ? 8 : 1;
+      const snap = (value: number) =>
+        gridSize <= 1 ? value : Math.round(value / gridSize) * gridSize;
+      const area = document.getElementById('window-area');
+      const areaRect = area ? area.getBoundingClientRect() : null;
+      const areaWidth = areaRect ? areaRect.width : window.innerWidth;
+      const areaHeight = areaRect ? areaRect.height : window.innerHeight;
+      const cols = template.cols || 1;
+      const rows = template.rows || 1;
+      const col = cellIndex % cols;
+      const row = Math.floor(cellIndex / cols);
+      const cellWidth = areaWidth / cols;
+      const cellHeight = areaHeight / rows;
+      const snappedWidth = snap(cellWidth);
+      const snappedHeight = snap(cellHeight);
+      let x = snap(col * cellWidth);
+      let y = snap(row * cellHeight);
+      const maxX = Math.max(areaWidth - snappedWidth, 0);
+      const maxY = Math.max(areaHeight - snappedHeight, 0);
+      if (x > maxX) x = snap(maxX);
+      if (y > maxY) y = snap(maxY);
+      return {
+        x,
+        y,
+        width: snappedWidth,
+        height: snappedHeight,
+      };
+    },
+    { template, cellIndex },
+  );
+}
+
+async function getWindowRect(page: Page, name: string) {
+  return page.evaluate((ariaLabel) => {
+    const node = document.querySelector(
+      `[role="dialog"][aria-label="${ariaLabel}"]`,
+    ) as HTMLElement | null;
+    if (!node) return null;
+    const rect = node.getBoundingClientRect();
+    return {
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+    };
+  }, name);
+}
+
+async function applyTemplate(
+  page: Page,
+  windowName: string,
+  template: TemplateConfig,
+  templateCell: number,
+) {
+  const overlay = await openTilingOverlay(page, windowName);
+  await page.locator(`[data-template="${template.id}"]`).click();
+  await expect(overlay).toBeHidden();
+
+  const expected = await computeExpectedRect(page, template, templateCell);
+  await page.waitForFunction(
+    ({ name, expected }) => {
+      const node = document.querySelector(
+        `[role="dialog"][aria-label="${name}"]`,
+      ) as HTMLElement | null;
+      if (!node) return false;
+      const rect = node.getBoundingClientRect();
+      return (
+        Math.abs(rect.x - expected.x) <= 2 &&
+        Math.abs(rect.y - expected.y) <= 2 &&
+        Math.abs(rect.width - expected.width) <= 4 &&
+        Math.abs(rect.height - expected.height) <= 4
+      );
+    },
+    { name: windowName, expected },
+  );
+
+  const firstRect = await getWindowRect(page, windowName);
+  if (!firstRect) throw new Error(`Window ${windowName} not found`);
+  await page.waitForTimeout(150);
+  const secondRect = await getWindowRect(page, windowName);
+  if (!secondRect) throw new Error(`Window ${windowName} not found`);
+  expect(Math.abs(secondRect.x - firstRect.x)).toBeLessThanOrEqual(1);
+  expect(Math.abs(secondRect.y - firstRect.y)).toBeLessThanOrEqual(1);
+  expect(Math.abs(secondRect.width - firstRect.width)).toBeLessThanOrEqual(1);
+  expect(Math.abs(secondRect.height - firstRect.height)).toBeLessThanOrEqual(1);
+
+  return firstRect;
+}
+
+test.describe('window tiling overlay', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.removeItem('window-tiling-templates');
+        window.localStorage.setItem('snap-enabled', 'true');
+      } catch (e) {
+        // ignore storage reset failures
+      }
+    });
+    await page.goto('/');
+    await expect(page.getByRole('dialog', { name: 'About Alex' })).toBeVisible();
+  });
+
+  for (const template of templates) {
+    test(`applies ${template.id} layout without jitter`, async ({ page }) => {
+      const rect = await applyTemplate(page, 'About Alex', template, 0);
+      const expected = await computeExpectedRect(page, template, 0);
+      expect(Math.abs(rect.x - expected.x)).toBeLessThanOrEqual(2);
+      expect(Math.abs(rect.y - expected.y)).toBeLessThanOrEqual(2);
+      expect(Math.abs(rect.width - expected.width)).toBeLessThanOrEqual(4);
+      expect(Math.abs(rect.height - expected.height)).toBeLessThanOrEqual(4);
+    });
+  }
+
+  test('tiles multiple windows sequentially in the same template', async ({ page }) => {
+    await applyTemplate(page, 'About Alex', templates[0], 0);
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('open-app', { detail: 'terminal' }));
+    });
+    await expect(page.getByRole('dialog', { name: 'Terminal' })).toBeVisible();
+
+    const terminalRect = await applyTemplate(page, 'Terminal', templates[0], 1);
+    const aboutRect = await getWindowRect(page, 'About Alex');
+    if (!aboutRect) throw new Error('About Alex window missing after tiling');
+
+    const expectedAbout = await computeExpectedRect(page, templates[0], 0);
+    expect(Math.abs(aboutRect.x - expectedAbout.x)).toBeLessThanOrEqual(2);
+    expect(Math.abs(aboutRect.y - expectedAbout.y)).toBeLessThanOrEqual(2);
+
+    const expectedTerminal = await computeExpectedRect(page, templates[0], 1);
+    expect(Math.abs(terminalRect.x - expectedTerminal.x)).toBeLessThanOrEqual(2);
+    expect(Math.abs(terminalRect.y - expectedTerminal.y)).toBeLessThanOrEqual(2);
+    expect(Math.abs(aboutRect.x - terminalRect.x)).toBeGreaterThanOrEqual(aboutRect.width - 8);
+  });
+});


### PR DESCRIPTION
## Summary
- add a tiling overlay component and surface it from window ctrl+drag
- track template assignments in desktop state and align resized windows to the snap grid
- add Playwright end-to-end coverage for each tiling template

## Testing
- yarn lint *(fails: repository has existing jsx-a11y and no-top-level-window violations)*
- yarn test *(fails: existing suites such as window/nmap/battleship exceed act/localStorage expectations)*
- npx playwright test *(fails: Next.js dev build for /apps and / timing out during page.goto)*

------
https://chatgpt.com/codex/tasks/task_e_68cc77ea1ce0832897de65f8a84375eb