### PR TITLE
[pwa] add category-aware offline fallbacks

### DIFF
--- a/docs/offline-fallback-qa.md
+++ b/docs/offline-fallback-qa.md
@@ -1,0 +1,56 @@
+# Offline fallback QA checklist
+
+This guide walks through verifying the category-aware offline fallbacks that the PWA service worker now serves. Use it during manual QA or before shipping changes to the caching strategy.
+
+## Prerequisites
+
+1. Install dependencies and start the dev server: `yarn install && yarn dev`.
+2. Open the site in a Chromium-based browser (Chrome, Edge, Brave). These steps rely on DevTools network throttling.
+3. Clear existing service worker state the first time you run the test (DevTools > Application > Service Workers > **Unregister**).
+
+## Shared preparation steps
+
+1. With the site online, open one example from each category so its assets are cached:
+   - Desktop: `/apps/terminal`
+   - Simulator: `/apps/wireshark`
+   - Game: `/apps/checkers`
+2. Confirm the window loads and close it. This seeds the offline cache and records the route metadata used by the fallback diagnostics.
+3. Open DevTools (F12 or `Cmd+Opt+I` on macOS). Keep it open for the rest of the checks.
+
+## Desktop fallback
+
+1. In DevTools, go to the **Network** tab and tick **Offline** in the throttling dropdown.
+2. Navigate to `/apps/terminal` again.
+3. Verify that the offline screen shows the “Desktop workspace unavailable offline” heading, the desktop-specific troubleshooting tips, and the cached Terminal entry in the “Available offline” list.
+4. Press **Run again** to ensure diagnostics update the timestamp and show the recorded last route/attempt values.
+5. Click **Retry connection** while still offline to ensure the page tries to reload and remains on the fallback without throwing errors.
+
+## Simulator fallback
+
+1. Staying in offline mode, navigate to `/apps/wireshark`.
+2. Confirm the fallback switches to the simulator copy (“Simulators need connectivity”) with the correct bullet points.
+3. Check that cached simulators appear when available; otherwise the empty-state message should prompt you to visit the app while online.
+4. Switch DevTools back to **Online** and click **Retry connection**. The simulator should reload successfully.
+
+## Games fallback
+
+1. Enable offline throttling again and browse to `/apps/checkers` or any other game.
+2. The fallback should show the games-specific messaging and any cached games under “Available offline.”
+3. Scroll through the tips to ensure they reference retro game behaviour.
+4. Toggle the network back online and press **Retry connection** to resume the game.
+
+## Direct games routes
+
+Some games also expose `/games/*` routes (for trainers or editors). With the network offline, open `/games/blackjack`. The same games fallback should render with diagnostics.
+
+## General fallback
+
+1. While still offline, open the launcher at `/apps`.
+2. Confirm the fallback defaults to the desktop category and that diagnostics continue to render.
+3. Optionally test a non-app page (e.g. `/projects`) to ensure the generic offline page still loads without category-specific styling.
+
+## Resetting after QA
+
+1. Untick the **Offline** checkbox in DevTools.
+2. Force-reload the page (`Cmd+Shift+R` / `Ctrl+Shift+R`) to fetch fresh assets.
+3. Clear site data if you want to reset cached apps (DevTools > Application > Storage > **Clear site data**).

--- a/public/offline.css
+++ b/public/offline.css
@@ -1,2 +1,193 @@
-body { font-family: sans-serif; padding: 2rem; text-align: center; }
-ul { list-style: none; padding: 0; }
+:root {
+  color-scheme: dark;
+  font-family: 'Ubuntu', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, #1f2937, #0f172a 65%);
+  color: #f8fafc;
+  padding: 1.5rem;
+}
+
+.offline-card {
+  width: min(720px, 100%);
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: 18px;
+  padding: clamp(1.5rem, 2vw, 2.5rem);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(16px);
+}
+
+.offline-header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.offline-subtitle {
+  margin: 0 0 0.5rem;
+  color: #cbd5f5;
+  font-size: 1rem;
+}
+
+.offline-context {
+  margin: 0;
+  color: #a5b4fc;
+  font-size: 0.95rem;
+}
+
+.offline-status {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: #38bdf8;
+  margin: 0 0 1rem;
+}
+
+.offline-section {
+  margin-top: 1.75rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  padding-top: 1.25rem;
+}
+
+.offline-section__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.offline-section h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.diagnostics-list {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.45fr) 1fr;
+  gap: 0.65rem 1.25rem;
+  margin: 1rem 0 0;
+  padding: 0;
+}
+
+.diagnostics-list dt {
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.diagnostics-list dd {
+  margin: 0;
+  color: #cbd5f5;
+  word-break: break-word;
+}
+
+.apps-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.apps-list li {
+  background: rgba(30, 41, 59, 0.85);
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.apps-list li strong {
+  font-size: 1rem;
+}
+
+.apps-list li a {
+  color: #38bdf8;
+  text-decoration: none;
+  font-size: 0.9rem;
+  word-break: break-word;
+}
+
+.apps-list li span {
+  color: #94a3b8;
+  font-size: 0.8rem;
+}
+
+.tips-list {
+  margin: 0.75rem 0 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.4rem;
+  color: #e2e8f0;
+}
+
+.primary,
+.secondary {
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  border: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.primary {
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  color: #0f172a;
+  box-shadow: 0 12px 30px rgba(56, 189, 248, 0.35);
+}
+
+.primary:hover,
+.secondary:hover {
+  transform: translateY(-1px);
+}
+
+.primary:active,
+.secondary:active {
+  transform: translateY(0);
+}
+
+.secondary {
+  background: transparent;
+  color: #38bdf8;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.offline-actions {
+  margin-top: 2rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1rem;
+  }
+
+  .offline-card {
+    padding: 1.25rem;
+  }
+
+  .offline-section__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .diagnostics-list {
+    grid-template-columns: 1fr;
+  }
+
+  .offline-actions {
+    justify-content: stretch;
+  }
+
+  .offline-actions .primary {
+    width: 100%;
+  }
+}

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,21 +1,47 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Offline</title>
-  <link rel="stylesheet" href="/offline.css">
-</head>
-<body>
-  <main>
-    <h1>Offline</h1>
-    <p>You appear to be offline. Please check your connection.</p>
-    <button id="retry">Retry</button>
-    <section>
-      <h2>Cached Apps</h2>
-      <ul id="apps"></ul>
-    </section>
-  </main>
-  <script src="/offline.js" defer></script>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Offline support</title>
+    <link rel="stylesheet" href="/offline.css" />
+  </head>
+  <body>
+    <main class="offline-card" role="main">
+      <header class="offline-header">
+        <p id="status-banner" class="offline-status" role="status"></p>
+        <h1 id="offline-title"></h1>
+        <p id="offline-subtitle" class="offline-subtitle"></p>
+        <p id="offline-context" class="offline-context"></p>
+      </header>
+
+      <section class="offline-section" aria-labelledby="diagnostics-heading">
+        <div class="offline-section__header">
+          <h2 id="diagnostics-heading">Diagnostics</h2>
+          <button id="run-diagnostics" class="secondary">Run again</button>
+        </div>
+        <dl id="diagnostics" class="diagnostics-list"></dl>
+      </section>
+
+      <section class="offline-section" aria-labelledby="cached-heading">
+        <div class="offline-section__header">
+          <div>
+            <h2 id="cached-heading">Available offline</h2>
+            <p id="cached-description" class="offline-description"></p>
+          </div>
+        </div>
+        <ul id="apps" class="apps-list" aria-live="polite"></ul>
+      </section>
+
+      <section class="offline-section" aria-labelledby="tips-heading">
+        <h2 id="tips-heading">Try these steps</h2>
+        <ul id="tips" class="tips-list"></ul>
+      </section>
+
+      <footer class="offline-actions">
+        <button id="retry" class="primary">Retry connection</button>
+      </footer>
+    </main>
+    <script src="/offline.js" defer></script>
+  </body>
 </html>

--- a/public/offline.js
+++ b/public/offline.js
@@ -1,36 +1,354 @@
-/* eslint-disable no-top-level-window/no-top-level-window-or-document */
-document.getElementById('retry').addEventListener('click', () => {
-  window.location.reload();
-});
+(function () {
+  const params = new URLSearchParams(window.location.search);
+  const category = params.get('category') || 'general';
+  const attemptedUrlParam = params.get('from');
 
-(async () => {
-  const list = document.getElementById('apps');
-  try {
-    const names = await caches.keys();
-    const urls = new Set();
-    for (const name of names) {
-      const cache = await caches.open(name);
-      const keys = await cache.keys();
-      for (const request of keys) {
-        const url = new URL(request.url);
-        if (url.pathname.startsWith('/apps/') && !url.pathname.endsWith('.js')) {
-          urls.add(url.pathname);
-        }
-      }
-    }
-    if (urls.size === 0) {
-      list.innerHTML = '<li>No apps available offline.</li>';
-    } else {
-      urls.forEach((path) => {
-        const li = document.createElement('li');
-        const a = document.createElement('a');
-        a.href = path;
-        a.textContent = path.replace('/apps/', '');
-        li.appendChild(a);
-        list.appendChild(li);
-      });
-    }
-  } catch (err) {
-    list.innerHTML = '<li>Unable to access cached apps.</li>';
+  const CATEGORY_COPY = {
+    general: {
+      label: 'Portfolio',
+      title: 'You are offline',
+      subtitle: 'The desktop experience is still available with limited functionality.',
+      description: 'Cached applications from every category appear below when available.',
+      empty: 'Visit apps while online to make them available for offline use.',
+      tips: [
+        'Toggle the browser\'s offline simulator off in DevTools once you finish testing.',
+        'Verify that airplane mode or VPN tools on your host machine are disabled.',
+        'Use the Retry button after confirming connectivity to reload the requested app.',
+      ],
+    },
+    desktop: {
+      label: 'Desktop apps',
+      title: 'Desktop workspace unavailable offline',
+      subtitle: 'Utilities like the terminal and notes app need a connection for live data sync.',
+      description: 'Previously opened desktop apps are listed here when cached on this device.',
+      empty: 'Open a desktop app while online to save a working copy for offline diagnostics.',
+      tips: [
+        'Check whether a corporate VPN or proxy is blocking the request.',
+        'If you use a custom DNS configuration, verify that it resolves internal APIs.',
+        'Refresh once you have a stable connection to restore the desktop workspace.',
+      ],
+    },
+    simulators: {
+      label: 'Security simulators',
+      title: 'Simulators need connectivity',
+      subtitle: 'Lab scenarios stream fixture data that is cached only after an initial sync.',
+      description: 'Cached simulators show up when their data fixtures are stored locally.',
+      empty: 'Launch a simulator while online so its demo data becomes available offline.',
+      tips: [
+        'Confirm that you are running the portfolio in demo/lab mode only.',
+        'Disable browser extensions that block indexedDB or service worker storage.',
+        'Retry after connectivity returns to reload the interactive simulator.',
+      ],
+    },
+    games: {
+      label: 'Retro games',
+      title: 'Games paused while offline',
+      subtitle: 'Game canvases rely on cached bundles. Load them once online to play offline.',
+      description: 'Games that are ready offline appear below and can launch without a network.',
+      empty: 'Open a game while connected to cache it for offline play.',
+      tips: [
+        'Close other heavy tabs so the browser keeps cached assets available.',
+        'Verify the PWA install permissions are granted to store save data locally.',
+        'Once you are back online, refresh to resume high score syncing.',
+      ],
+    },
+  };
+
+  const GAME_IDS = [
+    '2048',
+    'asteroids',
+    'battleship',
+    'blackjack',
+    'breakout',
+    'car-racer',
+    'lane-runner',
+    'checkers',
+    'chess',
+    'connect-four',
+    'frogger',
+    'hangman',
+    'memory',
+    'minesweeper',
+    'pacman',
+    'platformer',
+    'pong',
+    'reversi',
+    'simon',
+    'snake',
+    'sokoban',
+    'solitaire',
+    'tictactoe',
+    'tetris',
+    'tower-defense',
+    'word-search',
+    'wordle',
+    'flappy-bird',
+    'candy-crush',
+    'gomoku',
+    'pinball',
+    'sudoku',
+    'space-invaders',
+    'nonogram',
+  ];
+
+  const SIMULATOR_IDS = [
+    'beef',
+    'ettercap',
+    'ble-sensor',
+    'metasploit',
+    'wireshark',
+    'kismet',
+    'nikto',
+    'autopsy',
+    'plugin-manager',
+    'reaver',
+    'nessus',
+    'ghidra',
+    'mimikatz',
+    'mimikatz/offline',
+    'ssh',
+    'http',
+    'html-rewriter',
+    'hydra',
+    'nmap-nse',
+    'radare2',
+    'volatility',
+    'hashcat',
+    'msf-post',
+    'evidence-vault',
+    'dsniff',
+    'john',
+    'openvas',
+    'recon-ng',
+    'security-tools',
+  ];
+
+  const gameSet = new Set(GAME_IDS);
+  const simulatorSet = new Set(SIMULATOR_IDS);
+
+  const copy = CATEGORY_COPY[category] || CATEGORY_COPY.general;
+  document.title = `Offline — ${copy.label}`;
+
+  const titleEl = document.getElementById('offline-title');
+  const subtitleEl = document.getElementById('offline-subtitle');
+  const descEl = document.getElementById('cached-description');
+  const tipsEl = document.getElementById('tips');
+  const statusEl = document.getElementById('status-banner');
+  const contextEl = document.getElementById('offline-context');
+
+  titleEl.textContent = copy.title;
+  subtitleEl.textContent = copy.subtitle;
+  descEl.textContent = copy.description;
+
+  tipsEl.innerHTML = '';
+  copy.tips.forEach((tip) => {
+    const li = document.createElement('li');
+    li.textContent = tip;
+    tipsEl.appendChild(li);
+  });
+
+  function formatSegment(segment) {
+    return segment
+      .split('-')
+      .map((word) => (word ? word[0].toUpperCase() + word.slice(1) : ''))
+      .join(' ');
   }
+
+  function labelForCategory(cat) {
+    if (cat === 'games') return 'Game';
+    if (cat === 'simulators') return 'Simulator';
+    return 'Desktop';
+  }
+
+  function normaliseKey(path) {
+    return path.replace(/^\/+/, '').replace(/\/index$/, '');
+  }
+
+  function describeAttempt() {
+    try {
+      const storedAttempt = localStorage.getItem('pwa:last-attempt') || '';
+      const candidate = attemptedUrlParam || storedAttempt;
+      if (!candidate) return '';
+      const url = candidate.startsWith('http') ? new URL(candidate) : new URL(candidate, window.location.origin);
+      if (!url.pathname.startsWith('/apps')) {
+        return `Last route requested: ${url.pathname}`;
+      }
+      const key = normaliseKey(url.pathname.replace(/^\/apps\//, ''));
+      if (!key) return `Last route requested: ${url.pathname}`;
+      const segments = key.split('/').map(formatSegment);
+      return `Last attempted app: ${segments.join(' › ')}`;
+    } catch (err) {
+      console.error('Unable to read last attempt', err);
+      return '';
+    }
+  }
+
+  const attemptText = describeAttempt();
+  contextEl.textContent = attemptText || `Category: ${copy.label}`;
+
+  function updateStatusBanner() {
+    statusEl.textContent = navigator.onLine ? 'Connection detected' : 'Offline mode active';
+  }
+
+  updateStatusBanner();
+  window.addEventListener('online', updateStatusBanner);
+  window.addEventListener('offline', updateStatusBanner);
+
+  const diagnosticsEl = document.getElementById('diagnostics');
+  const appsEl = document.getElementById('apps');
+
+  function addDiagnostic(label, value) {
+    const dt = document.createElement('dt');
+    dt.textContent = label;
+    const dd = document.createElement('dd');
+    dd.textContent = value;
+    diagnosticsEl.appendChild(dt);
+    diagnosticsEl.appendChild(dd);
+  }
+
+  function readLocal(key) {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  function formatDate(value) {
+    try {
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return value;
+      return date.toLocaleString();
+    } catch {
+      return value;
+    }
+  }
+
+  function categorizeApp(key) {
+    const primary = key.split('/')[0];
+    if (gameSet.has(primary) || gameSet.has(key)) return 'games';
+    if (simulatorSet.has(primary) || simulatorSet.has(key)) return 'simulators';
+    return 'desktop';
+  }
+
+  function formatLabel(key) {
+    const segments = key.split('/').map(formatSegment);
+    return segments.join(' › ');
+  }
+
+  async function collectCachedApps() {
+    if (!('caches' in window)) return [];
+    const seen = new Map();
+    const cacheNames = await caches.keys();
+    await Promise.all(
+      cacheNames.map(async (name) => {
+        const cache = await caches.open(name);
+        const requests = await cache.keys();
+        requests.forEach((request) => {
+          try {
+            const url = new URL(request.url);
+            if (!url.pathname.startsWith('/apps/')) return;
+            if (url.pathname.endsWith('.js') || url.pathname.includes('.worker')) return;
+            const key = normaliseKey(url.pathname.replace(/^\/apps\//, ''));
+            if (!key || key.includes('.')) return;
+            if (!seen.has(key)) {
+              const categoryForApp = categorizeApp(key);
+              seen.set(key, {
+                key,
+                path: `/apps/${key}`,
+                label: formatLabel(key),
+                category: categoryForApp,
+              });
+            }
+          } catch (err) {
+            console.warn('Failed to inspect cached request', err);
+          }
+        });
+      }),
+    );
+    return Array.from(seen.values()).sort((a, b) => a.label.localeCompare(b.label));
+  }
+
+  async function populateApps() {
+    appsEl.innerHTML = '';
+    try {
+      const apps = await collectCachedApps();
+      const relevant =
+        category === 'general' ? apps : apps.filter((app) => app.category === category);
+
+      if (relevant.length === 0) {
+        const empty = document.createElement('li');
+        empty.textContent = copy.empty;
+        appsEl.appendChild(empty);
+        return;
+      }
+
+      relevant.forEach((app) => {
+        const li = document.createElement('li');
+        const name = document.createElement('strong');
+        name.textContent = app.label;
+        li.appendChild(name);
+
+        const link = document.createElement('a');
+        link.href = app.path;
+        link.textContent = app.path;
+        li.appendChild(link);
+
+        if (category === 'general') {
+          const chip = document.createElement('span');
+          chip.textContent = `${labelForCategory(app.category)} app`;
+          li.appendChild(chip);
+        }
+
+        appsEl.appendChild(li);
+      });
+    } catch (err) {
+      const failure = document.createElement('li');
+      failure.textContent = 'Unable to read cached applications.';
+      appsEl.appendChild(failure);
+      console.error('Failed to enumerate caches', err);
+    }
+  }
+
+  async function runDiagnostics() {
+    diagnosticsEl.innerHTML = '';
+
+    addDiagnostic('Status', navigator.onLine ? 'Online' : 'Offline');
+    addDiagnostic('Checked at', new Date().toLocaleString());
+
+    const lastOnline = readLocal('pwa:last-online');
+    if (lastOnline) addDiagnostic('Last online', formatDate(lastOnline));
+
+    const lastRoute = readLocal('pwa:last-route');
+    if (lastRoute) addDiagnostic('Last completed page', lastRoute);
+
+    const attempt = readLocal('pwa:last-attempt');
+    if (attempt) addDiagnostic('Last attempted route', attempt);
+
+    const connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+    if (connection?.effectiveType) {
+      addDiagnostic('Connection type', connection.effectiveType);
+    }
+
+    const swActive = navigator.serviceWorker?.controller ? 'Active' : 'Unavailable';
+    addDiagnostic('Service worker', swActive);
+
+    await populateApps();
+  }
+
+  const retryBtn = document.getElementById('retry');
+  retryBtn.addEventListener('click', () => {
+    window.location.reload();
+  });
+
+  const diagnosticsBtn = document.getElementById('run-diagnostics');
+  diagnosticsBtn.addEventListener('click', () => {
+    runDiagnostics().catch((err) => {
+      console.error('Diagnostics failed', err);
+    });
+  });
+
+  runDiagnostics().catch((err) => {
+    console.error('Initial diagnostics failed', err);
+  });
 })();


### PR DESCRIPTION
## Summary
- redesign the static offline page with diagnostics UI and category-specific copy
- enrich the offline runtime script to surface cached apps by category and read stored metadata
- record navigation/online state in _app and teach the service worker to redirect to category-aware fallbacks
- document a manual QA flow for exercising the new fallbacks in DevTools offline mode

## Testing
- yarn lint *(fails: repository currently has hundreds of existing accessibility violations, e.g. missing labels, before these changes)*
- yarn test *(fails: suite already contains failing modal/window tests under jsdom prior to this work)*

------
https://chatgpt.com/codex/tasks/task_e_68cca697e16c8328bac53e95f8e9edff