### PR TITLE
[undo] capture conflict failures in undo flow

### DIFF
--- a/__tests__/UndoConflictDialog.test.tsx
+++ b/__tests__/UndoConflictDialog.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import UndoConflictDialog from '../components/common/UndoConflictDialog';
+import type { UndoConflict } from '../src/undo/types';
+import type { Logger } from '../lib/logger';
+
+const createLoggerMock = (): Logger => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+describe('UndoConflictDialog', () => {
+  it('renders nothing when there is no conflict', () => {
+    const logger = createLoggerMock();
+    const { container } = render(
+      <UndoConflictDialog conflict={null} onResolve={() => {}} logger={logger} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('renders conflict details and logs user actions', () => {
+    const conflict: UndoConflict = {
+      entryId: 'undo-1',
+      entryLabel: 'Delete widget',
+      message: 'A newer edit conflicts with this undo.',
+      blockingEntries: [
+        { id: 'undo-2', label: 'Rename widget' },
+        { id: 'undo-3', label: 'Move widget' },
+      ],
+    };
+
+    const logger = createLoggerMock();
+    const onResolve = jest.fn();
+    const onRetry = jest.fn();
+
+    render(
+      <UndoConflictDialog
+        conflict={conflict}
+        onResolve={onResolve}
+        onRetry={onRetry}
+        logger={logger}
+      />,
+    );
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    expect(screen.getByText(conflict.message)).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(conflict.blockingEntries.length);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Undo conflict encountered',
+      expect.objectContaining({ entryId: conflict.entryId }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      'Undo conflict retry requested',
+      expect.objectContaining({ entryId: conflict.entryId }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      'Undo conflict dismissed',
+      expect.objectContaining({ entryId: conflict.entryId }),
+    );
+  });
+});

--- a/__tests__/undoManager.test.ts
+++ b/__tests__/undoManager.test.ts
@@ -1,0 +1,99 @@
+import { UndoManager, UndoConflictError } from '../src/undo';
+import type { UndoConflict } from '../src/undo';
+import type { Logger } from '../lib/logger';
+
+const createLoggerMock = (): Logger => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+describe('UndoManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('marks entries as successful after undo completes', async () => {
+    const manager = new UndoManager(createLoggerMock());
+    const undo = jest.fn();
+
+    manager.record({ id: '1', label: 'Create file', undo });
+
+    const result = await manager.undo();
+
+    expect(result.success).toBe(true);
+    expect(undo).toHaveBeenCalledTimes(1);
+
+    const [entry] = manager.getEntries();
+    expect(entry.status).toBe('success');
+    expect(entry.error).toBeUndefined();
+  });
+
+  it('marks entries as failed when undo throws and keeps stack usable', async () => {
+    const logger = createLoggerMock();
+    const manager = new UndoManager(logger);
+    const firstUndo = jest.fn();
+
+    manager.record({ id: 'first', label: 'First change', undo: firstUndo });
+    manager.record({
+      id: 'second',
+      label: 'Second change',
+      undo: () => {
+        throw new Error('boom');
+      },
+    });
+
+    const firstResult = await manager.undo();
+    expect(firstResult.success).toBe(false);
+
+    const entriesAfterFailure = manager.getEntries();
+    expect(entriesAfterFailure[1].status).toBe('error');
+    expect(entriesAfterFailure[1].error).toBe('boom');
+    expect(logger.error).toHaveBeenCalledWith('Undo failed', expect.objectContaining({ entryId: 'second' }));
+
+    const secondResult = await manager.undo();
+    expect(secondResult.success).toBe(true);
+    expect(firstUndo).toHaveBeenCalledTimes(1);
+
+    const entriesAfterSuccess = manager.getEntries();
+    expect(entriesAfterSuccess[0].status).toBe('success');
+    expect(entriesAfterSuccess[0].error).toBeUndefined();
+  });
+
+  it('returns conflict details when undo throws UndoConflictError', async () => {
+    const logger = createLoggerMock();
+    const manager = new UndoManager(logger);
+
+    const conflict: UndoConflict = {
+      entryId: 'conflict',
+      entryLabel: 'Rename project',
+      message: 'Blocked by newer changes',
+      blockingEntries: [{ id: 'existing', label: 'Existing rename' }],
+    };
+
+    manager.record({
+      id: conflict.entryId,
+      label: conflict.entryLabel,
+      undo: () => {
+        throw new UndoConflictError('conflict detected', conflict);
+      },
+    });
+
+    const result = await manager.undo();
+
+    expect(result.success).toBe(false);
+    expect(result.conflict).toEqual(conflict);
+    expect(logger.warn).toHaveBeenCalledWith('Undo conflict encountered', expect.objectContaining({ entryId: conflict.entryId }));
+
+    const [entry] = manager.getEntries();
+    expect(entry.status).toBe('error');
+    expect(entry.error).toBe('conflict detected');
+  });
+
+  it('returns false when there is nothing to undo', async () => {
+    const manager = new UndoManager(createLoggerMock());
+    const result = await manager.undo();
+    expect(result.success).toBe(false);
+  });
+});

--- a/components/common/UndoConflictDialog.tsx
+++ b/components/common/UndoConflictDialog.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { createLogger, type Logger } from '../../lib/logger';
+import type { UndoConflict } from '../../src/undo/types';
+
+interface UndoConflictDialogProps {
+  conflict: UndoConflict | null;
+  onResolve: () => void;
+  onRetry?: () => void;
+  logger?: Logger;
+}
+
+const UndoConflictDialog: React.FC<UndoConflictDialogProps> = ({
+  conflict,
+  onResolve,
+  onRetry,
+  logger = createLogger(),
+}) => {
+  useEffect(() => {
+    if (!conflict) return;
+    logger.warn('Undo conflict encountered', {
+      entryId: conflict.entryId,
+      message: conflict.message,
+      blockingEntryIds: conflict.blockingEntries.map(entry => entry.id),
+    });
+  }, [conflict, logger]);
+
+  if (!conflict) {
+    return null;
+  }
+
+  const handleResolve = () => {
+    logger.info('Undo conflict dismissed', { entryId: conflict.entryId });
+    onResolve();
+  };
+
+  const handleRetry = () => {
+    logger.info('Undo conflict retry requested', { entryId: conflict.entryId });
+    onRetry?.();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="undo-conflict-title"
+      aria-describedby="undo-conflict-message"
+    >
+      <div className="w-full max-w-md overflow-hidden rounded border border-gray-700 bg-ub-cool-grey text-white shadow-xl">
+        <div className="border-b border-gray-700 px-4 py-3">
+          <h2 id="undo-conflict-title" className="text-lg font-semibold">
+            Undo Conflict
+          </h2>
+          <p className="mt-1 text-xs text-gray-300">
+            {conflict.entryLabel} could not be undone.
+          </p>
+        </div>
+        <div className="space-y-3 px-4 py-3">
+          <p id="undo-conflict-message" className="text-sm text-gray-100">
+            {conflict.message}
+          </p>
+          {conflict.blockingEntries.length > 0 && (
+            <div>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-300">
+                Blocking changes
+              </h3>
+              <ul className="mt-2 space-y-1" aria-label="Blocking entries">
+                {conflict.blockingEntries.map(blocking => (
+                  <li
+                    key={blocking.id}
+                    className="rounded border border-gray-700 bg-black bg-opacity-40 px-3 py-2 text-sm"
+                  >
+                    <span className="font-medium">{blocking.label}</span>
+                    <span className="ml-2 text-xs text-gray-400">#{blocking.id}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+        <div className="flex justify-end gap-2 border-t border-gray-700 px-4 py-3">
+          {onRetry && (
+            <button
+              type="button"
+              onClick={handleRetry}
+              className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            >
+              Retry
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleResolve}
+            className="rounded bg-gray-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-400"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UndoConflictDialog;

--- a/src/undo/UndoManager.ts
+++ b/src/undo/UndoManager.ts
@@ -1,0 +1,106 @@
+import { createLogger, type Logger } from '../../lib/logger';
+import { UndoConflictError } from './errors';
+import type { JournalEntry, UndoConflict } from './types';
+
+export interface RecordEntryInput {
+  id: string;
+  label: string;
+  undo: () => Promise<void> | void;
+  timestamp?: number;
+  meta?: Record<string, unknown>;
+}
+
+export interface UndoResult {
+  success: boolean;
+  entry?: JournalEntry;
+  conflict?: UndoConflict;
+}
+
+export class UndoManager {
+  private readonly journal: JournalEntry[] = [];
+  private readonly logger: Logger;
+
+  constructor(logger: Logger = createLogger()) {
+    this.logger = logger;
+  }
+
+  record(input: RecordEntryInput): JournalEntry {
+    const entry: JournalEntry = {
+      id: input.id,
+      label: input.label,
+      undo: input.undo,
+      timestamp: input.timestamp ?? Date.now(),
+      status: 'pending',
+      meta: input.meta,
+    };
+
+    this.journal.push(entry);
+    this.logger.debug('Undo entry recorded', {
+      entryId: entry.id,
+      label: entry.label,
+    });
+
+    return { ...entry };
+  }
+
+  getEntries(): JournalEntry[] {
+    return this.journal.map(entry => ({ ...entry }));
+  }
+
+  async undo(): Promise<UndoResult> {
+    const entry = this.findLastPending();
+    if (!entry) {
+      this.logger.debug('No undo entries available');
+      return { success: false };
+    }
+
+    try {
+      await Promise.resolve(entry.undo());
+      entry.status = 'success';
+      delete entry.error;
+
+      this.logger.info('Undo completed', {
+        entryId: entry.id,
+        label: entry.label,
+      });
+
+      return { success: true, entry: { ...entry } };
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      entry.status = 'error';
+      entry.error = message;
+
+      if (error instanceof UndoConflictError) {
+        this.logger.warn('Undo conflict encountered', {
+          entryId: entry.id,
+          label: entry.label,
+          conflict: error.conflict,
+        });
+
+        return {
+          success: false,
+          entry: { ...entry },
+          conflict: error.conflict,
+        };
+      }
+
+      this.logger.error('Undo failed', {
+        entryId: entry.id,
+        label: entry.label,
+        error: message,
+      });
+
+      return { success: false, entry: { ...entry } };
+    }
+  }
+
+  private findLastPending(): JournalEntry | undefined {
+    for (let i = this.journal.length - 1; i >= 0; i -= 1) {
+      const entry = this.journal[i];
+      if (entry.status === 'pending') {
+        return entry;
+      }
+    }
+    return undefined;
+  }
+}

--- a/src/undo/errors.ts
+++ b/src/undo/errors.ts
@@ -1,0 +1,8 @@
+import type { UndoConflict } from './types';
+
+export class UndoConflictError extends Error {
+  constructor(message: string, public readonly conflict: UndoConflict) {
+    super(message);
+    this.name = 'UndoConflictError';
+  }
+}

--- a/src/undo/index.ts
+++ b/src/undo/index.ts
@@ -1,0 +1,3 @@
+export type { JournalEntry, JournalStatus, UndoConflict } from './types';
+export { UndoConflictError } from './errors';
+export { UndoManager } from './UndoManager';

--- a/src/undo/types.ts
+++ b/src/undo/types.ts
@@ -1,0 +1,18 @@
+export type JournalStatus = 'pending' | 'success' | 'error';
+
+export interface JournalEntry {
+  id: string;
+  label: string;
+  undo: () => Promise<void> | void;
+  timestamp: number;
+  status: JournalStatus;
+  error?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface UndoConflict {
+  entryId: string;
+  entryLabel: string;
+  message: string;
+  blockingEntries: Array<Pick<JournalEntry, 'id' | 'label'>>;
+}


### PR DESCRIPTION
## Summary
- add a reusable undo journal manager that records status/error metadata and surfaces conflicts
- surface undo conflicts through a dedicated dialog that logs via the shared logger helper
- cover the manager and dialog with unit tests verifying success, failure, and conflict flows

## Testing
- yarn lint *(fails: existing repository accessibility/no-top-level-window issues unrelated to the change)*
- yarn test --runTestsByPath __tests__/undoManager.test.ts __tests__/UndoConflictDialog.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cce5cddb9883288e5fa40e31b5caaf