### PR TITLE
[notifications] Add per-app notification preferences

### DIFF
--- a/__tests__/notificationPreferences.test.tsx
+++ b/__tests__/notificationPreferences.test.tsx
@@ -1,0 +1,216 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderHook } from '@testing-library/react';
+import Settings from '../apps/settings';
+import NotificationCenter from '../components/common/NotificationCenter';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+import useNotifications from '../hooks/useNotifications';
+
+type PropsWithChildren = { children: React.ReactNode };
+
+const wrapWithSettings = ({ children }: PropsWithChildren) => (
+  <SettingsProvider>{children}</SettingsProvider>
+);
+
+const flushMicrotasks = () => act(async () => {
+  await Promise.resolve();
+});
+
+describe('notification preferences', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('sanitizes and persists per-app notification preferences', async () => {
+    const { result, unmount } = renderHook(() => useSettings(), {
+      wrapper: wrapWithSettings,
+    });
+    await flushMicrotasks();
+
+    act(() => {
+      result.current.updateNotificationPreference('terminal', {
+        banners: false,
+        sounds: true,
+        badges: true,
+      });
+    });
+
+    await waitFor(() => {
+      const raw = window.localStorage.getItem('notification-preferences');
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw!)).toEqual({
+        terminal: { banners: false, sounds: false, badges: true },
+      });
+    });
+
+    expect(result.current.getNotificationPreference('terminal')).toEqual({
+      banners: false,
+      sounds: false,
+      badges: true,
+    });
+
+    unmount();
+
+    const rerendered = renderHook(() => useSettings(), {
+      wrapper: wrapWithSettings,
+    });
+    await flushMicrotasks();
+
+    await waitFor(() => {
+      expect(rerendered.result.current.getNotificationPreference('terminal')).toEqual({
+        banners: false,
+        sounds: false,
+        badges: true,
+      });
+    });
+
+    act(() => {
+      rerendered.result.current.resetNotificationPreference('terminal');
+    });
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem('notification-preferences')).toBeNull();
+    });
+  });
+
+  test('notifications tab enforces banner and sound dependencies', async () => {
+    const user = userEvent.setup();
+
+    render(<Settings />, { wrapper: wrapWithSettings });
+
+    await user.click(screen.getByRole('tab', { name: 'Notifications' }));
+    await waitFor(() => {
+      const select = screen.getByLabelText('Application') as HTMLSelectElement;
+      expect(select.value).not.toBe('');
+    });
+
+    const bannerSwitch = screen.getByRole('switch', {
+      name: 'Toggle notification banners',
+    });
+    const soundSwitch = screen.getByRole('switch', {
+      name: 'Toggle notification sounds',
+    });
+    const restoreButton = screen.getByRole('button', { name: 'Restore defaults' });
+
+    expect(bannerSwitch).toHaveAttribute('aria-checked', 'true');
+    expect(soundSwitch).toHaveAttribute('aria-checked', 'true');
+    expect(soundSwitch).not.toBeDisabled();
+    expect(restoreButton).toBeDisabled();
+
+    await user.click(bannerSwitch);
+
+    await waitFor(() => {
+      expect(bannerSwitch).toHaveAttribute('aria-checked', 'false');
+      expect(soundSwitch).toHaveAttribute('aria-checked', 'false');
+      expect(soundSwitch).toBeDisabled();
+      expect(restoreButton).not.toBeDisabled();
+    });
+
+    await user.click(restoreButton);
+
+    await waitFor(() => {
+      expect(bannerSwitch).toHaveAttribute('aria-checked', 'true');
+      expect(soundSwitch).toHaveAttribute('aria-checked', 'true');
+      expect(soundSwitch).not.toBeDisabled();
+      expect(restoreButton).toBeDisabled();
+    });
+  });
+
+  test('NotificationCenter respects updated preferences immediately', async () => {
+    const user = userEvent.setup();
+    const setAppBadge = jest.fn().mockResolvedValue(undefined);
+    const clearAppBadge = jest.fn().mockResolvedValue(undefined);
+    const originalSetAppBadge = (navigator as any).setAppBadge;
+    const originalClearAppBadge = (navigator as any).clearAppBadge;
+
+    Object.defineProperty(navigator, 'setAppBadge', {
+      configurable: true,
+      value: setAppBadge,
+    });
+    Object.defineProperty(navigator, 'clearAppBadge', {
+      configurable: true,
+      value: clearAppBadge,
+    });
+
+    const APP_ID = 'terminal';
+
+    const Harness = () => {
+      const notifications = useNotifications();
+      const { updateNotificationPreference } = useSettings();
+
+      return (
+        <>
+          <button onClick={() => notifications.pushNotification(APP_ID, 'Ping')}>
+            notify
+          </button>
+          <button
+            onClick={() => updateNotificationPreference(APP_ID, { banners: false })}
+          >
+            disable-banners
+          </button>
+          <button
+            onClick={() => updateNotificationPreference(APP_ID, { badges: false })}
+          >
+            disable-badges
+          </button>
+        </>
+      );
+    };
+
+    try {
+      render(
+        <SettingsProvider>
+          <NotificationCenter>
+            <Harness />
+          </NotificationCenter>
+        </SettingsProvider>,
+      );
+
+      await flushMicrotasks();
+
+      await user.click(screen.getByText('notify'));
+      await screen.findByRole('status');
+      await waitFor(() => {
+        expect(setAppBadge).toHaveBeenCalledWith(1);
+      });
+
+      await user.click(screen.getByText('disable-banners'));
+      await waitFor(() => {
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('notify'));
+      await waitFor(() => {
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('disable-badges'));
+      await user.click(screen.getByText('notify'));
+
+      await waitFor(() => {
+        expect(clearAppBadge).toHaveBeenCalled();
+      });
+
+      expect(screen.getAllByText('Ping').length).toBeGreaterThanOrEqual(3);
+    } finally {
+      if (originalSetAppBadge) {
+        Object.defineProperty(navigator, 'setAppBadge', {
+          configurable: true,
+          value: originalSetAppBadge,
+        });
+      } else {
+        delete (navigator as any).setAppBadge;
+      }
+
+      if (originalClearAppBadge) {
+        Object.defineProperty(navigator, 'clearAppBadge', {
+          configurable: true,
+          value: originalClearAppBadge,
+        });
+      } else {
+        delete (navigator as any).clearAppBadge;
+      }
+    }
+  });
+});

--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -6,6 +6,7 @@ interface ToggleSwitchProps {
   onChange: (checked: boolean) => void;
   className?: string;
   ariaLabel: string;
+  disabled?: boolean;
 }
 
 export default function ToggleSwitch({
@@ -13,16 +14,21 @@ export default function ToggleSwitch({
   onChange,
   className = "",
   ariaLabel,
+  disabled = false,
 }: ToggleSwitchProps) {
   return (
     <button
       role="switch"
       aria-checked={checked}
       aria-label={ariaLabel}
-      onClick={() => onChange(!checked)}
+      aria-disabled={disabled ? 'true' : undefined}
+      disabled={disabled}
+      onClick={() => {
+        if (!disabled) onChange(!checked);
+      }}
       className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
         checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
-      } ${className}`.trim()}
+      } ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`.trim()}
     >
       <span
         className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-ub-cool-grey transition-transform duration-200 ${

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,4 +1,15 @@
-import React, { createContext, useCallback, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import Toast from '../ui/Toast';
+import {
+  useSettings,
+  NotificationPreference,
+} from '../../hooks/useSettings';
 
 export interface AppNotification {
   id: string;
@@ -10,43 +21,150 @@ interface NotificationsContextValue {
   notifications: Record<string, AppNotification[]>;
   pushNotification: (appId: string, message: string) => void;
   clearNotifications: (appId?: string) => void;
+  preferences: Record<string, NotificationPreference>;
+  getPreference: (appId: string) => NotificationPreference;
+  updatePreference: (
+    appId: string,
+    updates: Partial<NotificationPreference>,
+  ) => void;
+  resetPreference: (appId?: string) => void;
+  setPreferences: (
+    prefs: Record<string, Partial<NotificationPreference>>,
+  ) => void;
 }
 
 export const NotificationsContext = createContext<NotificationsContextValue | null>(null);
 
+interface BannerNotification extends AppNotification {
+  appId: string;
+}
+
+let audioContext: AudioContext | null = null;
+
+const ensureAudioContext = (): AudioContext | null => {
+  if (typeof window === 'undefined') return null;
+  const Ctor =
+    (window as unknown as { AudioContext?: typeof AudioContext }).AudioContext ||
+    (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!Ctor) return null;
+  if (!audioContext) {
+    try {
+      audioContext = new Ctor();
+    } catch {
+      audioContext = null;
+    }
+  }
+  return audioContext;
+};
+
+const playNotificationSound = () => {
+  if (typeof window === 'undefined') return;
+  const ctx = ensureAudioContext();
+  if (!ctx) return;
+  try {
+    if (ctx.state === 'suspended') {
+      void ctx.resume().catch(() => {});
+    }
+  } catch {
+    // ignore resume failures caused by autoplay policies
+  }
+  const oscillator = ctx.createOscillator();
+  const gain = ctx.createGain();
+  oscillator.type = 'triangle';
+  oscillator.frequency.value = 880;
+  gain.gain.setValueAtTime(0.0001, ctx.currentTime);
+  oscillator.connect(gain);
+  gain.connect(ctx.destination);
+  const now = ctx.currentTime;
+  oscillator.start(now);
+  gain.gain.exponentialRampToValueAtTime(0.1, now + 0.01);
+  gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.3);
+  oscillator.stop(now + 0.3);
+  oscillator.onended = () => {
+    oscillator.disconnect();
+    gain.disconnect();
+  };
+};
+
 export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const {
+    notificationPreferences,
+    getNotificationPreference,
+    updateNotificationPreference,
+    resetNotificationPreference,
+    setNotificationPreferences,
+  } = useSettings();
   const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
+  const [bannerQueue, setBannerQueue] = useState<BannerNotification[]>([]);
+  const [activeBanner, setActiveBanner] = useState<BannerNotification | null>(null);
 
   const pushNotification = useCallback((appId: string, message: string) => {
+    const entry: AppNotification = {
+      id: `${Date.now()}-${Math.random()}`,
+      message,
+      date: Date.now(),
+    };
     setNotifications(prev => {
       const list = prev[appId] ?? [];
-      const next = {
+      return {
         ...prev,
-        [appId]: [
-          ...list,
-          {
-            id: `${Date.now()}-${Math.random()}`,
-            message,
-            date: Date.now(),
-          },
-        ],
+        [appId]: [...list, entry],
       };
-      return next;
     });
-  }, []);
+    const preference = getNotificationPreference(appId);
+    if (preference.banners) {
+      setBannerQueue(queue => [...queue, { ...entry, appId }]);
+    }
+    if (preference.sounds) {
+      playNotificationSound();
+    }
+  }, [getNotificationPreference]);
 
   const clearNotifications = useCallback((appId?: string) => {
     setNotifications(prev => {
       if (!appId) return {};
+      if (!(appId in prev)) return prev;
       const next = { ...prev };
       delete next[appId];
       return next;
     });
+    if (!appId) {
+      setBannerQueue([]);
+      setActiveBanner(null);
+      return;
+    }
+    setBannerQueue(queue => queue.filter(item => item.appId !== appId));
+    setActiveBanner(current => (current?.appId === appId ? null : current));
   }, []);
 
-  const totalCount = Object.values(notifications).reduce(
-    (sum, list) => sum + list.length,
-    0
+  useEffect(() => {
+    setBannerQueue(queue =>
+      queue.filter(item => getNotificationPreference(item.appId).banners),
+    );
+    setActiveBanner(current => {
+      if (!current) return current;
+      return getNotificationPreference(current.appId).banners ? current : null;
+    });
+  }, [getNotificationPreference]);
+
+  useEffect(() => {
+    if (!activeBanner && bannerQueue.length > 0) {
+      setActiveBanner(bannerQueue[0]);
+      setBannerQueue(queue => queue.slice(1));
+    }
+  }, [activeBanner, bannerQueue]);
+
+  const handleBannerClose = useCallback(() => {
+    setActiveBanner(null);
+  }, []);
+
+  const totalCount = useMemo(
+    () =>
+      Object.entries(notifications).reduce((sum, [appId, list]) => {
+        const prefs = getNotificationPreference(appId);
+        return prefs.badges ? sum + list.length : sum;
+      }, 0),
+    [notifications, getNotificationPreference],
   );
 
   useEffect(() => {
@@ -59,20 +177,40 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
 
   return (
     <NotificationsContext.Provider
-      value={{ notifications, pushNotification, clearNotifications }}
+      value={{
+        notifications,
+        pushNotification,
+        clearNotifications,
+        preferences: notificationPreferences,
+        getPreference: getNotificationPreference,
+        updatePreference: updateNotificationPreference,
+        resetPreference: resetNotificationPreference,
+        setPreferences: setNotificationPreferences,
+      }}
     >
       {children}
+      {activeBanner && (
+        <Toast
+          key={activeBanner.id}
+          message={`${activeBanner.appId}: ${activeBanner.message}`}
+          onClose={handleBannerClose}
+        />
+      )}
       <div className="notification-center">
-        {Object.entries(notifications).map(([appId, list]) => (
-          <section key={appId} className="notification-group">
-            <h3>{appId}</h3>
-            <ul>
-              {list.map(n => (
-                <li key={n.id}>{n.message}</li>
-              ))}
-            </ul>
-          </section>
-        ))}
+        {Object.keys(notifications).length === 0 ? (
+          <p className="notification-empty">No notifications</p>
+        ) : (
+          Object.entries(notifications).map(([appId, list]) => (
+            <section key={appId} className="notification-group">
+              <h3>{appId}</h3>
+              <ul>
+                {list.map(n => (
+                  <li key={n.id}>{n.message}</li>
+                ))}
+              </ul>
+            </section>
+          ))
+        )}
       </div>
     </NotificationsContext.Provider>
   );

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import NotificationCenter from '../components/common/NotificationCenter';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -157,21 +158,23 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+          <NotificationCenter>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </NotificationCenter>
         </SettingsProvider>
       </div>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- add per-app notification toggles to the settings app with per-application selection
- persist banner/sound/badge preferences and update the notification center in real time
- cover persistence, UI behavior, and notification provider reactions with new tests

## Testing
- yarn lint *(fails: existing accessibility and public asset lint errors)*
- yarn test *(fails: pre-existing suites that require full browser APIs/localStorage)*
- yarn test notificationPreferences.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc6fd8d6808328bf681ed58222959b