### PR TITLE
[tests] cover storage quota recovery

### DIFF
--- a/__tests__/qrStorage.test.ts
+++ b/__tests__/qrStorage.test.ts
@@ -17,4 +17,23 @@ describe('qrStorage', () => {
     const loaded = await loadScans();
     expect(loaded).toEqual([]);
   });
+
+  it('handles localStorage quota errors gracefully', async () => {
+    localStorage.setItem('qrScans', JSON.stringify(['existing']));
+    const quotaError = new DOMException('quota exceeded', 'QuotaExceededError');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const storageProto = Object.getPrototypeOf(window.localStorage);
+    const setSpy = jest.spyOn(storageProto, 'setItem').mockImplementation(function () {
+      throw quotaError;
+    });
+    const removeSpy = jest.spyOn(storageProto, 'removeItem');
+
+    await expect(saveScans(['d'])).resolves.toBeUndefined();
+    expect(removeSpy).toHaveBeenCalledWith('qrScans');
+    expect(await loadScans()).toEqual([]);
+
+    setSpy.mockRestore();
+    removeSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
 });

--- a/__tests__/settingsStore.quota.test.ts
+++ b/__tests__/settingsStore.quota.test.ts
@@ -1,0 +1,72 @@
+jest.mock('idb-keyval', () => {
+  const actual = jest.requireActual('idb-keyval');
+  return {
+    ...actual,
+    set: jest.fn(actual.set),
+    del: jest.fn(actual.del),
+  };
+});
+
+import * as idbKeyval from 'idb-keyval';
+
+type SettingsStoreModule = typeof import('../utils/settingsStore');
+
+let defaults: SettingsStoreModule['defaults'];
+let getAccent: SettingsStoreModule['getAccent'];
+let getDensity: SettingsStoreModule['getDensity'];
+let setAccent: SettingsStoreModule['setAccent'];
+let setDensity: SettingsStoreModule['setDensity'];
+
+beforeAll(async () => {
+  const module: SettingsStoreModule = await import('../utils/settingsStore');
+  ({ defaults, getAccent, getDensity, setAccent, setDensity } = module);
+});
+
+describe('settingsStore storage resilience', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.resetAllMocks();
+  });
+
+  it('cleans up after IndexedDB quota errors', async () => {
+    const quotaError = new DOMException('quota exceeded', 'QuotaExceededError');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const setMock = idbKeyval.set as jest.Mock;
+    const delMock = idbKeyval.del as jest.Mock;
+    setMock.mockRejectedValueOnce(quotaError);
+    delMock.mockResolvedValue(undefined);
+
+    await expect(setAccent('#ffffff')).resolves.toBeUndefined();
+    expect(delMock).toHaveBeenCalledWith('accent');
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[settingsStore] Failed to persist accent in IndexedDB',
+      quotaError
+    );
+    expect(await getAccent()).toBe(defaults.accent);
+
+    warnSpy.mockRestore();
+  });
+
+  it('resets localStorage keys on quota errors', async () => {
+    localStorage.setItem('density', 'compact');
+    const quotaError = new DOMException('quota exceeded', 'QuotaExceededError');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const storageProto = Object.getPrototypeOf(window.localStorage);
+    const setSpy = jest.spyOn(storageProto, 'setItem').mockImplementation(function () {
+      throw quotaError;
+    });
+    const removeSpy = jest.spyOn(storageProto, 'removeItem');
+
+    await expect(setDensity('compact')).resolves.toBeUndefined();
+    expect(removeSpy).toHaveBeenCalledWith('density');
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[settingsStore] Failed to persist density in localStorage',
+      quotaError
+    );
+    expect(await getDensity()).toBe(defaults.density);
+
+    removeSpy.mockRestore();
+    setSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,3 +22,25 @@ yarn dev
 See the [Architecture](./architecture.md) document for an overview of how the project is organized.
 
 For app contributions, see the [New App Checklist](./new-app-checklist.md).
+
+## Manual QA: Storage recovery
+
+Use this checklist when validating features that persist data via QR history or desktop settings. The goal is to confirm that
+quota failures recover without leaving the UI in a broken state.
+
+1. Open the browser DevTools console and execute the snippet below to simulate a quota-exceeded error:
+
+   ```js
+   try {
+     for (let i = 0; i < 200; i += 1) {
+       localStorage.setItem(`quota-fill-${i}`, 'x'.repeat(1024 * 1024));
+     }
+   } catch (error) {
+     console.warn('Simulated quota fill complete', error);
+   }
+   ```
+
+2. Trigger a write in the QR tool (scan a code or paste data) and adjust a desktop setting such as the density toggle.
+3. Confirm the UI falls back to an empty QR history and default settings values instead of crashing or leaving stale data.
+4. Check the console for `[qrStorage]` or `[settingsStore]` warnings that note the fallback. These indicate the recovery path ran.
+5. Clear `localStorage` (Application tab → Clear storage) before repeating other manual tests.

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -16,127 +16,200 @@ const DEFAULT_SETTINGS = {
   haptics: true,
 };
 
+const warn = (message, error) => {
+  console.warn(`[settingsStore] ${message}`, error);
+};
+
+const safeDeleteIdb = async (key) => {
+  if (typeof window === 'undefined') return;
+  try {
+    await del(key);
+  } catch (error) {
+    warn(`Failed to clear ${key} in IndexedDB`, error);
+  }
+};
+
+const safeSetIdb = async (key, value) => {
+  if (typeof window === 'undefined') return;
+  try {
+    await set(key, value);
+  } catch (error) {
+    warn(`Failed to persist ${key} in IndexedDB`, error);
+    await safeDeleteIdb(key);
+  }
+};
+
+const safeGetIdb = async (key) => {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    return await get(key);
+  } catch (error) {
+    warn(`Failed to read ${key} from IndexedDB`, error);
+    await safeDeleteIdb(key);
+    return undefined;
+  }
+};
+
+const safeRemoveLocal = (key) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch (error) {
+    warn(`Failed to clear ${key} in localStorage`, error);
+  }
+};
+
+const safeSetLocal = (key, value) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (error) {
+    warn(`Failed to persist ${key} in localStorage`, error);
+    safeRemoveLocal(key);
+  }
+};
+
+const safeGetLocal = (key) => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    warn(`Failed to read ${key} from localStorage`, error);
+    safeRemoveLocal(key);
+    return null;
+  }
+};
+
 export async function getAccent() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
-  return (await get('accent')) || DEFAULT_SETTINGS.accent;
+  const stored = await safeGetIdb('accent');
+  return stored || DEFAULT_SETTINGS.accent;
 }
 
 export async function setAccent(accent) {
   if (typeof window === 'undefined') return;
-  await set('accent', accent);
+  await safeSetIdb('accent', accent);
 }
 
 export async function getWallpaper() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
-  return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
+  const stored = await safeGetIdb('bg-image');
+  return stored || DEFAULT_SETTINGS.wallpaper;
 }
 
 export async function setWallpaper(wallpaper) {
   if (typeof window === 'undefined') return;
-  await set('bg-image', wallpaper);
+  await safeSetIdb('bg-image', wallpaper);
 }
 
 export async function getDensity() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  return safeGetLocal('density') || DEFAULT_SETTINGS.density;
 }
 
 export async function setDensity(density) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
+  safeSetLocal('density', density);
 }
 
 export async function getReducedMotion() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  const stored = window.localStorage.getItem('reduced-motion');
+  const stored = safeGetLocal('reduced-motion');
   if (stored !== null) {
     return stored === 'true';
   }
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  try {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch (error) {
+    warn('Failed to evaluate reduced-motion media query', error);
+    return DEFAULT_SETTINGS.reducedMotion;
+  }
 }
 
 export async function setReducedMotion(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+  safeSetLocal('reduced-motion', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
+  const stored = safeGetLocal('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  safeSetLocal('font-scale', String(scale));
 }
 
 export async function getHighContrast() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  return safeGetLocal('high-contrast') === 'true';
 }
 
 export async function setHighContrast(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+  safeSetLocal('high-contrast', value ? 'true' : 'false');
 }
 
 export async function getLargeHitAreas() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
+  return safeGetLocal('large-hit-areas') === 'true';
 }
 
 export async function setLargeHitAreas(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
+  safeSetLocal('large-hit-areas', value ? 'true' : 'false');
 }
 
 export async function getHaptics() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
-  const val = window.localStorage.getItem('haptics');
+  const val = safeGetLocal('haptics');
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
 export async function setHaptics(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('haptics', value ? 'true' : 'false');
+  safeSetLocal('haptics', value ? 'true' : 'false');
 }
 
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
+  const val = safeGetLocal('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
 export async function setPongSpin(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
+  safeSetLocal('pong-spin', value ? 'true' : 'false');
 }
 
 export async function getAllowNetwork() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
+  return safeGetLocal('allow-network') === 'true';
 }
 
 export async function setAllowNetwork(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+  safeSetLocal('allow-network', value ? 'true' : 'false');
 }
 
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
-    del('accent'),
-    del('bg-image'),
+    safeDeleteIdb('accent'),
+    safeDeleteIdb('bg-image'),
   ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
+  [
+    'density',
+    'reduced-motion',
+    'font-scale',
+    'high-contrast',
+    'large-hit-areas',
+    'pong-spin',
+    'allow-network',
+    'haptics',
+  ].forEach((key) => safeRemoveLocal(key));
 }
 
 export async function exportSettings() {


### PR DESCRIPTION
## Summary
- harden qrStorage utilities to clean up OPFS writes and guard localStorage fallbacks
- add safe persistence helpers across settingsStore so quota errors resolve to defaults
- exercise the new error paths in dedicated Jest suites and document manual recovery QA steps

## Testing
- yarn test __tests__/qrStorage.test.ts __tests__/settingsStore.quota.test.ts
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label and no-top-level-window lint errors across legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68cca67057d88328b40de6fe8ea87980