### PR TITLE
[settings] add remote sync adapter and conflict handling

### DIFF
--- a/__tests__/settingsSync.test.ts
+++ b/__tests__/settingsSync.test.ts
@@ -1,0 +1,83 @@
+import {
+  loadSettings,
+  resetRemoteState,
+  resolveConflictSelection,
+  saveSettings,
+  type SettingsConflict,
+  type SettingsPayload,
+} from '../utils/settingsSync';
+
+describe('settingsSync adapter', () => {
+  beforeEach(() => {
+    resetRemoteState();
+  });
+
+  const createLocalUpdate = (
+    base: SettingsPayload,
+    overrides: Partial<SettingsPayload>,
+  ): SettingsPayload => ({
+    ...base,
+    ...overrides,
+  });
+
+  it('detects conflicts and provides merge options', async () => {
+    const baseSnapshot = await loadSettings();
+    const remoteUpdate = createLocalUpdate(baseSnapshot.data, {
+      accent: '#e53e3e',
+      wallpaper: 'wall-4',
+    });
+    await saveSettings(remoteUpdate, {
+      strategy: 'last-write-wins',
+      baseSnapshot,
+    });
+
+    const localUpdate = createLocalUpdate(baseSnapshot.data, {
+      accent: '#805ad5',
+      theme: 'neon',
+    });
+
+    const result = await saveSettings(localUpdate, {
+      strategy: 'manual',
+      baseSnapshot,
+    });
+
+    expect(result.ok).toBe(false);
+    const conflict = (result as { ok: false; conflict: SettingsConflict }).conflict;
+    expect(conflict.conflictingKeys).toEqual(['accent']);
+    const optionIds = conflict.options.map((option) => option.id);
+    expect(optionIds).toEqual(
+      expect.arrayContaining(['keep-local', 'use-remote', 'merge']),
+    );
+    const merged = resolveConflictSelection(conflict, 'merge');
+    expect(merged.accent).toBe(remoteUpdate.accent);
+    expect(merged.theme).toBe('neon');
+  });
+
+  it('applies last write wins when requested', async () => {
+    const baseSnapshot = await loadSettings();
+    const remoteUpdate = createLocalUpdate(baseSnapshot.data, {
+      wallpaper: 'wall-3',
+    });
+    await saveSettings(remoteUpdate, {
+      strategy: 'last-write-wins',
+      baseSnapshot,
+    });
+
+    const staleLocal = createLocalUpdate(baseSnapshot.data, {
+      wallpaper: 'wall-1',
+    });
+
+    const result = await saveSettings(staleLocal, {
+      strategy: 'last-write-wins',
+      baseSnapshot,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.overwritten).toBe(true);
+    }
+
+    const latest = await loadSettings();
+    expect(latest.data.wallpaper).toBe('wall-1');
+  });
+});

--- a/__tests__/useSettingsSync.test.tsx
+++ b/__tests__/useSettingsSync.test.tsx
@@ -1,0 +1,89 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+import { loadSettings, resetRemoteState } from '../utils/settingsSync';
+
+describe('useSettings remote sync integration', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    resetRemoteState();
+  });
+
+  it('surfaces conflicts and allows manual merge resolution', async () => {
+    const { result } = renderHook(() => useSettings(), {
+      wrapper: SettingsProvider,
+    });
+
+    await waitFor(() => expect(result.current.syncStatus).toBe('idle'));
+
+    const baseSnapshot = await loadSettings();
+    resetRemoteState({
+      data: {
+        ...baseSnapshot.data,
+        accent: '#e53e3e',
+      },
+      version: baseSnapshot.version + 1,
+      updatedAt: Date.now(),
+    });
+
+    act(() => {
+      result.current.setTheme('neon');
+      result.current.setAccent('#805ad5');
+    });
+
+    await act(async () => {
+      await result.current.forceSync('manual');
+    });
+
+    await waitFor(() => expect(result.current.syncStatus).toBe('conflict'));
+
+    const conflict = result.current.syncConflict;
+    expect(conflict?.conflictingKeys).toEqual(['accent']);
+    expect(result.current.syncOptions.some((option) => option.id === 'merge')).toBe(
+      true,
+    );
+
+    await act(async () => {
+      await result.current.resolveSyncConflict('merge');
+    });
+
+    await waitFor(() => expect(result.current.syncStatus).toBe('idle'));
+    expect(result.current.theme).toBe('neon');
+    expect(result.current.accent).toBe('#e53e3e');
+  });
+
+  it('supports overriding remote data with last write wins', async () => {
+    const { result } = renderHook(() => useSettings(), {
+      wrapper: SettingsProvider,
+    });
+
+    await waitFor(() => expect(result.current.syncStatus).toBe('idle'));
+
+    const baseSnapshot = await loadSettings();
+    resetRemoteState({
+      data: {
+        ...baseSnapshot.data,
+        wallpaper: 'wall-4',
+      },
+      version: baseSnapshot.version + 1,
+      updatedAt: Date.now(),
+    });
+
+    act(() => {
+      result.current.setWallpaper('wall-2');
+    });
+
+    await act(async () => {
+      await result.current.forceSync('manual');
+    });
+
+    await waitFor(() => expect(result.current.syncStatus).toBe('conflict'));
+
+    await act(async () => {
+      await result.current.forceSync('last-write-wins');
+    });
+
+    await waitFor(() => expect(result.current.syncStatus).toBe('idle'));
+    const latest = await loadSettings();
+    expect(latest.data.wallpaper).toBe('wall-2');
+  });
+});

--- a/utils/settingsSync.ts
+++ b/utils/settingsSync.ts
@@ -1,0 +1,268 @@
+import { defaults } from './settingsStore';
+
+export type SettingsDensity = 'regular' | 'compact';
+
+export type SettingsPayload = {
+  accent: string;
+  wallpaper: string;
+  density: SettingsDensity;
+  reducedMotion: boolean;
+  fontScale: number;
+  highContrast: boolean;
+  largeHitAreas: boolean;
+  pongSpin: boolean;
+  allowNetwork: boolean;
+  haptics: boolean;
+  theme: string;
+};
+
+export type SettingsSnapshot = {
+  data: SettingsPayload;
+  version: number;
+  updatedAt: number;
+};
+
+export type SyncStrategy = 'last-write-wins' | 'manual';
+
+export type SettingsMergeOptionId = 'keep-local' | 'use-remote' | 'merge';
+
+export type SettingsMergeOption = {
+  id: SettingsMergeOptionId;
+  label: string;
+  description: string;
+  data: SettingsPayload;
+};
+
+export type SettingsConflict = {
+  type: 'version-mismatch';
+  local: SettingsPayload;
+  remote: SettingsSnapshot;
+  base: SettingsSnapshot;
+  conflictingKeys: (keyof SettingsPayload)[];
+  options: SettingsMergeOption[];
+};
+
+export type SaveOptions = {
+  strategy: SyncStrategy;
+  baseSnapshot: SettingsSnapshot;
+};
+
+export type SaveResult =
+  | {
+      ok: true;
+      snapshot: SettingsSnapshot;
+      overwritten: boolean;
+      previousVersion: number;
+    }
+  | {
+      ok: false;
+      conflict: SettingsConflict;
+    };
+
+type RemoteRecord = SettingsSnapshot;
+
+const DEFAULT_REMOTE_STATE: SettingsPayload = {
+  accent: defaults.accent,
+  wallpaper: defaults.wallpaper,
+  density: defaults.density as SettingsDensity,
+  reducedMotion: defaults.reducedMotion,
+  fontScale: defaults.fontScale,
+  highContrast: defaults.highContrast,
+  largeHitAreas: defaults.largeHitAreas,
+  pongSpin: defaults.pongSpin,
+  allowNetwork: defaults.allowNetwork,
+  haptics: defaults.haptics,
+  theme: 'default',
+};
+
+let remoteState: RemoteRecord = {
+  data: { ...DEFAULT_REMOTE_STATE },
+  version: 0,
+  updatedAt: Date.now(),
+};
+
+const listeners = new Set<(snapshot: SettingsSnapshot) => void>();
+
+const cloneSnapshot = (snapshot: SettingsSnapshot): SettingsSnapshot => ({
+  data: { ...snapshot.data },
+  version: snapshot.version,
+  updatedAt: snapshot.updatedAt,
+});
+
+const notify = (): void => {
+  const snapshot = cloneSnapshot(remoteState);
+  listeners.forEach((listener) => listener(snapshot));
+};
+
+const simulateLatency = async (): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 5));
+};
+
+const diffKeys = (
+  base: SettingsPayload,
+  next: SettingsPayload,
+): (keyof SettingsPayload)[] => {
+  const keys = Object.keys(base) as (keyof SettingsPayload)[];
+  return keys.filter((key) => base[key] !== next[key]);
+};
+
+const buildMergedPayload = (
+  base: SettingsPayload,
+  remote: SettingsPayload,
+  local: SettingsPayload,
+): {
+  merged: SettingsPayload;
+  conflictingKeys: (keyof SettingsPayload)[];
+} => {
+  const localChanges = diffKeys(base, local);
+  const remoteChanges = diffKeys(base, remote);
+  const conflictingKeys = Array.from(
+    new Set(
+      localChanges.filter(
+        (key) =>
+          remoteChanges.includes(key) &&
+          remote[key] !== local[key],
+      ),
+    ),
+  );
+
+  const merged: SettingsPayload = { ...remote };
+
+  localChanges.forEach((key) => {
+    if (!remoteChanges.includes(key)) {
+      merged[key] = local[key];
+    }
+  });
+
+  return { merged, conflictingKeys };
+};
+
+const createConflict = (
+  local: SettingsPayload,
+  remote: SettingsSnapshot,
+  base: SettingsSnapshot,
+): SettingsConflict => {
+  const { merged, conflictingKeys } = buildMergedPayload(
+    base.data,
+    remote.data,
+    local,
+  );
+
+  const options: SettingsMergeOption[] = [
+    {
+      id: 'keep-local',
+      label: 'Use local changes',
+      description: 'Overwrite remote settings with your version.',
+      data: { ...local },
+    },
+    {
+      id: 'use-remote',
+      label: 'Keep remote version',
+      description: 'Discard local edits and keep the remote settings.',
+      data: { ...remote.data },
+    },
+  ];
+
+  options.push({
+    id: 'merge',
+    label: 'Merge safely',
+    description:
+      conflictingKeys.length > 0
+        ? 'Keep remote values for conflicting settings and apply the rest of your edits.'
+        : 'Apply your changes on top of the remote settings.',
+    data: merged,
+  });
+
+  return {
+    type: 'version-mismatch',
+    local: { ...local },
+    remote: cloneSnapshot(remote),
+    base: cloneSnapshot(base),
+    conflictingKeys,
+    options,
+  };
+};
+
+export const loadSettings = async (): Promise<SettingsSnapshot> => {
+  await simulateLatency();
+  return cloneSnapshot(remoteState);
+};
+
+export const saveSettings = async (
+  data: SettingsPayload,
+  options: SaveOptions,
+): Promise<SaveResult> => {
+  await simulateLatency();
+  const { baseSnapshot, strategy } = options;
+  const versionsMatch = baseSnapshot.version === remoteState.version;
+
+  if (versionsMatch || strategy === 'last-write-wins') {
+    const previousVersion = remoteState.version;
+    const nextVersion = previousVersion + 1;
+    remoteState = {
+      data: { ...data },
+      version: nextVersion,
+      updatedAt: Date.now(),
+    };
+    notify();
+    return {
+      ok: true,
+      snapshot: cloneSnapshot(remoteState),
+      overwritten: !versionsMatch,
+      previousVersion,
+    };
+  }
+
+  const conflict = createConflict(data, remoteState, baseSnapshot);
+  return { ok: false, conflict };
+};
+
+export const subscribeToRemote = (
+  listener: (snapshot: SettingsSnapshot) => void,
+): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const resolveConflictSelection = (
+  conflict: SettingsConflict,
+  optionId: SettingsMergeOptionId,
+  overrides?: Partial<SettingsPayload>,
+): SettingsPayload => {
+  const option = conflict.options.find((candidate) => candidate.id === optionId);
+  if (!option) {
+    throw new Error(`Unknown merge option: ${optionId}`);
+  }
+  return {
+    ...option.data,
+    ...overrides,
+  };
+};
+
+export const resetRemoteState = (snapshot?: SettingsSnapshot): void => {
+  remoteState = snapshot
+    ? {
+        data: { ...snapshot.data },
+        version: snapshot.version,
+        updatedAt: snapshot.updatedAt,
+      }
+    : {
+        data: { ...DEFAULT_REMOTE_STATE },
+        version: 0,
+        updatedAt: Date.now(),
+      };
+};
+
+const settingsSync = {
+  load: loadSettings,
+  save: saveSettings,
+  subscribe: subscribeToRemote,
+  resolve: resolveConflictSelection,
+  reset: resetRemoteState,
+};
+
+export type SettingsSyncAdapter = typeof settingsSync;
+
+export default settingsSync;


### PR DESCRIPTION
## Summary
- add a simulated remote settings sync adapter supporting manual merge choices and last-write-wins
- integrate sync status, conflict handling, and manual resolution hooks into useSettings
- add unit tests covering adapter conflicts and the manual merge/override flows in the provider

## Testing
- yarn test --runInBand __tests__/settingsSync.test.ts __tests__/useSettingsSync.test.tsx
- yarn lint *(fails: existing accessibility and no-top-level-window lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cca68394d483289519f1ba9466f9b1