### PR TITLE
[core] add bug report modal and telemetry export

### DIFF
--- a/__tests__/bugReport.test.ts
+++ b/__tests__/bugReport.test.ts
@@ -1,0 +1,61 @@
+import { buildErrorContext, createBugReportPayload } from '../lib/bugReport';
+import { getTelemetryWindowMs, TelemetryEntry } from '../lib/telemetry';
+
+describe('createBugReportPayload', () => {
+  it('includes diagnostics and filters logs to the telemetry window', () => {
+    const telemetryWindowMs = getTelemetryWindowMs();
+    const now = Date.now();
+    const logs: TelemetryEntry[] = [
+      {
+        timestamp: now - telemetryWindowMs + 1000,
+        level: 'info',
+        message: 'recent message',
+      },
+      {
+        timestamp: now - telemetryWindowMs - 2000,
+        level: 'error',
+        message: 'stale message',
+      },
+    ];
+
+    const payload = createBugReportPayload({
+      description: 'Example bug',
+      route: '/apps/demo',
+      userAgent: 'JestAgent/1.0',
+      diagnostics: { language: 'en-US', platform: 'test' },
+      logs,
+      telemetryWindowMs,
+      now,
+    });
+
+    expect(payload.description).toBe('Example bug');
+    expect(payload.route).toBe('/apps/demo');
+    expect(payload.userAgent).toBe('JestAgent/1.0');
+    expect(payload.diagnostics).toMatchObject({ language: 'en-US', platform: 'test' });
+    expect(payload.telemetryWindowMs).toBe(telemetryWindowMs);
+    expect(payload.logs).toHaveLength(1);
+    expect(payload.logs[0].message).toBe('recent message');
+    expect(new Date(payload.createdAt).getTime()).toBe(now);
+  });
+});
+
+describe('buildErrorContext', () => {
+  it('serializes error information and notes', () => {
+    const error = new Error('boom');
+    const context = buildErrorContext({
+      error,
+      errorInfo: { componentStack: 'Component > Child' } as any,
+      source: 'test',
+      note: 'Opened from test',
+    });
+
+    expect(context?.source).toBe('test');
+    expect(context?.note).toBe('Opened from test');
+    expect(context?.error?.message).toBe('boom');
+    expect(context?.errorInfo?.componentStack).toContain('Component');
+  });
+
+  it('returns undefined when no data is provided', () => {
+    expect(buildErrorContext({})).toBeUndefined();
+  });
+});

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,12 +1,14 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import { useBugReport } from '../common/BugReportProvider';
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
+    const { open: openBugReport } = useBugReport();
 
     const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
 
@@ -256,6 +258,14 @@ export function Settings() {
                     className="px-4 py-2 rounded bg-ub-orange text-white"
                 >
                     Reset Desktop
+                </button>
+            </div>
+            <div className="flex justify-center my-4">
+                <button
+                    onClick={() => openBugReport({ source: 'settings' })}
+                    className="px-4 py-2 rounded bg-ubt-ubuntu text-white"
+                >
+                    Report a bug
                 </button>
             </div>
             <input

--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -11,6 +11,14 @@ interface ModalProps {
      * Defaults to the Next.js root (`__next`).
      */
     overlayRoot?: string | HTMLElement;
+    /**
+     * Optional id of the element labeling the dialog.
+     */
+    ariaLabelledby?: string;
+    /**
+     * Optional id of the element describing the dialog.
+     */
+    ariaDescribedby?: string;
 }
 
 const FOCUSABLE_SELECTORS = [
@@ -27,7 +35,7 @@ const FOCUSABLE_SELECTORS = [
     '[contenteditable]'
 ].join(',');
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot }) => {
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot, ariaLabelledby, ariaDescribedby }) => {
     const modalRef = useRef<HTMLDivElement>(null);
     const triggerRef = useRef<HTMLElement | null>(null);
     const portalRef = useRef<HTMLDivElement | null>(null);
@@ -113,6 +121,8 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
         <div
             role="dialog"
             aria-modal="true"
+            aria-labelledby={ariaLabelledby}
+            aria-describedby={ariaDescribedby}
             ref={modalRef}
             onKeyDown={handleKeyDown}
             tabIndex={-1}

--- a/components/common/BugReportProvider.tsx
+++ b/components/common/BugReportProvider.tsx
@@ -1,0 +1,333 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import type { ErrorInfo } from 'react';
+import Modal from '../base/Modal';
+import {
+  buildErrorContext,
+  collectDiagnostics,
+  createBugReportPayload,
+  DiagnosticsSnapshot,
+  SerializedErrorContext,
+} from '../../lib/bugReport';
+import {
+  exportTelemetryJson,
+  getTelemetryEntries,
+  getTelemetryWindowMs,
+  TelemetryEntry,
+} from '../../lib/telemetry';
+
+interface BugReportContextValue {
+  open: (options?: BugReportOpenOptions) => void;
+}
+
+export const BugReportContext = createContext<BugReportContextValue | null>(null);
+
+export function useBugReport() {
+  const ctx = useContext(BugReportContext);
+  if (!ctx) {
+    throw new Error('useBugReport must be used within a BugReportProvider');
+  }
+  return ctx;
+}
+
+interface BugReportProviderProps {
+  children: React.ReactNode;
+}
+
+interface BugReportOpenOptions {
+  description?: string;
+  source?: string;
+  error?: unknown;
+  errorInfo?: ErrorInfo | null;
+  note?: string;
+}
+
+interface ModalState {
+  isOpen: boolean;
+  description: string;
+  context?: SerializedErrorContext;
+  route: string;
+  userAgent: string;
+  diagnostics: DiagnosticsSnapshot;
+  logs: TelemetryEntry[];
+  telemetryWindowMs: number;
+  status: 'idle' | 'pending' | 'success' | 'error';
+  feedback?: string;
+}
+
+const INITIAL_STATE: ModalState = {
+  isOpen: false,
+  description: '',
+  route: '',
+  userAgent: '',
+  diagnostics: {},
+  logs: [],
+  telemetryWindowMs: getTelemetryWindowMs(),
+  status: 'idle',
+};
+
+const formatLogEntry = (entry: TelemetryEntry) => {
+  const { timestamp, ...rest } = entry;
+  return JSON.stringify(
+    {
+      timestamp: new Date(timestamp).toISOString(),
+      ...rest,
+    },
+    null,
+    2,
+  );
+};
+
+const BugReportProvider: React.FC<BugReportProviderProps> = ({ children }) => {
+  const router = useRouter();
+  const [state, setState] = useState<ModalState>(INITIAL_STATE);
+
+  const close = useCallback(() => {
+    setState((prev) => ({ ...prev, isOpen: false, status: 'idle', feedback: undefined }));
+  }, []);
+
+  const open = useCallback(
+    (options?: BugReportOpenOptions) => {
+      if (typeof window === 'undefined') return;
+      const diagnostics = collectDiagnostics();
+      const logs = getTelemetryEntries();
+      const userAgent = window.navigator?.userAgent || 'unknown';
+      const context = buildErrorContext({
+        error: options?.error,
+        errorInfo: options?.errorInfo ?? null,
+        source: options?.source,
+        note: options?.note,
+      });
+      setState({
+        isOpen: true,
+        description: options?.description ?? '',
+        context,
+        route: router.asPath ?? '',
+        userAgent,
+        diagnostics,
+        logs,
+        telemetryWindowMs: getTelemetryWindowMs(),
+        status: 'idle',
+        feedback: undefined,
+      });
+    },
+    [router.asPath],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    setState((prev) => ({ ...prev, status: 'pending', feedback: undefined }));
+    try {
+      const logsSnapshot = getTelemetryEntries(state.telemetryWindowMs);
+      const payload = createBugReportPayload({
+        description: state.description,
+        route: state.route,
+        userAgent: state.userAgent,
+        diagnostics: state.diagnostics,
+        logs: logsSnapshot,
+        telemetryWindowMs: state.telemetryWindowMs,
+        context: state.context,
+      });
+      const serialized = JSON.stringify(payload, null, 2);
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(serialized);
+        setState((prev) => ({
+          ...prev,
+          logs: logsSnapshot,
+          status: 'success',
+          feedback: 'Bug report copied to clipboard.',
+        }));
+      } else {
+        const blob = new Blob([serialized], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `bug-report-${Date.now()}.json`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        setState((prev) => ({
+          ...prev,
+          logs: logsSnapshot,
+          status: 'success',
+          feedback: 'Bug report downloaded.',
+        }));
+      }
+    } catch (err) {
+      console.error('Failed to prepare bug report payload', err);
+      setState((prev) => ({ ...prev, status: 'error', feedback: 'Could not prepare bug report. Please try again.' }));
+    }
+  }, [state.description, state.route, state.userAgent, state.diagnostics, state.telemetryWindowMs, state.context]);
+
+  const downloadTelemetry = useCallback(() => {
+    try {
+      const json = exportTelemetryJson(state.telemetryWindowMs);
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `telemetry-${Date.now()}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      setState((prev) => ({ ...prev, feedback: 'Telemetry downloaded.' }));
+    } catch (err) {
+      console.error('Failed to export telemetry', err);
+      setState((prev) => ({ ...prev, feedback: 'Unable to export telemetry.' }));
+    }
+  }, [state.telemetryWindowMs]);
+
+  const contextValue = useMemo(() => ({ open }), [open]);
+
+  return (
+    <BugReportContext.Provider value={contextValue}>
+      {children}
+      <Modal isOpen={state.isOpen} onClose={close} ariaLabelledby="bug-report-title">
+        {state.isOpen && (
+          <div className="fixed inset-0 z-[200] flex items-center justify-center px-4">
+            <div className="absolute inset-0 bg-black/70" aria-hidden="true" onClick={close} />
+            <div className="relative z-10 max-h-[90vh] w-full max-w-3xl overflow-y-auto rounded-lg bg-ub-cool-grey p-6 text-white shadow-2xl">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h2 id="bug-report-title" className="text-2xl font-semibold">
+                    Report a bug
+                  </h2>
+                  <p className="mt-1 text-sm text-ubt-grey">
+                    Share what happened and we will bundle recent telemetry, your route, and environment diagnostics.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={close}
+                  className="rounded bg-black/40 px-2 py-1 text-sm text-white transition hover:bg-black/60"
+                >
+                  Close
+                </button>
+              </div>
+              <div className="mt-4 flex flex-col gap-4">
+                <label className="flex flex-col gap-2">
+                  <span className="text-sm font-medium">What happened?</span>
+                  <textarea
+                    value={state.description}
+                    onChange={(event) =>
+                      setState((prev) => ({ ...prev, description: event.target.value, feedback: undefined }))
+                    }
+                    rows={4}
+                    className="min-h-[120px] w-full rounded-md border border-black/30 bg-black/30 p-3 text-sm text-white focus:border-ubt-ubuntu focus:outline-none"
+                    placeholder="Describe the issue, steps to reproduce, and expected behavior."
+                  />
+                </label>
+
+                {state.context?.error && (
+                  <div className="rounded-md border border-red-500/40 bg-red-500/10 p-3">
+                    <p className="text-sm font-semibold text-red-200">Captured error</p>
+                    <pre className="mt-2 max-h-32 overflow-y-auto whitespace-pre-wrap text-xs text-red-100">
+                      {state.context.error.stack || state.context.error.message}
+                    </pre>
+                  </div>
+                )}
+
+                {state.context?.errorInfo?.componentStack && (
+                  <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3">
+                    <p className="text-sm font-semibold text-yellow-200">Component stack</p>
+                    <pre className="mt-2 max-h-32 overflow-y-auto whitespace-pre-wrap text-xs text-yellow-100">
+                      {state.context.errorInfo.componentStack}
+                    </pre>
+                  </div>
+                )}
+
+                {state.context?.note && (
+                  <div className="rounded-md border border-blue-500/30 bg-blue-500/10 p-3">
+                    <p className="text-sm font-semibold text-blue-200">Context</p>
+                    {state.context?.source && (
+                      <p className="text-xs uppercase tracking-wide text-blue-200/80">
+                        Source: {state.context.source}
+                      </p>
+                    )}
+                    <p className="mt-1 text-sm text-blue-100">{state.context.note}</p>
+                  </div>
+                )}
+
+                <section aria-labelledby="bug-report-route">
+                  <h3 id="bug-report-route" className="text-lg font-semibold">
+                    Route &amp; environment
+                  </h3>
+                  <dl className="mt-2 grid grid-cols-1 gap-2 text-sm text-ubt-grey sm:grid-cols-2">
+                    <div>
+                      <dt className="font-medium text-white">Route</dt>
+                      <dd className="break-all">{state.route || 'Unknown'}</dd>
+                    </div>
+                    <div>
+                      <dt className="font-medium text-white">User agent</dt>
+                      <dd className="break-words">{state.userAgent || 'Unavailable'}</dd>
+                    </div>
+                    {Object.entries(state.diagnostics)
+                      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+                      .map(([key, value]) => (
+                        <div key={key} className="sm:col-span-1">
+                          <dt className="font-medium capitalize text-white">{key.replace(/([A-Z])/g, ' $1').trim()}</dt>
+                          <dd className="break-words">
+                            {typeof value === 'object' ? JSON.stringify(value) : String(value)}
+                          </dd>
+                        </div>
+                      ))}
+                  </dl>
+                </section>
+
+                <section aria-labelledby="bug-report-logs">
+                  <div className="flex items-center justify-between">
+                    <h3 id="bug-report-logs" className="text-lg font-semibold">
+                      Recent logs
+                    </h3>
+                    <span className="text-xs text-ubt-grey">
+                      Last {Math.round(state.telemetryWindowMs / 1000)} seconds
+                    </span>
+                  </div>
+                  <div className="mt-2 max-h-48 overflow-y-auto rounded-md border border-black/40 bg-black/40 p-3">
+                    {state.logs.length === 0 ? (
+                      <p className="text-sm text-ubt-grey">No telemetry captured in this window.</p>
+                    ) : (
+                      <ul className="flex flex-col gap-2 text-xs text-ubt-grey">
+                        {state.logs.map((entry, index) => (
+                          <li key={index}>
+                            <pre className="whitespace-pre-wrap break-words text-ubt-grey">
+                              {formatLogEntry(entry)}
+                            </pre>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                </section>
+
+                <div className="flex flex-wrap items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={handleSubmit}
+                    disabled={state.status === 'pending'}
+                    className="rounded bg-ubt-ubuntu px-4 py-2 text-sm font-semibold text-white transition hover:bg-ubt-ubuntu/80 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {state.status === 'pending' ? 'Preparing…' : 'Copy payload'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={downloadTelemetry}
+                    className="rounded border border-ubt-ubuntu px-4 py-2 text-sm font-semibold text-ubt-ubuntu transition hover:bg-ubt-ubuntu/20"
+                  >
+                    Download telemetry JSON
+                  </button>
+                  {state.feedback && (
+                    <span className="text-sm text-ubt-grey">{state.feedback}</span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </Modal>
+    </BugReportContext.Provider>
+  );
+};
+
+export default BugReportProvider;

--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -1,5 +1,7 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
+import type { ContextType } from 'react';
 import { createLogger } from '../../lib/logger';
+import { BugReportContext } from '../common/BugReportProvider';
 
 interface Props {
   children: ReactNode;
@@ -12,6 +14,11 @@ interface State {
 const log = createLogger();
 
 class ErrorBoundary extends Component<Props, State> {
+  static contextType = BugReportContext;
+  declare context: ContextType<typeof BugReportContext>;
+  private lastError: unknown;
+  private lastErrorInfo: ErrorInfo | null = null;
+
   constructor(props: Props) {
     super(props);
     this.state = { hasError: false };
@@ -22,15 +29,37 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
+    this.lastError = error;
+    this.lastErrorInfo = errorInfo;
     log.error('ErrorBoundary caught an error', { error, errorInfo });
   }
+
+  private handleReport = () => {
+    if (!this.context) return;
+    const { open } = this.context;
+    if (typeof open === 'function') {
+      open({
+        source: 'error-boundary',
+        error: this.lastError,
+        errorInfo: this.lastErrorInfo,
+        note: 'Triggered from global error boundary',
+      });
+    }
+  };
 
   render() {
     if (this.state.hasError) {
       return (
-        <div role="alert" className="p-4 text-center">
+        <div role="alert" className="p-6 text-center">
           <h1 className="text-xl font-bold">Something went wrong.</h1>
-          <p>Please refresh the page or try again.</p>
+          <p className="mt-2">Please refresh the page or try again.</p>
+          <button
+            type="button"
+            onClick={this.handleReport}
+            className="mt-4 rounded bg-ubt-ubuntu px-4 py-2 text-sm font-semibold text-white transition hover:bg-ubt-ubuntu/80"
+          >
+            Report this issue
+          </button>
         </div>
       );
     }

--- a/lib/bugReport.ts
+++ b/lib/bugReport.ts
@@ -1,0 +1,170 @@
+import type { ErrorInfo } from 'react';
+import { TelemetryEntry, getTelemetryWindowMs } from './telemetry';
+
+export interface DiagnosticsSnapshot {
+  language?: string;
+  languages?: string[];
+  platform?: string;
+  userAgent?: string;
+  timezone?: string;
+  online?: boolean;
+  hardwareConcurrency?: number;
+  deviceMemory?: number;
+  viewport?: { width: number; height: number };
+  screen?: { width: number; height: number; colorDepth?: number };
+  colorScheme?: 'light' | 'dark' | 'no-preference';
+  reducedMotion?: boolean;
+  cookiesEnabled?: boolean;
+}
+
+export interface SerializedError {
+  name?: string;
+  message?: string;
+  stack?: string;
+}
+
+export interface SerializedErrorContext {
+  error?: SerializedError;
+  errorInfo?: { componentStack?: string };
+  source?: string;
+  note?: string;
+}
+
+export interface BugReportDraft {
+  description: string;
+  route: string;
+  userAgent: string;
+  diagnostics: DiagnosticsSnapshot;
+  logs: TelemetryEntry[];
+  telemetryWindowMs?: number;
+  context?: SerializedErrorContext;
+  now?: number;
+}
+
+export interface BugReportPayload {
+  createdAt: string;
+  description: string;
+  route: string;
+  userAgent: string;
+  diagnostics: DiagnosticsSnapshot;
+  telemetryWindowMs: number;
+  logs: TelemetryEntry[];
+  context?: SerializedErrorContext;
+}
+
+export function collectDiagnostics(): DiagnosticsSnapshot {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+  const nav = window.navigator;
+  const matchMedia = typeof window.matchMedia === 'function' ? window.matchMedia.bind(window) : null;
+  const matchColorScheme = matchMedia ? matchMedia('(prefers-color-scheme: dark)') : null;
+  const matchLightScheme = matchMedia ? matchMedia('(prefers-color-scheme: light)') : null;
+  const matchReducedMotion = matchMedia ? matchMedia('(prefers-reduced-motion: reduce)') : null;
+
+  let timezone: string | undefined;
+  try {
+    timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    timezone = undefined;
+  }
+
+  let colorScheme: DiagnosticsSnapshot['colorScheme'];
+  if (matchColorScheme?.matches) {
+    colorScheme = 'dark';
+  } else if (matchLightScheme?.matches) {
+    colorScheme = 'light';
+  } else {
+    colorScheme = 'no-preference';
+  }
+
+  return {
+    language: nav?.language,
+    languages: nav?.languages,
+    platform: nav?.platform,
+    userAgent: nav?.userAgent,
+    timezone,
+    online: nav?.onLine,
+    hardwareConcurrency: nav?.hardwareConcurrency,
+    deviceMemory: (nav as any)?.deviceMemory,
+    viewport: typeof window.innerWidth === 'number' && typeof window.innerHeight === 'number'
+      ? { width: window.innerWidth, height: window.innerHeight }
+      : undefined,
+    screen: typeof window.screen === 'object'
+      ? {
+          width: window.screen.width,
+          height: window.screen.height,
+          colorDepth: window.screen.colorDepth,
+        }
+      : undefined,
+    colorScheme,
+    reducedMotion: Boolean(matchReducedMotion?.matches),
+    cookiesEnabled: nav ? nav.cookieEnabled : undefined,
+  };
+}
+
+export function serializeError(error: unknown): SerializedError | undefined {
+  if (!error) return undefined;
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+  if (typeof error === 'string') {
+    return { message: error };
+  }
+  if (typeof error === 'object') {
+    try {
+      return {
+        message: JSON.stringify(error),
+      };
+    } catch {
+      return { message: '[unserializable error object]' };
+    }
+  }
+  return { message: String(error) };
+}
+
+export function serializeErrorInfo(errorInfo?: ErrorInfo | null): SerializedErrorContext['errorInfo'] {
+  if (!errorInfo) return undefined;
+  const { componentStack } = errorInfo;
+  return componentStack ? { componentStack } : {};
+}
+
+export function createBugReportPayload(draft: BugReportDraft): BugReportPayload {
+  const telemetryWindowMs = draft.telemetryWindowMs ?? getTelemetryWindowMs();
+  const now = draft.now ?? Date.now();
+  const cutoff = now - telemetryWindowMs;
+  const logs = (draft.logs || []).filter((entry) => entry.timestamp >= cutoff);
+  return {
+    createdAt: new Date(now).toISOString(),
+    description: draft.description,
+    route: draft.route,
+    userAgent: draft.userAgent,
+    diagnostics: draft.diagnostics,
+    telemetryWindowMs,
+    logs,
+    context: draft.context,
+  };
+}
+
+export function buildErrorContext(options: {
+  error?: unknown;
+  errorInfo?: ErrorInfo | null;
+  source?: string;
+  note?: string;
+}): SerializedErrorContext | undefined {
+  const serializedError = serializeError(options.error);
+  const serializedInfo = serializeErrorInfo(options.errorInfo);
+  if (!serializedError && !serializedInfo && !options.source && !options.note) {
+    return undefined;
+  }
+  return {
+    error: serializedError,
+    errorInfo: serializedInfo,
+    source: options.source,
+    note: options.note,
+  };
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,3 +1,5 @@
+import { recordTelemetry } from './telemetry';
+
 const SENSITIVE_KEYS = new Set(['password', 'secret', 'token', 'key']);
 
 export interface Logger {
@@ -24,6 +26,19 @@ class ConsoleLogger implements Logger {
       ...safeMeta,
     };
     console.log(JSON.stringify(entry));
+    try {
+      recordTelemetry({
+        timestamp: Date.now(),
+        level,
+        message,
+        meta: {
+          correlationId: this.correlationId,
+          ...safeMeta,
+        },
+      });
+    } catch {
+      // ignore telemetry failures
+    }
   }
 
   info(message: string, meta?: Record<string, any>) {

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -1,0 +1,85 @@
+export type TelemetryLevel = 'info' | 'warn' | 'error' | 'debug' | string;
+
+export interface TelemetryEntry {
+  timestamp: number;
+  level: TelemetryLevel;
+  message: string;
+  meta?: Record<string, any>;
+}
+
+const TELEMETRY_WINDOW_MS = 60_000;
+const GLOBAL_KEY = '__KALI_TELEMETRY_BUFFER__';
+
+interface TelemetryState {
+  entries: TelemetryEntry[];
+}
+
+function getGlobalRoot(): any | null {
+  if (typeof window !== 'undefined') {
+    return window as any;
+  }
+  return null;
+}
+
+function getState(): TelemetryState | null {
+  const root = getGlobalRoot();
+  if (!root) return null;
+  if (!root[GLOBAL_KEY]) {
+    root[GLOBAL_KEY] = { entries: [] } as TelemetryState;
+  }
+  return root[GLOBAL_KEY] as TelemetryState;
+}
+
+function prune(state: TelemetryState, now: number) {
+  state.entries = state.entries.filter((entry) => now - entry.timestamp <= TELEMETRY_WINDOW_MS);
+}
+
+export function recordTelemetry(entry: TelemetryEntry) {
+  const state = getState();
+  if (!state) return;
+  prune(state, entry.timestamp);
+  state.entries.push(entry);
+}
+
+export function getTelemetryEntries(windowMs: number = TELEMETRY_WINDOW_MS): TelemetryEntry[] {
+  const state = getState();
+  if (!state) return [];
+  const now = Date.now();
+  prune(state, now);
+  const threshold = now - windowMs;
+  return state.entries
+    .filter((entry) => entry.timestamp >= threshold)
+    .map((entry) => ({ ...entry }));
+}
+
+export interface TelemetryExport {
+  generatedAt: string;
+  windowMs: number;
+  entries: TelemetryEntry[];
+}
+
+export function exportTelemetry(windowMs: number = TELEMETRY_WINDOW_MS): TelemetryExport {
+  const now = Date.now();
+  const entries = getTelemetryEntries(windowMs);
+  return {
+    generatedAt: new Date(now).toISOString(),
+    windowMs,
+    entries,
+  };
+}
+
+export function exportTelemetryJson(windowMs: number = TELEMETRY_WINDOW_MS): string {
+  const payload = exportTelemetry(windowMs);
+  return JSON.stringify(payload, null, 2);
+}
+
+export function getTelemetryWindowMs() {
+  return TELEMETRY_WINDOW_MS;
+}
+
+export function __dangerousResetTelemetry() {
+  const state = getState();
+  if (state) {
+    state.entries = [];
+  }
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,6 +14,7 @@ import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
+import BugReportProvider from '../components/common/BugReportProvider';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
@@ -147,34 +148,36 @@ function MyApp(props) {
   }, []);
 
   return (
-    <ErrorBoundary>
-      <Script src="/a2hs.js" strategy="beforeInteractive" />
-      <div className={ubuntu.className}>
-        <a
-          href="#app-grid"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
-        >
-          Skip to app grid
-        </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+    <BugReportProvider>
+      <ErrorBoundary>
+        <Script src="/a2hs.js" strategy="beforeInteractive" />
+        <div className={ubuntu.className}>
+          <a
+            href="#app-grid"
+            className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+          >
+            Skip to app grid
+          </a>
+          <SettingsProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
-      </div>
-    </ErrorBoundary>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </SettingsProvider>
+        </div>
+      </ErrorBoundary>
+    </BugReportProvider>
 
 
   );


### PR DESCRIPTION
## Summary
- add a reusable bug report provider with telemetry capture, diagnostics, and JSON export UI
- wrap the app shell in the provider and expose triggers via the global error boundary and Settings app
- instrument the logger with a client-side telemetry buffer and add unit tests for the bug-report payload helpers

## Testing
- yarn lint *(fails: repo has pre-existing accessibility and no-top-level-window rule violations in many legacy files)*
- yarn test --watch=false __tests__/bugReport.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cca693f3c48328b47b25cbcfd0de58