### PR TITLE
[security] add hsts header validation

### DIFF
--- a/__tests__/securityHeaders.test.js
+++ b/__tests__/securityHeaders.test.js
@@ -1,0 +1,25 @@
+const { ContentSecurityPolicy, securityHeaders } = require('../lib/securityHeaders.js');
+
+describe('security headers baseline', () => {
+  function getHeaderValue(key) {
+    const entry = securityHeaders.find((header) => header.key === key);
+    expect(entry).toBeDefined();
+    return entry?.value;
+  }
+
+  it('includes the headers required for an A-grade security headers scan', () => {
+    expect(getHeaderValue('Strict-Transport-Security')).toBe(
+      'max-age=63072000; includeSubDomains; preload'
+    );
+    expect(getHeaderValue('Content-Security-Policy')).toBe(ContentSecurityPolicy);
+    expect(getHeaderValue('X-Content-Type-Options')).toBe('nosniff');
+    expect(getHeaderValue('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+    expect(getHeaderValue('Permissions-Policy')).toBe('camera=(), microphone=(), geolocation=*');
+    expect(getHeaderValue('X-Frame-Options')).toBe('SAMEORIGIN');
+  });
+
+  it('keeps frame protections aligned between CSP and legacy headers', () => {
+    expect(ContentSecurityPolicy).toContain("frame-ancestors 'self'");
+    expect(ContentSecurityPolicy).toContain('upgrade-insecure-requests');
+  });
+});

--- a/lib/securityHeaders.js
+++ b/lib/securityHeaders.js
@@ -1,0 +1,64 @@
+// Central security header definitions used by Next.js configuration and tests.
+// Update README (section "CSP External Domains") when editing domains below.
+
+const ContentSecurityPolicy = [
+  "default-src 'self'",
+  // Prevent injection of external base URIs
+  "base-uri 'self'",
+  // Restrict form submissions to same origin
+  "form-action 'self'",
+  // Disallow all plugins and other embedded objects
+  "object-src 'none'",
+  // Allow external images and data URIs for badges/icons
+  "img-src 'self' https: data:",
+  // Allow inline styles
+  "style-src 'self' 'unsafe-inline'",
+  // Explicitly allow inline style tags
+  "style-src-elem 'self' 'unsafe-inline'",
+  // Restrict fonts to same origin
+  "font-src 'self'",
+  // External scripts required for embedded timelines
+  "script-src 'self' 'unsafe-inline' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+  // Allow outbound connections for embeds and the in-browser Chrome app
+  "connect-src 'self' https://example.com https://developer.mozilla.org https://en.wikipedia.org https://www.google.com https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
+  // Allow iframes from specific providers so the Chrome and StackBlitz apps can load allowed content
+  "frame-src 'self' https://vercel.live https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://example.com https://developer.mozilla.org https://en.wikipedia.org",
+
+  // Allow this site to embed its own resources (resume PDF)
+  "frame-ancestors 'self'",
+  // Enforce HTTPS for all requests
+  'upgrade-insecure-requests',
+].join('; ');
+
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: ContentSecurityPolicy,
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=*',
+  },
+  {
+    // Allow same-origin framing so the PDF resume renders in an <object>
+    key: 'X-Frame-Options',
+    value: 'SAMEORIGIN',
+  },
+];
+
+module.exports = {
+  ContentSecurityPolicy,
+  securityHeaders,
+};

--- a/next.config.js
+++ b/next.config.js
@@ -4,58 +4,7 @@
 
 const { validateServerEnv: validateEnv } = require('./lib/validate.js');
 
-const ContentSecurityPolicy = [
-  "default-src 'self'",
-  // Prevent injection of external base URIs
-  "base-uri 'self'",
-  // Restrict form submissions to same origin
-  "form-action 'self'",
-  // Disallow all plugins and other embedded objects
-  "object-src 'none'",
-  // Allow external images and data URIs for badges/icons
-  "img-src 'self' https: data:",
-  // Allow inline styles
-  "style-src 'self' 'unsafe-inline'",
-  // Explicitly allow inline style tags
-  "style-src-elem 'self' 'unsafe-inline'",
-  // Restrict fonts to same origin
-  "font-src 'self'",
-  // External scripts required for embedded timelines
-  "script-src 'self' 'unsafe-inline' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
-  // Allow outbound connections for embeds and the in-browser Chrome app
-  "connect-src 'self' https://example.com https://developer.mozilla.org https://en.wikipedia.org https://www.google.com https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
-  // Allow iframes from specific providers so the Chrome and StackBlitz apps can load allowed content
-  "frame-src 'self' https://vercel.live https://stackblitz.com https://*.google.com https://platform.twitter.com https://syndication.twitter.com https://*.twitter.com https://*.x.com https://www.youtube-nocookie.com https://open.spotify.com https://example.com https://developer.mozilla.org https://en.wikipedia.org",
-
-  // Allow this site to embed its own resources (resume PDF)
-  "frame-ancestors 'self'",
-  // Enforce HTTPS for all requests
-  'upgrade-insecure-requests',
-].join('; ');
-
-const securityHeaders = [
-  {
-    key: 'Content-Security-Policy',
-    value: ContentSecurityPolicy,
-  },
-  {
-    key: 'X-Content-Type-Options',
-    value: 'nosniff',
-  },
-  {
-    key: 'Referrer-Policy',
-    value: 'strict-origin-when-cross-origin',
-  },
-  {
-    key: 'Permissions-Policy',
-    value: 'camera=(), microphone=(), geolocation=*',
-  },
-  {
-    // Allow same-origin framing so the PDF resume renders in an <object>
-    key: 'X-Frame-Options',
-    value: 'SAMEORIGIN',
-  },
-];
+const { ContentSecurityPolicy, securityHeaders } = require('./lib/securityHeaders.js');
 
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',


### PR DESCRIPTION
## Summary
- add a shared security header module that now includes a preload-friendly Strict-Transport-Security policy
- wire Next.js config to consume the shared header list so the new HSTS header ships with the existing CSP and frame protections
- add a focused Jest test that asserts the header set matches the securityheaders.com A-grade baseline

## Testing
- yarn lint *(fails: existing jsx-a11y control-has-associated-label errors across legacy app files)*
- yarn test --runTestsByPath __tests__/securityHeaders.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cca67b1f588328b265143e9e00cf4d