### PR TITLE
feat(privacy): add consent controls for analytics and telemetry

### DIFF
--- a/__tests__/privacySettings.test.tsx
+++ b/__tests__/privacySettings.test.tsx
@@ -1,0 +1,172 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+import { PRIVACY_PROFILES, getPrivacyProfileDefaults } from '../utils/settingsStore';
+import { logEvent } from '../utils/analytics';
+import { trackEvent } from '../lib/analytics-client';
+
+jest.mock('react-ga4', () => {
+  const event = jest.fn();
+  const send = jest.fn();
+  const initialize = jest.fn();
+  return {
+    event,
+    send,
+    initialize,
+    __eventMock: event,
+  };
+});
+
+jest.mock('@vercel/analytics', () => ({
+  track: jest.fn(),
+}));
+
+describe('privacy settings', () => {
+  let consoleLogSpy: jest.SpyInstance;
+  const originalLocalStorage = window.localStorage;
+  const createMemoryStorage = () => {
+    let store: Record<string, string> = {};
+    return {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        store = {};
+      },
+    } as Storage;
+  };
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: createMemoryStorage(),
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: originalLocalStorage,
+    });
+  });
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <SettingsProvider>{children}</SettingsProvider>
+  );
+
+  it('persists analytics consent per profile', async () => {
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    await waitFor(() => expect(result.current.privacyProfile).toBe(PRIVACY_PROFILES[0].id));
+
+    act(() => {
+      result.current.setAnalyticsConsent(false);
+      result.current.setTelemetryConsent(false);
+    });
+
+    expect(result.current.analyticsConsent).toBe(false);
+    expect(result.current.telemetryConsent).toBe(false);
+    const storedStandard = window.localStorage.getItem('privacy-consent:standard');
+    expect(storedStandard && JSON.parse(storedStandard).analytics).toBe(false);
+    expect(storedStandard && JSON.parse(storedStandard).telemetry).toBe(false);
+
+    const secondaryProfile = PRIVACY_PROFILES[1];
+    expect(secondaryProfile).toBeDefined();
+
+    act(() => {
+      result.current.setPrivacyProfile(secondaryProfile.id);
+    });
+
+    await waitFor(() => expect(result.current.privacyProfile).toBe(secondaryProfile.id));
+    const defaults = getPrivacyProfileDefaults(secondaryProfile.id);
+    expect(result.current.analyticsConsent).toBe(defaults.analytics);
+
+    act(() => {
+      result.current.setAnalyticsConsent(true);
+    });
+    expect(result.current.analyticsConsent).toBe(true);
+    const storedSecondary = window.localStorage.getItem(
+      `privacy-consent:${secondaryProfile.id}`,
+    );
+    expect(storedSecondary && JSON.parse(storedSecondary).analytics).toBe(true);
+
+    act(() => {
+      result.current.setPrivacyProfile(PRIVACY_PROFILES[0].id);
+    });
+    await waitFor(() => expect(result.current.analyticsConsent).toBe(false));
+  });
+
+  it('disables analytics events when consent revoked', async () => {
+    const { __eventMock: eventMock } = jest.requireMock('react-ga4') as {
+      __eventMock: jest.Mock;
+    };
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    await waitFor(() => expect(result.current.analyticsConsent).not.toBeUndefined());
+
+    act(() => {
+      result.current.setAnalyticsConsent(true);
+    });
+
+    eventMock.mockClear();
+    logEvent({ category: 'test', action: 'enabled' } as any);
+    expect(eventMock).toHaveBeenCalled();
+
+    act(() => {
+      result.current.setAnalyticsConsent(false);
+    });
+    await waitFor(() => expect(result.current.analyticsConsent).toBe(false));
+
+    eventMock.mockClear();
+    logEvent({ category: 'test', action: 'disabled' } as any);
+    expect(eventMock).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.setAnalyticsConsent(true);
+    });
+    await waitFor(() => expect(result.current.analyticsConsent).toBe(true));
+
+    eventMock.mockClear();
+    logEvent({ category: 'test', action: 're-enabled' } as any);
+    expect(eventMock).toHaveBeenCalled();
+  });
+
+  it('stops telemetry events when telemetry consent is disabled', async () => {
+    const { result } = renderHook(() => useSettings(), { wrapper });
+    const { track: trackMock } = jest.requireMock('@vercel/analytics') as { track: jest.Mock };
+
+    await waitFor(() => expect(result.current.telemetryConsent).not.toBeUndefined());
+
+    act(() => {
+      result.current.setTelemetryConsent(true);
+    });
+    await waitFor(() => expect(result.current.telemetryConsent).toBe(true));
+
+    trackMock.mockClear();
+    trackEvent('cta_click');
+    expect(trackMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.setTelemetryConsent(false);
+    });
+    await waitFor(() => expect(result.current.telemetryConsent).toBe(false));
+
+    trackMock.mockClear();
+    trackEvent('cta_click');
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -65,6 +65,7 @@ const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 const FileExplorerApp = createDynamicApp('file-explorer', 'Files');
 const Radare2App = createDynamicApp('radare2', 'Radare2');
 const AboutAlexApp = createDynamicApp('alex', 'About Alex');
+const PrivacyApp = createDynamicApp('privacy', 'Privacy');
 
 const QrApp = createDynamicApp('qr', 'QR Tool');
 const AsciiArtApp = createDynamicApp('ascii_art', 'ASCII Art');
@@ -156,6 +157,7 @@ const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayFileExplorer = createDisplay(FileExplorerApp);
 const displayRadare2 = createDisplay(Radare2App);
 const displayAboutAlex = createDisplay(AboutAlexApp);
+const displayPrivacy = createDisplay(PrivacyApp);
 
 const displayQr = createDisplay(QrApp);
 const displayAsciiArt = createDisplay(AsciiArtApp);
@@ -702,6 +704,15 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displaySettings,
+  },
+  {
+    id: 'privacy',
+    title: 'Privacy Controls',
+    icon: '/themes/Yaru/apps/privacy.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayPrivacy,
   },
   {
     id: 'files',

--- a/apps/privacy/index.tsx
+++ b/apps/privacy/index.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import ToggleSwitch from "../../components/ToggleSwitch";
+import { useSettings } from "../../hooks/useSettings";
+
+const ANALYTICS_DOCS =
+  "https://github.com/Alex-Unnippillil/kali-linux-portfolio#analytics";
+const VERCEL_ANALYTICS_DOCS = "https://vercel.com/docs/analytics";
+const SPEED_INSIGHTS_DOCS = "https://vercel.com/docs/speed-insights";
+
+export default function PrivacyApp() {
+  const {
+    privacyProfile,
+    setPrivacyProfile,
+    analyticsConsent,
+    setAnalyticsConsent,
+    telemetryConsent,
+    setTelemetryConsent,
+    privacyProfiles,
+  } = useSettings();
+
+  const activeProfile =
+    privacyProfiles.find((profile) => profile.id === privacyProfile) ||
+    privacyProfiles[0];
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-y-auto bg-ub-cool-grey p-4 text-white">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold">Privacy Controls</h1>
+        <p className="text-sm text-ubt-grey">
+          Manage analytics and operational telemetry for this desktop. Changes are
+          stored per profile and applied immediately across running apps.
+        </p>
+      </div>
+
+      <section className="mt-6 space-y-3">
+        <label htmlFor="privacy-profile" className="text-sm font-medium">
+          Active profile
+        </label>
+        <select
+          id="privacy-profile"
+          value={privacyProfile}
+          onChange={(event) => setPrivacyProfile(event.target.value)}
+          className="w-full rounded border border-gray-700 bg-gray-900 px-3 py-2 text-sm text-white focus:border-ub-orange focus:outline-none"
+        >
+          {privacyProfiles.map((profile) => (
+            <option key={profile.id} value={profile.id}>
+              {profile.label}
+            </option>
+          ))}
+        </select>
+        {activeProfile && (
+          <div className="space-y-1 text-xs text-ubt-grey">
+            <p>{activeProfile.description}</p>
+            <a
+              href={activeProfile.docs}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 text-ub-orange hover:underline"
+            >
+              Learn more about this profile
+              <span aria-hidden>↗</span>
+            </a>
+          </div>
+        )}
+      </section>
+
+      <section className="mt-8 space-y-4">
+        <div className="flex flex-col gap-4 rounded border border-gray-800 bg-gray-900/70 p-4 md:flex-row md:items-center md:justify-between">
+          <div className="md:max-w-xl">
+            <h2 className="text-lg font-semibold">Usage analytics</h2>
+            <p className="mt-1 text-sm text-ubt-grey">
+              Controls Google Analytics instrumentation used for gameplay metrics,
+              UI focus tracking, and other aggregate insights.
+            </p>
+            <a
+              href={ANALYTICS_DOCS}
+              target="_blank"
+              rel="noreferrer"
+              className="mt-2 inline-flex items-center gap-2 text-xs text-ub-orange hover:underline"
+            >
+              View analytics implementation
+              <span aria-hidden>↗</span>
+            </a>
+          </div>
+          <ToggleSwitch
+            checked={analyticsConsent}
+            onChange={setAnalyticsConsent}
+            ariaLabel="Toggle Google Analytics"
+          />
+        </div>
+
+        <div className="flex flex-col gap-4 rounded border border-gray-800 bg-gray-900/70 p-4 md:flex-row md:items-center md:justify-between">
+          <div className="md:max-w-xl">
+            <h2 className="text-lg font-semibold">Operational telemetry</h2>
+            <p className="mt-1 text-sm text-ubt-grey">
+              Governs Vercel Analytics, Speed Insights, and custom events emitted
+              through <code>analytics-client.ts</code> for infrastructure health.
+            </p>
+            <div className="mt-2 flex flex-wrap gap-3 text-xs text-ubt-grey">
+              <a
+                href={VERCEL_ANALYTICS_DOCS}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-ub-orange hover:underline"
+              >
+                Vercel Analytics docs
+                <span aria-hidden>↗</span>
+              </a>
+              <a
+                href={SPEED_INSIGHTS_DOCS}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-ub-orange hover:underline"
+              >
+                Speed Insights docs
+                <span aria-hidden>↗</span>
+              </a>
+            </div>
+          </div>
+          <ToggleSwitch
+            checked={telemetryConsent}
+            onChange={setTelemetryConsent}
+            ariaLabel="Toggle Vercel telemetry"
+          />
+        </div>
+      </section>
+
+      <footer className="mt-6 text-xs text-ubt-grey">
+        Profile selections and toggle states are saved locally so you can switch
+        between demo, personal, or locked-down configurations without clearing the
+        entire desktop state.
+      </footer>
+    </div>
+  );
+}

--- a/lib/analytics-client.ts
+++ b/lib/analytics-client.ts
@@ -6,10 +6,13 @@ export type EventName =
   | 'outbound_link_click'
   | 'download_click';
 
+import { isTelemetryEnabled } from '@/utils/privacyControls';
+
 export function trackEvent(
   name: EventName,
   props?: Record<string, string | number | boolean>,
 ) {
+  if (!isTelemetryEnabled()) return;
   try {
     // Dynamically require to avoid ESM issues in test environment
     // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires

--- a/public/themes/Yaru/apps/privacy.svg
+++ b/public/themes/Yaru/apps/privacy.svg
@@ -1,0 +1,13 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="privacyGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1f2937" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="12" fill="url(#privacyGradient)" stroke="#f97316" stroke-width="2" />
+  <path
+    d="M32 18c-6.627 0-12 5.373-12 12v4h-2a2 2 0 0 0-2 2v13c0 1.105.895 2 2 2h24a2 2 0 0 0 2-2V36a2 2 0 0 0-2-2h-2v-4c0-6.627-5.373-12-12-12zm0 6c3.309 0 6 2.691 6 6v4H26v-4c0-3.309 2.691-6 6-6zm0 16a3 3 0 1 1-3 3 3 3 0 0 1 3-3z"
+    fill="#f8fafc"
+  />
+</svg>

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -1,8 +1,10 @@
 import ReactGA from 'react-ga4';
+import { isAnalyticsEnabled } from './privacyControls';
 
 type EventInput = Parameters<typeof ReactGA.event>[0];
 
 const safeEvent = (...args: Parameters<typeof ReactGA.event>): void => {
+  if (!isAnalyticsEnabled()) return;
   try {
     const eventFn = ReactGA.event;
     if (typeof eventFn === 'function') {

--- a/utils/privacyControls.ts
+++ b/utils/privacyControls.ts
@@ -1,0 +1,81 @@
+import ReactGA from 'react-ga4';
+
+const analyticsEnvEnabled =
+  typeof process !== 'undefined' && process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true';
+
+export interface PrivacyRuntimeState {
+  analyticsEnabled: boolean;
+  telemetryEnabled: boolean;
+}
+
+const runtimeState: PrivacyRuntimeState = {
+  analyticsEnabled: analyticsEnvEnabled,
+  telemetryEnabled: true,
+};
+
+type Listener = (state: PrivacyRuntimeState) => void;
+const listeners = new Set<Listener>();
+
+let originalEvent: ((...args: Parameters<typeof ReactGA.event>) => void) | null = null;
+let originalSend: ((...args: Parameters<typeof ReactGA.send>) => void) | null = null;
+
+const patchedEvent = (...args: Parameters<typeof ReactGA.event>) => {
+  if (!runtimeState.analyticsEnabled || !originalEvent) return;
+  try {
+    originalEvent(...args);
+  } catch {
+    // ignore analytics errors
+  }
+};
+
+const patchedSend = (...args: Parameters<typeof ReactGA.send>) => {
+  if (!runtimeState.analyticsEnabled || !originalSend) return;
+  try {
+    originalSend(...args);
+  } catch {
+    // ignore analytics errors
+  }
+};
+
+const ensurePatchedReactGa = () => {
+  if (typeof window === 'undefined') return;
+  if (typeof ReactGA.event === 'function' && ReactGA.event !== patchedEvent) {
+    originalEvent = ReactGA.event.bind(ReactGA);
+    ReactGA.event = patchedEvent;
+  }
+  if (typeof ReactGA.send === 'function' && ReactGA.send !== patchedSend) {
+    originalSend = ReactGA.send.bind(ReactGA);
+    ReactGA.send = patchedSend;
+  }
+};
+
+const notify = () => {
+  const snapshot: PrivacyRuntimeState = { ...runtimeState };
+  listeners.forEach((listener) => {
+    try {
+      listener(snapshot);
+    } catch {
+      // ignore listener errors
+    }
+  });
+};
+
+export const subscribePrivacyRuntime = (listener: Listener) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+export const setAnalyticsEnabled = (enabled: boolean) => {
+  runtimeState.analyticsEnabled = enabled;
+  ensurePatchedReactGa();
+  notify();
+};
+
+export const setTelemetryEnabled = (enabled: boolean) => {
+  runtimeState.telemetryEnabled = enabled;
+  notify();
+};
+
+export const isAnalyticsEnabled = () => runtimeState.analyticsEnabled;
+
+export const isTelemetryEnabled = () => runtimeState.telemetryEnabled;


### PR DESCRIPTION
## Summary
- add a dedicated Privacy app with per-profile controls for Google Analytics and Vercel telemetry plus documentation links
- persist analytics/telemetry consent in the settings store, expose the data through the settings context, and gate runtime hooks
- register the new privacy utility in the app catalog, update the analytics client wrappers, and add regression tests

## Testing
- npx eslint apps/privacy/index.tsx utils/privacyControls.ts hooks/useSettings.tsx __tests__/privacySettings.test.tsx --max-warnings=0
- yarn test __tests__/privacySettings.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cce5c7be908328ad32419f04bc48a8