### PR TITLE
[onboarding] add first run desktop tour

### DIFF
--- a/__tests__/firstRunTour.test.tsx
+++ b/__tests__/firstRunTour.test.tsx
@@ -1,0 +1,134 @@
+import { renderHook, act, waitFor, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import FirstRunTour from '../components/onboarding/FirstRunTour';
+import useFirstRunTour, { FIRST_RUN_TOUR_STORAGE_KEY } from '../hooks/useFirstRunTour';
+import { SettingsProvider } from '../hooks/useSettings';
+import { safeLocalStorage } from '../utils/safeStorage';
+
+jest.mock('../hooks/useSettings', () => {
+  const React = require('react');
+  let reducedMotion = false;
+  const setMockReducedMotion = (value: boolean) => {
+    reducedMotion = value;
+  };
+  const useSettings = () => ({ reducedMotion });
+  const SettingsProvider = ({ children }: { children: ReactNode }) =>
+    React.createElement(React.Fragment, null, children);
+  return {
+    __esModule: true,
+    useSettings,
+    SettingsProvider,
+    setMockReducedMotion,
+  };
+});
+
+jest.mock('../utils/safeStorage', () => {
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+  };
+  return {
+    safeLocalStorage: storage,
+  };
+});
+
+const { setMockReducedMotion } = jest.requireMock('../hooks/useSettings') as {
+  setMockReducedMotion: (value: boolean) => void;
+};
+
+const getMockStorage = () => {
+  if (!safeLocalStorage) {
+    throw new Error('safeLocalStorage mock not initialised');
+  }
+  return safeLocalStorage;
+};
+
+const installMockLocalStorage = () => {
+  const storage = getMockStorage();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    get: () => storage,
+  });
+  return storage;
+};
+
+describe('useFirstRunTour', () => {
+  beforeEach(() => {
+    setMockReducedMotion(false);
+    installMockLocalStorage().clear();
+  });
+
+  it('persists completion state', async () => {
+    const { result } = renderHook(() => useFirstRunTour(), {
+      wrapper: SettingsProvider,
+    });
+
+    expect(result.current.shouldShow).toBe(true);
+
+    act(() => {
+      result.current.complete();
+    });
+
+    await waitFor(() =>
+      expect(getMockStorage().getItem(FIRST_RUN_TOUR_STORAGE_KEY)).toBe('completed'),
+    );
+    expect(result.current.shouldShow).toBe(false);
+  });
+
+  it('honors reduced motion preference', async () => {
+    setMockReducedMotion(true);
+
+    const { result } = renderHook(() => useFirstRunTour(), {
+      wrapper: SettingsProvider,
+    });
+
+    expect(result.current.shouldShow).toBe(false);
+    expect(result.current.status).toBe('pending');
+  });
+});
+
+describe('FirstRunTour overlay', () => {
+  beforeEach(() => {
+    setMockReducedMotion(false);
+    installMockLocalStorage().clear();
+  });
+
+  it('does not steal focus when it appears', async () => {
+    function Wrapper({ ready }: { ready: boolean }) {
+      return (
+        <SettingsProvider>
+          <div>
+            <button data-testid="focus-anchor">Open apps</button>
+            <FirstRunTour desktopReady={ready} />
+          </div>
+        </SettingsProvider>
+      );
+    }
+
+    const { rerender } = render(<Wrapper ready={false} />);
+
+    const anchor = screen.getByTestId('focus-anchor');
+    act(() => {
+      anchor.focus();
+    });
+    expect(document.activeElement).toBe(anchor);
+
+    rerender(<Wrapper ready />);
+
+    await screen.findByTestId('first-run-tour');
+    expect(document.activeElement).toBe(anchor);
+    expect(screen.getByRole('button', { name: /skip tour/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /done/i })).toBeInTheDocument();
+  });
+});

--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -1,6 +1,7 @@
 import React, { act } from 'react';
 import { render, screen } from '@testing-library/react';
 import Ubuntu from '../components/ubuntu';
+import { SettingsProvider } from '../hooks/useSettings';
 
 jest.mock('../components/screen/desktop', () => function DesktopMock() {
   return <div data-testid="desktop" />;
@@ -24,7 +25,11 @@ describe('Ubuntu component', () => {
   });
 
   it('renders boot screen then desktop', () => {
-    render(<Ubuntu />);
+    render(
+      <SettingsProvider>
+        <Ubuntu />
+      </SettingsProvider>,
+    );
     const bootLogo = screen.getByAltText('Ubuntu Logo');
     const bootScreen = bootLogo.parentElement as HTMLElement;
     expect(bootScreen).toHaveClass('visible');
@@ -39,7 +44,11 @@ describe('Ubuntu component', () => {
 
   it('handles lockScreen when status bar is missing', () => {
     let instance: Ubuntu | null = null;
-    render(<Ubuntu ref={(c) => (instance = c)} />);
+    render(
+      <SettingsProvider>
+        <Ubuntu ref={(c) => (instance = c)} />
+      </SettingsProvider>,
+    );
     expect(instance).not.toBeNull();
     act(() => {
       instance!.lockScreen();
@@ -50,7 +59,11 @@ describe('Ubuntu component', () => {
 
   it('handles shutDown when status bar is missing', () => {
     let instance: Ubuntu | null = null;
-    render(<Ubuntu ref={(c) => (instance = c)} />);
+    render(
+      <SettingsProvider>
+        <Ubuntu ref={(c) => (instance = c)} />
+      </SettingsProvider>,
+    );
     expect(instance).not.toBeNull();
     act(() => {
       instance!.shutDown();

--- a/components/onboarding/FirstRunTour.tsx
+++ b/components/onboarding/FirstRunTour.tsx
@@ -1,0 +1,79 @@
+import { useId } from 'react';
+import useFirstRunTour from '../../hooks/useFirstRunTour';
+
+interface FirstRunTourProps {
+  desktopReady: boolean;
+  disabled?: boolean;
+}
+
+const TOUR_STEPS = [
+  {
+    title: 'Explore the dock',
+    description:
+      'Launch favourite tools with a single click or right-click to pin new apps for quick access.',
+  },
+  {
+    title: 'Browse the app grid',
+    description:
+      'Open the Whisker menu or press the super key to search across games, simulators, and utilities.',
+  },
+  {
+    title: 'Arrange your workspace',
+    description:
+      'Drag windows, snap them to edges, or cycle with Alt+Tab to manage multiple tasks at once.',
+  },
+];
+
+export default function FirstRunTour({ desktopReady, disabled = false }: FirstRunTourProps) {
+  const { shouldShow, complete, skip } = useFirstRunTour();
+  const descriptionId = useId();
+  const titleId = useId();
+
+  if (!desktopReady || disabled || !shouldShow) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="first-run-tour"
+      className="pointer-events-auto fixed inset-0 z-40 flex items-center justify-center bg-black/70 p-4 text-white"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+    >
+      <div className="w-full max-w-xl rounded-lg border border-ub-border-orange bg-slate-900/95 p-6 shadow-2xl backdrop-blur">
+        <h2 id={titleId} className="text-2xl font-semibold">
+          Welcome aboard
+        </h2>
+        <p id={descriptionId} className="mt-2 text-sm text-slate-200">
+          This quick tour highlights the essentials of the Kali Linux desktop simulation so you can start exploring right away.
+        </p>
+        <ul className="mt-4 space-y-3 text-sm text-slate-200">
+          {TOUR_STEPS.map((step) => (
+            <li key={step.title} className="rounded bg-white/5 p-3">
+              <p className="font-medium text-white">{step.title}</p>
+              <p className="mt-1 text-slate-200">{step.description}</p>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-6 flex flex-col gap-2 text-sm sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={skip}
+            className="rounded border border-transparent px-4 py-2 text-slate-300 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+          >
+            Skip tour
+          </button>
+          <button
+            type="button"
+            onClick={complete}
+            className="rounded bg-ub-orange px-4 py-2 font-medium text-black transition hover:bg-ub-border-orange focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -7,6 +7,7 @@ import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
+import FirstRunTour from './onboarding/FirstRunTour';
 
 export default class Ubuntu extends Component {
 	constructor() {
@@ -113,22 +114,26 @@ export default class Ubuntu extends Component {
                 safeLocalStorage?.setItem('shut-down', false);
 	};
 
-	render() {
-		return (
-			<div className="w-screen h-screen overflow-hidden" id="monitor-screen">
-				<LockScreen
-					isLocked={this.state.screen_locked}
-					bgImgName={this.state.bg_image_name}
-					unLockScreen={this.unLockScreen}
-				/>
-				<BootingScreen
-					visible={this.state.booting_screen}
-					isShutDown={this.state.shutDownScreen}
-					turnOn={this.turnOn}
-				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+        render() {
+                const desktopReady = !this.state.booting_screen && !this.state.shutDownScreen && !this.state.screen_locked;
+                const safeMode = process.env.NEXT_PUBLIC_SAFE_MODE === 'true';
+
+                return (
+                        <div className="w-screen h-screen overflow-hidden" id="monitor-screen">
+                                <LockScreen
+                                        isLocked={this.state.screen_locked}
+                                        bgImgName={this.state.bg_image_name}
+                                        unLockScreen={this.unLockScreen}
+                                />
+                                <BootingScreen
+                                        visible={this.state.booting_screen}
+                                        isShutDown={this.state.shutDownScreen}
+                                        turnOn={this.turnOn}
+                                />
+                                <Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
+                                <Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
+                                {!safeMode && <FirstRunTour desktopReady={desktopReady} />}
+                        </div>
+                );
+        }
 }

--- a/hooks/useFirstRunTour.ts
+++ b/hooks/useFirstRunTour.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { safeLocalStorage } from '../utils/safeStorage';
+import { useSettings } from './useSettings';
+
+export const FIRST_RUN_TOUR_STORAGE_KEY = 'first-run-tour-status';
+
+type StoredStatus = 'completed' | 'skipped';
+export type FirstRunTourStatus = StoredStatus | 'pending';
+
+const isStoredStatus = (value: unknown): value is StoredStatus =>
+  value === 'completed' || value === 'skipped';
+
+const readStoredStatus = (): StoredStatus | null => {
+  try {
+    const stored = safeLocalStorage?.getItem(FIRST_RUN_TOUR_STORAGE_KEY);
+    return isStoredStatus(stored) ? stored : null;
+  } catch (error) {
+    console.warn('Unable to read first run tour status', error);
+    return null;
+  }
+};
+
+export default function useFirstRunTour() {
+  const { reducedMotion } = useSettings();
+  const [status, setStatus] = useState<StoredStatus | null>(() => readStoredStatus());
+
+  useEffect(() => {
+    try {
+      if (!safeLocalStorage) return;
+      if (status) {
+        safeLocalStorage.setItem(FIRST_RUN_TOUR_STORAGE_KEY, status);
+      } else {
+        safeLocalStorage.removeItem(FIRST_RUN_TOUR_STORAGE_KEY);
+      }
+    } catch (error) {
+      console.warn('Unable to persist first run tour status', error);
+    }
+  }, [status]);
+
+  const complete = useCallback(() => {
+    setStatus('completed');
+  }, []);
+
+  const skip = useCallback(() => {
+    setStatus('skipped');
+  }, []);
+
+  const reset = useCallback(() => {
+    setStatus(null);
+  }, []);
+
+  const shouldShow = useMemo(() => !status && !reducedMotion, [status, reducedMotion]);
+
+  return {
+    status: (status ?? 'pending') as FirstRunTourStatus,
+    shouldShow,
+    complete,
+    skip,
+    reset,
+  };
+}


### PR DESCRIPTION
## Summary
- add a `useFirstRunTour` hook that persists tour completion with safeLocalStorage and respects reduced motion
- render a desktop-wide `FirstRunTour` overlay once boot completes (skipped in safe mode) with skip/done controls
- cover persistence and focus behaviour with dedicated tests and wrap Ubuntu tests in the settings provider

## Testing
- yarn lint *(fails: existing accessibility violations in unrelated apps)*
- yarn test firstRunTour.test.tsx ubuntu.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cce5eee6f483289ac00692c1bb6b70