### PR TITLE
feat(forms): add draft autosave hook

### DIFF
--- a/__tests__/draftAutosaveForms.test.tsx
+++ b/__tests__/draftAutosaveForms.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import ContactApp from '@/apps/contact';
+import DummyForm from '@/pages/dummy-form';
+import HydraPreview from '@/pages/hydra-preview';
+
+const dummyKey = 'dummy-form-draft';
+const contactKey = 'contact-draft';
+const hydraKey = 'hydra-preview-draft';
+
+describe('draft autosave forms', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('restores and clears dummy form draft', () => {
+    const payload = {
+      data: { name: 'Jane', email: 'jane@example.com', message: 'Hello' },
+      savedAt: Date.now(),
+    };
+    window.localStorage.setItem(dummyKey, JSON.stringify(payload));
+
+    render(<DummyForm />);
+
+    expect(screen.getByDisplayValue('Jane')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('jane@example.com')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Hello')).toBeInTheDocument();
+    expect(screen.getByText(/Saved|Recovered draft/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /clear draft/i }));
+
+    expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('');
+    expect((screen.getByLabelText('Email') as HTMLInputElement).value).toBe('');
+    expect((screen.getByLabelText('Message') as HTMLTextAreaElement).value).toBe('');
+    expect(window.localStorage.getItem(dummyKey)).toBeNull();
+  });
+
+  it('debounces dummy form updates to storage', () => {
+    render(<DummyForm />);
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'Draft User' },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(2100);
+    });
+
+    const stored = window.localStorage.getItem(dummyKey);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored!);
+    expect(parsed.data.name).toBe('Draft User');
+  });
+
+  it('restores and clears hydra wizard draft', () => {
+    const payload = {
+      data: {
+        step: 2,
+        target: 'example.com',
+        protocol: 'ftp',
+        wordlist: '/tmp/wordlist.txt',
+      },
+      savedAt: Date.now(),
+    };
+    window.localStorage.setItem(hydraKey, JSON.stringify(payload));
+
+    render(<HydraPreview />);
+
+    expect(screen.getByDisplayValue('/tmp/wordlist.txt')).toBeInTheDocument();
+    expect(screen.getByText(/Saved|Recovered draft/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Wordlist Path')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+
+    expect(screen.getByDisplayValue('example.com')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /clear draft/i }));
+
+    expect(window.localStorage.getItem(hydraKey)).toBeNull();
+    expect(screen.getByLabelText('Target Host')).toBeInTheDocument();
+    expect((screen.getByLabelText('Target Host') as HTMLInputElement).value).toBe('');
+  });
+
+  it('restores and clears contact form draft', () => {
+    const payload = {
+      data: { name: 'Alex', email: 'alex@example.com', message: 'Ping' },
+      savedAt: Date.now(),
+    };
+    window.localStorage.setItem(contactKey, JSON.stringify(payload));
+
+    render(<ContactApp />);
+
+    expect(screen.getByDisplayValue('Alex')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('alex@example.com')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Ping')).toBeInTheDocument();
+    expect(screen.getByText(/Saved|Recovered draft/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /clear draft/i })[0]);
+
+    expect(window.localStorage.getItem(contactKey)).toBeNull();
+    expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('');
+    expect((screen.getByLabelText('Email') as HTMLInputElement).value).toBe('');
+    expect((screen.getByLabelText('Message') as HTMLTextAreaElement).value).toBe('');
+  });
+});
+

--- a/hooks/useDraftAutosave.ts
+++ b/hooks/useDraftAutosave.ts
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+interface DraftPayload<T> {
+  data: T;
+  savedAt: number;
+}
+
+type IsEmpty<T> = (snapshot: T) => boolean;
+
+const defaultIsEmpty = <T,>(snapshot: T) => {
+  if (snapshot == null) return true;
+  if (typeof snapshot !== 'object') {
+    return snapshot === '' || snapshot === null;
+  }
+  return !Object.values(snapshot as Record<string, unknown>).some((value) => {
+    if (typeof value === 'string') {
+      return value.trim().length > 0;
+    }
+    if (Array.isArray(value)) {
+      return value.length > 0;
+    }
+    if (value && typeof value === 'object') {
+      return Object.keys(value).length > 0;
+    }
+    return Boolean(value);
+  });
+};
+
+const formatSavedMessage = (timestamp: number) => {
+  try {
+    const formatter = new Intl.DateTimeFormat(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+    return `Saved ${formatter.format(new Date(timestamp))}`;
+  } catch {
+    return 'Saved';
+  }
+};
+
+export interface UseDraftAutosaveOptions<T> {
+  storageKey: string;
+  snapshot: T;
+  debounceMs?: number;
+  isEmpty?: IsEmpty<T>;
+}
+
+export interface UseDraftAutosaveResult<T> {
+  draft: T | null;
+  lastSavedAt: number | null;
+  statusMessage: string;
+  recovered: boolean;
+  isHydrated: boolean;
+  clearDraft: () => void;
+}
+
+const useDraftAutosave = <T,>(
+  options: UseDraftAutosaveOptions<T>
+): UseDraftAutosaveResult<T> => {
+  const { storageKey, snapshot, debounceMs = 2000, isEmpty } = options;
+
+  const isEmptyRef = useRef<IsEmpty<T>>(isEmpty ?? defaultIsEmpty);
+  isEmptyRef.current = isEmpty ?? defaultIsEmpty;
+
+  const [draft, setDraft] = useState<T | null>(null);
+  const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
+  const [statusMessage, setStatusMessage] = useState('');
+  const [recovered, setRecovered] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
+
+  const timeoutRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+  const previousSnapshotRef = useRef<string | null>(null);
+
+  const clearDraft = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.removeItem(storageKey);
+    } catch {
+      /* ignore */
+    }
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setDraft(null);
+    setLastSavedAt(null);
+    setStatusMessage('');
+    setRecovered(false);
+    previousSnapshotRef.current = JSON.stringify(snapshot);
+  }, [storageKey, snapshot]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (raw) {
+        const parsed = JSON.parse(raw) as DraftPayload<T> | (T & {
+          savedAt?: number;
+        });
+        const payload = (parsed as DraftPayload<T>).data
+          ? (parsed as DraftPayload<T>)
+          : { data: parsed as T, savedAt: (parsed as any).savedAt };
+        setDraft(payload.data);
+        const hasContent = !isEmptyRef.current(payload.data);
+        setRecovered(hasContent);
+        if (payload.savedAt) {
+          setLastSavedAt(payload.savedAt);
+          setStatusMessage(formatSavedMessage(payload.savedAt));
+        } else if (hasContent) {
+          setStatusMessage('Saved earlier');
+        }
+        previousSnapshotRef.current = JSON.stringify(payload.data);
+      }
+    } catch {
+      /* ignore */
+    }
+    setHydrated(true);
+  }, [storageKey]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !hydrated) return;
+    const serialized = JSON.stringify(snapshot);
+    if (previousSnapshotRef.current === serialized) {
+      return;
+    }
+    const shouldStore = !isEmptyRef.current(snapshot);
+
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
+    timeoutRef.current = window.setTimeout(() => {
+      try {
+        if (shouldStore) {
+          const payload: DraftPayload<T> = {
+            data: snapshot,
+            savedAt: Date.now(),
+          };
+          window.localStorage.setItem(storageKey, JSON.stringify(payload));
+          setLastSavedAt(payload.savedAt);
+          setStatusMessage(formatSavedMessage(payload.savedAt));
+          setRecovered((prev) => prev || !isEmptyRef.current(snapshot));
+        } else {
+          window.localStorage.removeItem(storageKey);
+          setLastSavedAt(null);
+          setStatusMessage('');
+          setRecovered(false);
+        }
+        previousSnapshotRef.current = serialized;
+      } catch {
+        /* ignore */
+      }
+    }, debounceMs);
+
+    return () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, [snapshot, debounceMs, hydrated, storageKey]);
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    },
+    []
+  );
+
+  const result = useMemo(
+    () => ({
+      draft,
+      lastSavedAt,
+      statusMessage,
+      recovered,
+      isHydrated: hydrated,
+      clearDraft,
+    }),
+    [draft, lastSavedAt, statusMessage, recovered, hydrated, clearDraft]
+  );
+
+  return result;
+};
+
+export default useDraftAutosave;
+

--- a/pages/dummy-form.tsx
+++ b/pages/dummy-form.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import FormError from '../components/ui/FormError';
+import useDraftAutosave from '@/hooks/useDraftAutosave';
 
 const STORAGE_KEY = 'dummy-form-draft';
 
@@ -11,49 +12,18 @@ const DummyForm: React.FC = () => {
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
-  const [recovered, setRecovered] = useState(false);
+  const { draft, statusMessage, clearDraft, recovered } = useDraftAutosave({
+    storageKey: STORAGE_KEY,
+    snapshot: { name, email, message },
+    isEmpty: (data) => !data.name.trim() && !data.email.trim() && !data.message.trim(),
+  });
 
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    try {
-      const raw = window.localStorage.getItem(STORAGE_KEY);
-      if (raw) {
-        const stored = JSON.parse(raw) as {
-          name?: string;
-          email?: string;
-          message?: string;
-        };
-        if (stored.name || stored.email || stored.message) {
-          setName(stored.name || '');
-          setEmail(stored.email || '');
-          setMessage(stored.message || '');
-          setRecovered(true);
-        }
-      }
-    } catch {
-      // ignore parsing errors
-    }
-  }, []);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const handle = setTimeout(() => {
-      const hasContent = name || email || message;
-      try {
-        if (hasContent) {
-          window.localStorage.setItem(
-            STORAGE_KEY,
-            JSON.stringify({ name, email, message }),
-          );
-        } else {
-          window.localStorage.removeItem(STORAGE_KEY);
-        }
-      } catch {
-        // ignore write errors
-      }
-    }, 500);
-    return () => clearTimeout(handle);
-  }, [name, email, message]);
+    if (!draft) return;
+    setName(draft.name || '');
+    setEmail(draft.email || '');
+    setMessage(draft.message || '');
+  }, [draft]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -78,18 +48,33 @@ const DummyForm: React.FC = () => {
       });
     }
     setSuccess(true);
-    window.localStorage.removeItem(STORAGE_KEY);
+    clearDraft();
     setName('');
     setEmail('');
     setMessage('');
-    setRecovered(false);
   };
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100">
       <form onSubmit={handleSubmit} className="w-full max-w-md rounded bg-white p-6 shadow-md">
         <h1 className="mb-4 text-xl font-bold">Contact Us</h1>
-        {recovered && <p className="mb-4 text-sm text-blue-600">Recovered draft</p>}
+        {(statusMessage || recovered) && (
+          <div className="mb-4 flex flex-wrap items-center gap-2 text-xs text-gray-600">
+            <span>{statusMessage || 'Recovered draft'}</span>
+            <button
+              type="button"
+              onClick={() => {
+                setName('');
+                setEmail('');
+                setMessage('');
+                clearDraft();
+              }}
+              className="rounded border border-gray-300 px-2 py-1 text-gray-600 hover:border-gray-400 hover:text-gray-800"
+            >
+              Clear draft
+            </button>
+          </div>
+        )}
         {error && <FormError className="mb-4 mt-0">{error}</FormError>}
         {success && <p className="mb-4 text-sm text-green-600">Form submitted successfully!</p>}
         <label className="mb-2 block text-sm font-medium" htmlFor="name">Name</label>


### PR DESCRIPTION
## Summary
- add a shared `useDraftAutosave` hook that debounces localStorage writes and reports save timestamps
- surface draft recovery indicators and clear controls on the contact app, dummy form, and hydra wizard
- cover autosave recovery, clearing, and debounce behaviour with new regression tests

## Testing
- `yarn lint` *(fails: repository has pre-existing accessibility lint violations outside the change scope)*
- `yarn test --runTestsByPath __tests__/draftAutosaveForms.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68cca71142c883289e1bee0d212b8c3c