### PR TITLE
[ci] tighten quality gates

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,12 @@
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        strict: true
+        contexts:
+          - CI / lint
+          - CI / typecheck
+          - CI / test
+          - CI / e2e
+          - CI / lighthouse
+          - Accessibility / a11y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,29 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn test --coverage
 
+  e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - typecheck
+      - test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx playwright install --with-deps
+      - name: Run Playwright end-to-end tests
+        run: |
+          set -euxo pipefail
+          yarn dev &
+          DEV_PID=$!
+          trap "kill $DEV_PID" EXIT
+          npx wait-on http://127.0.0.1:3000
+          npx playwright test
+
   security:
     runs-on: ubuntu-latest
     needs: install
@@ -62,9 +85,42 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  lighthouse:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - typecheck
+      - test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn build
+      - name: Run Lighthouse audits
+        run: |
+          set -euxo pipefail
+          yarn start -p 3000 &
+          SERVER_PID=$!
+          trap "kill $SERVER_PID" EXIT
+          npx wait-on http://127.0.0.1:3000
+          npx @lhci/cli@0.14.0 collect \
+            --url=http://127.0.0.1:3000/ \
+            --numberOfRuns=1 \
+            --settings.chromeFlags="--headless --no-sandbox"
+          npx @lhci/cli@0.14.0 assert --preset=lighthouse:recommended
+
   vercel-preview:
     runs-on: ubuntu-latest
-    needs: install
+    needs:
+      - lint
+      - typecheck
+      - test
+      - security
+      - e2e
+      - lighthouse
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -1,47 +1,42 @@
-name: Node.js CI
+name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
 
 jobs:
-  build:
+  deploy:
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event == 'push' &&
+          github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'yarn'
-          cache-dependency-path: 'yarn.lock'
-      - name: Installing Packages
+          cache: yarn
+          cache-dependency-path: yarn.lock
+      - name: Install dependencies
         run: yarn install --immutable
-
-      - name: Test
-        run: yarn jest -w=1
-
-      - name: Lint
-        run: yarn lint
-
-      - name: Type Check
-        run: yarn tsc --noEmit
-
-      - name: Building
+      - name: Build production bundle
         run: yarn build
         env:
           NEXT_PUBLIC_TRACKING_ID: ${{ secrets.NEXT_PUBLIC_TRACKING_ID }}
           NEXT_PUBLIC_SERVICE_ID: ${{ secrets.NEXT_PUBLIC_SERVICE_ID }}
           NEXT_PUBLIC_TEMPLATE_ID: ${{ secrets.NEXT_PUBLIC_TEMPLATE_ID }}
           NEXT_PUBLIC_USER_ID: ${{ secrets.NEXT_PUBLIC_USER_ID }}
-
-      - name: Exporting Bundle File
+      - name: Export static output
         run: yarn export
       - run: touch ./out/.nojekyll
-
-      - name: Deploy to Github-Pages 
+      - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
-          branch: gh-pages 
-          folder: out 
+          branch: gh-pages
+          folder: out

--- a/next.config.js
+++ b/next.config.js
@@ -124,11 +124,6 @@ module.exports = withBundleAnalyzer(
   withPWA({
     ...(isStaticExport && { output: 'export' }),
     webpack: configureWebpack,
-
-    // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
-    eslint: {
-      ignoreDuringBuilds: true,
-    },
     images: {
       unoptimized: true,
       domains: [


### PR DESCRIPTION
## Summary
- require the lint, typecheck, unit, e2e, lighthouse, and accessibility checks before merging to `main`
- extend CI with dedicated Playwright e2e and Lighthouse jobs and gate Vercel preview deploys on their success
- deploy GitHub Pages only after a successful CI run and let `next build` fail on ESLint problems again

## Testing
- yarn lint *(fails: repository currently has hundreds of accessibility lint violations)*
- yarn test *(fails: multiple pre-existing Jest suites fail under jsdom)*


------
https://chatgpt.com/codex/tasks/task_e_68cca67ca8a483289aec2327e150e08f