### PR TITLE
[ui] add form primitives with shared accessibility tests

### DIFF
--- a/__tests__/ui-primitives.test.tsx
+++ b/__tests__/ui-primitives.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Checkbox from '../components/ui/Checkbox';
+import Input from '../components/ui/Input';
+import Radio from '../components/ui/Radio';
+import Select from '../components/ui/Select';
+import Switch from '../components/ui/Switch';
+import Textarea from '../components/ui/Textarea';
+
+describe('UI primitives', () => {
+  it('focuses the input when its label is clicked', async () => {
+    const user = userEvent.setup();
+    render(<Input id="name" label="Name" />);
+
+    await user.click(screen.getByText('Name'));
+
+    expect(screen.getByLabelText('Name')).toHaveFocus();
+  });
+
+  it('respects tab order across fields', async () => {
+    const user = userEvent.setup();
+    render(
+      <form>
+        <Input id="first" label="First" />
+        <Select id="second" label="Second" defaultValue="">
+          <option value="" disabled>
+            Select
+          </option>
+          <option value="one">One</option>
+        </Select>
+        <Textarea id="third" label="Third" />
+        <Checkbox id="fourth" label="Fourth" />
+        <Radio id="fifth" name="group" label="Fifth" />
+        <Switch id="sixth" label="Sixth" />
+      </form>,
+    );
+
+    await user.tab();
+    expect(screen.getByLabelText('First')).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByLabelText('Second')).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByLabelText('Third')).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByLabelText('Fourth')).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByLabelText('Fifth')).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByLabelText('Sixth')).toHaveFocus();
+  });
+
+  it('merges helper, error, and external aria descriptions', () => {
+    render(
+      <Input
+        id="email"
+        label="Email"
+        helperText="We never share your email."
+        errorText="Enter a valid email."
+        aria-describedby="external-note"
+      />,
+    );
+
+    const field = screen.getByLabelText('Email');
+
+    expect(field).toHaveAttribute('aria-invalid', 'true');
+    const describedBy = field.getAttribute('aria-describedby') ?? '';
+    expect(describedBy.split(' ')).toEqual(
+      expect.arrayContaining(['external-note', 'email-error', 'email-helper']),
+    );
+    expect(screen.getByText('Enter a valid email.')).toBeInTheDocument();
+    expect(screen.getByText('We never share your email.')).toBeInTheDocument();
+  });
+});

--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -2,6 +2,8 @@
 
 import React, { useEffect, useState } from "react";
 import FormError from "../../components/ui/FormError";
+import Input from "../../components/ui/Input";
+import Textarea from "../../components/ui/Textarea";
 import Toast from "../../components/ui/Toast";
 import { processContactForm } from "../../components/apps/contact";
 import { contactSchema } from "../../utils/contactSchema";
@@ -140,25 +142,21 @@ const ContactApp: React.FC = () => {
         </button>
       </p>
       <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
-        <div>
-          <label htmlFor="contact-name" className="mb-[6px] block text-sm">
-            Name
-          </label>
-          <div className="relative">
-            <input
-              id="contact-name"
-              className="h-11 w-full rounded border border-gray-700 bg-gray-800 pl-10 pr-3 text-white"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              required
-            />
+        <Input
+          id="contact-name"
+          label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          startAdornment={
             <svg
-              className="pointer-events-none absolute left-3 top-1/2 h-6 w-6 -translate-y-1/2 text-gray-400"
+              className="h-5 w-5 text-gray-400"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
               strokeWidth={1.5}
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"
@@ -166,30 +164,25 @@ const ContactApp: React.FC = () => {
                 d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.25v-1.5A4.5 4.5 0 0 1 9 14.25h6a4.5 4.5 0 0 1 4.5 4.5v1.5"
               />
             </svg>
-          </div>
-        </div>
-        <div>
-          <label htmlFor="contact-email" className="mb-[6px] block text-sm">
-            Email
-          </label>
-          <div className="relative">
-            <input
-              id="contact-email"
-              type="email"
-              className="h-11 w-full rounded border border-gray-700 bg-gray-800 pl-10 pr-3 text-white"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              aria-invalid={!!emailError}
-              aria-describedby={emailError ? "contact-email-error" : undefined}
-            />
+          }
+        />
+        <Input
+          id="contact-email"
+          type="email"
+          label="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          errorText={emailError}
+          startAdornment={
             <svg
-              className="pointer-events-none absolute left-3 top-1/2 h-6 w-6 -translate-y-1/2 text-gray-400"
+              className="h-5 w-5 text-gray-400"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
               strokeWidth={1.5}
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"
@@ -197,35 +190,25 @@ const ContactApp: React.FC = () => {
                 d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15A2.25 2.25 0 0 1 2.25 17.25V6.75A2.25 2.25 0 0 1 4.5 4.5h15a2.25 2.25 0 0 1 2.25 2.25ZM3 6l9 6 9-6"
               />
             </svg>
-          </div>
-          {emailError && (
-            <FormError id="contact-email-error" className="mt-2">
-              {emailError}
-            </FormError>
-          )}
-        </div>
-        <div>
-          <label htmlFor="contact-message" className="mb-[6px] block text-sm">
-            Message
-          </label>
-          <div className="relative">
-            <textarea
-              id="contact-message"
-              className="w-full rounded border border-gray-700 bg-gray-800 p-2 pl-10 text-white"
-              rows={4}
-              value={message}
-              onChange={(e) => setMessage(e.target.value)}
-              required
-              aria-invalid={!!messageError}
-              aria-describedby={messageError ? "contact-message-error" : undefined}
-            />
+          }
+        />
+        <Textarea
+          id="contact-message"
+          label="Message"
+          rows={4}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          required
+          errorText={messageError}
+          startAdornment={
             <svg
-              className="pointer-events-none absolute left-3 top-3 h-6 w-6 text-gray-400"
+              className="mt-1 h-5 w-5 text-gray-400"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
               strokeWidth={1.5}
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"
@@ -233,13 +216,8 @@ const ContactApp: React.FC = () => {
                 d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286a2.25 2.25 0 0 1-1.98 2.193c-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.1 2.1 0 0 1-.825-.242M3.75 7.5c0-1.621 1.152-3.026 2.76-3.235A48.455 48.455 0 0 1 12 3c2.115 0 4.198.137 6.24.402 1.608.209 2.76 1.614 2.76 3.235v6.226c0 1.621-1.152 3.026-2.76 3.235-.577.075-1.157.14-1.74.194V21L12.345 16.845"
               />
             </svg>
-          </div>
-          {messageError && (
-            <FormError id="contact-message-error" className="mt-2">
-              {messageError}
-            </FormError>
-          )}
-        </div>
+          }
+        />
         <input
           type="text"
           value={honeypot}

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -2,6 +2,8 @@
 
 import React, { useEffect, useState } from 'react';
 import FormError from '../../ui/FormError';
+import Input from '../../ui/Input';
+import Textarea from '../../ui/Textarea';
 import { copyToClipboard } from '../../../utils/clipboard';
 import { openMailto } from '../../../utils/mailto';
 import { contactSchema } from '../../../utils/contactSchema';
@@ -299,70 +301,40 @@ const ContactApp: React.FC = () => {
         </p>
       )}
       <form onSubmit={handleSubmit} className="space-y-6 max-w-md">
-        <div className="relative">
-          <input
-            id="contact-name"
-            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-            placeholder=" "
-          />
-          <label
-            htmlFor="contact-name"
-            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-blue-400"
-          >
-            Name
-          </label>
-        </div>
-        <div className="relative">
-          <input
-            id="contact-email"
-            type="email"
-            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            aria-invalid={!!emailError}
-            aria-describedby={emailError ? 'contact-email-error' : undefined}
-            placeholder=" "
-          />
-          <label
-            htmlFor="contact-email"
-            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-blue-400"
-          >
-            Email
-          </label>
-          {emailError && (
-            <FormError id="contact-email-error" className="mt-3">
-              {emailError}
-            </FormError>
-          )}
-        </div>
-        <div className="relative">
-          <textarea
-            id="contact-message"
-            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
-            rows={4}
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            required
-            aria-invalid={!!messageError}
-            aria-describedby={messageError ? 'contact-message-error' : undefined}
-            placeholder=" "
-          />
-          <label
-            htmlFor="contact-message"
-            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-blue-400"
-          >
-            Message
-          </label>
-          {messageError && (
-            <FormError id="contact-message-error" className="mt-3">
-              {messageError}
-            </FormError>
-          )}
-        </div>
+        <Input
+          id="contact-name"
+          label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          containerClassName="text-sm text-white"
+          fieldClassName="border border-gray-700 bg-gray-800"
+          className="text-white"
+        />
+        <Input
+          id="contact-email"
+          type="email"
+          label="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          errorText={emailError}
+          containerClassName="text-sm text-white"
+          fieldClassName="border border-gray-700 bg-gray-800"
+          className="text-white"
+        />
+        <Textarea
+          id="contact-message"
+          label="Message"
+          rows={4}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          required
+          errorText={messageError}
+          containerClassName="text-sm text-white"
+          fieldClassName="border border-gray-700 bg-gray-800"
+          className="text-white"
+        />
         <AttachmentUploader
           attachments={attachments}
           setAttachments={setAttachments}

--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import Input from '../../ui/Input';
+import Textarea from '../../ui/Textarea';
 import LabMode from '../../LabMode';
 import CommandBuilder from '../../CommandBuilder';
 import FixturesLoader from '../../FixturesLoader';
@@ -130,11 +132,15 @@ export default function SecurityTools() {
     <LabMode>
       <div className="w-full h-full bg-ub-dark text-white p-2 overflow-auto flex">
         <div className="flex-1 pr-2">
-          <input
+          <Input
+            label="Search all tools"
             value={query}
-            onChange={e => setQuery(e.target.value)}
+            onChange={(e) => setQuery(e.target.value)}
             placeholder="Search all tools"
-            className="w-full mb-2 p-1 text-black text-xs"
+            aria-label="Search all tools"
+            containerClassName="text-xs text-white"
+            fieldClassName="border border-gray-700 bg-gray-900"
+            className="text-white text-xs placeholder-gray-400"
           />
           {query ? (
             <div className="text-xs">
@@ -238,9 +244,24 @@ export default function SecurityTools() {
             {active === 'yara' && (
             <div>
               <p className="text-xs mb-2">Simplified YARA tester using sample text. Pattern matching is simulated.</p>
-              <textarea value={yaraRule} onChange={e=>setYaraRule(e.target.value)} className="w-full h-24 text-black p-1" />
-              <div className="text-xs mt-2 mb-1">Sample file:</div>
-              <textarea value={sampleText} readOnly className="w-full h-24 text-black p-1" />
+              <Textarea
+                label="YARA rule"
+                value={yaraRule}
+                onChange={(e) => setYaraRule(e.target.value)}
+                rows={6}
+                containerClassName="text-xs text-white"
+                fieldClassName="border border-gray-700 bg-gray-900"
+                className="text-white text-xs"
+              />
+              <Textarea
+                label="Sample file"
+                value={sampleText}
+                readOnly
+                rows={6}
+                containerClassName="text-xs text-white mt-2"
+                fieldClassName="border border-gray-700 bg-gray-900"
+                className="text-white text-xs"
+              />
               <button onClick={runYara} className="mt-2 px-2 py-1 bg-ub-green text-black text-xs">Scan</button>
               {yaraResult && <div className="mt-2 text-xs">{yaraResult}</div>}
             </div>

--- a/components/simulator/index.tsx
+++ b/components/simulator/index.tsx
@@ -1,4 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import Input from '../ui/Input';
+import Select from '../ui/Select';
+import Switch from '../ui/Switch';
 import usePersistentState from '../../hooks/usePersistentState';
 import type {
   SimulatorParserRequest,
@@ -126,8 +129,15 @@ const Simulator: React.FC = () => {
       title: 'Parsed',
       content: (
         <div className="p-2 space-y-2">
-          <div className="flex items-center space-x-2">
-            <input aria-label="Filter rows" className="border p-1 flex-grow" value={filter} onChange={(e)=>setFilter(e.target.value)} />
+          <div className="flex items-center gap-2">
+            <Input
+              aria-label="Filter rows"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              containerClassName="flex-1 text-sm text-gray-800"
+              fieldClassName="border border-gray-300 bg-white"
+              className="text-gray-900"
+            />
             <button className="px-2 py-1 bg-gray-200" onClick={exportCSV} aria-label="Export CSV">CSV</button>
           </div>
           <div className="overflow-auto" style={{ maxHeight: 200 }}>
@@ -159,25 +169,57 @@ const Simulator: React.FC = () => {
 
   return (
     <div className="space-y-4" aria-label="Simulator">
-      <div className="flex items-center space-x-2">
-        <input id="labmode" type="checkbox" checked={labMode} onChange={e=>setLabMode(e.target.checked)} />
-        <label htmlFor="labmode" className="font-semibold">Lab Mode</label>
-      </div>
+      <Switch
+        id="labmode"
+        label="Lab Mode"
+        checked={labMode}
+        onChange={(e) => setLabMode(e.target.checked)}
+        containerClassName="text-sm text-gray-800"
+      />
       {!labMode && (
         <div className="bg-yellow-100 text-yellow-800 p-2" role="alert">
           {LAB_BANNER}
         </div>
       )}
       <div className="space-y-2" aria-label="Command builder">
-        <input aria-label="Command input" className="border p-1 w-full" value={command} onChange={e=>setCommand(e.target.value)} />
+        <Input
+          label="Command"
+          aria-label="Command input"
+          value={command}
+          onChange={(e) => setCommand(e.target.value)}
+          containerClassName="text-sm text-gray-800"
+          fieldClassName="border border-gray-300 bg-white"
+          className="text-gray-900"
+        />
         <button className="px-2 py-1 bg-blue-600 text-white" onClick={copyCommand} aria-label="Copy command">Copy</button>
       </div>
       <div className="space-y-2" aria-label="Fixture loader">
-        <select onChange={onSampleChange} value={prefs.scenario} aria-label="Sample fixtures">
+        <Select
+          onChange={onSampleChange}
+          value={prefs.scenario}
+          label="Sample fixtures"
+          aria-label="Sample fixtures"
+          containerClassName="text-sm text-gray-800"
+          fieldClassName="border border-gray-300 bg-white"
+          className="text-gray-900"
+        >
           <option value="">Select sample</option>
-          {Object.keys(samples).map(k => <option key={k} value={k}>{k}</option>)}
-        </select>
-        <input type="file" accept=".txt,.json" onChange={onFile} aria-label="Load file" />
+          {Object.keys(samples).map((k) => (
+            <option key={k} value={k}>
+              {k}
+            </option>
+          ))}
+        </Select>
+        <Input
+          type="file"
+          accept=".txt,.json"
+          onChange={onFile}
+          label="Load file"
+          aria-label="Load file"
+          containerClassName="text-sm text-gray-800"
+          fieldClassName="border border-gray-300 bg-white"
+          className="text-gray-900 file:text-gray-900"
+        />
       </div>
       {fixtureText && (
         <div className="border rounded" aria-label="Results">

--- a/components/ui/Checkbox.tsx
+++ b/components/ui/Checkbox.tsx
@@ -1,0 +1,87 @@
+import React, { forwardRef, useId } from 'react';
+
+type CheckboxProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> & {
+  label?: React.ReactNode;
+  helperText?: React.ReactNode;
+  errorText?: React.ReactNode;
+  containerClassName?: string;
+};
+
+const join = (...values: Array<string | false | null | undefined>) =>
+  values.filter(Boolean).join(' ');
+
+const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref) => {
+  const {
+    label,
+    helperText,
+    errorText,
+    containerClassName = '',
+    className = '',
+    id: providedId,
+    disabled,
+    ...rest
+  } = props;
+
+  const reactId = useId();
+  const id = providedId ?? `checkbox-${reactId}`;
+  const helperId = helperText ? `${id}-helper` : undefined;
+  const errorId = errorText ? `${id}-error` : undefined;
+  const describedByFromProps = (rest['aria-describedby'] || '') as string;
+  const ariaInvalidFromProps = rest['aria-invalid'];
+  const describedBy = [
+    describedByFromProps,
+    errorId,
+    helperId,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .trim() || undefined;
+  const ariaInvalid =
+    ariaInvalidFromProps !== undefined
+      ? ariaInvalidFromProps
+      : errorText
+        ? true
+        : undefined;
+
+  const containerClasses = join('flex flex-col gap-1 text-sm text-gray-200', containerClassName);
+  const labelClasses = join(
+    'flex items-start gap-3 cursor-pointer',
+    disabled ? 'opacity-60 cursor-not-allowed' : undefined,
+  );
+  const inputClasses = join(
+    'mt-1 h-4 w-4 rounded border-gray-600 bg-gray-800 text-blue-500 focus:ring-blue-500 focus:ring-offset-0',
+    className,
+  );
+
+  return (
+    <div className={containerClasses}>
+      <label htmlFor={id} className={labelClasses}>
+        <input
+          {...rest}
+          id={id}
+          ref={ref}
+          type="checkbox"
+          disabled={disabled}
+          className={inputClasses}
+          aria-describedby={describedBy}
+          aria-invalid={ariaInvalid}
+        />
+        {label && <span className="pt-[2px] text-sm">{label}</span>}
+      </label>
+      {errorText && (
+        <p id={errorId} className="text-sm text-red-500">
+          {errorText}
+        </p>
+      )}
+      {helperText && (
+        <p id={helperId} className="text-sm text-gray-400">
+          {helperText}
+        </p>
+      )}
+    </div>
+  );
+});
+
+Checkbox.displayName = 'Checkbox';
+
+export default Checkbox;

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,0 +1,100 @@
+import React, { forwardRef, useId } from 'react';
+
+type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  label?: React.ReactNode;
+  helperText?: React.ReactNode;
+  errorText?: React.ReactNode;
+  startAdornment?: React.ReactNode;
+  endAdornment?: React.ReactNode;
+  containerClassName?: string;
+  fieldClassName?: string;
+};
+
+const join = (...values: Array<string | false | null | undefined>) =>
+  values.filter(Boolean).join(' ');
+
+const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+  const {
+    label,
+    helperText,
+    errorText,
+    startAdornment,
+    endAdornment,
+    containerClassName = '',
+    fieldClassName = '',
+    className = '',
+    id: providedId,
+    disabled,
+    ...rest
+  } = props;
+
+  const reactId = useId();
+  const id = providedId ?? `input-${reactId}`;
+  const helperId = helperText ? `${id}-helper` : undefined;
+  const errorId = errorText ? `${id}-error` : undefined;
+  const describedByFromProps = (rest['aria-describedby'] || '') as string;
+  const ariaInvalidFromProps = rest['aria-invalid'];
+  const describedBy = [
+    describedByFromProps,
+    errorId,
+    helperId,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .trim() || undefined;
+  const ariaInvalid =
+    ariaInvalidFromProps !== undefined
+      ? ariaInvalidFromProps
+      : errorText
+        ? true
+        : undefined;
+
+  const containerClasses = join('flex flex-col gap-1 text-sm', containerClassName);
+  const fieldClasses = join(
+    'relative flex items-center gap-2 rounded border border-gray-700 bg-gray-800 px-3 py-2 transition focus-within:border-blue-400 focus-within:ring-2 focus-within:ring-blue-500/60',
+    disabled ? 'opacity-60 cursor-not-allowed' : undefined,
+    fieldClassName,
+  );
+  const adornmentClasses = 'flex items-center text-gray-400';
+  const inputClasses = join(
+    'flex-1 bg-transparent text-white placeholder-gray-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed',
+    className,
+  );
+
+  return (
+    <div className={containerClasses}>
+      {label && (
+        <label htmlFor={id} className="text-sm font-medium text-gray-200">
+          {label}
+        </label>
+      )}
+      <div className={fieldClasses}>
+        {startAdornment && <span className={adornmentClasses}>{startAdornment}</span>}
+        <input
+          {...rest}
+          id={id}
+          ref={ref}
+          disabled={disabled}
+          className={inputClasses}
+          aria-describedby={describedBy}
+          aria-invalid={ariaInvalid}
+        />
+        {endAdornment && <span className={adornmentClasses}>{endAdornment}</span>}
+      </div>
+      {errorText && (
+        <p id={errorId} className="text-sm text-red-500">
+          {errorText}
+        </p>
+      )}
+      {helperText && (
+        <p id={helperId} className="text-sm text-gray-400">
+          {helperText}
+        </p>
+      )}
+    </div>
+  );
+});
+
+Input.displayName = 'Input';
+
+export default Input;

--- a/components/ui/Radio.tsx
+++ b/components/ui/Radio.tsx
@@ -1,0 +1,87 @@
+import React, { forwardRef, useId } from 'react';
+
+type RadioProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> & {
+  label?: React.ReactNode;
+  helperText?: React.ReactNode;
+  errorText?: React.ReactNode;
+  containerClassName?: string;
+};
+
+const join = (...values: Array<string | false | null | undefined>) =>
+  values.filter(Boolean).join(' ');
+
+const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
+  const {
+    label,
+    helperText,
+    errorText,
+    containerClassName = '',
+    className = '',
+    id: providedId,
+    disabled,
+    ...rest
+  } = props;
+
+  const reactId = useId();
+  const id = providedId ?? `radio-${reactId}`;
+  const helperId = helperText ? `${id}-helper` : undefined;
+  const errorId = errorText ? `${id}-error` : undefined;
+  const describedByFromProps = (rest['aria-describedby'] || '') as string;
+  const ariaInvalidFromProps = rest['aria-invalid'];
+  const describedBy = [
+    describedByFromProps,
+    errorId,
+    helperId,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .trim() || undefined;
+  const ariaInvalid =
+    ariaInvalidFromProps !== undefined
+      ? ariaInvalidFromProps
+      : errorText
+        ? true
+        : undefined;
+
+  const containerClasses = join('flex flex-col gap-1 text-sm text-gray-200', containerClassName);
+  const labelClasses = join(
+    'flex items-start gap-3 cursor-pointer',
+    disabled ? 'opacity-60 cursor-not-allowed' : undefined,
+  );
+  const inputClasses = join(
+    'mt-1 h-4 w-4 border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-0',
+    className,
+  );
+
+  return (
+    <div className={containerClasses}>
+      <label htmlFor={id} className={labelClasses}>
+        <input
+          {...rest}
+          id={id}
+          ref={ref}
+          type="radio"
+          disabled={disabled}
+          className={inputClasses}
+          aria-describedby={describedBy}
+          aria-invalid={ariaInvalid}
+        />
+        {label && <span className="pt-[2px] text-sm">{label}</span>}
+      </label>
+      {errorText && (
+        <p id={errorId} className="text-sm text-red-500">
+          {errorText}
+        </p>
+      )}
+      {helperText && (
+        <p id={helperId} className="text-sm text-gray-400">
+          {helperText}
+        </p>
+      )}
+    </div>
+  );
+});
+
+Radio.displayName = 'Radio';
+
+export default Radio;

--- a/components/ui/Select.tsx
+++ b/components/ui/Select.tsx
@@ -1,0 +1,100 @@
+import React, { forwardRef, useId } from 'react';
+
+type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement> & {
+  label?: React.ReactNode;
+  helperText?: React.ReactNode;
+  errorText?: React.ReactNode;
+  startAdornment?: React.ReactNode;
+  endAdornment?: React.ReactNode;
+  containerClassName?: string;
+  fieldClassName?: string;
+};
+
+const join = (...values: Array<string | false | null | undefined>) =>
+  values.filter(Boolean).join(' ');
+
+const Select = forwardRef<HTMLSelectElement, SelectProps>((props, ref) => {
+  const {
+    label,
+    helperText,
+    errorText,
+    startAdornment,
+    endAdornment,
+    containerClassName = '',
+    fieldClassName = '',
+    className = '',
+    id: providedId,
+    disabled,
+    ...rest
+  } = props;
+
+  const reactId = useId();
+  const id = providedId ?? `select-${reactId}`;
+  const helperId = helperText ? `${id}-helper` : undefined;
+  const errorId = errorText ? `${id}-error` : undefined;
+  const describedByFromProps = (rest['aria-describedby'] || '') as string;
+  const ariaInvalidFromProps = rest['aria-invalid'];
+  const describedBy = [
+    describedByFromProps,
+    errorId,
+    helperId,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .trim() || undefined;
+  const ariaInvalid =
+    ariaInvalidFromProps !== undefined
+      ? ariaInvalidFromProps
+      : errorText
+        ? true
+        : undefined;
+
+  const containerClasses = join('flex flex-col gap-1 text-sm', containerClassName);
+  const fieldClasses = join(
+    'relative flex items-center gap-2 rounded border border-gray-700 bg-gray-800 px-3 py-2 transition focus-within:border-blue-400 focus-within:ring-2 focus-within:ring-blue-500/60',
+    disabled ? 'opacity-60 cursor-not-allowed' : undefined,
+    fieldClassName,
+  );
+  const adornmentClasses = 'flex items-center text-gray-400';
+  const selectClasses = join(
+    'flex-1 bg-transparent text-white focus:outline-none focus:ring-0 disabled:cursor-not-allowed',
+    className,
+  );
+
+  return (
+    <div className={containerClasses}>
+      {label && (
+        <label htmlFor={id} className="text-sm font-medium text-gray-200">
+          {label}
+        </label>
+      )}
+      <div className={fieldClasses}>
+        {startAdornment && <span className={adornmentClasses}>{startAdornment}</span>}
+        <select
+          {...rest}
+          id={id}
+          ref={ref}
+          disabled={disabled}
+          className={selectClasses}
+          aria-describedby={describedBy}
+          aria-invalid={ariaInvalid}
+        />
+        {endAdornment && <span className={adornmentClasses}>{endAdornment}</span>}
+      </div>
+      {errorText && (
+        <p id={errorId} className="text-sm text-red-500">
+          {errorText}
+        </p>
+      )}
+      {helperText && (
+        <p id={helperId} className="text-sm text-gray-400">
+          {helperText}
+        </p>
+      )}
+    </div>
+  );
+});
+
+Select.displayName = 'Select';
+
+export default Select;

--- a/components/ui/Switch.tsx
+++ b/components/ui/Switch.tsx
@@ -1,0 +1,91 @@
+import React, { forwardRef, useId } from 'react';
+
+type SwitchProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> & {
+  label?: React.ReactNode;
+  helperText?: React.ReactNode;
+  errorText?: React.ReactNode;
+  containerClassName?: string;
+};
+
+const join = (...values: Array<string | false | null | undefined>) =>
+  values.filter(Boolean).join(' ');
+
+const Switch = forwardRef<HTMLInputElement, SwitchProps>((props, ref) => {
+  const {
+    label,
+    helperText,
+    errorText,
+    containerClassName = '',
+    className = '',
+    id: providedId,
+    disabled,
+    ...rest
+  } = props;
+
+  const reactId = useId();
+  const id = providedId ?? `switch-${reactId}`;
+  const helperId = helperText ? `${id}-helper` : undefined;
+  const errorId = errorText ? `${id}-error` : undefined;
+  const describedByFromProps = (rest['aria-describedby'] || '') as string;
+  const ariaInvalidFromProps = rest['aria-invalid'];
+  const describedBy = [
+    describedByFromProps,
+    errorId,
+    helperId,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .trim() || undefined;
+  const ariaInvalid =
+    ariaInvalidFromProps !== undefined
+      ? ariaInvalidFromProps
+      : errorText
+        ? true
+        : undefined;
+
+  const containerClasses = join('flex flex-col gap-1 text-sm text-gray-200', containerClassName);
+  const labelClasses = join(
+    'flex items-center gap-3 cursor-pointer',
+    disabled ? 'opacity-60 cursor-not-allowed' : undefined,
+  );
+  const inputClasses = join('peer sr-only', className);
+  const trackClasses = 'h-5 w-10 rounded-full bg-gray-600 transition peer-checked:bg-blue-500 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-blue-500 peer-disabled:bg-gray-500';
+  const thumbClasses = 'pointer-events-none absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white transition peer-checked:translate-x-5 peer-checked:bg-white peer-disabled:bg-gray-300';
+
+  return (
+    <div className={containerClasses}>
+      <label htmlFor={id} className={labelClasses}>
+        <span className="relative inline-flex items-center">
+          <input
+            {...rest}
+            id={id}
+            ref={ref}
+            type="checkbox"
+            role="switch"
+            disabled={disabled}
+            className={inputClasses}
+            aria-describedby={describedBy}
+            aria-invalid={ariaInvalid}
+          />
+          <span aria-hidden className={trackClasses} />
+          <span aria-hidden className={thumbClasses} />
+        </span>
+        {label && <span className="text-sm">{label}</span>}
+      </label>
+      {errorText && (
+        <p id={errorId} className="text-sm text-red-500">
+          {errorText}
+        </p>
+      )}
+      {helperText && (
+        <p id={helperId} className="text-sm text-gray-400">
+          {helperText}
+        </p>
+      )}
+    </div>
+  );
+});
+
+Switch.displayName = 'Switch';
+
+export default Switch;

--- a/components/ui/Textarea.tsx
+++ b/components/ui/Textarea.tsx
@@ -1,0 +1,100 @@
+import React, { forwardRef, useId } from 'react';
+
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  label?: React.ReactNode;
+  helperText?: React.ReactNode;
+  errorText?: React.ReactNode;
+  startAdornment?: React.ReactNode;
+  endAdornment?: React.ReactNode;
+  containerClassName?: string;
+  fieldClassName?: string;
+};
+
+const join = (...values: Array<string | false | null | undefined>) =>
+  values.filter(Boolean).join(' ');
+
+const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>((props, ref) => {
+  const {
+    label,
+    helperText,
+    errorText,
+    startAdornment,
+    endAdornment,
+    containerClassName = '',
+    fieldClassName = '',
+    className = '',
+    id: providedId,
+    disabled,
+    ...rest
+  } = props;
+
+  const reactId = useId();
+  const id = providedId ?? `textarea-${reactId}`;
+  const helperId = helperText ? `${id}-helper` : undefined;
+  const errorId = errorText ? `${id}-error` : undefined;
+  const describedByFromProps = (rest['aria-describedby'] || '') as string;
+  const ariaInvalidFromProps = rest['aria-invalid'];
+  const describedBy = [
+    describedByFromProps,
+    errorId,
+    helperId,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .trim() || undefined;
+  const ariaInvalid =
+    ariaInvalidFromProps !== undefined
+      ? ariaInvalidFromProps
+      : errorText
+        ? true
+        : undefined;
+
+  const containerClasses = join('flex flex-col gap-1 text-sm', containerClassName);
+  const fieldClasses = join(
+    'relative flex items-start gap-2 rounded border border-gray-700 bg-gray-800 px-3 py-2 transition focus-within:border-blue-400 focus-within:ring-2 focus-within:ring-blue-500/60',
+    disabled ? 'opacity-60 cursor-not-allowed' : undefined,
+    fieldClassName,
+  );
+  const adornmentClasses = 'flex items-start text-gray-400 pt-1';
+  const textareaClasses = join(
+    'min-h-[3rem] flex-1 bg-transparent text-white placeholder-gray-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed',
+    className,
+  );
+
+  return (
+    <div className={containerClasses}>
+      {label && (
+        <label htmlFor={id} className="text-sm font-medium text-gray-200">
+          {label}
+        </label>
+      )}
+      <div className={fieldClasses}>
+        {startAdornment && <span className={adornmentClasses}>{startAdornment}</span>}
+        <textarea
+          {...rest}
+          id={id}
+          ref={ref}
+          disabled={disabled}
+          className={textareaClasses}
+          aria-describedby={describedBy}
+          aria-invalid={ariaInvalid}
+        />
+        {endAdornment && <span className={adornmentClasses}>{endAdornment}</span>}
+      </div>
+      {errorText && (
+        <p id={errorId} className="text-sm text-red-500">
+          {errorText}
+        </p>
+      )}
+      {helperText && (
+        <p id={helperId} className="text-sm text-gray-400">
+          {helperText}
+        </p>
+      )}
+    </div>
+  );
+});
+
+Textarea.displayName = 'Textarea';
+
+export default Textarea;

--- a/pages/dummy-form.tsx
+++ b/pages/dummy-form.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState, useEffect } from 'react';
 import FormError from '../components/ui/FormError';
+import Input from '../components/ui/Input';
+import Textarea from '../components/ui/Textarea';
 
 const STORAGE_KEY = 'dummy-form-draft';
 
@@ -92,28 +94,34 @@ const DummyForm: React.FC = () => {
         {recovered && <p className="mb-4 text-sm text-blue-600">Recovered draft</p>}
         {error && <FormError className="mb-4 mt-0">{error}</FormError>}
         {success && <p className="mb-4 text-sm text-green-600">Form submitted successfully!</p>}
-        <label className="mb-2 block text-sm font-medium" htmlFor="name">Name</label>
-        <input
+        <Input
           id="name"
-          className="mb-4 w-full rounded border p-2"
-          type="text"
+          label="Name"
           value={name}
           onChange={(e) => setName(e.target.value)}
+          required
+          fieldClassName="border border-gray-300 bg-white"
+          className="text-gray-900"
         />
-        <label className="mb-2 block text-sm font-medium" htmlFor="email">Email</label>
-        <input
+        <Input
           id="email"
-          className="mb-4 w-full rounded border p-2"
           type="email"
+          label="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
+          required
+          fieldClassName="border border-gray-300 bg-white"
+          className="text-gray-900"
         />
-        <label className="mb-2 block text-sm font-medium" htmlFor="message">Message</label>
-        <textarea
+        <Textarea
           id="message"
-          className="mb-4 w-full rounded border p-2"
+          label="Message"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
+          rows={4}
+          required
+          fieldClassName="border border-gray-300 bg-white"
+          className="text-gray-900"
         />
         <button type="submit" className="w-full rounded bg-blue-600 p-2 text-white">Submit</button>
         <p className="mt-4 text-xs text-gray-500">


### PR DESCRIPTION
## Summary
- add Input, Select, Textarea, Checkbox, Radio, and Switch primitives that handle helper/error text, adornments, and aria wiring
- refactor contact flows, dummy form, simulator, and security tools screens to consume the new primitives
- add shared UI keyboard-navigation tests covering label focus, tab order, and aria attributes

## Testing
- yarn lint *(fails: repo has pre-existing jsx-a11y/no-top-level-window violations outside touched files)*
- yarn test *(fails: existing suites such as window, nmap NSE, and settings hooks require upstream fixes)*

------
https://chatgpt.com/codex/tasks/task_e_68cca7150a348328b803ff1894fabc8b