### PR TITLE
feat(security): enforce trusted types policy

### DIFF
--- a/__tests__/trustedTypes.test.ts
+++ b/__tests__/trustedTypes.test.ts
@@ -1,0 +1,42 @@
+import { TRUSTED_TYPES_POLICY_NAME } from '../utils/trustedTypes';
+
+describe('trustedTypes utilities', () => {
+  const POLICY_SYMBOL = Symbol.for('kali-linux-portfolio.trustedTypesPolicy');
+
+  afterEach(() => {
+    delete (globalThis as any).trustedTypes;
+    delete (globalThis as any)[POLICY_SYMBOL];
+    jest.resetModules();
+  });
+
+  it('returns raw HTML when Trusted Types are unavailable', async () => {
+    jest.resetModules();
+    const { createTrustedHTML } = await import('../utils/trustedTypes');
+    const html = '<p>demo</p>';
+    expect(createTrustedHTML(html)).toBe(html);
+  });
+
+  it('creates and reuses the shared policy when available', async () => {
+    const createHTML = jest.fn((input: string) => ({
+      toString: () => input,
+    }));
+    const policy = { createHTML } as TrustedTypePolicy;
+    (globalThis as any).trustedTypes = {
+      createPolicy: jest.fn(() => policy),
+    };
+
+    jest.resetModules();
+    const { createTrustedHTML, ensureTrustedTypesPolicy } = await import(
+      '../utils/trustedTypes'
+    );
+    const result = createTrustedHTML('<span>safe</span>');
+    expect(createHTML).toHaveBeenCalledWith('<span>safe</span>');
+    expect(result).toBe(createHTML.mock.results[0].value);
+    expect(ensureTrustedTypesPolicy()).toBe(policy);
+
+    const createPolicy = (globalThis as any).trustedTypes.createPolicy as jest.Mock;
+    expect(createPolicy).toHaveBeenCalledWith(TRUSTED_TYPES_POLICY_NAME, {
+      createHTML: expect.any(Function),
+    });
+  });
+});

--- a/apps/autopsy/components/KeywordTester.tsx
+++ b/apps/autopsy/components/KeywordTester.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import events from '../events.json';
+import { createTrustedHTML } from '../../../utils/trustedTypes';
 
 const escapeHtml = (str: string = '') =>
   str
@@ -73,20 +74,26 @@ function KeywordTester() {
             >
               <div
                 className="font-bold"
-                dangerouslySetInnerHTML={{ __html: highlight(artifact.name) }}
+                dangerouslySetInnerHTML={{
+                  __html: createTrustedHTML(highlight(artifact.name)),
+                }}
               />
               <div className="text-gray-400">{artifact.type}</div>
               {'user' in artifact && (
                 <div
                   className="text-xs"
                   dangerouslySetInnerHTML={{
-                    __html: `User: ${highlight(artifact.user)}`,
+                    __html: createTrustedHTML(
+                      `User: ${highlight(artifact.user)}`,
+                    ),
                   }}
                 />
               )}
               <div
                 className="text-xs"
-                dangerouslySetInnerHTML={{ __html: highlight(artifact.description) }}
+                dangerouslySetInnerHTML={{
+                  __html: createTrustedHTML(highlight(artifact.description)),
+                }}
               />
             </div>
           );

--- a/apps/beef/components/PayloadBuilder.tsx
+++ b/apps/beef/components/PayloadBuilder.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { createTrustedHTML } from '../../../utils/trustedTypes';
 
 interface Payload {
   name: string;
@@ -21,6 +22,7 @@ export default function PayloadBuilder() {
   const [copied, setCopied] = useState(false);
 
   const page = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><title>Payload</title></head><body><script>${selected.code}</script></body></html>`;
+  const preview = createTrustedHTML(page);
 
   const copyPage = async () => {
     try {
@@ -73,7 +75,7 @@ export default function PayloadBuilder() {
         <iframe
           title="preview"
           sandbox="allow-scripts"
-          srcDoc={page}
+          srcDoc={preview as unknown as string}
           className="w-full h-full border-0"
         />
       </div>

--- a/apps/chrome/components/FullPageCapture.tsx
+++ b/apps/chrome/components/FullPageCapture.tsx
@@ -27,8 +27,7 @@ export default function FullPageCapture() {
         backgroundColor: '#ffffff',
       });
       if (canvasContainer.current) {
-        canvasContainer.current.innerHTML = '';
-        canvasContainer.current.appendChild(canvas);
+        canvasContainer.current.replaceChildren(canvas);
       }
       const imgData = canvas.toDataURL('image/png');
       if (type === 'png') {

--- a/apps/chrome/components/ReadingMode.tsx
+++ b/apps/chrome/components/ReadingMode.tsx
@@ -5,6 +5,7 @@ import { Readability } from '@mozilla/readability';
 import DOMPurify from 'dompurify';
 import { createStore, set as idbSet } from 'idb-keyval';
 import usePersistentState from '../../../hooks/usePersistentState';
+import { createTrustedHTML } from '../../../utils/trustedTypes';
 
 const snapshotStore = createStore('reading-mode', 'snapshots');
 
@@ -58,7 +59,9 @@ const ReadingMode = () => {
           Save snapshot
         </button>
       </div>
-      <article dangerouslySetInnerHTML={{ __html: displayed }} />
+      <article
+        dangerouslySetInnerHTML={{ __html: createTrustedHTML(displayed) }}
+      />
     </div>
   );
 };

--- a/apps/clipboard_manager/main.js
+++ b/apps/clipboard_manager/main.js
@@ -11,7 +11,7 @@ if (isBrowser) {
   const clearBtn = document.getElementById('clear');
 
   function render() {
-    list.innerHTML = '';
+    list.replaceChildren();
     history.forEach((item) => {
       const li = document.createElement('li');
       li.textContent = item;

--- a/apps/color_picker/main.js
+++ b/apps/color_picker/main.js
@@ -28,7 +28,7 @@ if (isBrowser) {
   }
 
   function renderSwatches() {
-    swatches.innerHTML = '';
+    swatches.replaceChildren();
     colors.forEach((color) => {
       const swatch = document.createElement('div');
       swatch.className = 'swatch';

--- a/apps/timer_stopwatch/main.js
+++ b/apps/timer_stopwatch/main.js
@@ -107,7 +107,7 @@ function resetWatch() {
   stopwatchElapsed = 0;
   lapNumber = 1;
   updateStopwatchDisplay();
-  lapsList.innerHTML = '';
+  lapsList.replaceChildren();
 }
 
 function lapWatch() {

--- a/apps/weather_widget/main.js
+++ b/apps/weather_widget/main.js
@@ -28,7 +28,7 @@ unitToggle.value = unit;
 let savedCities = JSON.parse(safeLocalStorage?.getItem('savedCities') || '[]');
 
 function updateDatalist() {
-  datalist.innerHTML = '';
+  datalist.replaceChildren();
   savedCities.forEach((c) => {
     const option = document.createElement('option');
     option.value = c;
@@ -75,15 +75,23 @@ function renderWeather(data) {
         iconEl.className = 'icon animated-icon';
       }
       forecastEl.textContent = data.condition;
+      dailyEl.replaceChildren();
       if (data.forecast) {
-        dailyEl.innerHTML = data.forecast
-          .map(
-            (d) =>
-              `<div class="day"><img class="forecast-icon animated-icon" src="https://openweathermap.org/img/wn/${d.icon}.png" alt="${d.condition}"><div>${d.day} ${Math.round(
-                convertTemp(d.tempC)
-              )}°${unit === 'metric' ? 'C' : 'F'}</div></div>`
-          )
-          .join('');
+        data.forecast.forEach((d) => {
+          const day = document.createElement('div');
+          day.className = 'day';
+          const img = document.createElement('img');
+          img.className = 'forecast-icon animated-icon';
+          img.src = `https://openweathermap.org/img/wn/${d.icon}.png`;
+          img.alt = d.condition;
+          const label = document.createElement('div');
+          label.textContent = `${d.day} ${Math.round(convertTemp(d.tempC))}°${
+            unit === 'metric' ? 'C' : 'F'
+          }`;
+          day.appendChild(img);
+          day.appendChild(label);
+          dailyEl.appendChild(day);
+        });
       }
       sunriseEl.textContent = `Sunrise: ${formatTime(data.sunrise)}`;
       sunsetEl.textContent = `Sunset: ${formatTime(data.sunset)}`;

--- a/apps/x/index.tsx
+++ b/apps/x/index.tsx
@@ -170,7 +170,7 @@ export default function XTimeline() {
     setLoading(true);
     setScriptError(false);
     setTimelineLoaded(false);
-    timelineRef.current.innerHTML = '';
+    timelineRef.current.replaceChildren();
     const options = {
       chrome: 'noheader noborders',
       theme,

--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import DOMPurify from 'dompurify';
 import { marked } from 'marked';
+import { createTrustedHTML } from '../utils/trustedTypes';
 
 interface HelpPanelProps {
   appId: string;
@@ -68,7 +69,9 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
             className="bg-white text-black p-4 rounded max-w-md w-full h-full overflow-auto"
             onClick={(e) => e.stopPropagation()}
           >
-            <div dangerouslySetInnerHTML={{ __html: html }} />
+            <div
+              dangerouslySetInnerHTML={{ __html: createTrustedHTML(html) }}
+            />
           </div>
         </div>
       )}

--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Head from 'next/head';
 import { getCspNonce } from '../../utils/csp';
+import { createTrustedHTML } from '../../utils/trustedTypes';
 
 export default function Meta() {
     const nonce = getCspNonce();
@@ -54,12 +55,14 @@ export default function Meta() {
                 type="application/ld+json"
                 nonce={nonce}
                 dangerouslySetInnerHTML={{
-                    __html: JSON.stringify({
-                        "@context": "https://schema.org",
-                        "@type": "Person",
-                        name: "Alex Unnippillil",
-                        url: "https://unnippillil.com/",
-                    }),
+                    __html: createTrustedHTML(
+                        JSON.stringify({
+                            "@context": "https://schema.org",
+                            "@type": "Person",
+                            name: "Alex Unnippillil",
+                            url: "https://unnippillil.com/",
+                        }),
+                    ),
                 }}
             />
         </Head>

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -7,6 +7,7 @@ import Certs from '../certs';
 import data from '../alex/data.json';
 import SafetyNote from './SafetyNote';
 import { getCspNonce } from '../../../utils/csp';
+import { createTrustedHTML } from '../../../utils/trustedTypes';
 import AboutSlides from './slides';
 import ScrollableTimeline from '../../ScrollableTimeline';
 
@@ -116,7 +117,9 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
           <script
             type="application/ld+json"
             nonce={nonce}
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(structured) }}
+            dangerouslySetInnerHTML={{
+              __html: createTrustedHTML(JSON.stringify(structured)),
+            }}
           />
         </Head>
         <div

--- a/components/apps/ascii_art/index.js
+++ b/components/apps/ascii_art/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import DOMPurify from 'dompurify';
+import { createTrustedHTML } from '../../../utils/trustedTypes';
 
 // Preset character sets and color palettes
 const presetCharSets = {
@@ -574,7 +575,9 @@ export default function AsciiArt() {
       ) : (
         <pre
           className="font-mono whitespace-pre overflow-auto flex-1"
-          dangerouslySetInnerHTML={{ __html: asciiHtml }}
+          dangerouslySetInnerHTML={{
+            __html: createTrustedHTML(asciiHtml),
+          }}
         />
       )}
       <canvas ref={canvasRef} className="hidden w-full h-full" />

--- a/components/apps/autopsy/KeywordSearchPanel.js
+++ b/components/apps/autopsy/KeywordSearchPanel.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createTrustedHTML } from '../../../utils/trustedTypes';
 
 const escapeHtml = (str = '') =>
   str
@@ -71,7 +72,9 @@ function KeywordSearchPanel({ keyword, setKeyword, artifacts, onSelect }) {
                 {typeIcons[a.type] || '📁'}
               </span>
               <span
-                dangerouslySetInnerHTML={{ __html: highlight(a.name) }}
+                dangerouslySetInnerHTML={{
+                  __html: createTrustedHTML(highlight(a.name)),
+                }}
               />
             </div>
             <div className="text-gray-400">{a.type}</div>
@@ -81,12 +84,16 @@ function KeywordSearchPanel({ keyword, setKeyword, artifacts, onSelect }) {
             {a.user && (
               <div
                 className="text-xs"
-                dangerouslySetInnerHTML={{ __html: `User: ${highlight(a.user)}` }}
+                dangerouslySetInnerHTML={{
+                  __html: createTrustedHTML(`User: ${highlight(a.user)}`),
+                }}
               />
             )}
             <div
               className="text-xs"
-              dangerouslySetInnerHTML={{ __html: highlight(a.description) }}
+              dangerouslySetInnerHTML={{
+                __html: createTrustedHTML(highlight(a.description)),
+              }}
             />
           </button>
         ))}

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -5,6 +5,7 @@ import KeywordSearchPanel from './KeywordSearchPanel';
 import demoArtifacts from './data/sample-artifacts.json';
 import ReportExport from '../../../apps/autopsy/components/ReportExport';
 import demoCase from '../../../apps/autopsy/data/case.json';
+import { createTrustedHTML } from '../../../utils/trustedTypes';
 
 const escapeFilename = (str = '') =>
   str
@@ -590,7 +591,7 @@ function Autopsy({ initialArtifacts = null }) {
       <div
         aria-live="polite"
         className="sr-only"
-        dangerouslySetInnerHTML={{ __html: announcement }}
+        dangerouslySetInnerHTML={{ __html: createTrustedHTML(announcement) }}
       />
       <div className="flex space-x-2">
         <input
@@ -796,7 +797,9 @@ function Autopsy({ initialArtifacts = null }) {
           </button>
           <div
             className="font-bold"
-            dangerouslySetInnerHTML={{ __html: escapeFilename(selectedArtifact.name) }}
+            dangerouslySetInnerHTML={{
+              __html: createTrustedHTML(escapeFilename(selectedArtifact.name)),
+            }}
           />
           <div className="text-gray-400">{selectedArtifact.type}</div>
           <div className="text-xs">

--- a/components/apps/beef/index.js
+++ b/components/apps/beef/index.js
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import PayloadBuilder from '../../../apps/beef/components/PayloadBuilder';
+import { createTrustedHTML } from '../../../utils/trustedTypes';
 
 export default function Beef() {
-  const targetPage = `\n<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="utf-8"/>\n  <title>Sandboxed Target</title>\n</head>\n<body>\n  <h1>Sandboxed Target Page</h1>\n  <p>This page is isolated and cannot make network requests.</p>\n  <script>document.body.append(' - loaded');<\/script>\n</body>\n</html>`;
+  const targetPage = createTrustedHTML(`\n<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="utf-8"/>\n  <title>Sandboxed Target</title>\n</head>\n<body>\n  <h1>Sandboxed Target Page</h1>\n  <p>This page is isolated and cannot make network requests.</p>\n  <script>document.body.append(' - loaded');<\/script>\n</body>\n</html>`);
 
   const steps = [
     {

--- a/components/apps/chrome/Reader.tsx
+++ b/components/apps/chrome/Reader.tsx
@@ -3,6 +3,7 @@ import { Readability } from '@mozilla/readability';
 import TurndownService from 'turndown';
 import DOMPurify from 'dompurify';
 import { useReadLater } from './ReadLaterList';
+import { createTrustedHTML } from '../../../utils/trustedTypes';
 
 interface ReaderProps {
   url: string;
@@ -80,7 +81,7 @@ const Reader: React.FC<ReaderProps> = ({ url }) => {
   if (!article) return <div>Loading...</div>;
 
   const renderedContent = (
-    <div dangerouslySetInnerHTML={{ __html: article.content }} />
+    <div dangerouslySetInnerHTML={{ __html: createTrustedHTML(article.content) }} />
   );
 
   const markdownContent = (

--- a/components/apps/chrome/index.tsx
+++ b/components/apps/chrome/index.tsx
@@ -8,6 +8,7 @@ import React, {
 import { toPng } from 'html-to-image';
 import { Readability } from '@mozilla/readability';
 import DOMPurify from 'dompurify';
+import { createTrustedHTML } from '../../../utils/trustedTypes';
 import AddressBar from './AddressBar';
 import { getCachedFavicon, cacheFavicon } from './bookmarks';
 
@@ -776,7 +777,11 @@ const Chrome: React.FC = () => {
           ) : articles[activeId] ? (
             <main
               style={{ maxInlineSize: '60ch', margin: 'auto' }}
-              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(articles[activeId] ?? '') }}
+              dangerouslySetInnerHTML={{
+                __html: createTrustedHTML(
+                  DOMPurify.sanitize(articles[activeId] ?? ''),
+                ),
+              }}
             />
           ) : activeTab.blocked ? (
             blockedView

--- a/components/apps/ettercap/index.js
+++ b/components/apps/ettercap/index.js
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import data from './data.json';
 import ArpLab from './components/ArpLab';
 import vendors from '../kismet/oui.json';
+import { createTrustedHTML } from '../../../utils/trustedTypes';
 
 const { arpTable, flows } = data;
 const attackerMac = 'aa:aa:aa:aa:aa:aa';
@@ -724,7 +725,9 @@ const stopSpoof = () => {
           aria-label="syntax highlighted filter"
         >
           <code
-            dangerouslySetInnerHTML={{ __html: highlightFilter(filterText) }}
+            dangerouslySetInnerHTML={{
+              __html: createTrustedHTML(highlightFilter(filterText)),
+            }}
           />
         </pre>
       </div>

--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { createTrustedHTML } from '../../../utils/trustedTypes';
 
 const suggestions = {
   '/admin': 'Restrict access to the admin portal or remove it from public view.',
@@ -6,6 +7,14 @@ const suggestions = {
     'Remove or secure unnecessary CGI scripts and ensure they are up to date.',
   '/': 'Disable or standardize ETag headers to avoid disclosing inodes.',
 };
+
+const escapeHtml = (str = '') =>
+  String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 
 const NiktoApp = () => {
   const [host, setHost] = useState('');
@@ -48,7 +57,9 @@ const NiktoApp = () => {
     const rows = findings
       .map(
         (f) =>
-          `<tr><td>${f.path}</td><td>${f.finding}</td><td>${f.severity}</td></tr>`
+          `<tr><td>${escapeHtml(f.path)}</td><td>${escapeHtml(
+            f.finding,
+          )}</td><td>${escapeHtml(f.severity)}</td></tr>`
       )
       .join('');
     return `<!DOCTYPE html><html><body><h1>Nikto Report</h1><table border="1"><tr><th>Path</th><th>Finding</th><th>Severity</th></tr>${rows}</table></body></html>`;
@@ -287,7 +298,7 @@ const NiktoApp = () => {
         </div>
         <iframe
           title="Nikto HTML Report"
-          srcDoc={htmlReport}
+          srcDoc={createTrustedHTML(htmlReport)}
           className="w-full h-64 bg-white"
         />
       </div>

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -3,6 +3,7 @@ import TaskOverview from './task-overview';
 import PolicySettings from './policy-settings';
 import pciProfile from './templates/pci.json';
 import hipaaProfile from './templates/hipaa.json';
+import { createTrustedHTML } from '../../../utils/trustedTypes';
 
 const templates = { PCI: pciProfile, HIPAA: hipaaProfile };
 
@@ -519,7 +520,9 @@ const OpenVASApp = () => {
               >
                 <div className="flex items-center justify-between">
                   <span
-                    dangerouslySetInnerHTML={{ __html: escapeHtml(f.description) }}
+                    dangerouslySetInnerHTML={{
+                      __html: createTrustedHTML(escapeHtml(f.description)),
+                    }}
                   />
                   <div className="flex gap-1 ml-2">
                     <span className="px-1 py-0.5 bg-red-700 rounded text-xs">
@@ -590,7 +593,9 @@ const OpenVASApp = () => {
             <h3 className="text-lg mb-2">Issue Detail</h3>
             <p
               className="mb-2"
-              dangerouslySetInnerHTML={{ __html: escapeHtml(selected.description) }}
+              dangerouslySetInnerHTML={{
+                __html: createTrustedHTML(escapeHtml(selected.description)),
+              }}
             />
             <div className="flex gap-2 mb-2">
               {selected.cvss !== undefined && (

--- a/components/apps/x.js
+++ b/components/apps/x.js
@@ -76,7 +76,7 @@ export default function XApp() {
       if (!timelineRef.current || !window.twttr) return;
       setScriptError(false);
       setTimelineLoaded(false);
-      timelineRef.current.innerHTML = '';
+    timelineRef.current.replaceChildren();
       window.twttr.widgets
         .createTimeline(
           { sourceType: 'profile', screenName: feedUser },

--- a/components/tweet-embed.js
+++ b/components/tweet-embed.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import DOMPurify from 'dompurify';
+import { createTrustedHTML } from '../utils/trustedTypes';
 
 export default function TweetEmbed({ id }) {
   const [html, setHtml] = useState(null);
@@ -58,7 +59,7 @@ export default function TweetEmbed({ id }) {
     <>
       <div
         className="tweet-embed"
-        dangerouslySetInnerHTML={{ __html: html }}
+        dangerouslySetInnerHTML={{ __html: createTrustedHTML(html) }}
         suppressHydrationWarning
       />
       <style jsx>{`

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
+import { TRUSTED_TYPES_POLICY_NAME } from './utils/trustedTypes';
 
 function nonce() {
   const arr = new Uint8Array(16);
@@ -19,7 +20,9 @@ export function middleware(req: NextRequest) {
     "frame-ancestors 'self'",
     "object-src 'none'",
     "base-uri 'self'",
-    "form-action 'self'"
+    "form-action 'self'",
+    `trusted-types ${TRUSTED_TYPES_POLICY_NAME} nextjs`,
+    "require-trusted-types-for 'script'",
   ].join('; ');
 
   const res = NextResponse.next();

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,8 @@
 
 const { validateServerEnv: validateEnv } = require('./lib/validate.js');
 
+const TRUSTED_TYPES_POLICY = 'kali-portfolio#html';
+
 const ContentSecurityPolicy = [
   "default-src 'self'",
   // Prevent injection of external base URIs
@@ -29,6 +31,8 @@ const ContentSecurityPolicy = [
 
   // Allow this site to embed its own resources (resume PDF)
   "frame-ancestors 'self'",
+  `trusted-types ${TRUSTED_TYPES_POLICY} nextjs`,
+  "require-trusted-types-for 'script'",
   // Enforce HTTPS for all requests
   'upgrade-insecure-requests',
 ].join('; ');

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,10 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import {
+  attachTrustedTypesViolationLogger,
+  ensureTrustedTypesPolicy,
+} from '../utils/trustedTypes';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -24,9 +28,19 @@ const ubuntu = Ubuntu({
   weight: ['300', '400', '500', '700'],
 });
 
+ensureTrustedTypesPolicy();
+
 
 function MyApp(props) {
   const { Component, pageProps } = props;
+
+
+  useEffect(() => {
+    const detachLogger = attachTrustedTypesViolationLogger();
+    return () => {
+      detachLogger?.();
+    };
+  }, []);
 
 
   useEffect(() => {

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,4 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { ensureTrustedTypesPolicy } from '../utils/trustedTypes';
+
+ensureTrustedTypesPolicy();
 
 class MyDocument extends Document {
   /**

--- a/pages/security-education.tsx
+++ b/pages/security-education.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import WorkflowCard from '../components/WorkflowCard';
 import { WindowMainScreen } from '../components/base/window';
+import { createTrustedHTML } from '../utils/trustedTypes';
 
 interface FrameProps {
   title: string;
@@ -8,16 +9,21 @@ interface FrameProps {
   description: string;
 }
 
-const InfoFrame = ({ title, link, description }: FrameProps) => (
-  <iframe
-    title={title}
-    sandbox="allow-popups"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; geolocation; gyroscope; picture-in-picture"
-    referrerPolicy="no-referrer"
-    srcDoc={`<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'></head><body><h2>${title}</h2><p>${description}</p><p><a href='${link}' target='_blank' rel='noopener noreferrer'>Official Documentation</a></p></body></html>`}
-    style={{ width: '100%', border: '1px solid #ccc', height: '200px' }}
-  />
-);
+const InfoFrame = ({ title, link, description }: FrameProps) => {
+  const trustedSrcDoc = createTrustedHTML(
+    `<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'></head><body><h2>${title}</h2><p>${description}</p><p><a href='${link}' target='_blank' rel='noopener noreferrer'>Official Documentation</a></p></body></html>`,
+  );
+  return (
+    <iframe
+      title={title}
+      sandbox="allow-popups"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; geolocation; gyroscope; picture-in-picture"
+      referrerPolicy="no-referrer"
+      srcDoc={trustedSrcDoc as unknown as string}
+      style={{ width: '100%', border: '1px solid #ccc', height: '200px' }}
+    />
+  );
+};
 
 const SecurityEducation = () => (
   <WindowMainScreen

--- a/public/apps/tetris/main.js
+++ b/public/apps/tetris/main.js
@@ -528,12 +528,17 @@ function saveLeaderboard(type, value){
 function showLeaderboard(type){
   const key = `tetris-${type}`;
   const data = JSON.parse(localStorage.getItem(key) || '[]');
-  let html = `<h3>${type==='sprint'?'Sprint':'Marathon'} Leaderboard</h3><ol>`;
+  leaderboardDiv.replaceChildren();
+  const heading = document.createElement('h3');
+  heading.textContent = `${type==='sprint'?'Sprint':'Marathon'} Leaderboard`;
+  const list = document.createElement('ol');
   for(const v of data){
-    html += `<li>${type==='sprint'?v.toFixed(2)+'s':v}</li>`;
+    const item = document.createElement('li');
+    item.textContent = type==='sprint'?`${v.toFixed(2)}s`:`${v}`;
+    list.appendChild(item);
   }
-  html += '</ol>';
-  leaderboardDiv.innerHTML = html;
+  leaderboardDiv.appendChild(heading);
+  leaderboardDiv.appendChild(list);
 }
 
 document.getElementById('mode-sprint').addEventListener('click', ()=>{mode=null;showLeaderboard('sprint');startSprint();});

--- a/public/offline.js
+++ b/public/offline.js
@@ -19,8 +19,11 @@ document.getElementById('retry').addEventListener('click', () => {
       }
     }
     if (urls.size === 0) {
-      list.innerHTML = '<li>No apps available offline.</li>';
+      const empty = document.createElement('li');
+      empty.textContent = 'No apps available offline.';
+      list.replaceChildren(empty);
     } else {
+      list.replaceChildren();
       urls.forEach((path) => {
         const li = document.createElement('li');
         const a = document.createElement('a');
@@ -31,6 +34,8 @@ document.getElementById('retry').addEventListener('click', () => {
       });
     }
   } catch (err) {
-    list.innerHTML = '<li>Unable to access cached apps.</li>';
+    const errorItem = document.createElement('li');
+    errorItem.textContent = 'Unable to access cached apps.';
+    list.replaceChildren(errorItem);
   }
 })();

--- a/utils/trustedTypes.ts
+++ b/utils/trustedTypes.ts
@@ -1,0 +1,85 @@
+const POLICY_NAME = 'kali-portfolio#html';
+const POLICY_SYMBOL = Symbol.for('kali-linux-portfolio.trustedTypesPolicy');
+
+type GlobalWithPolicy = typeof globalThis & {
+  [POLICY_SYMBOL]?: TrustedTypePolicy | null;
+};
+
+function getGlobal(): GlobalWithPolicy {
+  return globalThis as GlobalWithPolicy;
+}
+
+function createPolicy(): TrustedTypePolicy | null {
+  const globalScope = getGlobal();
+  if (typeof globalScope.trustedTypes === 'undefined') {
+    globalScope[POLICY_SYMBOL] = null;
+    return null;
+  }
+
+  if (globalScope[POLICY_SYMBOL]) {
+    return globalScope[POLICY_SYMBOL] ?? null;
+  }
+
+  try {
+    const policy = globalScope.trustedTypes.createPolicy(POLICY_NAME, {
+      createHTML: (input) => input,
+    });
+    globalScope[POLICY_SYMBOL] = policy;
+    return policy;
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('Trusted Types policy registration failed', error);
+    }
+    globalScope[POLICY_SYMBOL] = null;
+    return null;
+  }
+}
+
+export function ensureTrustedTypesPolicy(): TrustedTypePolicy | null {
+  const globalScope = getGlobal();
+  if (typeof globalScope[POLICY_SYMBOL] !== 'undefined') {
+    return globalScope[POLICY_SYMBOL];
+  }
+  return createPolicy();
+}
+
+export function createTrustedHTML(html: string | TrustedHTML): string | TrustedHTML {
+  if (typeof html !== 'string') {
+    return html;
+  }
+  const policy = ensureTrustedTypesPolicy();
+  return policy ? policy.createHTML(html) : html;
+}
+
+export function attachTrustedTypesViolationLogger(): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const policy = ensureTrustedTypesPolicy();
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (policy) {
+      console.info(`Trusted Types policy "${POLICY_NAME}" active`);
+    } else {
+      console.info('Trusted Types unsupported; falling back to string HTML rendering');
+    }
+
+    const handler = (event: SecurityPolicyViolationEvent) => {
+      if (event.violatedDirective?.includes('trusted-types')) {
+        console.error('Trusted Types violation detected', {
+          blockedURI: event.blockedURI,
+          effectiveDirective: event.effectiveDirective,
+          originalPolicy: event.originalPolicy,
+        });
+      }
+    };
+
+    document.addEventListener('securitypolicyviolation', handler);
+    return () => document.removeEventListener('securitypolicyviolation', handler);
+  }
+
+  return () => {};
+}
+
+export { POLICY_NAME as TRUSTED_TYPES_POLICY_NAME };


### PR DESCRIPTION
## Summary
- add a shared Trusted Types helper with dev-mode violation logging and regression tests
- enforce Trusted Types via updated CSP headers in the middleware and Next.js config
- wrap existing HTML sinks with the Trusted Types policy and replace direct innerHTML usage in legacy scripts

## Testing
- yarn lint *(fails: numerous pre-existing accessibility lint errors across unrelated apps)*
- yarn test --watch=false *(fails: existing window/nmap/NES test suites and jsdom localStorage issues)*

------
https://chatgpt.com/codex/tasks/task_e_68cca67a38788328ba2fa4b540e06cb0