### PR TITLE
feat: add skeleton loading for heavy widgets

### DIFF
--- a/apps/hashcat/index.tsx
+++ b/apps/hashcat/index.tsx
@@ -1,9 +1,20 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
 import usePersistentState from '../../hooks/usePersistentState';
 import RulesSandbox from './components/RulesSandbox';
-import StatsChart from '../../components/StatsChart';
+import ChartSkeleton from '../../components/skeletons/ChartSkeleton';
+
+type StatsChartProps = {
+  count: number;
+  time: number;
+};
+
+const StatsChart = dynamic<StatsChartProps>(() => import('../../components/StatsChart'), {
+  ssr: false,
+  loading: () => <ChartSkeleton />,
+});
 
 interface Preset {
   value: string;

--- a/apps/john/index.tsx
+++ b/apps/john/index.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import AuditSimulator from './components/AuditSimulator';
+import dynamic from 'next/dynamic';
+import SimulatorSkeleton from '../../components/skeletons/SimulatorSkeleton';
+
+const AuditSimulator = dynamic(() => import('./components/AuditSimulator'), {
+  ssr: false,
+  loading: () => <SimulatorSkeleton />,
+});
 
 interface HashItem {
   hash: string;

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -8,7 +8,13 @@ import data from '../alex/data.json';
 import SafetyNote from './SafetyNote';
 import { getCspNonce } from '../../../utils/csp';
 import AboutSlides from './slides';
-import ScrollableTimeline from '../../ScrollableTimeline';
+import dynamic from 'next/dynamic';
+import TimelineSkeleton from '../../skeletons/TimelineSkeleton';
+
+const ScrollableTimeline = dynamic(() => import('../../ScrollableTimeline'), {
+  ssr: false,
+  loading: () => <TimelineSkeleton />,
+});
 
 class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_screen: string; navbar: boolean }> {
   screens: Record<string, React.ReactNode> = {};

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -1,6 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
+import dynamic from 'next/dynamic';
 import progressInfo from './progress.json';
-import StatsChart from '../../StatsChart';
+import ChartSkeleton from '../../skeletons/ChartSkeleton';
+const StatsChart = dynamic(() => import('../../StatsChart'), {
+  ssr: false,
+  loading: () => <ChartSkeleton />,
+});
+
 
 export const hashTypes = [
   {

--- a/components/skeletons/ChartSkeleton.tsx
+++ b/components/skeletons/ChartSkeleton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const shimmer = 'motion-safe:animate-pulse bg-slate-700/70';
+
+const ChartSkeleton: React.FC = () => (
+  <div
+    role="status"
+    aria-live="polite"
+    aria-busy="true"
+    className="w-full rounded-lg border border-slate-700/80 bg-slate-900/80 p-4 shadow-inner"
+  >
+    <div className="relative h-32 overflow-hidden rounded bg-slate-800/70">
+      <div className="absolute inset-x-0 bottom-0 flex items-end justify-around px-6">
+        <div className={`h-20 w-10 rounded-t ${shimmer}`} />
+        <div className={`h-16 w-10 rounded-t ${shimmer}`} />
+      </div>
+      <div className="absolute inset-0 bg-gradient-to-t from-slate-900/40 to-transparent" />
+    </div>
+    <div className="mt-4 flex justify-around text-xs uppercase tracking-wide text-slate-400">
+      <div className={`h-3 w-16 rounded ${shimmer}`} />
+      <div className={`h-3 w-16 rounded ${shimmer}`} />
+    </div>
+    <span className="sr-only">Loading chart...</span>
+  </div>
+);
+
+export default ChartSkeleton;

--- a/components/skeletons/SimulatorSkeleton.tsx
+++ b/components/skeletons/SimulatorSkeleton.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+const shimmer = 'motion-safe:animate-pulse bg-slate-700/70';
+
+const SimulatorSkeleton: React.FC = () => (
+  <div
+    role="status"
+    aria-live="polite"
+    aria-busy="true"
+    className="w-full rounded-xl border border-slate-700/80 bg-slate-900/80 p-4 shadow-inner"
+  >
+    <div className="flex flex-wrap gap-3">
+      <div className={`h-5 w-24 rounded ${shimmer}`} />
+      <div className={`h-5 w-28 rounded ${shimmer}`} />
+      <div className={`h-5 w-20 rounded ${shimmer}`} />
+    </div>
+    <div className="mt-4 space-y-3">
+      <div className={`h-10 rounded ${shimmer}`} />
+      <div className={`h-10 rounded ${shimmer}`} />
+    </div>
+    <div className="mt-4 space-y-2">
+      <div className={`h-4 w-36 rounded ${shimmer}`} />
+      <div className={`h-3 w-48 rounded ${shimmer}`} />
+    </div>
+    <div className="mt-4 rounded-lg border border-slate-700/60 bg-slate-800/60 p-3">
+      <div className={`mb-2 h-4 w-24 rounded ${shimmer}`} />
+      <div className="space-y-2 text-xs">
+        {[0, 1, 2, 3].map((line) => (
+          <div key={line} className={`h-3 w-full rounded ${shimmer}`} />
+        ))}
+      </div>
+    </div>
+    <div className="mt-4 flex flex-wrap gap-3">
+      <div className={`h-9 w-24 rounded ${shimmer}`} />
+      <div className={`h-9 w-24 rounded ${shimmer}`} />
+      <div className={`h-9 w-24 rounded ${shimmer}`} />
+    </div>
+    <span className="sr-only">Loading simulator...</span>
+  </div>
+);
+
+export default SimulatorSkeleton;

--- a/components/skeletons/TimelineSkeleton.tsx
+++ b/components/skeletons/TimelineSkeleton.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const shimmer = 'motion-safe:animate-pulse bg-slate-700/70';
+
+const TimelineSkeleton: React.FC = () => (
+  <div
+    role="status"
+    aria-live="polite"
+    aria-busy="true"
+    className="w-full max-w-3xl rounded-xl border border-slate-700/80 bg-slate-900/80 p-4 shadow-inner"
+  >
+    <div className="mb-6 flex items-center justify-between">
+      <div className={`h-6 w-32 rounded-full ${shimmer}`} />
+      <div className={`h-6 w-20 rounded-full ${shimmer}`} />
+    </div>
+    <div className="space-y-6">
+      {[0, 1, 2].map((idx) => (
+        <div key={idx} className="flex gap-4">
+          <div className="flex flex-col items-center">
+            <div className="h-3 w-3 rounded-full bg-sky-500/70 motion-safe:animate-pulse" />
+            <div className="mt-1 h-full w-px flex-1 bg-slate-700/60" />
+          </div>
+          <div className="flex-1 space-y-2">
+            <div className={`h-4 w-36 rounded ${shimmer}`} />
+            <div className={`h-3 w-24 rounded ${shimmer}`} />
+            <div className={`h-3 w-full rounded ${shimmer}`} />
+            <div className={`h-3 w-5/6 rounded ${shimmer}`} />
+          </div>
+        </div>
+      ))}
+    </div>
+    <div className="mt-6 flex justify-end gap-2">
+      <div className={`h-5 w-20 rounded ${shimmer}`} />
+      <div className={`h-5 w-24 rounded ${shimmer}`} />
+    </div>
+    <span className="sr-only">Loading timeline...</span>
+  </div>
+);
+
+export default TimelineSkeleton;

--- a/docs/perf/dynamic-widgets-after.json
+++ b/docs/perf/dynamic-widgets-after.json
@@ -1,0 +1,42 @@
+[
+  {
+    "url": "http://localhost:3000/profile",
+    "measuredAt": "2025-09-19T00:59:20.061Z",
+    "profile": {
+      "label": "Fast 3G",
+      "latency": 150,
+      "downloadKbps": 1600,
+      "uploadKbps": 750,
+      "cpuSlowdown": 4
+    },
+    "firstPaint": 260,
+    "firstContentfulPaint": 260,
+    "largestContentfulPaint": 12788.899999999907,
+    "navigationTiming": {
+      "domContentLoaded": 12788.899999999907,
+      "load": 12790.100000000093,
+      "responseStart": 260
+    },
+    "totalElapsedMs": 19323
+  },
+  {
+    "url": "http://localhost:3000/apps/john",
+    "measuredAt": "2025-09-19T00:59:39.468Z",
+    "profile": {
+      "label": "Fast 3G",
+      "latency": 150,
+      "downloadKbps": 1600,
+      "uploadKbps": 750,
+      "cpuSlowdown": 4
+    },
+    "firstPaint": 232.4000000001397,
+    "firstContentfulPaint": 232.4000000001397,
+    "largestContentfulPaint": 12722.90000000014,
+    "navigationTiming": {
+      "domContentLoaded": 12722.90000000014,
+      "load": 12723.199999999953,
+      "responseStart": 232.4000000001397
+    },
+    "totalElapsedMs": 19262
+  }
+]

--- a/docs/perf/dynamic-widgets-before.json
+++ b/docs/perf/dynamic-widgets-before.json
@@ -1,0 +1,42 @@
+[
+  {
+    "url": "http://localhost:3000/profile",
+    "measuredAt": "2025-09-19T00:54:11.540Z",
+    "profile": {
+      "label": "Fast 3G",
+      "latency": 150,
+      "downloadKbps": 1600,
+      "uploadKbps": 750,
+      "cpuSlowdown": 4
+    },
+    "firstPaint": 241.80000000004657,
+    "firstContentfulPaint": 241.80000000004657,
+    "largestContentfulPaint": 12689,
+    "navigationTiming": {
+      "domContentLoaded": 12689,
+      "load": 12689.699999999953,
+      "responseStart": 241.80000000004657
+    },
+    "totalElapsedMs": 19215
+  },
+  {
+    "url": "http://localhost:3000/apps/john",
+    "measuredAt": "2025-09-19T00:54:30.959Z",
+    "profile": {
+      "label": "Fast 3G",
+      "latency": 150,
+      "downloadKbps": 1600,
+      "uploadKbps": 750,
+      "cpuSlowdown": 4
+    },
+    "firstPaint": 239.90000000002328,
+    "firstContentfulPaint": 239.90000000002328,
+    "largestContentfulPaint": 12741,
+    "navigationTiming": {
+      "domContentLoaded": 12741,
+      "load": 12741.5,
+      "responseStart": 239.90000000002328
+    },
+    "totalElapsedMs": 19252
+  }
+]

--- a/pages/apps/john.jsx
+++ b/pages/apps/john.jsx
@@ -1,11 +1,11 @@
 import dynamic from 'next/dynamic';
+import SimulatorSkeleton from '../../components/skeletons/SimulatorSkeleton';
 
 const John = dynamic(() => import('../../apps/john'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  loading: () => <SimulatorSkeleton />,
 });
 
 export default function JohnPage() {
   return <John />;
 }
-

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,7 +1,13 @@
-import ScrollableTimeline from '../components/ScrollableTimeline';
+import dynamic from 'next/dynamic';
+import TimelineSkeleton from '../components/skeletons/TimelineSkeleton';
+
+const ScrollableTimeline = dynamic(() => import('../components/ScrollableTimeline'), {
+  ssr: false,
+  loading: () => <TimelineSkeleton />,
+});
 
 const ProfilePage = () => (
-  <main className="min-h-screen p-4 bg-gray-900 text-white">
+  <main className="min-h-screen bg-gray-900 p-4 text-white">
     <h1 className="mb-4 text-2xl">Timeline</h1>
     <ScrollableTimeline />
   </main>

--- a/scripts/perf/measure-fast3g.mjs
+++ b/scripts/perf/measure-fast3g.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { chromium } from '@playwright/test';
+
+const KB_IN_BYTES = 1024;
+const BITS_PER_BYTE = 8;
+const PAINT_WAIT_TIMEOUT_MS = 5000;
+
+const FAST_3G_PROFILE = {
+  label: 'Fast 3G',
+  latency: 150,
+  downloadKbps: 1600,
+  uploadKbps: 750,
+  cpuSlowdown: 4,
+};
+
+const toBytesPerSecond = (kbps) => Math.round((kbps * KB_IN_BYTES) / BITS_PER_BYTE);
+
+const parseArgs = (argv) => {
+  const urls = [];
+  let outputPath;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--url' && typeof argv[i + 1] === 'string') {
+      urls.push(argv[i + 1]);
+      i += 1;
+    } else if (arg === '--output' && typeof argv[i + 1] === 'string') {
+      outputPath = argv[i + 1];
+      i += 1;
+    }
+  }
+  return { urls, outputPath };
+};
+
+const emulateNetwork = async (client) => {
+  await client.send('Network.enable');
+  await client.send('Network.setCacheDisabled', { cacheDisabled: true });
+  await client.send('Emulation.setCPUThrottlingRate', {
+    rate: FAST_3G_PROFILE.cpuSlowdown,
+  });
+  await client.send('Network.emulateNetworkConditions', {
+    offline: false,
+    latency: FAST_3G_PROFILE.latency,
+    downloadThroughput: toBytesPerSecond(FAST_3G_PROFILE.downloadKbps),
+    uploadThroughput: toBytesPerSecond(FAST_3G_PROFILE.uploadKbps),
+    connectionType: 'cellular3g',
+  });
+};
+
+const collectMetrics = async (page) =>
+  page.evaluate(() => {
+    const fallbackPaints = performance.getEntriesByType('paint').map(({ name, startTime }) => ({
+      name,
+      startTime,
+    }));
+    const paints = Array.isArray(window.__perf?.paints) && window.__perf.paints.length > 0
+      ? window.__perf.paints
+      : fallbackPaints;
+    const navigation = performance.getEntriesByType('navigation')[0];
+    const navigationTiming = navigation
+      ? {
+          domContentLoaded: navigation.domContentLoadedEventEnd,
+          load: navigation.loadEventEnd,
+          responseStart: navigation.responseStart,
+        }
+      : null;
+    const fallbackLcp = performance.getEntriesByType('largest-contentful-paint').at(-1)?.startTime ?? null;
+    const largestContentfulPaint = typeof window.__perf?.lcp === 'number' ? window.__perf.lcp : fallbackLcp;
+    return { paints, navigationTiming, largestContentfulPaint };
+  });
+
+const initPerformanceObservers = async (context) => {
+  await context.addInitScript(() => {
+    if (typeof window === 'undefined' || typeof PerformanceObserver === 'undefined') {
+      return;
+    }
+    window.__perf = { paints: [], lcp: null };
+    try {
+      const paintObserver = new PerformanceObserver((list) => {
+        window.__perf.paints.push(
+          ...list.getEntries().map(({ name, startTime }) => ({ name, startTime }))
+        );
+      });
+      paintObserver.observe({ type: 'paint', buffered: true });
+    } catch (err) {
+      console.warn('Paint observer unavailable', err);
+    }
+    try {
+      const lcpObserver = new PerformanceObserver((list) => {
+        const last = list.getEntries().at(-1);
+        if (last) {
+          window.__perf.lcp = last.startTime;
+        }
+      });
+      lcpObserver.observe({ type: 'largest-contentful-paint', buffered: true });
+    } catch (err) {
+      console.warn('LCP observer unavailable', err);
+    }
+  });
+};
+
+const main = async () => {
+  const { urls, outputPath } = parseArgs(process.argv.slice(2));
+  const targets = urls.length > 0 ? urls : ['http://localhost:3000/'];
+
+  const browser = await chromium.launch({ headless: true });
+  const results = [];
+
+  try {
+    for (const target of targets) {
+      const context = await browser.newContext({
+        viewport: { width: 1280, height: 720 },
+        locale: 'en-US',
+        ignoreHTTPSErrors: true,
+      });
+      await initPerformanceObservers(context);
+      const page = await context.newPage();
+      const client = await context.newCDPSession(page);
+      await emulateNetwork(client);
+
+      const startedAt = Date.now();
+      await page.goto(target, { waitUntil: 'networkidle' });
+      await page.waitForTimeout(1000);
+      await page
+        .waitForFunction(
+          () => {
+            const entries = performance.getEntriesByType('paint');
+            return entries.length > 0 || (window.__perf?.paints?.length ?? 0) > 0;
+          },
+          undefined,
+          { timeout: PAINT_WAIT_TIMEOUT_MS }
+        )
+        .catch(() => {});
+
+      const { paints, navigationTiming, largestContentfulPaint } = await collectMetrics(page);
+      const rawFirstPaint = paints.find((entry) => entry.name === 'first-paint')?.startTime ?? null;
+      const rawFirstContentfulPaint = paints.find((entry) => entry.name === 'first-contentful-paint')?.startTime ?? null;
+      const fallbackFirst = navigationTiming?.responseStart ?? null;
+      const firstPaint = rawFirstPaint ?? fallbackFirst;
+      const firstContentfulPaint = rawFirstContentfulPaint ?? firstPaint;
+
+      results.push({
+        url: target,
+        measuredAt: new Date().toISOString(),
+        profile: FAST_3G_PROFILE,
+        firstPaint,
+        firstContentfulPaint,
+        largestContentfulPaint: largestContentfulPaint ?? navigationTiming?.domContentLoaded ?? null,
+        navigationTiming,
+        totalElapsedMs: Date.now() - startedAt,
+      });
+
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+
+  if (outputPath) {
+    await mkdir(path.dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, `${JSON.stringify(results, null, 2)}\n`, 'utf8');
+  } else {
+    process.stdout.write(`${JSON.stringify(results, null, 2)}\n`);
+  }
+};
+
+main().catch((error) => {
+  console.error('Failed to collect metrics', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- wrap the ScrollableTimeline, StatsChart, and AuditSimulator widgets in next/dynamic with polished skeleton loaders
- add reusable timeline, chart, and simulator skeleton components and update John page loader
- record Fast 3G performance metrics with a new playwright-based profiling script and capture before/after JSON snapshots

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window violations across legacy files)*
- yarn test *(fails: pre-existing issues in nmapNse, Modal, and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cca718ccbc832885a0df96b86f7df0