### PR TITLE
feat: add runtime locale switching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,18 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  locale-build:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn check:locale-build
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install

--- a/__tests__/locale-provider.test.tsx
+++ b/__tests__/locale-provider.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LocaleProvider, useLocale } from '../hooks/useLocale';
+import QuickSettings from '../components/ui/QuickSettings';
+
+describe('LocaleProvider', () => {
+  const LocaleProbe = () => {
+    const { t, locale, setLocale } = useLocale();
+    return (
+      <div>
+        <div data-testid="label">{t('whisker.buttonLabel')}</div>
+        <div data-testid="active-locale">{locale}</div>
+        <button type="button" onClick={() => setLocale(locale === 'en' ? 'es' : 'en')}>
+          toggle
+        </button>
+      </div>
+    );
+  };
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('switches translations at runtime without reloading the page', async () => {
+    render(
+      <LocaleProvider>
+        <LocaleProbe />
+      </LocaleProvider>,
+    );
+
+    expect(await screen.findByTestId('label')).toHaveTextContent('Applications');
+    await userEvent.click(screen.getByRole('button', { name: /toggle/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('label')).toHaveTextContent('Aplicaciones');
+    });
+  });
+
+  it('persists the selected locale for future sessions', async () => {
+    const { unmount } = render(
+      <LocaleProvider>
+        <LocaleProbe />
+      </LocaleProvider>,
+    );
+
+    await screen.findByTestId('label');
+    await userEvent.click(screen.getByRole('button', { name: /toggle/i }));
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem('desktop-locale')).toBe('es');
+    });
+
+    unmount();
+
+    render(
+      <LocaleProvider>
+        <LocaleProbe />
+      </LocaleProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('label')).toHaveTextContent('Aplicaciones');
+      expect(screen.getByTestId('active-locale')).toHaveTextContent('es');
+    });
+  });
+
+  it('does not emit warnings when toggling locales', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <LocaleProvider>
+        <LocaleProbe />
+      </LocaleProvider>,
+    );
+
+    await screen.findByTestId('label');
+    await userEvent.click(screen.getByRole('button', { name: /toggle/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('label')).toHaveTextContent('Aplicaciones');
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /toggle/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('label')).toHaveTextContent('Applications');
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});
+
+describe('QuickSettings layout', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('reserves space to avoid layout shifts when locale changes', async () => {
+    render(
+      <LocaleProvider>
+        <QuickSettings open />
+      </LocaleProvider>,
+    );
+
+    const panel = await screen.findByTestId('quick-settings-panel');
+    expect(panel).toHaveStyle({ minWidth: '18rem' });
+
+    const wrapper = screen.getByTestId('locale-select-wrapper');
+    expect(wrapper).toHaveStyle({ minWidth: '8.5rem' });
+  });
+});

--- a/components/common/LocaleSwitcher.tsx
+++ b/components/common/LocaleSwitcher.tsx
@@ -1,0 +1,46 @@
+import { ChangeEvent } from 'react';
+import { useLocale } from '../../hooks/useLocale';
+
+interface Props {
+  className?: string;
+}
+
+const LocaleSwitcher = ({ className }: Props) => {
+  const { locale, setLocale, options, isLoading, t } = useLocale();
+
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setLocale(event.target.value);
+  };
+
+  return (
+    <label className={`flex flex-col gap-1 text-ubt-grey ${className ?? ''}`}>
+      <span className="text-sm font-medium">{t('quickSettings.locale.label')}</span>
+      <div
+        className="relative"
+        data-testid="locale-select-wrapper"
+        style={{ minWidth: '8.5rem' }}
+      >
+        <select
+          value={locale}
+          onChange={handleChange}
+          aria-label={t('quickSettings.locale.label')}
+          title={t('quickSettings.locale.placeholder')}
+          data-testid="locale-select"
+          disabled={isLoading}
+          className="w-full appearance-none rounded border border-ubt-cool-grey bg-ub-cool-grey px-2 py-1 text-sm text-ubt-grey focus:border-ubb-orange focus:outline-none"
+        >
+          {options.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-xs text-ubt-grey">
+          ▾
+        </span>
+      </div>
+    </label>
+  );
+};
+
+export default LocaleSwitcher;

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { useLocale } from '../../hooks/useLocale';
 
 type AppMeta = {
   id: string;
@@ -12,17 +13,13 @@ type AppMeta = {
   favourite?: boolean;
 };
 
-const CATEGORIES = [
-  { id: 'all', label: 'All' },
-  { id: 'favorites', label: 'Favorites' },
-  { id: 'recent', label: 'Recent' },
-  { id: 'utilities', label: 'Utilities' },
-  { id: 'games', label: 'Games' }
-];
+const CATEGORY_IDS = ['all', 'favorites', 'recent', 'utilities', 'games'] as const;
+type CategoryId = (typeof CATEGORY_IDS)[number];
 
 const WhiskerMenu: React.FC = () => {
+  const { t } = useLocale();
   const [open, setOpen] = useState(false);
-  const [category, setCategory] = useState('all');
+  const [category, setCategory] = useState<CategoryId>('all');
   const [query, setQuery] = useState('');
   const [highlight, setHighlight] = useState(0);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -65,6 +62,15 @@ const WhiskerMenu: React.FC = () => {
     }
     return list;
   }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
+
+  const categories = useMemo(
+    () =>
+      CATEGORY_IDS.map((id) => ({
+        id,
+        label: t(`whisker.categories.${id}`),
+      })),
+    [t],
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -124,12 +130,12 @@ const WhiskerMenu: React.FC = () => {
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"
-          alt="Menu"
+          alt={t('whisker.buttonLabel')}
           width={16}
           height={16}
           className="inline mr-1"
         />
-        Applications
+        {t('whisker.buttonLabel')}
       </button>
       {open && (
         <div
@@ -143,7 +149,7 @@ const WhiskerMenu: React.FC = () => {
           }}
         >
           <div className="flex flex-col bg-gray-800 p-2">
-            {CATEGORIES.map(cat => (
+            {categories.map(cat => (
               <button
                 key={cat.id}
                 className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
@@ -156,7 +162,8 @@ const WhiskerMenu: React.FC = () => {
           <div className="p-3">
             <input
               className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
-              placeholder="Search"
+              placeholder={t('whisker.searchPlaceholder')}
+              aria-label={t('whisker.searchPlaceholder')}
               value={query}
               onChange={e => setQuery(e.target.value)}
               autoFocus

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,8 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import { useLocale } from '../../hooks/useLocale';
+import LocaleSwitcher from '../common/LocaleSwitcher';
 
 interface Props {
   open: boolean;
@@ -12,6 +14,7 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const { t, isLoading: localeLoading } = useLocale();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -23,34 +26,53 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
-        open ? '' : 'hidden'
+      aria-busy={localeLoading}
+      aria-label={t('quickSettings.panelLabel')}
+      className={`absolute top-9 right-3 rounded-md border border-black border-opacity-20 bg-ub-cool-grey py-4 shadow transition-opacity ${
+        open ? 'opacity-100' : 'pointer-events-none opacity-0'
       }`}
+      data-testid="quick-settings-panel"
+      style={{ minWidth: '18rem' }}
     >
-      <div className="px-4 pb-2">
+      <div className="flex flex-col gap-3 px-4 text-ubt-grey">
         <button
-          className="w-full flex justify-between"
+          className="flex items-center justify-between gap-4 rounded px-2 py-1 text-left transition hover:bg-black/10"
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          aria-label={t('quickSettings.theme')}
         >
-          <span>Theme</span>
-          <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
+          <span>{t('quickSettings.theme')}</span>
+          <span className="min-w-[5rem] text-right font-medium">
+            {theme === 'light' ? t('quickSettings.themeValue.light') : t('quickSettings.themeValue.dark')}
+          </span>
         </button>
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
-        <input
-          type="checkbox"
-          checked={reduceMotion}
-          onChange={() => setReduceMotion(!reduceMotion)}
-        />
+        <label className="flex items-center justify-between gap-4">
+          <span>{t('quickSettings.sound')}</span>
+          <input
+            type="checkbox"
+            aria-label={t('quickSettings.sound')}
+            checked={sound}
+            onChange={() => setSound(!sound)}
+          />
+        </label>
+        <label className="flex items-center justify-between gap-4">
+          <span>{t('quickSettings.network')}</span>
+          <input
+            type="checkbox"
+            aria-label={t('quickSettings.network')}
+            checked={online}
+            onChange={() => setOnline(!online)}
+          />
+        </label>
+        <label className="flex items-center justify-between gap-4">
+          <span>{t('quickSettings.reducedMotion')}</span>
+          <input
+            type="checkbox"
+            aria-label={t('quickSettings.reducedMotion')}
+            checked={reduceMotion}
+            onChange={() => setReduceMotion(!reduceMotion)}
+          />
+        </label>
+        <LocaleSwitcher className="pt-1" />
       </div>
     </div>
   );

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -2,11 +2,13 @@ import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
+import { useLocale } from '../../hooks/useLocale';
 
 const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
+  const { t } = useLocale();
   const [online, setOnline] = useState(true);
 
   useEffect(() => {
@@ -42,13 +44,19 @@ export default function Status() {
     <div className="flex justify-center items-center">
       <span
         className="mx-1.5 relative"
-        title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
+        title={
+          online
+            ? allowNetwork
+              ? t('status.online')
+              : t('status.onlineBlocked')
+            : t('status.offline')
+        }
       >
         <Image
           width={16}
           height={16}
           src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
-          alt={online ? "online" : "offline"}
+          alt={online ? t('status.online') : t('status.offline')}
           className="inline status-symbol w-4 h-4"
           sizes="16px"
         />

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -1,0 +1,37 @@
+{
+  "quickSettings": {
+    "panelLabel": "Quick settings",
+    "theme": "Theme",
+    "themeValue": {
+      "light": "Light",
+      "dark": "Dark"
+    },
+    "sound": "Sound",
+    "network": "Network",
+    "reducedMotion": "Reduced motion",
+    "locale": {
+      "label": "Language",
+      "placeholder": "Choose a language"
+    }
+  },
+  "locale": {
+    "en": "English",
+    "es": "Español"
+  },
+  "whisker": {
+    "buttonLabel": "Applications",
+    "searchPlaceholder": "Search",
+    "categories": {
+      "all": "All",
+      "favorites": "Favorites",
+      "recent": "Recent",
+      "utilities": "Utilities",
+      "games": "Games"
+    }
+  },
+  "status": {
+    "online": "Online",
+    "onlineBlocked": "Online (requests blocked)",
+    "offline": "Offline"
+  }
+}

--- a/data/locales/es.json
+++ b/data/locales/es.json
@@ -1,0 +1,37 @@
+{
+  "quickSettings": {
+    "panelLabel": "Ajustes rápidos",
+    "theme": "Tema",
+    "themeValue": {
+      "light": "Claro",
+      "dark": "Oscuro"
+    },
+    "sound": "Sonido",
+    "network": "Red",
+    "reducedMotion": "Reducir movimiento",
+    "locale": {
+      "label": "Idioma",
+      "placeholder": "Selecciona un idioma"
+    }
+  },
+  "locale": {
+    "en": "Inglés",
+    "es": "Español"
+  },
+  "whisker": {
+    "buttonLabel": "Aplicaciones",
+    "searchPlaceholder": "Buscar",
+    "categories": {
+      "all": "Todas",
+      "favorites": "Favoritas",
+      "recent": "Recientes",
+      "utilities": "Utilidades",
+      "games": "Juegos"
+    }
+  },
+  "status": {
+    "online": "En línea",
+    "onlineBlocked": "En línea (solicitudes bloqueadas)",
+    "offline": "Sin conexión"
+  }
+}

--- a/hooks/useLocale.tsx
+++ b/hooks/useLocale.tsx
@@ -1,0 +1,200 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import enMessages from '../data/locales/en.json';
+
+type Messages = Record<string, unknown>;
+
+const STORAGE_KEY = 'desktop-locale';
+
+const SUPPORTED_LOCALES = [
+  { id: 'en', label: 'English' },
+  { id: 'es', label: 'Español' },
+] as const;
+
+export type LocaleCode = (typeof SUPPORTED_LOCALES)[number]['id'];
+
+const LOCALE_OPTIONS = SUPPORTED_LOCALES.map((option) => ({
+  id: option.id,
+  label: option.label,
+})) as readonly { id: LocaleCode; label: string }[];
+
+const messageCache = new Map<LocaleCode, Messages>();
+messageCache.set('en', enMessages as Messages);
+
+const localeLoaders: Record<LocaleCode, () => Promise<Messages>> = {
+  en: async () => enMessages as Messages,
+  es: () => import('../data/locales/es.json').then((mod) => mod.default as Messages),
+};
+
+interface LocaleContextValue {
+  locale: LocaleCode;
+  setLocale: (locale: string) => void;
+  t: (key: string, values?: Record<string, string | number>) => string;
+  isLoading: boolean;
+  options: typeof LOCALE_OPTIONS;
+}
+
+const LocaleContext = createContext<LocaleContextValue | undefined>(undefined);
+
+function normalizeLocale(input?: string | null): LocaleCode {
+  if (!input) return 'en';
+  const candidate = input.toLowerCase();
+  const direct = SUPPORTED_LOCALES.find((option) => option.id === candidate);
+  if (direct) return direct.id;
+  const base = candidate.split('-')[0];
+  const fallback = SUPPORTED_LOCALES.find((option) => option.id === base);
+  return fallback?.id ?? 'en';
+}
+
+async function loadMessages(locale: LocaleCode): Promise<Messages> {
+  if (messageCache.has(locale)) {
+    return messageCache.get(locale)!;
+  }
+  const loader = localeLoaders[locale];
+  if (!loader) return messageCache.get('en')!;
+  const result = await loader();
+  messageCache.set(locale, result);
+  return result;
+}
+
+function resolvePath(messages: Messages, key: string): unknown {
+  return key.split('.').reduce<unknown>((accumulator, segment) => {
+    if (accumulator && typeof accumulator === 'object' && segment in accumulator) {
+      return (accumulator as Record<string, unknown>)[segment];
+    }
+    return undefined;
+  }, messages);
+}
+
+export function LocaleProvider({ children }: { children: ReactNode }) {
+  const defaultLocale = normalizeLocale(process.env.NEXT_PUBLIC_DEFAULT_LOCALE);
+  const [locale, setLocaleState] = useState<LocaleCode>(defaultLocale);
+  const [messages, setMessages] = useState<Messages>(messageCache.get('en')!);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const pendingLocale = useRef<LocaleCode>(defaultLocale);
+  const bootstrapped = useRef(false);
+
+  const applyLocale = useCallback(
+    async (nextLocale: LocaleCode, { persist = true }: { persist?: boolean } = {}) => {
+      if (pendingLocale.current === nextLocale && !isLoading) {
+        return;
+      }
+      pendingLocale.current = nextLocale;
+      setIsLoading(true);
+      try {
+        const loaded = await loadMessages(nextLocale);
+        if (pendingLocale.current !== nextLocale) return;
+        setMessages(loaded);
+        setLocaleState(nextLocale);
+        if (persist && typeof window !== 'undefined') {
+          window.localStorage.setItem(STORAGE_KEY, nextLocale);
+        }
+      } catch (error) {
+        console.error('Failed to load locale', error);
+        if (pendingLocale.current !== nextLocale) return;
+        setMessages(messageCache.get('en')!);
+        setLocaleState('en');
+        if (persist && typeof window !== 'undefined') {
+          window.localStorage.setItem(STORAGE_KEY, 'en');
+        }
+      } finally {
+        if (pendingLocale.current === nextLocale) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [isLoading],
+  );
+
+  useEffect(() => {
+    if (bootstrapped.current) return;
+    bootstrapped.current = true;
+    let initial = defaultLocale;
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      const navigatorLanguage = typeof window.navigator !== 'undefined' ? window.navigator.language : undefined;
+      initial = normalizeLocale(stored ?? navigatorLanguage ?? defaultLocale);
+    }
+    applyLocale(initial, { persist: false }).catch((error) => {
+      console.error('Failed to initialize locale', error);
+      setIsLoading(false);
+    });
+  }, [applyLocale, defaultLocale]);
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = locale;
+    }
+  }, [locale]);
+
+  useEffect(() => {
+    if (isLoading) return;
+    const others = SUPPORTED_LOCALES.map((option) => option.id).filter((id) => id !== locale) as LocaleCode[];
+    others.forEach((id) => {
+      loadMessages(id).catch(() => {
+        // Ignore prefetch errors
+      });
+    });
+  }, [locale, isLoading]);
+
+  const translate = useCallback(
+    (key: string, values?: Record<string, string | number>) => {
+      const message = resolvePath(messages, key) ?? resolvePath(messageCache.get('en')!, key);
+      if (typeof message !== 'string') {
+        return key;
+      }
+      if (!values) return message;
+      return message.replace(/\{(\w+)\}/g, (match, token) => {
+        const value = values[token];
+        return value === undefined || value === null ? match : String(value);
+      });
+    },
+    [messages],
+  );
+
+  const changeLocale = useCallback(
+    (next: string) => {
+      const normalized = normalizeLocale(next);
+      applyLocale(normalized).catch((error) => {
+        console.error('Unable to switch locale', error);
+      });
+    },
+    [applyLocale],
+  );
+
+  const contextValue = useMemo<LocaleContextValue>(
+    () => ({
+      locale,
+      setLocale: changeLocale,
+      t: translate,
+      isLoading,
+      options: LOCALE_OPTIONS,
+    }),
+    [locale, changeLocale, translate, isLoading],
+  );
+
+  return <LocaleContext.Provider value={contextValue}>{children}</LocaleContext.Provider>;
+}
+
+export function useLocale(): LocaleContextValue {
+  const context = useContext(LocaleContext);
+  if (!context) {
+    throw new Error('useLocale must be used within a LocaleProvider');
+  }
+  return context;
+}
+
+export function useTranslations() {
+  const { t } = useLocale();
+  return t;
+}
+
+export const availableLocales = LOCALE_OPTIONS;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
-    "verify:all": "node scripts/verify.mjs"
+    "verify:all": "node scripts/verify.mjs",
+    "check:locale-build": "node scripts/check-locale-build.mjs"
   },
   "engines": {
     "node": "20.19.5"

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { LocaleProvider } from '../hooks/useLocale';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -156,23 +157,25 @@ function MyApp(props) {
         >
           Skip to app grid
         </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+        <LocaleProvider>
+          <SettingsProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </SettingsProvider>
+        </LocaleProvider>
       </div>
     </ErrorBoundary>
 

--- a/scripts/check-locale-build.mjs
+++ b/scripts/check-locale-build.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { rm } from 'node:fs/promises';
+
+const locales = ['en', 'es'];
+
+async function runBuild(locale) {
+  console.log(`\nChecking build warnings for locale "${locale}"`);
+  await rm('.next', { recursive: true, force: true });
+
+  const child = spawn('yarn', ['build'], {
+    env: {
+      ...process.env,
+      NEXT_PUBLIC_DEFAULT_LOCALE: locale,
+      NEXT_TELEMETRY_DISABLED: '1',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let output = '';
+
+  child.stdout.on('data', (chunk) => {
+    const text = chunk.toString();
+    output += text;
+    process.stdout.write(text);
+  });
+
+  child.stderr.on('data', (chunk) => {
+    const text = chunk.toString();
+    output += text;
+    process.stderr.write(text);
+  });
+
+  const exitCode = await new Promise((resolve) => {
+    child.on('close', resolve);
+  });
+
+  if (exitCode !== 0) {
+    throw new Error(`Build failed for locale ${locale}`);
+  }
+
+  const warningPattern = /(^|\n)\s*(warn(?:ing)?\b)/i;
+  if (warningPattern.test(output)) {
+    throw new Error(`Build for locale ${locale} produced warnings.`);
+  }
+}
+
+(async () => {
+  try {
+    for (const locale of locales) {
+      await runBuild(locale);
+    }
+    console.log('\nLocale builds completed without warnings.');
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+})();


### PR DESCRIPTION
## Summary
- add a locale provider with translation loading, persistence, and document language updates
- translate quick settings, whisker menu, and system status while introducing a reusable locale switcher and localized strings
- cover runtime switching with tests and enforce warning-free builds for each locale via a new CI job

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window errors)*
- yarn test *(fails: pre-existing suites such as window, nmap NSE, and modal tests)*
- yarn check:locale-build

------
https://chatgpt.com/codex/tasks/task_e_68cca68f9dd083289326635a8093637e