### PR TITLE
feat(settings): add search with analytics

### DIFF
--- a/__tests__/settings-analytics.test.ts
+++ b/__tests__/settings-analytics.test.ts
@@ -1,0 +1,32 @@
+jest.mock('@/lib/analytics-client', () => ({
+  trackEvent: jest.fn(),
+}));
+
+import { trackEvent } from '@/lib/analytics-client';
+import { logSettingsSearch } from '@/apps/settings/analytics';
+
+describe('logSettingsSearch', () => {
+  beforeEach(() => {
+    (trackEvent as jest.Mock).mockClear();
+  });
+
+  it('sends analytics with duration metadata', () => {
+    logSettingsSearch('contrast', 2, 'high-contrast', 12.7);
+    expect(trackEvent).toHaveBeenCalledWith('settings_search', {
+      queryLength: 8,
+      resultCount: 2,
+      sectionId: 'high-contrast',
+      durationMs: 13,
+    });
+  });
+
+  it('handles missing optional fields', () => {
+    logSettingsSearch('', 0);
+    expect(trackEvent).toHaveBeenCalledWith('settings_search', {
+      queryLength: 0,
+      resultCount: 0,
+      sectionId: 'none',
+      durationMs: 0,
+    });
+  });
+});

--- a/__tests__/settings-search.test.ts
+++ b/__tests__/settings-search.test.ts
@@ -1,0 +1,45 @@
+import { performance } from 'perf_hooks';
+import {
+  buildSettingsSearchIndex,
+  filterSettingsSections,
+  sortSettingsMatches,
+  createSettingsSearch,
+  type SettingsSectionMeta,
+} from '@/apps/settings/searchIndex';
+
+describe('settings search index', () => {
+  const sections: SettingsSectionMeta[] = [
+    { id: 'theme', tabId: 'appearance', label: 'Theme', keywords: ['mode', 'appearance'] },
+    { id: 'high-contrast', tabId: 'accessibility', label: 'High Contrast', keywords: ['visibility'] },
+    { id: 'backup-restore', tabId: 'privacy', label: 'Backup & Restore', keywords: ['export', 'import'] },
+  ];
+
+  it('matches queries against labels and keywords case-insensitively', () => {
+    const index = buildSettingsSearchIndex(sections);
+    const matches = filterSettingsSections(index, 'IMPORT');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].id).toBe('backup-restore');
+  });
+
+  it('sorts matches by relevance and alphabetical order', () => {
+    const index = buildSettingsSearchIndex(sections);
+    const filtered = filterSettingsSections(index, 'theme');
+    const sorted = sortSettingsMatches(filtered, 'theme');
+    expect(sorted[0].id).toBe('theme');
+  });
+
+  it('remains responsive with large section counts', () => {
+    const largeSections: SettingsSectionMeta[] = Array.from({ length: 5000 }, (_, i) => ({
+      id: `section-${i}`,
+      tabId: i % 2 === 0 ? 'appearance' : 'accessibility',
+      label: `Setting ${i}`,
+      keywords: [`option ${i}`],
+    }));
+    const search = createSettingsSearch(largeSections);
+    const start = performance.now();
+    const results = search('Setting 4999');
+    const duration = performance.now() - start;
+    expect(results[0]?.id).toBe('section-4999');
+    expect(duration).toBeLessThan(60);
+  });
+});

--- a/apps/settings/analytics.ts
+++ b/apps/settings/analytics.ts
@@ -1,0 +1,16 @@
+import { trackEvent } from '@/lib/analytics-client';
+
+export const logSettingsSearch = (
+  query: string,
+  resultCount: number,
+  sectionId?: string,
+  durationMs?: number,
+) => {
+  const safeDuration = Number.isFinite(durationMs) ? Math.max(0, Math.round(durationMs ?? 0)) : 0;
+  trackEvent('settings_search', {
+    queryLength: query.length,
+    resultCount,
+    sectionId: sectionId ?? 'none',
+    durationMs: safeDuration,
+  });
+};

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useState, useRef } from "react";
+import {
+  useState,
+  useRef,
+  useMemo,
+  useEffect,
+  useCallback,
+} from "react";
+import type { KeyboardEvent } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
@@ -12,6 +19,143 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import type {
+  SettingsSectionMeta,
+  SettingsSearchIndexEntry,
+  SettingsTabId,
+} from "./searchIndex";
+import {
+  buildSettingsSearchIndex,
+  filterSettingsSections,
+  sortSettingsMatches,
+} from "./searchIndex";
+import { logSettingsSearch } from "./analytics";
+
+const SETTINGS_TABS: ReadonlyArray<{ id: SettingsTabId; label: string }> = [
+  { id: "appearance", label: "Appearance" },
+  { id: "accessibility", label: "Accessibility" },
+  { id: "privacy", label: "Privacy" },
+];
+
+const SETTINGS_SECTIONS: SettingsSectionMeta[] = [
+  {
+    id: "wallpaper-preview",
+    tabId: "appearance",
+    label: "Wallpaper Preview",
+    keywords: ["background", "wallpaper", "image", "appearance"],
+  },
+  {
+    id: "theme",
+    tabId: "appearance",
+    label: "Theme",
+    keywords: ["theme", "mode", "appearance"],
+  },
+  {
+    id: "accent",
+    tabId: "appearance",
+    label: "Accent Color",
+    keywords: ["accent", "color", "highlight"],
+  },
+  {
+    id: "wallpaper-slider",
+    tabId: "appearance",
+    label: "Wallpaper Selector",
+    keywords: ["wallpaper", "slider", "background"],
+  },
+  {
+    id: "wallpaper-slideshow",
+    tabId: "appearance",
+    label: "Wallpaper Slideshow",
+    keywords: ["slideshow", "background", "rotate"],
+  },
+  {
+    id: "wallpaper-gallery",
+    tabId: "appearance",
+    label: "Wallpaper Gallery",
+    keywords: ["wallpaper", "grid", "background", "preview"],
+  },
+  {
+    id: "reset-desktop",
+    tabId: "appearance",
+    label: "Reset Desktop",
+    keywords: ["reset", "defaults", "restore"],
+  },
+  {
+    id: "icon-size",
+    tabId: "accessibility",
+    label: "Icon Size",
+    keywords: ["icon", "size", "scale", "accessibility"],
+  },
+  {
+    id: "density",
+    tabId: "accessibility",
+    label: "Interface Density",
+    keywords: ["density", "layout", "compact"],
+  },
+  {
+    id: "reduced-motion",
+    tabId: "accessibility",
+    label: "Reduced Motion",
+    keywords: ["motion", "animation", "accessibility"],
+  },
+  {
+    id: "high-contrast",
+    tabId: "accessibility",
+    label: "High Contrast",
+    keywords: ["contrast", "visibility", "accessibility"],
+  },
+  {
+    id: "haptics",
+    tabId: "accessibility",
+    label: "Haptics",
+    keywords: ["feedback", "vibration", "controller"],
+  },
+  {
+    id: "shortcuts",
+    tabId: "accessibility",
+    label: "Keyboard Shortcuts",
+    keywords: ["shortcuts", "keymap", "keyboard"],
+  },
+  {
+    id: "backup-restore",
+    tabId: "privacy",
+    label: "Backup & Restore",
+    keywords: ["export", "import", "backup", "privacy"],
+  },
+];
+
+type SettingsSectionId = (typeof SETTINGS_SECTIONS)[number]["id"];
+
+const SECTIONS_BY_TAB: Record<SettingsTabId, SettingsSectionMeta[]> = {
+  appearance: [],
+  accessibility: [],
+  privacy: [],
+};
+
+const SECTION_BY_ID: Record<SettingsSectionId, SettingsSectionMeta> = {} as Record<
+  SettingsSectionId,
+  SettingsSectionMeta
+>;
+
+for (const section of SETTINGS_SECTIONS) {
+  SECTIONS_BY_TAB[section.tabId].push(section);
+  SECTION_BY_ID[section.id] = section;
+}
+
+const WALLPAPERS = [
+  "wall-1",
+  "wall-2",
+  "wall-3",
+  "wall-4",
+  "wall-5",
+  "wall-6",
+  "wall-7",
+  "wall-8",
+] as const;
+
+type WallpaperName = (typeof WALLPAPERS)[number];
+
+const now = () => (typeof performance !== "undefined" ? performance.now() : Date.now());
 
 export default function Settings() {
   const {
@@ -33,27 +177,58 @@ export default function Settings() {
     setTheme,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const searchStartedAtRef = useRef<number>(now());
 
-  const tabs = [
-    { id: "appearance", label: "Appearance" },
-    { id: "accessibility", label: "Accessibility" },
-    { id: "privacy", label: "Privacy" },
-  ] as const;
-  type TabId = (typeof tabs)[number]["id"];
-  const [activeTab, setActiveTab] = useState<TabId>("appearance");
+  const [activeTab, setActiveTab] = useState<SettingsTabId>("appearance");
+  const [showKeymap, setShowKeymap] = useState(false);
+  const [query, setQuery] = useState("");
 
-  const wallpapers = [
-    "wall-1",
-    "wall-2",
-    "wall-3",
-    "wall-4",
-    "wall-5",
-    "wall-6",
-    "wall-7",
-    "wall-8",
-  ];
+  const tabLabelMap = useMemo(
+    () => Object.fromEntries(SETTINGS_TABS.map((tab) => [tab.id, tab.label] as const)),
+    [],
+  );
 
-  const changeBackground = (name: string) => setWallpaper(name);
+  const searchIndex = useMemo(
+    () => buildSettingsSearchIndex(SETTINGS_SECTIONS),
+    [],
+  );
+
+  const matches = useMemo(
+    () => sortSettingsMatches(filterSettingsSections(searchIndex, query), query),
+    [searchIndex, query],
+  );
+
+  const matchesByTab = useMemo(() => {
+    const grouped: Record<SettingsTabId, SettingsSearchIndexEntry[]> = {
+      appearance: [],
+      accessibility: [],
+      privacy: [],
+    };
+    matches.forEach((match) => {
+      grouped[match.tabId].push(match);
+    });
+    return grouped;
+  }, [matches]);
+
+  const visibleSections = useMemo(() => {
+    if (!query.trim()) {
+      return new Set(
+        SECTIONS_BY_TAB[activeTab].map((section) => section.id),
+      );
+    }
+
+    return new Set(matchesByTab[activeTab].map((section) => section.id));
+  }, [activeTab, matchesByTab, query]);
+
+  const hasQuery = query.trim().length > 0;
+  const hasMatches = matches.length > 0;
+  const hasMatchesInActiveTab = matchesByTab[activeTab].length > 0;
+  const noMatchesInActiveTab = hasQuery && !hasMatchesInActiveTab;
+  const firstMatch = matches[0];
+  const displayedResults = hasQuery ? matches.slice(0, 8) : [];
+
+  const changeBackground = (name: WallpaperName) => setWallpaper(name);
 
   const handleExport = async () => {
     const data = await exportSettingsData();
@@ -88,7 +263,7 @@ export default function Settings() {
   const handleReset = async () => {
     if (
       !window.confirm(
-        "Reset desktop to default settings? This will clear all saved data."
+        "Reset desktop to default settings? This will clear all saved data.",
       )
     )
       return;
@@ -103,40 +278,186 @@ export default function Settings() {
     setTheme("default");
   };
 
-  const [showKeymap, setShowKeymap] = useState(false);
+  const handleQueryInput = (value: string) => {
+    searchStartedAtRef.current = now();
+    setQuery(value);
+  };
+
+  const openSection = useCallback(
+    (match: SettingsSearchIndexEntry) => {
+      const duration = now() - searchStartedAtRef.current;
+      logSettingsSearch(query, matches.length, match.id, duration);
+      setActiveTab(match.tabId);
+      searchStartedAtRef.current = now();
+
+      requestAnimationFrame(() => {
+        const element = document.getElementById(`settings-${match.id}`);
+        if (element) {
+          element.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+        if (typeof window !== "undefined") {
+          window.history.replaceState(null, "", `#settings-${match.id}`);
+        }
+      });
+    },
+    [matches.length, query],
+  );
+
+  const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (firstMatch) {
+        openSection(firstMatch);
+        searchInputRef.current?.blur();
+      }
+    } else if (event.key === "Escape" && query) {
+      event.preventDefault();
+      setQuery("");
+    }
+  };
+
+  const handleResultClick = (match: SettingsSearchIndexEntry) => {
+    openSection(match);
+    searchInputRef.current?.blur();
+  };
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const hash = window.location.hash.slice(1);
+    if (!hash.startsWith("settings-")) return;
+    const sectionId = hash.replace("settings-", "") as SettingsSectionId;
+    const section = SECTION_BY_ID[sectionId];
+    if (!section) return;
+    setActiveTab(section.tabId);
+    requestAnimationFrame(() => {
+      const element = document.getElementById(`settings-${sectionId}`);
+      if (element) {
+        element.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    });
+  }, []);
+
+  const isSectionVisible = useCallback(
+    (id: SettingsSectionId) => visibleSections.has(id),
+    [visibleSections],
+  );
 
   return (
     <div className="w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey">
-      <div className="flex justify-center border-b border-gray-900">
-        <Tabs tabs={tabs} active={activeTab} onChange={setActiveTab} />
+      <div className="px-4 py-3 border-b border-gray-900">
+        <label htmlFor="settings-search" className="sr-only">
+          Search settings
+        </label>
+        <input
+          ref={searchInputRef}
+          id="settings-search"
+          type="search"
+          value={query}
+          onChange={(e) => handleQueryInput(e.target.value)}
+          onKeyDown={handleSearchKeyDown}
+          placeholder="Search settings"
+          aria-autocomplete="list"
+          aria-expanded={hasQuery}
+          aria-controls={hasQuery ? "settings-search-results" : undefined}
+          className="w-full px-3 py-2 rounded bg-black bg-opacity-30 text-white placeholder-ubt-grey border border-gray-800 focus:outline-none focus:ring-2 focus:ring-ubt-blue"
+        />
+        {hasQuery && (
+          <div className="mt-3 rounded border border-gray-800 bg-black bg-opacity-30">
+            <ul
+              id="settings-search-results"
+              role="listbox"
+              aria-label="Settings search results"
+              className="divide-y divide-gray-800"
+            >
+              {displayedResults.length > 0 ? (
+                displayedResults.map((match) => (
+                  <li key={match.id}>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-label={`${match.label} in ${tabLabelMap[match.tabId]}`}
+                      className="w-full px-3 py-2 text-left text-sm text-white hover:bg-ubt-grey hover:bg-opacity-20"
+                      onClick={() => handleResultClick(match)}
+                    >
+                      <span>{match.label}</span>
+                      <span className="ml-2 text-xs text-ubt-grey">
+                        {tabLabelMap[match.tabId]}
+                      </span>
+                    </button>
+                  </li>
+                ))
+              ) : (
+                <li className="px-3 py-2 text-sm text-ubt-grey">
+                  No settings match "{query}"
+                </li>
+              )}
+            </ul>
+          </div>
+        )}
       </div>
+      <div className="flex justify-center border-b border-gray-900">
+        <Tabs tabs={SETTINGS_TABS} active={activeTab} onChange={setActiveTab} />
+      </div>
+      {noMatchesInActiveTab && (
+        <div className="px-4 py-6 text-center text-ubt-grey border-b border-gray-900">
+          <p className="mb-2">No matches in {tabLabelMap[activeTab]}.</p>
+          {hasMatches && firstMatch ? (
+            <p>
+              Press Enter to jump to <span className="text-white">{firstMatch.label}</span> in {tabLabelMap[firstMatch.tabId]}.
+            </p>
+          ) : (
+            <p>Try a different search term.</p>
+          )}
+        </div>
+      )}
       {activeTab === "appearance" && (
         <>
-          <div
-            className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
-            style={{
-              backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
-              backgroundSize: "cover",
-              backgroundRepeat: "no-repeat",
-              backgroundPosition: "center center",
-            }}
-          ></div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Theme:</label>
-            <select
-              value={theme}
-              onChange={(e) => setTheme(e.target.value)}
-              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-            >
-              <option value="default">Default</option>
-              <option value="dark">Dark</option>
-              <option value="neon">Neon</option>
-              <option value="matrix">Matrix</option>
-            </select>
-          </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Accent:</label>
-            <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
+          <SettingSection
+            id="wallpaper-preview"
+            title="Wallpaper Preview"
+            hidden={!isSectionVisible("wallpaper-preview")}
+            className="my-4"
+          >
+            <div
+              className="md:w-2/5 w-2/3 h-1/3 m-auto"
+              style={{
+                backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
+                backgroundSize: "cover",
+                backgroundRepeat: "no-repeat",
+                backgroundPosition: "center center",
+              }}
+              role="img"
+              aria-label={`Preview of ${wallpaper.replace("wall-", "wallpaper ")} background`}
+            />
+          </SettingSection>
+          <SettingSection
+            id="theme"
+            title="Theme"
+            hidden={!isSectionVisible("theme")}
+            className="flex justify-center my-4"
+          >
+            <label className="mr-2 text-ubt-grey">
+              Theme:
+              <select
+                value={theme}
+                onChange={(e) => setTheme(e.target.value)}
+                className="ml-2 bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+              >
+                <option value="default">Default</option>
+                <option value="dark">Dark</option>
+                <option value="neon">Neon</option>
+                <option value="matrix">Matrix</option>
+              </select>
+            </label>
+          </SettingSection>
+          <SettingSection
+            id="accent"
+            title="Accent Color"
+            hidden={!isSectionVisible("accent")}
+            className="flex justify-center my-4"
+          >
+            <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2 items-center">
+              <span className="mr-2 text-ubt-grey">Accent:</span>
               {ACCENT_OPTIONS.map((c) => (
                 <button
                   key={c}
@@ -149,28 +470,45 @@ export default function Settings() {
                 />
               ))}
             </div>
-          </div>
-          <div className="flex justify-center my-4">
-            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
+          </SettingSection>
+          <SettingSection
+            id="wallpaper-slider"
+            title="Wallpaper Selector"
+            hidden={!isSectionVisible("wallpaper-slider")}
+            className="flex justify-center my-4"
+          >
+            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">
+              Wallpaper:
+            </label>
             <input
               id="wallpaper-slider"
               type="range"
               min="0"
-              max={wallpapers.length - 1}
+              max={WALLPAPERS.length - 1}
               step="1"
-              value={wallpapers.indexOf(wallpaper)}
+              value={WALLPAPERS.indexOf(wallpaper)}
               onChange={(e) =>
-                changeBackground(wallpapers[parseInt(e.target.value, 10)])
+                changeBackground(WALLPAPERS[parseInt(e.target.value, 10)])
               }
               className="ubuntu-slider"
               aria-label="Wallpaper"
             />
-          </div>
-          <div className="flex justify-center my-4">
+          </SettingSection>
+          <SettingSection
+            id="wallpaper-slideshow"
+            title="Wallpaper Slideshow"
+            hidden={!isSectionVisible("wallpaper-slideshow")}
+            className="flex justify-center my-4"
+          >
             <BackgroundSlideshow />
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
-            {wallpapers.map((name) => (
+          </SettingSection>
+          <SettingSection
+            id="wallpaper-gallery"
+            title="Wallpaper Gallery"
+            hidden={!isSectionVisible("wallpaper-gallery")}
+            className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900"
+          >
+            {WALLPAPERS.map((name) => (
               <div
                 key={name}
                 role="button"
@@ -196,23 +534,35 @@ export default function Settings() {
                   backgroundRepeat: "no-repeat",
                   backgroundPosition: "center center",
                 }}
-              ></div>
+              />
             ))}
-          </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
+          </SettingSection>
+          <SettingSection
+            id="reset-desktop"
+            title="Reset Desktop"
+            hidden={!isSectionVisible("reset-desktop")}
+            className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center"
+          >
             <button
               onClick={handleReset}
               className="px-4 py-2 rounded bg-ub-orange text-white"
             >
               Reset Desktop
             </button>
-          </div>
+          </SettingSection>
         </>
       )}
       {activeTab === "accessibility" && (
         <>
-          <div className="flex justify-center my-4">
-            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
+          <SettingSection
+            id="icon-size"
+            title="Icon Size"
+            hidden={!isSectionVisible("icon-size")}
+            className="flex justify-center my-4"
+          >
+            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">
+              Icon Size:
+            </label>
             <input
               id="font-scale"
               type="range"
@@ -224,83 +574,146 @@ export default function Settings() {
               className="ubuntu-slider"
               aria-label="Icon size"
             />
-          </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Density:</label>
-            <select
-              value={density}
-              onChange={(e) => setDensity(e.target.value as any)}
-              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-            >
-              <option value="regular">Regular</option>
-              <option value="compact">Compact</option>
-            </select>
-          </div>
-          <div className="flex justify-center my-4 items-center">
+          </SettingSection>
+          <SettingSection
+            id="density"
+            title="Interface Density"
+            hidden={!isSectionVisible("density")}
+            className="flex justify-center my-4"
+          >
+            <label className="mr-2 text-ubt-grey">
+              Density:
+              <select
+                value={density}
+                onChange={(e) => setDensity(e.target.value as any)}
+                className="ml-2 bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+              >
+                <option value="regular">Regular</option>
+                <option value="compact">Compact</option>
+              </select>
+            </label>
+          </SettingSection>
+          <SettingSection
+            id="reduced-motion"
+            title="Reduced Motion"
+            hidden={!isSectionVisible("reduced-motion")}
+            className="flex justify-center my-4 items-center"
+          >
             <span className="mr-2 text-ubt-grey">Reduced Motion:</span>
             <ToggleSwitch
               checked={reducedMotion}
               onChange={setReducedMotion}
               ariaLabel="Reduced Motion"
             />
-          </div>
-          <div className="flex justify-center my-4 items-center">
+          </SettingSection>
+          <SettingSection
+            id="high-contrast"
+            title="High Contrast"
+            hidden={!isSectionVisible("high-contrast")}
+            className="flex justify-center my-4 items-center"
+          >
             <span className="mr-2 text-ubt-grey">High Contrast:</span>
             <ToggleSwitch
               checked={highContrast}
               onChange={setHighContrast}
               ariaLabel="High Contrast"
             />
-          </div>
-          <div className="flex justify-center my-4 items-center">
+          </SettingSection>
+          <SettingSection
+            id="haptics"
+            title="Haptics"
+            hidden={!isSectionVisible("haptics")}
+            className="flex justify-center my-4 items-center"
+          >
             <span className="mr-2 text-ubt-grey">Haptics:</span>
             <ToggleSwitch
               checked={haptics}
               onChange={setHaptics}
               ariaLabel="Haptics"
             />
-          </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
+          </SettingSection>
+          <SettingSection
+            id="shortcuts"
+            title="Keyboard Shortcuts"
+            hidden={!isSectionVisible("shortcuts")}
+            className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center"
+          >
             <button
               onClick={() => setShowKeymap(true)}
               className="px-4 py-2 rounded bg-ub-orange text-white"
             >
               Edit Shortcuts
             </button>
-          </div>
+          </SettingSection>
         </>
       )}
       {activeTab === "privacy" && (
-        <>
-          <div className="flex justify-center my-4 space-x-4">
-            <button
-              onClick={handleExport}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Export Settings
-            </button>
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Import Settings
-            </button>
-          </div>
-        </>
+        <SettingSection
+          id="backup-restore"
+          title="Backup & Restore"
+          hidden={!isSectionVisible("backup-restore")}
+          className="flex justify-center my-4 space-x-4"
+        >
+          <button
+            onClick={handleExport}
+            className="px-4 py-2 rounded bg-ub-orange text-white"
+          >
+            Export Settings
+          </button>
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            className="px-4 py-2 rounded bg-ub-orange text-white"
+          >
+            Import Settings
+          </button>
+        </SettingSection>
       )}
-        <input
-          type="file"
-          accept="application/json"
-          ref={fileInputRef}
-          aria-label="Import settings file"
-          onChange={(e) => {
-            const file = e.target.files && e.target.files[0];
-            if (file) handleImport(file);
-            e.target.value = "";
-          }}
-          className="hidden"
-        />
+      <input
+        type="file"
+        accept="application/json"
+        ref={fileInputRef}
+        aria-label="Import settings file"
+        onChange={(e) => {
+          const file = e.target.files && e.target.files[0];
+          if (file) handleImport(file);
+          e.target.value = "";
+        }}
+        className="hidden"
+      />
       <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
     </div>
+  );
+}
+
+type SettingSectionProps = {
+  id: SettingsSectionId;
+  title: string;
+  hidden: boolean;
+  className?: string;
+  children: React.ReactNode;
+};
+
+function SettingSection({ id, title, hidden, className, children }: SettingSectionProps) {
+  if (hidden) return null;
+
+  const classes = [
+    className,
+    "focus:outline-none",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <section
+      id={`settings-${id}`}
+      aria-labelledby={`settings-${id}-title`}
+      className={classes}
+      data-settings-section={id}
+    >
+      <span id={`settings-${id}-title`} className="sr-only">
+        {title}
+      </span>
+      {children}
+    </section>
   );
 }

--- a/apps/settings/searchIndex.ts
+++ b/apps/settings/searchIndex.ts
@@ -1,0 +1,66 @@
+export type SettingsTabId = 'appearance' | 'accessibility' | 'privacy';
+
+export interface SettingsSectionMeta {
+  id: string;
+  tabId: SettingsTabId;
+  label: string;
+  keywords?: string[];
+}
+
+export interface SettingsSearchIndexEntry extends SettingsSectionMeta {
+  haystack: string;
+}
+
+const normalize = (value: string): string => value.trim().toLowerCase();
+
+export const buildSettingsSearchIndex = (
+  sections: readonly SettingsSectionMeta[],
+): SettingsSearchIndexEntry[] =>
+  sections.map((section) => ({
+    ...section,
+    haystack: normalize(
+      [section.label, ...(section.keywords ?? [])].join(' '),
+    ),
+  }));
+
+export const filterSettingsSections = (
+  index: readonly SettingsSearchIndexEntry[],
+  query: string,
+): SettingsSearchIndexEntry[] => {
+  const normalizedQuery = normalize(query);
+  if (!normalizedQuery) {
+    return [...index];
+  }
+
+  return index.filter((entry) => entry.haystack.includes(normalizedQuery));
+};
+
+export const sortSettingsMatches = (
+  matches: readonly SettingsSearchIndexEntry[],
+  query: string,
+): SettingsSearchIndexEntry[] => {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return [...matches];
+  }
+
+  return [...matches].sort((a, b) => {
+    const aIndex = a.haystack.indexOf(normalizedQuery);
+    const bIndex = b.haystack.indexOf(normalizedQuery);
+
+    if (aIndex === bIndex) {
+      return a.label.localeCompare(b.label);
+    }
+
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
+};
+
+export const createSettingsSearch = (
+  sections: readonly SettingsSectionMeta[],
+) => {
+  const index = buildSettingsSearchIndex(sections);
+  return (query: string) => sortSettingsMatches(filterSettingsSections(index, query), query);
+};

--- a/lib/analytics-client.ts
+++ b/lib/analytics-client.ts
@@ -4,7 +4,8 @@ export type EventName =
   | 'contact_submit'
   | 'contact_submit_error'
   | 'outbound_link_click'
-  | 'download_click';
+  | 'download_click'
+  | 'settings_search';
 
 export function trackEvent(
   name: EventName,


### PR DESCRIPTION
## Summary
- add a reusable search index for settings sections and surface a type-ahead search experience with keyboard navigation and deep linking
- instrument settings search analytics and expose a GA event for the new interaction
- cover the search helpers with performance-oriented tests and verify analytics payloads

## Testing
- yarn lint *(fails: repository has hundreds of pre-existing accessibility and top-level window lint errors)*
- yarn test *(fails: repository has pre-existing failing suites such as window keyboard handling and nmap alerts)*

------
https://chatgpt.com/codex/tasks/task_e_68cca68b0b2c8328a43be71c0f91dd15