### PR TITLE
[ghidra] use dynamic capstone wasm import

### DIFF
--- a/components/apps/ghidra/index.js
+++ b/components/apps/ghidra/index.js
@@ -3,16 +3,20 @@ import PseudoDisasmViewer from './PseudoDisasmViewer';
 import FunctionTree from './FunctionTree';
 import CallGraph from './CallGraph';
 import ImportAnnotate from './ImportAnnotate';
-import { Capstone, Const, loadCapstone } from 'capstone-wasm';
-
-// Applies S1–S8 guidelines for responsive and accessible binary analysis UI
-const DEFAULT_WASM = '/wasm/ghidra.wasm';
+let cachedCapstoneModule = null;
 
 async function loadCapstoneModule() {
   if (typeof window === 'undefined') return null;
-  await loadCapstone();
-  return { Capstone, Const };
+  if (!cachedCapstoneModule) {
+    const mod = await import('capstone-wasm');
+    await mod.loadCapstone();
+    cachedCapstoneModule = { Capstone: mod.Capstone, Const: mod.Const };
+  }
+  return cachedCapstoneModule;
 }
+
+// Applies S1–S8 guidelines for responsive and accessible binary analysis UI
+const DEFAULT_WASM = '/wasm/ghidra.wasm';
 
 // Disassembly data is now loaded from pre-generated JSON
 


### PR DESCRIPTION
## Summary
- replace the static `capstone-wasm` import in the Ghidra app with a cached dynamic import that only runs in the browser
- leave the rest of the disassembler UI unchanged while ensuring the Capstone loader is only invoked client-side

## Testing
- yarn lint *(fails: repo has numerous existing a11y label violations in other apps)*
- yarn test *(fails: existing suites such as window, nmap NSE, and settings store continue to error)*
- CI=1 NO_COLOR=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68ccbc3166c48328a06eb00b97e5b91b