### PR TITLE
[qa] Add diagnostics Playwright spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,27 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  diagnostics:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - typecheck
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn build
+      - run: npx playwright install --with-deps
+      - run: |
+          yarn start &
+          SERVER_PID=$!
+          trap "kill $SERVER_PID" EXIT
+          npx wait-on http://localhost:3000
+          npx playwright test playwright/diagnostics.spec.ts
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -126,6 +126,11 @@ For each game below, build a canvas-based component with `requestAnimationFrame`
 - Flappy Bird
 - Pinball
 
+## QA & Diagnostics
+- Use the Diagnostics/Plugin Manager app to run every available test suite and confirm the output panel captures results.
+- Export the generated CSV artifact, open it locally, and verify the filename reflects the executed suite.
+- Close and reopen the app to ensure installed diagnostics and the last results persist in localStorage before sign-off.
+
 ## Housekeeping
 - Keep `apps.config.js` organized with utilities and games grouped and exported consistently.
 - Monitor `fast-glob` updates and explore hash optimizations for the custom service worker.

--- a/pages/apps/plugin-manager.jsx
+++ b/pages/apps/plugin-manager.jsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic';
+
+const PluginManagerApp = dynamic(() => import('../../apps/plugin-manager'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
+
+export default function PluginManagerPage() {
+  return <PluginManagerApp />;
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
+  testDir: '.',
+  testMatch: ['tests/**/*.spec.ts', 'playwright/**/*.spec.ts'],
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },

--- a/playwright/diagnostics.spec.ts
+++ b/playwright/diagnostics.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+
+test('diagnostics app runs without unhandled rejections', async ({ page, context }) => {
+  const pageErrors: Error[] = [];
+
+  await context.addInitScript(() => {
+    try {
+      window.localStorage.clear();
+    } catch {
+      // ignore storage access issues during setup
+    }
+  });
+
+  page.on('pageerror', (error) => {
+    if (error.message?.includes('Failed to update a ServiceWorker')) {
+      return;
+    }
+
+    pageErrors.push(error);
+  });
+
+  await page.goto('/apps');
+
+  const diagnosticsLink = page.getByRole('link', { name: 'Plugin Manager' });
+  await expect(diagnosticsLink).toBeVisible();
+  await diagnosticsLink.click();
+
+  await expect(page).toHaveURL(/\/apps\/plugin-manager$/);
+  await expect(page.getByRole('heading', { name: 'Plugin Catalog' })).toBeVisible();
+
+  const pluginRows = page.locator('ul li');
+  await expect(pluginRows.first()).toBeVisible();
+  const pluginCount = await pluginRows.count();
+  expect(pluginCount).toBeGreaterThan(0);
+
+  let lastPluginId = '';
+
+  for (let index = 0; index < pluginCount; index += 1) {
+    const row = pluginRows.nth(index);
+    const pluginId = (await row.locator('span').first().textContent())?.trim() || '';
+    expect(pluginId).not.toEqual('');
+    lastPluginId = pluginId;
+
+    const installButton = row.getByRole('button', { name: 'Install' });
+    if (await installButton.isVisible()) {
+      await installButton.click();
+      await expect(row.getByRole('button', { name: 'Installed' })).toBeVisible();
+    }
+
+    const runButton = row.getByRole('button', { name: 'Run' });
+    await expect(runButton).toBeVisible();
+    await runButton.click();
+
+    await expect(
+      page.getByRole('heading', { level: 2, name: new RegExp(`Last Run: ${pluginId}`) }),
+    ).toBeVisible();
+
+    const output = page.locator('pre').first();
+    await expect(output).toBeVisible();
+    await expect(output).toContainText(/\S/);
+  }
+
+  const exportButton = page.getByRole('button', { name: 'Export CSV' });
+  await expect(exportButton).toBeVisible();
+  const downloadPromise = page.waitForEvent('download');
+  await exportButton.click();
+  const download = await downloadPromise;
+  if (lastPluginId) {
+    expect(download.suggestedFilename()).toBe(`${lastPluginId}.csv`);
+  }
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/apps$/);
+  await page.getByRole('link', { name: 'Plugin Manager' }).click();
+
+  await expect(page).toHaveURL(/\/apps\/plugin-manager$/);
+  await expect(page.getByRole('button', { name: 'Installed' })).toHaveCount(pluginCount);
+  if (lastPluginId) {
+    await expect(
+      page.getByRole('heading', { level: 2, name: new RegExp(`Last Run: ${lastPluginId}`) }),
+    ).toBeVisible();
+  }
+
+  expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- add a Playwright diagnostics run that installs, executes, and exports every plugin without unhandled promise rejections
- expose the Plugin Manager UI at `/apps/plugin-manager` so the spec can drive the workflow directly
- wire the diagnostics spec into CI after lint/typecheck and document the manual diagnostics artifact review checklist

## Testing
- yarn lint *(fails: pre-existing lint violations across compiled bundles and app sources)*
- yarn tsc --noEmit
- CI=1 yarn build
- npx playwright test playwright/diagnostics.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cce5f09ea08328a2977785a4258a57