### PR TITLE
[ssr] Harden desktop components for SSR

### DIFF
--- a/__tests__/ssr-compat.test.tsx
+++ b/__tests__/ssr-compat.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment node
+ */
+
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import NotificationCenter from '../components/common/NotificationCenter';
+import WhiskerMenu from '../components/menu/WhiskerMenu';
+import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import ContextMenu from '../components/common/ContextMenu';
+import GameSettingsPanel from '../components/game/GameSettingsPanel';
+import InputHub from '../pages/input-hub';
+import GamepadCalibration from '../pages/gamepad-calibration';
+import ModuleWorkspace from '../pages/module-workspace';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: {},
+  }),
+}));
+
+jest.mock('@emailjs/browser', () => ({
+  init: jest.fn(),
+  send: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('next/image', () => {
+  return function MockImage(props: any) {
+    const { src, alt = '', ...rest } = props;
+    const resolvedSrc = typeof src === 'string' ? src : src?.src || '';
+    return React.createElement('img', { ...rest, src: resolvedSrc, alt });
+  };
+});
+
+describe('SSR safety', () => {
+  it('renders NotificationCenter without browser globals', () => {
+    expect(() =>
+      renderToString(
+        <NotificationCenter>
+          <div />
+        </NotificationCenter>
+      )
+    ).not.toThrow();
+  });
+
+  it('renders WhiskerMenu without browser globals', () => {
+    expect(() => renderToString(<WhiskerMenu />)).not.toThrow();
+  });
+
+  it('renders ShortcutOverlay without browser globals', () => {
+    expect(() => renderToString(<ShortcutOverlay />)).not.toThrow();
+  });
+
+  it('renders ContextMenu without browser globals', () => {
+    const ref = { current: null } as React.RefObject<HTMLElement>;
+    expect(() => renderToString(<ContextMenu targetRef={ref} items={[]} />)).not.toThrow();
+  });
+
+  it('renders GameSettingsPanel without browser globals', () => {
+    expect(() =>
+      renderToString(
+        <GameSettingsPanel
+          onApplyKeymap={jest.fn()}
+          getSnapshot={() => ({})}
+          loadSnapshot={jest.fn()}
+          currentScore={0}
+        />
+      )
+    ).not.toThrow();
+  });
+
+  it('renders InputHub page without browser globals', () => {
+    expect(() => renderToString(<InputHub />)).not.toThrow();
+  });
+
+  it('renders GamepadCalibration page without browser globals', () => {
+    expect(() => renderToString(<GamepadCalibration />)).not.toThrow();
+  });
+
+  it('renders ModuleWorkspace page without browser globals', () => {
+    expect(() => renderToString(<ModuleWorkspace />)).not.toThrow();
+  });
+});

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -61,15 +61,15 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
   }, [targetRef]);
 
   useEffect(() => {
-    if (open) {
-      window.dispatchEvent(new CustomEvent('context-menu-open'));
-    } else {
-      window.dispatchEvent(new CustomEvent('context-menu-close'));
-    }
+    if (typeof window === 'undefined') return;
+    const eventName = open ? 'context-menu-open' : 'context-menu-close';
+    window.dispatchEvent(new CustomEvent(eventName));
   }, [open]);
 
   useEffect(() => {
     if (!open) return;
+
+    if (typeof document === 'undefined') return undefined;
 
     const handleClick = (e: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useCallback, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 export interface AppNotification {
   id: string;
@@ -49,13 +55,22 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
     0
   );
 
+  const canUseAppBadging = useMemo(
+    () =>
+      typeof navigator !== 'undefined' &&
+      typeof (navigator as any).setAppBadge === 'function',
+    []
+  );
+
   useEffect(() => {
+    if (!canUseAppBadging) return;
     const nav: any = navigator;
-    if (nav && nav.setAppBadge) {
-      if (totalCount > 0) nav.setAppBadge(totalCount).catch(() => {});
-      else nav.clearAppBadge?.().catch(() => {});
+    if (totalCount > 0) {
+      nav.setAppBadge(totalCount).catch(() => {});
+    } else {
+      nav.clearAppBadge?.().catch(() => {});
     }
-  }, [totalCount]);
+  }, [canUseAppBadging, totalCount]);
 
   return (
     <NotificationsContext.Provider

--- a/components/common/ShortcutOverlay.tsx
+++ b/components/common/ShortcutOverlay.tsx
@@ -21,6 +21,7 @@ const ShortcutOverlay: React.FC = () => {
   const toggle = useCallback(() => setOpen((o) => !o), []);
 
   useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
     const handler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
       const isInput =
@@ -44,6 +45,8 @@ const ShortcutOverlay: React.FC = () => {
   }, [open, toggle, shortcuts]);
 
   const handleExport = () => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    if (typeof URL === 'undefined' || typeof Blob === 'undefined') return;
     const data = JSON.stringify(shortcuts, null, 2);
     const blob = new Blob([data], { type: 'application/json' });
     const url = URL.createObjectURL(blob);

--- a/components/game/GameSettingsPanel.jsx
+++ b/components/game/GameSettingsPanel.jsx
@@ -38,6 +38,7 @@ export default function GameSettingsPanel({
   );
 
   useEffect(() => {
+    if (typeof window === "undefined") return undefined;
     if (waitingFor) {
       window.addEventListener("keydown", assignKey, { once: true });
       return () => window.removeEventListener("keydown", assignKey);
@@ -50,6 +51,7 @@ export default function GameSettingsPanel({
 
   const [gamepadConnected, setGamepadConnected] = useState(false);
   useEffect(() => {
+    if (typeof window === "undefined") return undefined;
     const connect = () => setGamepadConnected(true);
     const disconnect = () => setGamepadConnected(false);
     window.addEventListener("gamepadconnected", connect);
@@ -67,6 +69,7 @@ export default function GameSettingsPanel({
 
   // --- Persistence -------------------------------------------------------
   const saveSnapshot = () => {
+    if (typeof window === "undefined") return;
     if (getSnapshot) {
       const snap = getSnapshot();
       try {
@@ -76,6 +79,7 @@ export default function GameSettingsPanel({
   };
 
   const loadSnapshotClick = () => {
+    if (typeof window === "undefined") return;
     if (loadSnapshot) {
       const data = window.localStorage.getItem("game-snapshot");
       if (data) loadSnapshot(JSON.parse(data));
@@ -111,6 +115,7 @@ export default function GameSettingsPanel({
   // --- Input Latency Tester ---------------------------------------------
   const [latency, setLatency] = useState(null);
   const startLatencyTest = () => {
+    if (typeof window === "undefined" || typeof performance === "undefined") return;
     const start = performance.now();
     const handler = () => {
       setLatency(performance.now() - start);

--- a/pages/gamepad-calibration.tsx
+++ b/pages/gamepad-calibration.tsx
@@ -16,6 +16,7 @@ export default function GamepadCalibration() {
   const [vendor, setVendor] = useState<string>("");
 
   useEffect(() => {
+    if (typeof window === "undefined" || typeof navigator === "undefined") return undefined;
     const connect = (e: GamepadEvent) => setPad(e.gamepad);
     const disconnect = () => setPad(null);
     window.addEventListener("gamepadconnected", connect);
@@ -34,7 +35,7 @@ export default function GamepadCalibration() {
   }, []);
 
   useEffect(() => {
-    if (!pad) return;
+    if (!pad || typeof window === "undefined" || typeof navigator === "undefined") return;
     const existing = loadCalibration(pad.id);
     if (existing) {
       setRanges(existing.axes.map((r) => ({ ...r })));
@@ -54,10 +55,14 @@ export default function GamepadCalibration() {
           max: Math.max(rng.max, p.axes[i]),
         }))
       );
-      raf = requestAnimationFrame(read);
+      raf = window.requestAnimationFrame ? window.requestAnimationFrame(read) : 0;
     };
-    raf = requestAnimationFrame(read);
-    return () => cancelAnimationFrame(raf);
+    raf = window.requestAnimationFrame ? window.requestAnimationFrame(read) : 0;
+    return () => {
+      if (raf && window.cancelAnimationFrame) {
+        window.cancelAnimationFrame(raf);
+      }
+    };
   }, [pad]);
 
   const handlePreset = (name: string) => {

--- a/pages/module-workspace.tsx
+++ b/pages/module-workspace.tsx
@@ -101,6 +101,11 @@ const ModuleWorkspace: React.FC = () => {
     setStoreData(getAll());
   }, [selected, optionValues]);
 
+  const copyResult = useCallback(() => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return;
+    navigator.clipboard.writeText(result).catch(() => {});
+  }, [result]);
+
   return (
     <div className="p-4 space-y-4 bg-ub-cool-grey text-white min-h-screen">
       <section className="space-y-2">
@@ -111,6 +116,7 @@ const ModuleWorkspace: React.FC = () => {
             onChange={(e) => setNewWorkspace(e.target.value)}
             placeholder="New workspace"
             className="p-1 rounded text-black"
+            aria-label="New workspace name"
           />
           <button
             onClick={addWorkspace}
@@ -184,6 +190,7 @@ const ModuleWorkspace: React.FC = () => {
                         })
                       }
                       className="mt-1 w-full p-1 rounded text-black"
+                      aria-label={`${opt.name} value`}
                     />
                   </label>
                 </div>
@@ -203,9 +210,7 @@ const ModuleWorkspace: React.FC = () => {
                     {result}
                   </pre>
                   <button
-                    onClick={() =>
-                      navigator.clipboard?.writeText(result)
-                    }
+                    onClick={copyResult}
                     className="px-2 py-1 text-sm rounded bg-gray-700"
                   >
                     Copy


### PR DESCRIPTION
## Summary
- memoize NotificationCenter badge updates and guard against missing navigator during SSR
- wrap menu, overlay, and form components in runtime browser guards and add aria labels needed for lint
- add a react-dom/server smoke test to ensure key components render without browser globals

## Testing
- yarn lint *(fails: repository has hundreds of pre-existing accessibility/global window lint errors)*
- yarn test __tests__/ssr-compat.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ccbc3d668883289a58840f99ae7e98