### PR TITLE
[build] configure turborepo caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: CI
 on:
   pull_request:
 
+env:
+  TURBO_LOG_ORDER: stream
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
 jobs:
   install:
     runs-on: ubuntu-latest
@@ -24,7 +29,14 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: npm run lint
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '.turboignore', 'package.json', 'yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+      - run: yarn turbo run lint --summarize
 
   typecheck:
     runs-on: ubuntu-latest
@@ -36,7 +48,14 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: npm run tsc -- --noEmit
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '.turboignore', 'package.json', 'yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+      - run: yarn turbo run typecheck --summarize
 
   test:
     runs-on: ubuntu-latest
@@ -48,7 +67,14 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: yarn test --coverage
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '.turboignore', 'package.json', 'yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+      - run: yarn turbo run test --summarize -- --coverage
 
   security:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dist
 # misc
 .DS_Store
 *.pem
+.turbo
 
 # debug
 npm-debug.log*

--- a/.turboignore
+++ b/.turboignore
@@ -1,0 +1,3 @@
+docs/**
+test-log.md
+.vscode/**

--- a/docs/build-caching.md
+++ b/docs/build-caching.md
@@ -1,0 +1,39 @@
+# Build caching
+
+The repository uses [Turborepo](https://turbo.build/) to orchestrate linting, tests, and production builds. Turbo stores cache
+artifacts in the local `.turbo/` directory and can optionally push or pull results from a remote cache.
+
+## Local development
+
+- Run tasks through Turbo to benefit from caching:
+  ```bash
+  yarn turbo run lint
+  yarn turbo run test -- --coverage
+  yarn turbo run build
+  ```
+- The cache is enabled by default. To bypass it for a single run, add `--no-cache` or use the `--force` flag to recompute the
+  task results.
+- Clear the local cache with `rm -rf .turbo` if you need to reset state. You can also relocate it by exporting
+  `TURBO_CACHE_DIR=/custom/path` before running commands.
+
+## Remote caching options
+
+### Vercel Remote Cache
+
+1. Generate a token with `yarn turbo login` or the Vercel dashboard.
+2. Store `TURBO_TEAM` and `TURBO_TOKEN` in your local shell (or CI secrets). Turbo will automatically reuse the remote cache
+   when both variables are present.
+3. Optionally set `TURBO_REMOTE_CACHE_SIGNATURE_KEY` to validate cache artifacts.
+
+### GitHub Actions cache
+
+The `ci.yml` workflow restores and saves `.turbo/` using `actions/cache@v4`. Cache keys combine the operating system,
+`turbo.json`, `.turboignore`, `package.json`, and `yarn.lock`, so updating any of those files will invalidate stale artifacts.
+
+## Observing cache health
+
+- Turbo prints a summary with cache hits and misses when `--summarize` is supplied. CI jobs use this flag so you can review hit
+  rates directly from workflow logs.
+- Adjust the patterns in `.turboignore` if content changes that should not affect builds are invalidating the cache.
+- Keep an eye on large environment-dependent features. Any value listed under `globalEnv` in `turbo.json` will be hashed as part
+  of the cache key, so updates to feature flags or API keys may legitimately invalidate caches.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,3 +22,5 @@ yarn dev
 See the [Architecture](./architecture.md) document for an overview of how the project is organized.
 
 For app contributions, see the [New App Checklist](./new-app-checklist.md).
+
+For build orchestration and cache controls, read [Build caching](./build-caching.md).

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "pa11y": "^9.0.0",
     "playwright-core": "^1.55.0",
     "test-exclude": "7.0.1",
+    "turbo": "^2.5.6",
     "typescript": "5.8.2",
     "wait-on": "^8.0.4",
     "webpack": "^5.92.0",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": [
+    "package.json",
+    "yarn.lock",
+    "next.config.js",
+    "postcss.config.js",
+    "tailwind.config.js",
+    "tsconfig.json",
+    "tsconfig.gamepad.json",
+    "apps.config.js"
+  ],
+  "globalEnv": [
+    "NODE_ENV",
+    "NEXT_PUBLIC_STATIC_EXPORT",
+    "NEXT_PUBLIC_ENABLE_ANALYTICS",
+    "FEATURE_TOOL_APIS",
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPABASE_ANON_KEY",
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+    "RECAPTCHA_SECRET",
+    "NEXT_PUBLIC_RECAPTCHA_SITE_KEY",
+    "NEXT_PUBLIC_RECAPTCHA_LANGUAGE"
+  ],
+  "tasks": {
+    "lint": {
+      "outputs": []
+    },
+    "typecheck": {
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["^test"],
+      "outputs": ["coverage/**"]
+    },
+    "build": {
+      "dependsOn": ["^build", "typecheck"],
+      "outputs": [
+        ".next/**",
+        "public/sw.js",
+        "public/workbox-*.js",
+        "public/sw.js.map"
+      ]
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13583,6 +13583,77 @@ __metadata:
   languageName: node
   linkType: hard
 
+"turbo-darwin-64@npm:2.5.6":
+  version: 2.5.6
+  resolution: "turbo-darwin-64@npm:2.5.6"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-darwin-arm64@npm:2.5.6":
+  version: 2.5.6
+  resolution: "turbo-darwin-arm64@npm:2.5.6"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo-linux-64@npm:2.5.6":
+  version: 2.5.6
+  resolution: "turbo-linux-64@npm:2.5.6"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-linux-arm64@npm:2.5.6":
+  version: 2.5.6
+  resolution: "turbo-linux-arm64@npm:2.5.6"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo-windows-64@npm:2.5.6":
+  version: 2.5.6
+  resolution: "turbo-windows-64@npm:2.5.6"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-windows-arm64@npm:2.5.6":
+  version: 2.5.6
+  resolution: "turbo-windows-arm64@npm:2.5.6"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo@npm:^2.5.6":
+  version: 2.5.6
+  resolution: "turbo@npm:2.5.6"
+  dependencies:
+    turbo-darwin-64: "npm:2.5.6"
+    turbo-darwin-arm64: "npm:2.5.6"
+    turbo-linux-64: "npm:2.5.6"
+    turbo-linux-arm64: "npm:2.5.6"
+    turbo-windows-64: "npm:2.5.6"
+    turbo-windows-arm64: "npm:2.5.6"
+  dependenciesMeta:
+    turbo-darwin-64:
+      optional: true
+    turbo-darwin-arm64:
+      optional: true
+    turbo-linux-64:
+      optional: true
+    turbo-linux-arm64:
+      optional: true
+    turbo-windows-64:
+      optional: true
+    turbo-windows-arm64:
+      optional: true
+  bin:
+    turbo: bin/turbo
+  checksum: 10c0/b9657bf211bbcfe3911496e4fee6c9a24526bc37e9cadf7f0c76d0376e9c9dfafaacec27f5a61bb621dfe330600ce68c1b21e4cdc19bdccd3ebfe66766fcf62f
+  languageName: node
+  linkType: hard
+
 "turndown@npm:^7.2.1":
   version: 7.2.1
   resolution: "turndown@npm:7.2.1"
@@ -13961,6 +14032,7 @@ __metadata:
     tailwindcss: "npm:^3.2.4"
     test-exclude: "npm:7.0.1"
     three: "npm:^0.179.1"
+    turbo: "npm:^2.5.6"
     turndown: "npm:^7.2.1"
     typescript: "npm:5.8.2"
     wait-on: "npm:^8.0.4"


### PR DESCRIPTION
## Summary
- add a turborepo config plus ignore rules so lint, test, and build tasks can cache safely
- document cache controls for contributors and link it from getting-started
- run CI quality gates through turbo with GitHub cache support and add the turbo dev dependency

## Testing
- `yarn turbo run lint typecheck --summarize` *(fails: existing lint violations in multiple apps)*
- `yarn turbo run typecheck --summarize`
- `yarn turbo run test --summarize -- --coverage` *(fails: existing window and nmap test expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbc16f9208328a47558f9bcf9e604