### PR TITLE
build: add lint-staged Husky pre-commit hook

### DIFF
--- a/.husky/_/.gitignore
+++ b/.husky/_/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!h
+!husky.sh
+!pre-commit

--- a/.husky/_/h
+++ b/.husky/_/h
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+[ "$HUSKY" = "2" ] && set -x
+n=$(basename "$0")
+s=$(dirname "$(dirname "$0")")/$n
+
+[ ! -f "$s" ] && exit 0
+
+if [ -f "$HOME/.huskyrc" ]; then
+	echo "husky - '~/.huskyrc' is DEPRECATED, please move your code to ~/.config/husky/init.sh"
+fi
+i="${XDG_CONFIG_HOME:-$HOME/.config}/husky/init.sh"
+[ -f "$i" ] && . "$i"
+
+[ "${HUSKY-}" = "0" ] && exit 0
+
+export PATH="node_modules/.bin:$PATH"
+sh -e "$s" "$@"
+c=$?
+
+[ $c != 0 ] && echo "husky - $n script failed (code $c)"
+[ $c = 127 ] && echo "husky - command not found in PATH=$PATH"
+exit $c

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,8 @@
+echo "husky - DEPRECATED"
+
+echo "Please remove the following two lines from $0:"
+
+echo "#!/usr/bin/env sh"
+echo ". \"\$(dirname -- \"\$0\")/_/husky.sh\""
+
+echo "They WILL FAIL in v10.0.0"

--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+is_automated_user() {
+  case "$1" in
+    *"[bot]"*|dependabot@*|github-actions@*|github-actions*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [ "${CI:-}" = "true" ] || [ -n "${SKIP_PRECOMMIT:-}" ] || [ -n "${HUSKY_SKIP_HOOKS:-}" ]; then
+  echo "Skipping pre-commit hook (CI or skip flag detected)."
+  exit 0
+fi
+
+if is_automated_user "${GIT_AUTHOR_NAME:-}" || is_automated_user "${GIT_COMMITTER_NAME:-}"; then
+  echo "Skipping pre-commit hook for automated commit user."
+  exit 0
+fi
+
+yarn lint-staged

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kali Linux Portfolio 
+# Kali Linux Portfolio
 
 A desktop-style portfolio built with Next.js and Tailwind that emulates a Kali/Ubuntu UI with windows, a dock, context menus, and a rich catalog of **security-tool simulations**, **utilities**, and **retro games**. This README is tailored for a professional full-stack engineer preparing **production deployment** and ongoing maintenance.
 
@@ -11,6 +11,7 @@ A desktop-style portfolio built with Next.js and Tailwind that emulates a Kali/U
 This repository showcases **static, non-operational simulations** of security tools for educational purposes only. Running real offensive commands against systems without explicit authorization is illegal and can cause damage or service disruption.
 
 **Potential Risks**
+
 - Network scans may trigger intrusion detection and block your IP.
 - Brute-force attempts can lock accounts or corrupt data.
 - Sample outputs are canned and not from live targets.
@@ -22,11 +23,13 @@ Always test inside controlled labs and obtain written permission before performi
 ## Setup
 
 ### Requirements
+
 - **Node.js 20.19.5** (repo includes `.nvmrc`; run `nvm use`)
 - **Yarn** or **npm**
 - Recommended: **pnpm** if you prefer stricter hoisting; update lock/config accordingly.
 
 ### Install & Run (Dev)
+
 ```bash
 cp .env.local.example .env.local  # populate with required keys
 nvm install  # installs Node 20.19.5 from .nvmrc if needed
@@ -36,22 +39,29 @@ yarn dev
 ```
 
 ### Production Build
+
 Serverful deployments run the built Next.js server so all API routes are available.
+
 ```bash
 yarn build && yarn start
 ```
+
 The service worker is automatically generated during `next build` via [`@ducanh2912/next-pwa`](https://github.com/DuCanhGH/next-pwa).
 After the server starts, exercise an API route to confirm server-side functionality:
+
 ```bash
 curl -X POST http://localhost:3000/api/dummy
 ```
 
 ### Static Export (for GitHub Pages / S3 Websites)
+
 This project supports static export. Serverless API routes will not be available; the UI falls back to demo data or hides features.
+
 ```bash
 yarn export && npx serve out
 
 ```
+
 Verify that features relying on `/api/*` return 404 or other placeholders when served statically.
 
 ### Install as PWA for Sharing
@@ -99,6 +109,25 @@ See `.env.local.example` for the full list.
 
 - Run `yarn lint` and `yarn test` before committing changes.
 - For manual smoke tests, start `yarn dev` and in another terminal run `yarn smoke` to visit every `/apps/*` route.
+
+## Git Hooks
+
+This repo uses [Husky](https://typicode.github.io/husky) and [lint-staged](https://github.com/okonet/lint-staged) to keep staged
+changes consistent before they land in the main branch. The `pre-commit` hook runs Prettier, ESLint, and a TypeScript
+typecheck on the files you stage. Formatting happens first, then linting with autofix, and finally a project-wide typecheck
+if any TypeScript files are included in the commit.
+
+### Setup locally
+
+1. Run `yarn install` (this executes the `prepare` script, which wires Git to `.husky/_`).
+2. If you ever need to re-create the hooks manually, run `yarn setup:hooks` which simply invokes the Husky CLI.
+
+### When automation should skip hooks
+
+The hook exits early when it detects CI (`CI=true`), when either `SKIP_PRECOMMIT` or `HUSKY_SKIP_HOOKS` is set, or when the
+commit author/committer name matches common bot identities (for example `github-actions[bot]`). Automated release tasks can
+set one of those flags to bypass local enforcement, while human commits will still run through the formatter, linter, and
+typecheck gates.
 
 ---
 
@@ -171,21 +200,25 @@ __tests__/
 ```
 
 **Windowing model.** The desktop (`components/screen/desktop.js`) manages:
+
 - z-ordering and focus of windows
 - global context menus (`components/context-menus/`)
 - favorites vs “All Applications” grid
 - analytics events for user actions
 
 **App registry.** `apps.config.js` registers apps using dynamic imports to keep the initial bundle lean:
+
 ```ts
 import dynamic from 'next/dynamic';
 
 const SudokuApp = dynamic(() => import('./components/apps/sudoku'));
 export const displaySudoku = () => <SudokuApp />;
 ```
+
 Heavy apps are wrapped with **dynamic import** and most games share a `GameLayout` with a help overlay.
 
 ### Prefetching dynamic apps
+
 Dynamic app modules include a `webpackPrefetch` hint and expose a `prefetch()` helper. Desktop tiles call this helper on hover or
 keyboard focus so bundles are warmed before launch. When adding a new app, export a default component and register it with
 `createDynamicApp` to opt into this behaviour.
@@ -196,29 +229,29 @@ keyboard focus so bundles are warmed before launch. When adding a new app, expor
 
 Copy `.env.local.example` to `.env.local` and fill in required values.
 
-| Name | Purpose |
-| --- | --- |
-| `NEXT_PUBLIC_TRACKING_ID` | GA4 measurement ID (e.g., `G-XXXXXXX`). |
-| `NEXT_PUBLIC_SERVICE_ID` | EmailJS service id. |
-| `NEXT_PUBLIC_TEMPLATE_ID` | EmailJS template id. |
-| `NEXT_PUBLIC_USER_ID` | EmailJS public key / user id. |
-| `NEXT_PUBLIC_YOUTUBE_API_KEY` | Used by the YouTube app for search/embed enhancements. |
-| `NEXT_PUBLIC_BEEF_URL` | Optional URL for the BeEF demo iframe (if used). |
-| `NEXT_PUBLIC_GHIDRA_URL` | Optional URL for a remote Ghidra Web interface. |
-| `NEXT_PUBLIC_GHIDRA_WASM` | Optional URL for a Ghidra WebAssembly build. |
-| `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` | ReCAPTCHA site key used on the client. |
-| `RECAPTCHA_SECRET` | ReCAPTCHA secret key for server-side verification. |
-| `SUPABASE_URL` | Supabase project URL for server-side access. |
-| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key for privileged operations. |
-| `SUPABASE_ANON_KEY` | Supabase anonymous key for server-side reads. |
-| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL exposed to the client. |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public Supabase anonymous key used on the client. |
-| `ADMIN_READ_KEY` | Secret key required by admin message APIs. Configure this directly as an environment variable (e.g., in the Vercel dashboard). |
-| `NEXT_PUBLIC_UI_EXPERIMENTS` | Enable experimental UI heuristics. |
-| `NEXT_PUBLIC_STATIC_EXPORT` | Set to `'true'` during `yarn export` to disable server APIs. |
-| `NEXT_PUBLIC_SHOW_BETA` | Set to `1` to display a small beta badge in the UI. |
-| `FEATURE_TOOL_APIS` | Enable server-side tool API routes like Hydra and John; set to `enabled` to allow. |
-| `FEATURE_HYDRA` | Allow the Hydra API (`/api/hydra`); requires `FEATURE_TOOL_APIS`. |
+| Name                             | Purpose                                                                                                                        |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `NEXT_PUBLIC_TRACKING_ID`        | GA4 measurement ID (e.g., `G-XXXXXXX`).                                                                                        |
+| `NEXT_PUBLIC_SERVICE_ID`         | EmailJS service id.                                                                                                            |
+| `NEXT_PUBLIC_TEMPLATE_ID`        | EmailJS template id.                                                                                                           |
+| `NEXT_PUBLIC_USER_ID`            | EmailJS public key / user id.                                                                                                  |
+| `NEXT_PUBLIC_YOUTUBE_API_KEY`    | Used by the YouTube app for search/embed enhancements.                                                                         |
+| `NEXT_PUBLIC_BEEF_URL`           | Optional URL for the BeEF demo iframe (if used).                                                                               |
+| `NEXT_PUBLIC_GHIDRA_URL`         | Optional URL for a remote Ghidra Web interface.                                                                                |
+| `NEXT_PUBLIC_GHIDRA_WASM`        | Optional URL for a Ghidra WebAssembly build.                                                                                   |
+| `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` | ReCAPTCHA site key used on the client.                                                                                         |
+| `RECAPTCHA_SECRET`               | ReCAPTCHA secret key for server-side verification.                                                                             |
+| `SUPABASE_URL`                   | Supabase project URL for server-side access.                                                                                   |
+| `SUPABASE_SERVICE_ROLE_KEY`      | Supabase service role key for privileged operations.                                                                           |
+| `SUPABASE_ANON_KEY`              | Supabase anonymous key for server-side reads.                                                                                  |
+| `NEXT_PUBLIC_SUPABASE_URL`       | Supabase project URL exposed to the client.                                                                                    |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY`  | Public Supabase anonymous key used on the client.                                                                              |
+| `ADMIN_READ_KEY`                 | Secret key required by admin message APIs. Configure this directly as an environment variable (e.g., in the Vercel dashboard). |
+| `NEXT_PUBLIC_UI_EXPERIMENTS`     | Enable experimental UI heuristics.                                                                                             |
+| `NEXT_PUBLIC_STATIC_EXPORT`      | Set to `'true'` during `yarn export` to disable server APIs.                                                                   |
+| `NEXT_PUBLIC_SHOW_BETA`          | Set to `1` to display a small beta badge in the UI.                                                                            |
+| `FEATURE_TOOL_APIS`              | Enable server-side tool API routes like Hydra and John; set to `enabled` to allow.                                             |
+| `FEATURE_HYDRA`                  | Allow the Hydra API (`/api/hydra`); requires `FEATURE_TOOL_APIS`.                                                              |
 
 > In production (Vercel/GitHub Actions), set these as **environment variables or repo secrets**. See **CI/CD** below.
 
@@ -238,26 +271,27 @@ Defined in `next.config.js`. See [CSP External Domains](#csp-external-domains) f
 
 These external domains are whitelisted in the default CSP. Update this list whenever `next.config.js` changes.
 
-| Domain | Purpose |
-| --- | --- |
-| `platform.twitter.com` | Twitter widgets and scripts |
-| `syndication.twitter.com` | Twitter embed scripts |
-| `cdn.syndication.twimg.com` | Twitter asset CDN |
-| `*.twitter.com` | Additional Twitter content |
-| `*.x.com` | X (Twitter) domain equivalents |
-| `*.google.com` | Google services and Chrome app favicons |
-| `example.com` | Chrome app demo origin |
-| `developer.mozilla.org` | Chrome app demo origin |
-| `en.wikipedia.org` | Chrome app demo origin |
-| `cdn.jsdelivr.net` | Math.js library |
-| `cdnjs.cloudflare.com` | PDF.js worker |
-| `stackblitz.com` | StackBlitz IDE embeds |
-| `www.youtube.com` | YouTube IFrame API |
-| `www.youtube-nocookie.com` | YouTube video embeds (privacy-enhanced) |
-| `open.spotify.com` | Spotify embeds |
-| `vercel.live` | Vercel toolbar |
+| Domain                      | Purpose                                 |
+| --------------------------- | --------------------------------------- |
+| `platform.twitter.com`      | Twitter widgets and scripts             |
+| `syndication.twitter.com`   | Twitter embed scripts                   |
+| `cdn.syndication.twimg.com` | Twitter asset CDN                       |
+| `*.twitter.com`             | Additional Twitter content              |
+| `*.x.com`                   | X (Twitter) domain equivalents          |
+| `*.google.com`              | Google services and Chrome app favicons |
+| `example.com`               | Chrome app demo origin                  |
+| `developer.mozilla.org`     | Chrome app demo origin                  |
+| `en.wikipedia.org`          | Chrome app demo origin                  |
+| `cdn.jsdelivr.net`          | Math.js library                         |
+| `cdnjs.cloudflare.com`      | PDF.js worker                           |
+| `stackblitz.com`            | StackBlitz IDE embeds                   |
+| `www.youtube.com`           | YouTube IFrame API                      |
+| `www.youtube-nocookie.com`  | YouTube video embeds (privacy-enhanced) |
+| `open.spotify.com`          | Spotify embeds                          |
+| `vercel.live`               | Vercel toolbar                          |
 
 **Notes for prod hardening**
+
 - Review `connect-src` and `frame-src` to ensure only required domains are present for your deployment.
 - Consider removing `'unsafe-inline'` from `style-src` once all inline styles are eliminated.
 - If deploying on a domain that serves a PDF resume via `<object>`, keep `X-Frame-Options: SAMEORIGIN`. Otherwise you can rely on CSP `frame-ancestors` instead.
@@ -267,9 +301,11 @@ These external domains are whitelisted in the default CSP. Update this list when
 ## Deployment
 
 ### Static export (GitHub Pages)
+
 Workflow: `.github/workflows/gh-deploy.yml`:
- - Installs Node, runs `yarn export`, adds `.nojekyll`, and deploys `./out` → `gh-pages` branch.
- - Uses **Node 20.19.5** to match `package.json`.
+
+- Installs Node, runs `yarn export`, adds `.nojekyll`, and deploys `./out` → `gh-pages` branch.
+- Uses **Node 20.19.5** to match `package.json`.
 - Required env variables (GitHub Secrets):
   - `NEXT_PUBLIC_TRACKING_ID`
   - `NEXT_PUBLIC_SERVICE_ID`
@@ -282,6 +318,7 @@ Workflow: `.github/workflows/gh-deploy.yml`:
   - `NEXT_PUBLIC_UI_EXPERIMENTS`
 
 ### Vercel deployment
+
 - Create a Vercel project and connect this repo.
 - Required env variables (Project Settings):
   - `NEXT_PUBLIC_TRACKING_ID`
@@ -301,6 +338,7 @@ Workflow: `.github/workflows/gh-deploy.yml`:
 - If you keep API routes, Vercel deploys them as serverless functions. For a static build, disable API routes or feature-flag those apps.
 
 ### Docker image build/run
+
 ```Dockerfile
 # node:20-alpine
 FROM node:20-alpine AS build
@@ -319,11 +357,13 @@ CMD ["yarn","start","-p","3000"]
 ```
 
 Build the image:
+
 ```bash
 docker build -t kali-portfolio .
 ```
 
 Run the container:
+
 ```bash
 docker run -p 3000:3000 \
   -e NEXT_PUBLIC_TRACKING_ID=... \
@@ -343,11 +383,13 @@ docker run -p 3000:3000 \
 ## Testing
 
 Jest is configured via `jest.config.js` with a **jsdom** environment and helpers in `jest.setup.ts`:
+
 - Mocks for `Image`, `OffscreenCanvas`, `AudioContext`, `Worker`, etc.
 - `__tests__/apps.smoke.test.tsx` dynamically imports each app and renders it to catch runtime errors.
 - Per-app logic tests (e.g., `blackjack.test.ts`, `sokoban.test.ts`, `nonogram.test.ts`).
 
 Commands:
+
 ```bash
 yarn test
 yarn test:watch
@@ -361,21 +403,22 @@ yarn lint
 Browse all apps, games, and security tool demos at `/apps`, which presents a searchable grid built from `apps.config.js`.
 
 ### Utilities & Media
-| App | Route | Category |
-| --- | --- | --- |
-| Alex | /apps/alex | Utility / Media |
-| Chrome | /apps/chrome | Utility / Media |
-| VS Code | /apps/vscode | StackBlitz IDE embed |
-| Spotify | /apps/spotify | Utility / Media |
-| Youtube | /apps/youtube | Utility / Media |
-| Weather | /apps/weather | Utility / Media |
-| X / Twitter | /apps/x | Utility / Media |
-| Todoist | /apps/todoist | Utility / Media |
-| Gedit | /apps/gedit | Utility / Media |
-| Settings | /apps/settings | Utility / Media |
-| Trash | /apps/trash | Utility / Media |
-| Project Gallery | /apps/project-gallery | Utility / Media |
-| Quote | /apps/quote | Utility / Media |
+
+| App             | Route                 | Category             |
+| --------------- | --------------------- | -------------------- |
+| Alex            | /apps/alex            | Utility / Media      |
+| Chrome          | /apps/chrome          | Utility / Media      |
+| VS Code         | /apps/vscode          | StackBlitz IDE embed |
+| Spotify         | /apps/spotify         | Utility / Media      |
+| Youtube         | /apps/youtube         | Utility / Media      |
+| Weather         | /apps/weather         | Utility / Media      |
+| X / Twitter     | /apps/x               | Utility / Media      |
+| Todoist         | /apps/todoist         | Utility / Media      |
+| Gedit           | /apps/gedit           | Utility / Media      |
+| Settings        | /apps/settings        | Utility / Media      |
+| Trash           | /apps/trash           | Utility / Media      |
+| Project Gallery | /apps/project-gallery | Utility / Media      |
+| Quote           | /apps/quote           | Utility / Media      |
 
 > The VS Code app now embeds a StackBlitz IDE via iframe instead of the local Monaco editor.
 
@@ -385,70 +428,73 @@ System so your choices restore on load. The last mood played is remembered, and
 play/pause and track controls include keyboard hotkeys.
 
 ### Terminal Commands
+
 - `clear` – clears the terminal display.
 - `help` – lists available commands.
 
 ### Games
-| Game | Route | Category |
-| --- | --- | --- |
-| 2048 | /apps/2048 | Game |
-| Asteroids | /apps/asteroids | Game |
-| Battleship | /apps/battleship | Game |
-| Blackjack | /apps/blackjack | Game |
-| Breakout | /apps/breakout | Game |
-| Candy Crush | /apps/candy-crush | Game |
-| Car Racer | /apps/car-racer | Game - ghost replays, lane assist, drift scoring |
-| Checkers | /apps/checkers | Game |
-| Chess | /apps/chess | Game |
-| Connect Four | /apps/connect-four | Game |
-| Flappy Bird | /apps/flappy-bird | Game |
-| Frogger | /apps/frogger | Game |
-| Gomoku | /apps/gomoku | Game |
-| Hangman | /apps/hangman | Game |
-| Memory | /apps/memory | Game |
-| Minesweeper | /apps/minesweeper | Game |
-| Nonogram | /apps/nonogram | Game |
-| Pacman | /apps/pacman | Game |
-| Pinball | /apps/pinball | Game |
-| Platformer | /apps/platformer | Game |
-| Pong | /apps/pong | Game |
-| Reversi | /apps/reversi | Game |
-| Simon | /apps/simon | Game |
-| Snake | /apps/snake | Game |
-| Sokoban | /apps/sokoban | Game |
-| Solitaire | /apps/solitaire | Game |
-| Space Invaders | /apps/space-invaders | Game |
-| Sudoku | /apps/sudoku | Game |
-| Tetris | /apps/tetris | Game |
-| Tic Tac Toe | /apps/tictactoe | Game |
-| Tower Defense | /apps/tower-defense | Game |
-| Word Search | /apps/word-search | Game |
-| Wordle | /apps/wordle | Game |
+
+| Game           | Route                | Category                                         |
+| -------------- | -------------------- | ------------------------------------------------ |
+| 2048           | /apps/2048           | Game                                             |
+| Asteroids      | /apps/asteroids      | Game                                             |
+| Battleship     | /apps/battleship     | Game                                             |
+| Blackjack      | /apps/blackjack      | Game                                             |
+| Breakout       | /apps/breakout       | Game                                             |
+| Candy Crush    | /apps/candy-crush    | Game                                             |
+| Car Racer      | /apps/car-racer      | Game - ghost replays, lane assist, drift scoring |
+| Checkers       | /apps/checkers       | Game                                             |
+| Chess          | /apps/chess          | Game                                             |
+| Connect Four   | /apps/connect-four   | Game                                             |
+| Flappy Bird    | /apps/flappy-bird    | Game                                             |
+| Frogger        | /apps/frogger        | Game                                             |
+| Gomoku         | /apps/gomoku         | Game                                             |
+| Hangman        | /apps/hangman        | Game                                             |
+| Memory         | /apps/memory         | Game                                             |
+| Minesweeper    | /apps/minesweeper    | Game                                             |
+| Nonogram       | /apps/nonogram       | Game                                             |
+| Pacman         | /apps/pacman         | Game                                             |
+| Pinball        | /apps/pinball        | Game                                             |
+| Platformer     | /apps/platformer     | Game                                             |
+| Pong           | /apps/pong           | Game                                             |
+| Reversi        | /apps/reversi        | Game                                             |
+| Simon          | /apps/simon          | Game                                             |
+| Snake          | /apps/snake          | Game                                             |
+| Sokoban        | /apps/sokoban        | Game                                             |
+| Solitaire      | /apps/solitaire      | Game                                             |
+| Space Invaders | /apps/space-invaders | Game                                             |
+| Sudoku         | /apps/sudoku         | Game                                             |
+| Tetris         | /apps/tetris         | Game                                             |
+| Tic Tac Toe    | /apps/tictactoe      | Game                                             |
+| Tower Defense  | /apps/tower-defense  | Game                                             |
+| Word Search    | /apps/word-search    | Game                                             |
+| Wordle         | /apps/wordle         | Game                                             |
 
 ### Security Tools (Simulated)
-| Tool | Route | Category |
-| --- | --- | --- |
-| Autopsy | /apps/autopsy | Security Tool (simulated) |
-| BeEF | /apps/beef | Security Tool (simulated) |
-| Bluetooth Tools | /apps/bluetooth | Security Tool (simulated) |
-| dsniff | /apps/dsniff | Security Tool (simulated) |
-| Ettercap | /apps/ettercap | Security Tool (simulated) |
-| Ghidra | /apps/ghidra | Security Tool (simulated) |
-| Hashcat | /apps/hashcat | Security Tool (simulated) |
-| Hydra | /apps/hydra | Security Tool (simulated) |
-| John the Ripper | /apps/john | Security Tool (simulated) |
-| Kismet | /apps/kismet | Security Tool (simulated) |
-| Metasploit | /apps/metasploit | Security Tool (simulated) |
-| Metasploit Post | /apps/metasploit-post | Security Tool (simulated) |
-| Mimikatz | /apps/mimikatz | Security Tool (simulated) |
-| Nessus | /apps/nessus | Security Tool (simulated) |
-| Nmap NSE | /apps/nmap-nse | Security Tool (simulated) |
-| OpenVAS | /apps/openvas | Security Tool (simulated) |
-| Radare2 | /apps/radare2 | Security Tool (simulated) |
-| Reaver | /apps/reaver | Security Tool (simulated) |
-| Recon-ng | /apps/reconng | Security Tool (simulated) |
-| Volatility | /apps/volatility | Security Tool (simulated) |
-| Wireshark | /apps/wireshark | Security Tool (simulated, lab use only) |
+
+| Tool            | Route                 | Category                                |
+| --------------- | --------------------- | --------------------------------------- |
+| Autopsy         | /apps/autopsy         | Security Tool (simulated)               |
+| BeEF            | /apps/beef            | Security Tool (simulated)               |
+| Bluetooth Tools | /apps/bluetooth       | Security Tool (simulated)               |
+| dsniff          | /apps/dsniff          | Security Tool (simulated)               |
+| Ettercap        | /apps/ettercap        | Security Tool (simulated)               |
+| Ghidra          | /apps/ghidra          | Security Tool (simulated)               |
+| Hashcat         | /apps/hashcat         | Security Tool (simulated)               |
+| Hydra           | /apps/hydra           | Security Tool (simulated)               |
+| John the Ripper | /apps/john            | Security Tool (simulated)               |
+| Kismet          | /apps/kismet          | Security Tool (simulated)               |
+| Metasploit      | /apps/metasploit      | Security Tool (simulated)               |
+| Metasploit Post | /apps/metasploit-post | Security Tool (simulated)               |
+| Mimikatz        | /apps/mimikatz        | Security Tool (simulated)               |
+| Nessus          | /apps/nessus          | Security Tool (simulated)               |
+| Nmap NSE        | /apps/nmap-nse        | Security Tool (simulated)               |
+| OpenVAS         | /apps/openvas         | Security Tool (simulated)               |
+| Radare2         | /apps/radare2         | Security Tool (simulated)               |
+| Reaver          | /apps/reaver          | Security Tool (simulated)               |
+| Recon-ng        | /apps/reconng         | Security Tool (simulated)               |
+| Volatility      | /apps/volatility      | Security Tool (simulated)               |
+| Wireshark       | /apps/wireshark       | Security Tool (simulated, lab use only) |
 
 > All security apps are **non-operational simulations** intended for education/demos. They **do not** execute exploits and should not be used for any unauthorized activity.
 > All reports and feed data are canned examples and not generated from live systems.
@@ -510,8 +556,7 @@ See [`LICENSE`](./LICENSE).
 
 ---
 
-*Generated on 2025-08-26*
-
+_Generated on 2025-08-26_
 
 ---
 
@@ -525,4 +570,3 @@ The calculator supports a subset of math.js expressions with the following featu
 - The previous answer is accessible via `Ans`.
 
 Invalid syntax is highlighted in the calculator input, selecting the character where parsing failed.
-

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,0 +1,13 @@
+const quoteFiles = (files) => files.map((file) => JSON.stringify(file)).join(' ');
+
+module.exports = {
+  '*.{js,jsx,ts,tsx,json,css,scss,md,mdx,yml,yaml,html}': (files) => {
+    if (files.length === 0) return [];
+    return [`prettier --write --ignore-unknown ${quoteFiles(files)}`];
+  },
+  '*.{js,jsx,ts,tsx}': (files) => {
+    if (files.length === 0) return [];
+    return [`eslint --max-warnings=0 --fix --cache --cache-location node_modules/.cache/eslint ${quoteFiles(files)}`];
+  },
+  '*.{ts,tsx}': () => 'yarn tsc --noEmit --pretty false',
+};

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
-    "verify:all": "node scripts/verify.mjs"
+    "verify:all": "node scripts/verify.mjs",
+    "prepare": "husky",
+    "lint-staged": "lint-staged --concurrent false",
+    "setup:hooks": "husky"
   },
   "engines": {
     "node": "20.19.5"
@@ -132,8 +135,10 @@
     "eslint-config-next": "15.5.2",
     "fake-indexeddb": "^6.1.0",
     "fast-glob": "^3.3.3",
+    "husky": "^9.1.7",
     "jest": "30.0.5",
     "jest-environment-jsdom": "30.0.5",
+    "lint-staged": "^16.1.6",
     "magic-string": "0.30.18",
     "node-mocks-http": "1.17.2",
     "pa11y": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4614,6 +4614,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-escapes@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "ansi-escapes@npm:7.1.0"
+  dependencies:
+    environment: "npm:^1.0.0"
+  checksum: 10c0/c3aeb677bb272213936e8b96250d742f4d3a17b8135189cc22295713392de84c40765599d16ad2d4e30db38283355e77c8be2aa0441b733c48d7fb960782fbe3
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -4648,6 +4657,13 @@ __metadata:
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
   checksum: 10c0/5d1ec38c123984bcedd996eac680d548f31828bd679a66db2bdf11844634dde55fec3efa9c6bb1d89056a5e79c1ac540c4c784d592ea1d25028a92227d2f2d5c
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^6.2.1":
+  version: 6.2.3
+  resolution: "ansi-styles@npm:6.2.3"
+  checksum: 10c0/23b8a4ce14e18fb854693b95351e286b771d23d8844057ed2e7d083cd3e708376c3323707ec6a24365f7d7eda3ca00327fe04092e29e551499ec4c8b7bfac868
   languageName: node
   linkType: hard
 
@@ -5473,6 +5489,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^5.6.0":
+  version: 5.6.2
+  resolution: "chalk@npm:5.6.2"
+  checksum: 10c0/99a4b0f0e7991796b1e7e3f52dceb9137cae2a9dfc8fc0784a550dc4c558e15ab32ed70b14b21b52beb2679b4892b41a0aa44249bcb996f01e125d58477c6976
+  languageName: node
+  linkType: hard
+
 "char-regex@npm:^1.0.2":
   version: 1.0.2
   resolution: "char-regex@npm:1.0.2"
@@ -5566,6 +5589,25 @@ __metadata:
   version: 2.5.1
   resolution: "classnames@npm:2.5.1"
   checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
+  languageName: node
+  linkType: hard
+
+"cli-cursor@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "cli-cursor@npm:5.0.0"
+  dependencies:
+    restore-cursor: "npm:^5.0.0"
+  checksum: 10c0/7ec62f69b79f6734ab209a3e4dbdc8af7422d44d360a7cb1efa8a0887bbe466a6e625650c466fe4359aee44dbe2dc0b6994b583d40a05d0808a5cb193641d220
+  languageName: node
+  linkType: hard
+
+"cli-truncate@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "cli-truncate@npm:5.1.0"
+  dependencies:
+    slice-ansi: "npm:^7.1.0"
+    string-width: "npm:^8.0.0"
+  checksum: 10c0/388a4c9813372fb82ef3958af9bcf233419e80f4f435386cc83666ba85c9ccfdaa4dd6e47a9fde8f70b1e2b485cfc5da97bc899ce4f3b24ed04933a2f878f7d6
   languageName: node
   linkType: hard
 
@@ -5664,6 +5706,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"colorette@npm:^2.0.20":
+  version: 2.0.20
+  resolution: "colorette@npm:2.0.20"
+  checksum: 10c0/e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
+  languageName: node
+  linkType: hard
+
 "combined-stream@npm:^1.0.8":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
@@ -5677,6 +5726,13 @@ __metadata:
   version: 12.1.0
   resolution: "commander@npm:12.1.0"
   checksum: 10c0/6e1996680c083b3b897bfc1cfe1c58dfbcd9842fd43e1aaf8a795fbc237f65efcc860a3ef457b318e73f29a4f4a28f6403c3d653d021d960e4632dd45bde54a9
+  languageName: node
+  linkType: hard
+
+"commander@npm:^14.0.0":
+  version: 14.0.1
+  resolution: "commander@npm:14.0.1"
+  checksum: 10c0/64439c0651ddd01c1d0f48c8f08e97c18a0a1fa693879451f1203ad01132af2c2aa85da24cf0d8e098ab9e6dc385a756be670d2999a3c628ec745c3ec124587b
   languageName: node
   linkType: hard
 
@@ -6469,6 +6525,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"emoji-regex@npm:^10.3.0":
+  version: 10.5.0
+  resolution: "emoji-regex@npm:10.5.0"
+  checksum: 10c0/17cf84335a461fc23bf90575122ace2902630dc760e53299474cd3b0b5e4cfbc6c0223a389a766817538e5d20bf0f36c67b753f27c9e705056af510b8777e312
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^8.0.0":
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
@@ -6531,6 +6594,13 @@ __metadata:
   bin:
     envinfo: dist/cli.js
   checksum: 10c0/059a031eee101e056bd9cc5cbfe25c2fab433fe1780e86cf0a82d24a000c6931e327da6a8ffb3dce528a24f83f256e7efc0b36813113eff8fdc6839018efe327
+  languageName: node
+  linkType: hard
+
+"environment@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "environment@npm:1.1.0"
+  checksum: 10c0/fb26434b0b581ab397039e51ff3c92b34924a98b2039dcb47e41b7bca577b9dbf134a8eadb364415c74464b682e2d3afe1a4c0eb9873dc44ea814c5d3103331d
   languageName: node
   linkType: hard
 
@@ -7654,6 +7724,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-east-asian-width@npm:^1.0.0, get-east-asian-width@npm:^1.3.0, get-east-asian-width@npm:^1.3.1":
+  version: 1.4.0
+  resolution: "get-east-asian-width@npm:1.4.0"
+  checksum: 10c0/4e481d418e5a32061c36fbb90d1b225a254cc5b2df5f0b25da215dcd335a3c111f0c2023ffda43140727a9cafb62dac41d022da82c08f31083ee89f714ee3b83
+  languageName: node
+  linkType: hard
+
 "get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
   version: 1.3.0
   resolution: "get-intrinsic@npm:1.3.0"
@@ -8051,6 +8128,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
+  bin:
+    husky: bin.js
+  checksum: 10c0/35bb110a71086c48906aa7cd3ed4913fb913823715359d65e32e0b964cb1e255593b0ae8014a5005c66a68e6fa66c38dcfa8056dbbdfb8b0187c0ffe7ee3a58f
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -8325,6 +8411,15 @@ __metadata:
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
   checksum: 10c0/bb11d825e049f38e04c06373a8d72782eee0205bda9d908cc550ccb3c59b99d750ff9537982e01733c1c94a58e35400661f57042158ff5e8f3e90cf936daf0fc
+  languageName: node
+  linkType: hard
+
+"is-fullwidth-code-point@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "is-fullwidth-code-point@npm:5.1.0"
+  dependencies:
+    get-east-asian-width: "npm:^1.3.1"
+  checksum: 10c0/c1172c2e417fb73470c56c431851681591f6a17233603a9e6f94b7ba870b2e8a5266506490573b607fb1081318589372034aa436aec07b465c2029c0bc7f07a4
   languageName: node
   linkType: hard
 
@@ -9540,6 +9635,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lint-staged@npm:^16.1.6":
+  version: 16.1.6
+  resolution: "lint-staged@npm:16.1.6"
+  dependencies:
+    chalk: "npm:^5.6.0"
+    commander: "npm:^14.0.0"
+    debug: "npm:^4.4.1"
+    lilconfig: "npm:^3.1.3"
+    listr2: "npm:^9.0.3"
+    micromatch: "npm:^4.0.8"
+    nano-spawn: "npm:^1.0.2"
+    pidtree: "npm:^0.6.0"
+    string-argv: "npm:^0.3.2"
+    yaml: "npm:^2.8.1"
+  bin:
+    lint-staged: bin/lint-staged.js
+  checksum: 10c0/e695edfec7e330f2c7cd0bb0e56220aa95d3b3655fe64a87a02140609a3594df67e1ea7abc2cc4ce69aa010418e406b1b24703ba4bd026c873a5b43a5ab16c6a
+  languageName: node
+  linkType: hard
+
+"listr2@npm:^9.0.3":
+  version: 9.0.4
+  resolution: "listr2@npm:9.0.4"
+  dependencies:
+    cli-truncate: "npm:^5.0.0"
+    colorette: "npm:^2.0.20"
+    eventemitter3: "npm:^5.0.1"
+    log-update: "npm:^6.1.0"
+    rfdc: "npm:^1.4.1"
+    wrap-ansi: "npm:^9.0.0"
+  checksum: 10c0/69feca532f5b3317112a74bc7589ad29f98ccfbe1a582bdab556d536978b094e5841b94069e01cf59ea919684dfb68218754526ddd317b1dc829ab57f7450e45
+  languageName: node
+  linkType: hard
+
 "load-bmfont@npm:^1.2.3":
   version: 1.4.2
   resolution: "load-bmfont@npm:1.4.2"
@@ -9606,6 +9735,19 @@ __metadata:
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+  languageName: node
+  linkType: hard
+
+"log-update@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "log-update@npm:6.1.0"
+  dependencies:
+    ansi-escapes: "npm:^7.0.0"
+    cli-cursor: "npm:^5.0.0"
+    slice-ansi: "npm:^7.1.0"
+    strip-ansi: "npm:^7.1.0"
+    wrap-ansi: "npm:^9.0.0"
+  checksum: 10c0/4b350c0a83d7753fea34dcac6cd797d1dc9603291565de009baa4aa91c0447eab0d3815a05c8ec9ac04fdfffb43c82adcdb03ec1fceafd8518e1a8c1cff4ff89
   languageName: node
   linkType: hard
 
@@ -9870,6 +10012,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mimic-function@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "mimic-function@npm:5.0.1"
+  checksum: 10c0/f3d9464dd1816ecf6bdf2aec6ba32c0728022039d992f178237d8e289b48764fee4131319e72eedd4f7f094e22ded0af836c3187a7edc4595d28dd74368fd81d
+  languageName: node
+  linkType: hard
+
 "mimic-response@npm:^1.0.0, mimic-response@npm:^1.0.1":
   version: 1.0.1
   resolution: "mimic-response@npm:1.0.1"
@@ -10073,6 +10222,13 @@ __metadata:
     object-assign: "npm:^4.0.1"
     thenify-all: "npm:^1.0.0"
   checksum: 10c0/103114e93f87362f0b56ab5b2e7245051ad0276b646e3902c98397d18bb8f4a77f2ea4a2c9d3ad516034ea3a56553b60d3f5f78220001ca4c404bd711bd0af39
+  languageName: node
+  linkType: hard
+
+"nano-spawn@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "nano-spawn@npm:1.0.3"
+  checksum: 10c0/ea18857e493710a50ded333dd71677953bd9bd9e6a17ade74af957763c50a9a02205ef31bc0d6784f5b3ad82db3d9f47531e9baac2acf01118f9b7c35bd9d5de
   languageName: node
   linkType: hard
 
@@ -10498,6 +10654,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"onetime@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "onetime@npm:7.0.0"
+  dependencies:
+    mimic-function: "npm:^5.0.0"
+  checksum: 10c0/5cb9179d74b63f52a196a2e7037ba2b9a893245a5532d3f44360012005c9cadb60851d56716ebff18a6f47129dab7168022445df47c2aff3b276d92585ed1221
+  languageName: node
+  linkType: hard
+
 "opener@npm:^1.5.2":
   version: 1.5.2
   resolution: "opener@npm:1.5.2"
@@ -10838,6 +11003,15 @@ __metadata:
   version: 4.0.3
   resolution: "picomatch@npm:4.0.3"
   checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
+  languageName: node
+  linkType: hard
+
+"pidtree@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "pidtree@npm:0.6.0"
+  bin:
+    pidtree: bin/pidtree.js
+  checksum: 10c0/0829ec4e9209e230f74ebf4265f5ccc9ebfb488334b525cb13f86ff801dca44b362c41252cd43ae4d7653a10a5c6ab3be39d2c79064d6895e0d78dc50a5ed6e9
   languageName: node
   linkType: hard
 
@@ -12246,6 +12420,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"restore-cursor@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "restore-cursor@npm:5.1.0"
+  dependencies:
+    onetime: "npm:^7.0.0"
+    signal-exit: "npm:^4.1.0"
+  checksum: 10c0/c2ba89131eea791d1b25205bdfdc86699767e2b88dee2a590b1a6caa51737deac8bad0260a5ded2f7c074b7db2f3a626bcf1fcf3cdf35974cbeea5e2e6764f60
+  languageName: node
+  linkType: hard
+
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -12257,6 +12441,13 @@ __metadata:
   version: 1.1.0
   resolution: "reusify@npm:1.1.0"
   checksum: 10c0/4eff0d4a5f9383566c7d7ec437b671cc51b25963bd61bf127c3f3d3f68e44a026d99b8d2f1ad344afff8d278a8fe70a8ea092650a716d22287e8bef7126bb2fa
+  languageName: node
+  linkType: hard
+
+"rfdc@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "rfdc@npm:1.4.1"
+  checksum: 10c0/4614e4292356cafade0b6031527eea9bc90f2372a22c012313be1dcc69a3b90c7338158b414539be863fa95bfcb2ddcd0587be696841af4e6679d85e62c060c7
   languageName: node
   linkType: hard
 
@@ -12643,7 +12834,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1":
+"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
@@ -12674,6 +12865,16 @@ __metadata:
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
   checksum: 10c0/e18488c6a42bdfd4ac5be85b2ced3ccd0224773baae6ad42cfbb9ec74fc07f9fa8396bd35ee638084ead7a2a0818eb5e7151111544d4731ce843019dab4be47b
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^7.1.0":
+  version: 7.1.2
+  resolution: "slice-ansi@npm:7.1.2"
+  dependencies:
+    ansi-styles: "npm:^6.2.1"
+    is-fullwidth-code-point: "npm:^5.0.0"
+  checksum: 10c0/36742f2eb0c03e2e81a38ed14d13a64f7b732fe38c3faf96cce0599788a345011e840db35f1430ca606ea3f8db2abeb92a8d25c2753a819e3babaa10c2e289a2
   languageName: node
   linkType: hard
 
@@ -12848,6 +13049,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-argv@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "string-argv@npm:0.3.2"
+  checksum: 10c0/75c02a83759ad1722e040b86823909d9a2fc75d15dd71ec4b537c3560746e33b5f5a07f7332d1e3f88319909f82190843aa2f0a0d8c8d591ec08e93d5b8dec82
+  languageName: node
+  linkType: hard
+
 "string-convert@npm:^0.2.0":
   version: 0.2.1
   resolution: "string-convert@npm:0.2.1"
@@ -12884,6 +13092,27 @@ __metadata:
     emoji-regex: "npm:^9.2.2"
     strip-ansi: "npm:^7.0.1"
   checksum: 10c0/ab9c4264443d35b8b923cbdd513a089a60de339216d3b0ed3be3ba57d6880e1a192b70ae17225f764d7adbf5994e9bb8df253a944736c15a0240eff553c678ca
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "string-width@npm:7.2.0"
+  dependencies:
+    emoji-regex: "npm:^10.3.0"
+    get-east-asian-width: "npm:^1.0.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10c0/eb0430dd43f3199c7a46dcbf7a0b34539c76fe3aa62763d0b0655acdcbdf360b3f66f3d58ca25ba0205f42ea3491fa00f09426d3b7d3040e506878fc7664c9b9
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^8.0.0":
+  version: 8.1.0
+  resolution: "string-width@npm:8.1.0"
+  dependencies:
+    get-east-asian-width: "npm:^1.3.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10c0/749b5d0dab2532b4b6b801064230f4da850f57b3891287023117ab63a464ad79dd208f42f793458f48f3ad121fe2e1f01dd525ff27ead957ed9f205e27406593
   languageName: node
   linkType: hard
 
@@ -12993,6 +13222,15 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10c0/a198c3762e8832505328cbf9e8c8381de14a4fa50a4f9b2160138158ea88c0f5549fb50cb13c651c3088f47e63a108b34622ec18c0499b6c8c3a5ddf6b305ac4
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^7.1.0":
+  version: 7.1.2
+  resolution: "strip-ansi@npm:7.1.2"
+  dependencies:
+    ansi-regex: "npm:^6.0.1"
+  checksum: 10c0/0d6d7a023de33368fd042aab0bf48f4f4077abdfd60e5393e73c7c411e85e1b3a83507c11af2e656188511475776215df9ca589b4da2295c9455cc399ce1858b
   languageName: node
   linkType: hard
 
@@ -13915,6 +14153,7 @@ __metadata:
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"
     html2canvas: "npm:^1.4.1"
+    husky: "npm:^9.1.7"
     idb: "npm:7.1.1"
     idb-keyval: "npm:^6.2.1"
     jest: "npm:30.0.5"
@@ -13922,6 +14161,7 @@ __metadata:
     jspdf: "npm:^3.0.2"
     kaitai-struct: "npm:^0.10.0"
     leaflet: "npm:^1.9.4"
+    lint-staged: "npm:^16.1.6"
     magic-string: "npm:0.30.18"
     marked: "npm:^16.2.1"
     mathjs: "npm:^14.6.0"
@@ -14635,6 +14875,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wrap-ansi@npm:^9.0.0":
+  version: 9.0.2
+  resolution: "wrap-ansi@npm:9.0.2"
+  dependencies:
+    ansi-styles: "npm:^6.2.1"
+    string-width: "npm:^7.0.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10c0/3305839b9a0d6fb930cb63a52f34d3936013d8b0682ff3ec133c9826512620f213800ffa19ea22904876d5b7e9a3c1f40682f03597d986a4ca881fa7b033688c
+  languageName: node
+  linkType: hard
+
 "wrappy@npm:1":
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
@@ -14774,7 +15025,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.3.4":
+"yaml@npm:^2.3.4, yaml@npm:^2.8.1":
   version: 2.8.1
   resolution: "yaml@npm:2.8.1"
   bin:


### PR DESCRIPTION
## Summary
- install husky and lint-staged with lint/type/format tasks on staged files
- add a Husky pre-commit hook that skips CI and common bot commits before running lint-staged
- document how contributors enable the hooks locally

## Testing
- yarn lint *(fails: existing accessibility and browser global lint violations in untouched files)*
- yarn test *(fails: existing suite failures around UI interactions and missing DOM APIs; run interrupted after repeated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cca66d0ef48328ba859cb93eb8583d