### PR TITLE
[libs] add capstone wrapper

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -3,7 +3,7 @@ import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';
 import CallGraph from './CallGraph';
 import ImportAnnotate from './ImportAnnotate';
-import { Capstone, Const, loadCapstone } from 'capstone-wasm';
+import { Capstone, Const, loadCapstone } from 'libs/capstone';
 
 // Applies S1–S8 guidelines for responsive and accessible binary analysis UI
 const DEFAULT_WASM = '/wasm/ghidra.wasm';

--- a/libs/capstone/index.ts
+++ b/libs/capstone/index.ts
@@ -1,0 +1,15 @@
+import * as capstoneWasm from 'capstone-wasm';
+
+// Shim module to normalize capstone-wasm exports across CJS/ESM builds.
+// If the upstream package stabilizes its export shape, delete this wrapper
+// and import the package directly again.
+type CapstoneModule = typeof capstoneWasm & {
+  default?: typeof capstoneWasm;
+};
+
+const normalized = (capstoneWasm as CapstoneModule).default ?? capstoneWasm;
+
+const { Capstone, Const, loadCapstone } = normalized;
+
+export { Capstone, Const, loadCapstone };
+export default Capstone;


### PR DESCRIPTION
## Summary
- add a capstone shim under libs/capstone that normalizes the capstone-wasm export shape
- repoint the ghidra app to the new wrapper so future package upgrades can be centralized
- document the shim so we can revisit removing it when the upstream package stabilizes

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint violations and global window/document usage in public app bundles)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbc33a8b08328b4ed478c1c674d5a