### PR TITLE
[ci] enforce next build warnings and add device api smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,24 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: npm run tsc -- --noEmit
 
+  next-build:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: node scripts/ci-next-build.mjs
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: next-build-log
+          path: artifacts/next-build.log
+          if-no-files-found: error
+
   test:
     runs-on: ubuntu-latest
     needs: install
@@ -61,6 +79,34 @@ jobs:
           cache: yarn
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
+
+  playwright:
+    runs-on: ubuntu-latest
+    needs: next-build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx playwright install --with-deps
+      - run: node scripts/ci-next-build.mjs
+        env:
+          CI_NEXT_BUILD_LOG: artifacts/next-build-playwright.log
+      - run: npx playwright test --reporter=html
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: ignore
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-test-results
+          path: test-results
+          if-no-files-found: ignore
 
   vercel-preview:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dist
 # misc
 .DS_Store
 *.pem
+artifacts/
 
 # debug
 npm-debug.log*

--- a/pages/apps/ble-sensor.tsx
+++ b/pages/apps/ble-sensor.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const BleSensor = dynamic(() => import('../../components/apps/ble-sensor'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default BleSensor;

--- a/pages/apps/screen-recorder.tsx
+++ b/pages/apps/screen-recorder.tsx
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic';
+
+const ScreenRecorder = dynamic(
+  () => import('../../components/apps/screen-recorder'),
+  {
+    ssr: false,
+    loading: () => <p>Loading...</p>,
+  }
+);
+
+export default ScreenRecorder;

--- a/pages/apps/webusb.tsx
+++ b/pages/apps/webusb.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const WebUSB = dynamic(() => import('../../components/apps/webusb'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default WebUSB;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,21 @@
 import { defineConfig } from '@playwright/test';
 
+const port = process.env.PORT || '3000';
+const baseURL = process.env.BASE_URL || `http://127.0.0.1:${port}`;
+
 export default defineConfig({
   testDir: './tests',
   testMatch: /.*\.spec\.ts/,
+  outputDir: 'test-results',
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    baseURL,
   },
+  webServer: process.env.BASE_URL
+    ? undefined
+    : {
+        command: `yarn start -p ${port} -H 0.0.0.0`,
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120 * 1000,
+      },
 });

--- a/scripts/ci-next-build.mjs
+++ b/scripts/ci-next-build.mjs
@@ -1,0 +1,78 @@
+import { spawn } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+async function run() {
+  const logFile = resolve(
+    process.cwd(),
+    process.env.CI_NEXT_BUILD_LOG ?? 'artifacts/next-build.log'
+  );
+  mkdirSync(dirname(logFile), { recursive: true });
+
+  const env = {
+    ...process.env,
+    NODE_ENV: 'production',
+    NEXT_TELEMETRY_DISABLED: '1',
+  };
+
+  const child = spawn('yarn', ['build'], {
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let output = '';
+
+  child.stdout.on('data', (data) => {
+    const text = data.toString();
+    output += text;
+    process.stdout.write(text);
+  });
+
+  child.stderr.on('data', (data) => {
+    const text = data.toString();
+    output += text;
+    process.stderr.write(text);
+  });
+
+  const exitCode = await new Promise((resolveChild, rejectChild) => {
+    child.on('error', rejectChild);
+    child.on('close', (code) => resolveChild(code ?? 1));
+  });
+
+  writeFileSync(logFile, output);
+
+  if (exitCode !== 0) {
+    console.error(`next build exited with code ${exitCode}. See ${logFile} for details.`);
+    process.exit(exitCode);
+  }
+
+  const lines = output.split(/\r?\n/);
+  const warningLines = lines.filter((line) => /\bwarn\s+-/i.test(line) || /\bwarning:/i.test(line));
+  const deprecationLines = lines.filter((line) => /deprecat/i.test(line));
+
+  if (warningLines.length > 0 || deprecationLines.length > 0) {
+    if (warningLines.length > 0) {
+      console.error('Warnings detected during next build:');
+      for (const warning of warningLines) {
+        console.error(`  ${warning}`);
+      }
+    }
+
+    if (deprecationLines.length > 0) {
+      console.error('Deprecation notices detected during next build:');
+      for (const deprecation of deprecationLines) {
+        console.error(`  ${deprecation}`);
+      }
+    }
+
+    console.error(`Build log saved to ${logFile}`);
+    process.exit(1);
+  }
+
+  console.log(`next build completed without warnings. Log saved to ${logFile}`);
+}
+
+run().catch((error) => {
+  console.error('Failed to run next build', error);
+  process.exit(1);
+});

--- a/tests/device-apis.spec.ts
+++ b/tests/device-apis.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import { promises as fs } from 'fs';
+
+interface Scenario {
+  name: string;
+  route: string;
+  readySelector: string;
+}
+
+const scenarios: Scenario[] = [
+  {
+    name: 'BLE Sensor',
+    route: '/apps/ble-sensor',
+    readySelector: 'button:has-text("Scan for Devices")',
+  },
+  {
+    name: 'WebUSB Console',
+    route: '/apps/webusb',
+    readySelector: 'button:has-text("Connect")',
+  },
+  {
+    name: 'Screen Recorder',
+    route: '/apps/screen-recorder',
+    readySelector: 'button:has-text("Start Recording")',
+  },
+];
+
+for (const scenario of scenarios) {
+  test.describe(scenario.name, () => {
+    test(`${scenario.name} renders without console issues`, async ({ page }) => {
+      const consoleEvents: { type: string; text: string }[] = [];
+      const pageErrors: string[] = [];
+
+      page.on('console', (message) => {
+        consoleEvents.push({ type: message.type(), text: message.text() });
+      });
+
+      page.on('pageerror', (error) => {
+        pageErrors.push(error.message);
+      });
+
+      await page.goto(scenario.route);
+      await expect(page.locator(scenario.readySelector)).toBeVisible();
+
+      const slug = scenario.route.replace(/\//g, '-').replace(/^-/, '');
+      const screenshotPath = test.info().outputPath(`${slug}.png`);
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+      await test.info().attach('screenshot', {
+        path: screenshotPath,
+        contentType: 'image/png',
+      });
+
+      const logPath = test.info().outputPath(`${slug}-console.log`);
+      const formattedLogs =
+        consoleEvents.map((entry) => `[${entry.type}] ${entry.text}`).join('\n') ||
+        'No console events captured.';
+      await fs.writeFile(logPath, formattedLogs, 'utf8');
+      await test.info().attach('console log', {
+        path: logPath,
+        contentType: 'text/plain',
+      });
+
+      const warningsOrErrors = consoleEvents.filter((event) =>
+        event.type === 'warning' || event.type === 'error'
+      );
+
+      expect(warningsOrErrors, 'Console emitted warnings or errors').toEqual([]);
+      expect(pageErrors, 'Unhandled page errors were thrown').toEqual([]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a dedicated `next-build` job that runs a production `next build` via a new guard script and uploads its log as an artifact
- wire a Playwright smoke job that provisions browsers, runs the console-checking device API test, and captures Playwright artifacts
- expose BLE Sensor, WebUSB, and Screen Recorder as routable `/apps/*` pages and cover them with a Playwright smoke suite that records screenshots and console logs

## Testing
- yarn lint *(fails: pre-existing jsx-a11y/no-top-level-window errors throughout legacy apps)*
- yarn test *(fails: existing Jest suites error on missing act wrappers and jsdom localStorage support)*
- node scripts/ci-next-build.mjs
- npx playwright test --reporter=html *(fails: container lacks required system libraries for Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbc3c25cc83288cdfef7c0491b0a9