### PR TITLE
[devcontainer] add VS Code container setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "Kali Linux Portfolio",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22",
+      "installYarnUsingCorepack": true
+    }
+  },
+  "mounts": [
+    "source=devcontainer-yarn-cache,target=${containerWorkspaceFolder}/.yarn,type=volume"
+  ],
+  "postCreateCommand": "corepack enable && corepack prepare yarn@4 --activate && yarn install --immutable"
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Always test inside controlled labs and obtain written permission before performi
 - **Yarn** or **npm**
 - Recommended: **pnpm** if you prefer stricter hoisting; update lock/config accordingly.
 
+### Dev Container (VS Code / Codespaces)
+
+This repo ships with [Dev Container](https://containers.dev/) settings under `.devcontainer/devcontainer.json` so contributors can get a reproducible environment with Docker, VS Code, or GitHub Codespaces:
+
+1. Install Docker Desktop (or another compatible container runtime) and the **Dev Containers** VS Code extension.
+2. Open this repository in VS Code and run **Dev Containers: Reopen in Container** from the Command Palette.
+3. The container uses `mcr.microsoft.com/devcontainers/javascript-node` with Node.js 22, enables Corepack, activates Yarn 4, and runs `yarn install --immutable` on first boot.
+4. The `.yarn` directory is mounted as a persistent Docker volume so the Yarn cache survives container rebuilds.
+
+Codespaces users get the same experience automatically when the workspace initializes.
+
 ### Install & Run (Dev)
 ```bash
 cp .env.local.example .env.local  # populate with required keys


### PR DESCRIPTION
## Summary
- add a dev container definition that pins the javascript-node image to Node 22, enables Corepack/Yarn 4, and runs yarn install after creation
- mount a persistent volume for the workspace .yarn directory so installs are cached between rebuilds
- document how to launch the Dev Container from VS Code or Codespaces in the README

## Testing
- yarn lint *(fails: numerous pre-existing jsx-a11y/control-has-associated-label and no-top-level-window errors in apps and public assets)*
- yarn test *(fails: pre-existing act/localStorage related test failures in window, nmap NSE, PopularModules, PdfViewer, and About apps)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbc492580832892202a290b308dcc