### PR TITLE
[a11y] add desktop landmarks semantics

### DIFF
--- a/__tests__/desktopAccessibility.test.tsx
+++ b/__tests__/desktopAccessibility.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+jest.mock('@vercel/analytics/next', () => ({ Analytics: () => null }));
+jest.mock('@vercel/speed-insights/next', () => ({ SpeedInsights: () => null }));
+jest.mock('next/dynamic', () => jest.fn(() => () => null));
+jest.mock('../hooks/useSettings', () => {
+  const actual = jest.requireActual('../hooks/useSettings');
+  const React = require('react');
+  return {
+    ...actual,
+    SettingsProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+jest.mock('../components/ui/QuickSettings', () => () => null);
+jest.mock('../components/util-components/status', () => () => null);
+jest.mock('../components/util-components/clock', () => () => null);
+jest.mock('../components/menu/WhiskerMenu', () => () => null);
+
+import MyApp from '../pages/_app.jsx';
+import Navbar from '../components/screen/navbar';
+import { Desktop } from '../components/screen/desktop';
+
+expect.extend(toHaveNoViolations);
+
+describe('Desktop shell accessibility', () => {
+  it('moves focus to the desktop main landmark when using the skip link', async () => {
+    const TestComponent = () => <main id="desktop-main" tabIndex={-1}>Main area</main>;
+    const user = userEvent.setup();
+    render(<MyApp Component={TestComponent} pageProps={{}} />);
+
+    await user.tab();
+    const skipLink = screen.getByRole('link', { name: /skip to main content/i });
+    expect(skipLink).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    const mainLandmark = screen.getByRole('main');
+    expect(mainLandmark).toHaveFocus();
+  });
+
+  it('exposes landmark structure recognised by axe', async () => {
+    const desktop = new Desktop();
+    desktop.props = { clearSession: jest.fn() } as any;
+
+    const { container } = render(
+      <>
+        <Navbar lockScreen={jest.fn()} shutDown={jest.fn()} />
+        {desktop.render()}
+      </>
+    );
+
+    expect(container.querySelector('#desktop-header')).toBeInTheDocument();
+    expect(container.querySelector('#desktop-top-nav')).toBeInTheDocument();
+    expect(container.querySelector('#desktop-main')).toBeInTheDocument();
+    expect(container.querySelector('#desktop-dock')).toBeInTheDocument();
+    expect(container.querySelector('#desktop-footer')).toBeInTheDocument();
+
+    const results = await axe(container, {
+      runOnly: {
+        type: 'rule',
+        values: ['landmark-one-main', 'landmark-unique'],
+      },
+    });
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -839,7 +839,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="New folder name" />
                 </div>
                 <div className="flex">
                     <button
@@ -865,12 +865,15 @@ export class Desktop extends Component {
 
     render() {
         return (
-            <main id="desktop" role="main" className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
+            <main
+                id="desktop-main"
+                tabIndex={-1}
+                className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}
+            >
 
                 {/* Window Area */}
                 <div
                     id="window-area"
-                    role="main"
                     className="absolute h-full w-full bg-transparent"
                     data-context="desktop-area"
                 >

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -13,35 +13,44 @@ export default class Navbar extends Component {
 		};
 	}
 
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
-                                <WhiskerMenu />
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
+        render() {
+                return (
+                        <header
+                                id="desktop-header"
+                                className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md bg-ub-grey text-ubt-grey text-sm select-none z-50"
+                        >
+                                <nav
+                                        id="desktop-top-nav"
+                                        aria-label="Global system controls"
+                                        className="flex flex-nowrap justify-between items-center"
                                 >
-                                        <Clock />
-                                </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
+                                        <div className="pl-3 pr-1">
+                                                <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
+                                        </div>
+                                        <WhiskerMenu />
+                                        <div
+                                                className={
+                                                        'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                }
+                                        >
+                                                <Clock />
+                                        </div>
+                                        <button
+                                                type="button"
+                                                id="status-bar"
+                                                aria-label="System status"
+                                                onClick={() => {
+                                                        this.setState({ status_card: !this.state.status_card });
+                                                }}
+                                                className={
+                                                        'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                                }
+                                        >
+                                                <Status />
+                                                <QuickSettings open={this.state.status_card} />
+                                        </button>
+                                </nav>
+                        </header>
+                );
+        }
 }

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -27,20 +27,27 @@ export default function SideBar(props) {
 
     return (
         <>
-            <nav
-                aria-label="Dock"
+            <aside
+                id="desktop-dock"
+                aria-label="Desktop dock"
                 className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
             >
-                {
-                    (
-                        Object.keys(props.closed_windows).length !== 0
-                            ? renderApps(props)
-                            : null
-                    )
-                }
-                <AllApps showApps={props.showAllApps} />
-            </nav>
+                <nav
+                    id="desktop-dock-nav"
+                    aria-label="Dock"
+                    className="flex flex-col justify-start items-center h-full w-full"
+                >
+                    {
+                        (
+                            Object.keys(props.closed_windows).length !== 0
+                                ? renderApps(props)
+                                : null
+                        )
+                    }
+                    <AllApps showApps={props.showAllApps} />
+                </nav>
+            </aside>
             <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-50"}></div>
         </>
     )

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -16,32 +16,37 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
-        </div>
+        <footer
+            id="desktop-footer"
+            className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40"
+        >
+            <div className="flex items-center w-full" role="toolbar" aria-label="Open applications">
+                {runningApps.map(app => (
+                    <button
+                        key={app.id}
+                        type="button"
+                        aria-label={app.title}
+                        data-context="taskbar"
+                        data-app-id={app.id}
+                        onClick={() => handleClick(app)}
+                        className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
+                            'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                        {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
+                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
+                        )}
+                    </button>
+                ))}
+            </div>
+        </footer>
     );
 }

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "fake-indexeddb": "^6.1.0",
     "fast-glob": "^3.3.3",
     "jest": "30.0.5",
+    "jest-axe": "^10.0.0",
     "jest-environment-jsdom": "30.0.5",
     "magic-string": "0.30.18",
     "node-mocks-http": "1.17.2",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -28,6 +28,14 @@ const ubuntu = Ubuntu({
 function MyApp(props) {
   const { Component, pageProps } = props;
 
+  const handleSkipToMain = (event) => {
+    const main = document.getElementById('desktop-main');
+    if (main) {
+      event.preventDefault();
+      main.focus();
+    }
+  };
+
 
   useEffect(() => {
     if (typeof window !== 'undefined' && typeof window.initA2HS === 'function') {
@@ -148,14 +156,15 @@ function MyApp(props) {
 
   return (
     <ErrorBoundary>
-      <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
         <a
-          href="#app-grid"
+          href="#desktop-main"
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+          onClick={handleSkipToMain}
         >
-          Skip to app grid
+          Skip to main content
         </a>
+        <Script src="/a2hs.js" strategy="beforeInteractive" />
         <SettingsProvider>
           <PipPortalProvider>
             <div aria-live="polite" id="live-region" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,6 +2201,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/schemas@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/schemas@npm:29.6.3"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.27.8"
+  checksum: 10c0/b329e89cd5f20b9278ae1233df74016ebf7b385e0d14b9f4c1ad18d096c4c19d1e687aa113a9c976b16ec07f021ae53dea811fb8c1248a50ac34fbe009fdf6be
+  languageName: node
+  linkType: hard
+
 "@jest/snapshot-utils@npm:30.0.5":
   version: 30.0.5
   resolution: "@jest/snapshot-utils@npm:30.0.5"
@@ -2997,6 +3006,13 @@ __metadata:
   version: 2.0.0
   resolution: "@sideway/pinpoint@npm:2.0.0"
   checksum: 10c0/d2ca75dacaf69b8fc0bb8916a204e01def3105ee44d8be16c355e5f58189eb94039e15ce831f3d544f229889ccfa35562a0ce2516179f3a7ee1bbe0b71e55b36
+  languageName: node
+  linkType: hard
+
+"@sinclair/typebox@npm:^0.27.8":
+  version: 0.27.8
+  resolution: "@sinclair/typebox@npm:0.27.8"
+  checksum: 10c0/ef6351ae073c45c2ac89494dbb3e1f87cc60a93ce4cde797b782812b6f97da0d620ae81973f104b43c9b7eaa789ad20ba4f6a1359f1cc62f63729a55a7d22d4e
   languageName: node
   linkType: hard
 
@@ -4959,6 +4975,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axe-core@npm:4.10.2":
+  version: 4.10.2
+  resolution: "axe-core@npm:4.10.2"
+  checksum: 10c0/0e20169077de96946a547fce0df39d9aeebe0077f9d3eeff4896518b96fde857f80b98f0d4279274a7178791744dd5a54bb4f322de45b4f561ffa2586ff9a09d
+  languageName: node
+  linkType: hard
+
 "axe-core@npm:^4.10.0, axe-core@npm:~4.10.3":
   version: 4.10.3
   resolution: "axe-core@npm:4.10.3"
@@ -5463,7 +5486,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
+"chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -6329,6 +6352,13 @@ __metadata:
   version: 1.2.2
   resolution: "didyoumean@npm:1.2.2"
   checksum: 10c0/95d0b53d23b851aacff56dfadb7ecfedce49da4232233baecfeecb7710248c4aa03f0aa8995062f0acafaf925adf8536bd7044a2e68316fd7d411477599bc27b
+  languageName: node
+  linkType: hard
+
+"diff-sequences@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "diff-sequences@npm:29.6.3"
+  checksum: 10c0/32e27ac7dbffdf2fb0eb5a84efd98a9ad084fbabd5ac9abb8757c6770d5320d2acd172830b28c4add29bb873d59420601dfc805ac4064330ce59b1adfd0593b2
   languageName: node
   linkType: hard
 
@@ -8654,6 +8684,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-axe@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "jest-axe@npm:10.0.0"
+  dependencies:
+    axe-core: "npm:4.10.2"
+    chalk: "npm:4.1.2"
+    jest-matcher-utils: "npm:29.2.2"
+    lodash.merge: "npm:4.6.2"
+  checksum: 10c0/0c79e4a09e120224e903542591bfadfaa2574132c73639d3c9aa2371a720799929b2f2d13a12367f2642192dd0c66daec184ea9a134c8b20061216cea6801439
+  languageName: node
+  linkType: hard
+
 "jest-changed-files@npm:30.0.5":
   version: 30.0.5
   resolution: "jest-changed-files@npm:30.0.5"
@@ -8785,6 +8827,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^29.2.1":
+  version: 29.7.0
+  resolution: "jest-diff@npm:29.7.0"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    diff-sequences: "npm:^29.6.3"
+    jest-get-type: "npm:^29.6.3"
+    pretty-format: "npm:^29.7.0"
+  checksum: 10c0/89a4a7f182590f56f526443dde69acefb1f2f0c9e59253c61d319569856c4931eae66b8a3790c443f529267a0ddba5ba80431c585deed81827032b2b2a1fc999
+  languageName: node
+  linkType: hard
+
 "jest-docblock@npm:30.0.1":
   version: 30.0.1
   resolution: "jest-docblock@npm:30.0.1"
@@ -8840,6 +8894,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-get-type@npm:^29.2.0, jest-get-type@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "jest-get-type@npm:29.6.3"
+  checksum: 10c0/552e7a97a983d3c2d4e412a44eb7de0430ff773dd99f7500962c268d6dfbfa431d7d08f919c9d960530e5f7f78eb47f267ad9b318265e5092b3ff9ede0db7c2b
+  languageName: node
+  linkType: hard
+
 "jest-haste-map@npm:30.0.5":
   version: 30.0.5
   resolution: "jest-haste-map@npm:30.0.5"
@@ -8869,6 +8930,18 @@ __metadata:
     "@jest/get-type": "npm:30.0.1"
     pretty-format: "npm:30.0.5"
   checksum: 10c0/04207ab6f44dec22d3d656b5f3b4f334440f4c01ccd21c55474f26706530244d34b8dc9922c9449e00e8649e5da1b8de4aca58c9895c9de19951d5ecdc0ff113
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:29.2.2":
+  version: 29.2.2
+  resolution: "jest-matcher-utils@npm:29.2.2"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    jest-diff: "npm:^29.2.1"
+    jest-get-type: "npm:^29.2.0"
+    pretty-format: "npm:^29.2.1"
+  checksum: 10c0/a554e683bcd18cc11e1e018597771051e88cb3bf79cdbb5896f7550bd4c787e473ba4727336db2049fea6149e21546c8f1cde4b78a76eb595199cfeaba6450b1
   languageName: node
   linkType: hard
 
@@ -9595,7 +9668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.merge@npm:^4.6.2":
+"lodash.merge@npm:4.6.2, lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: 10c0/402fa16a1edd7538de5b5903a90228aa48eb5533986ba7fa26606a49db2572bf414ff73a2c9f5d5fd36b31c46a5d5c7e1527749c07cbcf965ccff5fbdf32c506
@@ -11076,6 +11149,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^29.2.1, pretty-format@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "pretty-format@npm:29.7.0"
+  dependencies:
+    "@jest/schemas": "npm:^29.6.3"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^18.0.0"
+  checksum: 10c0/edc5ff89f51916f036c62ed433506b55446ff739358de77207e63e88a28ca2894caac6e73dcb68166a606e51c8087d32d400473e6a9fdd2dbe743f46c9c0276f
+  languageName: node
+  linkType: hard
+
 "proc-log@npm:^5.0.0":
   version: 5.0.0
   resolution: "proc-log@npm:5.0.0"
@@ -11920,7 +12004,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^18.2.0, react-is@npm:^18.3.1":
+"react-is@npm:^18.0.0, react-is@npm:^18.2.0, react-is@npm:^18.3.1":
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: 10c0/f2f1e60010c683479e74c63f96b09fb41603527cd131a9959e2aee1e5a8b0caf270b365e5ca77d4a6b18aae659b60a86150bb3979073528877029b35aecd2072
@@ -13918,6 +14002,7 @@ __metadata:
     idb: "npm:7.1.1"
     idb-keyval: "npm:^6.2.1"
     jest: "npm:30.0.5"
+    jest-axe: "npm:^10.0.0"
     jest-environment-jsdom: "npm:30.0.5"
     jspdf: "npm:^3.0.2"
     kaitai-struct: "npm:^0.10.0"


### PR DESCRIPTION
## Summary
- replace the desktop shell wrappers with semantic header, nav, main, aside, and footer landmarks that carry stable IDs
- retarget the global skip link to the desktop main region and focus it when activated
- add jest-axe powered accessibility tests and supporting dependency updates to cover skip link focus and landmark detection

## Testing
- yarn lint *(fails: existing repository lint violations unrelated to this change)*
- yarn test desktopAccessibility

------
https://chatgpt.com/codex/tasks/task_e_68cca70f90f48328b38d85ae1e290a99