### PR TITLE
build: add project-wide typecheck script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: npm run tsc -- --noEmit
+      - run: yarn typecheck:all
 
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ See `.env.local.example` for the full list.
 - `yarn dev` – start the development server with hot reloading.
 - `yarn test` – run the test suite.
 - `yarn lint` – check code for linting issues.
+- `yarn typecheck:all` – run TypeScript project references via `tsc -b` to ensure every package typechecks in order.
 - `yarn export` – generate a static export in the `out/` directory.
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,6 +19,14 @@ yarn install
 yarn dev
 ```
 
+## Type Checking
+
+Run the project reference build to verify all packages in dependency order:
+
+```bash
+yarn typecheck:all
+```
+
 See the [Architecture](./architecture.md) document for an overview of how the project is organized.
 
 For app contributions, see the [New App Checklist](./new-app-checklist.md).

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint . --max-warnings=0",
     "tsc": "tsc",
     "typecheck": "tsc --noEmit",
+    "typecheck:all": "tsc -b --noEmit tsconfig.all.json",
     "a11y": "node scripts/a11y.mjs",
     "smoke": "node scripts/smoke-all-apps.mjs",
     "module-report": "node scripts/generate-module-report.mjs",

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -36,7 +36,7 @@ const getPort = () =>
 
     await run('yarn', ['install', '--immutable']);
     await run('yarn', ['lint']);
-    await run('yarn', ['tsc', '--noEmit']);
+    await run('yarn', ['typecheck:all']);
     await run('yarn', ['build']);
 
     const port = await getPort();

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.json" },
+    { "path": "./tsconfig.gamepad.json" }
+  ]
+}

--- a/tsconfig.gamepad.json
+++ b/tsconfig.gamepad.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "noEmit": false,
     "outDir": "./dist",
     "rootDir": ".",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
-
-    }
+    },
+    "noEmit": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts"],
   "exclude": ["node_modules", "__tests__", "components/apps/archive", "components/apps/kismet"]


### PR DESCRIPTION
## Summary
- add a top-level `yarn typecheck:all` command that runs the project reference build
- document the new workflow script and wire it into local verification tooling
- update CI typecheck job to execute the shared command

## Testing
- yarn typecheck:all

------
https://chatgpt.com/codex/tasks/task_e_68ccbc1b230083288f3944b1ac7ce49d