### PR TITLE
ci: add bundle analysis and plugin boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: npm run lint
+      - run: yarn lint
 
   typecheck:
     runs-on: ubuntu-latest
@@ -49,6 +49,50 @@ jobs:
           cache: yarn
       - run: yarn install --immutable --immutable-cache
       - run: yarn test --coverage
+
+  analyze:
+    runs-on: ubuntu-latest
+    needs: install
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            relevant:
+              - 'app/**'
+              - 'pages/**'
+              - 'components/**'
+              - 'lib/**'
+              - 'src/**'
+              - 'workers/**'
+              - 'middleware.ts'
+              - 'middleware.js'
+              - 'plugins/**'
+      - name: Skip analysis summary
+        if: steps.changes.outputs.relevant != 'true'
+        run: echo "No server/client bundle changes detected; skipping bundle analysis." >> $GITHUB_STEP_SUMMARY
+      - name: Build with analyzer
+        if: steps.changes.outputs.relevant == 'true'
+        run: ANALYZE=true yarn build
+      - name: Inspect client bundle
+        if: steps.changes.outputs.relevant == 'true'
+        run: node scripts/analyze-client-bundle.mjs
+      - name: Publish bundle summary
+        if: steps.changes.outputs.relevant == 'true'
+        run: cat .next/analyze/summary.md >> $GITHUB_STEP_SUMMARY
+      - name: Upload bundle analyzer report
+        if: steps.changes.outputs.relevant == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle-analyzer-report
+          path: .next/analyze
 
   security:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build",
     "test": "jest",
     "test:watch": "jest --watch",
-    "lint": "eslint . --max-warnings=0",
+    "lint": "node scripts/check-plugin-boundaries.mjs && eslint . --max-warnings=0",
     "tsc": "tsc",
     "typecheck": "tsc --noEmit",
     "a11y": "node scripts/a11y.mjs",

--- a/scripts/analyze-client-bundle.mjs
+++ b/scripts/analyze-client-bundle.mjs
@@ -1,0 +1,122 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const REPORT_PATH = path.join(process.cwd(), '.next', 'analyze', 'client.json');
+const SUMMARY_PATH = path.join(process.cwd(), '.next', 'analyze', 'summary.md');
+
+const SERVER_ONLY_PATTERNS = [
+  { pattern: '/lib/service-client', reason: 'Supabase service client must only run on the server.' },
+  { pattern: '/lib/analytics-server', reason: 'Server analytics helpers must not ship to the browser.' },
+  { pattern: '/lib/validate', reason: 'Environment validation logic is server-only.' },
+  { pattern: '/pages/api/', reason: 'API route handlers must remain server-side.' },
+  { pattern: '/middleware', reason: 'Middleware code is evaluated on the server/edge only.' },
+];
+
+function collectModules(node, acc) {
+  if (!node || typeof node !== 'object') return;
+  const groups = Array.isArray(node.groups) ? node.groups : [];
+  const modules = Array.isArray(node.modules) ? node.modules : [];
+  if (groups.length === 0 && modules.length === 0 && typeof node.path === 'string') {
+    acc.push(node);
+    return;
+  }
+  for (const child of groups) {
+    collectModules(child, acc);
+  }
+  for (const child of modules) {
+    collectModules(child, acc);
+  }
+}
+
+function formatSize(bytes) {
+  if (bytes === 0) return '0 B';
+  if (!Number.isFinite(bytes)) return `${bytes}`;
+  const units = ['B', 'kB', 'MB'];
+  let size = bytes;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+  return `${size.toFixed(1)} ${units[unitIndex]}`;
+}
+
+async function loadReport() {
+  const raw = await fs.readFile(REPORT_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+function findViolations(modules) {
+  const findings = [];
+  for (const mod of modules) {
+    const modulePath = mod.path || mod.label || '';
+    for (const rule of SERVER_ONLY_PATTERNS) {
+      if (modulePath.includes(rule.pattern)) {
+        findings.push({ modulePath, rule });
+        break;
+      }
+    }
+  }
+  return findings;
+}
+
+function createSummary(modules) {
+  const totalParsed = modules.reduce((sum, mod) => sum + (mod.parsedSize || 0), 0);
+  const totalStat = modules.reduce((sum, mod) => sum + (mod.statSize || 0), 0);
+  const sorted = [...modules]
+    .sort((a, b) => (b.parsedSize || 0) - (a.parsedSize || 0))
+    .slice(0, 10);
+
+  const lines = [
+    '### Client bundle analysis',
+    '',
+    `* Modules analysed: **${modules.length}**`,
+    `* Total parsed size: **${formatSize(totalParsed)}**`,
+    `* Total stat size: **${formatSize(totalStat)}**`,
+    '',
+    '| Module | Parsed size |',
+    '| --- | --- |',
+  ];
+
+  for (const entry of sorted) {
+    const pathLabel = entry.path || entry.label || '(unknown)';
+    const normalized = pathLabel.replace(/^\.\/?/, '');
+    lines.push(`| \`${normalized}\` | ${formatSize(entry.parsedSize || 0)} |`);
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+async function main() {
+  try {
+    const report = await loadReport();
+    const modules = [];
+    for (const entry of report) {
+      collectModules(entry, modules);
+    }
+
+    if (modules.length === 0) {
+      throw new Error('Bundle analyzer report did not contain any module entries.');
+    }
+
+    const violations = findViolations(modules);
+    const summary = createSummary(modules);
+    await fs.writeFile(SUMMARY_PATH, summary, 'utf8');
+
+    console.log(summary);
+
+    if (violations.length > 0) {
+      console.error('Found server-only modules in the client bundle:');
+      for (const { modulePath, rule } of violations) {
+        console.error(` - ${modulePath} → ${rule.reason}`);
+      }
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error('Failed to analyse client bundle.');
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/check-plugin-boundaries.mjs
+++ b/scripts/check-plugin-boundaries.mjs
@@ -1,0 +1,105 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const CATALOG_DIR = path.join(process.cwd(), 'plugins', 'catalog');
+const ALLOWED_SANDBOXES = new Set(['worker', 'iframe']);
+
+async function loadManifests() {
+  const entries = await fs.readdir(CATALOG_DIR, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => entry.name);
+}
+
+async function validateManifest(filename) {
+  const fullPath = path.join(CATALOG_DIR, filename);
+  const errors = [];
+
+  try {
+    const raw = await fs.readFile(fullPath, 'utf8');
+    let manifest;
+    try {
+      manifest = JSON.parse(raw);
+    } catch (err) {
+      errors.push(`✖ ${filename}: invalid JSON (${err instanceof Error ? err.message : String(err)})`);
+      return errors;
+    }
+
+    const id = manifest?.id;
+    const sandbox = manifest?.sandbox;
+    const code = manifest?.code;
+
+    const expectedId = path.parse(filename).name;
+    if (typeof id !== 'string' || id.trim().length === 0) {
+      errors.push(`✖ ${filename}: missing string "id" field`);
+    } else if (id !== expectedId) {
+      errors.push(`✖ ${filename}: id "${id}" must match file name "${expectedId}"`);
+    }
+
+    if (!ALLOWED_SANDBOXES.has(sandbox)) {
+      errors.push(
+        `✖ ${filename}: sandbox must be one of ${Array.from(ALLOWED_SANDBOXES)
+          .map((s) => `"${s}"`)
+          .join(', ')}`,
+      );
+    }
+
+    if (typeof code !== 'string' || code.trim().length === 0) {
+      errors.push(`✖ ${filename}: missing plugin code string`);
+    }
+
+    if (typeof code === 'string' && sandbox === 'worker') {
+      const unsafeWorkerRefs = ['window', 'document'];
+      for (const ref of unsafeWorkerRefs) {
+        if (code.includes(ref)) {
+          errors.push(`✖ ${filename}: worker sandbox must not reference ${ref}`);
+        }
+      }
+    }
+
+    if (typeof code === 'string' && code.includes('</script')) {
+      errors.push(`✖ ${filename}: embedded script tags are not allowed in plugin code`);
+    }
+
+    const allowedKeys = new Set(['id', 'sandbox', 'code', 'description', 'version']);
+    for (const key of Object.keys(manifest)) {
+      if (!allowedKeys.has(key)) {
+        errors.push(`✖ ${filename}: unexpected field "${key}" not allowed in plugin manifest`);
+      }
+    }
+  } catch (err) {
+    errors.push(`✖ ${filename}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return errors;
+}
+
+(async () => {
+  try {
+    const manifests = await loadManifests();
+    const problems = [];
+
+    for (const file of manifests) {
+      const issues = await validateManifest(file);
+      problems.push(...issues);
+    }
+
+    if (problems.length > 0) {
+      for (const problem of problems) {
+        console.error(problem);
+      }
+      console.error(`Plugin boundary checks failed for ${problems.length} issue${
+        problems.length === 1 ? '' : 's'
+      }.`);
+      process.exit(1);
+    } else {
+      console.log(`✓ Plugin boundary checks passed (${manifests.length} manifest${
+        manifests.length === 1 ? '' : 's'
+      }).`);
+    }
+  } catch (err) {
+    console.error('✖ Failed to validate plugin manifests');
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- run plugin boundary validation before eslint in the lint script
- emit bundle analyzer JSON data and inspect client bundles for server-only modules during analysis builds
- extend CI with a conditional analyze job that uploads bundle reports and publishes summaries

## Testing
- yarn lint (fails: repository has existing JSX label violations and window/document usage in public app scripts)
- yarn test --runInBand (fails: existing window snapping and nmap NSE tests)

------
https://chatgpt.com/codex/tasks/task_e_68ccbc361e848328a8f9188695a508a0