### PR TITLE
[search] add quick actions to WhiskerMenu

### DIFF
--- a/__tests__/WhiskerMenu.test.tsx
+++ b/__tests__/WhiskerMenu.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import WhiskerMenu from '../components/menu/WhiskerMenu';
+
+describe('WhiskerMenu quick actions', () => {
+  it('dispatches desktop events and keeps overlay open', async () => {
+    const user = userEvent.setup();
+    render(<WhiskerMenu />);
+
+    const trigger = screen.getByRole('button', { name: /applications/i });
+    await user.click(trigger);
+
+    const searchInput = screen.getByPlaceholderText(/search/i);
+    await user.type(searchInput, 'about');
+
+    const dialog = await screen.findByRole('dialog', { name: /application search/i });
+
+    const openEvents: any[] = [];
+    const pinEvents: any[] = [];
+    const handleOpen = (event: Event) => {
+      openEvents.push((event as CustomEvent).detail);
+    };
+    const handlePin = (event: Event) => {
+      pinEvents.push((event as CustomEvent).detail);
+    };
+
+    window.addEventListener('open-app', handleOpen as EventListener);
+    window.addEventListener('desktop-pin-app', handlePin as EventListener);
+
+    try {
+      const openButton = await screen.findByRole('button', { name: /open about alex/i });
+      const openNewButton = await screen.findByRole('button', {
+        name: /open new window for about alex/i,
+      });
+      const pinButton = await screen.findByRole('button', { name: /pin about alex/i });
+
+      await user.click(openButton);
+      await user.click(openNewButton);
+      await user.click(pinButton);
+
+      expect(openEvents).toEqual([
+        { id: 'about' },
+        { id: 'about', spawnNew: true },
+      ]);
+      expect(pinEvents).toEqual([{ id: 'about' }]);
+      expect(searchInput).toHaveFocus();
+      expect(dialog).toBeVisible();
+      expect(screen.getByPlaceholderText(/search/i)).toHaveValue('about');
+    } finally {
+      window.removeEventListener('open-app', handleOpen as EventListener);
+      window.removeEventListener('desktop-pin-app', handlePin as EventListener);
+    }
+  });
+});

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -89,6 +89,7 @@ export class Desktop extends Component {
         window.addEventListener('trash-change', this.updateTrashIcon);
         document.addEventListener('keydown', this.handleGlobalShortcut);
         window.addEventListener('open-app', this.handleOpenAppEvent);
+        window.addEventListener('desktop-pin-app', this.handlePinAppEvent);
     }
 
     componentWillUnmount() {
@@ -96,6 +97,7 @@ export class Desktop extends Component {
         document.removeEventListener('keydown', this.handleGlobalShortcut);
         window.removeEventListener('trash-change', this.updateTrashIcon);
         window.removeEventListener('open-app', this.handleOpenAppEvent);
+        window.removeEventListener('desktop-pin-app', this.handlePinAppEvent);
     }
 
     checkForNewFolders = () => {
@@ -576,11 +578,36 @@ export class Desktop extends Component {
         return result;
     }
 
-    handleOpenAppEvent = (e) => {
-        const id = e.detail;
-        if (id) {
+    handleOpenAppEvent = async (e) => {
+        const detail = e.detail;
+        if (!detail) return;
+        if (typeof detail === 'string') {
+            this.openApp(detail);
+            return;
+        }
+        const { id, spawnNew } = detail;
+        if (!id) return;
+        if (spawnNew) {
+            await this.openNewWindow(id);
+        } else {
             this.openApp(id);
         }
+    }
+
+    handlePinAppEvent = (e) => {
+        const detail = e.detail;
+        if (!detail) return;
+        const id = typeof detail === 'string' ? detail : detail.id;
+        if (id) {
+            this.pinApp(id);
+        }
+    }
+
+    openNewWindow = async (id) => {
+        if (this.state.closed_windows[id] === false) {
+            await this.closeApp(id);
+        }
+        this.openApp(id);
     }
 
     openApp = (objId) => {


### PR DESCRIPTION
## Summary
- add quick action buttons to the Whisker menu search overlay while keeping focus on the search input after use
- wire desktop listeners for the new quick actions so pinning and spawning windows respond to overlay events
- cover the search overlay quick actions with a React Testing Library spec to confirm event dispatch and overlay persistence

## Testing
- yarn lint *(fails: existing jsx-a11y label violations across legacy apps and public demos)*
- yarn test WhiskerMenu

------
https://chatgpt.com/codex/tasks/task_e_68cce5e05bb083288dd1a993a398e900