### PR TITLE
[desktop] adopt shared context menu and edge tests

### DIFF
--- a/components/apps/ClipboardManager.tsx
+++ b/components/apps/ClipboardManager.tsx
@@ -68,6 +68,19 @@ const ClipboardManager: React.FC = () => {
     loadItems();
   }, [loadItems]);
 
+  useEffect(() => {
+    const handleExternalAdd = (event: Event) => {
+      const detail = (event as CustomEvent<{ text?: string }>).detail;
+      const text = detail?.text?.trim();
+      if (text) {
+        void addItem(text);
+      }
+    };
+
+    window.addEventListener('clipboard-manager:add', handleExternalAdd);
+    return () => window.removeEventListener('clipboard-manager:add', handleExternalAdd);
+  }, [addItem]);
+
   const handleCopy = useCallback(async () => {
     try {
       const perm = await (navigator.permissions as any)?.query?.({

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -31,18 +31,29 @@ export class UbuntuApp extends Component {
     }
 
     render() {
+        const isList = this.props.viewMode === 'list'
+        const classes = [
+            this.state.launching ? 'app-icon-launch' : '',
+            this.state.dragging ? 'opacity-70' : '',
+            'p-1 m-px z-10 select-none text-white font-normal transition-hover transition-active border border-transparent outline-none rounded',
+            'focus:border-yellow-700 focus:border-opacity-100',
+            this.props.selected ? 'bg-white bg-opacity-20 border-blue-500 border-opacity-60' : 'bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50',
+            isList ? 'w-64 max-w-xs h-auto flex flex-row items-center gap-3 px-3 py-2 text-left text-sm' : 'w-24 h-20 flex flex-col justify-start items-center text-center text-xs'
+        ].filter(Boolean).join(' ')
+
         return (
             <div
                 role="button"
                 aria-label={this.props.name}
                 aria-disabled={this.props.disabled}
+                aria-selected={this.props.selected}
+                data-view-mode={this.props.viewMode}
                 data-context="app"
                 data-app-id={this.props.id}
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
-                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                className={classes}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
@@ -53,7 +64,7 @@ export class UbuntuApp extends Component {
                 <Image
                     width={40}
                     height={40}
-                    className="mb-1 w-10"
+                    className={isList ? 'w-10' : 'mb-1 w-10'}
                     src={this.props.icon.replace('./', '/')}
                     alt={"Kali " + this.props.name}
                     sizes="40px"

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -1,122 +1,268 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';
 
-export interface MenuItem {
-  label: React.ReactNode;
-  onSelect: () => void;
+export type CloseReason = 'escape' | 'pointer' | 'select' | 'programmatic';
+
+interface AnchorPoint {
+  x: number;
+  y: number;
 }
 
-interface ContextMenuProps {
-  /** Element that triggers this context menu */
-  targetRef: React.RefObject<HTMLElement>;
-  /** Menu items to render */
-  items: MenuItem[];
+interface ContextMenuContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  open: boolean;
+  anchorPoint: AnchorPoint | null;
+  onClose: (reason?: CloseReason) => void;
+  label?: string;
+  labelledBy?: string;
 }
 
-/**
- * Accessible context menu that supports right click and Shift+F10
- * activation. Uses roving tab index for keyboard navigation and
- * dispatches global events when opened/closed so backgrounds can
- * be made inert.
- */
-const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
-  const [open, setOpen] = useState(false);
-  const [pos, setPos] = useState({ x: 0, y: 0 });
-  const menuRef = useRef<HTMLDivElement>(null);
+interface ContextMenuItemProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onSelect'> {
+  onSelect?: () => void | Promise<void>;
+  role?: 'menuitem' | 'menuitemcheckbox' | 'menuitemradio';
+  checked?: boolean;
+}
 
-  useFocusTrap(menuRef as React.RefObject<HTMLElement>, open);
-  useRovingTabIndex(
-    menuRef as React.RefObject<HTMLElement>,
-    open,
-    'vertical',
-  );
+interface MenuContextValue {
+  close: (reason?: CloseReason) => void;
+}
 
-  useEffect(() => {
-    const node = targetRef.current;
-    if (!node) return;
+const MenuContext = React.createContext<MenuContextValue | null>(null);
 
-    const handleContextMenu = (e: MouseEvent) => {
-      e.preventDefault();
-      setPos({ x: e.pageX, y: e.pageY });
-      setOpen(true);
-    };
+export const ContextMenuContent = React.forwardRef<HTMLDivElement, ContextMenuContentProps>(
+  (
+    {
+      open,
+      anchorPoint,
+      onClose,
+      className = '',
+      children,
+      label,
+      labelledBy,
+      id,
+      ...rest
+    },
+    forwardedRef
+  ) => {
+    const menuRef = useRef<HTMLDivElement>(null);
+    useImperativeHandle(forwardedRef, () => menuRef.current as HTMLDivElement);
 
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.shiftKey && e.key === 'F10') {
-        e.preventDefault();
-        const rect = node.getBoundingClientRect();
-        setPos({ x: rect.left, y: rect.bottom });
-        setOpen(true);
+    const [position, setPosition] = useState<AnchorPoint>({ x: -9999, y: -9999 });
+    const wasOpen = useRef(false);
+    const lastCloseReason = useRef<CloseReason>('programmatic');
+
+    const close = useCallback(
+      (reason?: CloseReason) => {
+        lastCloseReason.current = reason ?? 'programmatic';
+        onClose?.(reason);
+      },
+      [onClose]
+    );
+
+    useFocusTrap(menuRef as React.RefObject<HTMLElement>, open);
+    useRovingTabIndex(menuRef as React.RefObject<HTMLElement>, open, 'vertical');
+
+    useEffect(() => {
+      if (open && !wasOpen.current) {
+        window.dispatchEvent(new CustomEvent('context-menu-open'));
+      } else if (!open && wasOpen.current) {
+        window.dispatchEvent(
+          new CustomEvent('context-menu-close', {
+            detail: { reason: lastCloseReason.current },
+          })
+        );
+        lastCloseReason.current = 'programmatic';
       }
-    };
+      wasOpen.current = open;
+    }, [open]);
 
-    node.addEventListener('contextmenu', handleContextMenu);
-    node.addEventListener('keydown', handleKeyDown);
+    useLayoutEffect(() => {
+      if (!open || !anchorPoint) return;
+      const menu = menuRef.current;
+      if (!menu) return;
 
-    return () => {
-      node.removeEventListener('contextmenu', handleContextMenu);
-      node.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [targetRef]);
+      const OFFSET = 4;
+      const { innerHeight, innerWidth } = window;
 
-  useEffect(() => {
-    if (open) {
-      window.dispatchEvent(new CustomEvent('context-menu-open'));
-    } else {
-      window.dispatchEvent(new CustomEvent('context-menu-close'));
-    }
-  }, [open]);
+      // Ensure the menu is measured with up-to-date dimensions.
+      menu.style.visibility = 'hidden';
+      menu.style.left = `${anchorPoint.x}px`;
+      menu.style.top = `${anchorPoint.y}px`;
+      const rect = menu.getBoundingClientRect();
 
-  useEffect(() => {
-    if (!open) return;
+      let left = anchorPoint.x + OFFSET;
+      let top = anchorPoint.y + OFFSET;
 
-    const handleClick = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setOpen(false);
+      if (left + rect.width > innerWidth) {
+        left = anchorPoint.x - rect.width - OFFSET;
       }
-    };
-
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setOpen(false);
+      if (top + rect.height > innerHeight) {
+        top = anchorPoint.y - rect.height - OFFSET;
       }
-    };
 
-    document.addEventListener('mousedown', handleClick);
-    document.addEventListener('keydown', handleEscape);
+      left = Math.min(left, innerWidth - rect.width - OFFSET);
+      top = Math.min(top, innerHeight - rect.height - OFFSET);
+      left = Math.max(OFFSET, left);
+      top = Math.max(OFFSET, top);
 
-    return () => {
-      document.removeEventListener('mousedown', handleClick);
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [open]);
+      setPosition({ x: left, y: top });
+      menu.style.visibility = '';
+    }, [open, anchorPoint?.x, anchorPoint?.y]);
 
-  return (
-    <div
-      role="menu"
-      ref={menuRef}
-      aria-hidden={!open}
-      style={{ left: pos.x, top: pos.y }}
-      className={(open ? 'block ' : 'hidden ') +
-        'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
-    >
-      {items.map((item, i) => (
-        <button
-          key={i}
-          role="menuitem"
-          tabIndex={-1}
-          onClick={() => {
-            item.onSelect();
-            setOpen(false);
-          }}
-          className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+    useEffect(() => {
+      if (!open) return;
+
+      const handlePointer = (event: MouseEvent) => {
+        if (!menuRef.current?.contains(event.target as Node)) {
+          close('pointer');
+        }
+      };
+
+      const handleKey = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          window.dispatchEvent(
+            new CustomEvent('context-menu-request-close', {
+              detail: { reason: 'escape' },
+            })
+          );
+          close('escape');
+        }
+      };
+
+      document.addEventListener('mousedown', handlePointer);
+      document.addEventListener('contextmenu', handlePointer);
+      document.addEventListener('keydown', handleKey);
+
+      return () => {
+        document.removeEventListener('mousedown', handlePointer);
+        document.removeEventListener('contextmenu', handlePointer);
+        document.removeEventListener('keydown', handleKey);
+      };
+    }, [open, close]);
+
+    useEffect(() => {
+      if (!open) return;
+      const firstFocusable = menuRef.current?.querySelector<HTMLElement>(
+        '[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]'
+      );
+      firstFocusable?.focus();
+    }, [open]);
+
+    const providerValue = useMemo<MenuContextValue>(() => ({ close }), [close]);
+
+    return (
+      <MenuContext.Provider value={providerValue}>
+        <div
+          {...rest}
+          id={id}
+          ref={menuRef}
+          role="menu"
+          aria-hidden={!open}
+          aria-label={label}
+          aria-labelledby={labelledBy}
+          className={`${open ? 'block ' : 'hidden '}cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm ${className}`.trim()}
+          style={{ left: position.x, top: position.y }}
+          onMouseDown={(event) => event.stopPropagation()}
         >
-          {item.label}
-        </button>
-      ))}
-    </div>
-  );
+          {children}
+        </div>
+      </MenuContext.Provider>
+    );
+  }
+);
+
+ContextMenuContent.displayName = 'ContextMenuContent';
+
+export const ContextMenuItem = React.forwardRef<HTMLButtonElement, ContextMenuItemProps>(
+  (
+    { onSelect, className = '', role = 'menuitem', checked, disabled, children, ...rest },
+    ref
+  ) => {
+    const ctx = useContext(MenuContext);
+
+    const handleSelect = useCallback(() => {
+      if (disabled) return;
+      const result = onSelect?.();
+      if (result && typeof (result as Promise<unknown>).then === 'function') {
+        (result as Promise<unknown>).finally(() => ctx?.close('select'));
+      } else {
+        ctx?.close('select');
+      }
+    }, [onSelect, ctx, disabled]);
+
+    return (
+      <button
+        {...rest}
+        ref={ref}
+        type="button"
+        role={role}
+        tabIndex={-1}
+        aria-disabled={disabled ? 'true' : undefined}
+        aria-checked={
+          role === 'menuitemcheckbox' || role === 'menuitemradio' ? checked : undefined
+        }
+        disabled={disabled}
+        className={`w-full text-left cursor-default py-1.5 px-4 mb-1 last:mb-0 hover:bg-gray-700 focus-visible:bg-gray-700 focus:outline-none ${disabled ? 'text-gray-400 hover:bg-transparent cursor-not-allowed' : ''} ${className}`.trim()}
+        onClick={(event) => {
+          event.stopPropagation();
+          if (disabled) return;
+          handleSelect();
+        }}
+        onKeyDown={(event) => {
+          if ((event.key === 'Enter' || event.key === ' ') && !disabled) {
+            event.preventDefault();
+            handleSelect();
+          }
+        }}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+ContextMenuItem.displayName = 'ContextMenuItem';
+
+interface ContextMenuSeparatorProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const ContextMenuSeparator: React.FC<ContextMenuSeparatorProps> = ({ className = '', ...rest }) => (
+  <div
+    {...rest}
+    role="separator"
+    className={`flex justify-center w-full ${className}`.trim()}
+  >
+    <div className="border-t border-gray-900 py-1 w-2/5" />
+  </div>
+);
+
+interface ContextMenuLabelProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const ContextMenuLabel: React.FC<ContextMenuLabelProps> = ({ className = '', children, ...rest }) => (
+  <div
+    {...rest}
+    role="presentation"
+    className={`px-4 pb-1 text-xs uppercase tracking-wide text-gray-400 ${className}`.trim()}
+  >
+    {children}
+  </div>
+);
+
+const ContextMenu = {
+  Content: ContextMenuContent,
+  Item: ContextMenuItem,
+  Separator: ContextMenuSeparator,
+  Label: ContextMenuLabel,
 };
 
 export default ContextMenu;

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,144 +1,140 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
+import {
+    ContextMenuContent,
+    ContextMenuItem,
+    ContextMenuSeparator,
+} from '../common/ContextMenu'
 import logger from '../../utils/logger'
 
-function DesktopMenu(props) {
-
+function DesktopMenu({
+    open,
+    anchorPoint,
+    onClose,
+    onNewFolder,
+    onCreateShortcut,
+    onPaste,
+    canPaste,
+    onSelectAll,
+    sortOrder,
+    onToggleSort,
+    viewMode,
+    onToggleView,
+    openTerminal,
+    openSettings,
+    onClearSession,
+}) {
     const [isFullScreen, setIsFullScreen] = useState(false)
 
     useEffect(() => {
-        document.addEventListener('fullscreenchange', checkFullScreen);
-        return () => {
-            document.removeEventListener('fullscreenchange', checkFullScreen);
-        };
+        const handleFullScreen = () => setIsFullScreen(Boolean(document.fullscreenElement))
+        handleFullScreen()
+        document.addEventListener('fullscreenchange', handleFullScreen)
+        return () => document.removeEventListener('fullscreenchange', handleFullScreen)
     }, [])
 
-
-    const openTerminal = () => {
-        props.openApp("terminal");
-    }
-
-    const openSettings = () => {
-        props.openApp("settings");
-    }
-
-    const checkFullScreen = () => {
-        if (document.fullscreenElement) {
-            setIsFullScreen(true)
-        } else {
-            setIsFullScreen(false)
-        }
-    }
-
-    const goFullScreen = () => {
-        // make website full screen
+    const handleFullScreenToggle = () => {
         try {
             if (document.fullscreenElement) {
                 document.exitFullscreen()
             } else {
                 document.documentElement.requestFullscreen()
             }
-        }
-        catch (e) {
-            logger.error(e)
+        } catch (error) {
+            logger.error(error)
         }
     }
 
+    const sortLabel = sortOrder === 'desc' ? 'Sort by name (Z → A)' : 'Sort by name (A → Z)'
+    const viewLabel = viewMode === 'list' ? 'View as grid' : 'View as list'
+    const fullScreenLabel = isFullScreen ? 'Exit Full Screen' : 'Enter Full Screen'
+
     return (
-        <div
+        <ContextMenuContent
             id="desktop-menu"
-            role="menu"
-            aria-label="Desktop context menu"
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            open={open}
+            anchorPoint={anchorPoint}
+            onClose={onClose}
+            label="Desktop context menu"
         >
-            <button
-                onClick={props.addNewFolder}
-                type="button"
-                role="menuitem"
-                aria-label="New Folder"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            <ContextMenuItem
+                onSelect={onNewFolder}
+                aria-label="Create new folder"
             >
-                <span className="ml-5">New Folder</span>
-            </button>
-            <button
-                onClick={props.openShortcutSelector}
-                type="button"
-                role="menuitem"
-                aria-label="Create Shortcut"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                New Folder
+            </ContextMenuItem>
+            <ContextMenuItem
+                onSelect={onCreateShortcut}
+                aria-label="Create desktop shortcut"
             >
-                <span className="ml-5">Create Shortcut...</span>
-            </button>
-            <Devider />
-            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Paste</span>
-            </div>
-            <Devider />
-            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Show Desktop in Files</span>
-            </div>
-            <button
-                onClick={openTerminal}
-                type="button"
-                role="menuitem"
-                aria-label="Open in Terminal"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                Create Shortcut…
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem
+                onSelect={onPaste}
+                disabled={!canPaste}
+                aria-label="Paste clipboard contents"
             >
-                <span className="ml-5">Open in Terminal</span>
-            </button>
-            <Devider />
-            <button
-                onClick={openSettings}
-                type="button"
-                role="menuitem"
-                aria-label="Change Background"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                Paste
+            </ContextMenuItem>
+            <ContextMenuItem
+                onSelect={onSelectAll}
+                aria-label="Select all desktop icons"
             >
-                <span className="ml-5">Change Background...</span>
-            </button>
-            <Devider />
-            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Display Settings</span>
-            </div>
-            <button
-                onClick={openSettings}
-                type="button"
-                role="menuitem"
-                aria-label="Settings"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                Select All
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem
+                onSelect={onToggleSort}
+                role="menuitemcheckbox"
+                checked={sortOrder === 'desc'}
+                aria-label="Toggle desktop sort order"
             >
-                <span className="ml-5">Settings</span>
-            </button>
-            <Devider />
-            <button
-                onClick={goFullScreen}
-                type="button"
-                role="menuitem"
-                aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                {sortLabel}
+            </ContextMenuItem>
+            <ContextMenuItem
+                onSelect={onToggleView}
+                role="menuitemcheckbox"
+                checked={viewMode === 'list'}
+                aria-label="Toggle desktop view mode"
             >
-                <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
-            </button>
-            <Devider />
-            <button
-                onClick={props.clearSession}
-                type="button"
-                role="menuitem"
-                aria-label="Clear Session"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                {viewLabel}
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem
+                onSelect={openTerminal}
+                aria-label="Open in terminal"
             >
-                <span className="ml-5">Clear Session</span>
-            </button>
-        </div>
+                Open in Terminal
+            </ContextMenuItem>
+            <ContextMenuItem
+                onSelect={openSettings}
+                aria-label="Change background"
+            >
+                Change Background…
+            </ContextMenuItem>
+            <ContextMenuItem
+                onSelect={openSettings}
+                aria-label="Open settings"
+            >
+                Settings
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem
+                onSelect={handleFullScreenToggle}
+                aria-label={fullScreenLabel}
+            >
+                {fullScreenLabel}
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem
+                onSelect={onClearSession}
+                aria-label="Clear session"
+            >
+                Clear Session
+            </ContextMenuItem>
+        </ContextMenuContent>
     )
 }
 
-function Devider() {
-    return (
-        <div className="flex justify-center w-full">
-            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
-        </div>
-    );
-}
-
-
 export default DesktopMenu
+

--- a/hooks/useRovingTabIndex.ts
+++ b/hooks/useRovingTabIndex.ts
@@ -17,9 +17,16 @@ export default function useRovingTabIndex(
 
     const items = Array.from(
       node.querySelectorAll<HTMLElement>(
-        '[role="tab"], [role="menuitem"], [role="option"]'
+        '[role="tab"], [role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"], [role="option"]'
       )
-    );
+    ).filter((el) => {
+      const control = el as HTMLElement & { disabled?: boolean };
+      return (
+        el.getAttribute('aria-disabled') !== 'true' &&
+        !el.hasAttribute('data-roving-skip') &&
+        control.disabled !== true
+      );
+    });
     if (items.length === 0) return;
 
     let index = items.findIndex((el) => el.tabIndex === 0);

--- a/playwright/desktop-context-menu.spec.ts
+++ b/playwright/desktop-context-menu.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('desktop context menu', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('#desktop');
+  });
+
+  test('positions context menu within viewport near edges', async ({ page }) => {
+    const menu = page.locator('#desktop-menu');
+    const viewport = page.viewportSize();
+    if (!viewport) throw new Error('Viewport not available');
+
+    await page.mouse.click(viewport.width - 5, viewport.height - 5, { button: 'right' });
+    await expect(menu).toBeVisible();
+    const bottomRight = await menu.boundingBox();
+    expect(bottomRight).not.toBeNull();
+    if (!bottomRight) return;
+    expect(bottomRight.x + bottomRight.width).toBeLessThanOrEqual(viewport.width + 1);
+    expect(bottomRight.y + bottomRight.height).toBeLessThanOrEqual(viewport.height + 1);
+
+    await page.keyboard.press('Escape');
+    await expect(menu).toBeHidden();
+
+    await page.mouse.click(5, 5, { button: 'right' });
+    await expect(menu).toBeVisible();
+    const topLeft = await menu.boundingBox();
+    expect(topLeft).not.toBeNull();
+    if (!topLeft) return;
+    expect(topLeft.x).toBeGreaterThanOrEqual(0);
+    expect(topLeft.y).toBeGreaterThanOrEqual(0);
+  });
+
+  test('traps focus and restores it to the triggering icon on Escape', async ({ page }) => {
+    const firstIcon = page.locator('[data-context="app"]').first();
+    await firstIcon.focus();
+    await firstIcon.click({ button: 'right' });
+
+    const menu = page.locator('#desktop-menu');
+    await expect(menu).toBeVisible();
+
+    // Ensure focus starts inside the menu
+    await expect(menu.locator('button').first()).toBeFocused();
+
+    // Tab stays within the menu
+    for (let i = 0; i < 3; i += 1) {
+      await page.keyboard.press('Tab');
+      const focusedInside = await page.evaluate(() => {
+        const menuEl = document.getElementById('desktop-menu');
+        return menuEl?.contains(document.activeElement);
+      });
+      expect(focusedInside).toBeTruthy();
+    }
+
+    await page.keyboard.press('Escape');
+    await expect(menu).toBeHidden();
+    await expect(firstIcon).toBeFocused();
+  });
+
+  test('restores focus to desktop surface when opened from background', async ({ page }) => {
+    const surface = page.locator('#window-area');
+    await surface.focus();
+    const box = await surface.boundingBox();
+    if (!box) throw new Error('Desktop surface not found');
+
+    await page.mouse.click(box.x + 20, box.y + 20, { button: 'right' });
+    const menu = page.locator('#desktop-menu');
+    await expect(menu).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(menu).toBeHidden();
+    await expect(surface).toBeFocused();
+  });
+
+  test('select all marks desktop icons as selected', async ({ page }) => {
+    await page.mouse.click(20, 80, { button: 'right' });
+    const menu = page.locator('#desktop-menu');
+    await expect(menu).toBeVisible();
+
+    await page.getByRole('menuitem', { name: 'Select All' }).click();
+    await expect(menu).toBeHidden();
+
+    const icons = page.locator('[data-context="app"]');
+    const count = await icons.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i += 1) {
+      await expect(icons.nth(i)).toHaveAttribute('aria-selected', 'true');
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- replace the context menu implementation with shared primitives that handle focus trapping, global close events, and viewport-aware positioning
- wire the desktop to track context menu triggers, toggle sort/view modes, restore focus, and expose the new actions through the desktop menu
- update desktop icons and clipboard manager to support selection/paste flows and add Playwright coverage for context menu behaviour at viewport edges

## Testing
- yarn lint *(fails: repository contains numerous pre-existing accessibility violations)*
- yarn test *(fails: existing suites require additional setup and run in watch mode)*
- npx playwright test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc77f108f08328b1991085e353b12a