### PR TITLE
chore: enforce pinned node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - id: read-node-version
+        run: |
+          NODE_VERSION=$(tr -d ' \n\r' < .nvmrc)
+          if [ -z "$NODE_VERSION" ]; then
+            echo "::error file=.nvmrc::Unable to determine Node version from .nvmrc"
+            exit 1
+          fi
+          echo "version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ steps.read-node-version.outputs.version }}
           cache: yarn
+      - run: node scripts/check-node-version.mjs
       - run: yarn install --immutable --immutable-cache
 
   lint:
@@ -19,10 +28,19 @@ jobs:
     needs: install
     steps:
       - uses: actions/checkout@v4
+      - id: read-node-version
+        run: |
+          NODE_VERSION=$(tr -d ' \n\r' < .nvmrc)
+          if [ -z "$NODE_VERSION" ]; then
+            echo "::error file=.nvmrc::Unable to determine Node version from .nvmrc"
+            exit 1
+          fi
+          echo "version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ steps.read-node-version.outputs.version }}
           cache: yarn
+      - run: node scripts/check-node-version.mjs
       - run: yarn install --immutable --immutable-cache
       - run: npm run lint
 
@@ -31,10 +49,19 @@ jobs:
     needs: install
     steps:
       - uses: actions/checkout@v4
+      - id: read-node-version
+        run: |
+          NODE_VERSION=$(tr -d ' \n\r' < .nvmrc)
+          if [ -z "$NODE_VERSION" ]; then
+            echo "::error file=.nvmrc::Unable to determine Node version from .nvmrc"
+            exit 1
+          fi
+          echo "version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ steps.read-node-version.outputs.version }}
           cache: yarn
+      - run: node scripts/check-node-version.mjs
       - run: yarn install --immutable --immutable-cache
       - run: npm run tsc -- --noEmit
 
@@ -43,10 +70,19 @@ jobs:
     needs: install
     steps:
       - uses: actions/checkout@v4
+      - id: read-node-version
+        run: |
+          NODE_VERSION=$(tr -d ' \n\r' < .nvmrc)
+          if [ -z "$NODE_VERSION" ]; then
+            echo "::error file=.nvmrc::Unable to determine Node version from .nvmrc"
+            exit 1
+          fi
+          echo "version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ steps.read-node-version.outputs.version }}
           cache: yarn
+      - run: node scripts/check-node-version.mjs
       - run: yarn install --immutable --immutable-cache
       - run: yarn test --coverage
 
@@ -55,10 +91,19 @@ jobs:
     needs: install
     steps:
       - uses: actions/checkout@v4
+      - id: read-node-version
+        run: |
+          NODE_VERSION=$(tr -d ' \n\r' < .nvmrc)
+          if [ -z "$NODE_VERSION" ]; then
+            echo "::error file=.nvmrc::Unable to determine Node version from .nvmrc"
+            exit 1
+          fi
+          echo "version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ steps.read-node-version.outputs.version }}
           cache: yarn
+      - run: node scripts/check-node-version.mjs
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
@@ -71,10 +116,19 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
+      - id: read-node-version
+        run: |
+          NODE_VERSION=$(tr -d ' \n\r' < .nvmrc)
+          if [ -z "$NODE_VERSION" ]; then
+            echo "::error file=.nvmrc::Unable to determine Node version from .nvmrc"
+            exit 1
+          fi
+          echo "version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ steps.read-node-version.outputs.version }}
           cache: yarn
+      - run: node scripts/check-node-version.mjs
       - run: yarn install --immutable --immutable-cache
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Always test inside controlled labs and obtain written permission before performi
 - **Yarn** or **npm**
 - Recommended: **pnpm** if you prefer stricter hoisting; update lock/config accordingly.
 
+Run `yarn preflight` after checking out the repo or switching Node versions. It verifies that `.nvmrc`, `package.json#engines.node`, and your local runtime all agree and exits with a clear error if they diverge. This keeps contributor environments aligned with CI.
+
 ### Install & Run (Dev)
 ```bash
 cp .env.local.example .env.local  # populate with required keys

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "smoke": "node scripts/smoke-all-apps.mjs",
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
+    "preflight": "node scripts/check-node-version.mjs",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
     "verify:all": "node scripts/verify.mjs"
   },

--- a/scripts/check-node-version.mjs
+++ b/scripts/check-node-version.mjs
@@ -1,0 +1,44 @@
+import { readFile } from 'node:fs/promises';
+import process from 'node:process';
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+const [nvmrcRaw, packageJsonRaw] = await Promise.all([
+  readFile('.nvmrc', 'utf8'),
+  readFile('package.json', 'utf8'),
+]);
+
+const requiredVersion = nvmrcRaw.trim();
+if (!requiredVersion) {
+  fail('Unable to read a Node version from .nvmrc. Populate the file with the desired version (e.g. 20.19.5).');
+}
+
+let packageJson;
+try {
+  packageJson = JSON.parse(packageJsonRaw);
+} catch (error) {
+  fail(`Failed to parse package.json: ${error.message}`);
+}
+
+const enginesNode = packageJson?.engines?.node?.trim();
+if (!enginesNode) {
+  fail('package.json is missing an "engines.node" declaration. Add the required Node version to keep tooling in sync.');
+}
+
+if (requiredVersion !== enginesNode) {
+  fail(
+    `Node version mismatch. .nvmrc requires ${requiredVersion} but package.json#engines.node declares ${enginesNode}. Update both to the same version.`,
+  );
+}
+
+const runtimeVersion = process.versions?.node;
+if (runtimeVersion && runtimeVersion !== requiredVersion) {
+  fail(
+    `Local Node runtime is ${runtimeVersion}, but the project requires ${requiredVersion}. Run "nvm use" or install Node ${requiredVersion} before continuing.`,
+  );
+}
+
+console.log(`Node version check passed: ${requiredVersion}`);


### PR DESCRIPTION
## Summary
- update CI to read the pinned Node version from `.nvmrc`, fail when it goes missing, and run the new guard script ahead of installs
- add a reusable `scripts/check-node-version.mjs` preflight and expose it through a `yarn preflight` command
- document for contributors that the repo expects the pinned Node release and how to verify their setup

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint errors across multiple apps)*
- yarn test --watch=false *(fails: repository has pre-existing failing suites such as `__tests__/window.test.tsx` and `__tests__/nmapNse.test.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68cca68116c88328a9c6bcb1e43cc98b