### PR TITLE
[desktop] refine window focus styling

### DIFF
--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -7,3 +7,41 @@
   height: calc(100% + 10px);
   width: calc(100% - 10px);
 }
+
+.window {
+  --window-shadow-current: var(--window-shadow-inactive);
+  --window-opacity-current: var(--window-opacity-active);
+  --window-brightness-current: 1;
+  --window-titlebar-current: var(--window-titlebar-inactive);
+  box-shadow: var(--window-shadow-current);
+  transition: box-shadow var(--motion-fast) ease, filter var(--motion-fast) ease;
+  filter: opacity(var(--window-opacity-current)) brightness(var(--window-brightness-current));
+}
+
+.windowActive {
+  --window-shadow-current: var(--window-shadow-active);
+  --window-opacity-current: var(--window-opacity-active);
+  --window-brightness-current: 1;
+  --window-titlebar-current: var(--window-titlebar-active);
+}
+
+.windowInactive {
+  --window-shadow-current: var(--window-shadow-inactive);
+  --window-opacity-current: var(--window-opacity-inactive);
+  --window-brightness-current: 0.95;
+  --window-titlebar-current: var(--window-titlebar-inactive);
+}
+
+.titleBar {
+  background-color: var(--window-titlebar-current);
+  color: var(--window-titlebar-text);
+  transition: background-color var(--motion-fast) ease, color var(--motion-fast) ease;
+}
+
+.titleBarActive {
+  --window-titlebar-current: var(--window-titlebar-active);
+}
+
+.titleBarInactive {
+  --window-titlebar-current: var(--window-titlebar-inactive);
+}

--- a/docs/TASKS_UI_POLISH.md
+++ b/docs/TASKS_UI_POLISH.md
@@ -259,3 +259,8 @@ This document tracks UI polish tasks for the Kali/Ubuntu inspired desktop experi
     - **Accept:** 1200×630 Open Graph, 1080×1080 square fallback; served as static files and referenced in meta.
     - **Where:** `public/images/social/*`.
 
+
+### Focus contrast audit – window chrome
+
+- **Before:** Active and inactive title bars both used `#0C0F12` against `#F5F5F5` copy (contrast ratio 17.63:1).
+- **After:** Active title bar remains `#0C0F12` (17.63:1) while the inactive state shifts to `#1B1F24`, delivering a 15.19:1 contrast that stays above WCAG AA requirements while visually signalling blur.

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -27,6 +27,15 @@
   --color-text: #F5F5F5;
   --kali-bg: rgba(15, 19, 23, 0.85);
 
+  /* Window states */
+  --window-shadow-active: 0 18px 48px rgba(0, 0, 0, 0.55);
+  --window-shadow-inactive: 0 12px 32px rgba(0, 0, 0, 0.4);
+  --window-opacity-active: 1;
+  --window-opacity-inactive: 0.94;
+  --window-titlebar-active: var(--color-ub-window-title);
+  --window-titlebar-inactive: var(--color-ub-med-abrgn);
+  --window-titlebar-text: var(--color-text);
+
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
   --game-color-success: #15803d;


### PR DESCRIPTION
## Summary
- add dedicated tokens for active/inactive window shadows, opacity, and title bar colors and wire them into the window CSS module
- update the window component to react to desktop focus broadcasts, toggle focus classes, and expose data attributes for tests
- queue desktop focus broadcasts to fire quickly, clean up timers, and record the contrast audit in the UI polish notes

## Testing
- yarn test __tests__/window.test.tsx
- ⚠️ yarn lint (hangs on this repo; verified changed modules with `npx eslint components/base/window.js __tests__/window.test.tsx --max-warnings=0`)


------
https://chatgpt.com/codex/tasks/task_e_68cc77ee494c8328822c4910593a2b8b