### PR TITLE
[pwa] Add quota warnings and cache eviction toasts

### DIFF
--- a/__tests__/serviceWorkerToastBridge.test.tsx
+++ b/__tests__/serviceWorkerToastBridge.test.tsx
@@ -1,0 +1,116 @@
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import ServiceWorkerToastBridge from '../components/common/ServiceWorkerToastBridge';
+
+type StorageWithEstimate = Partial<StorageManager> & { estimate: jest.Mock };
+
+const flushPromises = () => new Promise((resolve) => {
+  setTimeout(resolve, 0);
+});
+
+describe('ServiceWorkerToastBridge', () => {
+  let originalStorage: StorageManager | undefined;
+  let originalServiceWorker: ServiceWorkerContainer | undefined;
+
+  beforeEach(() => {
+    originalStorage = (navigator as Navigator & { storage?: StorageManager }).storage;
+    originalServiceWorker = (navigator as Navigator & { serviceWorker?: ServiceWorkerContainer }).serviceWorker;
+    Object.defineProperty(window.navigator, 'storage', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(window.navigator, 'serviceWorker', {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window.navigator, 'storage', {
+      configurable: true,
+      value: originalStorage,
+    });
+    Object.defineProperty(window.navigator, 'serviceWorker', {
+      configurable: true,
+      value: originalServiceWorker,
+    });
+  });
+
+  it('renders a storage warning when usage exceeds the threshold', async () => {
+    const estimateMock = jest.fn().mockResolvedValue({ usage: 800, quota: 1000 });
+    Object.defineProperty(window.navigator, 'storage', {
+      configurable: true,
+      value: { estimate: estimateMock } as StorageWithEstimate,
+    });
+
+    render(<ServiceWorkerToastBridge />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(await screen.findByText(/Storage is 80% full/)).toBeInTheDocument();
+  });
+
+  it('handles storage estimate rejections without surfacing unhandled errors', async () => {
+    const estimateMock = jest.fn().mockRejectedValue(new Error('quota exceeded'));
+    Object.defineProperty(window.navigator, 'storage', {
+      configurable: true,
+      value: { estimate: estimateMock } as StorageWithEstimate,
+    });
+
+    const unhandledRejections: unknown[] = [];
+    const handler = (event: PromiseRejectionEvent) => {
+      unhandledRejections.push(event.reason);
+    };
+    window.addEventListener('unhandledrejection', handler);
+
+    render(<ServiceWorkerToastBridge />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    window.removeEventListener('unhandledrejection', handler);
+
+    expect(screen.queryByText(/Storage is/)).toBeNull();
+    expect(unhandledRejections).toHaveLength(0);
+  });
+
+  it('announces cache evictions received from the service worker', async () => {
+    const estimateMock = jest.fn().mockResolvedValue({ usage: 100, quota: 1000 });
+    Object.defineProperty(window.navigator, 'storage', {
+      configurable: true,
+      value: { estimate: estimateMock } as StorageWithEstimate,
+    });
+
+    const listeners: Record<string, (event: MessageEvent) => void> = {};
+    const serviceWorkerStub: Partial<ServiceWorkerContainer> = {
+      addEventListener: jest.fn((type: string, callback: EventListenerOrEventListenerObject) => {
+        listeners[type] = callback as (event: MessageEvent) => void;
+      }),
+      removeEventListener: jest.fn((type: string, callback: EventListenerOrEventListenerObject) => {
+        if (listeners[type] === callback) {
+          delete listeners[type];
+        }
+      }),
+    };
+
+    Object.defineProperty(window.navigator, 'serviceWorker', {
+      configurable: true,
+      value: serviceWorkerStub,
+    });
+
+    render(<ServiceWorkerToastBridge />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await act(async () => {
+      listeners.message?.({ data: { type: 'cache-evicted', urls: ['https://example.com/apps/a', 'https://example.com/apps/b'] } } as MessageEvent);
+    });
+
+    expect(await screen.findByText(/Removed cached content: \/apps\/a, \/apps\/b\./)).toBeInTheDocument();
+  });
+});

--- a/components/common/ServiceWorkerToastBridge.tsx
+++ b/components/common/ServiceWorkerToastBridge.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Toast from '../ui/Toast';
+
+const STORAGE_WARNING_THRESHOLD = 0.8;
+const WARNING_BUCKET_SIZE = 5; // percent bucket to avoid duplicate warnings
+
+const toPercent = (usage: number, quota: number): number => {
+  if (!quota || quota <= 0) return 0;
+  const ratio = usage / quota;
+  if (!Number.isFinite(ratio)) return 0;
+  return Math.max(0, Math.min(100, Math.round(ratio * 100)));
+};
+
+const normaliseUrl = (url: string): string => {
+  if (typeof window === 'undefined') return url;
+  try {
+    const parsed = new URL(url, window.location.origin);
+    return parsed.pathname || parsed.href;
+  } catch {
+    return url;
+  }
+};
+
+const createEvictionMessage = (urls: string[]): string => {
+  if (!urls.length) return '';
+  const formatted = urls.map(normaliseUrl);
+  const preview = formatted.slice(0, 3).join(', ');
+  const remainder = formatted.length - 3;
+  const suffix = remainder > 0 ? ` and ${remainder} more` : '';
+  return `Removed cached content: ${preview}${suffix}.`;
+};
+
+const createStorageMessage = (usage: number, quota: number): string | null => {
+  if (!quota || quota <= 0) return null;
+  const ratio = usage / quota;
+  if (!Number.isFinite(ratio) || ratio < STORAGE_WARNING_THRESHOLD) return null;
+  const percent = toPercent(usage, quota);
+  return `Storage is ${percent}% full. Offline data may be cleared automatically.`;
+};
+
+const useMessageQueue = () => {
+  const [messages, setMessages] = useState<string[]>([]);
+  const enqueue = useCallback((message: string) => {
+    if (!message) return;
+    setMessages((prev) => [...prev, message]);
+  }, []);
+  const dequeue = useCallback(() => {
+    setMessages((prev) => prev.slice(1));
+  }, []);
+  const current = messages[0] ?? '';
+  return useMemo(
+    () => ({ current, enqueue, dequeue }),
+    [current, dequeue, enqueue],
+  );
+};
+
+const ServiceWorkerToastBridge = () => {
+  const { current, enqueue, dequeue } = useMessageQueue();
+  const warningBucketRef = useRef<number | null>(null);
+
+  const showStorageWarning = useCallback(
+    (usage?: number, quota?: number) => {
+      if (typeof usage !== 'number' || typeof quota !== 'number') return;
+      const message = createStorageMessage(usage, quota);
+      if (!message) return;
+      const percent = toPercent(usage, quota);
+      const bucket = Math.floor(percent / WARNING_BUCKET_SIZE);
+      if (warningBucketRef.current === bucket) return;
+      warningBucketRef.current = bucket;
+      enqueue(message);
+    },
+    [enqueue],
+  );
+
+  const handleCacheEviction = useCallback(
+    (urls?: unknown) => {
+      if (!Array.isArray(urls) || urls.length === 0) return;
+      const message = createEvictionMessage(urls.filter((item): item is string => typeof item === 'string'));
+      if (message) enqueue(message);
+    },
+    [enqueue],
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const { serviceWorker } = navigator as Navigator & {
+      serviceWorker?: ServiceWorkerContainer;
+    };
+    if (!serviceWorker?.addEventListener) return undefined;
+
+    const listener = (event: MessageEvent) => {
+      const data = event.data;
+      if (!data || typeof data !== 'object') return;
+      if ('usage' in data || 'quota' in data) {
+        const usage = Number((data as { usage?: number }).usage);
+        const quota = Number((data as { quota?: number }).quota);
+        showStorageWarning(Number.isFinite(usage) ? usage : undefined, Number.isFinite(quota) ? quota : undefined);
+      }
+      switch ((data as { type?: string }).type) {
+        case 'storage-warning': {
+          const usage = Number((data as { usage?: number }).usage);
+          const quota = Number((data as { quota?: number }).quota);
+          showStorageWarning(Number.isFinite(usage) ? usage : undefined, Number.isFinite(quota) ? quota : undefined);
+          break;
+        }
+        case 'cache-evicted':
+          handleCacheEviction((data as { urls?: unknown }).urls);
+          break;
+        default:
+          break;
+      }
+    };
+
+    serviceWorker.addEventListener('message', listener);
+    return () => {
+      serviceWorker.removeEventListener?.('message', listener);
+    };
+  }, [handleCacheEviction, showStorageWarning]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const storage: StorageManager | undefined = (navigator as Navigator & { storage?: StorageManager }).storage;
+    let cancelled = false;
+    if (!storage?.estimate) return undefined;
+
+    storage
+      .estimate()
+      .then(({ usage, quota }) => {
+        if (cancelled) return;
+        showStorageWarning(usage, quota);
+      })
+      .catch(() => {
+        // ignore estimation failures to avoid surfacing unhandled rejections
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [showStorageWarning]);
+
+  if (!current) return null;
+
+  return <Toast message={current} onClose={dequeue} />;
+};
+
+export default ServiceWorkerToastBridge;
+
+export { createEvictionMessage, createStorageMessage, STORAGE_WARNING_THRESHOLD };

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -12,6 +12,7 @@ import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import ServiceWorkerToastBridge from '../components/common/ServiceWorkerToastBridge';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
@@ -161,6 +162,7 @@ function MyApp(props) {
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
             <ShortcutOverlay />
+            <ServiceWorkerToastBridge />
             <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;

--- a/public/workers/service-worker.js
+++ b/public/workers/service-worker.js
@@ -12,6 +12,160 @@ const ASSETS = [
   '/offline.html',
   '/manifest.webmanifest',
 ];
+const METADATA_KEY = '__asset-metadata__';
+const STORAGE_WARNING_THRESHOLD = 0.8;
+const WARNING_BUCKET_SIZE = 5; // percent bucket size
+const EVICTION_THRESHOLD = 0.95;
+
+let lastWarningBucket = null;
+
+const globalNavigator = /** @type {typeof navigator | undefined} */ (self.navigator);
+
+const toAbsoluteUrl = (input) => {
+  if (typeof input === 'string') {
+    try {
+      return new URL(input, self.location.origin).href;
+    } catch {
+      return input;
+    }
+  }
+  return input.url;
+};
+
+const toRequest = (input) => (typeof input === 'string' ? new Request(input) : input);
+
+const readMetadata = async (cache) => {
+  try {
+    const stored = await cache.match(METADATA_KEY);
+    if (!stored) return {};
+    return await stored.json();
+  } catch {
+    return {};
+  }
+};
+
+const writeMetadata = async (cache, metadata) => {
+  try {
+    await cache.put(
+      METADATA_KEY,
+      new Response(JSON.stringify(metadata), {
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+  } catch {
+    // Ignore metadata persistence issues
+  }
+};
+
+const broadcastMessage = async (message) => {
+  try {
+    const clients = await self.clients.matchAll({ includeUncontrolled: true, type: 'window' });
+    clients.forEach((client) => {
+      try {
+        client.postMessage(message);
+      } catch {
+        // Ignore messaging issues per client
+      }
+    });
+  } catch {
+    // Ignore broadcast failures
+  }
+};
+
+const getStorageEstimate = async () => {
+  const storage = globalNavigator?.storage;
+  if (!storage?.estimate) return null;
+  try {
+    return await storage.estimate();
+  } catch {
+    return null;
+  }
+};
+
+const warnIfNeeded = async (estimate) => {
+  try {
+    const data = estimate || (await getStorageEstimate());
+    if (!data) return;
+    const { usage = 0, quota } = data;
+    if (!quota || quota <= 0 || !Number.isFinite(quota)) return;
+    const ratio = usage / quota;
+    if (!Number.isFinite(ratio) || ratio < STORAGE_WARNING_THRESHOLD) return;
+    const percent = Math.max(0, Math.min(100, Math.round(ratio * 100)));
+    const bucket = Math.floor(percent / WARNING_BUCKET_SIZE);
+    if (lastWarningBucket === bucket) return;
+    lastWarningBucket = bucket;
+    await broadcastMessage({ type: 'storage-warning', usage, quota });
+  } catch {
+    // Ignore warning failures
+  }
+};
+
+const enforceLRU = async (cache, metadata, initialEstimate) => {
+  const removed = [];
+  try {
+    let estimate = initialEstimate || (await getStorageEstimate());
+    if (!estimate) return removed;
+    let { usage = 0, quota } = estimate;
+    if (!quota || quota <= 0 || !Number.isFinite(quota)) return removed;
+    const entries = Object.entries(metadata).sort(([, aTs], [, bTs]) => aTs - bTs);
+    for (const [key] of entries) {
+      if (!key || key === METADATA_KEY) continue;
+      if (usage / quota < EVICTION_THRESHOLD) break;
+      try {
+        const deleted = await cache.delete(key);
+        if (deleted) {
+          delete metadata[key];
+          removed.push(key);
+          estimate = (await getStorageEstimate()) || estimate;
+          usage = estimate.usage ?? usage;
+          quota = estimate.quota ?? quota;
+        }
+      } catch {
+        // ignore deletion errors
+      }
+    }
+    if (removed.length) {
+      await writeMetadata(cache, metadata);
+      await broadcastMessage({ type: 'cache-evicted', urls: removed });
+    }
+  } catch {
+    // ignore eviction issues
+  }
+  return removed;
+};
+
+const touchEntry = async (cache, requestInfo) => {
+  try {
+    const key = toAbsoluteUrl(requestInfo);
+    if (!key || key === METADATA_KEY) return;
+    const metadata = await readMetadata(cache);
+    metadata[key] = Date.now();
+    await writeMetadata(cache, metadata);
+  } catch {
+    // ignore access update issues
+  }
+};
+
+const cacheResponse = async (cache, requestInfo, response) => {
+  const request = toRequest(requestInfo);
+  try {
+    await cache.put(request, response.clone());
+  } catch {
+    return;
+  }
+  try {
+    const metadata = await readMetadata(cache);
+    const key = toAbsoluteUrl(requestInfo);
+    if (!key || key === METADATA_KEY) return;
+    metadata[key] = Date.now();
+    await writeMetadata(cache, metadata);
+    const estimate = await getStorageEstimate();
+    await warnIfNeeded(estimate);
+    await enforceLRU(cache, metadata, estimate);
+  } catch {
+    // ignore metadata update issues
+  }
+};
 
 async function prefetchAssets() {
   const cache = await caches.open(CACHE_NAME);
@@ -20,9 +174,9 @@ async function prefetchAssets() {
       try {
         const response = await fetch(url, { cache: 'no-cache' });
         if (response.ok) {
-          await cache.put(url, response.clone());
+          await cacheResponse(cache, url, response);
         }
-      } catch (err) {
+      } catch {
         // Ignore individual failures
       }
     }),
@@ -55,11 +209,16 @@ self.addEventListener('fetch', (event) => {
         try {
           const response = await fetch(request);
           if (response.ok) {
-            cache.put(request, response.clone());
+            await cacheResponse(cache, request, response);
           }
           return response;
         } catch (err) {
-          return cache.match(request);
+          const cached = await cache.match(request);
+          if (cached) {
+            await touchEntry(cache, request);
+            return cached;
+          }
+          throw err;
         }
       }),
     );
@@ -67,6 +226,19 @@ self.addEventListener('fetch', (event) => {
   }
 
   event.respondWith(
-    caches.match(request).then((cached) => cached || fetch(request)),
+    caches.open(CACHE_NAME).then(async (cache) => {
+      const cached = await cache.match(request);
+      if (cached) {
+        await touchEntry(cache, request);
+        return cached;
+      }
+      try {
+        return await fetch(request);
+      } catch (err) {
+        const fallback = await caches.match(request);
+        if (fallback) return fallback;
+        throw err;
+      }
+    }),
   );
 });

--- a/workers/service-worker.js
+++ b/workers/service-worker.js
@@ -12,6 +12,160 @@ const ASSETS = [
   '/offline.html',
   '/manifest.webmanifest',
 ];
+const METADATA_KEY = '__asset-metadata__';
+const STORAGE_WARNING_THRESHOLD = 0.8;
+const WARNING_BUCKET_SIZE = 5; // percent bucket size
+const EVICTION_THRESHOLD = 0.95;
+
+let lastWarningBucket = null;
+
+const globalNavigator = /** @type {typeof navigator | undefined} */ (self.navigator);
+
+const toAbsoluteUrl = (input) => {
+  if (typeof input === 'string') {
+    try {
+      return new URL(input, self.location.origin).href;
+    } catch {
+      return input;
+    }
+  }
+  return input.url;
+};
+
+const toRequest = (input) => (typeof input === 'string' ? new Request(input) : input);
+
+const readMetadata = async (cache) => {
+  try {
+    const stored = await cache.match(METADATA_KEY);
+    if (!stored) return {};
+    return await stored.json();
+  } catch {
+    return {};
+  }
+};
+
+const writeMetadata = async (cache, metadata) => {
+  try {
+    await cache.put(
+      METADATA_KEY,
+      new Response(JSON.stringify(metadata), {
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+  } catch {
+    // Ignore metadata persistence issues
+  }
+};
+
+const broadcastMessage = async (message) => {
+  try {
+    const clients = await self.clients.matchAll({ includeUncontrolled: true, type: 'window' });
+    clients.forEach((client) => {
+      try {
+        client.postMessage(message);
+      } catch {
+        // Ignore messaging issues per client
+      }
+    });
+  } catch {
+    // Ignore broadcast failures
+  }
+};
+
+const getStorageEstimate = async () => {
+  const storage = globalNavigator?.storage;
+  if (!storage?.estimate) return null;
+  try {
+    return await storage.estimate();
+  } catch {
+    return null;
+  }
+};
+
+const warnIfNeeded = async (estimate) => {
+  try {
+    const data = estimate || (await getStorageEstimate());
+    if (!data) return;
+    const { usage = 0, quota } = data;
+    if (!quota || quota <= 0 || !Number.isFinite(quota)) return;
+    const ratio = usage / quota;
+    if (!Number.isFinite(ratio) || ratio < STORAGE_WARNING_THRESHOLD) return;
+    const percent = Math.max(0, Math.min(100, Math.round(ratio * 100)));
+    const bucket = Math.floor(percent / WARNING_BUCKET_SIZE);
+    if (lastWarningBucket === bucket) return;
+    lastWarningBucket = bucket;
+    await broadcastMessage({ type: 'storage-warning', usage, quota });
+  } catch {
+    // Ignore warning failures
+  }
+};
+
+const enforceLRU = async (cache, metadata, initialEstimate) => {
+  const removed = [];
+  try {
+    let estimate = initialEstimate || (await getStorageEstimate());
+    if (!estimate) return removed;
+    let { usage = 0, quota } = estimate;
+    if (!quota || quota <= 0 || !Number.isFinite(quota)) return removed;
+    const entries = Object.entries(metadata).sort(([, aTs], [, bTs]) => aTs - bTs);
+    for (const [key] of entries) {
+      if (!key || key === METADATA_KEY) continue;
+      if (usage / quota < EVICTION_THRESHOLD) break;
+      try {
+        const deleted = await cache.delete(key);
+        if (deleted) {
+          delete metadata[key];
+          removed.push(key);
+          estimate = (await getStorageEstimate()) || estimate;
+          usage = estimate.usage ?? usage;
+          quota = estimate.quota ?? quota;
+        }
+      } catch {
+        // ignore deletion errors
+      }
+    }
+    if (removed.length) {
+      await writeMetadata(cache, metadata);
+      await broadcastMessage({ type: 'cache-evicted', urls: removed });
+    }
+  } catch {
+    // ignore eviction issues
+  }
+  return removed;
+};
+
+const touchEntry = async (cache, requestInfo) => {
+  try {
+    const key = toAbsoluteUrl(requestInfo);
+    if (!key || key === METADATA_KEY) return;
+    const metadata = await readMetadata(cache);
+    metadata[key] = Date.now();
+    await writeMetadata(cache, metadata);
+  } catch {
+    // ignore access update issues
+  }
+};
+
+const cacheResponse = async (cache, requestInfo, response) => {
+  const request = toRequest(requestInfo);
+  try {
+    await cache.put(request, response.clone());
+  } catch {
+    return;
+  }
+  try {
+    const metadata = await readMetadata(cache);
+    const key = toAbsoluteUrl(requestInfo);
+    if (!key || key === METADATA_KEY) return;
+    metadata[key] = Date.now();
+    await writeMetadata(cache, metadata);
+    const estimate = await getStorageEstimate();
+    await warnIfNeeded(estimate);
+    await enforceLRU(cache, metadata, estimate);
+  } catch {
+    // ignore metadata update issues
+  }
+};
 
 async function prefetchAssets() {
   const cache = await caches.open(CACHE_NAME);
@@ -20,9 +174,9 @@ async function prefetchAssets() {
       try {
         const response = await fetch(url, { cache: 'no-cache' });
         if (response.ok) {
-          await cache.put(url, response.clone());
+          await cacheResponse(cache, url, response);
         }
-      } catch (err) {
+      } catch {
         // Ignore individual failures
       }
     }),
@@ -55,11 +209,16 @@ self.addEventListener('fetch', (event) => {
         try {
           const response = await fetch(request);
           if (response.ok) {
-            cache.put(request, response.clone());
+            await cacheResponse(cache, request, response);
           }
           return response;
         } catch (err) {
-          return cache.match(request);
+          const cached = await cache.match(request);
+          if (cached) {
+            await touchEntry(cache, request);
+            return cached;
+          }
+          throw err;
         }
       }),
     );
@@ -67,6 +226,19 @@ self.addEventListener('fetch', (event) => {
   }
 
   event.respondWith(
-    caches.match(request).then((cached) => cached || fetch(request)),
+    caches.open(CACHE_NAME).then(async (cache) => {
+      const cached = await cache.match(request);
+      if (cached) {
+        await touchEntry(cache, request);
+        return cached;
+      }
+      try {
+        return await fetch(request);
+      } catch (err) {
+        const fallback = await caches.match(request);
+        if (fallback) return fallback;
+        throw err;
+      }
+    }),
   );
 });


### PR DESCRIPTION
## Summary
- surface storage quota and eviction messages in the UI via a new toast bridge component
- teach the service worker caches to track access metadata, warn near quota, and evict least-used entries
- cover storage warning, quota rejection, and eviction messaging with focused tests

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in unrelated files)*
- yarn test --watch=false --runTestsByPath __tests__/serviceWorkerToastBridge.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cca67770008328b08eeac504c1b984