### PR TITLE
chore: guard server utilities with server-only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+## Server-only utilities
+
+This project uses the [`server-only`](https://www.npmjs.com/package/server-only) package to make sure modules that depend on Node APIs are never imported in the browser bundle. Follow these conventions when adding or updating server code:
+
+- Start any new server utility (database clients, file-system helpers, etc.) with `import 'server-only';`. This mirrors the existing patterns in `lib/service-client.ts`, `lib/supabase.ts`, and `lib/analytics-server.ts`.
+- Reuse the shared wrappers when possible instead of importing Node modules directly:
+  - Supabase: call `getServiceClient()`/`getAnonServerClient()` from `lib/service-client.ts`.
+  - File system access: import from `lib/server/fs` rather than `fs`/`fs/promises`.
+- If you must introduce a new server-only helper, keep the implementation in `lib/server/` (or another server-only module) and ensure it calls `import 'server-only';` at the top of the file.
+
+These steps help catch accidental client imports during development and keep the browser bundle free of Node dependencies.

--- a/lib/analytics-server.ts
+++ b/lib/analytics-server.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 export default async function trackServerEvent(
   event: string,
   properties?: Record<string, any>,

--- a/lib/server/fs.ts
+++ b/lib/server/fs.ts
@@ -1,0 +1,6 @@
+import 'server-only';
+import fs from 'fs';
+
+export const promises = fs.promises;
+
+export default fs;

--- a/lib/service-client.ts
+++ b/lib/service-client.ts
@@ -1,4 +1,11 @@
+import 'server-only';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+function createSupabaseServerClient(url: string, key: string): SupabaseClient {
+  return createClient(url, key, {
+    auth: { persistSession: false },
+  });
+}
 
 export function getServiceClient(): SupabaseClient | null {
   const url = process.env.SUPABASE_URL;
@@ -9,7 +16,18 @@ export function getServiceClient(): SupabaseClient | null {
     );
     return null;
   }
-  return createClient(url, serviceKey, {
-    auth: { persistSession: false },
-  });
+  return createSupabaseServerClient(url, serviceKey);
+}
+
+export function getAnonServerClient(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
+  const anonKey =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    console.warn(
+      'Supabase anon client unavailable: NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY not set',
+    );
+    return null;
+  }
+  return createSupabaseServerClient(url, anonKey);
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 export function getServiceSupabase() {
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "react-window": "^2.0.2",
     "rrule": "2.7.2",
     "seedrandom": "^3.0.5",
+    "server-only": "^0.0.1",
     "sharp": "^0.34.3",
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",

--- a/pages/api/figlet/fonts.js
+++ b/pages/api/figlet/fonts.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from '../../../lib/server/fs';
 import path from 'path';
 
 export default function handler(req, res) {

--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -1,5 +1,5 @@
 import { execFile } from 'child_process';
-import { promises as fs } from 'fs';
+import { promises as fs } from '../../lib/server/fs';
 import { randomUUID } from 'crypto';
 import { promisify } from 'util';
 import path from 'path';

--- a/pages/api/john.js
+++ b/pages/api/john.js
@@ -1,5 +1,5 @@
 import { exec } from 'child_process';
-import { promises as fs } from 'fs';
+import { promises as fs } from '../../lib/server/fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { promisify } from 'util';

--- a/pages/api/leaderboard/submit.js
+++ b/pages/api/leaderboard/submit.js
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
+import { getServiceClient } from '../../../lib/service-client';
 
 export default async function handler(
   req,
@@ -21,15 +21,13 @@ export default async function handler(
     return;
   }
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !key) {
+  const supabase = getServiceClient();
+  if (!supabase) {
     console.warn('Leaderboard submission disabled: missing Supabase env');
     res.status(503).json({ error: 'Leaderboard unavailable' });
     return;
   }
 
-  const supabase = createClient(url, key);
   const { error } = await supabase
     .from('leaderboard')
     .insert({ game, username: username.slice(0, 50), score });

--- a/pages/api/leaderboard/top.js
+++ b/pages/api/leaderboard/top.js
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
+import { getAnonServerClient } from '../../../lib/service-client';
 
 export default async function handler(
   req,
@@ -13,15 +13,12 @@ export default async function handler(
   const game = typeof req.query.game === 'string' ? req.query.game : '2048';
   const limit = Number(req.query.limit ?? 10);
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!url || !key) {
+  const supabase = getAnonServerClient();
+  if (!supabase) {
     console.warn('Leaderboard read disabled: missing Supabase env');
     res.status(503).json([]);
     return;
   }
-
-  const supabase = createClient(url, key);
   const { data, error } = await supabase
     .from('leaderboard')
     .select('username, score, game')

--- a/pages/api/pacman/leaderboard.js
+++ b/pages/api/pacman/leaderboard.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from '../../../lib/server/fs';
 import path from 'path';
 
 const filePath = path.join(process.cwd(), 'data', 'pacman-leaderboard.json');

--- a/pages/api/plugins/[name].js
+++ b/pages/api/plugins/[name].js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from '../../../lib/server/fs';
 import path from 'path';
 
 export default function handler(req, res) {

--- a/pages/api/plugins/index.js
+++ b/pages/api/plugins/index.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from '../../../lib/server/fs';
 import path from 'path';
 
 export default function handler(_req, res) {

--- a/pages/api/radare2.js
+++ b/pages/api/radare2.js
@@ -1,5 +1,5 @@
 import { execFile } from 'child_process';
-import fs from 'fs';
+import fs from '../../lib/server/fs';
 import os from 'os';
 import path from 'path';
 import { promisify } from 'util';

--- a/pages/api/track.js
+++ b/pages/api/track.js
@@ -1,4 +1,4 @@
-import { createClient } from "@supabase/supabase-js";
+import { getServiceClient } from "../../lib/service-client";
 
 export default async function handler(
   req,
@@ -9,20 +9,18 @@ export default async function handler(
     return;
   }
 
-  const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !key) {
-    res.status(500).json({ ok: false, code: "missing_supabase_env" });
-    return;
-  }
-
   const { app_slug, event, payload } = req.body || {};
   if (!app_slug || !event) {
     res.status(400).json({ ok: false, code: "invalid_payload" });
     return;
   }
 
-  const supabase = createClient(url, key);
+  const supabase = getServiceClient();
+  if (!supabase) {
+    res.status(500).json({ ok: false, code: "missing_supabase_env" });
+    return;
+  }
+
   const { error } = await supabase
     .from("app_events")
     .insert({ app_slug, event, payload: payload ?? null });

--- a/pages/api/wallpapers.js
+++ b/pages/api/wallpapers.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from '../../lib/server/fs';
 import path from 'path';
 
 export default function handler(req, res) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12450,6 +12450,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"server-only@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "server-only@npm:0.0.1"
+  checksum: 10c0/4704f0ef85da0be981af6d4ed8e739d39bcfd265b9c246a684060acda5642d0fdc6daffc2308e71e2682c5f508090978802eae0a77623c9b90a49f9ae68048d6
+  languageName: node
+  linkType: hard
+
 "set-blocking@npm:^2.0.0":
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
@@ -13955,6 +13962,7 @@ __metadata:
     react-window: "npm:^2.0.2"
     rrule: "npm:2.7.2"
     seedrandom: "npm:^3.0.5"
+    server-only: "npm:^0.0.1"
     sharp: "npm:^0.34.3"
     stockfish: "npm:^16.0.0"
     swr: "npm:^2.2.5"


### PR DESCRIPTION
## Summary
- add the `server-only` dependency and wrap Supabase and analytics helpers so they throw if imported on the client
- add `lib/server/fs` and update filesystem-backed API routes to consume the guarded helper
- document the server-only convention for new utilities in `CONTRIBUTING.md`

## Testing
- yarn lint *(fails: repo has pre-existing accessibility and `no-top-level-window` violations)*
- yarn test *(fails: pre-existing React act/localStorage issues in the suite)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbc3744748328b4f4c65ead42ea53