### PR TITLE
[deps] refresh tailwind toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ See Vercel's [Speed Insights Quickstart](https://vercel.com/docs/speed-insights/
 ## Tech Stack
 
 - **Next.js 15** (app uses `/pages` routing) + **TypeScript** in parts
-- **Tailwind CSS** with custom Ubuntu/Kali theme tokens (`styles/index.css`, `tailwind.config.js`)
+- **Tailwind CSS 3.4.17** + **PostCSS 8.5.6** + **Autoprefixer 10.4.21** with custom Ubuntu/Kali theme tokens (`styles/index.css`, `tailwind.config.js`)
 - **React GA4** via a thin wrapper in `utils/analytics.ts`
 - **Vercel Analytics** (`@vercel/analytics`)
 - **EmailJS** for the contact (“Gedit”) app

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@zxing/library": "^0.21.3",
     "aframe": "^1.5.0",
     "antd": "5.27.2",
-    "autoprefixer": "^10.4.13",
+    "autoprefixer": "^10.4.21",
     "bad-words": "^3.0.4",
     "canvas-confetti": "1.9.3",
     "capstone-wasm": "^1.0.3",
@@ -98,7 +98,7 @@
     "sharp": "^0.34.3",
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",
-    "tailwindcss": "^3.2.4",
+    "tailwindcss": "^3.4.17",
     "three": "^0.179.1",
     "turndown": "^7.2.1",
     "zod": "^3.23.8"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,12 +2,26 @@ const plugin = require('tailwindcss/plugin');
 
 module.exports = {
   darkMode: 'class',
-  mode: 'jit',
   content: [
-    './pages/**/*.{js,ts,jsx,tsx}',
-    './components/**/*.{js,ts,jsx,tsx}',
+    './__mocks__/**/*.{js,ts,jsx,tsx}',
+    './__tests__/**/*.{js,ts,jsx,tsx}',
+    './app/**/*.{js,ts,jsx,tsx}',
     './apps/**/*.{js,ts,jsx,tsx}',
+    './calc/**/*.{js,ts,jsx,tsx}',
+    './chrome-extension/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+    './filters/**/*.{js,ts,jsx,tsx}',
+    './games/**/*.{js,ts,jsx,tsx}',
     './hooks/**/*.{js,ts,jsx,tsx}',
+    './modules/**/*.{js,ts,jsx,tsx}',
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './player/**/*.{js,ts,jsx,tsx}',
+    './src/**/*.{js,ts,jsx,tsx}',
+    './templates/**/*.{js,ts,jsx,tsx}',
+    './tests/**/*.{js,ts,jsx,tsx}',
+    './utils/**/*.{js,ts,jsx,tsx}',
+    './workers/**/*.{js,ts,jsx,tsx}',
+    './styles/**/*.{css,scss}',
   ],
   theme: {
     extend: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4932,7 +4932,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"autoprefixer@npm:^10.4.13":
+"autoprefixer@npm:^10.4.21":
   version: 10.4.21
   resolution: "autoprefixer@npm:10.4.21"
   dependencies:
@@ -13155,7 +13155,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:^3.2.4":
+"tailwindcss@npm:^3.4.17":
   version: 3.4.17
   resolution: "tailwindcss@npm:3.4.17"
   dependencies:
@@ -13893,7 +13893,7 @@ __metadata:
     "@zxing/library": "npm:^0.21.3"
     aframe: "npm:^1.5.0"
     antd: "npm:5.27.2"
-    autoprefixer: "npm:^10.4.13"
+    autoprefixer: "npm:^10.4.21"
     bad-words: "npm:^3.0.4"
     canvas-confetti: "npm:1.9.3"
     capstone-wasm: "npm:^1.0.3"
@@ -13958,7 +13958,7 @@ __metadata:
     sharp: "npm:^0.34.3"
     stockfish: "npm:^16.0.0"
     swr: "npm:^2.2.5"
-    tailwindcss: "npm:^3.2.4"
+    tailwindcss: "npm:^3.4.17"
     test-exclude: "npm:7.0.1"
     three: "npm:^0.179.1"
     turndown: "npm:^7.2.1"


### PR DESCRIPTION
## Summary
- upgrade tailwindcss to 3.4.17 with autoprefixer 10.4.21 so the toolchain stays compatible with PostCSS 8.5.6
- remove the deprecated Tailwind JIT mode flag and expand content globs to cover all app source directories
- document the Tailwind/PostCSS/Autoprefixer versions in the README for maintenance

## Testing
- CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68ccbc1577e083288ab72c4360919d03