### PR TITLE
[accessibility] centralize live region manager

### DIFF
--- a/__tests__/liveRegion.test.tsx
+++ b/__tests__/liveRegion.test.tsx
@@ -1,19 +1,116 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
+import React, { useState } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Toast from '../components/ui/Toast';
 import FormError from '../components/ui/FormError';
+import ProgressBar from '../components/ui/ProgressBar';
+import { LiveRegionProvider, useLiveRegion } from '../hooks/useLiveRegion';
 
-describe('live region components', () => {
-  it('Toast uses polite live region', () => {
-    const { unmount } = render(<Toast message="Saved" />);
-    const region = screen.getByRole('status');
-    expect(region).toHaveAttribute('aria-live', 'polite');
-    unmount();
+describe('live region manager', () => {
+  const renderWithLiveRegion = (
+    ui: React.ReactElement,
+    onAnnounce: (message: string) => void,
+  ) =>
+    render(
+      <LiveRegionProvider
+        onAnnounce={(message) => {
+          onAnnounce(message);
+        }}
+      >
+        {ui}
+      </LiveRegionProvider>,
+    );
+
+  it('announces toast messages once', async () => {
+    const announcements: string[] = [];
+    renderWithLiveRegion(<Toast message="Saved" />, (msg) => announcements.push(msg));
+
+    await waitFor(() => expect(announcements).toContain('Saved'));
+    expect(announcements.filter((msg) => msg === 'Saved')).toHaveLength(1);
   });
 
-  it('FormError announces politely', () => {
-    render(<FormError>Required field</FormError>);
-    const region = screen.getByRole('status');
-    expect(region).toHaveAttribute('aria-live', 'polite');
+  it('announces form errors when the text changes', async () => {
+    const announcements: string[] = [];
+    const handleAnnounce = (msg: string) => announcements.push(msg);
+    const { rerender } = render(
+      <LiveRegionProvider onAnnounce={handleAnnounce}>
+        <FormError>Required field</FormError>
+      </LiveRegionProvider>,
+    );
+
+    await waitFor(() => expect(announcements).toContain('Required field'));
+    expect(announcements.filter((msg) => msg === 'Required field')).toHaveLength(1);
+
+    rerender(
+      <LiveRegionProvider onAnnounce={handleAnnounce}>
+        <FormError>Still required</FormError>
+      </LiveRegionProvider>,
+    );
+
+    await waitFor(() => expect(announcements).toContain('Still required'));
+    expect(announcements.filter((msg) => msg === 'Still required')).toHaveLength(1);
+  });
+
+  it('throttles duplicate announcements', async () => {
+    const announcements: string[] = [];
+
+    const DuplicateAnnouncer = () => {
+      const { announce } = useLiveRegion();
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            announce('Saved message');
+            announce('Saved message');
+          }}
+        >
+          Trigger duplicates
+        </button>
+      );
+    };
+
+    renderWithLiveRegion(<DuplicateAnnouncer />, (msg) => announcements.push(msg));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger duplicates' }));
+
+    await waitFor(() => expect(announcements).toContain('Saved message'));
+    expect(announcements.filter((msg) => msg === 'Saved message')).toHaveLength(1);
+  });
+
+  it('emits a single announcement per progress update', async () => {
+    const announcements: string[] = [];
+
+    const ProgressHarness = () => {
+      const [value, setValue] = useState(0);
+      return (
+        <>
+          <ProgressBar progress={value} />
+          <button type="button" onClick={() => setValue(50)}>
+            Set to 50
+          </button>
+          <button type="button" onClick={() => setValue(50)}>
+            Set to 50 again
+          </button>
+          <button type="button" onClick={() => setValue(75)}>
+            Set to 75
+          </button>
+        </>
+      );
+    };
+
+    renderWithLiveRegion(<ProgressHarness />, (msg) => announcements.push(msg));
+
+    await waitFor(() => expect(announcements).toContain('Progress 0 percent'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set to 50' }));
+    await waitFor(() => expect(announcements).toContain('Progress 50 percent'));
+    expect(announcements.filter((msg) => msg === 'Progress 50 percent')).toHaveLength(1);
+
+    const countAfterFirst = announcements.length;
+    fireEvent.click(screen.getByRole('button', { name: 'Set to 50 again' }));
+    await waitFor(() => expect(announcements.length).toBe(countAfterFirst));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set to 75' }));
+    await waitFor(() => expect(announcements).toContain('Progress 75 percent'));
+    expect(announcements.filter((msg) => msg === 'Progress 75 percent')).toHaveLength(1);
   });
 });

--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import NmapNSEApp from '../components/apps/nmap-nse';
+import { LiveRegionProvider } from '../hooks/useLiveRegion';
 
 describe('NmapNSEApp', () => {
   it('shows example output for selected script', async () => {
@@ -18,7 +19,11 @@ describe('NmapNSEApp', () => {
         })
       );
 
-    render(<NmapNSEApp />);
+    render(
+      <LiveRegionProvider>
+        <NmapNSEApp />
+      </LiveRegionProvider>
+    );
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
 
     await userEvent.click(screen.getByLabelText(/ftp-anon/i));
@@ -44,7 +49,11 @@ describe('NmapNSEApp', () => {
     // @ts-ignore
     navigator.clipboard = { writeText };
 
-    render(<NmapNSEApp />);
+    render(
+      <LiveRegionProvider>
+        <NmapNSEApp />
+      </LiveRegionProvider>
+    );
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
     await userEvent.click(
       screen.getByRole('button', { name: /copy command/i })
@@ -73,7 +82,11 @@ describe('NmapNSEApp', () => {
     // @ts-ignore
     navigator.clipboard = { writeText };
 
-    render(<NmapNSEApp />);
+    render(
+      <LiveRegionProvider>
+        <NmapNSEApp />
+      </LiveRegionProvider>
+    );
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
 
     await userEvent.click(
@@ -120,7 +133,11 @@ describe('NmapNSEApp', () => {
         })
       );
 
-    render(<NmapNSEApp />);
+    render(
+      <LiveRegionProvider>
+        <NmapNSEApp />
+      </LiveRegionProvider>
+    );
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
 
     const hostNode = await screen.findByText('192.0.2.1');

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -519,46 +519,42 @@ export class Window extends Component {
     }
 
     handleKeyDown = (e) => {
+        const suppressEvent = () => {
+            if (typeof e.preventDefault === 'function') e.preventDefault();
+            if (typeof e.stopPropagation === 'function') e.stopPropagation();
+        };
         if (e.key === 'Escape') {
             this.closeWindow();
         } else if (e.key === 'Tab') {
             this.focusWindow();
         } else if (e.altKey) {
             if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                suppressEvent();
                 this.unsnapWindow();
             } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                suppressEvent();
                 this.snapWindow('left');
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                suppressEvent();
                 this.snapWindow('right');
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                suppressEvent();
                 this.snapWindow('top');
             }
             this.focusWindow();
         } else if (e.shiftKey) {
             const step = 1;
             if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                suppressEvent();
                 this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                suppressEvent();
                 this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                suppressEvent();
                 this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                suppressEvent();
                 this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
             }
             this.focusWindow();

--- a/components/ui/FormError.tsx
+++ b/components/ui/FormError.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLiveAnnouncement } from '../../hooks/useLiveRegion';
 
 interface FormErrorProps {
   id?: string;
@@ -6,15 +7,19 @@ interface FormErrorProps {
   children: React.ReactNode;
 }
 
-const FormError = ({ id, className = '', children }: FormErrorProps) => (
-  <p
-    id={id}
-    role="status"
-    aria-live="polite"
-    className={`text-red-600 text-sm mt-2 ${className}`.trim()}
-  >
-    {children}
-  </p>
-);
+const FormError = ({ id, className = '', children }: FormErrorProps) => {
+  useLiveAnnouncement(children, { politeness: 'assertive', priority: 'urgent' });
+
+  return (
+    <p
+      id={id}
+      role="status"
+      aria-live="off"
+      className={`text-red-600 text-sm mt-2 ${className}`.trim()}
+    >
+      {children}
+    </p>
+  );
+};
 
 export default FormError;

--- a/components/ui/ProgressBar.tsx
+++ b/components/ui/ProgressBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLiveAnnouncement } from '../../hooks/useLiveRegion';
 
 interface ProgressBarProps {
   progress: number;
@@ -7,11 +8,14 @@ interface ProgressBarProps {
 
 export default function ProgressBar({ progress, className = '' }: ProgressBarProps) {
   const clamped = Math.max(0, Math.min(progress, 100));
+  const percent = Math.round(clamped);
+
+  useLiveAnnouncement(`Progress ${percent} percent`, { politeness: 'polite' });
   return (
     <div
       className={`w-32 h-2 bg-gray-300 rounded ${className}`}
       role="progressbar"
-      aria-valuenow={Math.round(clamped)}
+      aria-valuenow={percent}
       aria-valuemin={0}
       aria-valuemax={100}
     >

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useLiveAnnouncement } from '../../hooks/useLiveRegion';
 
 interface ToastProps {
   message: string;
@@ -18,6 +19,11 @@ const Toast: React.FC<ToastProps> = ({
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [visible, setVisible] = useState(false);
 
+  useLiveAnnouncement(visible ? message : null, {
+    politeness: 'assertive',
+    priority: 'urgent',
+  });
+
   useEffect(() => {
     setVisible(true);
     timeoutRef.current = setTimeout(() => {
@@ -30,8 +36,7 @@ const Toast: React.FC<ToastProps> = ({
 
   return (
     <div
-      role="status"
-      aria-live="polite"
+      role="alert"
       className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
       <span>{message}</span>

--- a/hooks/useLiveRegion.tsx
+++ b/hooks/useLiveRegion.tsx
@@ -1,0 +1,224 @@
+import React, {
+  PropsWithChildren,
+  createContext,
+  isValidElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+const CLEAR_DELAY = 60;
+const NEXT_DELAY = 120;
+const DEDUP_WINDOW = 750;
+
+export type PolitenessSetting = 'polite' | 'assertive';
+
+export interface AnnouncementOptions {
+  politeness?: PolitenessSetting;
+  priority?: 'normal' | 'urgent';
+}
+
+interface QueuedAnnouncement {
+  id: number;
+  message: string;
+  options?: AnnouncementOptions;
+}
+
+interface LiveRegionContextValue {
+  announce: (message: string, options?: AnnouncementOptions) => void;
+}
+
+interface LiveRegionProviderProps extends PropsWithChildren {
+  onAnnounce?: (message: string, options: AnnouncementOptions) => void;
+}
+
+const LiveRegionContext = createContext<LiveRegionContextValue | null>(null);
+const fallbackContext: LiveRegionContextValue = {
+  announce: () => undefined,
+};
+let warnedMissingProvider = false;
+
+const toAnnouncementString = (node: React.ReactNode): string => {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return '';
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node
+      .map((item) => toAnnouncementString(item))
+      .filter(Boolean)
+      .join(' ');
+  }
+  if (isValidElement(node)) {
+    return toAnnouncementString(node.props.children);
+  }
+  return '';
+};
+
+export const LiveRegionProvider: React.FC<LiveRegionProviderProps> = ({
+  children,
+  onAnnounce,
+}) => {
+  const [current, setCurrent] = useState<{
+    message: string;
+    politeness: PolitenessSetting;
+  } | null>(null);
+
+  const queueRef = useRef<QueuedAnnouncement[]>([]);
+  const idRef = useRef(0);
+  const processingRef = useRef(false);
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const nextTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastAnnouncementRef = useRef<{
+    message: string;
+    timestamp: number;
+  } | null>(null);
+
+  const flushQueue = useCallback(() => {
+    if (processingRef.current) return;
+    if (!queueRef.current.length) return;
+
+    const now = Date.now();
+    let next: QueuedAnnouncement | undefined;
+
+    while (queueRef.current.length) {
+      const candidate = queueRef.current.shift();
+      if (!candidate) break;
+      const trimmed = candidate.message.trim();
+      if (!trimmed) continue;
+
+      const last = lastAnnouncementRef.current;
+      if (last && last.message === trimmed && now - last.timestamp < DEDUP_WINDOW) {
+        continue;
+      }
+
+      next = { ...candidate, message: trimmed };
+      break;
+    }
+
+    if (!next) {
+      if (queueRef.current.length) {
+        nextTimerRef.current = setTimeout(() => {
+          nextTimerRef.current = null;
+          flushQueue();
+        }, DEDUP_WINDOW);
+      }
+      return;
+    }
+
+    processingRef.current = true;
+    lastAnnouncementRef.current = { message: next.message, timestamp: now };
+
+    if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    if (nextTimerRef.current) {
+      clearTimeout(nextTimerRef.current);
+      nextTimerRef.current = null;
+    }
+
+    setCurrent(null);
+
+    clearTimerRef.current = setTimeout(() => {
+      const politeness = next?.options?.politeness ?? 'polite';
+      setCurrent({ message: next!.message, politeness });
+      onAnnounce?.(next!.message, next!.options ?? {});
+      processingRef.current = false;
+      clearTimerRef.current = null;
+
+      nextTimerRef.current = setTimeout(() => {
+        nextTimerRef.current = null;
+        flushQueue();
+      }, NEXT_DELAY);
+    }, CLEAR_DELAY);
+  }, [onAnnounce]);
+
+  const announce = useCallback(
+    (message: string, options?: AnnouncementOptions) => {
+      const trimmed = message?.trim();
+      if (!trimmed) return;
+
+      const announcement: QueuedAnnouncement = {
+        id: idRef.current++,
+        message: trimmed,
+        options,
+      };
+
+      if (options?.priority === 'urgent') {
+        queueRef.current.unshift(announcement);
+      } else {
+        queueRef.current.push(announcement);
+      }
+
+      flushQueue();
+    },
+    [flushQueue],
+  );
+
+  useEffect(
+    () => () => {
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+      if (nextTimerRef.current) clearTimeout(nextTimerRef.current);
+      queueRef.current = [];
+      processingRef.current = false;
+    },
+    [],
+  );
+
+  const contextValue = useMemo<LiveRegionContextValue>(() => ({ announce }), [announce]);
+
+  return (
+    <LiveRegionContext.Provider value={contextValue}>
+      {children}
+      <div
+        role="status"
+        aria-live={current?.politeness ?? 'polite'}
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {current?.message ?? ''}
+      </div>
+    </LiveRegionContext.Provider>
+  );
+};
+
+export const useLiveRegion = (): LiveRegionContextValue => {
+  const ctx = useContext(LiveRegionContext);
+  if (!ctx) {
+    if (process.env.NODE_ENV !== 'production' && !warnedMissingProvider) {
+      warnedMissingProvider = true;
+      console.warn(
+        'useLiveRegion used outside LiveRegionProvider; announcements will be ignored.',
+      );
+    }
+    return fallbackContext;
+  }
+  return ctx;
+};
+
+export const useLiveAnnouncement = (
+  message: React.ReactNode | null | undefined,
+  options?: AnnouncementOptions,
+) => {
+  const { announce } = useLiveRegion();
+  const text = useMemo(
+    () => toAnnouncementString(message ?? '').replace(/\s+/g, ' ').trim(),
+    [message],
+  );
+  const lastRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!text) {
+      lastRef.current = null;
+      return;
+    }
+    if (lastRef.current === text) return;
+    lastRef.current = text;
+    announce(text, options);
+  }, [announce, options?.politeness, options?.priority, text]);
+};
+
+export default LiveRegionProvider;


### PR DESCRIPTION
## Summary
- add a live region provider with queuing, throttling, and hooks for announcing messages
- wire the global app shell plus toast, form error, and progress components through the shared live region manager
- update window keyboard handling to guard synthetic events and expand tests around the new live region behavior

## Testing
- CI=1 yarn test
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cca70f5a448328a4706aaeaaa72eb2