### PR TITLE
[desktop] Add marquee selection support

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -7,6 +7,12 @@ export class UbuntuApp extends Component {
         this.state = { launching: false, dragging: false, prefetched: false };
     }
 
+    handleSelect = (event) => {
+        if (typeof this.props.onSelect === 'function') {
+            this.props.onSelect(event, this.props.id);
+        }
+    }
+
     handleDragStart = () => {
         this.setState({ dragging: true });
     }
@@ -31,20 +37,28 @@ export class UbuntuApp extends Component {
     }
 
     render() {
+        const selected = Boolean(this.props.selected);
+        const baseClass = " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active ";
+        const launching = this.state.launching ? " app-icon-launch " : "";
+        const dragging = this.state.dragging ? " opacity-70 " : "";
+        const selectedClass = selected ? " bg-opacity-20 border-blue-400 border " : "";
+
         return (
             <div
                 role="button"
                 aria-label={this.props.name}
                 aria-disabled={this.props.disabled}
+                aria-selected={selected}
                 data-context="app"
                 data-app-id={this.props.id}
+                data-selected={selected ? 'true' : 'false'}
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
-                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                className={`${launching}${dragging}${selectedClass}${baseClass}`}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
+                onClick={this.handleSelect}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
                 tabIndex={this.props.disabled ? -1 : 0}
                 onMouseEnter={this.handlePrefetch}

--- a/components/screen/desktop/desktop-marquee.js
+++ b/components/screen/desktop/desktop-marquee.js
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const MIN_DRAG_DISTANCE = 3;
+
+const noop = () => false;
+
+function intersects(selectionRect, itemRect) {
+    return (
+        selectionRect.left <= itemRect.right &&
+        selectionRect.right >= itemRect.left &&
+        selectionRect.top <= itemRect.bottom &&
+        selectionRect.bottom >= itemRect.top
+    );
+}
+
+export default function DesktopMarquee({
+    containerRef,
+    getItems,
+    isEnabled = noop,
+    measureItems,
+    onSelectionStart,
+    onSelectionChange,
+    onSelectionEnd,
+}) {
+    const [rect, setRect] = useState(null);
+    const pointerState = useRef({ active: false });
+    const pendingPoint = useRef(null);
+    const rafRef = useRef(null);
+
+    const clearPerformanceMarks = useCallback(() => {
+        if (typeof performance === 'undefined') return;
+        try { performance.clearMarks('desktop-marquee-update-start'); } catch (e) { /* ignore */ }
+        try { performance.clearMarks('desktop-marquee-update-end'); } catch (e) { /* ignore */ }
+        try { performance.clearMeasures('desktop-marquee-update'); } catch (e) { /* ignore */ }
+    }, []);
+
+    const flushFrame = useCallback(() => {
+        rafRef.current = null;
+        if (!pointerState.current.active || !pendingPoint.current) {
+            return;
+        }
+        const { origin, containerRect, ctrlKey, shiftKey } = pointerState.current;
+        const latest = pendingPoint.current;
+        const left = Math.min(origin.x, latest.x);
+        const top = Math.min(origin.y, latest.y);
+        const right = Math.max(origin.x, latest.x);
+        const bottom = Math.max(origin.y, latest.y);
+        const width = right - left;
+        const height = bottom - top;
+        pointerState.current.hasMoved = width > MIN_DRAG_DISTANCE || height > MIN_DRAG_DISTANCE;
+        if (!pointerState.current.hasMoved) {
+            setRect(null);
+            return;
+        }
+        const selectionRect = { left, top, right, bottom, width, height };
+        pointerState.current.selectionRect = selectionRect;
+        const offsetLeft = left - (containerRect?.left ?? 0);
+        const offsetTop = top - (containerRect?.top ?? 0);
+        setRect({
+            left: offsetLeft,
+            top: offsetTop,
+            width,
+            height,
+        });
+        const items = typeof getItems === 'function' ? getItems() : [];
+        const hits = [];
+        for (let i = 0; i < items.length; i += 1) {
+            const item = items[i];
+            if (!item || !item.rect) continue;
+            if (intersects(selectionRect, item.rect)) {
+                hits.push(item.id);
+            }
+        }
+        if (typeof onSelectionChange === 'function') {
+            onSelectionChange(hits, { ctrlKey, shiftKey });
+        }
+    }, [getItems, onSelectionChange]);
+
+    const scheduleFrame = useCallback(() => {
+        if (rafRef.current !== null) return;
+        rafRef.current = requestAnimationFrame(() => {
+            if (typeof performance !== 'undefined' && typeof performance.mark === 'function') {
+                performance.mark('desktop-marquee-update-start');
+            }
+            flushFrame();
+            if (typeof performance !== 'undefined' && typeof performance.mark === 'function' && typeof performance.measure === 'function') {
+                try {
+                    performance.mark('desktop-marquee-update-end');
+                    performance.measure('desktop-marquee-update', 'desktop-marquee-update-start', 'desktop-marquee-update-end');
+                } catch (e) {
+                    // ignore measure errors (e.g. if marks missing)
+                }
+            }
+            clearPerformanceMarks();
+        });
+    }, [clearPerformanceMarks, flushFrame]);
+
+    useEffect(() => () => {
+        if (rafRef.current !== null) {
+            cancelAnimationFrame(rafRef.current);
+            rafRef.current = null;
+        }
+    }, []);
+
+    useEffect(() => {
+        const container = containerRef?.current;
+        if (!container) return undefined;
+
+        const resetPointerState = () => {
+            pointerState.current = { active: false };
+            pendingPoint.current = null;
+        };
+
+        const finishInteraction = (cancelled) => {
+            if (!pointerState.current.active) return;
+            if (rafRef.current !== null) {
+                cancelAnimationFrame(rafRef.current);
+                rafRef.current = null;
+            }
+            if (pointerState.current.hasMoved) {
+                flushFrame();
+            }
+            if (!cancelled && typeof onSelectionEnd === 'function') {
+                onSelectionEnd({
+                    ctrlKey: pointerState.current.ctrlKey,
+                    shiftKey: pointerState.current.shiftKey,
+                    moved: Boolean(pointerState.current.hasMoved),
+                });
+            }
+            setRect(null);
+            try {
+                if (pointerState.current.pointerId !== undefined && container.releasePointerCapture) {
+                    container.releasePointerCapture(pointerState.current.pointerId);
+                }
+            } catch (e) {
+                // ignore capture release errors
+            }
+            resetPointerState();
+        };
+
+        const handlePointerDown = (event) => {
+            if (event.button !== 0) return;
+            if (typeof isEnabled === 'function' && !isEnabled()) return;
+            const contextTarget = event.target.closest('[data-context]');
+            const context = contextTarget ? contextTarget.dataset.context : null;
+            if (context && context !== 'desktop-area') return;
+            if (event.target.closest('.opened-window')) return;
+            if (measureItems) measureItems();
+            pointerState.current = {
+                active: true,
+                origin: { x: event.clientX, y: event.clientY },
+                ctrlKey: Boolean(event.ctrlKey || event.metaKey),
+                shiftKey: Boolean(event.shiftKey),
+                containerRect: container.getBoundingClientRect(),
+                pointerId: event.pointerId,
+                hasMoved: false,
+            };
+            pendingPoint.current = { x: event.clientX, y: event.clientY };
+            if (container.setPointerCapture) {
+                try {
+                    container.setPointerCapture(event.pointerId);
+                } catch (e) {
+                    // ignore capture errors
+                }
+            }
+            if (typeof onSelectionStart === 'function') {
+                onSelectionStart({
+                    ctrlKey: pointerState.current.ctrlKey,
+                    shiftKey: pointerState.current.shiftKey,
+                });
+            }
+            scheduleFrame();
+        };
+
+        const handlePointerMove = (event) => {
+            if (!pointerState.current.active) return;
+            pendingPoint.current = { x: event.clientX, y: event.clientY };
+            scheduleFrame();
+        };
+
+        const handlePointerUp = () => finishInteraction(false);
+        const handlePointerCancel = () => finishInteraction(true);
+
+        container.addEventListener('pointerdown', handlePointerDown);
+        container.addEventListener('pointermove', handlePointerMove);
+        container.addEventListener('pointerup', handlePointerUp);
+        container.addEventListener('pointercancel', handlePointerCancel);
+        container.addEventListener('lostpointercapture', handlePointerCancel);
+
+        return () => {
+            container.removeEventListener('pointerdown', handlePointerDown);
+            container.removeEventListener('pointermove', handlePointerMove);
+            container.removeEventListener('pointerup', handlePointerUp);
+            container.removeEventListener('pointercancel', handlePointerCancel);
+            container.removeEventListener('lostpointercapture', handlePointerCancel);
+        };
+    }, [containerRef, isEnabled, measureItems, onSelectionEnd, onSelectionStart, scheduleFrame]);
+
+    if (!rect) return null;
+
+    return (
+        <div
+            aria-hidden="true"
+            className="absolute z-20 border border-blue-400 bg-blue-500 bg-opacity-20 pointer-events-none"
+            style={{ left: `${rect.left}px`, top: `${rect.top}px`, width: `${rect.width}px`, height: `${rect.height}px` }}
+        />
+    );
+}

--- a/tests/desktop.marquee.spec.ts
+++ b/tests/desktop.marquee.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+const GENERATED_COUNT = 200;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+test('desktop marquee selection scales to hundreds of icons', async ({ page }) => {
+  await page.addInitScript((count) => {
+    const folders = Array.from({ length: count }, (_, index) => ({
+      id: `generated-${index}`,
+      name: `Generated ${index}`,
+    }));
+    window.localStorage.setItem('new_folders', JSON.stringify(folders));
+  }, GENERATED_COUNT);
+
+  await page.goto('/');
+  await page.waitForSelector('#desktop');
+  await page.waitForFunction((count) => {
+    return document.querySelectorAll('[data-context="app"]').length >= count;
+  }, GENERATED_COUNT);
+
+  const firstLocator = page.locator('#app-new-folder-generated-0');
+  const lastLocator = page.locator(`#app-new-folder-generated-${GENERATED_COUNT - 1}`);
+  await firstLocator.waitFor();
+  await lastLocator.waitFor();
+
+  const firstBox = await firstLocator.boundingBox();
+  const lastBox = await lastLocator.boundingBox();
+  if (!firstBox || !lastBox) {
+    throw new Error('Generated desktop icons are not visible');
+  }
+
+  const startX = clamp(firstBox.x - 20, 0, firstBox.x + firstBox.width);
+  const startY = clamp(firstBox.y - 20, 0, firstBox.y + firstBox.height);
+  const endX = lastBox.x + lastBox.width + 20;
+  const endY = lastBox.y + lastBox.height + 20;
+
+  const beforeMetrics = await page.metrics();
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(endX, endY, { steps: 30 });
+  await page.mouse.up();
+
+  await expect(page.locator('[data-selected="true"][id^="app-new-folder-generated-"]')).toHaveCount(GENERATED_COUNT);
+
+  const afterMetrics = await page.metrics();
+  expect(afterMetrics.TaskDuration - beforeMetrics.TaskDuration).toBeLessThan(0.4);
+});


### PR DESCRIPTION
## Summary
- add a requestAnimationFrame-driven DesktopMarquee overlay that batches pointer updates with cached icon geometry for smooth selection
- persist desktop selection state, integrate marquee updates with context menu behavior, and support multi-item pinning/unpinning
- expose selection styling on desktop icons and cover marquee selection of 200 icons with a Playwright drag test

## Testing
- ❌ `yarn lint` (fails on pre-existing accessibility and browser globals warnings throughout the repo)  
- ❌ `yarn test` (fails in existing suites such as window/nmap accessibility tests; jest stays in watch mode afterward)  
- ⚠️ `npx playwright test tests/desktop.marquee.spec.ts` (Playwright browser binaries are missing in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cc77f17c808328ad6fb5d3d0c089ae