### PR TITLE
[ci] enforce coverage gating

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Summary
+- _Describe your changes._
+
+## Testing
+- [ ] `yarn lint`
+- [ ] `yarn test --coverage` (meets or raises the global ≥70% line coverage threshold)
+- [ ] `yarn typecheck`
+- [ ] Additional notes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,20 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: yarn test --coverage
+      - name: Run unit tests with coverage
+        id: unit_tests
+        run: yarn test --coverage
+        continue-on-error: true
+      - name: Upload coverage report
+        if: always() && hashFiles('coverage/**/*') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage
+          retention-days: 7
+      - name: Fail if coverage or tests failed
+        if: steps.unit_tests.outcome != 'success'
+        run: exit 1
 
   security:
     runs-on: ubuntu-latest

--- a/docs/new-app-checklist.md
+++ b/docs/new-app-checklist.md
@@ -35,3 +35,8 @@ test('My App launches', async ({ page }) => {
   await expect(page.locator('[data-testid="my-app"]')).toBeVisible();
 });
 ```
+
+## Unit tests and coverage
+
+- Add or update Jest unit tests so the repository stays at or above the global **70% line coverage** threshold.
+- Run `yarn test --coverage` and check the summary (or downloaded CI artifact) before opening a PR.

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,12 @@ const customJestConfig = {
     '<rootDir>/__tests__/playwright/',
     '<rootDir>/tests/',
   ],
+  coverageThreshold: {
+    global: {
+      lines: 70,
+    },
+  },
+  coverageReporters: ['text', 'lcov', 'json-summary'],
 };
 
 module.exports = createJestConfig(customJestConfig);


### PR DESCRIPTION
## Summary
- require at least 70% global line coverage in the Jest config and emit text/lcov/json summaries
- upload the Jest coverage directory as a CI artifact while still failing the job when tests or coverage break
- reference the coverage requirement in the PR template and new app checklist so contributors add tests

## Testing
- `yarn lint` *(fails: repository has pre-existing accessibility and window/document lint errors)*
- `yarn test --coverage` *(fails: existing suite still running after 142/148 suites, aborted due to duration)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbc1c107083288710b50bd6908c30