### PR TITLE
[launcher] improve usage ranking

### DIFF
--- a/__tests__/appUsage.test.ts
+++ b/__tests__/appUsage.test.ts
@@ -1,0 +1,57 @@
+import { AppUsageMap, rankApps } from '../utils/appUsage';
+
+type TestApp = {
+  id: string;
+  title: string;
+};
+
+describe('rankApps', () => {
+  const apps: TestApp[] = [
+    { id: 'fresh', title: 'Fresh App' },
+    { id: 'stale', title: 'Stale App' },
+    { id: 'never', title: 'Never Used' },
+  ];
+
+  it('prefers recently opened apps when older usage decays', () => {
+    const now = 1_700_000_000_000;
+    const usage: AppUsageMap = {
+      fresh: { count: 2, lastOpened: now - 1_000 },
+      stale: { count: 10, lastOpened: now - 14 * 24 * 60 * 60 * 1000 },
+    };
+
+    const result = rankApps(apps, '', usage, now).map((app) => app.id);
+
+    expect(result).toEqual(['fresh', 'stale', 'never']);
+  });
+
+  it('prioritizes exact title matches over higher usage', () => {
+    const now = 1_700_000_000_000;
+    const usage: AppUsageMap = {
+      termite: { count: 50, lastOpened: now - 500 },
+    };
+    const searchApps: TestApp[] = [
+      { id: 'terminal', title: 'Terminal' },
+      { id: 'termite', title: 'Termite Analyzer' },
+    ];
+
+    const result = rankApps(searchApps, 'Terminal', usage, now).map((app) => app.id);
+
+    expect(result[0]).toBe('terminal');
+  });
+
+  it('boosts higher frequency apps for partial matches when recency is similar', () => {
+    const now = 1_700_000_000_000;
+    const usage: AppUsageMap = {
+      nmap: { count: 6, lastOpened: now - 5_000 },
+      notes: { count: 1, lastOpened: now - 4_000 },
+    };
+    const searchApps: TestApp[] = [
+      { id: 'nmap', title: 'Nmap Scanner' },
+      { id: 'notes', title: 'Notes' },
+    ];
+
+    const result = rankApps(searchApps, 'n', usage, now).map((app) => app.id);
+
+    expect(result[0]).toBe('nmap');
+  });
+});

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -22,6 +22,7 @@ import TaskbarMenu from '../context-menus/taskbar-menu';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { recordAppUsage } from '../../utils/appUsage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
 
 export class Desktop extends Component {
@@ -598,6 +599,7 @@ export class Desktop extends Component {
         if (this.state.closed_windows[objId] === false) {
             // if it's minimised, restore its last position
             if (this.state.minimized_windows[objId]) {
+                recordAppUsage(objId);
                 this.focus(objId);
                 var r = document.querySelector("#" + objId);
                 r.style.transform = `translate(${r.style.getPropertyValue("--window-transform-x")},${r.style.getPropertyValue("--window-transform-y")}) scale(1)`;
@@ -612,37 +614,7 @@ export class Desktop extends Component {
         } else {
             let closed_windows = this.state.closed_windows;
             let favourite_apps = this.state.favourite_apps;
-            let frequentApps = [];
-            try { frequentApps = JSON.parse(safeLocalStorage?.getItem('frequentApps') || '[]'); } catch (e) { frequentApps = []; }
-            var currentApp = frequentApps.find(app => app.id === objId);
-            if (currentApp) {
-                frequentApps.forEach((app) => {
-                    if (app.id === currentApp.id) {
-                        app.frequency += 1; // increase the frequency if app is found 
-                    }
-                });
-            } else {
-                frequentApps.push({ id: objId, frequency: 1 }); // new app opened
-            }
-
-            frequentApps.sort((a, b) => {
-                if (a.frequency < b.frequency) {
-                    return 1;
-                }
-                if (a.frequency > b.frequency) {
-                    return -1;
-                }
-                return 0; // sort according to decreasing frequencies
-            });
-
-            safeLocalStorage?.setItem('frequentApps', JSON.stringify(frequentApps));
-
-            let recentApps = [];
-            try { recentApps = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]'); } catch (e) { recentApps = []; }
-            recentApps = recentApps.filter(id => id !== objId);
-            recentApps.unshift(objId);
-            recentApps = recentApps.slice(0, 10);
-            safeLocalStorage?.setItem('recentApps', JSON.stringify(recentApps));
+            recordAppUsage(objId);
 
             setTimeout(() => {
                 favourite_apps[objId] = true; // adds opened app to sideBar

--- a/hooks/useAppUsage.ts
+++ b/hooks/useAppUsage.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  APP_USAGE_STORAGE_KEY,
+  APP_USAGE_UPDATED_EVENT,
+  AppUsageEventDetail,
+  AppUsageMap,
+  AppUsageRecord,
+  readAppUsage,
+} from '../utils/appUsage';
+
+const defaultRecord: AppUsageRecord = { count: 0, lastOpened: 0 };
+
+export const useAppUsage = () => {
+  const [usage, setUsage] = useState<AppUsageMap>(() => readAppUsage());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key && event.key !== APP_USAGE_STORAGE_KEY) {
+        return;
+      }
+      setUsage(readAppUsage());
+    };
+
+    const handleUsageUpdate = (event: Event) => {
+      const { detail } = event as CustomEvent<AppUsageEventDetail | undefined>;
+      if (detail && detail.id) {
+        setUsage((prev) => ({ ...prev, [detail.id]: detail.usage }));
+      } else {
+        setUsage(readAppUsage());
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+    window.addEventListener(APP_USAGE_UPDATED_EVENT, handleUsageUpdate as EventListener);
+
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+      window.removeEventListener(APP_USAGE_UPDATED_EVENT, handleUsageUpdate as EventListener);
+    };
+  }, []);
+
+  const getUsageFor = useCallback(
+    (id: string): AppUsageRecord => usage[id] ?? { ...defaultRecord },
+    [usage],
+  );
+
+  const refreshUsage = useCallback(() => {
+    setUsage(readAppUsage());
+  }, []);
+
+  return { usage, getUsageFor, refreshUsage };
+};
+
+export type UseAppUsageReturn = ReturnType<typeof useAppUsage>;

--- a/utils/appUsage.ts
+++ b/utils/appUsage.ts
@@ -1,0 +1,163 @@
+import { safeLocalStorage } from './safeStorage';
+
+export const APP_USAGE_STORAGE_KEY = 'appUsage';
+export const APP_USAGE_UPDATED_EVENT = 'app-usage-updated';
+
+export type AppUsageRecord = {
+  count: number;
+  lastOpened: number;
+};
+
+export type AppUsageMap = Record<string, AppUsageRecord>;
+
+const sanitizeRecord = (value: unknown): AppUsageRecord | undefined => {
+  if (!value || typeof value !== 'object') return undefined;
+  const count = Number((value as { count?: unknown }).count);
+  const lastOpened = Number((value as { lastOpened?: unknown }).lastOpened);
+  if (!Number.isFinite(count) || !Number.isFinite(lastOpened)) return undefined;
+  if (count < 0) return undefined;
+  if (lastOpened < 0) return undefined;
+  return {
+    count: Math.floor(count),
+    lastOpened,
+  };
+};
+
+export const readAppUsage = (): AppUsageMap => {
+  if (!safeLocalStorage) return {};
+  const raw = safeLocalStorage.getItem(APP_USAGE_STORAGE_KEY);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown> | null;
+    if (!parsed || typeof parsed !== 'object') return {};
+    const result: AppUsageMap = {};
+    Object.entries(parsed).forEach(([id, value]) => {
+      const record = sanitizeRecord(value);
+      if (record) {
+        result[id] = record;
+      }
+    });
+    return result;
+  } catch {
+    return {};
+  }
+};
+
+export const writeAppUsage = (usage: AppUsageMap): void => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(APP_USAGE_STORAGE_KEY, JSON.stringify(usage));
+  } catch {
+    // ignore storage errors
+  }
+};
+
+export const recordAppUsage = (appId: string, now: number = Date.now()): AppUsageRecord | undefined => {
+  if (!appId) return undefined;
+  const usage = readAppUsage();
+  const current = usage[appId];
+  const count = current ? Math.max(0, current.count) : 0;
+  const updated: AppUsageRecord = {
+    count: count + 1,
+    lastOpened: now,
+  };
+  usage[appId] = updated;
+  writeAppUsage(usage);
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    const event = new CustomEvent(APP_USAGE_UPDATED_EVENT, { detail: { id: appId, usage: updated } });
+    window.dispatchEvent(event);
+  }
+  return updated;
+};
+
+const DEFAULT_DECAY_MS = 1000 * 60 * 60 * 24 * 7; // one week
+
+export const computeUsageScore = (
+  record: AppUsageRecord | undefined,
+  now: number = Date.now(),
+  decayMs: number = DEFAULT_DECAY_MS,
+): number => {
+  if (!record) return 0;
+  if (!record.count || record.count <= 0) return 0;
+  if (!record.lastOpened || record.lastOpened <= 0) return 0;
+  const age = Math.max(0, now - record.lastOpened);
+  const normalizedDecay = decayMs > 0 ? decayMs : DEFAULT_DECAY_MS;
+  const decay = Math.exp(-age / normalizedDecay);
+  return Math.log1p(record.count) * decay;
+};
+
+export type RankableApp = {
+  id: string;
+  title: string;
+};
+
+type RankedApp = {
+  app: RankableApp;
+  score: number;
+  exactMatch: boolean;
+  lastOpened: number;
+};
+
+const normalize = (value: string): string => value.toLowerCase();
+
+export const rankApps = (
+  apps: RankableApp[],
+  query: string,
+  usage: AppUsageMap,
+  now: number = Date.now(),
+): RankableApp[] => {
+  const normalizedQuery = query.trim().toLowerCase();
+  const baseList = !normalizedQuery
+    ? [...apps]
+    : apps.filter((app) => {
+        const title = normalize(app.title);
+        const id = normalize(app.id);
+        return title.includes(normalizedQuery) || id.includes(normalizedQuery);
+      });
+
+  const ranked: RankedApp[] = baseList.map((app) => {
+    const titleLower = normalize(app.title);
+    const idLower = normalize(app.id);
+    const record = usage[app.id];
+    const usageScore = computeUsageScore(record, now);
+    let textScore = 0;
+    let exactMatch = false;
+    if (normalizedQuery) {
+      if (titleLower === normalizedQuery || idLower === normalizedQuery) {
+        textScore = 1000;
+        exactMatch = true;
+      } else if (titleLower.startsWith(normalizedQuery) || idLower.startsWith(normalizedQuery)) {
+        textScore = 100;
+      } else {
+        textScore = 10;
+      }
+    }
+    const score = textScore + usageScore;
+    return {
+      app,
+      score,
+      exactMatch,
+      lastOpened: record?.lastOpened ?? 0,
+    };
+  });
+
+  ranked.sort((a, b) => {
+    if (a.exactMatch !== b.exactMatch) {
+      return a.exactMatch ? -1 : 1;
+    }
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    if (b.lastOpened !== a.lastOpened) {
+      return b.lastOpened - a.lastOpened;
+    }
+    return a.app.title.localeCompare(b.app.title);
+  });
+
+  return ranked.map((entry) => entry.app);
+};
+
+export type AppUsageEventDetail = {
+  id: string;
+  usage: AppUsageRecord;
+};


### PR DESCRIPTION
## Summary
- record app usage counts and timestamps when desktop windows open
- expose a useAppUsage hook and rank WhiskerMenu results with decay-weighted history
- cover ranking scenarios with new unit tests

## Testing
- yarn lint *(fails: pre-existing accessibility and no-top-level-window violations across apps)*
- yarn test *(fails: existing suites such as nmapNse and jsdom localStorage assumptions)*

------
https://chatgpt.com/codex/tasks/task_e_68cce5e178148328a07ea71702a7555e