### PR TITLE
[ssr] Provide capstone stub for SSR

### DIFF
--- a/__tests__/wasm-ssr.test.tsx
+++ b/__tests__/wasm-ssr.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import GhidraPage from '../apps/ghidra';
+import WiresharkPage from '../apps/wireshark';
+
+jest.mock('next/image', () => {
+  const MockedImage = (props: any) => <img {...props} alt={props.alt ?? ''} />;
+  MockedImage.displayName = 'MockedImage';
+  return MockedImage;
+});
+
+describe('SSR compatibility for WASM-heavy pages', () => {
+  const originalWebAssembly = global.WebAssembly;
+
+  beforeEach(() => {
+    // @ts-ignore - allow overriding the global constructor for test isolation
+    global.WebAssembly = undefined;
+  });
+
+  afterEach(() => {
+    // @ts-ignore - restore whichever implementation the environment provided
+    global.WebAssembly = originalWebAssembly;
+  });
+
+  it('renders the standalone Ghidra page without crashing', () => {
+    expect(() => ReactDOMServer.renderToString(<GhidraPage />)).not.toThrow();
+  });
+
+  it('renders the standalone Wireshark page without crashing', () => {
+    expect(() => ReactDOMServer.renderToString(<WiresharkPage />)).not.toThrow();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ const customJestConfig = {
     '^@/(.*)$': '<rootDir>/$1',
     '^@xterm/xterm/css/xterm.css$': '<rootDir>/__mocks__/styleMock.js',
     '^@/(.*)$': '<rootDir>/$1',
+    '^capstone-wasm$': '<rootDir>/lib/capstone/server.ts',
   },
   testPathIgnorePatterns: [
     '<rootDir>/playwright/',

--- a/lib/capstone/server.ts
+++ b/lib/capstone/server.ts
@@ -1,0 +1,36 @@
+// Minimal server-side stub that mirrors the capstone-wasm API.
+// It allows SSR to import the module without attempting to
+// initialize WebAssembly in the Node runtime.
+
+export type DisasmOptions = {
+  address?: number;
+};
+
+export type Instruction = {
+  address?: number;
+  mnemonic?: string;
+  op_str?: string;
+};
+
+export class Capstone {
+  constructor(_arch?: number, _mode?: number) {}
+
+  disasm(_bytes: Uint8Array, _options?: DisasmOptions): Instruction[] {
+    return [];
+  }
+
+  close() {}
+}
+
+export const Const = {
+  ARCH_ARM: 0,
+  ARCH_X86: 1,
+  MODE_ARM: 0,
+  MODE_32: 0,
+};
+
+export async function loadCapstone(): Promise<void> {
+  return Promise.resolve();
+}
+
+export default { Capstone, Const, loadCapstone };

--- a/next.config.js
+++ b/next.config.js
@@ -101,10 +101,19 @@ function configureWebpack(config, { isServer }) {
     module: false,
     async_hooks: false,
   };
-  config.resolve.alias = {
+  const alias = {
     ...(config.resolve.alias || {}),
     'react-dom$': require('path').resolve(__dirname, 'lib/react-dom-shim.js'),
   };
+
+  if (isServer) {
+    alias['capstone-wasm'] = require('path').resolve(
+      __dirname,
+      'lib/capstone/server.ts',
+    );
+  }
+
+  config.resolve.alias = alias;
   if (isProd) {
     config.optimization = {
       ...(config.optimization || {}),


### PR DESCRIPTION
## Summary
- add a server-safe stub for the capstone-wasm module to avoid SSR crashes
- update Next.js and Jest configuration so only browser bundles pull in the real WASM build
- add SSR smoke tests for the Ghidra and Wireshark pages when WebAssembly is unavailable

## Testing
- yarn lint *(fails: numerous existing jsx-a11y/control-has-associated-label violations in unrelated files)*
- yarn test wasm-ssr

------
https://chatgpt.com/codex/tasks/task_e_68ccbc30d9648328bcb8fe47ce52b688