### PR TITLE
[apps] Enhance app grid navigation and persistence

### DIFF
--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -1,8 +1,68 @@
 import React, { useState, useMemo, useRef, useCallback, useEffect } from 'react';
 import UbuntuApp from '../base/ubuntu_app';
-import apps from '../../apps.config';
+import apps, { games, utilities } from '../../apps.config';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { Grid } from 'react-window';
+import { FixedSizeGrid as Grid } from 'react-window';
+import { useSettings } from '../../hooks/useSettings';
+
+const MIN_COLUMN_WIDTH = 150;
+const ROW_HEIGHT = 140;
+const DEFAULT_CATEGORY_ID = 'all';
+
+const gameIds = new Set(games.map((game) => game.id));
+const utilityIds = new Set(utilities.map((utility) => utility.id));
+const SECURITY_APP_IDS = new Set([
+  'autopsy',
+  'beef',
+  'ble-sensor',
+  'dsniff',
+  'evidence-vault',
+  'ettercap',
+  'ghidra',
+  'hashcat',
+  'http',
+  'hydra',
+  'john',
+  'kismet',
+  'metasploit',
+  'mimikatz',
+  'mimikatz-offline',
+  'msf-post',
+  'nessus',
+  'nikto',
+  'nmap-nse',
+  'openvas',
+  'radare2',
+  'reaver',
+  'recon-ng',
+  'security-tools',
+  'serial-terminal',
+  'ssh',
+  'volatility',
+  'wireshark',
+]);
+
+const CATEGORY_DEFINITIONS = [
+  { id: 'all', label: 'All', filter: () => true },
+  { id: 'favorites', label: 'Favorites', filter: (app) => Boolean(app.favourite) },
+  {
+    id: 'apps',
+    label: 'Apps',
+    filter: (app) => !gameIds.has(app.id) && !utilityIds.has(app.id) && !SECURITY_APP_IDS.has(app.id),
+  },
+  { id: 'utilities', label: 'Utilities', filter: (app) => utilityIds.has(app.id) },
+  { id: 'security', label: 'Security', filter: (app) => SECURITY_APP_IDS.has(app.id) },
+  { id: 'games', label: 'Games', filter: (app) => gameIds.has(app.id) },
+];
+
+const CATEGORY_MAP = {};
+CATEGORY_DEFINITIONS.forEach((category) => {
+  CATEGORY_MAP[category.id] = category;
+});
+
+function clampCategoryId(id) {
+  return CATEGORY_MAP[id] ? id : DEFAULT_CATEGORY_ID;
+}
 
 function fuzzyHighlight(text, query) {
   const q = query.toLowerCase();
@@ -20,104 +80,421 @@ function fuzzyHighlight(text, query) {
   return { matched: qi === q.length, nodes: result };
 }
 
-export default function AppGrid({ openApp }) {
-  const [query, setQuery] = useState('');
-  const gridRef = useRef(null);
-  const columnCountRef = useRef(1);
-  const [focusedIndex, setFocusedIndex] = useState(0);
-
-  const filtered = useMemo(() => {
-    if (!query) return apps.map((app) => ({ ...app, nodes: app.title }));
-    return apps
-      .map((app) => {
-        const { matched, nodes } = fuzzyHighlight(app.title, query);
-        return matched ? { ...app, nodes } : null;
-      })
-      .filter(Boolean);
-  }, [query]);
-
-  useEffect(() => {
-    if (focusedIndex >= filtered.length) {
-      setFocusedIndex(0);
-    }
-  }, [filtered, focusedIndex]);
-
-  const getColumnCount = (width) => {
-    if (width >= 1024) return 8;
-    if (width >= 768) return 6;
-    if (width >= 640) return 4;
-    return 3;
+const Cell = ({ columnIndex, rowIndex, style, data }) => {
+  const index = rowIndex * data.columnCount + columnIndex;
+  const app = data.items[index];
+  if (!app) {
+    return <div style={style} />;
+  }
+  const globalIndex = data.pageStart + index;
+  const isFocused = globalIndex === data.focusedIndex;
+  const cellStyle = {
+    ...style,
+    padding: '12px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
   };
+  const highlightStyle = isFocused
+    ? { boxShadow: '0 0 0 2px rgba(23, 147, 209, 0.7)', borderRadius: '12px' }
+    : { borderRadius: '12px' };
 
-  const handleKeyDown = useCallback(
-    (e) => {
-      if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
-      e.preventDefault();
-      const colCount = columnCountRef.current;
-      let idx = focusedIndex;
-      if (e.key === 'ArrowRight') idx = Math.min(idx + 1, filtered.length - 1);
-      if (e.key === 'ArrowLeft') idx = Math.max(idx - 1, 0);
-      if (e.key === 'ArrowDown') idx = Math.min(idx + colCount, filtered.length - 1);
-      if (e.key === 'ArrowUp') idx = Math.max(idx - colCount, 0);
-      setFocusedIndex(idx);
-      const row = Math.floor(idx / colCount);
-      const col = idx % colCount;
-      gridRef.current?.scrollToCell({ rowIndex: row, columnIndex: col, rowAlign: 'smart', columnAlign: 'smart' });
-      setTimeout(() => {
-        const el = document.getElementById('app-' + filtered[idx].id);
-        el?.focus();
-      }, 0);
-    },
-    [filtered, focusedIndex]
-  );
-
-  const Cell = ({ columnIndex, rowIndex, style, data }) => {
-    const index = rowIndex * data.columnCount + columnIndex;
-    if (index >= data.items.length) return null;
-    const app = data.items[index];
-    return (
-      <div style={{ ...style, display: 'flex', justifyContent: 'center', alignItems: 'center', padding: 12 }}>
+  return (
+    <div
+      role="gridcell"
+      aria-selected={isFocused}
+      style={cellStyle}
+      className="focus-within:z-10"
+      data-testid={`app-tile-${app.id}`}
+      onFocusCapture={() => data.onFocusIndexChange(globalIndex)}
+      onMouseDown={() => data.onFocusIndexChange(globalIndex)}
+    >
+      <div className="flex h-full w-full items-center justify-center transition-all" style={highlightStyle}>
         <UbuntuApp
           id={app.id}
           icon={app.icon}
           name={app.title}
-          displayName={<>{app.nodes}</>}
-          openApp={() => openApp && openApp(app.id)}
+          displayName={<>{app.nodes || app.title}</>}
+          openApp={() => data.openApp && data.openApp(app.id)}
+          disabled={app.disabled}
+          prefetch={app.screen?.prefetch}
         />
       </div>
-    );
-  };
+    </div>
+  );
+};
+
+const VirtualizedPage = ({
+  height,
+  width,
+  items,
+  page,
+  onPageChange,
+  focusedIndex,
+  onFocusIndexChange,
+  onLayoutChange,
+  gridRef,
+  openApp,
+}) => {
+  const columnCount = Math.max(1, Math.floor(width / MIN_COLUMN_WIDTH));
+  const rowHeight = ROW_HEIGHT;
+  const rowsPerPage = Math.max(1, Math.floor(height / rowHeight));
+  const pageSize = Math.max(columnCount, rowsPerPage * columnCount);
+  const totalPages = Math.max(1, Math.ceil(items.length / pageSize) || 1);
+  const clampedPage = Math.min(Math.max(page, 0), totalPages - 1);
+  const pageStart = clampedPage * pageSize;
+  const pageItems = items.slice(pageStart, pageStart + pageSize);
+  const visibleCount = pageItems.length;
+  const rowCount = Math.max(1, Math.ceil(Math.max(visibleCount, 1) / columnCount));
+  const columnWidth = columnCount === 0 ? width : width / columnCount;
+
+  useEffect(() => {
+    onLayoutChange({ columnCount, pageSize, pageStart, totalPages, visibleCount });
+  }, [columnCount, pageSize, pageStart, totalPages, visibleCount, onLayoutChange]);
+
+  useEffect(() => {
+    if (clampedPage !== page) {
+      onPageChange(clampedPage);
+    }
+  }, [clampedPage, onPageChange, page]);
+
+  useEffect(() => {
+    if (!visibleCount) {
+      if (focusedIndex !== 0) {
+        onFocusIndexChange(0);
+      }
+      return;
+    }
+    const minIndex = pageStart;
+    const maxIndex = pageStart + visibleCount - 1;
+    if (focusedIndex < minIndex || focusedIndex > maxIndex) {
+      onFocusIndexChange(minIndex);
+    }
+  }, [focusedIndex, visibleCount, pageStart, onFocusIndexChange]);
+
+  const itemData = useMemo(
+    () => ({
+      items: pageItems,
+      columnCount,
+      pageStart,
+      focusedIndex,
+      onFocusIndexChange,
+      openApp,
+    }),
+    [pageItems, columnCount, pageStart, focusedIndex, onFocusIndexChange, openApp]
+  );
 
   return (
-    <div className="flex flex-col items-center h-full">
+    <Grid
+      ref={gridRef}
+      columnCount={columnCount}
+      columnWidth={columnWidth}
+      height={height}
+      rowCount={rowCount}
+      rowHeight={rowHeight}
+      width={width}
+      itemData={itemData}
+      itemKey={({ columnIndex: ci, rowIndex: ri, data }) => {
+        const idx = ri * data.columnCount + ci;
+        const item = data.items[idx];
+        return item ? item.id : `empty-${ri}-${ci}`;
+      }}
+      className="scroll-smooth"
+    >
+      {Cell}
+    </Grid>
+  );
+};
+
+export default function AppGrid({ openApp }) {
+  const { appGridCategory, setAppGridCategory, appGridPage, setAppGridPage, hydrated } = useSettings();
+  const categoryId = clampCategoryId(appGridCategory);
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const gridRef = useRef(null);
+  const layoutRef = useRef({ columnCount: 1, pageSize: 1, pageStart: 0, visibleCount: 0, totalPages: 1 });
+  const [pageInfo, setPageInfo] = useState({ current: 0, total: 1 });
+  const hasHydratedRef = useRef(false);
+
+  useEffect(() => {
+    if (hydrated) {
+      hasHydratedRef.current = true;
+    }
+  }, [hydrated]);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setDebouncedQuery(query.trim());
+    }, 120);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  useEffect(() => {
+    if (!hydrated || !hasHydratedRef.current) return;
+    setFocusedIndex(0);
+    setAppGridPage(0);
+  }, [debouncedQuery, hydrated, setAppGridPage]);
+
+  useEffect(() => {
+    if (!CATEGORY_MAP[appGridCategory] && hydrated) {
+      setAppGridCategory(DEFAULT_CATEGORY_ID);
+    }
+  }, [appGridCategory, hydrated, setAppGridCategory]);
+
+  const filtered = useMemo(() => {
+    const category = CATEGORY_MAP[categoryId] || CATEGORY_MAP[DEFAULT_CATEGORY_ID];
+    const base = apps.filter((app) => !app.disabled && category.filter(app));
+    if (!debouncedQuery) {
+      return base.map((app) => ({ ...app, nodes: app.title }));
+    }
+    return base
+      .map((app) => {
+        const { matched, nodes } = fuzzyHighlight(app.title, debouncedQuery);
+        return matched ? { ...app, nodes } : null;
+      })
+      .filter(Boolean);
+  }, [categoryId, debouncedQuery]);
+
+  useEffect(() => {
+    if (!filtered.length) {
+      if (focusedIndex !== 0) setFocusedIndex(0);
+      return;
+    }
+    if (focusedIndex >= filtered.length) {
+      setFocusedIndex(filtered.length - 1);
+    }
+  }, [filtered, focusedIndex]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const target = filtered[focusedIndex];
+    if (!target) return undefined;
+    const frame = window.requestAnimationFrame(() => {
+      const el = document.getElementById(`app-${target.id}`);
+      el?.focus({ preventScroll: true });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [filtered, focusedIndex]);
+
+  useEffect(() => {
+    const layout = layoutRef.current;
+    if (!layout) return;
+    const { pageStart, columnCount, visibleCount } = layout;
+    if (visibleCount === 0) return;
+    const localIndex = focusedIndex - pageStart;
+    if (localIndex < 0 || localIndex >= visibleCount) return;
+    const rowIndex = Math.floor(localIndex / columnCount);
+    const columnIndex = localIndex % columnCount;
+    if (typeof gridRef.current?.scrollToItem === 'function') {
+      gridRef.current.scrollToItem({ columnIndex, rowIndex, align: 'smart' });
+    }
+  }, [focusedIndex]);
+
+  const handleLayoutChange = useCallback((layout) => {
+    layoutRef.current = layout;
+    const pageSize = Math.max(layout.pageSize, 1);
+    const current = pageSize ? Math.floor(layout.pageStart / pageSize) : 0;
+    setPageInfo((prev) => (prev.current === current && prev.total === layout.totalPages ? prev : { current, total: layout.totalPages }));
+  }, []);
+
+  const handlePageChange = useCallback(
+    (delta) => {
+      const layout = layoutRef.current;
+      if (!layout) return;
+      const maxPage = Math.max(layout.totalPages - 1, 0);
+      const current = Math.min(Math.max(appGridPage, 0), maxPage);
+      const next = Math.min(Math.max(current + delta, 0), maxPage);
+      if (next === current) return;
+      setAppGridPage(next);
+      const nextIndex = Math.min(next * Math.max(layout.pageSize, 1), Math.max(filtered.length - 1, 0));
+      setFocusedIndex(nextIndex);
+    },
+    [appGridPage, filtered.length, setAppGridPage]
+  );
+
+  const changeCategory = useCallback(
+    (nextCategory) => {
+      const normalized = clampCategoryId(nextCategory);
+      if (normalized === appGridCategory) return;
+      setAppGridCategory(normalized);
+      setFocusedIndex(0);
+      if (hydrated) {
+        setAppGridPage(0);
+      }
+    },
+    [appGridCategory, hydrated, setAppGridCategory, setAppGridPage]
+  );
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      const { key, ctrlKey } = event;
+      const layout = layoutRef.current;
+      if (!layout) return;
+
+      if (ctrlKey && (key === 'ArrowRight' || key === 'ArrowLeft')) {
+        event.preventDefault();
+        const currentIndex = CATEGORY_DEFINITIONS.findIndex((cat) => cat.id === categoryId);
+        if (currentIndex === -1) return;
+        const delta = key === 'ArrowRight' ? 1 : -1;
+        const nextIndex = (currentIndex + delta + CATEGORY_DEFINITIONS.length) % CATEGORY_DEFINITIONS.length;
+        changeCategory(CATEGORY_DEFINITIONS[nextIndex].id);
+        return;
+      }
+
+      if (key === 'PageDown' || key === 'PageUp') {
+        event.preventDefault();
+        handlePageChange(key === 'PageDown' ? 1 : -1);
+        return;
+      }
+
+      if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(key)) {
+        return;
+      }
+
+      const { columnCount, pageStart, visibleCount } = layout;
+      if (visibleCount === 0) return;
+      const lastIndex = pageStart + visibleCount - 1;
+      let nextIndex = focusedIndex;
+
+      if (key === 'ArrowRight') {
+        if (focusedIndex < lastIndex) {
+          nextIndex = Math.min(focusedIndex + 1, filtered.length - 1);
+        } else {
+          event.preventDefault();
+          handlePageChange(1);
+          return;
+        }
+      } else if (key === 'ArrowLeft') {
+        if (focusedIndex > pageStart) {
+          nextIndex = Math.max(focusedIndex - 1, 0);
+        } else {
+          event.preventDefault();
+          handlePageChange(-1);
+          return;
+        }
+      } else if (key === 'ArrowDown') {
+        const candidate = focusedIndex + columnCount;
+        if (candidate <= lastIndex && candidate < filtered.length) {
+          nextIndex = candidate;
+        } else {
+          event.preventDefault();
+          handlePageChange(1);
+          return;
+        }
+      } else if (key === 'ArrowUp') {
+        const candidate = focusedIndex - columnCount;
+        if (candidate >= pageStart) {
+          nextIndex = candidate;
+        } else {
+          event.preventDefault();
+          handlePageChange(-1);
+          return;
+        }
+      } else if (key === 'Home') {
+        nextIndex = pageStart;
+      } else if (key === 'End') {
+        nextIndex = lastIndex;
+      }
+
+      event.preventDefault();
+      setFocusedIndex(Math.max(0, Math.min(nextIndex, filtered.length - 1)));
+    },
+    [categoryId, changeCategory, filtered.length, focusedIndex, handlePageChange]
+  );
+
+  const displayedPage = Math.max(0, Math.min(pageInfo.current, Math.max(pageInfo.total - 1, 0)));
+  const totalPages = Math.max(pageInfo.total, 1);
+
+  return (
+    <div className="flex h-full w-full flex-col gap-4 px-4 py-4" data-testid="app-grid">
+      <label htmlFor="app-grid-search" className="sr-only">
+        Search applications
+      </label>
       <input
-        className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+        id="app-grid-search"
+        data-testid="app-grid-search"
+        className="w-full rounded-md bg-black/30 px-4 py-2 text-white placeholder-white/60 focus:outline-none focus:ring-2 focus:ring-ubt-blue"
         placeholder="Search"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
+        type="search"
       />
-      <div className="w-full flex-1 h-[70vh] outline-none" onKeyDown={handleKeyDown}>
-        <AutoSizer>
-          {({ height, width }) => {
-            const columnCount = getColumnCount(width);
-            columnCountRef.current = columnCount;
-            const rowCount = Math.ceil(filtered.length / columnCount);
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex flex-wrap items-center gap-2" role="group" aria-label="Filter applications by category">
+          {CATEGORY_DEFINITIONS.map((category) => {
+            const active = category.id === categoryId;
             return (
-              <Grid
-                gridRef={gridRef}
-                columnCount={columnCount}
-                columnWidth={width / columnCount}
-                height={height}
-                rowCount={rowCount}
-                rowHeight={112}
-                width={width}
-                className="scroll-smooth"
+              <button
+                key={category.id}
+                type="button"
+                className={`rounded-full px-3 py-1 text-sm transition focus:outline-none focus:ring-2 focus:ring-ubt-blue ${
+                  active ? 'bg-ubt-blue text-white' : 'bg-white/10 text-white/80 hover:bg-white/20'
+                }`}
+                aria-pressed={active}
+                data-testid={`category-${category.id}`}
+                onClick={() => changeCategory(category.id)}
               >
-                {(props) => <Cell {...props} data={{ items: filtered, columnCount }} />}
-              </Grid>
+                {category.label}
+              </button>
             );
-          }}
-        </AutoSizer>
+          })}
+        </div>
+        <div className="flex items-center gap-3 text-sm text-white/80" aria-live="polite">
+          <button
+            type="button"
+            className="rounded border border-white/20 px-3 py-1 text-white/80 transition hover:bg-white/10 disabled:opacity-40"
+            onClick={() => handlePageChange(-1)}
+            disabled={displayedPage === 0 || totalPages <= 1}
+            data-testid="prev-page"
+            aria-label="Previous page"
+          >
+            Prev
+          </button>
+          <span data-testid="page-indicator">
+            Page {Math.min(displayedPage + 1, totalPages)} of {totalPages}
+          </span>
+          <button
+            type="button"
+            className="rounded border border-white/20 px-3 py-1 text-white/80 transition hover:bg-white/10 disabled:opacity-40"
+            onClick={() => handlePageChange(1)}
+            disabled={displayedPage >= totalPages - 1 || totalPages <= 1}
+            data-testid="next-page"
+            aria-label="Next page"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+      <div
+        className="relative flex min-h-[20rem] flex-1 overflow-hidden rounded-lg bg-black/30"
+        role="grid"
+        aria-label="Application grid"
+        data-testid="app-grid-viewport"
+        onKeyDownCapture={handleKeyDown}
+      >
+        {filtered.length ? (
+          <AutoSizer>
+            {({ height, width }) => (
+              <VirtualizedPage
+                height={height}
+                width={width}
+                items={filtered}
+                page={appGridPage}
+                onPageChange={setAppGridPage}
+                focusedIndex={focusedIndex}
+                onFocusIndexChange={setFocusedIndex}
+                onLayoutChange={handleLayoutChange}
+                gridRef={gridRef}
+                openApp={openApp}
+              />
+            )}
+          </AutoSizer>
+        ) : (
+          <div className="flex h-full w-full items-center justify-center p-6 text-center text-sm text-white/70">
+            No applications match your filters.
+          </div>
+        )}
       </div>
     </div>
   );

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -1,69 +1,33 @@
-import Image from 'next/image';
-import { useEffect, useState } from 'react';
-import Link from 'next/link';
+import dynamic from 'next/dynamic';
+import { useCallback } from 'react';
+import { useRouter } from 'next/router';
+
+const AppGrid = dynamic(() => import('../../components/apps/app-grid'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex min-h-screen items-center justify-center bg-ub-grey text-white">
+      Loading applications…
+    </div>
+  ),
+});
 
 const AppsPage = () => {
-  const [apps, setApps] = useState([]);
-  const [query, setQuery] = useState('');
-
-  useEffect(() => {
-    let isMounted = true;
-    import('../../apps.config').then((mod) => {
-      if (isMounted) {
-        setApps(mod.default);
-      }
-    });
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  const filteredApps = apps.filter(
-    (app) => !app.disabled && app.title.toLowerCase().includes(query.toLowerCase()),
+  const router = useRouter();
+  const handleOpenApp = useCallback(
+    (id) => {
+      if (!id) return;
+      void router.push(`/apps/${id}`);
+    },
+    [router]
   );
 
   return (
-    <div className="p-4">
-      <label htmlFor="app-search" className="sr-only">
-        Search apps
-      </label>
-      <input
-        id="app-search"
-        type="search"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder="Search apps"
-        className="mb-4 w-full rounded border p-2"
-      />
-      <div
-        id="app-grid"
-        tabIndex="-1"
-        className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
-      >
-        {filteredApps.map((app) => (
-          <Link
-            key={app.id}
-            href={`/apps/${app.id}`}
-            className="flex flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
-            aria-label={app.title}
-          >
-            {app.icon && (
-              <Image
-                src={app.icon}
-                alt=""
-                width={64}
-                height={64}
-                sizes="64px"
-                className="h-16 w-16"
-              />
-            )}
-            <span className="mt-2">{app.title}</span>
-          </Link>
-        ))}
-      </div>
+    <div className="flex min-h-screen flex-col bg-ub-grey text-white">
+      <main className="flex flex-1 flex-col">
+        <AppGrid openApp={handleOpenApp} />
+      </main>
     </div>
   );
 };
 
 export default AppsPage;
-

--- a/tests/app-grid.spec.ts
+++ b/tests/app-grid.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('App grid interactions', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/apps');
+    await page.waitForSelector('[data-testid="app-grid-viewport"]');
+  });
+
+  test('filters quickly when typing in the search box', async ({ page }) => {
+    await page.locator('[data-testid="category-games"]').click();
+    const searchInput = page.getByTestId('app-grid-search');
+    await searchInput.fill('Chess');
+    await page.waitForTimeout(150);
+    await expect(page.locator('[data-testid="app-tile-chess"]')).toBeVisible();
+    await expect(page.locator('[data-testid="app-tile-2048"]')).toHaveCount(0);
+  });
+
+  test('paginates between result sets', async ({ page }) => {
+    await page.locator('[data-testid="category-games"]').click();
+    await page.waitForSelector('[data-testid^="app-tile-"]');
+    const firstTileBefore = await page.locator('[data-testid^="app-tile-"]').first().getAttribute('data-testid');
+    await page.locator('[data-testid="next-page"]').click();
+    await expect(page.locator('[data-testid="page-indicator"]')).toContainText('Page 2');
+    const firstTileAfter = await page.locator('[data-testid^="app-tile-"]').first().getAttribute('data-testid');
+    expect(firstTileAfter).not.toBe(firstTileBefore);
+  });
+
+  test('supports keyboard navigation for pages and categories', async ({ page }) => {
+    await page.locator('[data-testid="category-apps"]').click();
+    await page.waitForSelector('[data-testid^="app-tile-"]');
+    await page.locator('[data-testid^="app-tile-"]').first().click();
+    await page.keyboard.press('PageDown');
+    await expect(page.locator('[data-testid="page-indicator"]')).toContainText('Page 2');
+    await page.keyboard.down('Control');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.up('Control');
+    await expect(page.locator('[data-testid="category-utilities"]')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('[data-testid="page-indicator"]')).toContainText('Page 1');
+  });
+
+  test('persists last used category and page', async ({ page }) => {
+    await page.locator('[data-testid="category-games"]').click();
+    await page.locator('[data-testid="next-page"]').click();
+    await expect(page.locator('[data-testid="page-indicator"]')).toContainText('Page 2');
+    await page.reload();
+    await page.waitForSelector('[data-testid="app-grid-viewport"]');
+    await expect(page.locator('[data-testid="category-games"]')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('[data-testid="page-indicator"]')).toContainText('Page 2');
+  });
+});

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,8 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  appGridCategory: 'all',
+  appGridPage: 0,
 };
 
 export async function getAccent() {
@@ -123,6 +125,29 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getAppGridCategory() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.appGridCategory;
+  return window.localStorage.getItem('app-grid-category') || DEFAULT_SETTINGS.appGridCategory;
+}
+
+export async function setAppGridCategory(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('app-grid-category', value);
+}
+
+export async function getAppGridPage() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.appGridPage;
+  const stored = window.localStorage.getItem('app-grid-page');
+  const page = stored === null ? DEFAULT_SETTINGS.appGridPage : parseInt(stored, 10);
+  return Number.isNaN(page) ? DEFAULT_SETTINGS.appGridPage : page;
+}
+
+export async function setAppGridPage(value) {
+  if (typeof window === 'undefined') return;
+  const safeValue = Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+  window.localStorage.setItem('app-grid-page', String(safeValue));
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -137,6 +162,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('app-grid-category');
+  window.localStorage.removeItem('app-grid-page');
 }
 
 export async function exportSettings() {
@@ -151,6 +178,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    appGridCategory,
+    appGridPage,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +191,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getAppGridCategory(),
+    getAppGridPage(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -176,6 +207,8 @@ export async function exportSettings() {
     allowNetwork,
     haptics,
     theme,
+    appGridCategory,
+    appGridPage,
   });
 }
 
@@ -200,6 +233,8 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    appGridCategory,
+    appGridPage,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -211,6 +246,8 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (appGridCategory !== undefined) await setAppGridCategory(appGridCategory);
+  if (appGridPage !== undefined) await setAppGridPage(appGridPage);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- refactor the app grid to add category filters, paginated virtualization, and debounced search with improved keyboard and focus handling
- persist the last-used grid category and page via the shared settings store and load them during hydration
- render the grid client-side on /apps and add Playwright coverage for search, pagination, keyboard navigation, and persistence

## Testing
- `yarn lint` *(fails: existing accessibility and no-top-level-window violations across legacy apps)*
- `yarn test` *(fails: pre-existing jest failures and jsdom localStorage access issue)*
- `npx playwright test` *(fails: browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6fd71e4c8328afce554a91b51f3b