### PR TITLE
[lint] define exports for local eslint plugin

### DIFF
--- a/__tests__/eslint-plugin-no-top-level-window.test.ts
+++ b/__tests__/eslint-plugin-no-top-level-window.test.ts
@@ -1,0 +1,21 @@
+import { spawnSync } from 'child_process';
+import plugin from 'eslint-plugin-no-top-level-window';
+
+describe('eslint-plugin-no-top-level-window package boundaries', () => {
+  it('exposes the plugin through the root entry point', () => {
+    expect(plugin).toBeDefined();
+    expect(plugin).toHaveProperty('rules.no-top-level-window-or-document');
+  });
+
+  it('blocks deep imports that bypass the public API surface', () => {
+    expect.hasAssertions();
+
+    const result = spawnSync(process.execPath, [
+      '-e',
+      "require('eslint-plugin-no-top-level-window/no-top-level-window-or-document')",
+    ]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr.toString()).toContain('ERR_PACKAGE_PATH_NOT_EXPORTED');
+  });
+});

--- a/eslint-plugin-no-top-level-window/index.d.ts
+++ b/eslint-plugin-no-top-level-window/index.d.ts
@@ -1,0 +1,5 @@
+declare const plugin: {
+  readonly rules: Record<string, unknown>;
+};
+
+export = plugin;

--- a/eslint-plugin-no-top-level-window/package.json
+++ b/eslint-plugin-no-top-level-window/package.json
@@ -1,5 +1,16 @@
 {
   "name": "eslint-plugin-no-top-level-window",
   "version": "1.0.0",
-  "main": "index.js"
+  "type": "commonjs",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "module": "./index.js",
+      "import": "./index.js",
+      "default": "./index.js",
+      "require": "./index.js"
+    }
+  }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,5 @@
 import { FlatCompat } from '@eslint/eslintrc';
-import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
+import noTopLevelWindow from 'eslint-plugin-no-top-level-window';
 
 const compat = new FlatCompat();
 

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "@types/wicg-file-system-access": "^2023.10.6",
     "eslint": "^9.13.0",
     "eslint-config-next": "15.5.2",
+    "eslint-plugin-no-top-level-window": "file:eslint-plugin-no-top-level-window",
     "fake-indexeddb": "^6.1.0",
     "fast-glob": "^3.3.3",
     "jest": "30.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6925,6 +6925,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-no-top-level-window@file:eslint-plugin-no-top-level-window::locator=unnippillil%40workspace%3A.":
+  version: 1.0.0
+  resolution: "eslint-plugin-no-top-level-window@file:eslint-plugin-no-top-level-window#eslint-plugin-no-top-level-window::hash=bc649b&locator=unnippillil%40workspace%3A."
+  checksum: 10c0/6ab9250e775da97bdfc8f80beb4bd855f666af4b1ce3edd1f325815197f85332f3ae30ca85870a5e2218f99cd88c8b99202176970a49c54140f4fc1f368ee794
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-react-hooks@npm:^5.0.0":
   version: 5.2.0
   resolution: "eslint-plugin-react-hooks@npm:5.2.0"
@@ -13907,6 +13914,7 @@ __metadata:
     dompurify: "npm:^3.2.6"
     eslint: "npm:^9.13.0"
     eslint-config-next: "npm:15.5.2"
+    eslint-plugin-no-top-level-window: "file:eslint-plugin-no-top-level-window"
     fake-indexeddb: "npm:^6.1.0"
     fast-glob: "npm:^3.3.3"
     fast-xml-parser: "npm:^4.3.5"


### PR DESCRIPTION
## Summary
- add an explicit exports map and type definitions for the local eslint plugin package
- consume the plugin through its package entry point and cover deep import boundaries with a unit test

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label violations and public game scripts using window/document)*
- yarn test --runTestsByPath __tests__/eslint-plugin-no-top-level-window.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68ccbc33faa08328bdd1c129a2a118c4