### PR TITLE
[core] isolate server-only logging utilities

### DIFF
--- a/__tests__/adminMessages.test.ts
+++ b/__tests__/adminMessages.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMocks } from 'node-mocks-http';
 
 describe('admin messages api', () => {

--- a/lib/analytics-server.ts
+++ b/lib/analytics-server.ts
@@ -1,3 +1,7 @@
+import { serverOnly } from './server/server-only';
+
+serverOnly('lib/analytics-server');
+
 export default async function trackServerEvent(
   event: string,
   properties?: Record<string, any>,

--- a/lib/logger/base.ts
+++ b/lib/logger/base.ts
@@ -8,7 +8,7 @@ export interface Logger {
 }
 
 class ConsoleLogger implements Logger {
-  constructor(private correlationId: string) {}
+  constructor(private readonly correlationId: string) {}
 
   private log(level: string, message: string, meta: Record<string, any> = {}) {
     const safeMeta: Record<string, any> = {};
@@ -29,37 +29,28 @@ class ConsoleLogger implements Logger {
   info(message: string, meta?: Record<string, any>) {
     this.log('info', message, meta);
   }
+
   warn(message: string, meta?: Record<string, any>) {
     this.log('warn', message, meta);
   }
+
   error(message: string, meta?: Record<string, any>) {
     this.log('error', message, meta);
   }
+
   debug(message: string, meta?: Record<string, any>) {
     this.log('debug', message, meta);
   }
 }
 
-function generateCorrelationId(): string {
-  if (typeof globalThis === 'object') {
-    const cryptoObj: any = (globalThis as any).crypto;
-    if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
-      return cryptoObj.randomUUID();
-    }
-  }
-  try {
-    const { randomUUID } = require('crypto');
-    return randomUUID();
-  } catch {
-    // Fallback for environments without crypto support
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-      const r = (Math.random() * 16) | 0;
-      const v = c === 'x' ? r : (r & 0x3) | 0x8;
-      return v.toString(16);
-    });
-  }
+export function createConsoleLogger(correlationId: string): Logger {
+  return new ConsoleLogger(correlationId);
 }
 
-export function createLogger(correlationId: string = generateCorrelationId()): Logger {
-  return new ConsoleLogger(correlationId);
+export function fallbackCorrelationId(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
 }

--- a/lib/logger/client.ts
+++ b/lib/logger/client.ts
@@ -1,0 +1,56 @@
+import { createConsoleLogger, fallbackCorrelationId, type Logger } from './base';
+
+type CryptoLike = {
+  randomUUID?: () => string;
+  getRandomValues?: (array: Uint8Array) => Uint8Array;
+};
+
+function getGlobalCrypto(): CryptoLike | undefined {
+  if (typeof globalThis !== 'object') {
+    return undefined;
+  }
+  const cryptoObj = (globalThis as { crypto?: CryptoLike }).crypto;
+  return cryptoObj;
+}
+
+function uuidFromRandomValues(cryptoObj: CryptoLike): string | undefined {
+  if (typeof cryptoObj.getRandomValues !== 'function') {
+    return undefined;
+  }
+  try {
+    const bytes = new Uint8Array(16);
+    cryptoObj.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function generateCorrelationId(): string {
+  const cryptoObj = getGlobalCrypto();
+  if (cryptoObj) {
+    if (typeof cryptoObj.randomUUID === 'function') {
+      try {
+        return cryptoObj.randomUUID();
+      } catch {
+        // continue to fallback
+      }
+    }
+
+    const valueBased = uuidFromRandomValues(cryptoObj);
+    if (valueBased) {
+      return valueBased;
+    }
+  }
+
+  return fallbackCorrelationId();
+}
+
+export function createLogger(correlationId: string = generateCorrelationId()): Logger {
+  return createConsoleLogger(correlationId);
+}
+
+export type { Logger };

--- a/lib/logger/index.ts
+++ b/lib/logger/index.ts
@@ -1,0 +1,2 @@
+export { createLogger } from './client';
+export type { Logger } from './base';

--- a/lib/server/logger.ts
+++ b/lib/server/logger.ts
@@ -1,0 +1,43 @@
+import { createConsoleLogger, fallbackCorrelationId, type Logger } from '../logger/base';
+import { serverOnly } from './server-only';
+
+type NodeRandomUUID = () => string;
+
+serverOnly('lib/server/logger');
+
+let cachedRandomUUID: NodeRandomUUID | null | undefined;
+
+function loadNodeRandomUUID(): NodeRandomUUID | null {
+  if (cachedRandomUUID !== undefined) {
+    return cachedRandomUUID;
+  }
+
+  try {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+    const { randomUUID } = require('crypto') as typeof import('crypto');
+    cachedRandomUUID = randomUUID;
+  } catch {
+    cachedRandomUUID = null;
+  }
+
+  return cachedRandomUUID;
+}
+
+function generateCorrelationId(): string {
+  const nodeRandomUUID = loadNodeRandomUUID();
+  if (nodeRandomUUID) {
+    try {
+      return nodeRandomUUID();
+    } catch {
+      // continue to fallback
+    }
+  }
+
+  return fallbackCorrelationId();
+}
+
+export function createLogger(correlationId: string = generateCorrelationId()): Logger {
+  return createConsoleLogger(correlationId);
+}
+
+export type { Logger } from '../logger/base';

--- a/lib/server/server-only.ts
+++ b/lib/server/server-only.ts
@@ -1,0 +1,15 @@
+export function serverOnly(moduleName: string): void {
+  const isBrowser = typeof window !== 'undefined' || typeof document !== 'undefined';
+  if (isBrowser) {
+    throw new Error(`${moduleName} is only available on the server.`);
+  }
+
+  const runtime =
+    typeof process !== 'undefined' && process && 'env' in process
+      ? (process as NodeJS.Process).env?.NEXT_RUNTIME
+      : undefined;
+
+  if (runtime && runtime !== 'nodejs') {
+    throw new Error(`${moduleName} is not supported in the ${runtime} runtime.`);
+  }
+}

--- a/lib/server/service-client.ts
+++ b/lib/server/service-client.ts
@@ -1,4 +1,7 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { serverOnly } from './server-only';
+
+serverOnly('lib/server/service-client');
 
 export function getServiceClient(): SupabaseClient | null {
   const url = process.env.SUPABASE_URL;

--- a/pages/api/admin/messages.js
+++ b/pages/api/admin/messages.js
@@ -1,5 +1,5 @@
-import { getServiceClient } from '../../../lib/service-client';
-import { createLogger } from '../../../lib/logger';
+import { getServiceClient } from '../../../lib/server/service-client';
+import { createLogger } from '../../../lib/server/logger';
 
 export default async function handler(
   req,


### PR DESCRIPTION
## Summary
- refactor logging helpers into shared base, browser-safe client entry, and guarded server entry to avoid bundling Node crypto
- add a reusable `serverOnly` guard, move Supabase service client under `lib/server`, and update the admin messages API to pull the server variants
- mark the admin messages API test to run in a Node environment and gate analytics server helpers with the new guard

## Testing
- yarn lint *(fails: numerous pre-existing JSX a11y and window/document lint violations across apps)*
- CI=1 yarn test *(fails: existing window snapping, Nmap NSE clipboard, modal focus, and admin messages suites — admin test fixed by running under node env once guard applied)*
- yarn analyze

------
https://chatgpt.com/codex/tasks/task_e_68ccbc3ca3348328848c1df2914a2405