### PR TITLE
[a11y] add contrast overlay tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ See `.env.local.example` for the full list.
 - `yarn dev` – start the development server with hot reloading.
 - `yarn test` – run the test suite.
 - `yarn lint` – check code for linting issues.
+- `yarn contrast` – run the Playwright contrast audit (requires a dev server on `http://localhost:3000`).
 - `yarn export` – generate a static export in the `out/` directory.
 
 ---
@@ -99,6 +100,20 @@ See `.env.local.example` for the full list.
 
 - Run `yarn lint` and `yarn test` before committing changes.
 - For manual smoke tests, start `yarn dev` and in another terminal run `yarn smoke` to visit every `/apps/*` route.
+
+---
+
+## Accessibility Developer Overlay
+
+- Append `?devtools=contrast` or `?contrastOverlay=1` to any route (e.g. `http://localhost:3000/?devtools=contrast`) to enable the contrast overlay in supported environments.
+- To persist the overlay locally without a query string, run `localStorage.setItem('kali-devtools', 'contrast')` in the browser console and refresh.
+- Highlight colors:
+  - **Red** outline – text nodes below **4.5:1** contrast, with the DOM path label.
+  - **Orange** outline – UI blocks (backgrounds, interactive surfaces) below **3:1** contrast against their container.
+- The scanner is throttled (~500 ms) and ignores the overlay itself to avoid layout jank.
+- Details are mirrored to the developer console via `console.table` for easier auditing or copy/paste into bug reports.
+
+Run `yarn contrast` after starting `yarn dev` to execute the automated audit over `/` and `/apps` headlessly. The test fails if any <4.5:1 text or <3:1 UI contrast violations remain.
 
 ---
 

--- a/components/dev/ContrastOverlay.tsx
+++ b/components/dev/ContrastOverlay.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { scanForContrastViolations } from '../../modules/a11y/contrast-scan';
+
+const OVERLAY_ATTRIBUTE = 'data-contrast-overlay';
+const THROTTLE_DELAY = 500;
+
+const normalizeToggles = (raw: string | null) => {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+};
+
+const isTruthy = (value: string | null) => {
+  if (value === null) return false;
+  if (value === '') return true;
+  const normalized = value.trim().toLowerCase();
+  return ['1', 'true', 'on', 'yes', 'y'].includes(normalized);
+};
+
+type ThrottledFn = () => void;
+
+const throttle = (fn: () => void, delay: number): ThrottledFn => {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  let lastRun = 0;
+
+  return () => {
+    const now = Date.now();
+    const invoke = () => {
+      lastRun = Date.now();
+      timeout = null;
+      fn();
+    };
+
+    if (now - lastRun >= delay) {
+      invoke();
+      return;
+    }
+
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
+    timeout = setTimeout(invoke, Math.max(0, delay - (now - lastRun)));
+  };
+};
+
+const computeActive = (searchParams: URLSearchParams, isProd: boolean) => {
+  const devtoolsParam = normalizeToggles(searchParams.get('devtools'));
+  const urlEnabled =
+    devtoolsParam.includes('contrast') ||
+    isTruthy(searchParams.get('a11yOverlay')) ||
+    isTruthy(searchParams.get('contrastOverlay')) ||
+    searchParams.has('contrastOverlay');
+
+  if (urlEnabled) return true;
+
+  try {
+    const storedValue =
+      window.localStorage.getItem('kali-devtools') ?? window.localStorage.getItem('devtools');
+    const stored = normalizeToggles(storedValue);
+    if (stored.includes('contrast')) return true;
+  } catch {
+    // localStorage unavailable
+  }
+
+  return false;
+};
+
+const createLabelPosition = (height: number, top: number) => {
+  const offset = height >= 32 ? -24 : height + 4;
+  const clampedTop = top < 24 ? height + 4 : offset;
+  return clampedTop;
+};
+
+function renderHighlights(root: HTMLDivElement) {
+  const violations = scanForContrastViolations({ ignoreAttribute: OVERLAY_ATTRIBUTE });
+  root.replaceChildren();
+
+  if (violations.length === 0) {
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  for (const violation of violations) {
+    const { boundingRect, ratio, type, path } = violation;
+    const highlight = document.createElement('div');
+    highlight.setAttribute(OVERLAY_ATTRIBUTE, 'true');
+    highlight.style.position = 'absolute';
+    highlight.style.top = `${boundingRect.top}px`;
+    highlight.style.left = `${boundingRect.left}px`;
+    highlight.style.width = `${boundingRect.width}px`;
+    highlight.style.height = `${boundingRect.height}px`;
+    highlight.style.outline = `2px solid ${type === 'text' ? '#ff3b30' : '#ff9500'}`;
+    highlight.style.backgroundColor = type === 'text' ? 'rgba(255, 59, 48, 0.16)' : 'rgba(255, 149, 0, 0.18)';
+    highlight.style.pointerEvents = 'none';
+    highlight.style.boxSizing = 'border-box';
+    highlight.style.zIndex = '2147483647';
+
+    const label = document.createElement('div');
+    label.setAttribute(OVERLAY_ATTRIBUTE, 'true');
+    label.textContent = `${type === 'text' ? 'Text' : 'UI'} ${ratio.toFixed(2)}:1 — ${path}`;
+    label.style.position = 'absolute';
+    label.style.left = '0';
+    label.style.top = `${createLabelPosition(boundingRect.height, boundingRect.top)}px`;
+    label.style.padding = '2px 4px';
+    label.style.backgroundColor = type === 'text' ? '#ff3b30' : '#ff9500';
+    label.style.color = '#000';
+    label.style.fontFamily = "'Ubuntu Mono', Menlo, monospace";
+    label.style.fontSize = '11px';
+    label.style.fontWeight = '600';
+    label.style.maxWidth = '320px';
+    label.style.whiteSpace = 'normal';
+    label.style.wordBreak = 'break-word';
+    label.style.boxShadow = '0 2px 8px rgba(0, 0, 0, 0.35)';
+
+    highlight.appendChild(label);
+    fragment.appendChild(highlight);
+  }
+
+  root.appendChild(fragment);
+
+  if (violations.length > 0) {
+    const summary = violations.map((violation) => ({
+      type: violation.type,
+      ratio: violation.ratio.toFixed(2),
+      path: violation.path,
+      foreground: violation.foreground,
+      background: violation.background,
+    }));
+    console.table(summary);
+  }
+}
+
+export default function ContrastOverlay() {
+  const router = useRouter();
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const isProd = process.env.NODE_ENV === 'production';
+
+    const update = () => {
+      if (typeof window === 'undefined') {
+        setEnabled(false);
+        return;
+      }
+
+      const search = router.asPath.split('?')[1] || '';
+      const params = new URLSearchParams(search);
+      setEnabled(computeActive(params, isProd));
+    };
+
+    update();
+
+    window.addEventListener('storage', update);
+    return () => {
+      window.removeEventListener('storage', update);
+    };
+  }, [router.asPath]);
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return undefined;
+
+    const overlayRoot = document.createElement('div');
+    overlayRoot.setAttribute(OVERLAY_ATTRIBUTE, 'true');
+    overlayRoot.style.position = 'fixed';
+    overlayRoot.style.inset = '0';
+    overlayRoot.style.pointerEvents = 'none';
+    overlayRoot.style.zIndex = '2147483647';
+    overlayRoot.style.mixBlendMode = 'normal';
+
+    document.body.appendChild(overlayRoot);
+
+    const render = () => renderHighlights(overlayRoot);
+    const throttledRender = throttle(render, THROTTLE_DELAY);
+
+    const observer = new MutationObserver(() => {
+      throttledRender();
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      characterData: true,
+    });
+
+    window.addEventListener('resize', throttledRender, { passive: true } as EventListenerOptions);
+    document.addEventListener('scroll', throttledRender, true);
+
+    throttledRender();
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', throttledRender);
+      document.removeEventListener('scroll', throttledRender, true);
+      overlayRoot.remove();
+    };
+  }, [enabled]);
+
+  return null;
+}

--- a/modules/a11y/contrast-scan.js
+++ b/modules/a11y/contrast-scan.js
@@ -1,0 +1,231 @@
+export function scanForContrastViolations(options = {}) {
+  const { ignoreAttribute } = options;
+  const MIN_TEXT_RATIO = 4.5;
+  const MIN_UI_RATIO = 3;
+  const TRANSPARENT = { r: 0, g: 0, b: 0, a: 0 };
+
+  const parseColor = (value) => {
+    if (!value || typeof value !== 'string') return null;
+    const normalized = value.trim().toLowerCase();
+    if (!normalized || normalized === 'transparent') return { ...TRANSPARENT };
+
+    const hexMatch = normalized.match(/^#([0-9a-f]{3,8})$/i);
+    if (hexMatch) {
+      const hex = hexMatch[1];
+      const expanded = hex.length === 3 || hex.length === 4
+        ? hex.split('').map((char) => char + char).join('')
+        : hex;
+      const hasAlpha = expanded.length === 8;
+      const intVal = parseInt(expanded, 16);
+      const r = (intVal >> (hasAlpha ? 24 : 16)) & 255;
+      const g = (intVal >> (hasAlpha ? 16 : 8)) & 255;
+      const b = (intVal >> (hasAlpha ? 8 : 0)) & 255;
+      const a = hasAlpha ? (intVal & 255) / 255 : 1;
+      return { r, g, b, a };
+    }
+
+    const rgbMatch = normalized.match(/^rgba?\(([^)]+)\)$/);
+    if (rgbMatch) {
+      const parts = rgbMatch[1].split(',').map((part) => part.trim());
+      if (parts.length < 3) return null;
+      const [rRaw, gRaw, bRaw, aRaw] = parts;
+      const parseChannel = (channel) => {
+        if (channel.endsWith('%')) {
+          return Math.round((parseFloat(channel) / 100) * 255);
+        }
+        return Number(channel);
+      };
+      const r = parseChannel(rRaw);
+      const g = parseChannel(gRaw);
+      const b = parseChannel(bRaw);
+      const a = parts.length === 4 ? Math.min(1, Math.max(0, Number(aRaw))) : 1;
+      if ([r, g, b].some((channel) => Number.isNaN(channel))) return null;
+      return { r, g, b, a };
+    }
+
+    // Fallback: try letting the browser parse unknown formats.
+    const temp = document.createElement('span');
+    temp.style.color = value;
+    const container = document.body || document.documentElement;
+    container.appendChild(temp);
+    const computed = window.getComputedStyle(temp).color;
+    temp.remove();
+    if (computed === value) return null;
+    return parseColor(computed);
+  };
+
+  const blendColors = (top, bottom) => {
+    const alpha = top.a + bottom.a * (1 - top.a);
+    if (alpha <= 0) {
+      return { ...TRANSPARENT };
+    }
+    return {
+      r: (top.r * top.a + bottom.r * bottom.a * (1 - top.a)) / alpha,
+      g: (top.g * top.a + bottom.g * bottom.a * (1 - top.a)) / alpha,
+      b: (top.b * top.a + bottom.b * bottom.a * (1 - top.a)) / alpha,
+      a: alpha,
+    };
+  };
+
+  const srgbToLinear = (value) => {
+    const channel = value / 255;
+    return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+  };
+
+  const getLuminance = (color) => {
+    if (!color) return 0;
+    const r = srgbToLinear(color.r);
+    const g = srgbToLinear(color.g);
+    const b = srgbToLinear(color.b);
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  };
+
+  const getContrastRatio = (c1, c2) => {
+    if (!c1 || !c2) return 0;
+    const l1 = getLuminance(c1);
+    const l2 = getLuminance(c2);
+    const lighter = Math.max(l1, l2);
+    const darker = Math.min(l1, l2);
+    return (lighter + 0.05) / (darker + 0.05);
+  };
+
+  const getDocumentBackground = () => {
+    const docBg = parseColor(window.getComputedStyle(document.documentElement).backgroundColor);
+    const bodyBg = parseColor(document.body ? window.getComputedStyle(document.body).backgroundColor : null);
+    return docBg || bodyBg || { r: 255, g: 255, b: 255, a: 1 };
+  };
+
+  const getEffectiveBackground = (element) => {
+    let color = { ...TRANSPARENT };
+    let current = element;
+    while (current && current !== document.documentElement) {
+      const bg = parseColor(window.getComputedStyle(current).backgroundColor);
+      if (bg && bg.a > 0) {
+        color = blendColors(bg, color);
+        if (color.a >= 0.99) {
+          break;
+        }
+      }
+      current = current.parentElement;
+    }
+    if (color.a < 0.99) {
+      color = blendColors(getDocumentBackground(), color);
+    }
+    return color;
+  };
+
+  const isHidden = (element, style) => {
+    if (!style) return true;
+    if (style.display === 'none' || style.visibility === 'hidden') return true;
+    if (Number.parseFloat(style.opacity) === 0) return true;
+    if (element.getAttribute('aria-hidden') === 'true') return true;
+    if (!element.getClientRects || element.getClientRects().length === 0) return true;
+    return false;
+  };
+
+  const hasDirectText = (element) => {
+    return Array.from(element.childNodes).some(
+      (node) => node.nodeType === Node.TEXT_NODE && node.textContent && node.textContent.trim().length > 0,
+    );
+  };
+
+  const getElementPath = (element) => {
+    const parts = [];
+    let current = element;
+    while (current && current.nodeType === Node.ELEMENT_NODE && current !== document.documentElement) {
+      let selector = current.tagName.toLowerCase();
+      if (current.id) {
+        selector += `#${current.id}`;
+        parts.unshift(selector);
+        break;
+      }
+      if (current.classList.length > 0) {
+        const classes = Array.from(current.classList).filter(Boolean).slice(0, 2).join('.');
+        if (classes) {
+          selector += `.${classes}`;
+        }
+      }
+      if (current.parentElement) {
+        const siblings = Array.from(current.parentElement.children).filter(
+          (child) => child.tagName === current.tagName,
+        );
+        if (siblings.length > 1) {
+          selector += `:nth-of-type(${siblings.indexOf(current) + 1})`;
+        }
+      }
+      parts.unshift(selector);
+      current = current.parentElement;
+    }
+    parts.unshift('html');
+    return parts.join(' > ');
+  };
+
+  const colorToString = (color) =>
+    `rgba(${Math.round(color.r)}, ${Math.round(color.g)}, ${Math.round(color.b)}, ${Number(color.a.toFixed(2))})`;
+
+  const violations = [];
+  const root = document.body || document.documentElement;
+  if (!root || !root.querySelectorAll) {
+    return violations;
+  }
+
+  const elements = Array.from(root.querySelectorAll('*'));
+  for (const element of elements) {
+    if (ignoreAttribute && element.closest?.(`[${ignoreAttribute}]`)) continue;
+    if (['SCRIPT', 'STYLE', 'NOSCRIPT', 'LINK', 'META'].includes(element.tagName)) continue;
+
+    const style = window.getComputedStyle(element);
+    if (isHidden(element, style)) continue;
+
+    const rect = element.getBoundingClientRect();
+    if (!rect || rect.width === 0 || rect.height === 0) continue;
+
+    if (hasDirectText(element)) {
+      const textColor = parseColor(style.color);
+      if (textColor && textColor.a > 0) {
+        const backgroundColor = getEffectiveBackground(element);
+        const ratio = getContrastRatio(textColor, backgroundColor);
+        if (ratio > 0 && ratio + 0.01 < MIN_TEXT_RATIO) {
+          violations.push({
+            type: 'text',
+            ratio,
+            path: getElementPath(element),
+            foreground: colorToString(textColor),
+            background: colorToString(backgroundColor),
+            boundingRect: {
+              top: rect.top,
+              left: rect.left,
+              width: rect.width,
+              height: rect.height,
+            },
+          });
+        }
+      }
+    }
+
+    const backgroundColor = parseColor(style.backgroundColor);
+    if (backgroundColor && backgroundColor.a > 0.05) {
+      const parentBackground = element.parentElement
+        ? getEffectiveBackground(element.parentElement)
+        : getDocumentBackground();
+      const ratio = getContrastRatio(backgroundColor, parentBackground);
+      if (ratio > 0 && ratio + 0.01 < MIN_UI_RATIO) {
+        violations.push({
+          type: 'ui',
+          ratio,
+          path: getElementPath(element),
+          foreground: colorToString(backgroundColor),
+          background: colorToString(parentBackground),
+          boundingRect: {
+            top: rect.top,
+            left: rect.left,
+            width: rect.width,
+            height: rect.height,
+          },
+        });
+      }
+    }
+  }
+
+  return violations;
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "tsc": "tsc",
     "typecheck": "tsc --noEmit",
     "a11y": "node scripts/a11y.mjs",
+    "contrast": "playwright test tests/contrast.spec.ts",
     "smoke": "node scripts/smoke-all-apps.mjs",
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,6 +14,7 @@ import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
+import ContrastOverlay from '../components/dev/ContrastOverlay';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
@@ -161,6 +162,7 @@ function MyApp(props) {
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
             <ShortcutOverlay />
+            <ContrastOverlay />
             <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;

--- a/tests/contrast.spec.ts
+++ b/tests/contrast.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { scanForContrastViolations } from '../modules/a11y/contrast-scan';
+
+const ROUTES = ['/', '/apps'];
+const IGNORE_ATTRIBUTE = 'data-contrast-overlay';
+
+type ContrastViolation = {
+  type: string;
+  ratio: number;
+  path: string;
+  foreground: string;
+  background: string;
+};
+
+const formatViolations = (violations: ContrastViolation[]) =>
+  violations.map((violation) => ({
+    type: violation.type,
+    ratio: violation.ratio.toFixed(2),
+    path: violation.path,
+    foreground: violation.foreground,
+    background: violation.background,
+  }));
+
+for (const route of ROUTES) {
+  test(`has accessible contrast on ${route}`, async ({ page }) => {
+    await page.goto(route);
+    await page.waitForLoadState('networkidle');
+
+    const violations: ContrastViolation[] = await page.evaluate(scanForContrastViolations, {
+      ignoreAttribute: IGNORE_ATTRIBUTE,
+    });
+
+    if (violations.length > 0) {
+      console.table(formatViolations(violations));
+    }
+
+    expect(violations, `Contrast violations detected on ${route}`).toEqual([]);
+  });
+}


### PR DESCRIPTION
## Summary
- add a developer-only contrast overlay that scans rendered DOM nodes and annotates issues with element paths
- share the scanning logic in a reusable module and render the overlay in `_app`
- document the toggle plus add a Playwright audit (`yarn contrast`) that fails when text <4.5:1 or UI <3:1

## Testing
- yarn lint *(fails: repository has existing jsx-a11y label errors and node_modules lint issues)*
- yarn test *(fails: repository has existing failing suites such as nmapNse and modal/contact API tests)*
- npx eslint components/dev/ContrastOverlay.tsx modules/a11y/contrast-scan.js tests/contrast.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68cca70e4a0c8328b3dd3a7be5897757