### PR TITLE
[build] Add version manifest and cache cleanup logic

### DIFF
--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -1,6 +1,6 @@
 import React, { act } from 'react';
 import { render, screen } from '@testing-library/react';
-import Ubuntu from '../components/ubuntu';
+import Ubuntu, { VERSION_STORAGE_KEY } from '../components/ubuntu';
 
 jest.mock('../components/screen/desktop', () => function DesktopMock() {
   return <div data-testid="desktop" />;
@@ -11,20 +11,41 @@ jest.mock('../components/screen/navbar', () => function NavbarMock() {
 jest.mock('../components/screen/lock_screen', () => function LockScreenMock() {
   return <div data-testid="lock-screen" />;
 });
+jest.mock('../components/ui/Toast', () => function ToastMock() {
+  return <div data-testid="toast" />;
+});
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 
 describe('Ubuntu component', () => {
   beforeEach(() => {
     jest.useFakeTimers();
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ appVersion: '2.1.0', cacheVersion: 'periodic-cache-v1' }),
+    });
+    (global as any).caches = {
+      keys: jest.fn().mockResolvedValue([]),
+      delete: jest.fn().mockResolvedValue(true),
+    };
+    localStorage.clear();
   });
 
   afterEach(() => {
-    jest.runOnlyPendingTimers();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
     jest.useRealTimers();
+    jest.resetAllMocks();
+    delete (global as any).fetch;
+    delete (global as any).caches;
+    localStorage.clear();
   });
 
-  it('renders boot screen then desktop', () => {
-    render(<Ubuntu />);
+  it('renders boot screen then desktop', async () => {
+    await act(async () => {
+      render(<Ubuntu />);
+      await Promise.resolve();
+    });
     const bootLogo = screen.getByAltText('Ubuntu Logo');
     const bootScreen = bootLogo.parentElement as HTMLElement;
     expect(bootScreen).toHaveClass('visible');
@@ -37,9 +58,12 @@ describe('Ubuntu component', () => {
     expect(screen.getByTestId('desktop')).toBeInTheDocument();
   });
 
-  it('handles lockScreen when status bar is missing', () => {
+  it('handles lockScreen when status bar is missing', async () => {
     let instance: Ubuntu | null = null;
-    render(<Ubuntu ref={(c) => (instance = c)} />);
+    await act(async () => {
+      render(<Ubuntu ref={(c) => (instance = c)} />);
+      await Promise.resolve();
+    });
     expect(instance).not.toBeNull();
     act(() => {
       instance!.lockScreen();
@@ -48,13 +72,50 @@ describe('Ubuntu component', () => {
     expect(instance!.state.screen_locked).toBe(true);
   });
 
-  it('handles shutDown when status bar is missing', () => {
+  it('handles shutDown when status bar is missing', async () => {
     let instance: Ubuntu | null = null;
-    render(<Ubuntu ref={(c) => (instance = c)} />);
+    await act(async () => {
+      render(<Ubuntu ref={(c) => (instance = c)} />);
+      await Promise.resolve();
+    });
     expect(instance).not.toBeNull();
     act(() => {
       instance!.shutDown();
     });
     expect(instance!.state.shutDownScreen).toBe(true);
+  });
+
+  it('clears outdated caches when version changes', async () => {
+    const keysMock = jest.fn().mockResolvedValue(['cache-a', 'cache-b']);
+    const deleteMock = jest.fn().mockResolvedValue(true);
+    (global as any).caches = {
+      keys: keysMock,
+      delete: deleteMock,
+    };
+
+    const firstVersion = { appVersion: '1.0.0', cacheVersion: 'cache-v1' };
+    const nextVersion = { appVersion: '2.0.0', cacheVersion: 'cache-v2' };
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => firstVersion })
+      .mockResolvedValueOnce({ ok: true, json: async () => nextVersion });
+
+    localStorage.setItem(VERSION_STORAGE_KEY, JSON.stringify(firstVersion));
+
+    let instance: Ubuntu | null = null;
+    await act(async () => {
+      render(<Ubuntu ref={(c) => (instance = c)} />);
+      await Promise.resolve();
+    });
+    expect(instance).not.toBeNull();
+
+    await act(async () => {
+      await instance!.verifyAppVersion();
+    });
+
+    expect(keysMock).toHaveBeenCalledTimes(1);
+    expect(deleteMock).toHaveBeenCalledTimes(2);
+    const stored = localStorage.getItem(VERSION_STORAGE_KEY);
+    expect(stored).toContain('2.0.0');
   });
 });

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -5,130 +5,263 @@ import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
+import Toast from './ui/Toast';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
+import { createLogger } from '../lib/logger';
+
+export const VERSION_STORAGE_KEY = 'kali-portfolio-version';
 
 export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
-			screen_locked: false,
-			bg_image_name: 'wall-2',
-			booting_screen: true,
-			shutDownScreen: false
-		};
-	}
+        constructor() {
+                super();
+                this.logger = createLogger('ubuntu-desktop');
+                this._isMounted = false;
+                this.state = {
+                        screen_locked: false,
+                        bg_image_name: 'wall-2',
+                        booting_screen: true,
+                        shutDownScreen: false,
+                        toastMessage: ''
+                };
+        }
 
-	componentDidMount() {
-		this.getLocalData();
-	}
+        componentDidMount() {
+                this._isMounted = true;
+                this.getLocalData();
+                this.verifyAppVersion();
+        }
 
-	setTimeOutBootScreen = () => {
-		setTimeout(() => {
-			this.setState({ booting_screen: false });
-		}, 2000);
-	};
+        componentWillUnmount() {
+                this._isMounted = false;
+        }
 
-	getLocalData = () => {
-		// Get Previously selected Background Image
+        setTimeOutBootScreen = () => {
+                setTimeout(() => {
+                        this.setState({ booting_screen: false });
+                }, 2000);
+        };
+
+        getLocalData = () => {
+                // Get Previously selected Background Image
                 let bg_image_name = safeLocalStorage?.getItem('bg-image');
-		if (bg_image_name !== null && bg_image_name !== undefined) {
-			this.setState({ bg_image_name });
-		}
+                if (bg_image_name !== null && bg_image_name !== undefined) {
+                        this.setState({ bg_image_name });
+                }
 
                 let booting_screen = safeLocalStorage?.getItem('booting_screen');
-		if (booting_screen !== null && booting_screen !== undefined) {
-			// user has visited site before
-			this.setState({ booting_screen: false });
-		} else {
-			// user is visiting site for the first time
+                if (booting_screen !== null && booting_screen !== undefined) {
+                        // user has visited site before
+                        this.setState({ booting_screen: false });
+                } else {
+                        // user is visiting site for the first time
                         safeLocalStorage?.setItem('booting_screen', false);
-			this.setTimeOutBootScreen();
-		}
+                        this.setTimeOutBootScreen();
+                }
 
-		// get shutdown state
+                // get shutdown state
                 let shut_down = safeLocalStorage?.getItem('shut-down');
-		if (shut_down !== null && shut_down !== undefined && shut_down === 'true') this.shutDown();
-		else {
-			// Get previous lock screen state
+                if (shut_down !== null && shut_down !== undefined && shut_down === 'true') this.shutDown();
+                else {
+                        // Get previous lock screen state
                         let screen_locked = safeLocalStorage?.getItem('screen-locked');
-			if (screen_locked !== null && screen_locked !== undefined) {
-				this.setState({ screen_locked: screen_locked === 'true' ? true : false });
-			}
-		}
-	};
+                        if (screen_locked !== null && screen_locked !== undefined) {
+                                this.setState({ screen_locked: screen_locked === 'true' ? true : false });
+                        }
+                }
+        };
 
-	lockScreen = () => {
-		// google analytics
-		ReactGA.send({ hitType: "pageview", page: "/lock-screen", title: "Lock Screen" });
-		ReactGA.event({
-			category: `Screen Change`,
-			action: `Set Screen to Locked`
-		});
+        verifyAppVersion = async () => {
+                if (typeof fetch !== 'function') {
+                        return;
+                }
+
+                try {
+                        const response = await fetch('/version.json', { cache: 'no-store' });
+                        if (!response?.ok) {
+                                throw new Error(`Failed to load version manifest: ${response?.status || 'unknown status'}`);
+                        }
+
+                        const versionPayload = await response.json();
+                        const storedRaw = safeLocalStorage?.getItem(VERSION_STORAGE_KEY);
+                        let storedVersion = null;
+                        let hadStoredValue = false;
+                        if (storedRaw) {
+                                hadStoredValue = true;
+                                try {
+                                        storedVersion = JSON.parse(storedRaw);
+                                } catch (error) {
+                                        this.logger.warn('Failed to parse stored version data', {
+                                                error: error instanceof Error ? error.message : String(error)
+                                        });
+                                }
+                        }
+
+                        const versionChanged =
+                                !storedVersion ||
+                                storedVersion.appVersion !== versionPayload.appVersion ||
+                                storedVersion.cacheVersion !== versionPayload.cacheVersion;
+                        const shouldClearCaches = versionChanged && (hadStoredValue || storedVersion);
+                        let clearedCaches = [];
+
+                        if (shouldClearCaches) {
+                                clearedCaches = await this.clearOutdatedCaches();
+                                if (hadStoredValue && this._isMounted) {
+                                        this.setState({ toastMessage: 'Assets refreshed. Reload to use the latest updates.' });
+                                }
+                                this.logger.info('Refreshed cached application assets', {
+                                        previousAppVersion: storedVersion?.appVersion ?? null,
+                                        newAppVersion: versionPayload.appVersion,
+                                        previousCacheVersion: storedVersion?.cacheVersion ?? null,
+                                        newCacheVersion: versionPayload.cacheVersion,
+                                        clearedCaches
+                                });
+                        } else {
+                                this.logger.debug('Application assets already current', {
+                                        appVersion: versionPayload.appVersion,
+                                        cacheVersion: versionPayload.cacheVersion
+                                });
+                        }
+
+                        safeLocalStorage?.setItem(
+                                VERSION_STORAGE_KEY,
+                                JSON.stringify({
+                                        appVersion: versionPayload.appVersion,
+                                        cacheVersion: versionPayload.cacheVersion
+                                })
+                        );
+                } catch (error) {
+                        this.logger.warn('Failed to verify cached assets', {
+                                error: error instanceof Error ? error.message : String(error)
+                        });
+                }
+        };
+
+        clearOutdatedCaches = async () => {
+                if (typeof caches === 'undefined') {
+                        this.logger.debug('Cache API unavailable; skipping cache cleanup');
+                        return [];
+                }
+
+                try {
+                        const cacheKeys = await caches.keys();
+                        const removed = [];
+                        await Promise.all(
+                                cacheKeys.map(async (key) => {
+                                        try {
+                                                const deleted = await caches.delete(key);
+                                                if (deleted) {
+                                                        removed.push(key);
+                                                }
+                                        } catch (error) {
+                                                this.logger.warn('Failed to delete cache', {
+                                                        cacheName: key,
+                                                        error: error instanceof Error ? error.message : String(error)
+                                                });
+                                        }
+                                })
+                        );
+                        return removed;
+                } catch (error) {
+                        this.logger.warn('Unable to enumerate caches', {
+                                error: error instanceof Error ? error.message : String(error)
+                        });
+                        return [];
+                }
+        };
+
+        dismissToast = () => {
+                if (this._isMounted) {
+                        this.setState({ toastMessage: '' });
+                }
+        };
+
+        refreshPage = () => {
+                if (typeof window !== 'undefined' && window.location) {
+                        window.location.reload();
+                }
+        };
+
+        lockScreen = () => {
+                // google analytics
+                ReactGA.send({ hitType: "pageview", page: "/lock-screen", title: "Lock Screen" });
+                ReactGA.event({
+                        category: `Screen Change`,
+                        action: `Set Screen to Locked`
+                });
 
                 const statusBar = document.getElementById('status-bar');
                 // Consider using a React ref if the status bar element lives within this component tree
                 statusBar?.blur();
-		setTimeout(() => {
-			this.setState({ screen_locked: true });
-		}, 100); // waiting for all windows to close (transition-duration)
+                setTimeout(() => {
+                        this.setState({ screen_locked: true });
+                }, 100); // waiting for all windows to close (transition-duration)
                 safeLocalStorage?.setItem('screen-locked', true);
-	};
+        };
 
-	unLockScreen = () => {
-		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        unLockScreen = () => {
+                ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
-		window.removeEventListener('click', this.unLockScreen);
-		window.removeEventListener('keypress', this.unLockScreen);
+                window.removeEventListener('click', this.unLockScreen);
+                window.removeEventListener('keypress', this.unLockScreen);
 
-		this.setState({ screen_locked: false });
+                this.setState({ screen_locked: false });
                 safeLocalStorage?.setItem('screen-locked', false);
-	};
+        };
 
-	changeBackgroundImage = (img_name) => {
-		this.setState({ bg_image_name: img_name });
+        changeBackgroundImage = (img_name) => {
+                this.setState({ bg_image_name: img_name });
                 safeLocalStorage?.setItem('bg-image', img_name);
-	};
+        };
 
-	shutDown = () => {
-		ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
+        shutDown = () => {
+                ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
 
-		ReactGA.event({
-			category: `Screen Change`,
-			action: `Switched off the Ubuntu`
-		});
+                ReactGA.event({
+                        category: `Screen Change`,
+                        action: `Switched off the Ubuntu`
+                });
 
                 const statusBar = document.getElementById('status-bar');
                 // Consider using a React ref if the status bar element lives within this component tree
                 statusBar?.blur();
-		this.setState({ shutDownScreen: true });
+                this.setState({ shutDownScreen: true });
                 safeLocalStorage?.setItem('shut-down', true);
-	};
+        };
 
-	turnOn = () => {
-		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        turnOn = () => {
+                ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
-		this.setState({ shutDownScreen: false, booting_screen: true });
-		this.setTimeOutBootScreen();
+                this.setState({ shutDownScreen: false, booting_screen: true });
+                this.setTimeOutBootScreen();
                 safeLocalStorage?.setItem('shut-down', false);
-	};
+        };
 
-	render() {
-		return (
-			<div className="w-screen h-screen overflow-hidden" id="monitor-screen">
-				<LockScreen
-					isLocked={this.state.screen_locked}
-					bgImgName={this.state.bg_image_name}
-					unLockScreen={this.unLockScreen}
-				/>
-				<BootingScreen
-					visible={this.state.booting_screen}
-					isShutDown={this.state.shutDownScreen}
-					turnOn={this.turnOn}
-				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+        render() {
+                return (
+                        <div className="w-screen h-screen overflow-hidden" id="monitor-screen">
+                                <LockScreen
+                                        isLocked={this.state.screen_locked}
+                                        bgImgName={this.state.bg_image_name}
+                                        unLockScreen={this.unLockScreen}
+                                />
+                                <BootingScreen
+                                        visible={this.state.booting_screen}
+                                        isShutDown={this.state.shutDownScreen}
+                                        turnOn={this.turnOn}
+                                />
+                                <Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
+                                <Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
+                                {this.state.toastMessage ? (
+                                        <Toast
+                                                message={this.state.toastMessage}
+                                                actionLabel="Reload"
+                                                onAction={this.refreshPage}
+                                                onClose={this.dismissToast}
+                                                duration={10000}
+                                        />
+                                ) : null}
+                        </div>
+                );
+        }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://unnippillil.com/",
   "scripts": {
     "build:gamepad": "tsc -p tsconfig.gamepad.json",
-    "prebuild": "tsc -p tsconfig.gamepad.json",
+    "prebuild": "node scripts/generate-version.mjs && tsc -p tsconfig.gamepad.json",
     "dev": "next dev",
     "build": "next build",
     "postbuild": "node scripts/safe-copy.mjs",

--- a/public/version.json
+++ b/public/version.json
@@ -1,0 +1,4 @@
+{
+  "appVersion": "2.1.0",
+  "cacheVersion": "periodic-cache-v1"
+}

--- a/scripts/generate-version.mjs
+++ b/scripts/generate-version.mjs
@@ -1,0 +1,53 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = dirname(__dirname);
+
+async function getPackageVersion() {
+  const packageJsonPath = join(projectRoot, 'package.json');
+  const raw = await readFile(packageJsonPath, 'utf8');
+  const pkg = JSON.parse(raw);
+  return String(pkg.version ?? '0.0.0');
+}
+
+async function getCacheVersion() {
+  const serviceWorkerPath = join(projectRoot, 'public', 'workers', 'service-worker.js');
+  try {
+    const sw = await readFile(serviceWorkerPath, 'utf8');
+    const match = sw.match(/const\s+CACHE_NAME\s*=\s*['"`]([^'"`]+)['"`]/);
+    if (match) {
+      return match[1];
+    }
+  } catch (error) {
+    if (error && error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+  return 'unknown';
+}
+
+async function writeVersionFile({ appVersion, cacheVersion }) {
+  const versionPath = join(projectRoot, 'public', 'version.json');
+  const data = {
+    appVersion,
+    cacheVersion,
+  };
+  const contents = `${JSON.stringify(data, null, 2)}\n`;
+  await writeFile(versionPath, contents, 'utf8');
+}
+
+async function main() {
+  const [appVersion, cacheVersion] = await Promise.all([
+    getPackageVersion(),
+    getCacheVersion(),
+  ]);
+  await writeVersionFile({ appVersion, cacheVersion });
+}
+
+main().catch((error) => {
+  console.error('Failed to generate version manifest', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- generate a version manifest during prebuild so service workers can detect app changes
- clear outdated caches on boot, surface a toast prompting reload, and log refresh events
- add a Jest test that verifies cache invalidation when versions change

## Testing
- yarn test __tests__/ubuntu.test.tsx
- npx eslint components/ubuntu.js __tests__/ubuntu.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cce5ca76ec8328ba852dd6d78fd9ee