### PR TITLE
[settings] add schema migration framework

### DIFF
--- a/__tests__/settingsStore.test.ts
+++ b/__tests__/settingsStore.test.ts
@@ -1,0 +1,97 @@
+import {
+  CURRENT_SETTINGS_SCHEMA_VERSION,
+  defaults,
+  getAllowNetwork,
+  getDensity,
+  getFontScale,
+  getHaptics,
+  getReducedMotion,
+} from '../utils/settingsStore';
+
+const clearIndexedDb = async () =>
+  new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase('keyval-store');
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error ?? new Error('Failed to reset keyval-store'));
+    request.onblocked = () => resolve();
+  });
+
+describe('settings schema migrations', () => {
+  beforeEach(async () => {
+    window.localStorage.clear();
+    await clearIndexedDb();
+  });
+
+  test('normalizes legacy values and records schema version', async () => {
+    window.localStorage.setItem('reduced-motion', 'TRUE');
+    window.localStorage.setItem('haptics', '0');
+    window.localStorage.setItem('allow-network', 'YES');
+    window.localStorage.setItem('density', 'tablet');
+    window.localStorage.setItem('font-scale', '-5');
+
+    await expect(getDensity()).resolves.toBe(defaults.density);
+    await expect(getReducedMotion()).resolves.toBe(true);
+    await expect(getHaptics()).resolves.toBe(false);
+    await expect(getAllowNetwork()).resolves.toBe(false);
+    await expect(getFontScale()).resolves.toBe(defaults.fontScale);
+
+    expect(window.localStorage.getItem('reduced-motion')).toBe('true');
+    expect(window.localStorage.getItem('haptics')).toBe('false');
+    expect(window.localStorage.getItem('allow-network')).toBe('false');
+    expect(window.localStorage.getItem('density')).toBe(defaults.density);
+    expect(window.localStorage.getItem('font-scale')).toBe(String(defaults.fontScale));
+    expect(window.localStorage.getItem('settings-schema-version')).toBe(
+      String(CURRENT_SETTINGS_SCHEMA_VERSION),
+    );
+  });
+
+  test('re-running migrations leaves normalized data untouched', async () => {
+    window.localStorage.setItem('density', 'compact');
+    window.localStorage.setItem('font-scale', '2.5');
+
+    await expect(getDensity()).resolves.toBe('compact');
+    expect(window.localStorage.getItem('settings-schema-version')).toBe(
+      String(CURRENT_SETTINGS_SCHEMA_VERSION),
+    );
+
+    window.localStorage.setItem('settings-schema-version', '0');
+
+    await expect(getDensity()).resolves.toBe('compact');
+    await expect(getFontScale()).resolves.toBeCloseTo(2.5);
+    expect(window.localStorage.getItem('font-scale')).toBe('2.5');
+    expect(window.localStorage.getItem('density')).toBe('compact');
+    expect(window.localStorage.getItem('settings-schema-version')).toBe(
+      String(CURRENT_SETTINGS_SCHEMA_VERSION),
+    );
+  });
+
+  test('rolls back when schema version update fails', async () => {
+    window.localStorage.setItem('density', 'compact');
+
+    const storageProto = Object.getPrototypeOf(window.localStorage);
+    const originalSetItem = storageProto.setItem;
+    let shouldFail = true;
+    const setItemSpy = jest.spyOn(storageProto, 'setItem').mockImplementation(function (key, value) {
+      if (shouldFail && key === 'settings-schema-version') {
+        shouldFail = false;
+        throw new Error('boom');
+      }
+      return originalSetItem.call(this, key, value);
+    });
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(getDensity()).resolves.toBe('compact');
+      expect(window.localStorage.getItem('settings-schema-version')).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      await expect(getDensity()).resolves.toBe('compact');
+      expect(window.localStorage.getItem('settings-schema-version')).toBe(
+        String(CURRENT_SETTINGS_SCHEMA_VERSION),
+      );
+    } finally {
+      setItemSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -16,38 +16,204 @@ const DEFAULT_SETTINGS = {
   haptics: true,
 };
 
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 1;
+
+const SETTINGS_VERSION_KEY = 'settings-schema-version';
+
+const BOOLEAN_SETTINGS = [
+  { key: 'reduced-motion', defaultValue: DEFAULT_SETTINGS.reducedMotion },
+  { key: 'high-contrast', defaultValue: DEFAULT_SETTINGS.highContrast },
+  { key: 'large-hit-areas', defaultValue: DEFAULT_SETTINGS.largeHitAreas },
+  { key: 'pong-spin', defaultValue: DEFAULT_SETTINGS.pongSpin },
+  { key: 'allow-network', defaultValue: DEFAULT_SETTINGS.allowNetwork },
+  { key: 'haptics', defaultValue: DEFAULT_SETTINGS.haptics },
+];
+
+const VALID_DENSITIES = new Set(['regular', 'compact']);
+
+const IDB_SETTING_KEYS = ['accent', 'bg-image'];
+
+let migrationPromise = null;
+
+function readSchemaVersion() {
+  if (typeof window === 'undefined') return CURRENT_SETTINGS_SCHEMA_VERSION;
+  const raw = window.localStorage.getItem(SETTINGS_VERSION_KEY);
+  if (!raw) return 0;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function writeSchemaVersion(version) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(SETTINGS_VERSION_KEY, String(version));
+}
+
+async function captureSnapshot() {
+  if (typeof window === 'undefined') return null;
+
+  const localEntries = [];
+  for (let index = 0; index < window.localStorage.length; index += 1) {
+    const key = window.localStorage.key(index);
+    if (!key) continue;
+    localEntries.push([key, window.localStorage.getItem(key)]);
+  }
+
+  const idbValues = await Promise.all(
+    IDB_SETTING_KEYS.map(async (key) => [key, await get(key)]),
+  );
+
+  return { localEntries, idbValues };
+}
+
+async function restoreSnapshot(snapshot) {
+  if (!snapshot || typeof window === 'undefined') return;
+
+  window.localStorage.clear();
+  snapshot.localEntries.forEach(([key, value]) => {
+    if (typeof value === 'string') {
+      window.localStorage.setItem(key, value);
+    }
+  });
+
+  await Promise.all(
+    snapshot.idbValues.map(async ([key, value]) => {
+      if (value === undefined) {
+        await del(key);
+      } else {
+        await set(key, value);
+      }
+    }),
+  );
+}
+
+function normalizeBooleanSettings() {
+  BOOLEAN_SETTINGS.forEach(({ key, defaultValue }) => {
+    const raw = window.localStorage.getItem(key);
+    if (raw === null) return;
+    const normalized = raw.trim().toLowerCase();
+    if (normalized === 'true' || normalized === 'false') {
+      if (normalized !== raw) {
+        window.localStorage.setItem(key, normalized);
+      }
+      return;
+    }
+    if (raw === '1') {
+      window.localStorage.setItem(key, 'true');
+      return;
+    }
+    if (raw === '0') {
+      window.localStorage.setItem(key, 'false');
+      return;
+    }
+    window.localStorage.setItem(key, defaultValue ? 'true' : 'false');
+  });
+}
+
+function normalizeDensity() {
+  const density = window.localStorage.getItem('density');
+  if (density && !VALID_DENSITIES.has(density)) {
+    window.localStorage.setItem('density', DEFAULT_SETTINGS.density);
+  }
+}
+
+function normalizeFontScale() {
+  const stored = window.localStorage.getItem('font-scale');
+  if (stored === null) return;
+  const parsed = Number.parseFloat(stored);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    window.localStorage.setItem('font-scale', String(DEFAULT_SETTINGS.fontScale));
+  } else {
+    window.localStorage.setItem('font-scale', String(parsed));
+  }
+}
+
+async function migrateZeroToOne() {
+  if (typeof window === 'undefined') return;
+  normalizeBooleanSettings();
+  normalizeDensity();
+  normalizeFontScale();
+}
+
+const MIGRATIONS = new Map([
+  [0, { to: 1, migrate: migrateZeroToOne }],
+]);
+
+async function ensureMigrations() {
+  if (typeof window === 'undefined') return;
+
+  if (!migrationPromise) {
+    migrationPromise = (async () => {
+      const startingVersion = readSchemaVersion();
+      if (startingVersion >= CURRENT_SETTINGS_SCHEMA_VERSION) return;
+
+      const snapshot = await captureSnapshot();
+
+      try {
+        let version = startingVersion;
+        while (version < CURRENT_SETTINGS_SCHEMA_VERSION) {
+          const step = MIGRATIONS.get(version);
+          if (!step) {
+            throw new Error(`Missing migration for schema version ${version}`);
+          }
+          await step.migrate();
+          version = step.to;
+          writeSchemaVersion(version);
+        }
+      } catch (error) {
+        await restoreSnapshot(snapshot);
+        throw error;
+      }
+    })();
+  }
+
+  try {
+    await migrationPromise;
+  } catch (error) {
+    console.error('[settingsStore] Failed to migrate settings schema', error);
+  } finally {
+    migrationPromise = null;
+  }
+}
+
 export async function getAccent() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
+  await ensureMigrations();
   return (await get('accent')) || DEFAULT_SETTINGS.accent;
 }
 
 export async function setAccent(accent) {
   if (typeof window === 'undefined') return;
+  await ensureMigrations();
   await set('accent', accent);
 }
 
 export async function getWallpaper() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
+  await ensureMigrations();
   return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
 }
 
 export async function setWallpaper(wallpaper) {
   if (typeof window === 'undefined') return;
+  await ensureMigrations();
   await set('bg-image', wallpaper);
 }
 
 export async function getDensity() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
+  await ensureMigrations();
   return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
 }
 
 export async function setDensity(density) {
   if (typeof window === 'undefined') return;
+  await ensureMigrations();
   window.localStorage.setItem('density', density);
 }
 
 export async function getReducedMotion() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
+  await ensureMigrations();
   const stored = window.localStorage.getItem('reduced-motion');
   if (stored !== null) {
     return stored === 'true';
@@ -57,69 +223,82 @@ export async function getReducedMotion() {
 
 export async function setReducedMotion(value) {
   if (typeof window === 'undefined') return;
+  await ensureMigrations();
   window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
+  await ensureMigrations();
   const stored = window.localStorage.getItem('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
   if (typeof window === 'undefined') return;
+  await ensureMigrations();
   window.localStorage.setItem('font-scale', String(scale));
 }
 
 export async function getHighContrast() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
+  await ensureMigrations();
   return window.localStorage.getItem('high-contrast') === 'true';
 }
 
 export async function setHighContrast(value) {
   if (typeof window === 'undefined') return;
+  await ensureMigrations();
   window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
 }
 
 export async function getLargeHitAreas() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
+  await ensureMigrations();
   return window.localStorage.getItem('large-hit-areas') === 'true';
 }
 
 export async function setLargeHitAreas(value) {
   if (typeof window === 'undefined') return;
+  await ensureMigrations();
   window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
 export async function getHaptics() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
+  await ensureMigrations();
   const val = window.localStorage.getItem('haptics');
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
 export async function setHaptics(value) {
   if (typeof window === 'undefined') return;
+  await ensureMigrations();
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
+  await ensureMigrations();
   const val = window.localStorage.getItem('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
 export async function setPongSpin(value) {
   if (typeof window === 'undefined') return;
+  await ensureMigrations();
   window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
 }
 
 export async function getAllowNetwork() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
+  await ensureMigrations();
   return window.localStorage.getItem('allow-network') === 'true';
 }
 
 export async function setAllowNetwork(value) {
   if (typeof window === 'undefined') return;
+  await ensureMigrations();
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
@@ -137,9 +316,12 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem(SETTINGS_VERSION_KEY);
 }
 
 export async function exportSettings() {
+  await ensureMigrations();
+  const schemaVersion = readSchemaVersion();
   const [
     accent,
     wallpaper,
@@ -165,6 +347,7 @@ export async function exportSettings() {
   ]);
   const theme = getTheme();
   return JSON.stringify({
+    schemaVersion,
     accent,
     wallpaper,
     density,
@@ -188,7 +371,9 @@ export async function importSettings(json) {
     console.error('Invalid settings', e);
     return;
   }
+  await ensureMigrations();
   const {
+    schemaVersion: _schemaVersion,
     accent,
     wallpaper,
     density,


### PR DESCRIPTION
## Summary
- introduce a schema version tracker and migration runner in the settings store with rollback handling
- normalize legacy boolean, density, and font-scale values and embed the schema version in exports
- add targeted unit tests verifying migrations are idempotent and rollback after failures

## Testing
- yarn lint *(fails: repository has pre-existing accessibility/no-top-level-window errors)*
- yarn test --runTestsByPath __tests__/settingsStore.test.ts *(passes; Jest warns about open handles but tests complete)*

------
https://chatgpt.com/codex/tasks/task_e_68cca68ecdb88328aa64c2c84016fa4a