### PR TITLE
[release] add rollback metadata and UI controls

### DIFF
--- a/__tests__/releaseRollback.test.ts
+++ b/__tests__/releaseRollback.test.ts
@@ -1,0 +1,131 @@
+import { performRollback, RELEASE_OVERRIDE_KEY } from '../utils/releases';
+import type { ReleaseMetadata } from '../utils/releases';
+import { logEvent } from '../utils/analytics';
+
+jest.mock('../utils/analytics', () => ({
+  logEvent: jest.fn(),
+}));
+
+jest.mock('../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
+}));
+
+const mockManifest = (channel: string, current: ReleaseMetadata, previous: ReleaseMetadata | null) => ({
+  channels: {
+    [channel]: {
+      current,
+      previous,
+    },
+  },
+});
+
+describe('performRollback', () => {
+  const channel = 'stable';
+  const currentRelease: ReleaseMetadata = {
+    channel,
+    version: '2.2.0',
+    buildId: 'build-current',
+    exportedAt: '2024-01-01T00:00:00.000Z',
+    baseUrl: '/',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createFetchMock = (manifest: unknown) =>
+    jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => manifest,
+    });
+
+  const createStorageMock = () => {
+    const store = new Map<string, string>();
+    return {
+      getItem: jest.fn((key: string) => store.get(key) ?? null),
+      setItem: jest.fn((key: string, value: string) => {
+        store.set(key, value);
+      }),
+      removeItem: jest.fn((key: string) => {
+        store.delete(key);
+      }),
+    } as unknown as Storage;
+  };
+
+  const createCacheMock = (keys: string[] = []) => ({
+    keys: jest.fn().mockResolvedValue(keys),
+    delete: jest.fn().mockResolvedValue(true),
+  });
+
+  it('throws when no previous release is available', async () => {
+    const fetchMock = createFetchMock(mockManifest(channel, currentRelease, null));
+    const storage = createStorageMock();
+    const caches = createCacheMock();
+
+    await expect(
+      performRollback({
+        channel,
+        fetchImpl: fetchMock,
+        cacheStorage: caches,
+        storage,
+        location: { href: 'https://portfolio.test/', assign: jest.fn() },
+      }),
+    ).rejects.toThrow('No previous release available for channel stable');
+
+    expect(caches.delete).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('purges caches, stores override, logs event, and reloads on success', async () => {
+    const previousRelease: ReleaseMetadata = {
+      channel,
+      version: '2.1.0',
+      buildId: 'build-prev',
+      exportedAt: '2023-12-31T00:00:00.000Z',
+      baseUrl: '/releases/stable/prev/',
+    };
+
+    const fetchMock = createFetchMock(
+      mockManifest(channel, currentRelease, previousRelease),
+    );
+    const storage = createStorageMock();
+    const caches = createCacheMock(['a', 'b']);
+    const assign = jest.fn();
+
+    await performRollback({
+      channel,
+      fetchImpl: fetchMock,
+      cacheStorage: caches,
+      storage,
+      location: { href: 'https://portfolio.test/apps', assign },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/releases.json', { cache: 'no-store' });
+    expect(caches.keys).toHaveBeenCalled();
+    expect(caches.delete).toHaveBeenCalledTimes(2);
+    expect(caches.delete).toHaveBeenNthCalledWith(1, 'a');
+    expect(caches.delete).toHaveBeenNthCalledWith(2, 'b');
+    expect(storage.setItem).toHaveBeenCalledWith(
+      RELEASE_OVERRIDE_KEY,
+      expect.any(String),
+    );
+    const stored = storage.getItem(RELEASE_OVERRIDE_KEY);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored as string);
+    expect(parsed).toMatchObject({
+      buildId: 'build-prev',
+      channel,
+      targetUrl: 'https://portfolio.test/releases/stable/prev/',
+    });
+
+    expect(assign).toHaveBeenCalledWith('https://portfolio.test/releases/stable/prev/');
+    expect(logEvent).toHaveBeenCalledWith({
+      category: 'release',
+      action: 'rollback',
+      label: `${channel}:build-prev`,
+    });
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import ReleaseChannelPanel from "../../components/common/ReleaseChannelPanel";
 
 export default function Settings() {
   const {
@@ -38,6 +39,7 @@ export default function Settings() {
     { id: "appearance", label: "Appearance" },
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
+    { id: "about", label: "About" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
@@ -287,6 +289,13 @@ export default function Settings() {
             </button>
           </div>
         </>
+      )}
+      {activeTab === "about" && (
+        <div className="px-4 py-6 flex justify-center">
+          <div className="w-full max-w-xl">
+            <ReleaseChannelPanel />
+          </div>
+        </div>
       )}
         <input
           type="file"

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -9,6 +9,7 @@ import SafetyNote from './SafetyNote';
 import { getCspNonce } from '../../../utils/csp';
 import AboutSlides from './slides';
 import ScrollableTimeline from '../../ScrollableTimeline';
+import ReleaseChannelPanel from '../../common/ReleaseChannelPanel';
 
 class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_screen: string; navbar: boolean }> {
   screens: Record<string, React.ReactNode> = {};
@@ -338,6 +339,9 @@ function Education() {
           <div className="text-sm text-gray-300 font-bold mt-1"> </div>
         </li>
       </ul>
+      <div className="w-5/6 md:w-3/4 mt-6">
+        <ReleaseChannelPanel variant="compact" />
+      </div>
     </>
   );
 }
@@ -349,13 +353,14 @@ const SkillSection = ({ title, badges }: { title: string; badges: { src: string;
   return (
     <div className="px-2 w-full">
       <div className="text-sm text-center md:text-base font-bold">{title}</div>
-      <input
-        type="text"
-        placeholder="Filter..."
-        className="mt-2 w-full px-2 py-1 rounded text-black"
-        value={filter}
-        onChange={(e) => setFilter(e.target.value)}
-      />
+        <input
+          type="text"
+          placeholder="Filter..."
+          aria-label="Filter skills"
+          className="mt-2 w-full px-2 py-1 rounded text-black"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
         {filteredBadges.map((badge) => (
           <img

--- a/components/common/ReleaseChannelPanel.tsx
+++ b/components/common/ReleaseChannelPanel.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  DEFAULT_CHANNEL,
+  getChannelReleases,
+  performRollback,
+  ReleaseMetadata,
+} from "../../utils/releases";
+
+interface ReleaseChannelPanelProps {
+  channel?: string;
+  className?: string;
+  variant?: "default" | "compact";
+}
+
+type LoadState = "idle" | "loading" | "loaded" | "error";
+
+type ActionState = "idle" | "pending" | "error";
+
+interface ReleaseState {
+  current: ReleaseMetadata | null;
+  previous: ReleaseMetadata | null;
+}
+
+const formatTimestamp = (value?: string) => {
+  if (!value) return "Unknown";
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(date);
+  } catch {
+    return value;
+  }
+};
+
+const descriptor = (release: ReleaseMetadata | null) => {
+  if (!release) return "Unavailable";
+  const version = release.version ? `v${release.version}` : "v?.?";
+  const build = release.buildId || "unknown";
+  return `${version} (${build})`;
+};
+
+export default function ReleaseChannelPanel({
+  channel = DEFAULT_CHANNEL,
+  className = "",
+  variant = "default",
+}: ReleaseChannelPanelProps) {
+  const [loadState, setLoadState] = useState<LoadState>("idle");
+  const [actionState, setActionState] = useState<ActionState>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [releases, setReleases] = useState<ReleaseState>({ current: null, previous: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadState("loading");
+    setError(null);
+    setReleases({ current: null, previous: null });
+
+    getChannelReleases(channel)
+      .then((info) => {
+        if (cancelled) return;
+        setReleases({ current: info.current ?? null, previous: info.previous ?? null });
+        setLoadState("loaded");
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setError(err.message || "Failed to load release metadata");
+        setLoadState("error");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [channel]);
+
+  const handleRollback = async () => {
+    if (!releases.previous || actionState === "pending") return;
+    setActionState("pending");
+    setActionError(null);
+    try {
+      await performRollback({ channel });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Rollback failed";
+      setActionError(message);
+      setActionState("error");
+    }
+  };
+
+  const baseClasses =
+    "rounded-md border border-gray-900 bg-ub-grey text-ubt-grey shadow-inner";
+  const variantClasses = variant === "compact" ? "text-xs p-3" : "text-sm p-4";
+
+  return (
+    <section
+      aria-live="polite"
+      className={`${baseClasses} ${variantClasses} ${className}`.trim()}
+    >
+      <header className="flex items-center justify-between mb-2">
+        <div>
+          <p className="text-ubt-grey text-xs uppercase tracking-wide">Release Channel</p>
+          <h3 className="text-white font-semibold">{channel}</h3>
+        </div>
+        {releases.current?.exportedAt && (
+          <span className="text-ubt-grey text-xs">
+            Updated {formatTimestamp(releases.current.exportedAt)}
+          </span>
+        )}
+      </header>
+
+      {loadState === "loading" && <p>Loading release metadata…</p>}
+      {loadState === "error" && error && (
+        <p className="text-red-400">{error}</p>
+      )}
+
+      {loadState === "loaded" && (
+        <div className="space-y-3">
+          <div>
+            <p className="text-white font-medium">Current build</p>
+            <p>{descriptor(releases.current)}</p>
+            {releases.current?.assets && (
+              <p className="text-xs text-ubt-grey">
+                {releases.current.assets.length} tracked assets
+              </p>
+            )}
+          </div>
+
+          {releases.previous ? (
+            <div className="space-y-2">
+              <div>
+                <p className="text-white font-medium">Previous build</p>
+                <p>{descriptor(releases.previous)}</p>
+                {releases.previous.exportedAt && (
+                  <p className="text-xs text-ubt-grey">
+                    Exported {formatTimestamp(releases.previous.exportedAt)}
+                  </p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={handleRollback}
+                disabled={actionState === "pending"}
+                className={`px-3 py-2 rounded bg-ub-orange text-white hover:bg-orange-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-orange transition-colors duration-150 ${
+                  actionState === "pending" ? "opacity-60 cursor-not-allowed" : ""
+                }`}
+              >
+                {actionState === "pending"
+                  ? "Rolling back…"
+                  : "Rollback to previous release"}
+              </button>
+            </div>
+          ) : (
+            <p>No previous release is stored for this channel yet.</p>
+          )}
+        </div>
+      )}
+
+      {actionError && (
+        <p className="mt-2 text-red-400" role="alert">
+          {actionError}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -129,4 +129,15 @@ For each game below, build a canvas-based component with `requestAnimationFrame`
 ## Housekeeping
 - Keep `apps.config.js` organized with utilities and games grouped and exported consistently.
 - Monitor `fast-glob` updates and explore hash optimizations for the custom service worker.
+- Document and verify the release rollback workflow using `public/releases.json` and the deployment scripts.
+
+## Release Management
+- After each `yarn export`, `scripts/update-release-metadata.mjs` snapshots the build into `public/releases.json` and writes
+  channel-specific metadata under `public/releases/<channel>/<buildId>.json`.
+- Set `NEXT_PUBLIC_RELEASE_CHANNEL` (and optionally `RELEASE_CHANNEL`) per deployment so settings/About can fetch the proper
+  channel. `RELEASE_BASE_URL` and `RELEASE_BUILD_ID` may be provided to override defaults when rolling back from a CDN path.
+- The manifest keeps the latest and previous builds accessible for rollback; do not delete the per-channel metadata files so
+  prior assets remain discoverable.
+- To roll back, use the Settings → About tab or the About window rollout button. Both invoke the shared rollback helper which
+  purges caches, logs the analytics event, stores the override, and reloads the page.
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "postbuild": "node scripts/safe-copy.mjs",
     "start": "next start",
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build",
+    "postexport": "node scripts/update-release-metadata.mjs",
     "test": "jest",
     "test:watch": "jest --watch",
     "lint": "eslint . --max-warnings=0",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { getStoredOverride } from '../utils/releases';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -30,6 +31,21 @@ function MyApp(props) {
 
 
   useEffect(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const override = getStoredOverride();
+        if (override?.targetUrl) {
+          const target = new URL(override.targetUrl, window.location.href).toString();
+          if (window.location.href !== target) {
+            window.location.replace(target);
+            return;
+          }
+        }
+      } catch (err) {
+        console.error('Release override failed', err);
+      }
+    }
+
     if (typeof window !== 'undefined' && typeof window.initA2HS === 'function') {
       window.initA2HS();
     }

--- a/public/releases.json
+++ b/public/releases.json
@@ -1,0 +1,18 @@
+{
+  "channels": {
+    "stable": {
+      "current": {
+        "channel": "stable",
+        "version": "2.1.0",
+        "buildId": "development",
+        "commit": "local",
+        "exportedAt": "1970-01-01T00:00:00.000Z",
+        "baseUrl": "/",
+        "assetPrefix": "/_next/static/development",
+        "assets": []
+      },
+      "previous": null,
+      "history": []
+    }
+  }
+}

--- a/public/releases/stable/development.json
+++ b/public/releases/stable/development.json
@@ -1,0 +1,10 @@
+{
+  "channel": "stable",
+  "version": "2.1.0",
+  "buildId": "development",
+  "commit": "local",
+  "exportedAt": "1970-01-01T00:00:00.000Z",
+  "baseUrl": "/",
+  "assetPrefix": "/_next/static/development",
+  "assets": []
+}

--- a/scripts/update-release-metadata.mjs
+++ b/scripts/update-release-metadata.mjs
@@ -1,0 +1,127 @@
+import { readFile, writeFile, mkdir, stat, access } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+import fg from 'fast-glob';
+
+const toFilePath = (url) => path.resolve(path.dirname(fileURLToPath(url)));
+const rootDir = path.resolve(toFilePath(import.meta.url), '..');
+const releasesPath = path.join(rootDir, 'public', 'releases.json');
+
+const readJson = async (filePath) => {
+  try {
+    const content = await readFile(filePath, 'utf8');
+    return JSON.parse(content);
+  } catch (err) {
+    if (err && 'code' in err && err.code === 'ENOENT') {
+      return null;
+    }
+    console.warn(`[release] Failed to read ${filePath}:`, err.message);
+    return null;
+  }
+};
+
+const ensureDir = (dir) => mkdir(dir, { recursive: true });
+
+const pkg = (await readJson(path.join(rootDir, 'package.json'))) ?? { version: '0.0.0' };
+
+const channel = process.env.RELEASE_CHANNEL ?? process.env.NEXT_PUBLIC_RELEASE_CHANNEL ?? 'stable';
+const version = process.env.RELEASE_VERSION ?? pkg.version ?? '0.0.0';
+
+let buildId = process.env.RELEASE_BUILD_ID;
+if (!buildId) {
+  try {
+    buildId = (await readFile(path.join(rootDir, '.next', 'BUILD_ID'), 'utf8')).trim();
+  } catch {
+    buildId = 'development';
+  }
+}
+
+let commit = process.env.RELEASE_COMMIT;
+if (!commit) {
+  try {
+    commit = execSync('git rev-parse HEAD', {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    commit = 'unknown';
+  }
+}
+
+const baseUrl = process.env.RELEASE_BASE_URL ?? '/';
+const exportedAt = new Date().toISOString();
+
+let assets = [];
+let assetPrefix = null;
+const staticDir = path.join(rootDir, 'out', '_next', 'static');
+try {
+  await access(staticDir, constants.F_OK);
+  const files = await fg('**/*', { cwd: staticDir, onlyFiles: true });
+  assets = await Promise.all(
+    files.map(async (relativePath) => {
+      const fullPath = path.join(staticDir, relativePath);
+      const fileStat = await stat(fullPath);
+      return {
+        path: `/_next/static/${relativePath.replace(/\\\\/g, '/')}`,
+        size: fileStat.size,
+      };
+    }),
+  );
+  const prefixedDir = path.join(staticDir, buildId);
+  try {
+    await access(prefixedDir, constants.F_OK);
+    assetPrefix = `/_next/static/${buildId}`;
+  } catch {
+    assetPrefix = `/_next/static/${buildId}`;
+  }
+} catch (err) {
+  console.warn('[release] Unable to enumerate static assets:', err.message);
+}
+
+const releases = (await readJson(releasesPath)) ?? { channels: {} };
+if (!releases.channels || typeof releases.channels !== 'object') {
+  releases.channels = {};
+}
+
+const channelEntry = releases.channels[channel] ?? { current: null, previous: null, history: [] };
+const previous = channelEntry.current ? { ...channelEntry.current } : null;
+
+const releaseEntry = {
+  channel,
+  version,
+  buildId,
+  commit,
+  exportedAt,
+  baseUrl,
+  assetPrefix,
+  assets,
+};
+
+channelEntry.previous = previous;
+channelEntry.current = releaseEntry;
+
+const history = Array.isArray(channelEntry.history) ? channelEntry.history.slice() : [];
+const filtered = history.filter((entry) => entry?.buildId !== releaseEntry.buildId);
+channelEntry.history = [releaseEntry, ...filtered].slice(0, 10);
+
+releases.channels[channel] = channelEntry;
+
+const channelDir = path.join(rootDir, 'public', 'releases', channel);
+await ensureDir(channelDir);
+
+await writeFile(releasesPath, `${JSON.stringify(releases, null, 2)}\n`, 'utf8');
+await writeFile(path.join(channelDir, `${buildId}.json`), `${JSON.stringify(releaseEntry, null, 2)}\n`, 'utf8');
+
+if (previous?.buildId) {
+  const previousPath = path.join(channelDir, `${previous.buildId}.json`);
+  try {
+    await access(previousPath, constants.F_OK);
+  } catch {
+    await writeFile(previousPath, `${JSON.stringify(previous, null, 2)}\n`, 'utf8');
+  }
+}
+
+console.log(`[release] Updated ${channel} channel to build ${buildId}`);

--- a/utils/releases.ts
+++ b/utils/releases.ts
@@ -1,0 +1,217 @@
+import { logEvent } from './analytics';
+import log from './logger';
+
+export interface ReleaseAsset {
+  path: string;
+  size: number;
+}
+
+export interface ReleaseMetadata {
+  channel: string;
+  version: string;
+  buildId: string;
+  commit?: string;
+  exportedAt: string;
+  baseUrl?: string;
+  assetPrefix?: string | null;
+  assets?: ReleaseAsset[];
+}
+
+export interface ChannelReleases {
+  current: ReleaseMetadata | null;
+  previous: ReleaseMetadata | null;
+  history?: ReleaseMetadata[];
+}
+
+export interface ReleasesManifest {
+  channels: Record<string, ChannelReleases | undefined>;
+}
+
+export interface ReleaseOverride {
+  channel: string;
+  targetUrl: string;
+  buildId: string;
+  appliedAt: string;
+}
+
+export const RELEASES_PATH = '/releases.json';
+export const RELEASE_OVERRIDE_KEY = 'release:override';
+export const DEFAULT_CHANNEL =
+  process.env.NEXT_PUBLIC_RELEASE_CHANNEL ?? 'stable';
+
+type FetchImpl = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+interface CacheStorageLike {
+  keys(): Promise<string[]>;
+  delete(key: string): Promise<boolean>;
+}
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+interface LocationLike {
+  href: string;
+  assign(url: string): void;
+}
+
+const defaultFetch: FetchImpl | undefined =
+  typeof fetch === 'function' ? (fetch as FetchImpl) : undefined;
+
+const getGlobalObject = (): typeof globalThis | undefined =>
+  typeof globalThis === 'undefined' ? undefined : globalThis;
+
+const resolveStorage = (storage?: StorageLike): StorageLike | undefined => {
+  if (storage) return storage;
+  const globalObj = getGlobalObject() as { localStorage?: StorageLike } | undefined;
+  return globalObj?.localStorage;
+};
+
+const resolveCaches = (cacheStorage?: CacheStorageLike): CacheStorageLike | undefined => {
+  if (cacheStorage) return cacheStorage;
+  const globalObj = getGlobalObject() as { caches?: CacheStorageLike } | undefined;
+  return globalObj?.caches;
+};
+
+const resolveLocation = (location?: LocationLike): LocationLike | undefined => {
+  if (location) return location;
+  const globalObj = getGlobalObject() as { location?: LocationLike } | undefined;
+  return globalObj?.location;
+};
+
+export const getStoredOverride = (
+  storage?: StorageLike,
+): ReleaseOverride | null => {
+  const activeStorage = resolveStorage(storage);
+  if (!activeStorage) return null;
+  const raw = activeStorage.getItem(RELEASE_OVERRIDE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      typeof parsed.channel !== 'string' ||
+      typeof parsed.buildId !== 'string' ||
+      typeof parsed.targetUrl !== 'string'
+    ) {
+      activeStorage.removeItem?.(RELEASE_OVERRIDE_KEY);
+      return null;
+    }
+    return parsed as ReleaseOverride;
+  } catch (err) {
+    log.error('Failed to parse stored release override', err);
+    activeStorage.removeItem?.(RELEASE_OVERRIDE_KEY);
+    return null;
+  }
+};
+
+export const setStoredOverride = (
+  override: ReleaseOverride,
+  storage?: StorageLike,
+): void => {
+  const activeStorage = resolveStorage(storage);
+  if (!activeStorage) return;
+  activeStorage.setItem(RELEASE_OVERRIDE_KEY, JSON.stringify(override));
+};
+
+export const clearStoredOverride = (
+  storage?: StorageLike,
+): void => {
+  const activeStorage = resolveStorage(storage);
+  activeStorage?.removeItem?.(RELEASE_OVERRIDE_KEY);
+};
+
+export const fetchReleases = async (
+  fetchImpl: FetchImpl | undefined = defaultFetch,
+): Promise<ReleasesManifest> => {
+  if (!fetchImpl) {
+    throw new Error('No fetch implementation available for releases manifest');
+  }
+  const res = await fetchImpl(RELEASES_PATH, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error(`Failed to load ${RELEASES_PATH}: ${res.status}`);
+  }
+  const data = await res.json();
+  if (!data || typeof data !== 'object' || !('channels' in data)) {
+    throw new Error('Invalid release manifest received');
+  }
+  return data as ReleasesManifest;
+};
+
+export const getChannelReleases = async (
+  channel: string,
+  fetchImpl?: FetchImpl,
+): Promise<ChannelReleases> => {
+  const manifest = await fetchReleases(fetchImpl);
+  const info = manifest.channels[channel];
+  if (!info) {
+    throw new Error(`No release data found for channel ${channel}`);
+  }
+  const { current = null, previous = null, history = [] } = info;
+  return { current, previous, history };
+};
+
+interface RollbackOptions {
+  channel?: string;
+  fetchImpl?: FetchImpl;
+  cacheStorage?: CacheStorageLike;
+  storage?: StorageLike;
+  location?: LocationLike;
+}
+
+export const performRollback = async ({
+  channel = DEFAULT_CHANNEL,
+  fetchImpl,
+  cacheStorage,
+  storage,
+  location,
+}: RollbackOptions = {}): Promise<ReleaseMetadata> => {
+  const { previous } = await getChannelReleases(channel, fetchImpl);
+  if (!previous) {
+    throw new Error(`No previous release available for channel ${channel}`);
+  }
+
+  const activeCaches = resolveCaches(cacheStorage);
+  if (activeCaches?.keys) {
+    try {
+      const keys = await activeCaches.keys();
+      await Promise.all(keys.map((key) => activeCaches.delete(key).catch(() => false)));
+    } catch (err) {
+      log.error('Failed to purge caches during rollback', err);
+    }
+  }
+
+  const base = previous.baseUrl && previous.baseUrl.trim() ? previous.baseUrl : '/';
+  const activeLocation = resolveLocation(location);
+  const targetUrl = activeLocation
+    ? new URL(base, activeLocation.href).toString()
+    : base;
+
+  const override: ReleaseOverride = {
+    channel,
+    targetUrl,
+    buildId: previous.buildId,
+    appliedAt: new Date().toISOString(),
+  };
+
+  try {
+    setStoredOverride(override, storage);
+  } catch (err) {
+    log.error('Failed to store rollback override', err);
+  }
+
+  logEvent({
+    category: 'release',
+    action: 'rollback',
+    label: `${channel}:${previous.buildId}`,
+  });
+
+  if (activeLocation?.assign) {
+    activeLocation.assign(targetUrl);
+  }
+
+  return previous;
+};


### PR DESCRIPTION
## Summary
- add a post-export script that snapshots release metadata, writes per-channel history, and preserves previous builds under `public/releases`
- introduce a shared release rollback helper with UI in Settings/About plus load-time override handling
- document the release workflow and add regression coverage for missing-previous and successful rollback paths

## Testing
- npx eslint utils/releases.ts components/common/ReleaseChannelPanel.tsx apps/settings/index.tsx components/apps/About/index.tsx pages/_app.jsx
- yarn test releaseRollback.test.ts
- yarn lint *(fails: existing repo violations for unlabeled controls / legacy public scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68cce5c9b260832884ae4565b8661c4c