### PR TITLE
[wizard] add reusable controller and tests

### DIFF
--- a/__tests__/hooks/useWizardController.test.tsx
+++ b/__tests__/hooks/useWizardController.test.tsx
@@ -1,0 +1,127 @@
+import React, { useMemo } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import useWizardController from '../../hooks/useWizardController';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+type RouterMock = {
+  pathname: string;
+  query: Record<string, any>;
+  isReady: boolean;
+  replace: jest.Mock;
+};
+
+const createRouterMock = (initialQuery: Record<string, string> = {}): RouterMock => {
+  const router: RouterMock = {
+    pathname: '/hydra-preview',
+    query: { ...initialQuery },
+    isReady: true,
+    replace: jest.fn().mockImplementation((url) => {
+      if (typeof url !== 'string' && url?.query) {
+        router.query = { ...url.query };
+      }
+      return Promise.resolve(true);
+    }),
+  };
+  return router;
+};
+
+type WizardData = {
+  target: string;
+  protocol: string;
+  wordlist: string;
+};
+
+const HydraWizardHarness: React.FC<{ initialTarget: string }> = ({ initialTarget }) => {
+  const config = useMemo(
+    () => ({
+      paramName: 'step',
+      steps: [
+        {
+          id: 'target',
+          initialData: initialTarget,
+          validate: ({ data }: { data: string }) => (data && data.trim() ? null : 'Target is required'),
+        },
+        {
+          id: 'protocol',
+          initialData: 'ssh',
+          validate: ({ data }: { data: string }) => (data ? null : 'Protocol is required'),
+        },
+        {
+          id: 'wordlist',
+          initialData: '/tmp/list.txt',
+          validate: ({ data }: { data: string }) => (data && data.trim() ? null : 'Wordlist is required'),
+        },
+        { id: 'review' },
+      ],
+    }),
+    [initialTarget],
+  );
+
+  const wizard = useWizardController<WizardData>(config);
+
+  return (
+    <div>
+      <div data-testid="current-step">{wizard.currentStepId}</div>
+      <div data-testid="error">{wizard.stepErrors[wizard.currentStepId] ?? ''}</div>
+      <button type="button" onClick={() => wizard.goToStep('review')} data-testid="jump">
+        Jump to review
+      </button>
+    </div>
+  );
+};
+
+const useRouterMock = useRouter as jest.Mock;
+
+describe('useWizardController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deep links to the requested step when prerequisites are satisfied', async () => {
+    const router = createRouterMock({ step: 'review' });
+    useRouterMock.mockReturnValue(router);
+
+    render(<HydraWizardHarness initialTarget="example.com" />);
+
+    await waitFor(() => expect(screen.getByTestId('current-step')).toHaveTextContent('review'));
+    expect(screen.getByTestId('error')).toHaveTextContent('');
+    expect(router.query.step).toBe('review');
+  });
+
+  it('falls back to the first invalid step when deep linking past missing inputs', async () => {
+    const router = createRouterMock({ step: 'review' });
+    useRouterMock.mockReturnValue(router);
+
+    render(<HydraWizardHarness initialTarget="" />);
+
+    await waitFor(() => expect(screen.getByTestId('current-step')).toHaveTextContent('target'));
+    expect(screen.getByTestId('error')).toHaveTextContent('Target is required');
+    expect(router.query.step).toBe('target');
+    const replaceCalls = router.replace.mock.calls as Array<[
+      Record<string, any>,
+      unknown,
+      Record<string, unknown>
+    ]>;
+    const hasFallback = replaceCalls.some(([url]) => typeof url !== 'string' && url?.query?.step === 'target');
+    expect(hasFallback).toBe(true);
+  });
+
+  it('prevents manual navigation beyond invalid steps', async () => {
+    const router = createRouterMock();
+    useRouterMock.mockReturnValue(router);
+
+    render(<HydraWizardHarness initialTarget="" />);
+
+    await waitFor(() => expect(screen.getByTestId('current-step')).toHaveTextContent('target'));
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('jump'));
+
+    expect(screen.getByTestId('current-step')).toHaveTextContent('target');
+    expect(screen.getByTestId('error')).toHaveTextContent('Target is required');
+  });
+});

--- a/hooks/useWizardController.ts
+++ b/hooks/useWizardController.ts
@@ -1,0 +1,300 @@
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export interface WizardValidationContext<Data, AllData extends Record<string, unknown>> {
+  data: Data;
+  allData: AllData;
+}
+
+export type WizardValidator<Data, AllData extends Record<string, unknown>> = (
+  context: WizardValidationContext<Data, AllData>,
+) => string | null | undefined;
+
+export interface WizardStepConfig<Data = unknown, AllData extends Record<string, unknown> = Record<string, unknown>> {
+  id: string;
+  initialData?: Data;
+  validate?: WizardValidator<Data, AllData>;
+}
+
+export interface WizardController<AllData extends Record<string, unknown>> {
+  currentStepId: string;
+  currentStepIndex: number;
+  stepOrder: string[];
+  stepData: AllData;
+  stepErrors: Record<string, string>;
+  goToStep: (stepId: string, options?: { force?: boolean }) => boolean;
+  goNext: () => boolean;
+  goBack: () => boolean;
+  updateStepData: <Key extends keyof AllData>(
+    stepId: Key,
+    value: AllData[Key] | ((previous: AllData[Key]) => AllData[Key]),
+  ) => void;
+  resetTo: (stepId?: string) => void;
+  isFirst: boolean;
+  isLast: boolean;
+}
+
+export interface UseWizardControllerOptions<AllData extends Record<string, unknown>> {
+  steps: WizardStepConfig<any, AllData>[];
+  paramName?: string;
+  defaultStepId?: string;
+}
+
+const getQueryValue = (value: string | string[] | undefined): string | undefined => {
+  if (Array.isArray(value)) {
+    return value[value.length - 1];
+  }
+  return value;
+};
+
+function useWizardController<AllData extends Record<string, unknown>>(
+  options: UseWizardControllerOptions<AllData>,
+): WizardController<AllData> {
+  const { steps, paramName = 'step', defaultStepId } = options;
+  const router = useRouter();
+
+  const stepOrder = useMemo(() => steps.map((step) => step.id), [steps]);
+
+  const initialData = useMemo(() => {
+    const seed = {} as AllData;
+    for (const step of steps) {
+      const value = step.initialData as AllData[keyof AllData] | undefined;
+      if (value !== undefined) {
+        seed[step.id as keyof AllData] = value;
+      }
+    }
+    return seed;
+  }, [steps]);
+
+  const [stepData, setStepData] = useState<AllData>(initialData);
+  const [currentStepId, setCurrentStepId] = useState<string>(() => {
+    if (defaultStepId && stepOrder.includes(defaultStepId)) {
+      return defaultStepId;
+    }
+    return stepOrder[0] ?? '';
+  });
+  const [stepErrors, setStepErrors] = useState<Record<string, string>>({});
+
+  const stepDataRef = useRef(stepData);
+  const currentStepIdRef = useRef(currentStepId);
+  const initialDataRef = useRef(initialData);
+  const hasHydratedFromUrl = useRef(false);
+
+  useEffect(() => {
+    stepDataRef.current = stepData;
+  }, [stepData]);
+
+  useEffect(() => {
+    currentStepIdRef.current = currentStepId;
+  }, [currentStepId]);
+
+  useEffect(() => {
+    initialDataRef.current = initialData;
+  }, [initialData]);
+
+  const validateStep = useCallback(
+    (index: number): string | null => {
+      if (index < 0 || index >= steps.length) {
+        return null;
+      }
+      const config = steps[index];
+      const validator = config.validate as WizardValidator<unknown, AllData> | undefined;
+      if (!validator) {
+        setStepErrors((prev) => {
+          if (prev[config.id] == null) {
+            return prev;
+          }
+          const next = { ...prev };
+          delete next[config.id];
+          return next;
+        });
+        return null;
+      }
+
+      const value = stepDataRef.current[config.id as keyof AllData];
+      const result = validator({
+        data: value,
+        allData: stepDataRef.current,
+      } as WizardValidationContext<unknown, AllData>);
+
+      const normalized = result ?? null;
+      setStepErrors((prev) => {
+        if (normalized == null) {
+          if (prev[config.id] == null) {
+            return prev;
+          }
+          const next = { ...prev };
+          delete next[config.id];
+          return next;
+        }
+        if (prev[config.id] === normalized) {
+          return prev;
+        }
+        return { ...prev, [config.id]: normalized };
+      });
+      return normalized;
+    },
+    [steps],
+  );
+
+  const validateStepsBefore = useCallback(
+    (targetIndex: number): { index: number; error: string } | null => {
+      for (let i = 0; i < targetIndex; i += 1) {
+        const error = validateStep(i);
+        if (error) {
+          return { index: i, error };
+        }
+      }
+      return null;
+    },
+    [validateStep],
+  );
+
+  const goToIndex = useCallback(
+    (targetIndex: number, options?: { force?: boolean }) => {
+      if (targetIndex < 0 || targetIndex >= stepOrder.length) {
+        return false;
+      }
+      const { force = false } = options ?? {};
+      const currentIndex = stepOrder.indexOf(currentStepIdRef.current);
+
+      if (!force && targetIndex > currentIndex) {
+        const invalid = validateStepsBefore(targetIndex);
+        if (invalid) {
+          setCurrentStepId(stepOrder[invalid.index]);
+          return false;
+        }
+      }
+
+      const nextId = stepOrder[targetIndex];
+      if (!nextId) {
+        return false;
+      }
+      setCurrentStepId(nextId);
+      return true;
+    },
+    [stepOrder, validateStepsBefore],
+  );
+
+  const goToStep = useCallback(
+    (stepId: string, options?: { force?: boolean }) => {
+      const targetIndex = stepOrder.indexOf(stepId);
+      if (targetIndex === -1) {
+        return false;
+      }
+      return goToIndex(targetIndex, options);
+    },
+    [goToIndex, stepOrder],
+  );
+
+  const goNext = useCallback(() => {
+    const currentIndex = stepOrder.indexOf(currentStepIdRef.current);
+    if (currentIndex === -1 || currentIndex >= stepOrder.length - 1) {
+      return false;
+    }
+    return goToIndex(currentIndex + 1);
+  }, [goToIndex, stepOrder]);
+
+  const goBack = useCallback(() => {
+    const currentIndex = stepOrder.indexOf(currentStepIdRef.current);
+    if (currentIndex <= 0) {
+      return false;
+    }
+    return goToIndex(currentIndex - 1, { force: true });
+  }, [goToIndex, stepOrder]);
+
+  const updateStepData = useCallback(
+    <Key extends keyof AllData>(
+      stepId: Key,
+      value: AllData[Key] | ((previous: AllData[Key]) => AllData[Key]),
+    ) => {
+      setStepData((prev) => {
+        const previousValue = prev[stepId];
+        const nextValue = typeof value === 'function' ? (value as (prev: AllData[Key]) => AllData[Key])(previousValue) : value;
+        if (previousValue === nextValue) {
+          return prev;
+        }
+        const next = { ...prev, [stepId]: nextValue };
+        return next;
+      });
+      setStepErrors((prev) => {
+        if (prev[String(stepId)] == null) {
+          return prev;
+        }
+        const next = { ...prev };
+        delete next[String(stepId)];
+        return next;
+      });
+    },
+    [],
+  );
+
+  const resetTo = useCallback(
+    (stepId?: string) => {
+      setStepData(initialDataRef.current);
+      setStepErrors({});
+      const fallbackId = stepId && stepOrder.includes(stepId) ? stepId : stepOrder[0];
+      if (fallbackId) {
+        setCurrentStepId(fallbackId);
+      }
+    },
+    [stepOrder],
+  );
+
+  useEffect(() => {
+    if (!router.isReady || hasHydratedFromUrl.current) {
+      return;
+    }
+    hasHydratedFromUrl.current = true;
+
+    const requested = getQueryValue(router.query[paramName]);
+    if (requested && stepOrder.includes(requested)) {
+      const requestedIndex = stepOrder.indexOf(requested);
+      const invalid = validateStepsBefore(requestedIndex);
+      if (invalid) {
+        setCurrentStepId(stepOrder[invalid.index]);
+        return;
+      }
+      setCurrentStepId(requested);
+    }
+  }, [paramName, router.isReady, router.query, stepOrder, validateStepsBefore]);
+
+  useEffect(() => {
+    if (!router.isReady || !currentStepId) {
+      return;
+    }
+    const currentQueryValue = getQueryValue(router.query[paramName]);
+    if (currentQueryValue === currentStepId) {
+      return;
+    }
+    router.replace(
+      {
+        pathname: router.pathname,
+        query: { ...router.query, [paramName]: currentStepId },
+      },
+      undefined,
+      { shallow: true },
+    );
+  }, [currentStepId, paramName, router]);
+
+  const currentStepIndex = stepOrder.indexOf(currentStepId);
+  const isFirst = currentStepIndex <= 0;
+  const isLast = currentStepIndex === stepOrder.length - 1;
+
+  return {
+    currentStepId,
+    currentStepIndex,
+    stepOrder,
+    stepData,
+    stepErrors,
+    goToStep,
+    goNext,
+    goBack,
+    updateStepData,
+    resetTo,
+    isFirst,
+    isLast,
+  };
+}
+
+export default useWizardController;

--- a/pages/wps-attack.tsx
+++ b/pages/wps-attack.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useMemo } from 'react';
 import Meta from '../components/SEO/Meta';
+import useWizardController from '../hooks/useWizardController';
 
 interface Step {
   title: string;
@@ -38,8 +39,16 @@ Connection established to ExampleAP`,
 ];
 
 const WpsAttack = () => {
-  const [current, setCurrent] = useState(0);
-  const step = steps[current];
+  const wizard = useWizardController<Record<string, never>>(
+    useMemo(
+      () => ({
+        paramName: 'step',
+        steps: steps.map((_, index) => ({ id: `phase-${index}` })),
+      }),
+      [],
+    ),
+  );
+  const step = steps[wizard.currentStepIndex] ?? steps[0];
 
   return (
     <>
@@ -51,11 +60,11 @@ const WpsAttack = () => {
             <li
               key={s.title}
               className={`p-4 rounded border ${
-                idx === current ? 'bg-black border-green-400' : 'bg-ub-grey border-gray-600'
+                idx === wizard.currentStepIndex ? 'bg-black border-green-400' : 'bg-ub-grey border-gray-600'
               }`}
             >
               <div className="font-bold">{`Step ${idx + 1}: ${s.title}`}</div>
-              {idx === current && (
+              {idx === wizard.currentStepIndex && (
                 <pre className="bg-ub-black text-green-400 p-2 mt-2 text-sm overflow-auto whitespace-pre-wrap">
 {`$ ${s.command}
 ${s.output}`}
@@ -67,15 +76,15 @@ ${s.output}`}
         <div className="flex justify-between mt-4">
           <button
             className="px-4 py-2 bg-gray-700 rounded disabled:opacity-50"
-            onClick={() => setCurrent((c) => Math.max(c - 1, 0))}
-            disabled={current === 0}
+            onClick={wizard.goBack}
+            disabled={wizard.isFirst}
           >
             Previous
           </button>
           <button
             className="px-4 py-2 bg-ub-green text-black rounded disabled:opacity-50"
-            onClick={() => setCurrent((c) => Math.min(c + 1, steps.length - 1))}
-            disabled={current === steps.length - 1}
+            onClick={wizard.goNext}
+            disabled={wizard.isLast}
           >
             Next
           </button>


### PR DESCRIPTION
## Summary
- add a reusable wizard controller hook that persists step data, validates prerequisites, and syncs the active step with the URL
- refactor hydra preview and wps attack flows to use the shared controller and gate forward navigation on passing validation
- cover deep-link routing and skip-prevention behaviour with focused wizard controller tests

## Testing
- yarn lint *(fails: repository contains pre-existing accessibility and window globals lint violations)*
- yarn test __tests__/hooks/useWizardController.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cca71072448328ac47ca7707c1da4c