### PR TITLE
[storage] Introduce typed IndexedDB wrapper and migrations

### DIFF
--- a/__tests__/storageMigration.test.ts
+++ b/__tests__/storageMigration.test.ts
@@ -1,0 +1,111 @@
+import 'fake-indexeddb/auto';
+
+// Provide a lightweight structuredClone polyfill for fake-indexeddb environments.
+// @ts-ignore
+if (typeof globalThis.structuredClone !== 'function') {
+  // @ts-ignore
+  globalThis.structuredClone = (val: any) => JSON.parse(JSON.stringify(val));
+}
+
+import { deleteDB } from 'idb';
+import { del, get, set } from 'idb-keyval';
+import {
+  KEYBINDS_PRIMARY_KEY,
+  LEGACY_KEYBINDS_KEY,
+  LEGACY_PROGRESS_KEY,
+  LEGACY_REPLAYS_KEY,
+  PROGRESS_PRIMARY_KEY,
+  STORAGE_DB_NAME,
+  STORE_KEYBINDS,
+  STORE_PROGRESS,
+  STORE_REPLAYS,
+  createStorageDatabase,
+  storageDb,
+} from '@/lib/storage/storageDb';
+import { getKeybinds, getProgress, getReplays } from '@/utils/storage';
+import type { Keybinds, ProgressData, Replay } from '@/types/storage';
+
+const resetDatabases = async () => {
+  await storageDb.close();
+  await deleteDB(STORAGE_DB_NAME).catch(() => undefined);
+  await Promise.all([
+    del(LEGACY_PROGRESS_KEY).catch(() => undefined),
+    del(LEGACY_KEYBINDS_KEY).catch(() => undefined),
+    del(LEGACY_REPLAYS_KEY).catch(() => undefined),
+  ]);
+};
+
+const seedLegacyStore = async (
+  progress: ProgressData | null,
+  keybinds: Keybinds | null,
+  replays: Replay[] | null,
+) => {
+  const tasks: Promise<unknown>[] = [];
+  if (progress) tasks.push(set(LEGACY_PROGRESS_KEY, progress));
+  if (keybinds) tasks.push(set(LEGACY_KEYBINDS_KEY, keybinds));
+  if (replays) tasks.push(set(LEGACY_REPLAYS_KEY, replays));
+  await Promise.all(tasks);
+};
+
+describe('storage migrations', () => {
+  beforeEach(async () => {
+    await resetDatabases();
+  });
+
+  afterEach(async () => {
+    await resetDatabases();
+  });
+
+  test('migrates legacy keyval-store data into typed stores', async () => {
+    await seedLegacyStore(
+      { mission: 'alpha' },
+      { jump: 'Space' },
+      [
+        { id: 'r1', data: { score: 10 } },
+        { id: 'r2', data: { score: 25 }, createdAt: 5 },
+      ],
+    );
+
+    expect(await get(LEGACY_PROGRESS_KEY)).toEqual({ mission: 'alpha' });
+
+    const progress = await getProgress();
+    expect(progress).toEqual({ mission: 'alpha' });
+
+    const db = await storageDb.getDbInstance();
+    if (!db) throw new Error('storage database unavailable');
+    const tx = db.transaction(STORE_PROGRESS, 'readonly');
+    const storedProgress = await tx.store.get(PROGRESS_PRIMARY_KEY);
+    expect(storedProgress).toEqual({ mission: 'alpha' });
+
+    const keybinds = await getKeybinds();
+    expect(keybinds).toEqual({ jump: 'Space' });
+
+    const replays = await getReplays();
+    expect(replays).toHaveLength(2);
+    expect(replays.map((r) => r.id).sort()).toEqual(['r1', 'r2']);
+    expect(replays.every((r) => typeof r.createdAt === 'number')).toBe(true);
+
+    expect(await get(LEGACY_PROGRESS_KEY)).toBeUndefined();
+    expect(await get(LEGACY_KEYBINDS_KEY)).toBeUndefined();
+    expect(await get(LEGACY_REPLAYS_KEY)).toBeUndefined();
+  });
+
+  test('preserves existing data when upgrading the storage schema', async () => {
+    const versionOneDb = createStorageDatabase(1);
+    await versionOneDb.put(STORE_PROGRESS, { stage: 4 }, PROGRESS_PRIMARY_KEY);
+    await versionOneDb.put(STORE_KEYBINDS, { fire: 'F' }, KEYBINDS_PRIMARY_KEY);
+    await versionOneDb.put(STORE_REPLAYS, { id: 'r-one', data: { moves: 12 }, createdAt: 1234 });
+    await versionOneDb.close();
+
+    const progress = await getProgress();
+    expect(progress).toEqual({ stage: 4 });
+
+    const keybinds = await getKeybinds();
+    expect(keybinds).toEqual({ fire: 'F' });
+
+    const replays = await getReplays();
+    expect(replays).toEqual([
+      { id: 'r-one', data: { moves: 12 }, createdAt: 1234 },
+    ]);
+  });
+});

--- a/lib/storage/indexeddb.ts
+++ b/lib/storage/indexeddb.ts
@@ -1,0 +1,206 @@
+import {
+  openDB,
+  type DBSchema,
+  type IDBPDatabase,
+  type IDBPTransaction,
+  type IDBTransactionMode,
+  type StoreKey,
+  type StoreNames,
+  type StoreValue,
+} from 'idb';
+import { hasIndexedDB } from '@/utils/isBrowser';
+
+export interface MigrationContext<Schema extends DBSchema> {
+  oldVersion: number;
+  newVersion: number;
+  transaction: IDBPTransaction<Schema, StoreNames<Schema>[], 'versionchange'>;
+}
+
+export interface Migration<Schema extends DBSchema> {
+  version: number;
+  migrate:
+    | ((db: IDBPDatabase<Schema>, context: MigrationContext<Schema>) => void)
+    | ((db: IDBPDatabase<Schema>, context: MigrationContext<Schema>) => Promise<void>);
+}
+
+export interface CreateDatabaseOptions<Schema extends DBSchema> {
+  name: string;
+  migrations: Migration<Schema>[];
+  version?: number;
+}
+
+export class TypedDatabase<Schema extends DBSchema> {
+  private dbPromise: Promise<IDBPDatabase<Schema>> | null | undefined;
+
+  constructor(
+    private readonly opener: () => Promise<IDBPDatabase<Schema>> | null,
+    private readonly supported: boolean,
+  ) {
+    this.dbPromise = supported ? undefined : null;
+  }
+
+  isSupported(): boolean {
+    return this.supported;
+  }
+
+  private async getDatabase(): Promise<IDBPDatabase<Schema> | null> {
+    if (!this.supported) return null;
+    if (this.dbPromise === undefined) {
+      const opened = this.opener();
+      if (!opened) {
+        this.dbPromise = null;
+        return null;
+      }
+      this.dbPromise = opened;
+    }
+    if (this.dbPromise === null) return null;
+    try {
+      return await this.dbPromise;
+    } catch {
+      this.dbPromise = undefined;
+      return null;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (!this.supported) return;
+    if (!this.dbPromise) {
+      this.dbPromise = undefined;
+      return;
+    }
+    try {
+      const db = await this.dbPromise;
+      db?.close();
+    } catch {
+      // ignore close errors
+    } finally {
+      this.dbPromise = undefined;
+    }
+  }
+
+  async get<Store extends StoreNames<Schema>>(
+    store: Store,
+    key: StoreKey<Schema, Store>,
+  ): Promise<StoreValue<Schema, Store> | undefined> {
+    const db = await this.getDatabase();
+    if (!db) return undefined;
+    try {
+      return await db.get(store, key);
+    } catch {
+      return undefined;
+    }
+  }
+
+  async put<Store extends StoreNames<Schema>>(
+    store: Store,
+    value: StoreValue<Schema, Store>,
+    key?: StoreKey<Schema, Store>,
+  ): Promise<void> {
+    const db = await this.getDatabase();
+    if (!db) return;
+    try {
+      if (key !== undefined) {
+        await db.put(store, value, key);
+      } else {
+        await db.put(store, value);
+      }
+    } catch {
+      // ignore write errors
+    }
+  }
+
+  async delete<Store extends StoreNames<Schema>>(
+    store: Store,
+    key: StoreKey<Schema, Store>,
+  ): Promise<void> {
+    const db = await this.getDatabase();
+    if (!db) return;
+    try {
+      await db.delete(store, key);
+    } catch {
+      // ignore delete errors
+    }
+  }
+
+  async clear<Store extends StoreNames<Schema>>(store: Store): Promise<void> {
+    const db = await this.getDatabase();
+    if (!db) return;
+    try {
+      await db.clear(store);
+    } catch {
+      // ignore clear errors
+    }
+  }
+
+  async getAll<Store extends StoreNames<Schema>>(
+    store: Store,
+  ): Promise<StoreValue<Schema, Store>[]> {
+    const db = await this.getDatabase();
+    if (!db) return [];
+    try {
+      return await db.getAll(store);
+    } catch {
+      return [];
+    }
+  }
+
+  async transaction<Mode extends IDBTransactionMode, Result>(
+    storeNames: StoreNames<Schema>[] | StoreNames<Schema>,
+    mode: Mode,
+    callback: (
+      tx: IDBPTransaction<Schema, StoreNames<Schema>[], Mode>,
+    ) => Promise<Result> | Result,
+  ): Promise<Result | undefined> {
+    const db = await this.getDatabase();
+    if (!db) return undefined;
+    const namesArray = Array.isArray(storeNames) ? storeNames : [storeNames];
+    const tx = db.transaction(namesArray, mode);
+    try {
+      const result = await callback(tx as IDBPTransaction<Schema, StoreNames<Schema>[], Mode>);
+      await tx.done;
+      return result;
+    } catch (error) {
+      try {
+        tx.abort();
+      } catch {
+        // ignore abort errors
+      }
+      throw error;
+    }
+  }
+
+  async getDbInstance(): Promise<IDBPDatabase<Schema> | null> {
+    return this.getDatabase();
+  }
+}
+
+export function createDatabase<Schema extends DBSchema>({
+  name,
+  migrations,
+  version,
+}: CreateDatabaseOptions<Schema>): TypedDatabase<Schema> {
+  const sortedMigrations = [...migrations].sort((a, b) => a.version - b.version);
+  const latestVersion = sortedMigrations.at(-1)?.version ?? 1;
+  const targetVersion = version ?? latestVersion;
+  const applicableMigrations = sortedMigrations.filter((migration) => migration.version <= targetVersion);
+  const supported = hasIndexedDB;
+
+  const opener = () => {
+    if (!supported) return null;
+    return openDB<Schema>(name, targetVersion, {
+      upgrade: async (db, oldVersion, newVersion, transaction) => {
+        for (const migration of applicableMigrations) {
+          if (migration.version > oldVersion && migration.version <= (newVersion ?? targetVersion)) {
+            await migration.migrate(db, {
+              oldVersion,
+              newVersion: newVersion ?? targetVersion,
+              transaction: transaction as IDBPTransaction<Schema, StoreNames<Schema>[], 'versionchange'>,
+            });
+          }
+        }
+      },
+    });
+  };
+
+  return new TypedDatabase<Schema>(opener, supported);
+}

--- a/lib/storage/storageDb.ts
+++ b/lib/storage/storageDb.ts
@@ -1,0 +1,126 @@
+import type { DBSchema } from 'idb';
+import { del as keyvalDel, get as keyvalGet } from 'idb-keyval';
+import type { Keybinds, ProgressData, Replay } from '@/types/storage';
+import { createDatabase, type Migration, type MigrationContext, type TypedDatabase } from './indexeddb';
+
+export const STORAGE_DB_NAME = 'kali-storage';
+export const STORE_PROGRESS = 'progress';
+export const STORE_KEYBINDS = 'keybinds';
+export const STORE_REPLAYS = 'replays';
+export const REPLAY_INDEX_CREATED_AT = 'byCreatedAt';
+export const PROGRESS_PRIMARY_KEY = 'global';
+export const KEYBINDS_PRIMARY_KEY = 'default';
+
+export const LEGACY_PROGRESS_KEY = 'progress';
+export const LEGACY_KEYBINDS_KEY = 'keybinds';
+export const LEGACY_REPLAYS_KEY = 'replays';
+
+export interface StorageSchema extends DBSchema {
+  progress: {
+    key: typeof PROGRESS_PRIMARY_KEY;
+    value: ProgressData;
+  };
+  keybinds: {
+    key: typeof KEYBINDS_PRIMARY_KEY;
+    value: Keybinds;
+  };
+  replays: {
+    key: string;
+    value: Replay;
+    indexes: {
+      [REPLAY_INDEX_CREATED_AT]: number;
+    };
+  };
+}
+
+const migrations: Migration<StorageSchema>[] = [
+  {
+    version: 1,
+    migrate: (db) => {
+      if (!db.objectStoreNames.contains(STORE_PROGRESS)) {
+        db.createObjectStore(STORE_PROGRESS);
+      }
+      if (!db.objectStoreNames.contains(STORE_KEYBINDS)) {
+        db.createObjectStore(STORE_KEYBINDS);
+      }
+      if (!db.objectStoreNames.contains(STORE_REPLAYS)) {
+        const store = db.createObjectStore(STORE_REPLAYS, { keyPath: 'id' });
+        store.createIndex(REPLAY_INDEX_CREATED_AT, 'createdAt');
+      }
+    },
+  },
+  {
+    version: 2,
+    migrate: async (db, context) => {
+      await ensureReplayIndex(context);
+      await migrateLegacyKeyval(db, context);
+    },
+  },
+];
+
+function createReplayTimestampGenerator() {
+  let ts = Date.now();
+  return () => ts++;
+}
+
+async function migrateLegacyKeyval(
+  _db: Parameters<Migration<StorageSchema>['migrate']>[0],
+  context: MigrationContext<StorageSchema>,
+): Promise<void> {
+  try {
+    const [legacyProgress, legacyKeybinds, legacyReplays] = await Promise.all([
+      keyvalGet<ProgressData | undefined>(LEGACY_PROGRESS_KEY).catch(() => undefined),
+      keyvalGet<Keybinds | undefined>(LEGACY_KEYBINDS_KEY).catch(() => undefined),
+      keyvalGet<Replay[] | undefined>(LEGACY_REPLAYS_KEY).catch(() => undefined),
+    ]);
+
+    const progressStore = context.transaction.objectStore(STORE_PROGRESS);
+    if (legacyProgress && !(await progressStore.get(PROGRESS_PRIMARY_KEY))) {
+      await progressStore.put(legacyProgress, PROGRESS_PRIMARY_KEY);
+    }
+
+    const keybindsStore = context.transaction.objectStore(STORE_KEYBINDS);
+    if (legacyKeybinds && !(await keybindsStore.get(KEYBINDS_PRIMARY_KEY))) {
+      await keybindsStore.put(legacyKeybinds, KEYBINDS_PRIMARY_KEY);
+    }
+
+    const replaysStore = context.transaction.objectStore(STORE_REPLAYS);
+    const hasExistingReplays = (await replaysStore.count()) > 0;
+    if (Array.isArray(legacyReplays) && !hasExistingReplays) {
+      const nextTimestamp = createReplayTimestampGenerator();
+      for (const replay of legacyReplays as Replay[]) {
+        if (!replay || typeof replay.id !== 'string') continue;
+        const entry: Replay = {
+          ...replay,
+          createdAt: replay.createdAt ?? nextTimestamp(),
+        };
+        await replaysStore.put(entry);
+      }
+    }
+
+    await Promise.all([
+      keyvalDel(LEGACY_PROGRESS_KEY).catch(() => undefined),
+      keyvalDel(LEGACY_KEYBINDS_KEY).catch(() => undefined),
+      keyvalDel(LEGACY_REPLAYS_KEY).catch(() => undefined),
+    ]);
+  } catch {
+    // Ignore migration failures and keep existing data intact
+  }
+}
+
+async function ensureReplayIndex(context: MigrationContext<StorageSchema>): Promise<void> {
+  const store = context.transaction.objectStore(STORE_REPLAYS);
+  if (!store.indexNames.contains(REPLAY_INDEX_CREATED_AT)) {
+    store.createIndex(REPLAY_INDEX_CREATED_AT, 'createdAt');
+  }
+}
+
+export const createStorageDatabase = (version?: number): TypedDatabase<StorageSchema> =>
+  createDatabase<StorageSchema>({
+    name: STORAGE_DB_NAME,
+    migrations,
+    version,
+  });
+
+export const storageDb = createStorageDatabase();
+export { migrations as storageMigrations };

--- a/types/storage.ts
+++ b/types/storage.ts
@@ -1,0 +1,7 @@
+export type ProgressData = Record<string, unknown>;
+export type Keybinds = Record<string, string>;
+export type Replay = {
+  id: string;
+  data: unknown;
+  createdAt?: number;
+};

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -1,48 +1,196 @@
 "use client";
 
-import { get, set, update } from 'idb-keyval';
+import {
+  KEYBINDS_PRIMARY_KEY,
+  LEGACY_KEYBINDS_KEY,
+  LEGACY_PROGRESS_KEY,
+  LEGACY_REPLAYS_KEY,
+  PROGRESS_PRIMARY_KEY,
+  STORE_KEYBINDS,
+  STORE_PROGRESS,
+  STORE_REPLAYS,
+  storageDb,
+} from '@/lib/storage/storageDb';
+import type { Keybinds, ProgressData, Replay } from '@/types/storage';
+import { del as keyvalDel, get as keyvalGet } from 'idb-keyval';
 
-const PROGRESS_KEY = 'progress';
-const KEYBINDS_KEY = 'keybinds';
-const REPLAYS_KEY = 'replays';
+export type { Keybinds, ProgressData, Replay } from '@/types/storage';
 
-export type ProgressData = Record<string, unknown>;
-export type Keybinds = Record<string, string>;
-export type Replay = { id: string; data: unknown };
+const sortReplays = (replays: Replay[]): Replay[] =>
+  replays
+    .map((entry) => ({ ...entry, createdAt: entry.createdAt ?? 0 }))
+    .sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0));
 
-export const getProgress = async (): Promise<ProgressData> =>
-  (typeof window === 'undefined'
-    ? {}
-    : (await get<ProgressData>(PROGRESS_KEY)) || {});
+const withTimestamp = (replay: Replay): Replay => ({
+  ...replay,
+  createdAt: replay.createdAt ?? Date.now(),
+});
+
+let legacyMigration: Promise<void> | null = null;
+
+type LegacySnapshot = {
+  progress?: ProgressData;
+  keybinds?: Keybinds;
+  replays?: Replay[];
+};
+
+type MigrationNeeds = {
+  needsProgress: boolean;
+  needsKeybinds: boolean;
+  needsReplays: boolean;
+};
+
+const loadLegacySnapshot = async (): Promise<LegacySnapshot> => {
+  const [legacyProgress, legacyKeybinds, legacyReplays] = await Promise.all([
+    keyvalGet<ProgressData | undefined>(LEGACY_PROGRESS_KEY).catch(() => undefined),
+    keyvalGet<Keybinds | undefined>(LEGACY_KEYBINDS_KEY).catch(() => undefined),
+    keyvalGet<Replay[] | undefined>(LEGACY_REPLAYS_KEY).catch(() => undefined),
+  ]);
+
+  return {
+    progress: legacyProgress ?? undefined,
+    keybinds: legacyKeybinds ?? undefined,
+    replays: Array.isArray(legacyReplays) ? legacyReplays : undefined,
+  };
+};
+
+const hasLegacyData = (snapshot: LegacySnapshot): boolean =>
+  Boolean(snapshot.progress) ||
+  Boolean(snapshot.keybinds) ||
+  (Array.isArray(snapshot.replays) && snapshot.replays.length > 0);
+
+const clearLegacyEntries = async (): Promise<void> => {
+  await Promise.all([
+    keyvalDel(LEGACY_PROGRESS_KEY).catch(() => undefined),
+    keyvalDel(LEGACY_KEYBINDS_KEY).catch(() => undefined),
+    keyvalDel(LEGACY_REPLAYS_KEY).catch(() => undefined),
+  ]);
+};
+
+const getMigrationNeeds = async (): Promise<MigrationNeeds | undefined> =>
+  storageDb.transaction(
+    [STORE_PROGRESS, STORE_KEYBINDS, STORE_REPLAYS],
+    'readonly',
+    async (tx) => {
+      const progressStore = tx.objectStore(STORE_PROGRESS);
+      const keybindsStore = tx.objectStore(STORE_KEYBINDS);
+      const replaysStore = tx.objectStore(STORE_REPLAYS);
+      const [existingProgress, existingKeybinds, existingReplayCount] = await Promise.all([
+        progressStore.get(PROGRESS_PRIMARY_KEY),
+        keybindsStore.get(KEYBINDS_PRIMARY_KEY),
+        replaysStore.count(),
+      ]);
+
+      return {
+        needsProgress: !existingProgress,
+        needsKeybinds: !existingKeybinds,
+        needsReplays: existingReplayCount === 0,
+      };
+    },
+  );
+
+const runLegacyMigration = async (): Promise<void> => {
+  if (!storageDb.isSupported()) return;
+
+  const needs = await getMigrationNeeds();
+  if (!needs) return;
+
+  if (!needs.needsProgress && !needs.needsKeybinds && !needs.needsReplays) {
+    await clearLegacyEntries();
+    return;
+  }
+
+  const snapshot = await loadLegacySnapshot();
+  if (!hasLegacyData(snapshot)) {
+    await clearLegacyEntries();
+    return;
+  }
+
+  await storageDb.transaction(
+    [STORE_PROGRESS, STORE_KEYBINDS, STORE_REPLAYS],
+    'readwrite',
+    async (tx) => {
+      const progressStore = tx.objectStore(STORE_PROGRESS);
+      if (snapshot.progress && !(await progressStore.get(PROGRESS_PRIMARY_KEY))) {
+        await progressStore.put(snapshot.progress, PROGRESS_PRIMARY_KEY);
+      }
+
+      const keybindsStore = tx.objectStore(STORE_KEYBINDS);
+      if (snapshot.keybinds && !(await keybindsStore.get(KEYBINDS_PRIMARY_KEY))) {
+        await keybindsStore.put(snapshot.keybinds, KEYBINDS_PRIMARY_KEY);
+      }
+
+      const replaysStore = tx.objectStore(STORE_REPLAYS);
+      const hasExistingReplays = (await replaysStore.count()) > 0;
+      if (Array.isArray(snapshot.replays) && !hasExistingReplays) {
+        let timestamp = Date.now();
+        for (const replay of snapshot.replays) {
+          if (!replay || typeof replay.id !== 'string') continue;
+          const entry: Replay = {
+            ...replay,
+            createdAt: replay.createdAt ?? timestamp++,
+          };
+          await replaysStore.put(entry);
+        }
+      }
+    },
+  );
+
+  await clearLegacyEntries();
+};
+
+const ensureLegacyMigrated = async (): Promise<void> => {
+  if (!legacyMigration) {
+    const pending = runLegacyMigration();
+    legacyMigration = pending.catch((error) => {
+      legacyMigration = null;
+      throw error;
+    });
+  }
+
+  try {
+    await legacyMigration;
+  } catch {
+    // Ignore migration failures and allow callers to proceed with best-effort storage.
+  }
+};
+
+export const getProgress = async (): Promise<ProgressData> => {
+  await ensureLegacyMigrated();
+  const progress = await storageDb.get(STORE_PROGRESS, PROGRESS_PRIMARY_KEY);
+  return progress ?? {};
+};
 
 export const setProgress = async (progress: ProgressData): Promise<void> => {
-  if (typeof window === 'undefined') return;
-  await set(PROGRESS_KEY, progress);
+  await storageDb.put(STORE_PROGRESS, progress, PROGRESS_PRIMARY_KEY);
 };
 
-export const getKeybinds = async (): Promise<Keybinds> =>
-  (typeof window === 'undefined'
-    ? {}
-    : (await get<Keybinds>(KEYBINDS_KEY)) || {});
+export const getKeybinds = async (): Promise<Keybinds> => {
+  await ensureLegacyMigrated();
+  const keybinds = await storageDb.get(STORE_KEYBINDS, KEYBINDS_PRIMARY_KEY);
+  return keybinds ?? {};
+};
 
 export const setKeybinds = async (keybinds: Keybinds): Promise<void> => {
-  if (typeof window === 'undefined') return;
-  await set(KEYBINDS_KEY, keybinds);
+  await storageDb.put(STORE_KEYBINDS, keybinds, KEYBINDS_PRIMARY_KEY);
 };
 
-export const getReplays = async (): Promise<Replay[]> =>
-  (typeof window === 'undefined'
-    ? []
-    : (await get<Replay[]>(REPLAYS_KEY)) || []);
+export const getReplays = async (): Promise<Replay[]> => {
+  await ensureLegacyMigrated();
+  const replays = await storageDb.getAll(STORE_REPLAYS);
+  return sortReplays(replays);
+};
 
 export const saveReplay = async (replay: Replay): Promise<void> => {
-  if (typeof window === 'undefined') return;
-  await update<Replay[]>(REPLAYS_KEY, (replays = []) => [...replays, replay]);
+  const entry = withTimestamp(replay);
+  await storageDb.transaction([STORE_REPLAYS], 'readwrite', async (tx) => {
+    const store = tx.objectStore(STORE_REPLAYS);
+    await store.put(entry);
+  });
 };
 
 export const clearReplays = async (): Promise<void> => {
-  if (typeof window === 'undefined') return;
-  await set(REPLAYS_KEY, []);
+  await storageDb.clear(STORE_REPLAYS);
 };
 
 const storage = {


### PR DESCRIPTION
## Summary
- add a typed IndexedDB helper plus a storage schema with migrations for progress, keybinds, and replays
- route `utils/storage` through the wrapper with a guarded legacy migration that cleans up stale `idb-keyval` entries
- share storage types and cover legacy migration + upgrade flows with unit tests

## Testing
- npx eslint utils/storage.ts lib/storage/storageDb.ts __tests__/storageMigration.test.ts
- yarn test storageMigration --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cca676163c8328b2f2e42d34bf1d68