### PR TITLE
[diagnostics] add network diagnostics sampler

### DIFF
--- a/__tests__/diagnosticsNetworkTest.test.tsx
+++ b/__tests__/diagnosticsNetworkTest.test.tsx
@@ -1,0 +1,83 @@
+import { act, render } from '@testing-library/react';
+import NetworkTest from '../components/apps/diagnostics/NetworkTest';
+
+describe('NetworkTest visibility behaviour', () => {
+  let fetchSpy: jest.SpyInstance;
+  let hidden = false;
+  const originalHidden = Object.getOwnPropertyDescriptor(document, 'hidden');
+
+  const sampleResponse = {
+    seq: 0,
+    timestamp: new Date('2024-01-01T00:00:00Z').toISOString(),
+    downloadMbps: 120,
+    uploadMbps: 55,
+    latencyMs: 24,
+    jitterMs: 3,
+    packetLoss: 0.12,
+  };
+
+  const advanceTimers = async (ms: number) => {
+    await act(async () => {
+      jest.advanceTimersByTime(ms);
+      await Promise.resolve();
+    });
+  };
+
+  beforeEach(() => {
+    hidden = false;
+    jest.useFakeTimers();
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ...sampleResponse }),
+      } as Response),
+    );
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => hidden,
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    if (originalHidden) {
+      Object.defineProperty(document, 'hidden', originalHidden);
+    } else {
+      delete (document as any).hidden;
+    }
+  });
+
+  it('pauses sampling when hidden and resumes when visible', async () => {
+    const { unmount } = render(
+      <NetworkTest isRunning intervalMs={50} burstSize={1} />,
+    );
+
+    await advanceTimers(60);
+    expect(fetchSpy).toHaveBeenCalled();
+
+    fetchSpy.mockClear();
+
+    act(() => {
+      hidden = true;
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await advanceTimers(200);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      hidden = false;
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await advanceTimers(60);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -73,6 +73,7 @@ const ProjectGalleryApp = createDynamicApp('project-gallery', 'Project Gallery')
 const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
 const SubnetCalculatorApp = createDynamicApp('subnet-calculator', 'Subnet Calculator');
+const DiagnosticsApp = createDynamicApp('diagnostics', 'Diagnostics Toolbox');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
@@ -167,6 +168,7 @@ const displaySerialTerminal = createDisplay(SerialTerminalApp);
 const displayWeatherWidget = createDisplay(WeatherWidgetApp);
 const displayInputLab = createDisplay(InputLabApp);
 const displaySubnetCalculator = createDisplay(SubnetCalculatorApp);
+const displayDiagnostics = createDisplay(DiagnosticsApp);
 
 const displayGhidra = createDisplay(GhidraApp);
 
@@ -268,6 +270,15 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayInputLab,
+  },
+  {
+    id: 'diagnostics',
+    title: 'Diagnostics Toolbox',
+    icon: '/themes/Yaru/apps/radar-symbolic.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayDiagnostics,
   },
   {
     id: 'subnet-calculator',

--- a/components/apps/diagnostics/NetworkTest.tsx
+++ b/components/apps/diagnostics/NetworkTest.tsx
@@ -1,0 +1,396 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import StatsChart from '../../StatsChart';
+
+export interface NetworkSample {
+  seq: number;
+  timestamp: string;
+  downloadMbps: number;
+  uploadMbps: number;
+  latencyMs: number;
+  jitterMs: number;
+  packetLoss: number;
+}
+
+interface BurstSummary {
+  id: string;
+  startedAt: number;
+  durationMs: number;
+  timestamp: string;
+  sampleCount: number;
+  seqStart: number;
+  seqEnd: number;
+  downloadAvg: number;
+  uploadAvg: number;
+  latencyAvg: number;
+  jitterAvg: number;
+  packetLossAvg: number;
+  error?: string;
+}
+
+export interface NetworkTestProps {
+  endpoint?: string;
+  intervalMs?: number;
+  burstSize?: number;
+  isRunning: boolean;
+  resetSignal?: number;
+  onAutoPauseChange?: (autoPaused: boolean) => void;
+}
+
+const MAX_HISTORY = 8;
+
+const now = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+const toNumber = (value: unknown, fallback = 0) =>
+  typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+
+const normaliseSample = (payload: unknown, fallbackSeq: number): NetworkSample => {
+  if (payload && typeof payload === 'object') {
+    const maybeSamples = (payload as { samples?: unknown }).samples;
+    if (Array.isArray(maybeSamples) && maybeSamples.length > 0) {
+      return normaliseSample(maybeSamples[0], fallbackSeq);
+    }
+    const sample = payload as Partial<NetworkSample>;
+    return {
+      seq: toNumber(sample.seq, fallbackSeq),
+      timestamp:
+        typeof sample.timestamp === 'string'
+          ? sample.timestamp
+          : new Date(Date.now()).toISOString(),
+      downloadMbps: toNumber(sample.downloadMbps),
+      uploadMbps: toNumber(sample.uploadMbps),
+      latencyMs: toNumber(sample.latencyMs),
+      jitterMs: toNumber(sample.jitterMs),
+      packetLoss: toNumber(sample.packetLoss),
+    };
+  }
+  return {
+    seq: fallbackSeq,
+    timestamp: new Date(Date.now()).toISOString(),
+    downloadMbps: 0,
+    uploadMbps: 0,
+    latencyMs: 0,
+    jitterMs: 0,
+    packetLoss: 0,
+  };
+};
+
+const summariseBurst = (
+  samples: NetworkSample[],
+  startedAt: number,
+  endedAt: number,
+  counter: number,
+): BurstSummary => {
+  const sampleCount = samples.length;
+  const seqStart = sampleCount ? Math.min(...samples.map((s) => s.seq)) : 0;
+  const seqEnd = sampleCount ? Math.max(...samples.map((s) => s.seq)) : seqStart;
+  const timestamp =
+    sampleCount > 0 ? samples[sampleCount - 1].timestamp : new Date().toISOString();
+
+  const sums = samples.reduce(
+    (acc, sample) => {
+      acc.download += sample.downloadMbps;
+      acc.upload += sample.uploadMbps;
+      acc.latency += sample.latencyMs;
+      acc.jitter += sample.jitterMs;
+      acc.packetLoss += sample.packetLoss;
+      return acc;
+    },
+    { download: 0, upload: 0, latency: 0, jitter: 0, packetLoss: 0 },
+  );
+
+  const average = (value: number) => (sampleCount > 0 ? value / sampleCount : 0);
+
+  return {
+    id: `${counter}-${seqStart}-${seqEnd}-${startedAt.toFixed(2)}`,
+    startedAt,
+    durationMs: Math.max(0, endedAt - startedAt),
+    timestamp,
+    sampleCount,
+    seqStart,
+    seqEnd,
+    downloadAvg: average(sums.download),
+    uploadAvg: average(sums.upload),
+    latencyAvg: average(sums.latency),
+    jitterAvg: average(sums.jitter),
+    packetLossAvg: average(sums.packetLoss),
+  };
+};
+
+const NetworkTest: React.FC<NetworkTestProps> = ({
+  endpoint = '/api/network-sample',
+  intervalMs = 4000,
+  burstSize = 3,
+  isRunning,
+  resetSignal = 0,
+  onAutoPauseChange,
+}) => {
+  const [bursts, setBursts] = useState<BurstSummary[]>([]);
+  const [autoPaused, setAutoPaused] = useState<boolean>(
+    typeof document !== 'undefined' ? Boolean(document.hidden) : false,
+  );
+  const [lastError, setLastError] = useState<string | null>(null);
+  const [isSampling, setIsSampling] = useState(false);
+
+  const sequenceRef = useRef(0);
+  const burstCounterRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hiddenRef = useRef<boolean>(typeof document !== 'undefined' ? !!document.hidden : false);
+  const manualRunRef = useRef<boolean>(isRunning);
+  const samplingRef = useRef(false);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const pushBurst = useCallback((summary: BurstSummary) => {
+    setBursts((prev) => {
+      const next = [...prev, summary];
+      return next.length > MAX_HISTORY ? next.slice(next.length - MAX_HISTORY) : next;
+    });
+  }, []);
+
+  const runBurst = useCallback(async () => {
+    if (!manualRunRef.current || hiddenRef.current || samplingRef.current) return;
+    samplingRef.current = true;
+    setIsSampling(true);
+
+    const burstStart = now();
+    const startSeq = sequenceRef.current;
+    const requests = Array.from({ length: burstSize }, (_, idx) => {
+      const seq = startSeq + idx;
+      return fetch(`${endpoint}?seq=${seq}`, { cache: 'no-store' })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+          }
+          return response.json();
+        })
+        .then((payload) => normaliseSample(payload, seq));
+    });
+
+    sequenceRef.current += burstSize;
+
+    try {
+      const results = await Promise.all(requests);
+      const burstEnd = now();
+      const counter = burstCounterRef.current++;
+      pushBurst(summariseBurst(results, burstStart, burstEnd, counter));
+      setLastError(null);
+    } catch (error) {
+      const burstEnd = now();
+      const counter = burstCounterRef.current++;
+      pushBurst({
+        id: `${counter}-error-${startSeq}-${burstStart.toFixed(2)}`,
+        startedAt: burstStart,
+        durationMs: Math.max(0, burstEnd - burstStart),
+        timestamp: new Date().toISOString(),
+        sampleCount: 0,
+        seqStart: startSeq,
+        seqEnd: startSeq + burstSize - 1,
+        downloadAvg: 0,
+        uploadAvg: 0,
+        latencyAvg: 0,
+        jitterAvg: 0,
+        packetLossAvg: 0,
+        error: (error as Error).message || 'Request failed',
+      });
+      setLastError((error as Error).message || 'Request failed');
+    } finally {
+      samplingRef.current = false;
+      setIsSampling(false);
+    }
+
+    if (!manualRunRef.current || hiddenRef.current) return;
+
+    clearTimer();
+    timerRef.current = setTimeout(() => {
+      runBurst();
+    }, intervalMs);
+  }, [burstSize, clearTimer, endpoint, intervalMs, pushBurst]);
+
+  useEffect(() => {
+    manualRunRef.current = isRunning;
+    if (!isRunning) {
+      clearTimer();
+      return;
+    }
+    if (!hiddenRef.current) {
+      runBurst();
+    }
+  }, [clearTimer, isRunning, runBurst]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const handleVisibility = () => {
+      const hidden = Boolean(document.hidden);
+      hiddenRef.current = hidden;
+      setAutoPaused(hidden);
+      onAutoPauseChange?.(hidden);
+      if (hidden) {
+        clearTimer();
+      } else if (manualRunRef.current) {
+        runBurst();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    handleVisibility();
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [clearTimer, onAutoPauseChange, runBurst]);
+
+  useEffect(() => {
+    clearTimer();
+    samplingRef.current = false;
+    setIsSampling(false);
+    sequenceRef.current = 0;
+    burstCounterRef.current = 0;
+    setBursts([]);
+    setLastError(null);
+    if (manualRunRef.current && !hiddenRef.current) {
+      runBurst();
+    }
+  }, [clearTimer, resetSignal, runBurst]);
+
+  useEffect(() => () => {
+    manualRunRef.current = false;
+    clearTimer();
+  }, [clearTimer]);
+
+  const latestSuccessful = useMemo(() => {
+    for (let i = bursts.length - 1; i >= 0; i -= 1) {
+      const burst = bursts[i];
+      if (!burst.error && burst.sampleCount > 0) return burst;
+    }
+    return null;
+  }, [bursts]);
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-4 text-white" data-testid="network-test">
+      <section className="rounded border border-ubt-grey/60 bg-black/40 p-4 shadow-inner">
+        <div className="flex items-center justify-between gap-4">
+          <h2 className="text-lg font-semibold">Network burst sampler</h2>
+          <span
+            className={`text-xs uppercase tracking-wide ${
+              isSampling ? 'text-emerald-300' : 'text-ubt-grey'
+            }`}
+          >
+            {isSampling ? 'Sampling…' : 'Idle'}
+          </span>
+        </div>
+        <p className="mt-2 text-sm text-ubt-grey">
+          Fetching {burstSize} samples from{' '}
+          <code className="text-xs text-emerald-200">{endpoint}</code> every{' '}
+          {(intervalMs / 1000).toFixed(1)} seconds to emulate traffic bursts.
+        </p>
+        {!isRunning && (
+          <p className="mt-2 text-xs text-ubt-grey" role="status">
+            Sampling paused via controls.
+          </p>
+        )}
+        {autoPaused && (
+          <p className="mt-2 text-xs text-yellow-300" role="status">
+            Hidden tab detected — sampling suspended until focus returns.
+          </p>
+        )}
+        {lastError && (
+          <p className="mt-2 text-xs text-red-300" role="alert">
+            Last error: {lastError}
+          </p>
+        )}
+      </section>
+      <section className="grid gap-4 lg:grid-cols-2">
+        <div className="rounded border border-ubt-grey/60 bg-black/40 p-4">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-ubt-grey">
+            Throughput vs latency
+          </h3>
+          <div className="mt-2 h-24 w-full">
+            {latestSuccessful ? (
+              <StatsChart
+                count={Math.max(latestSuccessful.downloadAvg, 0)}
+                time={Math.max(latestSuccessful.latencyAvg, 0)}
+              />
+            ) : (
+              <div className="flex h-full items-center justify-center text-xs text-ubt-grey">
+                Waiting for successful samples…
+              </div>
+            )}
+          </div>
+          {latestSuccessful && (
+            <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs text-ubt-grey">
+              <div>
+                <dt className="font-medium text-white">Download</dt>
+                <dd>{latestSuccessful.downloadAvg.toFixed(1)} Mbps</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-white">Upload</dt>
+                <dd>{latestSuccessful.uploadAvg.toFixed(1)} Mbps</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-white">Latency</dt>
+                <dd>{latestSuccessful.latencyAvg.toFixed(1)} ms</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-white">Jitter</dt>
+                <dd>{latestSuccessful.jitterAvg.toFixed(2)} ms</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-white">Packet loss</dt>
+                <dd>{latestSuccessful.packetLossAvg.toFixed(3)}%</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-white">Samples</dt>
+                <dd>{latestSuccessful.sampleCount}</dd>
+              </div>
+            </dl>
+          )}
+        </div>
+        <div className="rounded border border-ubt-grey/60 bg-black/40 p-4">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-ubt-grey">
+            Recent bursts
+          </h3>
+          <ul className="mt-3 space-y-2 text-xs">
+            {bursts.length === 0 ? (
+              <li className="text-ubt-grey">No bursts sampled yet.</li>
+            ) : (
+              bursts
+                .slice()
+                .reverse()
+                .map((burst) => (
+                  <li
+                    key={burst.id}
+                    className="rounded border border-ubt-grey/40 bg-black/50 p-2"
+                  >
+                    <div className="flex items-center justify-between gap-2 text-ubt-grey">
+                      <span>
+                        Seq {burst.seqStart}–{burst.seqEnd}
+                      </span>
+                      <span>{new Date(burst.timestamp).toLocaleTimeString()}</span>
+                    </div>
+                    <div className="mt-1 grid grid-cols-2 gap-x-4 gap-y-1">
+                      <span>↓ {burst.downloadAvg.toFixed(1)} Mbps</span>
+                      <span>↑ {burst.uploadAvg.toFixed(1)} Mbps</span>
+                      <span>Latency {burst.latencyAvg.toFixed(1)} ms</span>
+                      <span>Jitter {burst.jitterAvg.toFixed(2)} ms</span>
+                    </div>
+                    <div className="mt-1 text-ubt-grey">
+                      Duration {burst.durationMs.toFixed(0)} ms · Packet loss{' '}
+                      {burst.packetLossAvg.toFixed(3)}%
+                    </div>
+                    {burst.error && (
+                      <p className="mt-1 text-red-300">Error: {burst.error}</p>
+                    )}
+                  </li>
+                ))
+            )}
+          </ul>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default NetworkTest;

--- a/components/apps/diagnostics/index.tsx
+++ b/components/apps/diagnostics/index.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import NetworkTest from './NetworkTest';
+
+interface DiagnosticsToolboxProps {
+  addFolder?: (...args: unknown[]) => void;
+  openApp?: (...args: unknown[]) => void;
+}
+
+const DiagnosticsToolbox: React.FC<DiagnosticsToolboxProps> = () => {
+  const [running, setRunning] = useState(true);
+  const [resetCounter, setResetCounter] = useState(0);
+  const [autoPaused, setAutoPaused] = useState(false);
+
+  const toggleRunning = useCallback(() => {
+    setRunning((prev) => !prev);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setResetCounter((prev) => prev + 1);
+    setRunning(true);
+  }, []);
+
+  return (
+    <div className="flex h-full w-full flex-col bg-ub-cool-grey text-white">
+      <header className="border-b border-ubt-grey/60 bg-black/30 p-4">
+        <h1 className="text-xl font-semibold">Diagnostics Toolbox</h1>
+        <p className="mt-1 text-sm text-ubt-grey">
+          Run synthetic network fetch bursts to observe simulated throughput and latency trends without
+          hitting real infrastructure.
+        </p>
+        {autoPaused && (
+          <p className="mt-2 text-xs text-yellow-300" role="status">
+            Sampling paused automatically while this tab is hidden.
+          </p>
+        )}
+      </header>
+      <div className="flex flex-wrap items-center gap-2 border-b border-ubt-grey/60 bg-black/20 px-4 py-3 text-sm">
+        <button
+          type="button"
+          onClick={toggleRunning}
+          aria-pressed={!running}
+          className="rounded bg-gray-700 px-3 py-1 font-medium transition hover:bg-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+        >
+          {running ? 'Pause' : 'Resume'}
+        </button>
+        <button
+          type="button"
+          onClick={handleReset}
+          className="rounded bg-red-700 px-3 py-1 font-medium transition hover:bg-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+        >
+          Reset
+        </button>
+        <span className="text-xs text-ubt-grey sm:text-sm">
+          Endpoint: <code className="text-emerald-200">/api/network-sample</code>
+        </span>
+      </div>
+      <div className="flex-1 overflow-auto">
+        <NetworkTest
+          isRunning={running}
+          resetSignal={resetCounter}
+          onAutoPauseChange={setAutoPaused}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default DiagnosticsToolbox;
+
+export const displayDiagnostics = (
+  addFolder?: (...args: unknown[]) => void,
+  openApp?: (...args: unknown[]) => void,
+) => <DiagnosticsToolbox addFolder={addFolder} openApp={openApp} />;

--- a/pages/api/network-sample.ts
+++ b/pages/api/network-sample.ts
@@ -1,0 +1,87 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface NetworkSample {
+  seq: number;
+  timestamp: string;
+  downloadMbps: number;
+  uploadMbps: number;
+  latencyMs: number;
+  jitterMs: number;
+  packetLoss: number;
+}
+
+type NetworkSampleResponse =
+  | NetworkSample
+  | { samples: NetworkSample[] }
+  | { error: string };
+
+const START_TIME = Date.UTC(2024, 0, 1, 0, 0, 0);
+
+const round = (value: number, precision = 2) => {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+};
+
+const toSample = (index: number): NetworkSample => {
+  const seq = Number.isFinite(index) ? index : 0;
+  const baseTime = START_TIME + Math.max(0, seq) * 15_000;
+  const wave = Math.sin(seq * 0.9);
+  const phase = Math.cos(seq * 0.6);
+
+  const download = 320 + wave * 45 + ((seq % 5) - 2) * 6;
+  const upload = 140 + phase * 20 + ((seq % 4) - 1.5) * 4;
+  const latency = 18 + Math.abs(Math.sin(seq * 0.4)) * 8 + (seq % 3) * 1.5;
+  const jitter = 2 + Math.abs(Math.cos(seq * 1.2)) * 3;
+  const loss = 0.05 + Math.abs(Math.sin(seq * 0.8)) * 0.25 + (seq % 12 === 0 ? 0.3 : 0);
+
+  return {
+    seq,
+    timestamp: new Date(baseTime).toISOString(),
+    downloadMbps: round(Math.max(download, 0)),
+    uploadMbps: round(Math.max(upload, 0)),
+    latencyMs: round(Math.max(latency, 0)),
+    jitterMs: round(Math.max(jitter, 0), 3),
+    packetLoss: round(Math.min(Math.max(loss, 0), 5), 3),
+  };
+};
+
+const parseNumber = (value: string | string[] | undefined, fallback: number) => {
+  if (Array.isArray(value)) {
+    const first = value[0];
+    const parsed = Number(first);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  return fallback;
+};
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<NetworkSampleResponse>,
+) {
+  if (req.method && req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const countParam = parseNumber(req.query.count, 1);
+  const startParam = parseNumber(req.query.start, 0);
+
+  res.setHeader('Cache-Control', 'no-store, max-age=0');
+
+  if (countParam > 1) {
+    const limit = Math.min(Math.max(Math.floor(countParam), 1), 20);
+    const start = Number.isFinite(startParam) ? startParam : 0;
+    const samples = Array.from({ length: limit }, (_, idx) => toSample(start + idx));
+    res.status(200).json({ samples });
+    return;
+  }
+
+  const seqParam = parseNumber(req.query.seq, startParam);
+  const sample = toSample(seqParam);
+  res.status(200).json(sample);
+}


### PR DESCRIPTION
## Summary
- add a deterministic `/api/network-sample` endpoint for simulated throughput payloads
- build a diagnostics toolbox with a network burst sampler UI and register it in the utilities catalog
- cover the sampler with a Jest test that verifies visibility-driven pause and resume behaviour

## Testing
- yarn lint *(fails: pre-existing jsx-a11y control labeling violations across legacy apps)*
- yarn test diagnosticsNetworkTest


------
https://chatgpt.com/codex/tasks/task_e_68cce5f1fd0c832888c7fde1782a1355