### PR TITLE
feat: add diagnostics self test

### DIFF
--- a/__tests__/selfTest.test.ts
+++ b/__tests__/selfTest.test.ts
@@ -1,0 +1,57 @@
+import { runSelfTest, type SelfTestResult } from '../lib/selfTest';
+
+describe('runSelfTest', () => {
+  it('returns a passing result with timing data', async () => {
+    let tick = 0;
+    const now = () => {
+      tick += 5;
+      return tick;
+    };
+    const openCatalog = jest.fn();
+    const launchApp = jest.fn();
+    const closeApp = jest.fn();
+
+    const result = await runSelfTest({
+      now,
+      candidateApps: ['calculator'],
+      openCatalog,
+      launchApp,
+      closeApp,
+    });
+
+    expect(openCatalog).toHaveBeenCalled();
+    expect(launchApp).toHaveBeenCalled();
+    expect(closeApp).toHaveBeenCalled();
+    expect(result.status).toBe('pass');
+    expect(result.steps).toHaveLength(4);
+    result.steps.forEach((step) => {
+      expect(step.status).toBe('pass');
+      expect(typeof step.durationMs).toBe('number');
+    });
+  });
+
+  it('skips heavy apps when safe mode is active', async () => {
+    let tick = 0;
+    const now = () => {
+      tick += 10;
+      return tick;
+    };
+    const launchApp = jest.fn();
+
+    const result: SelfTestResult = await runSelfTest({
+      safeMode: true,
+      now,
+      candidateApps: ['terminal', 'calculator'],
+      heavyApps: ['terminal'],
+      openCatalog: jest.fn(),
+      launchApp,
+      closeApp: jest.fn(),
+    });
+
+    expect(result.appId.toLowerCase()).toBe('calculator');
+    expect(launchApp).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.stringMatching(/calculator/i) }),
+    );
+    expect(result.status).toBe('pass');
+  });
+});

--- a/__tests__/settings-diagnostics.test.tsx
+++ b/__tests__/settings-diagnostics.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import DiagnosticsPanel from '../apps/settings/components/DiagnosticsPanel';
+import { runSelfTest } from '../lib/selfTest';
+
+jest.mock('../lib/selfTest');
+
+const mockRunSelfTest = runSelfTest as jest.MockedFunction<typeof runSelfTest>;
+
+describe('DiagnosticsPanel', () => {
+  beforeEach(() => {
+    mockRunSelfTest.mockReset();
+    window.localStorage.clear();
+  });
+
+  it('runs the self test and shows a passing result', async () => {
+    mockRunSelfTest.mockResolvedValue({
+      status: 'pass',
+      safeMode: false,
+      appId: 'calculator',
+      startedAt: 100,
+      finishedAt: 150,
+      totalDurationMs: 50,
+      steps: [
+        { id: 'open-launcher', label: 'Open launcher', status: 'pass', durationMs: 10 },
+        { id: 'select-app', label: 'Select test app', status: 'pass', durationMs: 12 },
+        { id: 'launch-app', label: 'Launch Calculator', status: 'pass', durationMs: 14 },
+        { id: 'close-app', label: 'Close app session', status: 'pass', durationMs: 8 },
+      ],
+    });
+
+    render(<DiagnosticsPanel />);
+
+    const button = screen.getByRole('button', { name: /run self test/i });
+    fireEvent.click(button);
+
+    expect(await screen.findByText(/self test passed/i)).toBeInTheDocument();
+
+    const trace = screen.getByRole('list', { name: /self test trace/i });
+    expect(trace).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem('diagnostics:self-test')).toContain('"status":"pass"');
+    });
+  });
+
+  it('shows failure details when the self test reports an error', async () => {
+    mockRunSelfTest.mockResolvedValue({
+      status: 'fail',
+      safeMode: true,
+      appId: 'terminal',
+      startedAt: 200,
+      finishedAt: 280,
+      totalDurationMs: 80,
+      error: 'Launch failed',
+      steps: [
+        { id: 'open-launcher', label: 'Open launcher', status: 'pass', durationMs: 12 },
+        {
+          id: 'launch-app',
+          label: 'Launch Terminal',
+          status: 'fail',
+          durationMs: 18,
+          detail: 'Timed out',
+        },
+      ],
+    });
+
+    render(<DiagnosticsPanel />);
+
+    fireEvent.click(screen.getByRole('button', { name: /run self test/i }));
+
+    expect(await screen.findByText(/self test failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Launch failed/i)).toBeInTheDocument();
+    const listItems = screen.getAllByRole('listitem');
+    const failureEntry = listItems.find((item) => {
+      const text = item.textContent ? item.textContent.replace(/\s+/g, ' ').trim() : '';
+      return text.includes('Launch Terminal') && text.includes('Fail');
+    });
+    expect(failureEntry).toBeTruthy();
+  });
+});

--- a/apps/settings/components/DiagnosticsPanel.tsx
+++ b/apps/settings/components/DiagnosticsPanel.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { runSelfTest, type SelfTestResult } from "../../../lib/selfTest";
+import { safeLocalStorage } from "../../../utils/safeStorage";
+
+const STORAGE_KEY = "diagnostics:self-test";
+
+const formatDuration = (ms: number) => `${Math.round(ms)}ms`;
+
+const formatTimestamp = (value: number) => {
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return "";
+  }
+};
+
+const isSelfTestResult = (value: unknown): value is SelfTestResult => {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as SelfTestResult;
+  return (
+    (candidate.status === "pass" || candidate.status === "fail") &&
+    Array.isArray(candidate.steps)
+  );
+};
+
+export default function DiagnosticsPanel() {
+  const [result, setResult] = useState<SelfTestResult | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!safeLocalStorage) return;
+    try {
+      const stored = safeLocalStorage.getItem(STORAGE_KEY);
+      if (!stored) return;
+      const parsed = JSON.parse(stored);
+      if (isSelfTestResult(parsed)) {
+        setResult(parsed);
+      }
+    } catch (error) {
+      console.warn("Failed to restore self test result", error);
+    }
+  }, []);
+
+  const persistResult = useCallback((value: SelfTestResult) => {
+    if (!safeLocalStorage) return;
+    try {
+      safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+    } catch (error) {
+      console.warn("Failed to persist self test result", error);
+    }
+  }, []);
+
+  const handleRun = useCallback(async () => {
+    setIsRunning(true);
+    setErrorMessage(null);
+    try {
+      const outcome = await runSelfTest();
+      setResult(outcome);
+      persistResult(outcome);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Self test failed";
+      setErrorMessage(message);
+    } finally {
+      setIsRunning(false);
+    }
+  }, [persistResult]);
+
+  const statusMessage = useMemo(() => {
+    if (isRunning) return "Running self test…";
+    if (!result) return "Self test has not been run yet.";
+    return result.status === "pass" ? "Self test passed" : "Self test failed";
+  }, [isRunning, result]);
+
+  return (
+    <section className="flex flex-col gap-4 p-4 text-ubt-grey">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handleRun}
+          className="px-4 py-2 rounded bg-ub-orange text-white disabled:opacity-60"
+          disabled={isRunning}
+        >
+          Run self test
+        </button>
+        <p role="status" aria-live="polite" className="text-sm">
+          {statusMessage}
+        </p>
+      </div>
+      {errorMessage && (
+        <p role="alert" className="text-sm text-red-400">
+          {errorMessage}
+        </p>
+      )}
+      {result && (
+        <div className="space-y-2">
+          <p className="text-sm">
+            Last run: {formatTimestamp(result.finishedAt) || "Unknown"} · Mode:{" "}
+            {result.safeMode ? "Safe" : "Standard"} · App: {result.appId || "unknown"}
+          </p>
+          {result.error && result.status === "fail" && (
+            <p className="text-sm text-red-300">{result.error}</p>
+          )}
+          <ol
+            className="list-decimal pl-5 space-y-1 text-sm"
+            aria-label="Self test trace"
+          >
+            {result.steps.map((step) => (
+              <li key={step.id}>
+                <span className="font-medium">{step.label}</span>: {step.status === "pass" ? "Pass" : "Fail"}
+                {` in ${formatDuration(step.durationMs)}`}
+                {step.detail ? ` – ${step.detail}` : ""}
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -10,6 +10,7 @@ import {
   importSettings as importSettingsData,
 } from "../../utils/settingsStore";
 import KeymapOverlay from "./components/KeymapOverlay";
+import DiagnosticsPanel from "./components/DiagnosticsPanel";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
 
@@ -38,6 +39,7 @@ export default function Settings() {
     { id: "appearance", label: "Appearance" },
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
+    { id: "diagnostics", label: "Diagnostics" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
@@ -288,6 +290,7 @@ export default function Settings() {
           </div>
         </>
       )}
+      {activeTab === "diagnostics" && <DiagnosticsPanel />}
         <input
           type="file"
           accept="application/json"

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -519,46 +519,42 @@ export class Window extends Component {
     }
 
     handleKeyDown = (e) => {
+        const prevent = () => {
+            if (typeof e.preventDefault === 'function') e.preventDefault();
+            if (typeof e.stopPropagation === 'function') e.stopPropagation();
+        };
         if (e.key === 'Escape') {
             this.closeWindow();
         } else if (e.key === 'Tab') {
             this.focusWindow();
         } else if (e.altKey) {
             if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.unsnapWindow();
             } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.snapWindow('left');
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.snapWindow('right');
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.snapWindow('top');
             }
             this.focusWindow();
         } else if (e.shiftKey) {
             const step = 1;
             if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
             }
             this.focusWindow();

--- a/lib/selfTest.ts
+++ b/lib/selfTest.ts
@@ -1,0 +1,290 @@
+import appsCatalog from '../apps.config';
+import { createLogger, type Logger } from './logger';
+import { safeLocalStorage } from '../utils/safeStorage';
+
+const DEFAULT_CANDIDATE_APPS = ['calculator', 'terminal', 'quote', 'figlet'];
+const DEFAULT_HEAVY_APPS = [
+  'terminal',
+  'metasploit',
+  'wireshark',
+  'hashcat',
+  'autopsy',
+  'radare2',
+  'volatility',
+  'openvas',
+  'mimikatz',
+  'screen-recorder',
+  'msf-post',
+  'nessus',
+  'reaver',
+  'recon-ng',
+  'john',
+];
+const SAFE_MODE_STORAGE_KEYS = ['desktop-safe-mode', 'safe-mode'];
+
+const TRUE_VALUES = new Set(['1', 'true', 'on', 'yes']);
+const FALSE_VALUES = new Set(['0', 'false', 'off', 'no']);
+
+interface AppDefinition {
+  id: string;
+  title: string;
+  disabled?: boolean;
+  screen?: (addFolder?: unknown, openApp?: unknown) => unknown;
+}
+
+export interface SelfTestStep {
+  id: string;
+  label: string;
+  status: 'pass' | 'fail';
+  durationMs: number;
+  detail?: string;
+}
+
+export interface SelfTestResult {
+  status: 'pass' | 'fail';
+  safeMode: boolean;
+  appId: string;
+  startedAt: number;
+  finishedAt: number;
+  totalDurationMs: number;
+  steps: SelfTestStep[];
+  error?: string;
+}
+
+export interface SelfTestOptions {
+  safeMode?: boolean;
+  candidateApps?: string[];
+  heavyApps?: string[];
+  logger?: Logger;
+  now?: () => number;
+  openCatalog?: () => void | Promise<void>;
+  launchApp?: (app: AppDefinition) => void | Promise<void>;
+  closeApp?: (app: AppDefinition) => void | Promise<void>;
+}
+
+const defaultNow = () => Date.now();
+
+const defaultOpenCatalog = async () => {
+  const catalog = appsCatalog as AppDefinition[];
+  if (!Array.isArray(catalog) || catalog.length === 0) {
+    throw new Error('Application catalog is empty');
+  }
+};
+
+const defaultLaunchApp = async (app: AppDefinition) => {
+  if (typeof app.screen !== 'function') {
+    throw new Error(`App ${app.id} does not expose a launcher`);
+  }
+  const element = app.screen(() => {}, () => {});
+  if (element === null || typeof element === 'undefined') {
+    throw new Error(`App ${app.id} failed to render`);
+  }
+};
+
+const defaultCloseApp = async () => {
+  // The self test only verifies launch capability. Closing is a no-op but kept
+  // as a hook so tests can assert it was invoked.
+};
+
+function parseFlag(value?: string | null): boolean | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().toLowerCase();
+  if (TRUE_VALUES.has(trimmed)) return true;
+  if (FALSE_VALUES.has(trimmed)) return false;
+  return null;
+}
+
+function detectSafeMode(options: SelfTestOptions): boolean {
+  if (typeof options.safeMode === 'boolean') {
+    return options.safeMode;
+  }
+
+  if (typeof process !== 'undefined' && process.env) {
+    const envValue =
+      process.env.SELF_TEST_SAFE_MODE ?? process.env.NEXT_PUBLIC_SAFE_MODE;
+    const parsedEnv = parseFlag(envValue);
+    if (parsedEnv !== null) {
+      return parsedEnv;
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const queryValue = params.get('safeMode') ?? params.get('safe-mode');
+      const parsedQuery = parseFlag(queryValue);
+      if (parsedQuery !== null) {
+        return parsedQuery;
+      }
+    } catch {
+      // ignore invalid query parsing
+    }
+  }
+
+  for (const key of SAFE_MODE_STORAGE_KEYS) {
+    const stored = safeLocalStorage?.getItem(key);
+    const parsedStored = parseFlag(stored ?? undefined);
+    if (parsedStored !== null) {
+      return parsedStored;
+    }
+  }
+
+  return false;
+}
+
+function pickTargetApp(
+  catalog: AppDefinition[],
+  safeMode: boolean,
+  candidateApps: string[] | undefined,
+  heavyApps: string[] | undefined,
+  logger: Logger,
+): AppDefinition {
+  const heavySet = new Set((heavyApps ?? DEFAULT_HEAVY_APPS).map((id) => id.toLowerCase()));
+  const desired = (candidateApps && candidateApps.length > 0
+    ? candidateApps
+    : DEFAULT_CANDIDATE_APPS
+  ).map((id) => id.toLowerCase());
+
+  const filtered = safeMode
+    ? desired.filter((id) => {
+        const skip = heavySet.has(id);
+        if (skip) {
+          logger.info('Skipping heavy app during self test', { appId: id });
+        }
+        return !skip;
+      })
+    : desired;
+
+  const searchOrder = filtered.length > 0 ? filtered : desired;
+
+  const resolved = searchOrder
+    .map((id) => catalog.find((app) => app.id.toLowerCase() === id && !app.disabled))
+    .find((entry): entry is AppDefinition => Boolean(entry));
+
+  if (resolved) {
+    if (safeMode && heavySet.has(resolved.id.toLowerCase())) {
+      throw new Error('Selected app is marked heavy during safe mode');
+    }
+    return resolved;
+  }
+
+  const fallback = catalog.find(
+    (app) => !app.disabled && (!safeMode || !heavySet.has(app.id.toLowerCase())),
+  );
+
+  if (!fallback) {
+    throw new Error('No suitable application available for the self test');
+  }
+
+  return fallback;
+}
+
+async function runStep<T>(
+  id: string,
+  label: string,
+  action: () => T | Promise<T>,
+  now: () => number,
+  steps: SelfTestStep[],
+  logger: Logger,
+): Promise<T> {
+  const started = now();
+  logger.info('Self test step started', { step: id, label });
+  try {
+    const value = await action();
+    const finished = now();
+    const duration = Math.max(0, finished - started);
+    steps.push({ id, label, status: 'pass', durationMs: duration });
+    logger.info('Self test step finished', { step: id, label, durationMs: duration });
+    return value;
+  } catch (error) {
+    const finished = now();
+    const duration = Math.max(0, finished - started);
+    const message = error instanceof Error ? error.message : String(error);
+    steps.push({ id, label, status: 'fail', durationMs: duration, detail: message });
+    logger.error('Self test step failed', {
+      step: id,
+      label,
+      durationMs: duration,
+      error: message,
+    });
+    throw error;
+  }
+}
+
+export async function runSelfTest(options: SelfTestOptions = {}): Promise<SelfTestResult> {
+  const logger = options.logger ?? createLogger();
+  const now = options.now ?? defaultNow;
+  const steps: SelfTestStep[] = [];
+  const safeMode = detectSafeMode(options);
+  const result: SelfTestResult = {
+    status: 'fail',
+    safeMode,
+    appId: '',
+    startedAt: now(),
+    finishedAt: 0,
+    totalDurationMs: 0,
+    steps,
+  };
+
+  try {
+    await runStep(
+      'open-launcher',
+      'Open launcher',
+      () => (options.openCatalog ?? defaultOpenCatalog)(),
+      now,
+      steps,
+      logger,
+    );
+
+    const catalog = appsCatalog as AppDefinition[];
+    const app = await runStep(
+      'select-app',
+      'Select test app',
+      () => pickTargetApp(catalog, safeMode, options.candidateApps, options.heavyApps, logger),
+      now,
+      steps,
+      logger,
+    );
+    result.appId = app.id;
+
+    await runStep(
+      'launch-app',
+      `Launch ${app.title}`,
+      () => (options.launchApp ?? defaultLaunchApp)(app),
+      now,
+      steps,
+      logger,
+    );
+
+    await runStep(
+      'close-app',
+      'Close app session',
+      () => (options.closeApp ?? defaultCloseApp)(app),
+      now,
+      steps,
+      logger,
+    );
+
+    result.status = 'pass';
+    logger.info('Self test completed successfully', {
+      appId: result.appId,
+      safeMode: result.safeMode,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    result.error = message;
+    logger.warn('Self test completed with errors', {
+      appId: result.appId,
+      safeMode: result.safeMode,
+      error: message,
+    });
+  } finally {
+    result.finishedAt = now();
+    result.totalDurationMs = Math.max(0, result.finishedAt - result.startedAt);
+  }
+
+  return result;
+}
+
+export type { AppDefinition as SelfTestAppDefinition };
+export { SAFE_MODE_STORAGE_KEYS };


### PR DESCRIPTION
## Summary
- add a self test orchestrator that logs timings and respects safe mode
- expose a diagnostics tab in settings to run the self test and show stored results
- harden window keyboard handling and add targeted unit/RTL coverage

## Testing
- yarn test __tests__/selfTest.test.ts -i
- yarn test __tests__/settings-diagnostics.test.tsx -i
- yarn test __tests__/window.test.tsx -i


------
https://chatgpt.com/codex/tasks/task_e_68cce5f0cfe083288726013652a3a41f