### PR TITLE
[ci] publish dependency health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,23 @@ jobs:
         with:
           node-version: 20
           cache: yarn
-      - run: yarn install --immutable --immutable-cache
+      - name: Install dependencies
+        run: |
+          set -o pipefail
+          yarn install --immutable --immutable-cache 2>&1 | tee yarn-install.log
+      - name: Fail on Yarn warnings
+        run: |
+          if grep -i "warning" yarn-install.log; then
+            echo "::error::Yarn install produced warnings"
+            exit 1
+          else
+            echo "No Yarn warnings detected"
+          fi
+      - name: Upload Yarn install log
+        uses: actions/upload-artifact@v4
+        with:
+          name: yarn-install-log
+          path: yarn-install.log
 
   lint:
     runs-on: ubuntu-latest
@@ -60,7 +76,41 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: yarn npm audit
+      - name: Run Yarn npm audit (high severity)
+        run: |
+          set -o pipefail
+          audit_exit=0
+          yarn npm audit --severity high --json > audit.json || audit_exit=$?
+          if [ ! -s audit.json ]; then
+            echo '{"type":"auditSummary","message":"No audit suggestions","severity":"high"}' > audit.json
+          fi
+          cat audit.json
+          if [ "$audit_exit" -ne 0 ]; then
+            echo "::error::High severity vulnerabilities detected by npm audit"
+            exit "$audit_exit"
+          fi
+      - name: Check for outdated dependencies
+        env:
+          NPM_CONFIG_LOGLEVEL: error
+          npm_config_loglevel: error
+        run: |
+          set -o pipefail
+          outdated_exit=0
+          yarn exec npm outdated --json > outdated.json || outdated_exit=$?
+          if [ ! -s outdated.json ]; then
+            echo '{}' > outdated.json
+          fi
+          cat outdated.json
+          if [ "$outdated_exit" -ne 0 ]; then
+            echo "::warning::npm outdated exited with code $outdated_exit"
+          fi
+      - name: Upload dependency health artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-health
+          path: |
+            audit.json
+            outdated.json
 
   vercel-preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- capture yarn install output, fail on warnings, and publish the log as an artifact
- extend the security workflow to run high-severity npm audits and npm outdated with JSON output
- archive audit and outdated reports so maintainers can track dependency health over time

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ccbc4547f883288d6388f61aa98b25