### PR TITLE
[error-boundaries] Telemetry-aware fallbacks and bug report metadata

### DIFF
--- a/__tests__/ErrorBoundary.test.tsx
+++ b/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ErrorBoundary from '../components/core/ErrorBoundary';
+
+jest.mock('../lib/client-error-reporter', () => ({
+  reportClientError: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('ErrorBoundary', () => {
+  it('renders fallback with copyable error id and bug report link', async () => {
+    const Problem: React.FC = () => {
+      throw new Error('explode');
+    };
+
+    render(
+      <ErrorBoundary>
+        <Problem />
+      </ErrorBoundary>
+    );
+
+    const bugLink = await screen.findByRole('link', { name: /Report bug/i });
+    expect(bugLink.getAttribute('href')).toContain('errorId=');
+    expect(screen.getByRole('button', { name: /Copy error ID/i })).toBeInTheDocument();
+  });
+});
+

--- a/__tests__/bugReport.test.ts
+++ b/__tests__/bugReport.test.ts
@@ -1,0 +1,27 @@
+import { buildBugReportURL } from '../utils/bugReport';
+
+describe('buildBugReportURL', () => {
+  it('encodes metadata and error id for bug reports', () => {
+    const href = buildBugReportURL({
+      errorId: 'ERR-1234',
+      appId: 'terminal',
+      appTitle: 'Terminal',
+      context: 'app:terminal',
+      currentUrl: 'https://example.com/apps/terminal',
+    });
+
+    expect(href.startsWith('/input-hub?')).toBe(true);
+    const params = new URLSearchParams(href.replace('/input-hub?', ''));
+    expect(params.get('preset')).toBe('bug-report');
+    expect(params.get('errorId')).toBe('ERR-1234');
+    expect(params.get('appId')).toBe('terminal');
+    expect(params.get('appTitle')).toBe('Terminal');
+    expect(params.get('context')).toBe('app:terminal');
+    expect(params.get('url')).toBe('https://example.com/apps/terminal');
+    expect(params.get('title')).toBe('Terminal bug report');
+    const text = params.get('text') || '';
+    expect(text).toContain('App: Terminal');
+    expect(text).toContain('Context: app:terminal');
+  });
+});
+

--- a/__tests__/inputHub.bug-report.test.tsx
+++ b/__tests__/inputHub.bug-report.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import InputHub from '../pages/input-hub';
+
+jest.mock('@emailjs/browser', () => ({
+  init: jest.fn(),
+  send: jest.fn(),
+}));
+
+const replace = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: {
+      preset: 'bug-report',
+      errorId: 'ERR-987',
+      appId: 'terminal',
+      appTitle: 'Terminal',
+      context: 'app:terminal',
+      url: 'https://example.com/apps/terminal',
+    },
+    replace,
+  }),
+}));
+
+describe('InputHub bug report prefill', () => {
+  it('prefills bug report fields with the error metadata', async () => {
+    render(<InputHub />);
+
+    await waitFor(() =>
+      expect(
+        (screen.getByRole('combobox') as HTMLSelectElement).value
+      ).toBe('Bug Report')
+    );
+
+    const messageField = screen.getByPlaceholderText('Message') as HTMLTextAreaElement;
+
+    await waitFor(() =>
+      expect(messageField.value).toContain('Error ID: ERR-987')
+    );
+    expect(messageField.value).toContain('App ID: terminal');
+    expect(messageField.value).toContain('App: Terminal');
+    expect(messageField.value).toContain('Context: app:terminal');
+    expect(messageField.value).toContain('URL: https://example.com/apps/terminal');
+  });
+});
+

--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -1,15 +1,169 @@
-import { Component, ErrorInfo, ReactNode } from 'react';
+import {
+  Component,
+  ErrorInfo,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import { createLogger } from '../../lib/logger';
+import { reportClientError } from '../../lib/client-error-reporter';
+import { buildBugReportURL } from '../../utils/bugReport';
+
+interface FallbackRenderProps {
+  errorId: string;
+  reset: () => void;
+  error?: unknown;
+  context?: string;
+}
 
 interface Props {
   children: ReactNode;
+  fallback?: (props: FallbackRenderProps) => ReactNode;
+  onReset?: () => void;
+  context?: string;
 }
 
 interface State {
   hasError: boolean;
+  errorId?: string;
+  error?: unknown;
+  errorInfo?: ErrorInfo;
 }
 
-const log = createLogger();
+interface ErrorIdDisplayProps {
+  errorId: string;
+  className?: string;
+  buttonClassName?: string;
+  codeClassName?: string;
+}
+
+interface DefaultFallbackProps {
+  errorId: string;
+  onTryAgain: () => void;
+  bugReportHref: string;
+  context?: string;
+}
+
+function copyText(text: string): Promise<boolean> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    return navigator.clipboard
+      .writeText(text)
+      .then(() => true)
+      .catch(() => false);
+  }
+
+  if (typeof document !== 'undefined') {
+    try {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'absolute';
+      textarea.style.left = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.select();
+      const result = document.execCommand('copy');
+      document.body.removeChild(textarea);
+      return Promise.resolve(result);
+    } catch {
+      return Promise.resolve(false);
+    }
+  }
+
+  return Promise.resolve(false);
+}
+
+const DefaultFallback: React.FC<DefaultFallbackProps> = ({
+  errorId,
+  onTryAgain,
+  bugReportHref,
+  context,
+}) => {
+  const handleReload = useCallback(() => {
+    if (typeof window !== 'undefined' && typeof window.location?.reload === 'function') {
+      window.location.reload();
+    }
+  }, []);
+
+  return (
+    <div className="flex min-h-screen w-full flex-col items-center justify-center gap-4 bg-ub-cool-grey p-6 text-center text-white">
+      <h1 className="text-2xl font-bold">Something went wrong.</h1>
+      <p className="max-w-lg text-sm opacity-90">
+        We logged the crash to our telemetry. You can try the action again or send the error ID below when
+        reporting the issue.
+      </p>
+      <ErrorIdDisplay errorId={errorId} />
+      {context && (
+        <p className="text-xs uppercase tracking-wide text-white/70">Context: {context}</p>
+      )}
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <button
+          type="button"
+          onClick={onTryAgain}
+          className="rounded bg-white px-4 py-2 text-sm font-medium text-black transition hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-white/60"
+        >
+          Try again
+        </button>
+        <button
+          type="button"
+          onClick={handleReload}
+          className="rounded border border-white/60 px-4 py-2 text-sm font-medium transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/60"
+        >
+          Reload page
+        </button>
+        <a
+          href={bugReportHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded border border-white/60 px-4 py-2 text-sm font-medium transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/60"
+        >
+          Report bug
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export const ErrorIdDisplay: React.FC<ErrorIdDisplayProps> = ({
+  errorId,
+  className,
+  buttonClassName,
+  codeClassName,
+}) => {
+  const [status, setStatus] = useState<'idle' | 'copied' | 'failed'>('idle');
+
+  useEffect(() => {
+    if (status === 'idle') return;
+    const timeout = setTimeout(() => setStatus('idle'), 2000);
+    return () => clearTimeout(timeout);
+  }, [status]);
+
+  const handleCopy = useCallback(async () => {
+    const ok = await copyText(errorId);
+    setStatus(ok ? 'copied' : 'failed');
+  }, [errorId]);
+
+  return (
+    <div className={className ?? 'flex flex-col items-center gap-2'}>
+      <code className={codeClassName ?? 'rounded bg-black/40 px-2 py-1 font-mono text-sm'}>{errorId}</code>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className={
+            buttonClassName ??
+            'rounded bg-white px-3 py-1 text-sm font-medium text-black transition hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-white/60'
+          }
+        >
+          Copy error ID
+        </button>
+        <span aria-live="polite" className="text-xs">
+          {status === 'copied' ? 'Copied!' : status === 'failed' ? 'Copy failed' : ''}
+        </span>
+      </div>
+    </div>
+  );
+};
 
 class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
@@ -17,21 +171,122 @@ class ErrorBoundary extends Component<Props, State> {
     this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(): State {
-    return { hasError: true };
+  private static generateErrorId(): string {
+    if (typeof globalThis === 'object') {
+      const cryptoObj = (globalThis as any).crypto;
+      if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+        return cryptoObj.randomUUID();
+      }
+    }
+
+    try {
+      const { randomUUID } = require('crypto');
+      if (typeof randomUUID === 'function') {
+        return randomUUID();
+      }
+    } catch {
+      // ignore
+    }
+
+    return `err-${Math.random().toString(36).slice(2, 10)}`;
   }
 
+  private static normalizeError(error: unknown): Error {
+    if (error instanceof Error) {
+      return error;
+    }
+
+    if (typeof error === 'string') {
+      return new Error(error);
+    }
+
+    try {
+      return new Error(JSON.stringify(error));
+    } catch {
+      return new Error('Unknown error');
+    }
+  }
+
+  private static serializeError(error: unknown) {
+    if (error instanceof Error) {
+      return {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+      };
+    }
+
+    if (typeof error === 'string') {
+      return { message: error };
+    }
+
+    try {
+      return { message: JSON.stringify(error) };
+    } catch {
+      return { message: 'Non-serializable error' };
+    }
+  }
+
+  private resetErrorBoundary = () => {
+    this.setState({ hasError: false, error: undefined, errorId: undefined, errorInfo: undefined }, () => {
+      if (typeof this.props.onReset === 'function') {
+        this.props.onReset();
+      }
+    });
+  };
+
   componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
-    log.error('ErrorBoundary caught an error', { error, errorInfo });
+    const errorId =
+      this.state.hasError && this.state.errorId
+        ? this.state.errorId
+        : ErrorBoundary.generateErrorId();
+
+    this.setState({ hasError: true, error, errorInfo, errorId });
+
+    const logger = createLogger(errorId);
+    logger.error('ErrorBoundary caught an error', {
+      error: ErrorBoundary.serializeError(error),
+      componentStack: errorInfo?.componentStack,
+      context: this.props.context,
+    });
+
+    const normalized = ErrorBoundary.normalizeError(error);
+    const telemetryError = new Error(`${normalized.message} (errorId: ${errorId})`);
+    telemetryError.name = normalized.name;
+    telemetryError.stack = normalized.stack;
+    void reportClientError(telemetryError, errorInfo?.componentStack);
   }
 
   render() {
     if (this.state.hasError) {
+      const errorId = this.state.errorId ?? 'unavailable';
+      const context = this.props.context;
+
+      if (this.props.fallback) {
+        return this.props.fallback({
+          errorId,
+          reset: this.resetErrorBoundary,
+          error: this.state.error,
+          context,
+        });
+      }
+
+      const bugReportHref = buildBugReportURL({
+        errorId,
+        context,
+        currentUrl:
+          typeof window !== 'undefined' && typeof window.location?.href === 'string'
+            ? window.location.href
+            : undefined,
+      });
+
       return (
-        <div role="alert" className="p-4 text-center">
-          <h1 className="text-xl font-bold">Something went wrong.</h1>
-          <p>Please refresh the page or try again.</p>
-        </div>
+        <DefaultFallback
+          errorId={errorId}
+          onTryAgain={this.resetErrorBoundary}
+          bugReportHref={bugReportHref}
+          context={context}
+        />
       );
     }
 

--- a/pages/input-hub.tsx
+++ b/pages/input-hub.tsx
@@ -35,14 +35,30 @@ const InputHub = () => {
   const [emailjsReady, setEmailjsReady] = useState(false);
 
   useEffect(() => {
-    const { preset, title, text, url, files } = router.query;
+    const {
+      preset,
+      title,
+      text,
+      url,
+      files,
+      errorId,
+      context,
+      appId,
+      appTitle,
+    } = router.query;
     if (preset === 'contact') {
       setSubject('General Inquiry');
+    } else if (preset === 'bug-report') {
+      setSubject('Bug Report');
     }
     const parts: string[] = [];
+    if (errorId) parts.push(`Error ID: ${String(errorId)}`);
+    if (appTitle) parts.push(`App: ${String(appTitle)}`);
+    if (appId) parts.push(`App ID: ${String(appId)}`);
+    if (context) parts.push(`Context: ${String(context)}`);
     if (title) parts.push(String(title));
     if (text) parts.push(String(text));
-    if (url) parts.push(String(url));
+    if (url) parts.push(`URL: ${String(url)}`);
     if (files) {
       try {
         const list = JSON.parse(

--- a/pages/nessus-dashboard.tsx
+++ b/pages/nessus-dashboard.tsx
@@ -15,6 +15,8 @@ const NessusDashboard: React.FC = () => {
 
   return (
     <WindowMainScreen
+      title="Nessus Dashboard"
+      appId="nessus-dashboard"
       screen={() => (
         <div className="p-4 text-white">
           <h1 className="mb-4 text-2xl">Nessus Dashboard</h1>

--- a/pages/security-education.tsx
+++ b/pages/security-education.tsx
@@ -21,6 +21,8 @@ const InfoFrame = ({ title, link, description }: FrameProps) => (
 
 const SecurityEducation = () => (
   <WindowMainScreen
+    title="Security Education"
+    appId="security-education"
     screen={() => (
       <div>
         <div

--- a/utils/bugReport.ts
+++ b/utils/bugReport.ts
@@ -1,0 +1,61 @@
+export interface BugReportOptions {
+  errorId: string;
+  appId?: string | null;
+  appTitle?: string | null;
+  context?: string | null;
+  currentUrl?: string | null;
+  additionalDetails?: string | null;
+}
+
+export function buildBugReportURL({
+  errorId,
+  appId,
+  appTitle,
+  context,
+  currentUrl,
+  additionalDetails,
+}: BugReportOptions): string {
+  const params = new URLSearchParams();
+  params.set('preset', 'bug-report');
+  params.set('errorId', errorId);
+
+  if (appTitle) {
+    params.set('title', `${appTitle} bug report`);
+    params.set('appTitle', appTitle);
+  } else {
+    params.set('title', 'Bug report');
+  }
+
+  if (appId) {
+    params.set('appId', appId);
+  }
+
+  if (context) {
+    params.set('context', context);
+  }
+
+  if (currentUrl) {
+    params.set('url', currentUrl);
+  }
+
+  const lines: string[] = [];
+  if (appTitle) {
+    lines.push(`App: ${appTitle}`);
+  }
+  if (context) {
+    lines.push(`Context: ${context}`);
+  }
+  if (appId) {
+    lines.push(`App ID: ${appId}`);
+  }
+  if (additionalDetails) {
+    lines.push(additionalDetails);
+  }
+
+  if (lines.length) {
+    params.set('text', lines.join('\n'));
+  }
+
+  return `/input-hub?${params.toString()}`;
+}
+


### PR DESCRIPTION
## Summary
- overhaul the shared ErrorBoundary to generate stable IDs, log telemetry, and surface copyable IDs in its default fallback
- wrap window content in per-app boundaries so crashes stay scoped and recovery links include contextual bug report metadata
- add a bug-report URL helper, prefill InputHub from query params, and cover the new flows with unit tests

## Testing
- npx eslint pages/input-hub.tsx *(fails: jsx-a11y/control-has-associated-label on existing form controls)*
- yarn test *(fails: legacy suites relying on jsdom localStorage/act behavior)*

------
https://chatgpt.com/codex/tasks/task_e_68cca6958a2083288f7a17cce53d2f62