### PR TITLE
chore: add fresh clone verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ See `.env.local.example` for the full list.
 - `yarn test` – run the test suite.
 - `yarn lint` – check code for linting issues.
 - `yarn export` – generate a static export in the `out/` directory.
+- `yarn verify:fresh` – run install, build, and a short preview start while failing on any ESLint/TypeScript/Next.js warnings.
+
+## Fresh Clone Verification
+
+- Always run `yarn verify:fresh` from a clean working tree (ideally a brand-new clone or after `git clean -xfd` and `rm -rf node_modules`) before cutting releases or upgrading dependencies.
+- The script executes `yarn install --immutable`, `yarn build`, and a production `yarn start` preview. It fails if the build or preview logs ESLint, TypeScript, or Next.js warnings, so fix those before committing. Yarn install output still surfaces dependency warnings for visibility.
+- Maintainers can add a nightly CI job that calls `yarn verify:fresh` to detect ecosystem drift (for example, `yarn install --immutable` failures or new build warnings) before they reach contributors.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,6 +19,16 @@ yarn install
 yarn dev
 ```
 
+## Fresh Clone Verification
+
+Before major upgrades or releases, create a clean working tree (new clone or `git clean -xfd && rm -rf node_modules`) and run:
+
+```bash
+yarn verify:fresh
+```
+
+The command installs dependencies with `--immutable`, runs `yarn build`, and briefly starts the production server. It fails fast when the build or preview logs ESLint, TypeScript, or Next.js warnings so contributors can fix issues before they reach CI, while still surfacing Yarn install output for dependency drift.
+
 See the [Architecture](./architecture.md) document for an overview of how the project is organized.
 
 For app contributions, see the [New App Checklist](./new-app-checklist.md).

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
-    "verify:all": "node scripts/verify.mjs"
+    "verify:all": "node scripts/verify.mjs",
+    "verify:fresh": "node scripts/verify-fresh.mjs"
   },
   "engines": {
     "node": "20.19.5"

--- a/scripts/verify-fresh.mjs
+++ b/scripts/verify-fresh.mjs
@@ -1,0 +1,170 @@
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import { once } from 'node:events';
+import waitOn from 'wait-on';
+
+const yarnCmd = process.platform === 'win32' ? 'yarn.cmd' : 'yarn';
+const baseEnv = {
+  ...process.env,
+  NEXT_TELEMETRY_DISABLED: '1',
+  CI: process.env.CI ?? '1',
+};
+
+const warningPattern = /(?:^|\s)warn(?:ing|ings)?(?=\s|:|-|\(|\.|,)/i;
+const ansiPattern = /\u001b\[[0-9;]*m/g;
+const yarnCodePattern = /(?:^|\s)YN(\d{4}):/i;
+
+const stripAnsi = (value) => value.replace(ansiPattern, '');
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const checkForWarnings = (label, output) => {
+  const sanitized = stripAnsi(output);
+  const lines = sanitized.split(/\r?\n/);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const yarnMatch = trimmed.match(yarnCodePattern);
+    if (yarnMatch && yarnMatch[1] !== '0000') {
+      throw new Error(`${label} emitted a warning: ${trimmed}`);
+    }
+    if (warningPattern.test(trimmed)) {
+      throw new Error(`${label} emitted a warning: ${trimmed}`);
+    }
+  }
+};
+
+const runYarnCommand = (label, args, options = {}) =>
+  new Promise((resolve, reject) => {
+    console.log(`\n▶ ${label}`);
+
+    const child = spawn(yarnCmd, args, {
+      stdio: ['inherit', 'pipe', 'pipe'],
+      env: { ...baseEnv, ...options.env },
+      cwd: options.cwd ?? process.cwd(),
+    });
+
+    let combined = '';
+
+    child.stdout.on('data', (chunk) => {
+      process.stdout.write(chunk);
+      combined += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk) => {
+      process.stderr.write(chunk);
+      combined += chunk.toString();
+    });
+
+    child.on('error', reject);
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`${label} failed with exit code ${code}`));
+        return;
+      }
+
+      try {
+        if (options.checkWarnings !== false) {
+          checkForWarnings(label, combined);
+        }
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+
+const getOpenPort = () =>
+  new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+
+const ensurePreviewServer = async () => {
+  const port = await getOpenPort();
+  console.log(`\n▶ yarn start (preview) on port ${port}`);
+
+  const server = spawn(yarnCmd, ['start', '-p', String(port)], {
+    stdio: ['inherit', 'pipe', 'pipe'],
+    env: { ...baseEnv },
+  });
+
+  let combined = '';
+  server.stdout.on('data', (chunk) => {
+    process.stdout.write(chunk);
+    combined += chunk.toString();
+  });
+  server.stderr.on('data', (chunk) => {
+    process.stderr.write(chunk);
+    combined += chunk.toString();
+  });
+  let closed = false;
+  const closePromise = once(server, 'close').then((result) => {
+    closed = true;
+    return result;
+  });
+
+  try {
+    const readyPromise = waitOn({ resources: [`http://127.0.0.1:${port}`], timeout: 60000 });
+    const errorPromise = once(server, 'error').then(([err]) => {
+      throw err;
+    });
+
+    await Promise.race([readyPromise, errorPromise]);
+    const response = await fetch(`http://127.0.0.1:${port}`);
+    if (!response.ok) {
+      throw new Error(`Preview responded with status ${response.status}`);
+    }
+    console.log(`Preview responded with ${response.status} ${response.statusText}`);
+  } finally {
+    if (server.pid) {
+      for (const signal of ['SIGINT', 'SIGTERM']) {
+        if (closed || server.exitCode !== null || server.signalCode !== null) {
+          break;
+        }
+        try {
+          server.kill(signal);
+        } catch (err) {
+          if (err?.code !== 'ESRCH') {
+            throw err;
+          }
+        }
+        await Promise.race([closePromise, delay(5000)]);
+      }
+
+      if (!closed && server.exitCode === null && server.signalCode === null) {
+        console.warn('Preview did not exit after SIGTERM, sending SIGKILL.');
+        try {
+          server.kill('SIGKILL');
+        } catch (err) {
+          if (err?.code !== 'ESRCH') {
+            throw err;
+          }
+        }
+        await closePromise;
+      }
+    }
+    server.removeAllListeners('error');
+  }
+
+  checkForWarnings('yarn start', combined);
+};
+
+const main = async () => {
+  await runYarnCommand('yarn install --immutable', ['install', '--immutable'], { checkWarnings: false });
+  await runYarnCommand('yarn build', ['build']);
+  await ensurePreviewServer();
+
+  console.log('\n✅ verify:fresh complete — no warnings detected.');
+};
+
+main().catch((err) => {
+  console.error('\n❌ verify:fresh failed');
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a verify:fresh helper that installs dependencies, builds the site, and spins up a short preview run while failing on build/start warnings
- register the command in package.json and document when contributors should run it from clean clones
- note that maintainers can schedule the script to catch dependency drift automatically

## Testing
- node scripts/verify-fresh.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc7ca41f8483289d45f2ad4aa50332