### PR TITLE
[ci] enforce warning-free builds

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,7 @@
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        strict: true
+        contexts:
+          - CI / build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,58 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  build:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build (capture warnings)
+        id: build
+        env:
+          CI: true
+        run: |
+          set -o pipefail
+          yarn build 2>&1 | tee build.log
+          status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+          warnings=false
+          if grep -E "^(warn\s+-|warning\s|Warning:)" build.log > build-warnings.log; then
+            warnings=true
+          else
+            rm -f build-warnings.log
+          fi
+
+          echo "warnings=$warnings" >> "$GITHUB_OUTPUT"
+      - name: Upload build logs
+        if: ${{ steps.build.outputs.status != '0' || steps.build.outputs.warnings == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs
+          path: |
+            build.log
+            build-warnings.log
+          if-no-files-found: ignore
+      - name: Ensure build succeeded without warnings
+        if: ${{ steps.build.outputs.status != '0' || steps.build.outputs.warnings == 'true' }}
+        env:
+          BUILD_STATUS: ${{ steps.build.outputs.status }}
+          HAD_WARNINGS: ${{ steps.build.outputs.warnings }}
+        run: |
+          if [ "$BUILD_STATUS" != "0" ]; then
+            echo "::error::yarn build failed with exit code $BUILD_STATUS."
+          fi
+          if [ "$HAD_WARNINGS" = "true" ]; then
+            echo "::error::yarn build produced warnings. See build.log for details."
+          fi
+          exit 1
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install


### PR DESCRIPTION
## Summary
- add a CI job that installs dependencies immutably and runs `yarn build`
- capture build output and upload it as an artifact whenever the build fails or emits warnings
- codify branch protection so the `CI / build` status check is required on `main`

## Testing
- [ ] yarn lint *(fails: repository currently has accessibility lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbc16700883288a89d07ef7d67f99