### PR TITLE
[ci] enforce react dedupe check

### DIFF
--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -35,6 +35,15 @@ const getPort = () =>
     console.log(`next: ${nextVersion}`);
 
     await run('yarn', ['install', '--immutable']);
+    await run('yarn', [
+      'dedupe',
+      '--check',
+      'react',
+      'react-dom',
+      'next',
+      '@types/react',
+      '@types/react-dom',
+    ]);
     await run('yarn', ['lint']);
     await run('yarn', ['tsc', '--noEmit']);
     await run('yarn', ['build']);


### PR DESCRIPTION
## Summary
- confirmed there are no additional manifests under apps/, modules/, or components that override the React/Next stack
- added a yarn dedupe --check step to the verify script so CI will fail if React/Next/@types dependencies drift

## Testing
- yarn dedupe --check react react-dom next @types/react @types/react-dom
- yarn lint *(fails: repository currently has pre-existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbc46e9f08328874a127be4aaf965