### PR TITLE
[ui] improve taskbar pinning and recents

### DIFF
--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -18,6 +18,11 @@ describe('Taskbar', () => {
         focused_windows={{ app1: true }}
         openApp={openApp}
         minimize={minimize}
+        pinned={[]}
+        recentItems={[]}
+        onPin={jest.fn()}
+        onUnpin={jest.fn()}
+        recentRequestKey={0}
       />
     );
     const button = screen.getByRole('button', { name: /app one/i });
@@ -37,10 +42,88 @@ describe('Taskbar', () => {
         focused_windows={{ app1: false }}
         openApp={openApp}
         minimize={minimize}
+        pinned={[]}
+        recentItems={[]}
+        onPin={jest.fn()}
+        onUnpin={jest.fn()}
+        recentRequestKey={0}
       />
     );
     const button = screen.getByRole('button', { name: /app one/i });
     fireEvent.click(button);
     expect(openApp).toHaveBeenCalledWith('app1');
+  });
+
+  it('persists pinned ids to storage', () => {
+    window.localStorage.clear();
+    const { rerender } = render(
+      <Taskbar
+        apps={apps}
+        closed_windows={{}}
+        minimized_windows={{}}
+        focused_windows={{}}
+        openApp={jest.fn()}
+        minimize={jest.fn()}
+        pinned={[]}
+        recentItems={[]}
+        onPin={jest.fn()}
+        onUnpin={jest.fn()}
+        recentRequestKey={0}
+      />
+    );
+    expect(window.localStorage.getItem('pinnedApps')).toBe('[]');
+    rerender(
+      <Taskbar
+        apps={apps}
+        closed_windows={{}}
+        minimized_windows={{}}
+        focused_windows={{}}
+        openApp={jest.fn()}
+        minimize={jest.fn()}
+        pinned={['app1']}
+        recentItems={[]}
+        onPin={jest.fn()}
+        onUnpin={jest.fn()}
+        recentRequestKey={0}
+      />
+    );
+    expect(window.localStorage.getItem('pinnedApps')).toBe(JSON.stringify(['app1']));
+  });
+
+  it('shows recents after an app is unpinned', () => {
+    const now = Date.now();
+    const recentItems = [{ id: 'app1', title: 'App One', icon: '/icon.png', lastOpened: now }];
+    const { rerender } = render(
+      <Taskbar
+        apps={apps}
+        closed_windows={{}}
+        minimized_windows={{}}
+        focused_windows={{}}
+        openApp={jest.fn()}
+        minimize={jest.fn()}
+        pinned={['app1']}
+        recentItems={recentItems}
+        onPin={jest.fn()}
+        onUnpin={jest.fn()}
+        recentRequestKey={1}
+      />
+    );
+    expect(screen.queryByRole('menuitem', { name: /app one/i })).not.toBeInTheDocument();
+    rerender(
+      <Taskbar
+        apps={apps}
+        closed_windows={{}}
+        minimized_windows={{}}
+        focused_windows={{}}
+        openApp={jest.fn()}
+        minimize={jest.fn()}
+        pinned={[]}
+        recentItems={recentItems}
+        onPin={jest.fn()}
+        onUnpin={jest.fn()}
+        recentRequestKey={2}
+      />
+    );
+    expect(screen.getByRole('menuitem', { name: /app one/i })).toBeInTheDocument();
   });
 });

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -23,6 +23,20 @@ function TaskbarMenu(props) {
         props.onCloseMenu && props.onCloseMenu();
     };
 
+    const handlePinToggle = () => {
+        if (props.pinned) {
+            props.onUnpin && props.onUnpin();
+        } else {
+            props.onPin && props.onPin();
+        }
+        props.onCloseMenu && props.onCloseMenu();
+    };
+
+    const handleShowRecent = () => {
+        props.onShowRecent && props.onShowRecent();
+        props.onCloseMenu && props.onCloseMenu();
+    };
+
     return (
         <div
             id="taskbar-menu"
@@ -40,6 +54,25 @@ function TaskbarMenu(props) {
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
+            </button>
+            <button
+                type="button"
+                onClick={handleShowRecent}
+                disabled={!props.hasRecent}
+                role="menuitem"
+                aria-label="Show Recent Apps"
+                className={`w-full text-left cursor-default py-0.5 mb-1.5 ${props.hasRecent ? 'hover:bg-gray-700' : 'opacity-50 cursor-not-allowed'}`}
+            >
+                <span className="ml-5">Show Recent</span>
+            </button>
+            <button
+                type="button"
+                onClick={handlePinToggle}
+                role="menuitem"
+                aria-label={props.pinned ? 'Unpin from Taskbar' : 'Pin to Taskbar'}
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">{props.pinned ? 'Unpin from Taskbar' : 'Pin to Taskbar'}</span>
             </button>
             <button
                 type="button"

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,47 +1,240 @@
-import React from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
+import { safeLocalStorage } from '../../utils/safeStorage';
+import RecentPopover from './taskbar/RecentPopover';
+
+const formatIcon = (icon) => icon ? icon.replace('./', '/') : '/themes/Yaru/system/view-app-grid-symbolic.svg';
 
 export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const {
+        apps,
+        closed_windows,
+        minimized_windows,
+        focused_windows,
+        openApp,
+        minimize,
+        pinned = [],
+        recentItems = [],
+        onPin,
+        onUnpin,
+        recentRequestKey = 0,
+    } = props;
+
+    const appMap = useMemo(() => {
+        const map = new Map();
+        apps.forEach(app => {
+            map.set(app.id, app);
+        });
+        return map;
+    }, [apps]);
+
+    const pinnedSet = useMemo(() => new Set(pinned), [pinned]);
+
+    const pinnedApps = useMemo(
+        () => pinned.map(id => appMap.get(id)).filter(Boolean),
+        [pinned, appMap]
+    );
+
+    const runningApps = useMemo(
+        () => apps.filter(app => closed_windows[app.id] === false && !pinnedSet.has(app.id)),
+        [apps, closed_windows, pinnedSet]
+    );
+
+    const taskbarApps = useMemo(
+        () => [...pinnedApps, ...runningApps],
+        [pinnedApps, runningApps]
+    );
+
+    const recents = useMemo(() => {
+        const items = recentItems
+            .filter(item => item && item.id && !pinnedSet.has(item.id))
+            .map(item => {
+                const meta = appMap.get(item.id) || {};
+                return {
+                    ...item,
+                    title: item.title || meta.title || item.id,
+                    icon: formatIcon(item.icon || meta.icon),
+                };
+            });
+        items.sort((a, b) => (b.lastOpened || 0) - (a.lastOpened || 0));
+        return items;
+    }, [recentItems, pinnedSet, appMap]);
+
+    useEffect(() => {
+        if (!Array.isArray(pinned)) return;
+        safeLocalStorage?.setItem('pinnedApps', JSON.stringify(pinned));
+    }, [pinned]);
+
+    const recentsButtonRef = useRef(null);
+    const popoverContainerRef = useRef(null);
+    const lastRequestKey = useRef(recentRequestKey);
+    const [recentVisible, setRecentVisible] = useState(false);
+    const [manualRecent, setManualRecent] = useState(false);
+
+    const showManualRecent = () => {
+        setRecentVisible(true);
+        setManualRecent(true);
+        setTimeout(() => {
+            recentsButtonRef.current?.focus();
+        }, 0);
+    };
+
+    useEffect(() => {
+        if (recentRequestKey === 0) {
+            lastRequestKey.current = recentRequestKey;
+            return;
+        }
+        if (recentRequestKey !== lastRequestKey.current) {
+            lastRequestKey.current = recentRequestKey;
+            showManualRecent();
+        }
+    }, [recentRequestKey]);
+
+    useEffect(() => {
+        if (!recentVisible) return;
+        const handlePointer = (event) => {
+            const container = popoverContainerRef.current;
+            const button = recentsButtonRef.current;
+            if (!container || !button) return;
+            if (container.contains(event.target) || button.contains(event.target)) return;
+            setRecentVisible(false);
+            setManualRecent(false);
+        };
+        document.addEventListener('mousedown', handlePointer);
+        document.addEventListener('touchstart', handlePointer);
+        const handleFocus = (event) => {
+            const container = popoverContainerRef.current;
+            const button = recentsButtonRef.current;
+            if (!container || !button) return;
+            if (container.contains(event.target) || button.contains(event.target)) return;
+            setRecentVisible(false);
+            setManualRecent(false);
+        };
+        document.addEventListener('focusin', handleFocus);
+        return () => {
+            document.removeEventListener('mousedown', handlePointer);
+            document.removeEventListener('touchstart', handlePointer);
+            document.removeEventListener('focusin', handleFocus);
+        };
+    }, [recentVisible]);
+
+    const handleRecentMouseEnter = () => {
+        setRecentVisible(true);
+        setManualRecent(false);
+    };
+
+    const handleRecentMouseLeave = () => {
+        if (manualRecent) return;
+        setRecentVisible(false);
+    };
+
+    const handleRecentFocus = () => {
+        showManualRecent();
+    };
+
+    const handleRecentClose = () => {
+        setRecentVisible(false);
+        setManualRecent(false);
+        recentsButtonRef.current?.focus();
+    };
+
+    const handleRecentSelect = (id) => {
+        openApp(id);
+        handleRecentClose();
+    };
 
     const handleClick = (app) => {
         const id = app.id;
-        if (props.minimized_windows[id]) {
-            props.openApp(id);
-        } else if (props.focused_windows[id]) {
-            props.minimize(id);
+        const isOpen = closed_windows[id] === false;
+        if (!isOpen) {
+            openApp(id);
+            return;
+        }
+        if (minimized_windows[id]) {
+            openApp(id);
+        } else if (focused_windows[id]) {
+            minimize(id);
         } else {
-            props.openApp(id);
+            openApp(id);
         }
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
+        <div
+            className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40 px-2 relative"
+            role="toolbar"
+        >
+            {taskbarApps.map(app => {
+                const id = app.id;
+                const isOpen = closed_windows[id] === false;
+                const isFocused = focused_windows[id] && !minimized_windows[id];
+                const isMinimized = minimized_windows[id];
+                const isPinned = pinnedSet.has(id);
+                const handleTaskbarKeyDown = (event) => {
+                    if ((event.key === 'p' || event.key === 'P') && (event.ctrlKey || event.metaKey)) {
+                        event.preventDefault();
+                        if (isPinned) {
+                            onUnpin && onUnpin(id);
+                        } else {
+                            onPin && onPin(id);
+                        }
+                    }
+                };
+                return (
+                    <button
+                        key={id}
+                        type="button"
+                        aria-label={app.title}
+                        title={`${app.title}${isPinned ? ' (Pinned)' : ''}`}
+                        data-context="taskbar"
+                        data-app-id={id}
+                        onClick={() => handleClick(app)}
+                        onKeyDown={handleTaskbarKeyDown}
+                        className={
+                            (isFocused ? ' bg-white bg-opacity-20 ' : ' ') +
+                            'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-70'
+                        }
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={formatIcon(app.icon)}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                        {isOpen && !isFocused && !isMinimized && (
+                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
+                        )}
+                    </button>
+                );
+            })}
+
+            <div
+                ref={popoverContainerRef}
+                onMouseEnter={handleRecentMouseEnter}
+                onMouseLeave={handleRecentMouseLeave}
+                className="ml-auto relative"
+            >
                 <button
-                    key={app.id}
                     type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    ref={recentsButtonRef}
+                    className="flex items-center px-3 py-1 rounded text-sm text-white hover:bg-white hover:bg-opacity-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-70"
+                    aria-haspopup="true"
+                    aria-expanded={recentVisible}
+                    onFocus={handleRecentFocus}
                 >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
+                    Recent
                 </button>
-            ))}
+                <RecentPopover
+                    anchorRef={recentsButtonRef}
+                    items={recents}
+                    visible={recentVisible}
+                    onSelect={handleRecentSelect}
+                    onClose={handleRecentClose}
+                />
+            </div>
         </div>
     );
 }

--- a/components/screen/taskbar/RecentPopover.js
+++ b/components/screen/taskbar/RecentPopover.js
@@ -1,0 +1,97 @@
+import React, { useEffect, useId, useRef } from 'react';
+import Image from 'next/image';
+import useFocusTrap from '../../../hooks/useFocusTrap';
+import useRovingTabIndex from '../../../hooks/useRovingTabIndex';
+
+const UNKNOWN_TIME = 'Unknown time';
+
+const formatTimestamp = (value) => {
+    if (!value) return UNKNOWN_TIME;
+    try {
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return UNKNOWN_TIME;
+        return new Intl.DateTimeFormat(undefined, {
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false,
+            day: '2-digit',
+            month: 'short',
+        }).format(date);
+    } catch (e) {
+        return UNKNOWN_TIME;
+    }
+};
+
+export default function RecentPopover({
+    anchorRef,
+    items = [],
+    visible = false,
+    onSelect,
+    onClose,
+}) {
+    const popoverRef = useRef(null);
+    const headingId = useId();
+
+    useFocusTrap(popoverRef, visible);
+    useRovingTabIndex(popoverRef, visible, 'vertical');
+
+    useEffect(() => {
+        if (!visible) return;
+        const firstItem = popoverRef.current?.querySelector('[role="menuitem"]');
+        firstItem?.focus();
+    }, [visible, items]);
+
+    const handleKeyDown = (event) => {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            onClose?.();
+            anchorRef?.current?.focus();
+        }
+    };
+
+    return (
+        <div
+            role="menu"
+            aria-hidden={!visible}
+            aria-labelledby={headingId}
+            ref={popoverRef}
+            onKeyDown={handleKeyDown}
+            className={`${visible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'} absolute bottom-12 right-0 w-64 rounded-md shadow-lg context-menu-bg border border-gray-900 text-white transition-opacity duration-150 z-50`}
+        >
+            <div id={headingId} className="px-3 py-2 text-xs font-semibold tracking-wide uppercase text-gray-300">
+                Recent Apps
+            </div>
+            <div className="max-h-60 overflow-auto py-1" role="none">
+                {items.length === 0 ? (
+                    <div className="px-3 py-2 text-sm text-gray-300" role="none">
+                        No recent apps yet
+                    </div>
+                ) : (
+                    items.map((item) => (
+                        <button
+                            key={item.id}
+                            type="button"
+                            role="menuitem"
+                            tabIndex={-1}
+                            className="w-full flex items-center gap-3 px-3 py-2 text-left text-sm hover:bg-gray-700 focus:outline-none focus-visible:bg-gray-700"
+                            onClick={() => onSelect?.(item.id)}
+                        >
+                            <Image
+                                src={item.icon}
+                                alt=""
+                                width={24}
+                                height={24}
+                                className="w-5 h-5 flex-shrink-0"
+                                sizes="24px"
+                            />
+                            <div className="flex flex-col">
+                                <span className="font-medium text-white">{item.title}</span>
+                                <span className="text-xs text-gray-300">Last opened {formatTimestamp(item.lastOpened)}</span>
+                            </div>
+                        </button>
+                    ))
+                )}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add persisted pin order and a hover-triggered recent popover to the taskbar
- track pinned ids and recent metadata in the desktop manager and expose a taskbar context action
- extend the taskbar context menu and add tests covering pin persistence and recent updates

## Testing
- yarn test taskbar
- yarn lint *(fails: repository has numerous pre-existing accessibility and no-top-level-window lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cc77e3253c832892513155629e00ab