### PR TITLE
refactor: add client directives for interactive modules

### DIFF
--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useRef, useState } from 'react';
 import useIntersection from '../hooks/useIntersection';
 

--- a/components/CommandBuilder.tsx
+++ b/components/CommandBuilder.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import TerminalOutput from './TerminalOutput';
 

--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState } from 'react';
 import Head from 'next/head';
 

--- a/components/GitHubStars.js
+++ b/components/GitHubStars.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import usePersistentState from '../hooks/usePersistentState';
 

--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 import { ModuleMetadata } from '../modules/metadata';
 

--- a/components/NetworkAttackStepper.tsx
+++ b/components/NetworkAttackStepper.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState } from 'react';
 import WarningBanner from './WarningBanner';
 

--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState } from 'react';
 import modulesData from '../data/module-index.json';
 import versionInfo from '../data/module-version.json';

--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   useState,
   useMemo,

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import { getUnlockedThemes } from '../utils/theme';
 import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';

--- a/components/TerminalOutput.tsx
+++ b/components/TerminalOutput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 
 interface TerminalOutputProps {

--- a/components/UseRouteAbortGuard.tsx
+++ b/components/UseRouteAbortGuard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 

--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useRef, useEffect } from 'react';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { createContext, useCallback, useEffect, useState } from 'react';
 
 export interface AppNotification {

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useRef } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useRef } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useEffect } from 'react'
 import logger from '../../utils/logger'
 

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useRef } from 'react';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState } from 'react'
 import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState, useRef } from 'react';
 
 export default function WindowSwitcher({ windows = [], onSelect, onClose }) {

--- a/components/simulator/index.tsx
+++ b/components/simulator/index.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
+
 import type {
   SimulatorParserRequest,
   SimulatorParserResponse,

--- a/components/tweet-embed.js
+++ b/components/tweet-embed.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState } from 'react';
 import DOMPurify from 'dompurify';
 

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useCallback, useEffect, useRef, useState, createContext, useContext } from 'react';
 
 function middleEllipsis(text: string, max = 30) {

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useRef, useState } from 'react';
 
 interface ToastProps {

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState } from "react";
 import Image from 'next/image';
 import SmallArrow from "./small_arrow";

--- a/pages/admin/messages.tsx
+++ b/pages/admin/messages.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 
 export default function AdminMessages() {

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';

--- a/pages/apps/weather_widget.jsx
+++ b/pages/apps/weather_widget.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 

--- a/pages/hydra-preview.tsx
+++ b/pages/hydra-preview.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState } from 'react';
 import FormError from '../components/ui/FormError';
 

--- a/pages/module-workspace.tsx
+++ b/pages/module-workspace.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useMemo, useCallback } from 'react';
 import usePersistentState from '../hooks/usePersistentState';
 import { setValue, getAll } from '../utils/moduleStore';

--- a/pages/nessus-dashboard.tsx
+++ b/pages/nessus-dashboard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState } from 'react';
 import { loadFalsePositives, loadJobDefinitions } from '../components/apps/nessus/index';
 import { WindowMainScreen } from '../components/base/window';

--- a/pages/network-topology.tsx
+++ b/pages/network-topology.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState } from 'react';
 import Meta from '../components/SEO/Meta';
 

--- a/pages/recon/graph.tsx
+++ b/pages/recon/graph.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 

--- a/pages/sekurlsa_logonpasswords.tsx
+++ b/pages/sekurlsa_logonpasswords.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useMemo } from 'react';
 import Meta from '../components/SEO/Meta';
 

--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
 

--- a/pages/wps-attack.tsx
+++ b/pages/wps-attack.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState } from 'react';
 import Meta from '../components/SEO/Meta';
 


### PR DESCRIPTION
## Summary
- mark interactive shared components under `components/` as client modules so hooks, effects, and DOM access run inside the browser bundle
- flag hook-based and event-driven pages (e.g. module workspace, WPS attack, video gallery) with `'use client'` to keep them compatible with the App Router expectations
- align context menus, notifications, simulator shell, and other UI infrastructure with explicit client boundaries to avoid mixed client/server concerns

## Testing
- ❌ `yarn lint` *(fails: existing accessibility and no-top-level-window issues throughout legacy apps)*
- ✅ `CI=1 yarn next build`


------
https://chatgpt.com/codex/tasks/task_e_68ccbc3a8e408328827956722bb791ee