### PR TITLE
[search] add launcher synonym index

### DIFF
--- a/__tests__/searchSynonyms.test.ts
+++ b/__tests__/searchSynonyms.test.ts
@@ -1,0 +1,38 @@
+import { renderHook } from '@testing-library/react';
+import { useSearchIndex } from '../hooks/useSearchIndex';
+
+describe('useSearchIndex', () => {
+  const apps = [
+    { id: 'terminal', title: 'Terminal', icon: '' },
+    { id: 'wireshark', title: 'Wireshark', icon: '' },
+    { id: 'dsniff', title: 'dsniff', icon: '' },
+    { id: 'john', title: 'John the Ripper', icon: '' },
+    { id: 'hashcat', title: 'Hashcat', icon: '' },
+    { id: 'hydra', title: 'Hydra', icon: '' },
+  ];
+
+  it('matches apps by title substring', () => {
+    const { result } = renderHook(() => useSearchIndex(apps));
+    expect(result.current.search('term').map((app) => app.id)).toEqual(['terminal']);
+  });
+
+  it('resolves a single alias to its app id', () => {
+    const { result } = renderHook(() => useSearchIndex(apps));
+    expect(result.current.search('cmd').map((app) => app.id)).toEqual(['terminal']);
+  });
+
+  it('supports partial alias matches', () => {
+    const { result } = renderHook(() => useSearchIndex(apps));
+    expect(result.current.search('packet sniff').map((app) => app.id)).toEqual(['wireshark', 'dsniff']);
+  });
+
+  it('returns multiple apps for a shared alias', () => {
+    const { result } = renderHook(() => useSearchIndex(apps));
+    expect(result.current.search('password cracker').map((app) => app.id)).toEqual(['john', 'hashcat']);
+  });
+
+  it('filters to valid ids when synonyms reference unknown apps', () => {
+    const { result } = renderHook(() => useSearchIndex(apps.slice(0, 2)));
+    expect(result.current.search('password cracker')).toHaveLength(0);
+  });
+});

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { useSearchIndex } from '../../hooks/useSearchIndex';
 
 type AppMeta = {
   id: string;
@@ -40,6 +41,7 @@ const WhiskerMenu: React.FC = () => {
   }, [allApps, open]);
   const utilityApps: AppMeta[] = utilities as any;
   const gameApps: AppMeta[] = games as any;
+  const { search } = useSearchIndex(allApps);
 
   const currentApps = useMemo(() => {
     let list: AppMeta[];
@@ -59,12 +61,13 @@ const WhiskerMenu: React.FC = () => {
       default:
         list = allApps;
     }
-    if (query) {
-      const q = query.toLowerCase();
-      list = list.filter(a => a.title.toLowerCase().includes(q));
+    const trimmedQuery = query.trim();
+    if (trimmedQuery) {
+      const matchIds = new Set(search(trimmedQuery).map(app => app.id));
+      list = list.filter(a => matchIds.has(a.id));
     }
     return list;
-  }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
+  }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps, search]);
 
   useEffect(() => {
     if (!open) return;

--- a/data/search-synonyms.json
+++ b/data/search-synonyms.json
@@ -1,0 +1,9 @@
+{
+  "cmd": "terminal",
+  "command prompt": "terminal",
+  "terminal emulator": "terminal",
+  "packet capture": ["wireshark"],
+  "packet sniffer": ["wireshark", "dsniff"],
+  "password cracker": ["john", "hashcat"],
+  "credential brute force": "hydra"
+}

--- a/docs/new-app-checklist.md
+++ b/docs/new-app-checklist.md
@@ -35,3 +35,10 @@ test('My App launches', async ({ page }) => {
   await expect(page.locator('[data-testid="my-app"]')).toBeVisible();
 });
 ```
+
+## Launcher search index
+
+- Add any common aliases for the app to `data/search-synonyms.json`. Each key should be the alias text and the value either a
+  single app id or an array of ids that should appear for that alias.
+- Keep aliases in lowercase for readability; the search hook normalizes casing at runtime.
+- Run `yarn test searchSynonyms` to confirm the Whisker Menu resolves the new aliases.

--- a/hooks/useSearchIndex.ts
+++ b/hooks/useSearchIndex.ts
@@ -1,0 +1,64 @@
+import { useCallback, useMemo } from 'react';
+import synonymsData from '../data/search-synonyms.json';
+
+type SearchSynonymConfig = Record<string, string | string[]>;
+
+type SearchableApp = {
+  id: string;
+  title: string;
+};
+
+type SearchIndex = Map<string, string[]>;
+
+const normalizeSynonyms = (apps: SearchableApp[]): SearchIndex => {
+  const validIds = new Set(apps.map((app) => app.id));
+  const aliasMap: SearchIndex = new Map();
+  const config = synonymsData as SearchSynonymConfig;
+
+  Object.entries(config).forEach(([alias, target]) => {
+    const key = alias.trim().toLowerCase();
+    if (!key) {
+      return;
+    }
+    const ids = Array.isArray(target) ? target : [target];
+    const unique = Array.from(new Set(ids.filter((id) => validIds.has(id))));
+    if (unique.length > 0) {
+      aliasMap.set(key, unique);
+    }
+  });
+
+  return aliasMap;
+};
+
+export const useSearchIndex = <T extends SearchableApp>(apps: T[]) => {
+  const aliasIndex = useMemo(() => normalizeSynonyms(apps), [apps]);
+
+  const search = useCallback(
+    (term: string): T[] => {
+      const normalized = term.trim().toLowerCase();
+      if (!normalized) {
+        return apps;
+      }
+
+      const matchedIds = new Set<string>();
+
+      aliasIndex.forEach((ids, alias) => {
+        if (alias.includes(normalized)) {
+          ids.forEach((id) => matchedIds.add(id));
+        }
+      });
+
+      return apps.filter((app) => {
+        if (matchedIds.has(app.id)) {
+          return true;
+        }
+        return app.title.toLowerCase().includes(normalized);
+      });
+    },
+    [aliasIndex, apps]
+  );
+
+  return { search };
+};
+
+export default useSearchIndex;


### PR DESCRIPTION
## Summary
- add a maintained data/search-synonyms.json map for launcher aliases
- expose a reusable useSearchIndex hook and wire it into the WhiskerMenu
- document the update flow and cover the alias resolution behaviour with tests

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window warnings in unrelated files)*
- yarn test searchSynonyms.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cce5e20b3483288f7a505657f8d395