### PR TITLE
desktop: add session restore support and tests

### DIFF
--- a/__tests__/desktopSessionRestore.test.tsx
+++ b/__tests__/desktopSessionRestore.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Desktop from '../components/screen/desktop';
+import { clearSessionProviders } from '../utils/sessionStore';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+jest.mock('html-to-image', () => ({ toPng: jest.fn(() => Promise.resolve('data:image/png;base64,')) }));
+
+jest.mock('../components/base/window', () => {
+  const React = require('react');
+  return function WindowMock(props: any) {
+    React.useEffect(() => {
+      if (props.onPositionChange) {
+        props.onPositionChange(props.initialX ?? 60, props.initialY ?? 10);
+      }
+    }, [props.onPositionChange, props.initialX, props.initialY]);
+    return (
+      <div data-testid={`window-${props.id}`} id={props.id}>
+        {props.screen(props.addFolder, props.openApp, props.sessionState)}
+      </div>
+    );
+  };
+});
+
+jest.mock('../components/screen/side_bar', () => () => null);
+jest.mock('../components/screen/taskbar', () => () => null);
+jest.mock('../components/context-menus/desktop-menu', () => () => null);
+jest.mock('../components/context-menus/default', () => () => null);
+jest.mock('../components/context-menus/app-menu', () => () => null);
+jest.mock('../components/context-menus/taskbar-menu', () => () => null);
+jest.mock('../components/screen/all-applications', () => () => null);
+jest.mock('../components/screen/shortcut-selector', () => () => null);
+jest.mock('../components/screen/window-switcher', () => () => null);
+jest.mock('../components/util-components/background-image', () => () => null);
+
+jest.mock('../apps.config', () => {
+  const React = require('react');
+  const { registerSessionProvider } = require('../utils/sessionStore');
+
+  const AboutApp = () => <div data-testid="about-app">About</div>;
+
+  function TestApp({ session }: { session?: { value?: string } }) {
+    const [value, setValue] = React.useState(session?.value || '');
+    React.useEffect(() => {
+      const unregister = registerSessionProvider('test-app', () => ({ value }));
+      return unregister;
+    }, [value]);
+    return (
+      <label>
+        <span className="sr-only">Value</span>
+        <input
+          data-testid="app-input"
+          value={value}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => setValue(event.target.value)}
+        />
+      </label>
+    );
+  }
+
+  const apps = [
+    {
+      id: 'about-alex',
+      title: 'About',
+      icon: '',
+      disabled: false,
+      favourite: true,
+      desktop_shortcut: false,
+      screen: () => <AboutApp />,
+    },
+    {
+      id: 'test-app',
+      title: 'Test App',
+      icon: '',
+      disabled: false,
+      favourite: false,
+      desktop_shortcut: false,
+      screen: (_addFolder: any, _openApp: any, session: any) => <TestApp session={session} />,
+    },
+  ];
+
+  return Object.assign(apps, { games: [], utilities: [] });
+});
+
+const renderDesktop = () =>
+  render(
+    <Desktop
+      bg_image_name="wall-2"
+      changeBackgroundImage={() => {}}
+    />,
+  );
+
+describe('Desktop session restore banner', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+    localStorage.clear();
+    clearSessionProviders();
+  });
+
+  it('restores previous windows when the user accepts the prompt', async () => {
+    localStorage.setItem(
+      'desktop-session',
+      JSON.stringify({
+        windows: [
+          {
+            id: 'test-app',
+            x: 120,
+            y: 80,
+            minimized: false,
+            snapshot: { value: 'persisted' },
+          },
+        ],
+        dock: ['about-alex'],
+        pendingRestore: true,
+        lastUpdated: Date.now() - 60000,
+      }),
+    );
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    renderDesktop();
+
+    expect(await screen.findByText(/restore session/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /restore/i }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    const input = await screen.findByTestId('app-input');
+    expect((input as HTMLInputElement).value).toBe('persisted');
+
+    await user.clear(input);
+    await user.type(input, 'updated');
+
+    await act(async () => {
+      jest.advanceTimersByTime(16000);
+    });
+
+    const stored = JSON.parse(localStorage.getItem('desktop-session') || '{}');
+    expect(stored.windows[0].snapshot.value).toBe('updated');
+    expect(stored.pendingRestore).toBe(true);
+
+    await act(async () => {
+      window.dispatchEvent(new Event('beforeunload'));
+    });
+
+    const finalSession = JSON.parse(localStorage.getItem('desktop-session') || '{}');
+    expect(finalSession.pendingRestore).toBe(false);
+  });
+
+  it('clears stored windows when the user starts fresh', async () => {
+    localStorage.setItem(
+      'desktop-session',
+      JSON.stringify({
+        windows: [
+          {
+            id: 'test-app',
+            x: 50,
+            y: 40,
+            minimized: false,
+            snapshot: { value: 'persisted' },
+          },
+        ],
+        dock: ['about-alex'],
+        pendingRestore: true,
+        lastUpdated: Date.now() - 120000,
+      }),
+    );
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    renderDesktop();
+
+    expect(await screen.findByText(/restore session/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /start fresh/i }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(screen.queryByText(/restore session/i)).not.toBeInTheDocument();
+    expect(await screen.findByTestId('about-app')).toBeInTheDocument();
+
+    const stored = JSON.parse(localStorage.getItem('desktop-session') || '{}');
+    expect(stored.windows).toHaveLength(0);
+    expect(stored.pendingRestore).toBe(false);
+  });
+});
+

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -657,13 +657,14 @@ export class Window extends Component {
                             close={this.closeWindow}
                             id={this.id}
                             allowMaximize={this.props.allowMaximize !== false}
-                            pip={() => this.props.screen(this.props.addFolder, this.props.openApp)}
+                            pip={() => this.props.screen(this.props.addFolder, this.props.openApp, this.props.sessionState)}
                         />
                         {(this.id === "settings"
                             ? <Settings />
                             : <WindowMainScreen screen={this.props.screen} title={this.props.title}
                                 addFolder={this.props.id === "terminal" ? this.props.addFolder : null}
-                                openApp={this.props.openApp} />)}
+                                openApp={this.props.openApp}
+                                session={this.props.sessionState} />)}
                     </div>
                 </Draggable >
             </>
@@ -839,7 +840,7 @@ export class WindowMainScreen extends Component {
     render() {
         return (
             <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey")}>
-                {this.props.screen(this.props.addFolder, this.props.openApp)}
+                {this.props.screen(this.props.addFolder, this.props.openApp, this.props.session)}
             </div>
         )
     }

--- a/components/ui/SessionRestoreBanner.tsx
+++ b/components/ui/SessionRestoreBanner.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+interface SessionRestoreBannerProps {
+  updatedAt?: number;
+  onRestore: () => void;
+  onDismiss: () => void;
+}
+
+const formatRelativeTime = (timestamp?: number): string | null => {
+  if (!timestamp) return null;
+  const diff = Math.max(Date.now() - timestamp, 0);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diff < minute) return 'moments ago';
+  if (diff < hour) {
+    const minutes = Math.round(diff / minute);
+    return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  }
+  if (diff < day) {
+    const hours = Math.round(diff / hour);
+    return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  }
+  const days = Math.round(diff / day);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+};
+
+export default function SessionRestoreBanner({
+  updatedAt,
+  onRestore,
+  onDismiss,
+}: SessionRestoreBannerProps) {
+  const relative = formatRelativeTime(updatedAt);
+  const detail = relative
+    ? `We found windows from your last visit (${relative}).`
+    : 'We found windows from your last visit.';
+
+  return (
+    <div
+      className="bg-amber-100 text-amber-900 p-3 rounded shadow flex flex-col sm:flex-row sm:items-center gap-3"
+      role="alert"
+    >
+      <div className="flex-1 text-sm">
+        <p className="font-semibold text-base">Restore session?</p>
+        <p>{detail} Restore them or start a new session.</p>
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onRestore}
+          className="px-3 py-1 rounded bg-amber-600 text-white hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500"
+        >
+          Restore
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="px-3 py-1 rounded border border-amber-600 text-amber-900 hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+        >
+          Start fresh
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -5,40 +5,123 @@ export interface SessionWindow {
   id: string;
   x: number;
   y: number;
+  minimized?: boolean;
+  snapshot?: unknown;
 }
 
 export interface DesktopSession {
   windows: SessionWindow[];
   wallpaper: string;
   dock: string[];
+  pendingRestore?: boolean;
+  lastUpdated?: number;
+  version?: number;
 }
+
+const SESSION_VERSION = 2;
 
 const initialSession: DesktopSession = {
   windows: [],
   wallpaper: defaults.wallpaper,
   dock: [],
+  pendingRestore: false,
+  lastUpdated: 0,
+  version: SESSION_VERSION,
 };
 
 function isSession(value: unknown): value is DesktopSession {
   if (!value || typeof value !== 'object') return false;
-  const s = value as DesktopSession;
+  const {
+    windows,
+    dock,
+    wallpaper,
+    pendingRestore,
+    lastUpdated,
+  } = value as {
+    windows?: unknown;
+    dock?: unknown;
+    wallpaper?: unknown;
+    pendingRestore?: unknown;
+    lastUpdated?: unknown;
+  };
+
+  const windowsValid =
+    windows === undefined || Array.isArray(windows);
+  const dockValid = dock === undefined || Array.isArray(dock);
+  const wallpaperValid =
+    wallpaper === undefined || typeof wallpaper === 'string';
+  const pendingRestoreValid =
+    pendingRestore === undefined || typeof pendingRestore === 'boolean';
+  const lastUpdatedValid =
+    lastUpdated === undefined || typeof lastUpdated === 'number';
+
   return (
-    Array.isArray(s.windows) &&
-    typeof s.wallpaper === 'string' &&
-    Array.isArray(s.dock)
+    windowsValid &&
+    dockValid &&
+    wallpaperValid &&
+    pendingRestoreValid &&
+    lastUpdatedValid
   );
 }
 
+const normalizeWindow = (value: unknown): SessionWindow | null => {
+  if (!value || typeof value !== 'object') return null;
+  const win = value as Partial<SessionWindow> & { id?: unknown; x?: unknown; y?: unknown };
+  if (typeof win.id !== 'string' || !win.id) return null;
+  const x = typeof win.x === 'number' ? win.x : 60;
+  const y = typeof win.y === 'number' ? win.y : 10;
+  const minimized = typeof win.minimized === 'boolean' ? win.minimized : false;
+  const snapshot = (win as any).snapshot;
+  return { id: win.id, x, y, minimized, snapshot };
+};
+
+const normalizeSession = (value: DesktopSession): DesktopSession => {
+  const windows = Array.isArray((value as any).windows)
+    ? (value as any).windows
+        .map(normalizeWindow)
+        .filter((win): win is SessionWindow => Boolean(win))
+    : [];
+  const dock = Array.isArray((value as any).dock)
+    ? (value as any).dock.filter((id): id is string => typeof id === 'string')
+    : [];
+  const wallpaper =
+    typeof (value as any).wallpaper === 'string'
+      ? (value as any).wallpaper
+      : defaults.wallpaper;
+  const pendingRestore = Boolean((value as any).pendingRestore);
+  const lastUpdated =
+    typeof (value as any).lastUpdated === 'number'
+      ? (value as any).lastUpdated
+      : Date.now();
+
+  return {
+    windows,
+    dock,
+    wallpaper,
+    pendingRestore,
+    lastUpdated,
+    version: SESSION_VERSION,
+  };
+};
+
+export { SESSION_VERSION, initialSession };
+
 export default function useSession() {
-  const [session, setSession, _reset, clear] = usePersistentState<DesktopSession>(
+  const [stored, setStored, _reset, clear] = usePersistentState<DesktopSession>(
     'desktop-session',
     initialSession,
     isSession,
   );
 
+  const session = normalizeSession(stored);
+
+  const updateSession = (next: DesktopSession) => {
+    setStored(normalizeSession(next));
+  };
+
   const resetSession = () => {
     clear();
   };
 
-  return { session, setSession, resetSession };
+  return { session, setSession: updateSession, resetSession };
 }

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -13,11 +13,13 @@ export const createDynamicApp = (id, title) =>
         return mod.default;
       } catch (err) {
         console.error(`Failed to load ${title}`, err);
-        return () => (
+        const Fallback = () => (
           <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
             {`Unable to load ${title}`}
           </div>
         );
+        Fallback.displayName = `${title}Fallback`;
+        return Fallback;
       }
     },
     {
@@ -34,8 +36,8 @@ export const createDisplay = (Component) => {
   const DynamicComponent = dynamic(() => Promise.resolve({ default: Component }), {
     ssr: false,
   });
-  const Display = (addFolder, openApp) => (
-    <DynamicComponent addFolder={addFolder} openApp={openApp} />
+  const Display = (addFolder, openApp, session) => (
+    <DynamicComponent addFolder={addFolder} openApp={openApp} session={session} />
   );
 
   Display.prefetch = () => {
@@ -43,6 +45,9 @@ export const createDisplay = (Component) => {
       Component.preload();
     }
   };
+
+  Display.displayName =
+    Component.displayName || Component.name || 'DynamicAppDisplay';
 
   return Display;
 };

--- a/utils/sessionStore.ts
+++ b/utils/sessionStore.ts
@@ -1,0 +1,38 @@
+"use client";
+
+export type SessionSnapshot = unknown;
+
+type SnapshotProvider = () => SessionSnapshot;
+
+const providers = new Map<string, SnapshotProvider>();
+
+export function registerSessionProvider(
+  id: string,
+  provider: SnapshotProvider,
+): () => void {
+  if (!id) return () => {};
+  providers.set(id, provider);
+  return () => {
+    const existing = providers.get(id);
+    if (existing === provider) {
+      providers.delete(id);
+    }
+  };
+}
+
+export function collectSessionSnapshot(
+  id: string,
+): SessionSnapshot | undefined {
+  const provider = providers.get(id);
+  if (!provider) return undefined;
+  try {
+    return provider();
+  } catch {
+    return undefined;
+  }
+}
+
+export function clearSessionProviders() {
+  providers.clear();
+}
+


### PR DESCRIPTION
## Summary
- persist window positions, minimization state, and app snapshots via a new session store and banner-driven restore flow on the desktop
- hydrate app windows (e.g., Gedit) from stored session data and ensure dynamic app wrappers expose stable display names
- normalize stored sessions, propagate session payloads through the window system, and add integration tests covering restore/opt-out flows

## Testing
- yarn test __tests__/desktopSessionRestore.test.tsx
- npx eslint components/screen/desktop.js utils/createDynamicApp.js hooks/useSession.ts


------
https://chatgpt.com/codex/tasks/task_e_68cca6953d5c8328a19b52d125016472