### PR TITLE
[settings] add release channel toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Copy `.env.local.example` to `.env.local` and fill in required values.
 | `NEXT_PUBLIC_UI_EXPERIMENTS` | Enable experimental UI heuristics. |
 | `NEXT_PUBLIC_STATIC_EXPORT` | Set to `'true'` during `yarn export` to disable server APIs. |
 | `NEXT_PUBLIC_SHOW_BETA` | Set to `1` to display a small beta badge in the UI. |
+| `NEXT_PUBLIC_DEFAULT_CHANNEL` | Sets the default release channel (e.g., `stable`). |
 | `FEATURE_TOOL_APIS` | Enable server-side tool API routes like Hydra and John; set to `enabled` to allow. |
 | `FEATURE_HYDRA` | Allow the Hydra API (`/api/hydra`); requires `FEATURE_TOOL_APIS`. |
 

--- a/__tests__/releaseChannelSettings.test.tsx
+++ b/__tests__/releaseChannelSettings.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderHook, act } from '@testing-library/react';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+import AboutApp from '../components/apps/About';
+
+describe('release channel settings', () => {
+  const originalDefaultChannel = process.env.NEXT_PUBLIC_DEFAULT_CHANNEL;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    process.env.NEXT_PUBLIC_DEFAULT_CHANNEL = 'stable';
+  });
+
+  afterAll(() => {
+    process.env.NEXT_PUBLIC_DEFAULT_CHANNEL = originalDefaultChannel;
+  });
+
+  it('persists the release channel per profile', async () => {
+    window.localStorage.setItem('profile:active', 'pentest');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <SettingsProvider>{children}</SettingsProvider>
+    );
+    const { result } = renderHook(() => useSettings(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.releaseChannel).toBe('stable'));
+
+    act(() => {
+      result.current.setReleaseChannel('preview');
+    });
+
+    expect(window.localStorage.getItem('release-channel:pentest')).toBe('preview');
+  });
+
+  it('shows a restart prompt after switching channels', async () => {
+    const user = userEvent.setup();
+    render(
+      <SettingsProvider>
+        <AboutApp />
+      </SettingsProvider>,
+    );
+
+    const toggle = await screen.findByRole('switch', { name: /release channel/i });
+    await user.click(toggle);
+
+    expect(
+      screen.getByText(/restart required to finish switching/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -15,6 +15,7 @@ const publicEnvSchema = z.object({
   NEXT_PUBLIC_GHIDRA_URL: z.string().optional(),
   NEXT_PUBLIC_SUPABASE_URL: z.string().optional(),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
+  NEXT_PUBLIC_DEFAULT_CHANNEL: z.string().optional(),
 });
 
 const serverEnvSchema = publicEnvSchema.extend({

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -15,6 +15,7 @@ const publicEnvSchema = z.object({
   NEXT_PUBLIC_GHIDRA_URL: z.string().optional(),
   NEXT_PUBLIC_SUPABASE_URL: z.string().optional(),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
+  NEXT_PUBLIC_DEFAULT_CHANNEL: z.string().optional(),
 });
 
 const serverEnvSchema = publicEnvSchema.extend({


### PR DESCRIPTION
## Summary
- add release channel state and cache busting to the global settings provider
- persist release channel values per profile and expose a toggle with restart guidance in the About app
- document the default channel env var and add regression coverage for persistence and the restart prompt

## Testing
- yarn lint *(fails: repository has existing accessibility lint violations)*
- yarn test releaseChannelSettings

------
https://chatgpt.com/codex/tasks/task_e_68cce5caf984832898721290bd9eb6c3