### PR TITLE
[core] add shared error code catalog

### DIFF
--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -1,4 +1,12 @@
+import Link from 'next/link';
 import { Component, ErrorInfo, ReactNode } from 'react';
+import {
+  DEFAULT_LOCALE,
+  ErrorCode,
+  Locale,
+  getLocalizedErrorCopy,
+  matchLocale,
+} from '../../types/errorCodes';
 import { createLogger } from '../../lib/logger';
 
 interface Props {
@@ -7,6 +15,7 @@ interface Props {
 
 interface State {
   hasError: boolean;
+  locale: Locale;
 }
 
 const log = createLogger();
@@ -14,23 +23,50 @@ const log = createLogger();
 class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { hasError: false, locale: DEFAULT_LOCALE };
   }
 
-  static getDerivedStateFromError(): State {
+  static getDerivedStateFromError(): Pick<State, 'hasError'> {
     return { hasError: true };
   }
 
   componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
-    log.error('ErrorBoundary caught an error', { error, errorInfo });
+    log.error('ErrorBoundary caught an error', {
+      error,
+      errorInfo,
+      errorCode: ErrorCode.UI_UNEXPECTED,
+    });
+  }
+
+  componentDidMount(): void {
+    if (typeof navigator === 'undefined') return;
+    this.setState({ locale: matchLocale(navigator.language) });
   }
 
   render() {
     if (this.state.hasError) {
+      const localized = getLocalizedErrorCopy(
+        ErrorCode.UI_UNEXPECTED,
+        this.state.locale
+      );
+      const bugReportHref = `/input-hub?preset=bug-report&errorCode=${encodeURIComponent(
+        localized.code
+      )}&title=${encodeURIComponent(localized.summary)}`;
       return (
         <div role="alert" className="p-4 text-center">
-          <h1 className="text-xl font-bold">Something went wrong.</h1>
-          <p>Please refresh the page or try again.</p>
+          <h1 className="text-xl font-bold">{localized.summary}</h1>
+          <p className="mt-2">{localized.remediation}</p>
+          <p className="mt-2 text-sm text-gray-500">
+            Error code: {localized.code}
+          </p>
+          <div className="mt-4">
+            <Link
+              href={bugReportHref}
+              className="inline-flex items-center justify-center rounded bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+            >
+              Report this issue
+            </Link>
+          </div>
         </div>
       );
     }

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,27 @@
+# Error code reference
+
+The portfolio now surfaces the same error codes across the UI, bug-report form, and logs. Codes live in [`types/errorCodes.ts`](../types/errorCodes.ts) and include localized copy for English and Spanish so support agents can paste responses in either language.
+
+## Quick usage notes
+
+- **Error boundary** – When the desktop shell crashes it shows the localized summary, remediation text, and the code `ERR-UI-001`. The "Report this issue" button forwards the code into the Input Hub form.
+- **Bug reports/Input Hub** – The bug-report preset can attach any code from the catalog. Submitted messages prepend the code so EmailJS tickets contain the reference automatically. Status toasts reuse the same catalog when EmailJS is offline or a send fails.
+- **Logs** – The error boundary logger now tags telemetry with the same code, which lets you search for incidents server-side.
+
+## Catalog
+
+| Code | Summary (English) | Where it appears | Support remediation checklist |
+| --- | --- | --- | --- |
+| `ERR-UI-001` | Unexpected interface error | Error boundary overlay and bug-report picker | 1. Ask for the steps to reproduce and browser/OS.<br>2. Check Vercel or browser console logs for matching `ERR-UI-001` entries.<br>3. If repeatable, file an issue with the component name and stack trace. |
+| `ERR-CONTACT-001` | Message service is offline | Input Hub status banner, bug-report picker | 1. Confirm EmailJS keys are present in the active `.env`.<br>2. Verify the EmailJS dashboard for service availability.<br>3. Communicate an alternate contact channel until the service is restored. |
+| `ERR-CONTACT-002` | Message delivery failed | Input Hub status banner, bug-report picker | 1. Attempt a resend with reCAPTCHA enabled.<br>2. Review EmailJS dashboard for template errors or rate limits.<br>3. If failures persist, capture the payload and raise to engineering with the code. |
+
+## Localization coverage
+
+All codes ship with Spanish (`es`) strings alongside English (`en`). To add another locale, extend `SUPPORTED_LOCALES` in [`types/errorCodes.ts`](../types/errorCodes.ts) and populate the new language keys for each catalog entry.
+
+## Adding a new code
+
+1. Define the enum entry and localized copy in [`types/errorCodes.ts`](../types/errorCodes.ts).
+2. Update any UI or logging surfaces that should raise the code.
+3. Append a new row to the table above so the support rotation knows how to triage it.

--- a/pages/input-hub.tsx
+++ b/pages/input-hub.tsx
@@ -1,14 +1,44 @@
 "use client";
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import emailjs from '@emailjs/browser';
 import { useRouter } from 'next/router';
+import {
+  DEFAULT_LOCALE,
+  ErrorCode,
+  Locale,
+  getLocalizedErrorCopy,
+  isErrorCode,
+  listErrorCodes,
+  matchLocale,
+} from '../types/errorCodes';
 
 const subjectTemplates = [
   'General Inquiry',
   'Bug Report',
   'Feedback',
 ];
+
+type FormStatus =
+  | { type: 'idle' }
+  | { type: 'info'; message: string }
+  | { type: 'success'; message: string }
+  | { type: 'error'; code: ErrorCode };
+
+interface QueuedMessage {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+  useCaptcha: boolean;
+  errorCode?: ErrorCode;
+}
+
+const formatMessageBody = (body: string, code?: ErrorCode) => {
+  if (!code) return body;
+  const tagged = `[Error code: ${code}]`;
+  return body.includes(tagged) ? body : `${tagged}\n${body}`;
+};
 
 const getRecaptchaToken = (siteKey: string): Promise<string> =>
   new Promise((resolve) => {
@@ -30,14 +60,35 @@ const InputHub = () => {
   const [email, setEmail] = useState('');
   const [subject, setSubject] = useState(subjectTemplates[0]);
   const [message, setMessage] = useState('');
-  const [status, setStatus] = useState('');
+  const [locale, setLocale] = useState<Locale>(DEFAULT_LOCALE);
+  const [errorCode, setErrorCode] = useState<ErrorCode | ''>('');
+  const [status, setStatus] = useState<FormStatus>({ type: 'idle' });
   const [useCaptcha, setUseCaptcha] = useState(false);
   const [emailjsReady, setEmailjsReady] = useState(false);
+  const errorOptions = useMemo(() => listErrorCodes(), []);
+  const selectedError = useMemo(
+    () => (errorCode ? getLocalizedErrorCopy(errorCode, locale) : null),
+    [errorCode, locale]
+  );
+  const statusDescriptor =
+    status.type === 'error'
+      ? getLocalizedErrorCopy(status.code, locale)
+      : null;
 
   useEffect(() => {
-    const { preset, title, text, url, files } = router.query;
+    const { preset, title, text, url, files, errorCode: errorCodeQuery } =
+      router.query;
     if (preset === 'contact') {
       setSubject('General Inquiry');
+    }
+    if (preset === 'bug-report') {
+      setSubject('Bug Report');
+      if (
+        typeof errorCodeQuery === 'string' &&
+        isErrorCode(errorCodeQuery)
+      ) {
+        setErrorCode(errorCodeQuery);
+      }
     }
     const parts: string[] = [];
     if (title) parts.push(String(title));
@@ -60,6 +111,17 @@ const InputHub = () => {
       setMessage((m) => (m ? `${m}\n${incoming}` : incoming));
     }
   }, [router.query]);
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined') return;
+    setLocale(matchLocale(navigator.language));
+  }, []);
+
+  useEffect(() => {
+    if (subject !== 'Bug Report' && errorCode) {
+      setErrorCode('');
+    }
+  }, [subject, errorCode]);
 
   useEffect(() => {
     const userId = process.env.NEXT_PUBLIC_USER_ID;
@@ -91,7 +153,7 @@ const InputHub = () => {
       if (!emailjsReady || !navigator.onLine) return;
       try {
         const raw = localStorage.getItem(QUEUE_KEY);
-        const queue: any[] = raw ? JSON.parse(raw) : [];
+        const queue: QueuedMessage[] = raw ? JSON.parse(raw) : [];
         for (const q of queue) {
           const token = q.useCaptcha
             ? await getRecaptchaToken(siteKey)
@@ -100,7 +162,8 @@ const InputHub = () => {
             name: q.name,
             email: q.email,
             subject: q.subject,
-            message: q.message,
+            message: formatMessageBody(q.message, q.errorCode),
+            error_code: q.errorCode ?? '',
             'g-recaptcha-response': token,
           });
         }
@@ -115,16 +178,10 @@ const InputHub = () => {
     return () => window.removeEventListener('online', flushQueue);
   }, [emailjsReady]);
 
-  const enqueueMessage = (msg: {
-    name: string;
-    email: string;
-    subject: string;
-    message: string;
-    useCaptcha: boolean;
-  }) => {
+  const enqueueMessage = (msg: QueuedMessage) => {
     try {
       const raw = localStorage.getItem(QUEUE_KEY);
-      const queue = raw ? JSON.parse(raw) : [];
+      const queue: QueuedMessage[] = raw ? JSON.parse(raw) : [];
       queue.push(msg);
       localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
     } catch {
@@ -135,36 +192,57 @@ const InputHub = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!emailjsReady) {
-      setStatus('Email service unavailable');
+      setStatus({
+        type: 'error',
+        code: ErrorCode.CONTACT_SERVICE_UNAVAILABLE,
+      });
       return;
     }
     const serviceId = process.env.NEXT_PUBLIC_SERVICE_ID as string;
     const templateId = process.env.NEXT_PUBLIC_TEMPLATE_ID as string;
     const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || '';
     if (!navigator.onLine) {
-      enqueueMessage({ name, email, subject, message, useCaptcha });
-      setStatus('Message queued; will send when online.');
+      enqueueMessage({
+        name,
+        email,
+        subject,
+        message,
+        useCaptcha,
+        errorCode: errorCode || undefined,
+      });
+      setStatus({
+        type: 'success',
+        message: 'Message queued; will send when online.',
+      });
       setName('');
       setEmail('');
       setMessage('');
       return;
     }
     const token = useCaptcha ? await getRecaptchaToken(siteKey) : '';
-    setStatus('Sending...');
+    setStatus({ type: 'info', message: 'Sending...' });
     try {
+      const preparedMessage = formatMessageBody(
+        message,
+        errorCode || undefined
+      );
       await emailjs.send(serviceId, templateId, {
         name,
         email,
         subject,
-        message,
+        message: preparedMessage,
+        error_code: errorCode || '',
         'g-recaptcha-response': token,
       });
-      setStatus('Message sent!');
+      setStatus({ type: 'success', message: 'Message sent!' });
       setName('');
       setEmail('');
       setMessage('');
     } catch {
-      setStatus('Failed to send message');
+      setStatus({
+        type: 'error',
+        code: ErrorCode.CONTACT_DELIVERY_FAILED,
+      });
     }
   };
 
@@ -205,6 +283,42 @@ const InputHub = () => {
             </option>
           ))}
         </select>
+        {subject === 'Bug Report' && (
+          <div className="rounded border border-gray-300 bg-gray-100 p-2 text-sm text-black">
+            <label className="flex flex-col gap-1">
+              <span className="text-xs font-semibold uppercase text-gray-600">
+                Attach error code
+              </span>
+              <select
+                className="p-1"
+                value={errorCode}
+                onChange={(e) =>
+                  setErrorCode(
+                    e.target.value
+                      ? (e.target.value as ErrorCode)
+                      : ''
+                  )
+                }
+              >
+                <option value="">Select an error code (optional)</option>
+                {errorOptions.map((code) => {
+                  const descriptor = getLocalizedErrorCopy(code, locale);
+                  return (
+                    <option key={code} value={code}>
+                      {`${code} — ${descriptor.summary}`}
+                    </option>
+                  );
+                })}
+              </select>
+            </label>
+            {selectedError && (
+              <div className="mt-2 space-y-1 text-xs text-gray-700">
+                <p className="font-semibold">{selectedError.summary}</p>
+                <p>{selectedError.remediation}</p>
+              </div>
+            )}
+          </div>
+        )}
         <textarea
           className="p-1 border"
           placeholder="Message"
@@ -225,9 +339,29 @@ const InputHub = () => {
           Send
         </button>
       </form>
-      {status && (
-        <div role="status" aria-live="polite" className="mt-2 text-sm">
-          {status}
+      {status.type !== 'idle' && (
+        <div
+          role="status"
+          aria-live="polite"
+          className={`mt-2 text-sm ${
+            status.type === 'error'
+              ? 'text-red-600'
+              : status.type === 'success'
+              ? 'text-green-700'
+              : 'text-gray-800'
+          }`}
+        >
+          {status.type === 'error' && statusDescriptor ? (
+            <div className="space-y-1">
+              <p className="font-semibold">{statusDescriptor.summary}</p>
+              <p>{statusDescriptor.remediation}</p>
+              <p className="text-xs text-gray-600">
+                Error code: {statusDescriptor.code}
+              </p>
+            </div>
+          ) : status.type === 'info' || status.type === 'success' ? (
+            <span>{status.message}</span>
+          ) : null}
         </div>
       )}
     </div>

--- a/types/errorCodes.ts
+++ b/types/errorCodes.ts
@@ -1,0 +1,95 @@
+export const SUPPORTED_LOCALES = ['en', 'es'] as const;
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+export const DEFAULT_LOCALE: Locale = 'en';
+
+export type LocalizedText = Partial<Record<Locale, string>> & {
+  [DEFAULT_LOCALE]: string;
+};
+
+export enum ErrorCode {
+  UI_UNEXPECTED = 'ERR-UI-001',
+  CONTACT_SERVICE_UNAVAILABLE = 'ERR-CONTACT-001',
+  CONTACT_DELIVERY_FAILED = 'ERR-CONTACT-002',
+}
+
+export interface ErrorCatalogEntry {
+  summary: LocalizedText;
+  remediation: LocalizedText;
+  area: 'ui' | 'messaging';
+}
+
+export const ERROR_CATALOG: Record<ErrorCode, ErrorCatalogEntry> = {
+  [ErrorCode.UI_UNEXPECTED]: {
+    area: 'ui',
+    summary: {
+      en: 'Unexpected interface error',
+      es: 'Error inesperado de la interfaz',
+    },
+    remediation: {
+      en: 'Refresh the page or reopen the app. If the problem persists, capture steps to reproduce and include the error code when you contact support.',
+      es: 'Actualice la página o vuelva a abrir la aplicación. Si el problema continúa, documente los pasos para reproducirlo e incluya el código de error al contactar con soporte.',
+    },
+  },
+  [ErrorCode.CONTACT_SERVICE_UNAVAILABLE]: {
+    area: 'messaging',
+    summary: {
+      en: 'Message service is offline',
+      es: 'El servicio de mensajes está fuera de línea',
+    },
+    remediation: {
+      en: 'Wait a few minutes and try again. If the issue remains, verify the EmailJS credentials in the environment and notify the support team with this code.',
+      es: 'Espere unos minutos y vuelva a intentarlo. Si el problema continúa, verifique las credenciales de EmailJS en el entorno y avise al equipo de soporte con este código.',
+    },
+  },
+  [ErrorCode.CONTACT_DELIVERY_FAILED]: {
+    area: 'messaging',
+    summary: {
+      en: 'Message delivery failed',
+      es: 'El envío del mensaje falló',
+    },
+    remediation: {
+      en: 'Retry sending the message. If it fails again, enable reCAPTCHA if available and include this code in your support ticket.',
+      es: 'Intente enviar el mensaje nuevamente. Si vuelve a fallar, active reCAPTCHA si está disponible e incluya este código en su ticket de soporte.',
+    },
+  },
+};
+
+export const getSupportedLocales = () => [...SUPPORTED_LOCALES];
+
+export const matchLocale = (candidate?: string): Locale => {
+  if (!candidate) return DEFAULT_LOCALE;
+  const lowered = candidate.toLowerCase();
+  const found = SUPPORTED_LOCALES.find((locale) => lowered.startsWith(locale));
+  return found ?? DEFAULT_LOCALE;
+};
+
+export interface LocalizedErrorCopy {
+  code: ErrorCode;
+  summary: string;
+  remediation: string;
+  locale: Locale;
+  area: ErrorCatalogEntry['area'];
+}
+
+export const getLocalizedErrorCopy = (
+  code: ErrorCode,
+  locale: Locale = DEFAULT_LOCALE
+): LocalizedErrorCopy => {
+  const entry = ERROR_CATALOG[code];
+  const resolvedLocale = entry.summary[locale] ? locale : DEFAULT_LOCALE;
+  return {
+    code,
+    area: entry.area,
+    locale: resolvedLocale,
+    summary: entry.summary[resolvedLocale] ?? entry.summary[DEFAULT_LOCALE],
+    remediation:
+      entry.remediation[resolvedLocale] ?? entry.remediation[DEFAULT_LOCALE],
+  };
+};
+
+export const isErrorCode = (value: unknown): value is ErrorCode =>
+  typeof value === 'string' &&
+  (Object.values(ErrorCode) as string[]).includes(value);
+
+export const listErrorCodes = (): ErrorCode[] =>
+  Object.values(ErrorCode);


### PR DESCRIPTION
## Summary
- add a centralized error code catalog with localized summaries and remediation guidance
- update the error boundary and Input Hub bug-report flow to surface shared error codes
- document the support playbook for each error code

## Testing
- yarn lint *(fails: repo already reports hundreds of `jsx-a11y/control-has-associated-label` violations in legacy apps)*
- yarn test *(fails: existing suites such as `__tests__/window.test.tsx` and `__tests__/nmapNse.test.tsx` fail before exercising new code)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7ca6036c8328a54b91e02d4b46fe