### PR TITLE
[settings] add rtl layout toggle

### DIFF
--- a/apps/chrome/components/AddressBar.tsx
+++ b/apps/chrome/components/AddressBar.tsx
@@ -77,6 +77,7 @@ export default function AddressBar({ url, onNavigate }: Props) {
         onClick={goBack}
         disabled={index <= 0}
         className="px-2 border rounded"
+        aria-label="Back"
       >
         ◀
       </button>
@@ -85,6 +86,7 @@ export default function AddressBar({ url, onNavigate }: Props) {
         onClick={goForward}
         disabled={index >= history.length - 1}
         className="px-2 border rounded"
+        aria-label="Forward"
       >
         ▶
       </button>

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -31,6 +31,8 @@ export default function Settings() {
     setHaptics,
     theme,
     setTheme,
+    direction,
+    setDirection,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -80,6 +82,8 @@ export default function Settings() {
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
+      if (parsed.direction !== undefined)
+        setDirection(parsed.direction === "rtl" ? "rtl" : "ltr");
     } catch (err) {
       console.error("Invalid settings", err);
     }
@@ -101,6 +105,7 @@ export default function Settings() {
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
     setTheme("default");
+    setDirection(defaults.direction as "ltr" | "rtl");
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
@@ -250,6 +255,14 @@ export default function Settings() {
               checked={highContrast}
               onChange={setHighContrast}
               ariaLabel="High Contrast"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Right-to-left layout:</span>
+            <ToggleSwitch
+              checked={direction === "rtl"}
+              onChange={(value) => setDirection(value ? "rtl" : "ltr")}
+              ariaLabel="Right-to-left layout"
             />
           </div>
           <div className="flex justify-center my-4 items-center">

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -20,10 +20,13 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getDirection as loadDirection,
+  setDirection as saveDirection,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
+type Direction = 'ltr' | 'rtl';
 
 // Predefined accent palette exposed to settings UI
 export const ACCENT_OPTIONS = [
@@ -63,6 +66,7 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  direction: Direction;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setDensity: (density: Density) => void;
@@ -74,6 +78,7 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setDirection: (value: Direction) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -88,6 +93,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  direction: defaults.direction as Direction,
   setAccent: () => {},
   setWallpaper: () => {},
   setDensity: () => {},
@@ -99,6 +105,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setDirection: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -113,6 +120,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [direction, setDirection] = useState<Direction>(
+    defaults.direction as Direction,
+  );
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -128,6 +138,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
       setTheme(loadTheme());
+      setDirection(await loadDirection());
     })();
   }, []);
 
@@ -236,6 +247,16 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveDirection(direction);
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('dir', direction);
+      if (document.body) {
+        document.body.setAttribute('dir', direction);
+      }
+    }
+  }, [direction]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -250,6 +271,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        direction,
         setAccent,
         setWallpaper,
         setDensity,
@@ -261,6 +283,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setDirection,
       }}
     >
       {children}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -8,6 +8,7 @@ import '../styles/globals.css';
 import '../styles/index.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';
+import '../styles/rtl.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';

--- a/styles/rtl.css
+++ b/styles/rtl.css
@@ -1,0 +1,198 @@
+html[dir='rtl'] {
+  direction: rtl;
+}
+
+html[dir='rtl'] body {
+  direction: rtl;
+}
+
+html[dir='rtl'] .text-left {
+  text-align: right;
+}
+
+html[dir='rtl'] .text-right {
+  text-align: left;
+}
+
+html[dir='rtl'] .ml-0 {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+html[dir='rtl'] .ml-1 {
+  margin-left: 0;
+  margin-right: 0.25rem;
+}
+
+html[dir='rtl'] .ml-2 {
+  margin-left: 0;
+  margin-right: 0.5rem;
+}
+
+html[dir='rtl'] .ml-3 {
+  margin-left: 0;
+  margin-right: 0.75rem;
+}
+
+html[dir='rtl'] .ml-4 {
+  margin-left: 0;
+  margin-right: 1rem;
+}
+
+html[dir='rtl'] .ml-5 {
+  margin-left: 0;
+  margin-right: 1.25rem;
+}
+
+html[dir='rtl'] .ml-6 {
+  margin-left: 0;
+  margin-right: 1.5rem;
+}
+
+html[dir='rtl'] .ml-auto {
+  margin-left: 0;
+  margin-right: auto;
+}
+
+html[dir='rtl'] .mr-0 {
+  margin-right: 0;
+  margin-left: 0;
+}
+
+html[dir='rtl'] .mr-1 {
+  margin-right: 0;
+  margin-left: 0.25rem;
+}
+
+html[dir='rtl'] .mr-2 {
+  margin-right: 0;
+  margin-left: 0.5rem;
+}
+
+html[dir='rtl'] .mr-4 {
+  margin-right: 0;
+  margin-left: 1rem;
+}
+
+html[dir='rtl'] .pl-0 {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+html[dir='rtl'] .pl-2 {
+  padding-left: 0;
+  padding-right: 0.5rem;
+}
+
+html[dir='rtl'] .pl-2\.5 {
+  padding-left: 0;
+  padding-right: 0.625rem;
+}
+
+html[dir='rtl'] .pl-3 {
+  padding-left: 0;
+  padding-right: 0.75rem;
+}
+
+html[dir='rtl'] .pl-4 {
+  padding-left: 0;
+  padding-right: 1rem;
+}
+
+html[dir='rtl'] .pl-5 {
+  padding-left: 0;
+  padding-right: 1.25rem;
+}
+
+html[dir='rtl'] .pl-6 {
+  padding-left: 0;
+  padding-right: 1.5rem;
+}
+
+html[dir='rtl'] .pl-10 {
+  padding-left: 0;
+  padding-right: 2.5rem;
+}
+
+html[dir='rtl'] .pr-1 {
+  padding-right: 0;
+  padding-left: 0.25rem;
+}
+
+html[dir='rtl'] .pr-2 {
+  padding-right: 0;
+  padding-left: 0.5rem;
+}
+
+html[dir='rtl'] .pr-3 {
+  padding-right: 0;
+  padding-left: 0.75rem;
+}
+
+html[dir='rtl'] .pr-4 {
+  padding-right: 0;
+  padding-left: 1rem;
+}
+
+html[dir='rtl'] [class*='space-x-'] > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 1;
+}
+
+html[dir='rtl'] .border-l {
+  border-left-width: 0;
+  border-right-width: 1px;
+}
+
+html[dir='rtl'] .border-l-2 {
+  border-left-width: 0;
+  border-right-width: 2px;
+}
+
+html[dir='rtl'] .border-l-4 {
+  border-left-width: 0;
+  border-right-width: 4px;
+}
+
+html[dir='rtl'] .border-r {
+  border-right-width: 0;
+  border-left-width: 1px;
+}
+
+html[dir='rtl'] .border-r-0 {
+  border-right-width: 0;
+  border-left-width: 0;
+}
+
+html[dir='rtl'] .rounded-l {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+html[dir='rtl'] .rtl\:flip-x {
+  transform: scaleX(-1);
+}
+
+html[dir='rtl'] [aria-label='Back'],
+html[dir='rtl'] [aria-label='Forward'] {
+  transform: scaleX(-1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+html[dir='rtl'] nav[aria-label='Dock'] {
+  left: auto;
+  right: 0;
+}
+
+html[dir='rtl'] nav[aria-label='Dock'] + div {
+  left: auto;
+  right: 0;
+}
+
+html[dir='rtl'] nav[aria-label='Dock'] .left-full {
+  left: auto;
+  right: 100%;
+}

--- a/tests/rtl.spec.ts
+++ b/tests/rtl.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('RTL layout toggle', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage?.setItem('direction', 'ltr');
+    });
+  });
+
+  test('applies and removes RTL layout settings', async ({ page }) => {
+    await page.goto('http://localhost:3000/apps/settings');
+
+    await page.getByRole('tab', { name: 'Accessibility' }).click();
+    const rtlSwitch = page.getByRole('switch', { name: 'Right-to-left layout' });
+
+    if ((await rtlSwitch.getAttribute('aria-checked')) !== 'true') {
+      await rtlSwitch.click();
+    }
+
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.getAttribute('dir')))
+      .toBe('rtl');
+    await expect(page.locator('body')).toHaveAttribute('dir', 'rtl');
+
+    const dock = page.locator('nav[aria-label="Dock"]');
+    await expect(dock).toHaveCSS('right', '0px');
+
+    await rtlSwitch.click();
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.getAttribute('dir')))
+      .toBe('ltr');
+  });
+});

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  direction: 'ltr',
 };
 
 export async function getAccent() {
@@ -102,6 +103,17 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getDirection() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.direction;
+  const value = window.localStorage.getItem('direction');
+  return value === 'rtl' ? 'rtl' : 'ltr';
+}
+
+export async function setDirection(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('direction', value);
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -137,6 +149,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('direction');
 }
 
 export async function exportSettings() {
@@ -151,6 +164,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    direction,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +176,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getDirection(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -176,6 +191,7 @@ export async function exportSettings() {
     allowNetwork,
     haptics,
     theme,
+    direction,
   });
 }
 
@@ -200,6 +216,7 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    direction,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -212,6 +229,7 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (direction !== undefined) await setDirection(direction);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add RTL direction state and persistence to the global settings provider
- surface a right-to-left layout toggle in the settings app and update UI labels
- provide RTL-aware utility styles and coverage via a Playwright regression test

## Testing
- yarn lint *(fails: existing accessibility warnings across repository)*
- yarn test *(fails: existing jsdom/localStorage limitations in legacy suites)*
- npx playwright test *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cca690462c8328bcece8f478a9a501