### PR TITLE
feat: optimize timeline and gallery images

### DIFF
--- a/apps/project-gallery/pages/index.tsx
+++ b/apps/project-gallery/pages/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect, useMemo, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
@@ -282,15 +283,22 @@ export default function ProjectGalleryPage() {
                 </div>
               </div>
             ))
-          : filtered.map((p) => (
+          : filtered.map((p, index) => (
               <div
                 key={p.id}
                 tabIndex={0}
                 className="group relative h-72 flex flex-col border rounded overflow-hidden transition-transform transition-opacity duration-300 hover:scale-105 hover:opacity-90 focus:scale-105 focus:opacity-90 focus:outline-none"
                 aria-label={`${p.title}: ${p.description}`}
               >
-                <div className="w-full aspect-video overflow-hidden">
-                  <img src={p.thumbnail} alt={p.title} className="w-full h-full object-cover" />
+                <div className="relative w-full aspect-video overflow-hidden">
+                  <Image
+                    src={p.thumbnail}
+                    alt={p.title}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                    priority={index === 0}
+                  />
                 </div>
                 <div className="p-2 flex-1">
                   <h3 className="font-semibold text-base line-clamp-2">{p.title}</h3>

--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -4,6 +4,7 @@ import React, {
   useRef,
   useEffect,
 } from 'react';
+import Image from 'next/image';
 import rawMilestones from '../data/milestones.json';
 
 interface Milestone {
@@ -126,11 +127,16 @@ const ScrollableTimeline: React.FC = () => {
                       className="text-left w-full focus:outline-none"
                     >
                       <div className="text-ubt-blue font-bold text-lg mb-2">{year}</div>
-                      <img
-                        src={first.image}
-                        alt={first.title}
-                        className="w-full h-32 object-cover mb-2 rounded"
-                      />
+                      <div className="relative w-full h-32 mb-2 overflow-hidden rounded">
+                        <Image
+                          src={first.image}
+                          alt={first.title}
+                          fill
+                          className="object-cover"
+                          sizes="(max-width: 768px) 70vw, 16rem"
+                          priority={index === 0}
+                        />
+                      </div>
                       <p className="text-sm md:text-base mb-2">{first.title}</p>
                       {renderTags(first.tags)}
                     </button>
@@ -155,11 +161,15 @@ const ScrollableTimeline: React.FC = () => {
                     rel="noopener noreferrer"
                     className="block mb-2"
                   >
-                    <img
-                      src={m.image}
-                      alt={m.title}
-                      className="w-full h-32 object-cover mb-2 rounded"
-                    />
+                    <div className="relative w-full h-32 mb-2 overflow-hidden rounded">
+                      <Image
+                        src={m.image}
+                        alt={m.title}
+                        fill
+                        className="object-cover"
+                        sizes="(max-width: 768px) 70vw, 16rem"
+                      />
+                    </div>
                     <p className="text-sm md:text-base">{m.title}</p>
                   </a>
                   {renderTags(m.tags)}

--- a/components/apps/project-gallery.tsx
+++ b/components/apps/project-gallery.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
+import Image from 'next/image';
 import projectsData from '../../data/projects.json';
 
 interface Project {
@@ -254,18 +255,22 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
         </div>
       )}
       <div className="columns-1 sm:columns-2 md:columns-3 gap-4">
-        {filtered.map((project) => (
+        {filtered.map((project, index) => (
           <div
             key={project.id}
             className="mb-4 break-inside-avoid bg-gray-800 rounded shadow overflow-hidden"
           >
             <div className="flex flex-col md:flex-row h-48">
-              <img
-                src={project.thumbnail}
-                alt={project.title}
-                className="w-full md:w-1/2 h-48 object-cover"
-                loading="lazy"
-              />
+              <div className="relative w-full md:w-1/2 h-48">
+                <Image
+                  src={project.thumbnail}
+                  alt={project.title}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, (max-width: 1280px) 20vw, 15vw"
+                  priority={index === 0}
+                />
+              </div>
               <div className="w-full md:w-1/2 h-48">
                 <Editor
                   height="100%"


### PR DESCRIPTION
## Summary
- replace timeline card `<img>` usage with `next/image`, adding responsive sizes and priority for the first visible milestone
- update both project gallery UIs to render thumbnails with `next/image`, responsive sizing, and eager loading of the lead card for better LCP

## Testing
- ❌ `yarn lint` *(fails on pre-existing accessibility and node globals warnings across unrelated apps)*
- ❌ `yarn test` *(fails due to legacy suites expecting browser APIs; run aborted after repeated suite failures)*
- ✅ `CHROME_PATH=/root/.cache/ms-playwright/chromium-1187/chrome-linux/chrome npx --yes lighthouse http://localhost:3000/profile --only-categories=performance --output=json --output-path=./lighthouse-profile.json --chrome-flags="--headless --no-sandbox --disable-dev-shm-usage --disable-gpu"`
- ⚠️ `CHROME_PATH=/root/.cache/ms-playwright/chromium-1187/chrome-linux/chrome npx --yes lighthouse http://localhost:3000/apps/project-gallery --only-categories=performance --output=json --output-path=./lighthouse-project-gallery.json --chrome-flags="--headless --no-sandbox --disable-dev-shm-usage --disable-gpu"` *(timed out in DevTools protocol despite extended wait; gallery UI contains many dynamic widgets)*

------
https://chatgpt.com/codex/tasks/task_e_68cca7198fa48328bae81f537fbc1979