### PR TITLE
[hooks] add shared form submission guard

### DIFF
--- a/__tests__/useFormSubmission.test.tsx
+++ b/__tests__/useFormSubmission.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import useFormSubmission from '../hooks/useFormSubmission';
+
+type Deferred = {
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+const createDeferred = (): Deferred => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+const TestForm: React.FC<{ onSubmit: () => Promise<void> }> = ({ onSubmit }) => {
+  const { pending, handleSubmit, submitProps } = useFormSubmission<React.FormEvent<HTMLFormElement>>({
+    onSubmit: async (event) => {
+      event.preventDefault();
+      await onSubmit();
+    },
+  });
+
+  return (
+    <form onSubmit={handleSubmit} data-testid="form">
+      <button type="submit" {...submitProps}>
+        {pending ? 'Pending' : 'Submit'}
+      </button>
+    </form>
+  );
+};
+
+describe('useFormSubmission', () => {
+  it('ignores duplicate submits while pending and re-enables afterward', async () => {
+    const first = createDeferred();
+    const second = createDeferred();
+    const submit = jest
+      .fn<Promise<void>, []>()
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise);
+
+    render(<TestForm onSubmit={submit} />);
+
+    const form = screen.getByTestId('form');
+    const button = screen.getByRole('button');
+
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(button).toBeDisabled();
+
+    first.resolve();
+    await waitFor(() => expect(button).not.toBeDisabled());
+
+    fireEvent.submit(form);
+    expect(submit).toHaveBeenCalledTimes(2);
+
+    second.resolve();
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
+});

--- a/hooks/useFormSubmission.tsx
+++ b/hooks/useFormSubmission.tsx
@@ -1,0 +1,138 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { SyntheticEvent } from 'react';
+
+export type FormSubmissionStatus = 'success' | 'error';
+
+export interface FormSubmissionResult {
+  status?: FormSubmissionStatus;
+  message?: string;
+  suppressToast?: boolean;
+}
+
+type MaybeSubmissionResult = FormSubmissionResult | string | void | null;
+
+interface FormToast {
+  status: FormSubmissionStatus;
+  message: string;
+}
+
+interface UseFormSubmissionOptions<TEvent extends SyntheticEvent> {
+  onSubmit: (event: TEvent) => Promise<MaybeSubmissionResult> | MaybeSubmissionResult;
+  onSuccess?: (result?: FormSubmissionResult) => void;
+  onError?: (error: unknown) => void;
+  successMessage?: string | ((result?: FormSubmissionResult) => string | undefined);
+  errorMessage?: string | ((error: unknown) => string | undefined);
+}
+
+const normalizeResult = (
+  value: MaybeSubmissionResult,
+): FormSubmissionResult | undefined => {
+  if (!value) return undefined;
+  if (typeof value === 'string') {
+    return { status: 'success', message: value };
+  }
+  if (typeof value === 'object') {
+    return value as FormSubmissionResult;
+  }
+  return undefined;
+};
+
+const defaultSpinner = (
+  <span className="inline-flex items-center gap-2">
+    <span
+      className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+      aria-hidden="true"
+    />
+    <span className="sr-only">Submitting…</span>
+  </span>
+);
+
+export function useFormSubmission<TEvent extends SyntheticEvent>(
+  options: UseFormSubmissionOptions<TEvent>,
+) {
+  const { onSubmit, onSuccess, onError, successMessage, errorMessage } = options;
+  const [pending, setPending] = useState(false);
+  const [toast, setToast] = useState<FormToast | null>(null);
+  const pendingRef = useRef(false);
+
+  const spinner = useMemo(() => defaultSpinner, []);
+
+  const dismissToast = useCallback(() => setToast(null), []);
+
+  const submitProps = useMemo(
+    () => ({
+      disabled: pending,
+      'aria-disabled': pending || undefined,
+    }),
+    [pending],
+  );
+
+  const handleSubmit = useCallback(
+    async (event: TEvent) => {
+      if (pendingRef.current) {
+        event.preventDefault?.();
+        event.stopPropagation?.();
+        return;
+      }
+      pendingRef.current = true;
+      setPending(true);
+      setToast(null);
+      try {
+        const rawResult = await onSubmit(event);
+        const normalized = normalizeResult(rawResult);
+        const status: FormSubmissionStatus = normalized?.status ?? 'success';
+        const suppressToast = normalized?.suppressToast;
+
+        if (status === 'error') {
+          if (!suppressToast) {
+            const message =
+              normalized?.message ??
+              (typeof errorMessage === 'function'
+                ? errorMessage(normalized)
+                : errorMessage);
+            if (message) {
+              setToast({ status: 'error', message });
+            }
+          }
+          return;
+        }
+
+        onSuccess?.(normalized);
+        if (!suppressToast) {
+          const message =
+            normalized?.message ??
+            (typeof successMessage === 'function'
+              ? successMessage(normalized)
+              : successMessage);
+          if (message) {
+            setToast({ status: 'success', message });
+          }
+        }
+      } catch (error) {
+        onError?.(error);
+        const message =
+          typeof errorMessage === 'function'
+            ? errorMessage(error)
+            : errorMessage ?? (error instanceof Error ? error.message : 'Submission failed');
+        if (message) {
+          setToast({ status: 'error', message });
+        }
+      } finally {
+        pendingRef.current = false;
+        setPending(false);
+      }
+    },
+    [errorMessage, onError, onSubmit, onSuccess, successMessage],
+  );
+
+  return {
+    pending,
+    handleSubmit,
+    spinner,
+    toast,
+    dismissToast,
+    submitProps,
+  };
+}
+
+export default useFormSubmission;


### PR DESCRIPTION
## Summary
- add a reusable `useFormSubmission` hook that centralizes pending state, toast messaging, and spinner rendering
- wire the dummy form, input hub, and Nessus login to the shared hook so double-submits are blocked and feedback is consistent
- add a focused unit test proving the hook ignores rapid duplicate submissions

## Testing
- yarn lint *(fails: repository has pre-existing accessibility and window/document lint errors)*
- yarn test *(fails: existing suites expect global DOM access and unwrapped act usage)*
- CI=1 yarn test --runTestsByPath __tests__/useFormSubmission.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cca711dfd88328891be846d32f1652