### PR TITLE
[desktop] Improve fullscreen window handling

### DIFF
--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,17 +1,6 @@
-import React, { useState, useEffect } from 'react'
-import logger from '../../utils/logger'
+import React from 'react'
 
 function DesktopMenu(props) {
-
-    const [isFullScreen, setIsFullScreen] = useState(false)
-
-    useEffect(() => {
-        document.addEventListener('fullscreenchange', checkFullScreen);
-        return () => {
-            document.removeEventListener('fullscreenchange', checkFullScreen);
-        };
-    }, [])
-
 
     const openTerminal = () => {
         props.openApp("terminal");
@@ -19,28 +8,6 @@ function DesktopMenu(props) {
 
     const openSettings = () => {
         props.openApp("settings");
-    }
-
-    const checkFullScreen = () => {
-        if (document.fullscreenElement) {
-            setIsFullScreen(true)
-        } else {
-            setIsFullScreen(false)
-        }
-    }
-
-    const goFullScreen = () => {
-        // make website full screen
-        try {
-            if (document.fullscreenElement) {
-                document.exitFullscreen()
-            } else {
-                document.documentElement.requestFullscreen()
-            }
-        }
-        catch (e) {
-            logger.error(e)
-        }
     }
 
     return (
@@ -110,13 +77,13 @@ function DesktopMenu(props) {
             </button>
             <Devider />
             <button
-                onClick={goFullScreen}
+                onClick={props.onToggleFullScreen}
                 type="button"
                 role="menuitem"
-                aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
+                aria-label={props.isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
-                <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
+                <span className="ml-5">{props.isFullScreen ? "Exit" : "Enter"} Full Screen</span>
             </button>
             <Devider />
             <button

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -15,6 +15,9 @@ let renderApps = (props) => {
 
 export default function SideBar(props) {
 
+    const forceHidden = props.forceHidden;
+    const isHidden = props.hide || forceHidden;
+
     function showSideBar() {
         props.hideSideBar(null, false);
     }
@@ -29,7 +32,9 @@ export default function SideBar(props) {
         <>
             <nav
                 aria-label="Dock"
-                className={(props.hide ? " -translate-x-full " : "") +
+                aria-hidden={isHidden ? 'true' : undefined}
+                className={(isHidden ? " -translate-x-full " : "") +
+                    (forceHidden ? " opacity-0 pointer-events-none " : "") +
                     " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
             >
                 {
@@ -41,7 +46,9 @@ export default function SideBar(props) {
                 }
                 <AllApps showApps={props.showAllApps} />
             </nav>
-            <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-50"}></div>
+            {!forceHidden && (
+                <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-50"}></div>
+            )}
         </>
     )
 }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -15,8 +15,17 @@ export default function Taskbar(props) {
         }
     };
 
+    const hidden = props.hidden;
+    const containerClass =
+        (hidden ? ' translate-y-full opacity-0 pointer-events-none ' : ' ') +
+        'absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40';
+
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div
+            className={containerClass}
+            role="toolbar"
+            aria-hidden={hidden ? 'true' : undefined}
+        >
             {runningApps.map(app => (
                 <button
                     key={app.id}

--- a/tests/window.behavior.spec.ts
+++ b/tests/window.behavior.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+const tolerance = 4;
+
+test.describe('desktop window behavior', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('#about-alex')).toBeVisible();
+  });
+
+  test('double clicking the title bar toggles maximize and restore', async ({ page }) => {
+    const windowLocator = page.locator('#about-alex');
+    const titleBar = windowLocator.locator('.bg-ub-window-title');
+
+    const initial = await windowLocator.boundingBox();
+    if (!initial) throw new Error('Initial window bounds unavailable');
+
+    await titleBar.dblclick();
+    await page.waitForTimeout(400);
+    const maximized = await windowLocator.boundingBox();
+    if (!maximized) throw new Error('Maximized window bounds unavailable');
+
+    expect(maximized.width).toBeGreaterThan(initial.width + 100);
+    expect(maximized.height).toBeGreaterThan(initial.height + 50);
+
+    await titleBar.dblclick();
+    await page.waitForTimeout(400);
+    const restored = await windowLocator.boundingBox();
+    if (!restored) throw new Error('Restored window bounds unavailable');
+
+    expect(Math.abs(restored.x - initial.x)).toBeLessThanOrEqual(tolerance);
+    expect(Math.abs(restored.y - initial.y)).toBeLessThanOrEqual(tolerance);
+    expect(Math.abs(restored.width - initial.width)).toBeLessThanOrEqual(tolerance);
+    expect(Math.abs(restored.height - initial.height)).toBeLessThanOrEqual(tolerance);
+  });
+
+  test('fullscreen mode hides chrome and restores on exit', async ({ page }) => {
+    const desktop = page.locator('#desktop');
+    const taskbar = page.locator('[role="toolbar"]');
+
+    await expect(taskbar).toBeVisible();
+
+    await page.click('#window-area', { button: 'right' });
+    const menu = page.locator('#desktop-menu');
+    await expect(menu).toBeVisible();
+    await menu.getByRole('menuitem', { name: /Enter Full Screen/i }).click();
+
+    await expect.poll(async () => page.evaluate(() => document.fullscreenElement !== null)).toBeTruthy();
+    await expect(desktop).toHaveClass(/.*pt-0.*/);
+    await expect(taskbar).not.toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect.poll(async () => page.evaluate(() => document.fullscreenElement === null)).toBeTruthy();
+    await expect(desktop).toHaveClass(/.*pt-8.*/);
+    await expect(taskbar).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- capture window bounds before maximizing and use them to restore windows on double-click or keyboard toggles
- centralize desktop fullscreen state to hide the chrome/taskbar and expose the toggle through the context menu
- add Playwright coverage that exercises window maximize/restore and fullscreen entry/exit flows

## Testing
- yarn lint *(fails: repository has many existing accessibility violations)*
- yarn test *(fails: existing suites fail before exercising new changes)*
- npx playwright test *(fails: container is missing required system dependencies for Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68cc77edbc40832884542fba77a76537