### PR TITLE
[core] centralize client env access

### DIFF
--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -8,6 +8,7 @@ import { contactSchema } from "../../utils/contactSchema";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openMailto } from "../../utils/mailto";
 import { trackEvent } from "@/lib/analytics-client";
+import { RECAPTCHA_SITE_KEY } from "@/env.client";
 
 const DRAFT_KEY = "contact-draft";
 const EMAIL = "alex.unnippillil@hotmail.com";
@@ -82,7 +83,7 @@ const ContactApp: React.FC = () => {
       return;
     }
 
-    const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || "";
+    const siteKey = RECAPTCHA_SITE_KEY;
     const recaptchaToken = await getRecaptchaToken(siteKey);
     if (!recaptchaToken) {
       setError("Captcha verification failed. Please try again.");

--- a/apps/contact/utils/sendEmail.ts
+++ b/apps/contact/utils/sendEmail.ts
@@ -1,4 +1,5 @@
 import emailjs from '@emailjs/browser';
+import { EMAIL_SERVICE_ID, EMAIL_TEMPLATE_ID, EMAIL_USER_ID } from '@/env.client';
 
 export interface EmailData {
   name: string;
@@ -9,9 +10,9 @@ export interface EmailData {
 let initialized = false;
 
 export const sendEmail = async ({ name, email, message }: EmailData) => {
-  const serviceId = process.env.NEXT_PUBLIC_SERVICE_ID || '';
-  const templateId = process.env.NEXT_PUBLIC_TEMPLATE_ID || '';
-  const userId = process.env.NEXT_PUBLIC_USER_ID || '';
+  const serviceId = EMAIL_SERVICE_ID;
+  const templateId = EMAIL_TEMPLATE_ID;
+  const userId = EMAIL_USER_ID;
 
   if (!initialized && userId) {
     try {

--- a/apps/ghidra/components/DemoRunner.tsx
+++ b/apps/ghidra/components/DemoRunner.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import GhidraApp from '../../../components/apps/ghidra';
+import { GHIDRA_WASM_URL } from '@/env.client';
 
 export default function DemoRunner() {
-  const wasmUrl = process.env.NEXT_PUBLIC_GHIDRA_WASM;
+  const wasmUrl = GHIDRA_WASM_URL;
   const [enabled, setEnabled] = useState(false);
 
   useEffect(() => {

--- a/components/BetaBadge.jsx
+++ b/components/BetaBadge.jsx
@@ -1,5 +1,7 @@
+import { SHOW_BETA_BADGE } from '@/env.client';
+
 export default function BetaBadge() {
-  if (process.env.NEXT_PUBLIC_SHOW_BETA !== '1') return null;
+  if (!SHOW_BETA_BADGE) return null;
   return (
     <button
       type="button"

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -9,6 +9,7 @@ import AttachmentUploader, {
   MAX_TOTAL_ATTACHMENT_SIZE,
 } from '../../../apps/contact/components/AttachmentUploader';
 import AttachmentCarousel from '../../../apps/contact/components/AttachmentCarousel';
+import { RECAPTCHA_SITE_KEY } from '@/env.client';
 
 const sanitize = (str: string) =>
   str.replace(/[&<>"']/g, (c) => ({
@@ -166,7 +167,7 @@ const ContactApp: React.FC = () => {
     })();
     const meta = document.querySelector('meta[name="csrf-token"]');
     setCsrfToken(meta?.getAttribute('content') || '');
-    const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || '';
+    const siteKey = RECAPTCHA_SITE_KEY;
     if (!siteKey || !(window as any).grecaptcha) {
       setFallback(true);
     }
@@ -213,7 +214,7 @@ const ContactApp: React.FC = () => {
       return;
     }
     let recaptchaToken = '';
-    const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || '';
+    const siteKey = RECAPTCHA_SITE_KEY;
     let shouldFallback = fallback;
     if (!shouldFallback && siteKey && (window as any).grecaptcha) {
       recaptchaToken = await getRecaptchaToken(siteKey);

--- a/components/apps/converter/CurrencyConverter.js
+++ b/components/apps/converter/CurrencyConverter.js
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useMemo } from 'react';
+import { CURRENCY_API_URL } from '@/env.client';
 
-const apiBase = process.env.NEXT_PUBLIC_CURRENCY_API_URL || 'https://api.exchangerate.host/latest';
-const isDemo = !process.env.NEXT_PUBLIC_CURRENCY_API_URL;
+const apiBase = CURRENCY_API_URL || 'https://api.exchangerate.host/latest';
+const isDemo = !CURRENCY_API_URL;
 
 const CurrencyConverter = () => {
   const [rates, setRates] = useState({});

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -4,6 +4,7 @@ import ReactGA from 'react-ga4';
 import emailjs from '@emailjs/browser';
 import ProgressBar from '../ui/ProgressBar';
 import { createDisplay } from '../../utils/createDynamicApp';
+import { EMAIL_USER_ID, EMAIL_SERVICE_ID, EMAIL_TEMPLATE_ID } from '@/env.client';
 
 export class Gedit extends Component {
 
@@ -29,7 +30,7 @@ export class Gedit extends Component {
     }
 
     componentDidMount() {
-        emailjs.init(process.env.NEXT_PUBLIC_USER_ID);
+        emailjs.init(EMAIL_USER_ID);
         this.fetchLocation();
     }
 
@@ -110,8 +111,8 @@ export class Gedit extends Component {
             }, 500);
         }, 10000);
 
-        const serviceID = process.env.NEXT_PUBLIC_SERVICE_ID;
-        const templateID = process.env.NEXT_PUBLIC_TEMPLATE_ID;
+        const serviceID = EMAIL_SERVICE_ID;
+        const templateID = EMAIL_TEMPLATE_ID;
         const templateParams = {
             'name': name,
             'subject': subject,

--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -4,6 +4,7 @@ import FunctionTree from './FunctionTree';
 import CallGraph from './CallGraph';
 import ImportAnnotate from './ImportAnnotate';
 import { Capstone, Const, loadCapstone } from 'capstone-wasm';
+import { GHIDRA_WASM_URL } from '@/env.client';
 
 // Applies S1–S8 guidelines for responsive and accessible binary analysis UI
 const DEFAULT_WASM = '/wasm/ghidra.wasm';
@@ -99,7 +100,7 @@ export default function GhidraApp() {
   }, []);
 
   useEffect(() => {
-    const wasmUrl = process.env.NEXT_PUBLIC_GHIDRA_WASM || DEFAULT_WASM;
+    const wasmUrl = GHIDRA_WASM_URL || DEFAULT_WASM;
     if (typeof WebAssembly === 'undefined') {
       setEngine('capstone');
       ensureCapstone();

--- a/components/apps/hydra/index.js
+++ b/components/apps/hydra/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState, useMemo } from 'react';
 import Stepper from './Stepper';
 import AttemptTimeline from './Timeline';
+import { IS_STATIC_EXPORT } from '@/env.client';
 
 const baseServices = ['ssh', 'ftp', 'http-get', 'http-post-form', 'smtp'];
 const pluginServices = [];
@@ -124,7 +125,7 @@ const HydraApp = () => {
     setAnnounce('Hydra resumed');
     announceRef.current = Date.now();
     try {
-      if (process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true') {
+      if (!IS_STATIC_EXPORT) {
         const res = await fetch('/api/hydra', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -329,7 +330,7 @@ const HydraApp = () => {
     setAnnounce('Hydra started');
     announceRef.current = Date.now();
     try {
-      if (process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true') {
+      if (!IS_STATIC_EXPORT) {
         const res = await fetch('/api/hydra', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -396,7 +397,7 @@ const HydraApp = () => {
   const pauseHydra = async () => {
     setPaused(true);
     setAnnounce('Hydra paused');
-    if (process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true') {
+    if (!IS_STATIC_EXPORT) {
       await fetch('/api/hydra', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -408,7 +409,7 @@ const HydraApp = () => {
   const resumeHydra = async () => {
     setPaused(false);
     setAnnounce('Hydra resumed');
-    if (process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true') {
+    if (!IS_STATIC_EXPORT) {
       await fetch('/api/hydra', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -424,7 +425,7 @@ const HydraApp = () => {
     setOutput('');
     setTimeline([]);
     startRef.current = null;
-    if (process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true') {
+    if (!IS_STATIC_EXPORT) {
       await fetch('/api/hydra', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/components/apps/john/index.js
+++ b/components/apps/john/index.js
@@ -8,6 +8,7 @@ import {
 } from './utils';
 import FormError from '../../ui/FormError';
 import StatsChart from '../../StatsChart';
+import { IS_STATIC_EXPORT } from '@/env.client';
 
 // Enhanced John the Ripper interface that supports rule uploads,
 // basic hash analysis and mock distribution of cracking tasks.
@@ -247,7 +248,7 @@ const JohnApp = () => {
         for (const h of hs) {
           if (signal.aborted) throw new Error('cancelled');
           incrementProgress('wordlist');
-          if (process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true') {
+          if (!IS_STATIC_EXPORT) {
             const res = await fetch('/api/john', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },

--- a/components/apps/metasploit/metasploit.jsx
+++ b/components/apps/metasploit/metasploit.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import modules from './modules.json';
 import usePersistentState from '../../../hooks/usePersistentState';
 import ConsolePane from './ConsolePane';
+import { IS_DEMO_MODE, IS_STATIC_EXPORT } from '@/env.client';
 
 const severities = ['critical', 'high', 'medium', 'low'];
 const severityStyles = {
@@ -18,7 +19,7 @@ const timelineSteps = 5;
 const banner = `Metasploit Framework Console (mock)\nFor legal and ethical use only.\nType 'search <term>' to search modules.`;
 
 const MetasploitApp = ({
-  demoMode = process.env.NEXT_PUBLIC_DEMO_MODE === 'true',
+  demoMode = IS_DEMO_MODE,
   onLoadingChange = () => {},
 } = {}) => {
   const [command, setCommand] = useState('');
@@ -146,7 +147,7 @@ const MetasploitApp = ({
     if (!cmd) return;
     setLoading(true);
     try {
-      if (demoMode || process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true') {
+      if (demoMode || IS_STATIC_EXPORT) {
         setOutput(
           (prev) => `${prev}\nmsf6 > ${cmd}\n[demo mode] command disabled`
         );

--- a/components/apps/pacman.js
+++ b/components/apps/pacman.js
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import useAssetLoader from '../../hooks/useAssetLoader';
 import SpeedControls from '../../games/pacman/components/SpeedControls';
+import { IS_STATIC_EXPORT } from '@/env.client';
 
 /**
  * Small Pacman implementation used inside the portfolio. The goal of this
@@ -232,7 +233,7 @@ const Pacman = () => {
   };
 
   useEffect(() => {
-    if (process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true') return;
+    if (IS_STATIC_EXPORT) return;
     const load = async () => {
       try {
         const res = await fetch('/api/pacman/leaderboard');
@@ -247,7 +248,7 @@ const Pacman = () => {
 
   const submitScore = useCallback(
     async (finalScore) => {
-      if (process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true') return;
+      if (IS_STATIC_EXPORT) return;
       try {
         const name = window.prompt('Enter your name', 'Player');
         if (!name) return;

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import useWatchLater, {
   Video as WatchLaterVideo,
 } from '../../../apps/youtube/state/watchLater';
+import { YOUTUBE_API_KEY } from '@/env.client';
 
 type Video = WatchLaterVideo;
 
@@ -14,7 +15,6 @@ interface Props {
 const VIDEO_CACHE_NAME = 'youtube-video-cache';
 const CACHED_LIST_KEY = 'youtube:cached-videos';
 const MAX_CACHE_BYTES = 100 * 1024 * 1024;
-const YOUTUBE_API_KEY = process.env.NEXT_PUBLIC_YOUTUBE_API_KEY;
 
 async function trimVideoCache() {
   if (!('storage' in navigator) || !navigator.storage?.estimate) return;

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -7,6 +7,7 @@ import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
 import styles from './window.module.css';
+import { UI_EXPERIMENTS_ENABLED } from '@/env.client';
 
 export class Window extends Component {
     constructor(props) {
@@ -35,7 +36,7 @@ export class Window extends Component {
             grabbed: false,
         }
         this._usageTimeout = null;
-        this._uiExperiments = process.env.NEXT_PUBLIC_UI_EXPERIMENTS === 'true';
+        this._uiExperiments = UI_EXPERIMENTS_ENABLED;
         this._menuOpener = null;
     }
 

--- a/env.client.ts
+++ b/env.client.ts
@@ -1,0 +1,13 @@
+export const SHOW_BETA_BADGE = process.env.NEXT_PUBLIC_SHOW_BETA === '1';
+export const UI_EXPERIMENTS_ENABLED = process.env.NEXT_PUBLIC_UI_EXPERIMENTS === 'true';
+
+export const GHIDRA_WASM_URL = process.env.NEXT_PUBLIC_GHIDRA_WASM ?? '';
+export const RECAPTCHA_SITE_KEY = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY ?? '';
+export const EMAIL_SERVICE_ID = process.env.NEXT_PUBLIC_SERVICE_ID ?? '';
+export const EMAIL_TEMPLATE_ID = process.env.NEXT_PUBLIC_TEMPLATE_ID ?? '';
+export const EMAIL_USER_ID = process.env.NEXT_PUBLIC_USER_ID ?? '';
+export const YOUTUBE_API_KEY = process.env.NEXT_PUBLIC_YOUTUBE_API_KEY ?? '';
+export const CURRENCY_API_URL = process.env.NEXT_PUBLIC_CURRENCY_API_URL ?? '';
+
+export const IS_STATIC_EXPORT = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';
+export const IS_DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE === 'true';

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,22 @@ const config = [
       'no-restricted-globals': ['error', 'window', 'document'],
     },
   },
+  {
+    files: [
+      'components/**/*.{js,jsx,ts,tsx}',
+      'apps/**/*.{js,jsx,ts,tsx}',
+      'hooks/**/*.{js,jsx,ts,tsx}',
+    ],
+    rules: {
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'process',
+          message: 'Import from env.client.ts instead of using process.env in client code.',
+        },
+      ],
+    },
+  },
   ...compat.config({
     extends: ['next/core-web-vitals'],
     rules: {


### PR DESCRIPTION
## Summary
- add a shared env.client.ts helper that exposes the public env flags and keys for client components
- refactor client-side apps and widgets to consume the new helpers instead of reading process.env directly
- extend the ESLint config for apps/, components/, and hooks/ to forbid direct access to process

## Testing
- `yarn lint` *(fails: existing jsx-a11y/control-has-associated-label violations in unrelated app fixtures)*
- `CI=1 yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68ccbc2c96748328afc12213506eeae4