### PR TITLE
settings: add consent center data purge flow

### DIFF
--- a/apps/settings/components/ConsentCenter.tsx
+++ b/apps/settings/components/ConsentCenter.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState } from "react";
+import Modal from "../../../components/base/Modal";
+import { resetSettings } from "../../../utils/settingsStore";
+import { useSettings } from "../../../hooks/useSettings";
+import useSession from "../../../hooks/useSession";
+import useProfiles from "../../../hooks/useProfiles";
+
+const CONFIRM_CODE = "DELETE";
+
+const DATA_SUMMARY = [
+  {
+    title: "Desktop session",
+    description:
+      "Open windows, dock favourites, and window positions saved for quick resume.",
+  },
+  {
+    title: "Appearance & accessibility",
+    description:
+      "Theme, wallpaper, accent colour, motion preferences, and accessibility options including safe mode toggles.",
+  },
+  {
+    title: "Device and simulation profiles",
+    description:
+      "Bluetooth captures, router profiles, and other operational data cached in the browser's file system.",
+  },
+  {
+    title: "Offline caches",
+    description:
+      "Local storage, session data, and cached game saves created across Kali Linux Portfolio apps.",
+  },
+] as const;
+
+type Step = "closed" | "summary" | "confirm";
+
+export default function ConsentCenter() {
+  const { resetToDefaults } = useSettings();
+  const { resetSession } = useSession();
+  const { clearProfiles } = useProfiles();
+  const [step, setStep] = useState<Step>("closed");
+  const [confirmText, setConfirmText] = useState("");
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const closeModal = () => {
+    if (isProcessing) return;
+    setStep("closed");
+    setConfirmText("");
+    setError(null);
+  };
+
+  const openModal = () => {
+    setStatusMessage(null);
+    setError(null);
+    setConfirmText("");
+    setStep("summary");
+  };
+
+  const goToConfirm = () => {
+    setError(null);
+    setStep("confirm");
+  };
+
+  const goToSummary = () => {
+    if (isProcessing) return;
+    setError(null);
+    setStep("summary");
+  };
+
+  const handleDeletion = async () => {
+    if (confirmText !== CONFIRM_CODE) return;
+    setIsProcessing(true);
+    setError(null);
+    try {
+      await clearProfiles();
+      resetSession();
+      await resetSettings();
+      if (typeof window !== "undefined") {
+        try {
+          window.localStorage.clear();
+        } catch {
+          // ignore storage errors
+        }
+        if (typeof caches !== "undefined") {
+          try {
+            const keys = await caches.keys();
+            await Promise.all(keys.map((key) => caches.delete(key)));
+          } catch {
+            // ignore cache errors
+          }
+        }
+      }
+      resetToDefaults();
+      setStatusMessage(
+        "All local data has been removed and the desktop has been returned to its default state."
+      );
+      setStep("closed");
+      setConfirmText("");
+    } catch (err) {
+      console.error(err);
+      setError("Unable to clear saved data. Please try again.");
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <section className="mx-auto mb-6 w-full max-w-2xl rounded border border-gray-900 bg-black/40 p-4 text-ubt-grey">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-lg font-semibold text-white">Consent Center</h3>
+          <p className="mt-2 text-sm">
+            Review the personal data stored in this desktop and permanently delete it when needed.
+          </p>
+        </div>
+        <button
+          onClick={openModal}
+          className="rounded bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+        >
+          Delete stored data
+        </button>
+      </div>
+      {statusMessage && (
+        <p role="status" className="mt-4 rounded border border-green-500/40 bg-green-500/10 p-3 text-sm text-green-300">
+          {statusMessage}
+        </p>
+      )}
+
+      <Modal isOpen={step !== "closed"} onClose={closeModal}>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <div className="w-full max-w-xl rounded border border-gray-800 bg-ub-cool-grey p-6 text-white shadow-xl">
+            {step === "summary" && (
+              <>
+                <h4 className="text-xl font-semibold">Review data for removal</h4>
+                <p className="mt-2 text-sm text-ubt-grey">
+                  The following categories of locally stored data will be permanently deleted. This cannot be undone.
+                </p>
+                <ul className="mt-4 space-y-3 text-sm text-ubt-grey">
+                  {DATA_SUMMARY.map((item) => (
+                    <li key={item.title} className="rounded border border-gray-800/60 bg-black/30 p-3">
+                      <p className="font-semibold text-white">{item.title}</p>
+                      <p className="mt-1 leading-relaxed">{item.description}</p>
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-6 flex justify-end gap-3">
+                  <button
+                    onClick={closeModal}
+                    className="rounded border border-gray-700 px-4 py-2 text-sm text-ubt-grey hover:bg-black/40"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={goToConfirm}
+                    className="rounded bg-ub-orange px-4 py-2 text-sm font-semibold text-white hover:bg-orange-500"
+                  >
+                    Continue
+                  </button>
+                </div>
+              </>
+            )}
+            {step === "confirm" && (
+              <>
+                <h4 className="text-xl font-semibold">Confirm deletion</h4>
+                <p className="mt-2 text-sm text-ubt-grey">
+                  Type <span className="font-semibold text-white">{CONFIRM_CODE}</span> to confirm you want to permanently delete this data.
+                </p>
+                <input
+                  value={confirmText}
+                  onChange={(e) => setConfirmText(e.target.value.toUpperCase())}
+                  placeholder={`Type ${CONFIRM_CODE}`}
+                  className="mt-4 w-full rounded border border-gray-700 bg-black/60 p-2 text-sm uppercase tracking-[0.2em] placeholder:text-ubt-grey focus:border-ub-orange focus:outline-none"
+                  aria-label={`Type ${CONFIRM_CODE} to confirm deletion`}
+                  disabled={isProcessing}
+                />
+                {error && (
+                  <p role="alert" className="mt-3 text-sm text-red-400">
+                    {error}
+                  </p>
+                )}
+                <div className="mt-6 flex justify-between gap-3">
+                  <button
+                    onClick={goToSummary}
+                    className="rounded border border-gray-700 px-4 py-2 text-sm text-ubt-grey hover:bg-black/40"
+                    disabled={isProcessing}
+                  >
+                    Back
+                  </button>
+                  <button
+                    onClick={handleDeletion}
+                    disabled={confirmText !== CONFIRM_CODE || isProcessing}
+                    className="rounded bg-red-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+                  >
+                    {isProcessing ? "Deleting…" : "Delete everything"}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </Modal>
+    </section>
+  );
+}

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -3,9 +3,9 @@
 import { useState, useRef } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
+import ConsentCenter from "./components/ConsentCenter";
 import {
   resetSettings,
-  defaults,
   exportSettings as exportSettingsData,
   importSettings as importSettingsData,
 } from "../../utils/settingsStore";
@@ -31,6 +31,7 @@ export default function Settings() {
     setHaptics,
     theme,
     setTheme,
+    resetToDefaults,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -94,13 +95,7 @@ export default function Settings() {
       return;
     await resetSettings();
     window.localStorage.clear();
-    setAccent(defaults.accent);
-    setWallpaper(defaults.wallpaper);
-    setDensity(defaults.density as any);
-    setReducedMotion(defaults.reducedMotion);
-    setFontScale(defaults.fontScale);
-    setHighContrast(defaults.highContrast);
-    setTheme("default");
+    resetToDefaults();
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
@@ -286,6 +281,7 @@ export default function Settings() {
               Import Settings
             </button>
           </div>
+          <ConsentCenter />
         </>
       )}
         <input

--- a/hooks/useProfiles.ts
+++ b/hooks/useProfiles.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useCallback } from "react";
+
+const BLE_CHANNEL = "ble-profiles";
+const ROUTER_PROFILE_KEY = "reaver-router-profile";
+
+type DirHandle = any;
+
+type EntryHandle = { kind?: string } & Record<string, unknown>;
+
+async function clearOpfsDirectory() {
+  if (
+    typeof navigator === "undefined" ||
+    !(navigator as any).storage?.getDirectory
+  ) {
+    return;
+  }
+
+  try {
+    const dir: DirHandle = await (navigator as any).storage.getDirectory();
+    const removals: Promise<unknown>[] = [];
+    for await (const [name, handle] of (dir as any).entries() as AsyncIterable<
+      [string, EntryHandle]
+    >) {
+      if ((handle as EntryHandle).kind === "directory") {
+        removals.push((dir as any).removeEntry(name, { recursive: true }));
+      } else {
+        removals.push((dir as any).removeEntry(name));
+      }
+    }
+    await Promise.allSettled(removals);
+  } catch {
+    // Ignore OPFS removal issues
+  }
+}
+
+function clearRouterProfiles() {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(ROUTER_PROFILE_KEY);
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+function broadcastProfileReset() {
+  if (typeof window === "undefined" || !("BroadcastChannel" in window)) {
+    return;
+  }
+  try {
+    const channel = new BroadcastChannel(BLE_CHANNEL);
+    channel.postMessage("update");
+    channel.close();
+  } catch {
+    // Ignore broadcast errors
+  }
+}
+
+export default function useProfiles() {
+  const clearProfiles = useCallback(async () => {
+    clearRouterProfiles();
+    await clearOpfsDirectory();
+    broadcastProfileReset();
+  }, []);
+
+  return { clearProfiles };
+}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -1,4 +1,12 @@
-import { createContext, useContext, useEffect, useState, ReactNode, useRef } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+  useRef,
+  useCallback,
+} from 'react';
 import {
   getAccent as loadAccent,
   setAccent as saveAccent,
@@ -74,6 +82,7 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  resetToDefaults: () => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -99,6 +108,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  resetToDefaults: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -236,6 +246,32 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  const resetToDefaults = useCallback(() => {
+    setAccent(defaults.accent);
+    setWallpaper(defaults.wallpaper);
+    setDensity(defaults.density as Density);
+    setReducedMotion(defaults.reducedMotion);
+    setFontScale(defaults.fontScale);
+    setHighContrast(defaults.highContrast);
+    setLargeHitAreas(defaults.largeHitAreas);
+    setPongSpin(defaults.pongSpin);
+    setAllowNetwork(defaults.allowNetwork);
+    setHaptics(defaults.haptics);
+    setTheme('default');
+  }, [
+    setAccent,
+    setWallpaper,
+    setDensity,
+    setReducedMotion,
+    setFontScale,
+    setHighContrast,
+    setLargeHitAreas,
+    setPongSpin,
+    setAllowNetwork,
+    setHaptics,
+    setTheme,
+  ]);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -261,6 +297,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        resetToDefaults,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- add a consent center modal with a two-step confirmation, success toast, and cache clearing that returns the desktop to defaults
- provide a `useProfiles` hook that clears stored profiles from OPFS/localStorage and notifies listeners when data is removed
- expose a `resetToDefaults` helper from `useSettings` and wire the consent center into the privacy tab reset flow

## Testing
- yarn lint *(fails: repository already has widespread jsx-a11y and top-level window usage violations)*
- yarn test *(fails: existing suites such as reconng rely on browser-only storage in jsdom; run aborted after repeated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cce5c561708328a082f7a94d7a1515