### PR TITLE
feat(ops): add routing preferences to resource monitor

### DIFF
--- a/__tests__/NetworkInsights.test.tsx
+++ b/__tests__/NetworkInsights.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import NetworkInsights from '../apps/resource-monitor/components/NetworkInsights';
+import { SettingsProvider } from '../hooks/useSettings';
+import NotificationCenter from '../components/common/NotificationCenter';
+
+describe('NetworkInsights routing preferences', () => {
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <SettingsProvider>
+      <NotificationCenter title="Routed alerts" emptyMessage="No alerts routed yet.">
+        {children}
+      </NotificationCenter>
+    </SettingsProvider>
+  );
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('persists the selected alert route via useSettings', async () => {
+    render(<NetworkInsights />, { wrapper: Wrapper });
+
+    const select = screen.getByLabelText(/alert routing/i);
+    fireEvent.change(select, { target: { value: 'network' } });
+
+    await waitFor(() => expect(window.localStorage.getItem('ops-route')).toBe('network'));
+    expect(select).toHaveValue('network');
+  });
+
+  it('routes notifications to the currently selected destination', async () => {
+    render(<NetworkInsights />, { wrapper: Wrapper });
+
+    const select = screen.getByLabelText(/alert routing/i);
+    fireEvent.change(select, { target: { value: 'network' } });
+    await waitFor(() => expect(window.localStorage.getItem('ops-route')).toBe('network'));
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('fetchproxy-end', {
+          detail: {
+            id: 1,
+            method: 'GET',
+            url: '/api/test-network',
+            duration: 5005,
+          },
+        }),
+      );
+    });
+
+    const networkHeading = await screen.findByRole('heading', {
+      level: 3,
+      name: 'Network On-Call',
+    });
+    const networkGroup = networkHeading.closest('section');
+    expect(networkGroup).not.toBeNull();
+    if (!networkGroup) throw new Error('Missing network notification group');
+    expect(networkGroup).toHaveTextContent('Slow 5005ms');
+    expect(networkGroup).toHaveTextContent('/api/test-network');
+
+    fireEvent.change(select, { target: { value: 'security' } });
+    await waitFor(() => expect(window.localStorage.getItem('ops-route')).toBe('security'));
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('fetchproxy-end', {
+          detail: {
+            id: 2,
+            method: 'POST',
+            url: '/api/incident',
+            status: 503,
+            duration: 1200,
+          },
+        }),
+      );
+    });
+
+    const securityHeading = await screen.findByRole('heading', {
+      level: 3,
+      name: 'Security Response',
+    });
+    const securityGroup = securityHeading.closest('section');
+    expect(securityGroup).not.toBeNull();
+    if (!securityGroup) throw new Error('Missing security notification group');
+    expect(securityGroup).toHaveTextContent('HTTP 503');
+    expect(securityGroup).toHaveTextContent('/api/incident');
+
+    const networkItems = within(networkGroup).getAllByRole('listitem');
+    expect(networkItems).toHaveLength(1);
+    const securityItems = within(securityGroup).getAllByRole('listitem');
+    expect(securityItems).toHaveLength(1);
+  });
+});

--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
+import { useSettings, type OpsRoute } from '../../../hooks/useSettings';
+import useNotifications from '../../../hooks/useNotifications';
 import {
   onFetchProxy,
   getActiveFetches,
@@ -11,6 +13,44 @@ import { exportMetrics } from '../export';
 import RequestChart from './RequestChart';
 
 const HISTORY_KEY = 'network-insights-history';
+const SLOW_THRESHOLD = 4000;
+
+const ROUTE_OPTIONS: { value: OpsRoute; label: string; description: string }[] = [
+  {
+    value: 'global',
+    label: 'Global Ops Center',
+    description: 'Broadcast to the global operations bridge for awareness across teams.',
+  },
+  {
+    value: 'network',
+    label: 'Network On-Call',
+    description: 'Escalate connectivity regressions to the network operations rotation.',
+  },
+  {
+    value: 'security',
+    label: 'Security Response',
+    description: 'Route suspicious failures directly to the security incident handlers.',
+  },
+];
+
+const ROUTE_LABELS = ROUTE_OPTIONS.reduce(
+  (acc, option) => {
+    acc[option.value] = option.label;
+    return acc;
+  },
+  {} as Record<OpsRoute, string>,
+);
+
+const getAlertReason = (entry: FetchEntry): string | null => {
+  if (entry.error) return 'Request failed';
+  if (typeof entry.status === 'number' && entry.status >= 500) {
+    return `HTTP ${entry.status}`;
+  }
+  if (typeof entry.duration === 'number' && entry.duration > SLOW_THRESHOLD) {
+    return `Slow ${Math.round(entry.duration)}ms`;
+  }
+  return null;
+};
 
 const formatBytes = (bytes?: number) =>
   typeof bytes === 'number' ? `${(bytes / 1024).toFixed(1)} kB` : '—';
@@ -18,61 +58,131 @@ const formatBytes = (bytes?: number) =>
 export default function NetworkInsights() {
   const [active, setActive] = useState<FetchEntry[]>(getActiveFetches());
   const [history, setHistory] = usePersistentState<FetchEntry[]>(HISTORY_KEY, []);
+  const { opsRoute, setOpsRoute } = useSettings();
+  const { pushNotification } = useNotifications();
+  const routeRef = useRef<OpsRoute>(opsRoute);
+
+  useEffect(() => {
+    routeRef.current = opsRoute;
+  }, [opsRoute]);
+
+  const selectedRoute = useMemo(
+    () => ROUTE_OPTIONS.find((option) => option.value === opsRoute) ?? ROUTE_OPTIONS[0],
+    [opsRoute],
+  );
 
   useEffect(() => {
     const unsubStart = onFetchProxy('start', () => setActive(getActiveFetches()));
     const unsubEnd = onFetchProxy('end', (e: CustomEvent<FetchEntry>) => {
+      const entry = e.detail;
       setActive(getActiveFetches());
-      setHistory((h) => [...h, e.detail]);
+      setHistory((h) => [...h, entry]);
+      const reason = getAlertReason(entry);
+      if (reason) {
+        const label = ROUTE_LABELS[routeRef.current] ?? routeRef.current;
+        pushNotification(label, `${reason} – ${entry.method} ${entry.url}`);
+      }
     });
     return () => {
       unsubStart();
       unsubEnd();
     };
-  }, [setHistory]);
+  }, [setHistory, pushNotification]);
+
+  const handleTestAlert = () => {
+    const label = ROUTE_LABELS[routeRef.current] ?? routeRef.current;
+    pushNotification(label, `Test alert routed to ${label}`);
+  };
 
   return (
-    <div className="p-2 text-xs text-white bg-[var(--kali-bg)]">
-      <h2 className="font-bold mb-1">Active Fetches</h2>
-      <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
-        {active.length === 0 && <li className="p-1 text-gray-400">None</li>}
-        {active.map((f) => (
-          <li key={f.id} className="p-1">
-            <div className="truncate">
-              {f.method} {f.url}
+    <div className="space-y-3 bg-[var(--kali-bg)] p-2 text-xs text-white">
+      <div className="rounded border border-gray-700 bg-[var(--kali-panel)] p-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <label
+            htmlFor="ops-route"
+            className="text-sm font-semibold uppercase tracking-wide text-gray-200"
+          >
+            Alert routing
+          </label>
+          <select
+            id="ops-route"
+            value={opsRoute}
+            onChange={(event) => setOpsRoute(event.target.value as OpsRoute)}
+            className="rounded border border-gray-600 bg-[var(--kali-bg)] px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-white"
+          >
+            {ROUTE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={handleTestAlert}
+            className="rounded border border-gray-600 bg-[var(--kali-bg)] px-2 py-1 text-xs font-semibold uppercase tracking-wide hover:bg-[var(--kali-panel)] focus:outline-none focus:ring-1 focus:ring-white"
+          >
+            Send test alert
+          </button>
+        </div>
+        <p className="mt-2 text-[11px] text-gray-400">{selectedRoute.description}</p>
+      </div>
+
+      <section>
+        <h2 className="mb-1 font-bold uppercase tracking-wide text-gray-300">Active fetches</h2>
+        <ul className="divide-y divide-gray-700 rounded border border-gray-700 bg-[var(--kali-panel)]">
+          {active.length === 0 && <li className="p-1 text-gray-400">None</li>}
+          {active.map((f) => (
+            <li key={f.id} className="p-1">
+              <div className="truncate">
+                {f.method} {f.url}
             </div>
             <div className="text-gray-400">
               {((typeof performance !== 'undefined' ? performance.now() : Date.now()) - f.startTime).toFixed(0)}ms elapsed
             </div>
           </li>
         ))}
-      </ul>
-      <div className="flex items-center mb-1">
-        <h2 className="font-bold">History</h2>
-        <button
-          onClick={() => exportMetrics(history)}
-          className="ml-auto px-2 py-1 rounded bg-[var(--kali-panel)]"
-        >
-          Export
-        </button>
-      </div>
-      <ul className="divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
-        {history.length === 0 && <li className="p-1 text-gray-400">No requests</li>}
-        {history.map((f) => (
-          <li key={f.id} className="p-1">
-            <div className="truncate">
-              {f.method} {f.url}
-              {f.fromServiceWorkerCache && (
-                <span className="ml-2 text-green-400">(SW cache)</span>
-              )}
-            </div>
-            <div className="text-gray-400">
-              {f.duration ? `${f.duration.toFixed(0)}ms` : ''} · req {formatBytes(f.requestSize)} · res {formatBytes(f.responseSize)}
-            </div>
-          </li>
-        ))}
-      </ul>
-      <div className="mt-2 flex justify-center">
+          </ul>
+      </section>
+
+      <section>
+        <div className="mb-1 flex items-center">
+          <h2 className="font-bold uppercase tracking-wide text-gray-300">History</h2>
+          <button
+            onClick={() => exportMetrics(history)}
+            className="ml-auto rounded border border-gray-600 bg-[var(--kali-bg)] px-2 py-1 text-xs font-semibold uppercase tracking-wide hover:bg-[var(--kali-panel)] focus:outline-none focus:ring-1 focus:ring-white"
+          >
+            Export
+          </button>
+        </div>
+        <ul className="divide-y divide-gray-700 rounded border border-gray-700 bg-[var(--kali-panel)]">
+          {history.length === 0 && <li className="p-1 text-gray-400">No requests</li>}
+          {history.map((f) => {
+            const reason = getAlertReason(f);
+            return (
+              <li key={f.id} className="p-1">
+                <div className="truncate">
+                  {f.method} {f.url}
+                  {f.fromServiceWorkerCache && (
+                    <span className="ml-2 text-green-400">(SW cache)</span>
+                  )}
+                </div>
+                <div className="flex flex-wrap items-center gap-2 text-gray-400">
+                  <span>
+                    {f.duration ? `${f.duration.toFixed(0)}ms` : ''} · req {formatBytes(f.requestSize)} · res {formatBytes(f.responseSize)}
+                  </span>
+                  {reason && (
+                    <span className="rounded bg-ub-orange/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-ub-orange">
+                      Routed ({reason})
+                    </span>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      <div className="flex justify-center">
         <RequestChart
           data={history.map((h) => h.duration ?? 0)}
           label="Request duration (ms)"

--- a/apps/resource-monitor/index.tsx
+++ b/apps/resource-monitor/index.tsx
@@ -1,12 +1,19 @@
 'use client';
 
 import React from 'react';
+import NotificationCenter from '../../components/common/NotificationCenter';
 import NetworkInsights from './components/NetworkInsights';
 
 export default function ResourceMonitorApp() {
   return (
     <div className="h-full w-full bg-ub-cool-grey overflow-auto">
-      <NetworkInsights />
+      <NotificationCenter
+        className="px-2 text-white"
+        emptyMessage="No alerts routed yet."
+        title="Routed alerts"
+      >
+        <NetworkInsights />
+      </NotificationCenter>
     </div>
   );
 }

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useEffect, useMemo, useState } from 'react';
 
 export interface AppNotification {
   id: string;
@@ -14,7 +14,21 @@ interface NotificationsContextValue {
 
 export const NotificationsContext = createContext<NotificationsContextValue | null>(null);
 
-export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+interface NotificationCenterProps {
+  children?: React.ReactNode;
+  className?: string;
+  emptyMessage?: string;
+  title?: string;
+  showClearAll?: boolean;
+}
+
+export const NotificationCenter: React.FC<NotificationCenterProps> = ({
+  children,
+  className,
+  emptyMessage = 'No notifications',
+  title,
+  showClearAll = true,
+}) => {
   const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
 
   const pushNotification = useCallback((appId: string, message: string) => {
@@ -49,6 +63,9 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
     0
   );
 
+  const grouped = useMemo(() => Object.entries(notifications), [notifications]);
+  const hasNotifications = grouped.length > 0;
+
   useEffect(() => {
     const nav: any = navigator;
     if (nav && nav.setAppBadge) {
@@ -57,22 +74,65 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
     }
   }, [totalCount]);
 
+  const containerClasses = ['notification-center', 'mt-4', 'space-y-3'];
+  if (className) containerClasses.push(className);
+
   return (
     <NotificationsContext.Provider
       value={{ notifications, pushNotification, clearNotifications }}
     >
       {children}
-      <div className="notification-center">
-        {Object.entries(notifications).map(([appId, list]) => (
-          <section key={appId} className="notification-group">
-            <h3>{appId}</h3>
-            <ul>
-              {list.map(n => (
-                <li key={n.id}>{n.message}</li>
-              ))}
-            </ul>
-          </section>
-        ))}
+      <div className={containerClasses.join(' ')}>
+        {title && (
+          <div className="flex items-center gap-3">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-300">
+              {title}
+            </h2>
+            {hasNotifications && showClearAll && (
+              <button
+                type="button"
+                onClick={() => clearNotifications()}
+                className="ml-auto text-xs text-gray-400 hover:text-white focus:outline-none focus:ring-1 focus:ring-white"
+              >
+                Clear all
+              </button>
+            )}
+          </div>
+        )}
+        {hasNotifications ? (
+          grouped.map(([appId, list]) => (
+            <section
+              key={appId}
+              className="notification-group rounded border border-gray-700 bg-[var(--kali-panel)] p-3 shadow-lg shadow-black/40"
+            >
+              <div className="flex items-center gap-3">
+                <h3 className="text-sm font-semibold text-white">{appId}</h3>
+                <button
+                  type="button"
+                  onClick={() => clearNotifications(appId)}
+                  className="ml-auto text-xs text-gray-400 hover:text-white focus:outline-none focus:ring-1 focus:ring-white"
+                >
+                  Dismiss
+                </button>
+              </div>
+              <ul className="mt-2 space-y-1 text-xs text-white">
+                {list.map(n => (
+                  <li
+                    key={n.id}
+                    className="rounded bg-black/40 px-2 py-1 leading-relaxed"
+                  >
+                    <span className="block text-[10px] uppercase tracking-wide text-gray-400">
+                      {new Date(n.date).toLocaleTimeString()}
+                    </span>
+                    <span>{n.message}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))
+        ) : (
+          <p className="text-sm text-gray-400">{emptyMessage}</p>
+        )}
       </div>
     </NotificationsContext.Provider>
   );

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -14,6 +14,35 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  opsRoute: 'global',
+};
+
+const safeGetItem = (key, fallback = null) => {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const value = window.localStorage.getItem(key);
+    return value === null ? fallback : value;
+  } catch {
+    return fallback;
+  }
+};
+
+const safeSetItem = (key, value) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // ignore write failures
+  }
+};
+
+const safeRemoveItem = (key) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // ignore remove failures
+  }
 };
 
 export async function getAccent() {
@@ -38,17 +67,16 @@ export async function setWallpaper(wallpaper) {
 
 export async function getDensity() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  return safeGetItem('density', DEFAULT_SETTINGS.density);
 }
 
 export async function setDensity(density) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
+  safeSetItem('density', density);
 }
 
 export async function getReducedMotion() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  const stored = window.localStorage.getItem('reduced-motion');
+  const stored = safeGetItem('reduced-motion');
   if (stored !== null) {
     return stored === 'true';
   }
@@ -56,71 +84,76 @@ export async function getReducedMotion() {
 }
 
 export async function setReducedMotion(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+  safeSetItem('reduced-motion', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
+  const stored = safeGetItem('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  safeSetItem('font-scale', String(scale));
 }
 
 export async function getHighContrast() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  const stored = safeGetItem('high-contrast');
+  return stored === null ? DEFAULT_SETTINGS.highContrast : stored === 'true';
 }
 
 export async function setHighContrast(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+  safeSetItem('high-contrast', value ? 'true' : 'false');
 }
 
 export async function getLargeHitAreas() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
+  const stored = safeGetItem('large-hit-areas');
+  return stored === null ? DEFAULT_SETTINGS.largeHitAreas : stored === 'true';
 }
 
 export async function setLargeHitAreas(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
+  safeSetItem('large-hit-areas', value ? 'true' : 'false');
 }
 
 export async function getHaptics() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
-  const val = window.localStorage.getItem('haptics');
+  const val = safeGetItem('haptics');
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
 export async function setHaptics(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('haptics', value ? 'true' : 'false');
+  safeSetItem('haptics', value ? 'true' : 'false');
 }
 
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
+  const val = safeGetItem('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
 export async function setPongSpin(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
+  safeSetItem('pong-spin', value ? 'true' : 'false');
 }
 
 export async function getAllowNetwork() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
+  const stored = safeGetItem('allow-network');
+  return stored === null ? DEFAULT_SETTINGS.allowNetwork : stored === 'true';
 }
 
 export async function setAllowNetwork(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+  safeSetItem('allow-network', value ? 'true' : 'false');
+}
+
+export async function getOpsRoute() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.opsRoute;
+  return safeGetItem('ops-route', DEFAULT_SETTINGS.opsRoute);
+}
+
+export async function setOpsRoute(value) {
+  safeSetItem('ops-route', value);
 }
 
 export async function resetSettings() {
@@ -129,14 +162,15 @@ export async function resetSettings() {
     del('accent'),
     del('bg-image'),
   ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
+  safeRemoveItem('density');
+  safeRemoveItem('reduced-motion');
+  safeRemoveItem('font-scale');
+  safeRemoveItem('high-contrast');
+  safeRemoveItem('large-hit-areas');
+  safeRemoveItem('pong-spin');
+  safeRemoveItem('allow-network');
+  safeRemoveItem('haptics');
+  safeRemoveItem('ops-route');
 }
 
 export async function exportSettings() {
@@ -151,6 +185,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    opsRoute,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +197,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getOpsRoute(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +211,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    opsRoute,
     theme,
   });
 }
@@ -199,6 +236,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    opsRoute,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +249,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (opsRoute !== undefined) await setOpsRoute(opsRoute);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add routing preference controls to the resource monitor dashboard and dispatch alerts through the notification center
- persist the selected ops route via the global settings store and harden localStorage helpers
- enhance the notification center UI for grouped alerts and add unit coverage for the new routing behaviour

## Testing
- yarn test __tests__/NetworkInsights.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cce5c12d388328a2bd417603afb3eb