### PR TITLE
[desktop] Add grid snapping controls and regression coverage

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -31,6 +31,8 @@ export class UbuntuApp extends Component {
     }
 
     render() {
+        const dragging = this.props.isDragging || this.state.dragging;
+        const extraClassName = this.props.className ? ` ${this.props.className} ` : ' ';
         return (
             <div
                 role="button"
@@ -38,14 +40,23 @@ export class UbuntuApp extends Component {
                 aria-disabled={this.props.disabled}
                 data-context="app"
                 data-app-id={this.props.id}
-                draggable
-                onDragStart={this.handleDragStart}
-                onDragEnd={this.handleDragEnd}
-                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                draggable={this.props.draggable ?? false}
+                onDragStart={this.props.draggable ? this.handleDragStart : undefined}
+                onDragEnd={this.props.draggable ? this.handleDragEnd : undefined}
+                className={(this.state.launching ? " app-icon-launch " : "") + (dragging ? " opacity-70 " : "") +
+                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active " + extraClassName}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
+                onKeyDown={(e) => {
+                    if (typeof this.props.onKeyDown === 'function') {
+                        this.props.onKeyDown(e);
+                        if (e.defaultPrevented) return;
+                    }
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        this.openApp();
+                    }
+                }}
                 tabIndex={this.props.disabled ? -1 : 0}
                 onMouseEnter={this.handlePrefetch}
                 onFocus={this.handlePrefetch}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,19 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },
+  projects: [
+    {
+      name: 'smoke',
+      testDir: './tests',
+      testMatch: /.*\.spec\.ts/,
+    },
+    {
+      name: 'desktop-regression',
+      testDir: './playwright',
+      testMatch: /.*\.spec\.ts/,
+    },
+  ],
 });

--- a/playwright/desktop-grid.spec.ts
+++ b/playwright/desktop-grid.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('desktop grid alignment', () => {
+  test('icons snap to grid and persist between renders', async ({ page }) => {
+    await page.goto('/');
+    const layer = page.locator('[data-desktop-icon-layer]');
+    await layer.waitFor();
+
+    const icon = page.locator('[data-desktop-icon="about-alex"]');
+    await expect(icon).toBeVisible();
+
+    const metrics = await page.evaluate(() => {
+      const style = getComputedStyle(document.documentElement);
+      const cellWidth = parseFloat(style.getPropertyValue('--desktop-grid-cell-width'));
+      const cellHeight = parseFloat(style.getPropertyValue('--desktop-grid-cell-height'));
+      return { cellWidth, cellHeight };
+    });
+
+    const parseAttr = async (attr: string) =>
+      parseInt((await icon.getAttribute(attr)) ?? '0', 10);
+
+    const initialRow = await parseAttr('data-grid-row');
+    const initialCol = await parseAttr('data-grid-col');
+
+    const iconBox = await icon.boundingBox();
+    const layerBox = await layer.boundingBox();
+    if (!iconBox || !layerBox) {
+      throw new Error('Failed to measure desktop icon');
+    }
+
+    const centerX = iconBox.x + iconBox.width / 2;
+    const centerY = iconBox.y + iconBox.height / 2;
+    const maxRight = layerBox.x + layerBox.width - metrics.cellWidth * 0.5;
+    const minLeft = layerBox.x + metrics.cellWidth * 0.5;
+    let targetX = centerX + metrics.cellWidth * 1.5;
+    if (targetX > maxRight) {
+      targetX = centerX - metrics.cellWidth * 1.5;
+    }
+    if (targetX < minLeft) {
+      targetX = Math.min(maxRight, centerX + metrics.cellWidth);
+    }
+    const maxBottom = layerBox.y + layerBox.height - metrics.cellHeight * 0.5;
+    const minTop = layerBox.y + metrics.cellHeight * 0.5;
+    let targetY = centerY + metrics.cellHeight;
+    if (targetY > maxBottom) {
+      targetY = centerY - metrics.cellHeight;
+    }
+    if (targetY < minTop) {
+      targetY = Math.min(maxBottom, centerY + metrics.cellHeight * 0.75);
+    }
+
+    await page.mouse.move(centerX, centerY);
+    await page.mouse.down();
+    await page.mouse.move(targetX, targetY, { steps: 10 });
+    await page.mouse.up();
+
+    await expect
+      .poll(async () => ({ col: await parseAttr('data-grid-col'), row: await parseAttr('data-grid-row') }))
+      .toSatisfy(({ col, row }) => col !== initialCol || row !== initialRow);
+
+    const draggedRow = await parseAttr('data-grid-row');
+    const draggedCol = await parseAttr('data-grid-col');
+    const draggedBox = await icon.boundingBox();
+    const freshLayerBox = await layer.boundingBox();
+    if (!draggedBox || !freshLayerBox) {
+      throw new Error('Failed to measure dragged icon');
+    }
+    const relDragX = draggedBox.x - freshLayerBox.x;
+    const relDragY = draggedBox.y - freshLayerBox.y;
+    expect(Math.abs(relDragX - draggedCol * metrics.cellWidth)).toBeLessThan(2);
+    expect(Math.abs(relDragY - draggedRow * metrics.cellHeight)).toBeLessThan(2);
+
+    await page.locator('#app-about-alex').focus();
+    await page.keyboard.press('ArrowRight');
+    await expect(icon).toHaveAttribute('data-grid-col', String(draggedCol + 1));
+    await page.keyboard.press('Shift+ArrowDown');
+    await expect(icon).toHaveAttribute('data-grid-row', String(draggedRow + 5));
+
+    const keyedRow = await parseAttr('data-grid-row');
+    const keyedCol = await parseAttr('data-grid-col');
+    const keyedBox = await icon.boundingBox();
+    const keyedLayerBox = await layer.boundingBox();
+    if (!keyedBox || !keyedLayerBox) {
+      throw new Error('Failed to measure keyboard-adjusted icon');
+    }
+    const relKeyX = keyedBox.x - keyedLayerBox.x;
+    const relKeyY = keyedBox.y - keyedLayerBox.y;
+    expect(Math.abs(relKeyX - keyedCol * metrics.cellWidth)).toBeLessThan(2);
+    expect(Math.abs(relKeyY - keyedRow * metrics.cellHeight)).toBeLessThan(2);
+
+    await page.reload();
+    await layer.waitFor();
+    const iconAfterReload = page.locator('[data-desktop-icon="about-alex"]');
+    await expect(iconAfterReload).toHaveAttribute('data-grid-col', String(keyedCol));
+    await expect(iconAfterReload).toHaveAttribute('data-grid-row', String(keyedRow));
+  });
+});

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,5 +1,13 @@
 @import './globals.css';
 
+:root {
+    --desktop-icon-width: 6rem;
+    --desktop-icon-height: 6rem;
+    --desktop-grid-spacing: 32px;
+    --desktop-grid-cell-width: calc(var(--desktop-icon-width) + var(--desktop-grid-spacing));
+    --desktop-grid-cell-height: calc(var(--desktop-icon-height) + var(--desktop-grid-spacing));
+}
+
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
 }
@@ -145,6 +153,34 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 .windowMainScreen::-webkit-scrollbar-thumb {
     background-color: var(--color-border);
     border-radius: 5px;
+}
+
+#window-area {
+    z-index: 5;
+}
+
+.desktop-icon-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.desktop-icon {
+    position: absolute;
+    pointer-events: auto;
+    touch-action: none;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    box-sizing: border-box;
+    will-change: transform;
+    transition: transform 120ms ease;
+}
+
+.desktop-icon--dragging {
+    transition: none;
+    z-index: 3;
 }
 
 /* SideBarApp Scale image onClick */


### PR DESCRIPTION
## Summary
- add desktop grid presets and spacing controls with CSS variable support
- refactor desktop icons to snap to the grid via drag or keyboard and adjust styling
- introduce Playwright desktop grid regression coverage and guard settings storage for tests

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in unrelated files)*
- yarn test reconng
- npx playwright test *(fails: playwright browsers missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc77f275b48328bc564cf553ea551c