### PR TITLE
pwa: add runtime caching and api status toasts

### DIFF
--- a/__tests__/apiStatusToasts.test.tsx
+++ b/__tests__/apiStatusToasts.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import ApiStatusToasts from '../components/common/ApiStatusToasts';
+
+jest.mock('workbox-broadcast-update', () => ({
+  BroadcastUpdatePlugin: class BroadcastUpdatePlugin {},
+}));
+jest.mock('workbox-cacheable-response', () => ({
+  CacheableResponsePlugin: class CacheableResponsePlugin {},
+}));
+jest.mock('workbox-expiration', () => ({
+  ExpirationPlugin: class ExpirationPlugin {},
+}));
+
+const globalAny: any = globalThis;
+if (typeof globalAny.self === 'undefined') {
+  globalAny.self = globalAny;
+}
+
+const runtimeConfig = require('../lib/pwa/runtimeCaching.js');
+const { API_BROADCAST_CHANNEL, API_CACHE_NAME } = runtimeConfig;
+
+class MockBroadcastChannel {
+  static instances: MockBroadcastChannel[] = [];
+  name: string;
+  listeners: Set<(event: MessageEvent) => void> = new Set();
+
+  constructor(name: string) {
+    this.name = name;
+    MockBroadcastChannel.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void) {
+    if (type === 'message') {
+      this.listeners.add(listener);
+    }
+  }
+
+  removeEventListener(type: string, listener: (event: MessageEvent) => void) {
+    if (type === 'message') {
+      this.listeners.delete(listener);
+    }
+  }
+
+  postMessage(data: unknown) {
+    this.dispatch(data);
+  }
+
+  close() {
+    this.listeners.clear();
+  }
+
+  dispatch(data: unknown) {
+    const event = { data } as MessageEvent;
+    this.listeners.forEach((listener) => listener(event));
+  }
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var BroadcastChannel: typeof MockBroadcastChannel | undefined;
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  MockBroadcastChannel.instances = [];
+  global.BroadcastChannel = MockBroadcastChannel as unknown as typeof BroadcastChannel;
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+  delete (global as any).BroadcastChannel;
+});
+
+const dispatchTimeoutEvent = (detail: any) => {
+  act(() => {
+    window.dispatchEvent(new CustomEvent('fetchproxy-timeout', { detail }));
+  });
+};
+
+test('shows toast when API request times out', async () => {
+  render(<ApiStatusToasts />);
+
+  dispatchTimeoutEvent({ id: 1, url: '/api/demo', method: 'GET', startTime: 0 });
+
+  expect(
+    await screen.findByText(/Request to \/api\/demo exceeded/i),
+  ).toBeInTheDocument();
+});
+
+test('shows toast when background refresh completes', async () => {
+  render(<ApiStatusToasts />);
+
+  // Ensure the effect has run and the channel exists
+  await act(async () => {
+    await Promise.resolve();
+  });
+
+  const channel = MockBroadcastChannel.instances.find((c) => c.name === API_BROADCAST_CHANNEL);
+  expect(channel).toBeDefined();
+
+  act(() => {
+    channel?.dispatch({
+      type: 'CACHE_UPDATED',
+      payload: { cacheName: API_CACHE_NAME, updatedUrl: '/api/fresh' },
+    });
+  });
+
+  expect(
+    await screen.findByText(/Background refresh completed for \/api\/fresh/i),
+  ).toBeInTheDocument();
+});

--- a/__tests__/pwaRuntimeCaching.test.ts
+++ b/__tests__/pwaRuntimeCaching.test.ts
@@ -1,0 +1,52 @@
+jest.mock('workbox-broadcast-update', () => ({
+  BroadcastUpdatePlugin: class BroadcastUpdatePlugin {},
+}));
+jest.mock('workbox-cacheable-response', () => ({
+  CacheableResponsePlugin: class CacheableResponsePlugin {},
+}));
+jest.mock('workbox-expiration', () => ({
+  ExpirationPlugin: class ExpirationPlugin {},
+}));
+
+const globalAny: any = globalThis;
+if (typeof globalAny.self === 'undefined') {
+  globalAny.self = globalAny;
+}
+
+const runtimeConfig = require('../lib/pwa/runtimeCaching.js');
+const { BroadcastUpdatePlugin } = require('workbox-broadcast-update');
+
+const {
+  runtimeCaching,
+  API_CACHE_NAME,
+  SHELL_CACHE_NAME,
+  STATIC_CACHE_NAME,
+  API_TIMEOUT_SECONDS,
+} = runtimeConfig;
+
+describe('PWA runtime caching configuration', () => {
+  it('uses cache-first for static assets', () => {
+    const entry = runtimeCaching.find((item: any) => item.options?.cacheName === STATIC_CACHE_NAME);
+    expect(entry).toBeDefined();
+    expect(entry.handler).toBe('CacheFirst');
+  });
+
+  it('uses stale-while-revalidate for navigations', () => {
+    const entry = runtimeCaching.find((item: any) => item.options?.cacheName === SHELL_CACHE_NAME);
+    expect(entry).toBeDefined();
+    expect(entry.handler).toBe('StaleWhileRevalidate');
+    expect(
+      entry.options?.plugins?.some((plugin: any) => plugin instanceof BroadcastUpdatePlugin),
+    ).toBe(true);
+  });
+
+  it('uses network-first with timeout for APIs', () => {
+    const entry = runtimeCaching.find((item: any) => item.options?.cacheName === API_CACHE_NAME);
+    expect(entry).toBeDefined();
+    expect(entry.handler).toBe('NetworkFirst');
+    expect(entry.options?.networkTimeoutSeconds).toBe(API_TIMEOUT_SECONDS);
+    expect(
+      entry.options?.plugins?.some((plugin: any) => plugin instanceof BroadcastUpdatePlugin),
+    ).toBe(true);
+  });
+});

--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -6,7 +6,9 @@ import {
   onFetchProxy,
   getActiveFetches,
   FetchEntry,
+  API_TIMEOUT_MS,
 } from '../../../lib/fetchProxy';
+import { API_BROADCAST_CHANNEL, API_CACHE_NAME } from '../../../lib/pwa/runtimeCaching.js';
 import { exportMetrics } from '../export';
 import RequestChart from './RequestChart';
 
@@ -15,24 +17,104 @@ const HISTORY_KEY = 'network-insights-history';
 const formatBytes = (bytes?: number) =>
   typeof bytes === 'number' ? `${(bytes / 1024).toFixed(1)} kB` : '—';
 
+const toPathname = (input: string) => {
+  try {
+    return new URL(input, typeof window !== 'undefined' ? window.location.href : undefined).pathname;
+  } catch {
+    return input;
+  }
+};
+
 export default function NetworkInsights() {
   const [active, setActive] = useState<FetchEntry[]>(getActiveFetches());
   const [history, setHistory] = usePersistentState<FetchEntry[]>(HISTORY_KEY, []);
+  const [lastTimeout, setLastTimeout] = useState<FetchEntry | null>(null);
+  const [lastRefreshPath, setLastRefreshPath] = useState<string | null>(null);
 
   useEffect(() => {
     const unsubStart = onFetchProxy('start', () => setActive(getActiveFetches()));
     const unsubEnd = onFetchProxy('end', (e: CustomEvent<FetchEntry>) => {
       setActive(getActiveFetches());
       setHistory((h) => [...h, e.detail]);
+      if (e.detail.timedOut && !e.detail.error) {
+        setLastRefreshPath(toPathname(e.detail.url));
+      }
     });
+    const unsubTimeout = onFetchProxy('timeout', (e: CustomEvent<FetchEntry>) => {
+      setLastTimeout(e.detail);
+    });
+
+    let channel: BroadcastChannel | null = null;
+    let serviceWorkerListener: ((event: MessageEvent) => void) | null = null;
+
+    const handleBroadcast = (data: any) => {
+      if (!data || data.type !== 'CACHE_UPDATED') return;
+      const payload = data.payload || {};
+      if (payload.cacheName !== API_CACHE_NAME || !payload.updatedUrl) return;
+      setLastRefreshPath(toPathname(payload.updatedUrl));
+    };
+
+    if (typeof BroadcastChannel !== 'undefined') {
+      channel = new BroadcastChannel(API_BROADCAST_CHANNEL);
+      channel.addEventListener('message', (event) => handleBroadcast(event.data));
+    } else if (typeof navigator !== 'undefined' && navigator.serviceWorker) {
+      serviceWorkerListener = (event: MessageEvent) => {
+        if (!event?.data) return;
+        handleBroadcast(event.data);
+      };
+      try {
+        navigator.serviceWorker.addEventListener('message', serviceWorkerListener);
+      } catch {
+        // ignore failures from unsupported browsers
+      }
+    }
+
     return () => {
       unsubStart();
       unsubEnd();
+      unsubTimeout();
+      if (channel) {
+        try {
+          channel.close();
+        } catch {
+          // ignore
+        }
+      }
+      if (serviceWorkerListener && navigator?.serviceWorker) {
+        try {
+          navigator.serviceWorker.removeEventListener('message', serviceWorkerListener);
+        } catch {
+          // ignore
+        }
+      }
     };
   }, [setHistory]);
 
   return (
     <div className="p-2 text-xs text-white bg-[var(--kali-bg)]">
+      {lastTimeout && (
+        <div className="mb-2 rounded border border-amber-600 bg-[var(--kali-panel)]/60 p-2 text-amber-200">
+          <div className="font-semibold">Timeout fallback in use</div>
+          <div className="truncate">
+            {lastTimeout.method} {toPathname(lastTimeout.url)}
+          </div>
+          <div>
+            Timed out after
+            {' '}
+            {Math.round(
+              (lastTimeout.timeoutAt ?? lastTimeout.endTime ?? lastTimeout.startTime + API_TIMEOUT_MS) -
+                lastTimeout.startTime,
+            )}
+            ms · retrying in background
+          </div>
+        </div>
+      )}
+      {lastRefreshPath && (
+        <div className="mb-2 rounded border border-sky-600 bg-[var(--kali-panel)]/60 p-2 text-sky-200">
+          <div className="font-semibold">Background refresh completed</div>
+          <div>{lastRefreshPath}</div>
+        </div>
+      )}
       <h2 className="font-bold mb-1">Active Fetches</h2>
       <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
         {active.length === 0 && <li className="p-1 text-gray-400">None</li>}
@@ -69,6 +151,16 @@ export default function NetworkInsights() {
             <div className="text-gray-400">
               {f.duration ? `${f.duration.toFixed(0)}ms` : ''} · req {formatBytes(f.requestSize)} · res {formatBytes(f.responseSize)}
             </div>
+            {f.timedOut && (
+              <div className="text-amber-300">
+                Timed out after
+                {' '}
+                {Math.round(
+                  (f.timeoutAt ?? f.endTime ?? f.startTime + API_TIMEOUT_MS) - f.startTime,
+                )}
+                ms · served cached response
+              </div>
+            )}
           </li>
         ))}
       </ul>

--- a/components/common/ApiStatusToasts.tsx
+++ b/components/common/ApiStatusToasts.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Toast from '../ui/Toast';
+import { API_TIMEOUT_MS, onFetchProxy, type FetchLog } from '../../lib/fetchProxy';
+import {
+  API_BROADCAST_CHANNEL,
+  API_CACHE_NAME,
+} from '../../lib/pwa/runtimeCaching.js';
+
+interface ToastMessage {
+  id: string;
+  message: string;
+  duration?: number;
+}
+
+const TIMEOUT_SECONDS = Math.round(API_TIMEOUT_MS / 1000);
+
+function getPathname(input: string, base?: string) {
+  try {
+    const url = new URL(input, base ?? (typeof window !== 'undefined' ? window.location.href : undefined));
+    return url.pathname + url.search;
+  } catch {
+    return input;
+  }
+}
+
+export default function ApiStatusToasts() {
+  const [queue, setQueue] = useState<ToastMessage[]>([]);
+  const [active, setActive] = useState<ToastMessage | null>(null);
+
+  const pushToast = useCallback((message: string, duration?: number) => {
+    setQueue((prev) => [
+      ...prev,
+      {
+        id: `${Date.now()}-${Math.random()}`,
+        message,
+        duration,
+      },
+    ]);
+  }, []);
+
+  useEffect(() => {
+    if (!active && queue.length > 0) {
+      setActive(queue[0]);
+      setQueue((prev) => prev.slice(1));
+    }
+  }, [queue, active]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const origin = window.location.origin;
+    const shouldTrack = (entry: FetchLog) => {
+      if (!entry.url) return false;
+      try {
+        const requestUrl = new URL(entry.url, origin);
+        return requestUrl.origin === origin && requestUrl.pathname.startsWith('/api/');
+      } catch {
+        return false;
+      }
+    };
+
+    const timeoutHandler = (event: CustomEvent<FetchLog>) => {
+      const entry = event.detail;
+      if (!shouldTrack(entry)) return;
+      const path = getPathname(entry.url, origin);
+      pushToast(
+        `Request to ${path} exceeded ${TIMEOUT_SECONDS}s. Showing cached data while retrying.`,
+      );
+    };
+
+    const refreshHandler = (event: CustomEvent<FetchLog>) => {
+      const entry = event.detail;
+      if (!entry.timedOut || !shouldTrack(entry) || entry.error) return;
+      const path = getPathname(entry.url, origin);
+      pushToast(`Background refresh completed for ${path}.`);
+    };
+
+    const unsubTimeout = onFetchProxy('timeout', timeoutHandler);
+    const unsubEnd = onFetchProxy('end', refreshHandler);
+
+    let channel: BroadcastChannel | null = null;
+    let fallbackListener: ((event: MessageEvent) => void) | null = null;
+
+    const handleBroadcast = (data: any) => {
+      if (!data || data.type !== 'CACHE_UPDATED') return;
+      const payload = data.payload || {};
+      if (payload.cacheName !== API_CACHE_NAME) return;
+      const updatedUrl = payload.updatedUrl as string | undefined;
+      if (!updatedUrl) return;
+      const path = getPathname(updatedUrl, origin);
+      pushToast(`Background refresh completed for ${path}.`);
+    };
+
+    if (typeof BroadcastChannel !== 'undefined') {
+      channel = new BroadcastChannel(API_BROADCAST_CHANNEL);
+      channel.addEventListener('message', (event) => handleBroadcast(event.data));
+    } else if (typeof navigator !== 'undefined' && navigator.serviceWorker) {
+      fallbackListener = (event: MessageEvent) => {
+        if (!event?.data) return;
+        handleBroadcast(event.data);
+      };
+      try {
+        navigator.serviceWorker.addEventListener('message', fallbackListener);
+      } catch {
+        // ignore
+      }
+    }
+
+    return () => {
+      unsubTimeout();
+      unsubEnd();
+      if (channel) {
+        try {
+          channel.close();
+        } catch {
+          // ignore
+        }
+      }
+      if (fallbackListener && navigator?.serviceWorker) {
+        try {
+          navigator.serviceWorker.removeEventListener('message', fallbackListener);
+        } catch {
+          // ignore
+        }
+      }
+    };
+  }, [pushToast]);
+
+  const handleClose = useCallback(() => {
+    setActive(null);
+  }, []);
+
+  if (!active) return null;
+
+  return (
+    <Toast
+      key={active.id}
+      message={active.message}
+      duration={active.duration}
+      onClose={handleClose}
+    />
+  );
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -5,6 +5,12 @@ if (typeof global.structuredClone !== 'function') {
   // @ts-ignore
   global.structuredClone = (val) => (val === undefined ? val : JSON.parse(JSON.stringify(val)));
 }
+// Ensure workbox and other service-worker aware packages see a self reference
+// @ts-ignore
+if (typeof globalThis.self === 'undefined') {
+  // @ts-ignore
+  globalThis.self = globalThis;
+}
 require('fake-indexeddb/auto');
 import '@testing-library/jest-dom';
 

--- a/lib/pwa/runtimeCaching.js
+++ b/lib/pwa/runtimeCaching.js
@@ -1,0 +1,92 @@
+if (typeof globalThis !== 'undefined') {
+  if (typeof globalThis.self === 'undefined') {
+    globalThis.self = globalThis;
+  }
+  if (typeof globalThis.navigator === 'undefined') {
+    globalThis.navigator = {};
+  }
+}
+
+const { BroadcastUpdatePlugin } = require('workbox-broadcast-update');
+const { CacheableResponsePlugin } = require('workbox-cacheable-response');
+const { ExpirationPlugin } = require('workbox-expiration');
+
+const STATIC_CACHE_NAME = 'static-assets-v1';
+const SHELL_CACHE_NAME = 'shell-runtime-v1';
+const API_CACHE_NAME = 'api-runtime-v1';
+const STATIC_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+const STATIC_MAX_ENTRIES = 128;
+const SHELL_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
+const API_TIMEOUT_SECONDS = 5;
+const API_MAX_ENTRIES = 50;
+const API_MAX_AGE_SECONDS = 24 * 60 * 60;
+const API_BROADCAST_CHANNEL = 'api-updates';
+const SHELL_BROADCAST_CHANNEL = 'shell-updates';
+
+const runtimeCaching = [
+  {
+    urlPattern: ({ request, sameOrigin, url }) => {
+      if (!request || !sameOrigin) return false;
+      if (['style', 'script', 'worker', 'font'].includes(request.destination)) {
+        return true;
+      }
+      return /\.(?:js|css|woff2?|ttf)$/.test(url.pathname);
+    },
+    handler: 'CacheFirst',
+    options: {
+      cacheName: STATIC_CACHE_NAME,
+      plugins: [
+        new CacheableResponsePlugin({ statuses: [0, 200] }),
+        new ExpirationPlugin({
+          maxEntries: STATIC_MAX_ENTRIES,
+          maxAgeSeconds: STATIC_MAX_AGE_SECONDS,
+          purgeOnQuotaError: true,
+        }),
+      ],
+    },
+  },
+  {
+    urlPattern: ({ request }) => request?.mode === 'navigate',
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: SHELL_CACHE_NAME,
+      plugins: [
+        new CacheableResponsePlugin({ statuses: [0, 200] }),
+        new ExpirationPlugin({
+          maxEntries: 20,
+          maxAgeSeconds: SHELL_MAX_AGE_SECONDS,
+          purgeOnQuotaError: true,
+        }),
+        new BroadcastUpdatePlugin({ channelName: SHELL_BROADCAST_CHANNEL }),
+      ],
+    },
+  },
+  {
+    urlPattern: ({ sameOrigin, url, request }) =>
+      Boolean(sameOrigin && request && request.method === 'GET' && url.pathname.startsWith('/api/')),
+    handler: 'NetworkFirst',
+    options: {
+      cacheName: API_CACHE_NAME,
+      networkTimeoutSeconds: API_TIMEOUT_SECONDS,
+      plugins: [
+        new CacheableResponsePlugin({ statuses: [0, 200] }),
+        new ExpirationPlugin({
+          maxEntries: API_MAX_ENTRIES,
+          maxAgeSeconds: API_MAX_AGE_SECONDS,
+          purgeOnQuotaError: true,
+        }),
+        new BroadcastUpdatePlugin({ channelName: API_BROADCAST_CHANNEL }),
+      ],
+    },
+  },
+];
+
+module.exports = {
+  runtimeCaching,
+  STATIC_CACHE_NAME,
+  SHELL_CACHE_NAME,
+  API_CACHE_NAME,
+  API_TIMEOUT_SECONDS,
+  API_BROADCAST_CHANNEL,
+  SHELL_BROADCAST_CHANNEL,
+};

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@
 // Update README (section "CSP External Domains") when editing domains below.
 
 const { validateServerEnv: validateEnv } = require('./lib/validate.js');
+const { runtimeCaching } = require('./lib/pwa/runtimeCaching.js');
 
 const ContentSecurityPolicy = [
   "default-src 'self'",
@@ -81,6 +82,7 @@ const withPWA = require('@ducanh2912/next-pwa').default({
       { url: '/offline.html', revision: null },
       { url: '/manifest.webmanifest', revision: null },
     ],
+    runtimeCaching,
   },
 });
 

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -10,12 +10,14 @@ import '../styles/resume-print.css';
 import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
+import '../lib/fetchProxy';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import ApiStatusToasts from '../components/common/ApiStatusToasts';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -159,6 +161,7 @@ function MyApp(props) {
         <SettingsProvider>
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />
+            <ApiStatusToasts />
             <Component {...pageProps} />
             <ShortcutOverlay />
             <Analytics


### PR DESCRIPTION
## Summary
- add centralized runtimeCaching config to next-pwa with cache-first static assets, stale-while-revalidate shell, and timed network-first APIs
- surface API timeout and background refresh UX via a new ApiStatusToasts component and enhanced resource monitor messaging
- extend fetch proxy timeout tracking and add integration tests covering the new caching config and status toasts

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint errors)*
- yarn test *(fails: upstream suites such as window, nmapNse, pdfviewer currently failing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cca70a250c8328a5435109d4f999d3