### PR TITLE
[profiles] Implement profile store and tests

### DIFF
--- a/__tests__/profiles.test.tsx
+++ b/__tests__/profiles.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import {
+  ProfilesProvider,
+  useProfiles,
+  ACTIVE_PROFILE_STORAGE_KEY,
+} from '../hooks/useProfiles';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+import useSession from '../hooks/useSession';
+import { __resetProfilesDbForTests } from '../utils/safeIDB';
+import { getAccent } from '../utils/settingsStore';
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('profile management', () => {
+  beforeEach(async () => {
+    window.localStorage.clear();
+    await new Promise<void>((resolve) => {
+      const request = indexedDB.deleteDatabase('kali-desktop');
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+      request.onblocked = () => resolve();
+    });
+    __resetProfilesDbForTests();
+  });
+
+  const ProfilesWrapper = ({ children }: { children: React.ReactNode }) => (
+    <ProfilesProvider>{children}</ProfilesProvider>
+  );
+
+  const AppWrapper = ({ children }: { children: React.ReactNode }) => (
+    <ProfilesProvider>
+      <SettingsProvider>{children}</SettingsProvider>
+    </ProfilesProvider>
+  );
+
+  test('creates profiles and persists metadata', async () => {
+    const { result } = renderHook(() => useProfiles(), { wrapper: ProfilesWrapper });
+    await act(async () => {
+      await flushPromises();
+    });
+    await waitFor(() => {
+      if (!result.current) throw new Error('Profiles not ready');
+      expect(result.current.ready).toBe(true);
+    });
+    const initial = result.current.profiles.length;
+    await act(async () => {
+      await result.current.createProfile('Tester');
+    });
+    expect(result.current.profiles.length).toBe(initial + 1);
+    expect(result.current.profiles.some((profile) => profile.name === 'Tester')).toBe(true);
+  });
+
+  test('switching profiles updates active id and storage', async () => {
+    const { result } = renderHook(() => useProfiles(), { wrapper: ProfilesWrapper });
+    await act(async () => {
+      await flushPromises();
+    });
+    await waitFor(() => {
+      if (!result.current) throw new Error('Profiles not ready');
+      expect(result.current.ready).toBe(true);
+    });
+    const initialSetter = result.current.setActiveProfile;
+    const firstProfile = result.current.activeProfileId;
+    expect(firstProfile).not.toBeNull();
+    await act(async () => {
+      await result.current.createProfile('Second');
+    });
+    const secondProfile = result.current.activeProfileId;
+    expect(secondProfile).not.toBe(firstProfile);
+    await act(async () => {
+      await result.current.setActiveProfile(firstProfile!);
+    });
+    await waitFor(() => expect(result.current.activeProfileId).toBe(firstProfile));
+    expect(window.localStorage.getItem(ACTIVE_PROFILE_STORAGE_KEY)).toBe(firstProfile);
+  });
+
+  test('switching profiles reloads session and settings quickly', async () => {
+    const { result } = renderHook(
+      () => ({
+        profiles: useProfiles(),
+        session: useSession(),
+        settings: useSettings(),
+      }),
+      { wrapper: AppWrapper },
+    );
+
+    await act(async () => {
+      await flushPromises();
+    });
+    await waitFor(() => {
+      if (!result.current || !result.current.profiles) throw new Error('Profiles not ready');
+      expect(result.current.profiles.ready).toBe(true);
+    });
+    await waitFor(() => expect(result.current!.settings.hydrated).toBe(true));
+    const firstProfile = result.current.profiles.activeProfileId!;
+
+    act(() => {
+      result.current.session.setSession({
+        windows: [{ id: 'alpha', x: 10, y: 20 }],
+        wallpaper: 'wall-2',
+        dock: ['terminal'],
+      });
+      result.current.settings.setWallpaper('wall-2');
+      result.current.settings.setAccent('#1793d1');
+    });
+
+    await act(async () => {
+      await result.current.profiles.createProfile('Analyst');
+    });
+    await waitFor(() => expect(result.current.settings.hydrated).toBe(false));
+    await waitFor(() => expect(result.current.settings.hydrated).toBe(true));
+    expect(result.current.profiles.profiles.length).toBe(2);
+    const secondProfile = result.current.profiles.activeProfileId!;
+
+    act(() => {
+      result.current.session.setSession({
+        windows: [{ id: 'beta', x: 5, y: 15 }],
+        wallpaper: 'wall-5',
+        dock: ['browser'],
+      });
+      result.current.settings.setWallpaper('wall-5');
+      result.current.settings.setAccent('#ed64a6');
+    });
+    expect(result.current.settings.accent).toBe('#ed64a6');
+    await waitFor(async () => {
+      expect(await getAccent(secondProfile)).toBe('#ed64a6');
+    });
+
+    const startFirst = Date.now();
+    await act(async () => {
+      await result.current.profiles.setActiveProfile(firstProfile);
+    });
+    await waitFor(
+      () =>
+        result.current.settings.hydrated &&
+        result.current.session.session.windows[0]?.id === 'alpha' &&
+        result.current.settings.wallpaper === 'wall-2' &&
+        result.current.settings.accent === '#1793d1',
+      { timeout: 1500 },
+    );
+    const firstDuration = Date.now() - startFirst;
+    expect(firstDuration).toBeLessThanOrEqual(1500);
+    expect(result.current.settings.accent).toBe('#1793d1');
+
+    const startSecond = Date.now();
+    await act(async () => {
+      await result.current.profiles.setActiveProfile(secondProfile);
+    });
+    await waitFor(
+      () =>
+        result.current.settings.hydrated &&
+        result.current.session.session.windows[0]?.id === 'beta' &&
+        result.current.settings.wallpaper === 'wall-5' &&
+        result.current.settings.accent === '#ed64a6',
+      { timeout: 1500 },
+    );
+    const secondDuration = Date.now() - startSecond;
+    expect(secondDuration).toBeLessThanOrEqual(1500);
+    await waitFor(() => expect(result.current.settings.accent).toBe('#ed64a6'));
+  });
+});

--- a/__tests__/themePersistence.test.tsx
+++ b/__tests__/themePersistence.test.tsx
@@ -1,24 +1,46 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { SettingsProvider, useSettings } from '../hooks/useSettings';
+import { ProfilesProvider, ACTIVE_PROFILE_STORAGE_KEY } from '../hooks/useProfiles';
 import { getTheme, getUnlockedThemes, setTheme } from '../utils/theme';
+import { getProfileScopedKey } from '../utils/profileKeys';
+import { __resetProfilesDbForTests } from '../utils/safeIDB';
 
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe('theme persistence and unlocking', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     window.localStorage.clear();
     document.documentElement.dataset.theme = '';
     document.documentElement.className = '';
+    await new Promise<void>((resolve) => {
+      const request = indexedDB.deleteDatabase('kali-desktop');
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+      request.onblocked = () => resolve();
+    });
+    __resetProfilesDbForTests();
   });
 
-  test('theme persists across sessions', () => {
+  test('theme persists across sessions', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <ProfilesProvider>
+        <SettingsProvider>{children}</SettingsProvider>
+      </ProfilesProvider>
+    );
     const { result } = renderHook(() => useSettings(), {
-      wrapper: SettingsProvider,
+      wrapper,
     });
+    await act(async () => {
+      await flushPromises();
+    });
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
     act(() => result.current.setTheme('dark'));
     expect(result.current.theme).toBe('dark');
-    expect(getTheme()).toBe('dark');
-    expect(window.localStorage.getItem('app:theme')).toBe('dark');
-
+    await waitFor(() => expect(window.localStorage.getItem(ACTIVE_PROFILE_STORAGE_KEY)).not.toBeNull());
+    const activeProfileId = window.localStorage.getItem(ACTIVE_PROFILE_STORAGE_KEY);
+    const themeKey = getProfileScopedKey(activeProfileId, 'app:theme');
+    expect(getTheme(activeProfileId)).toBe('dark');
+    expect(window.localStorage.getItem(themeKey)).toBe('dark');
   });
 
   test('themes unlock at score milestones', () => {
@@ -28,9 +50,10 @@ describe('theme persistence and unlocking', () => {
   });
 
   test('dark class applied for neon and matrix themes', () => {
-    setTheme('neon');
+    const activeProfileId = window.localStorage.getItem(ACTIVE_PROFILE_STORAGE_KEY);
+    setTheme('neon', activeProfileId);
     expect(document.documentElement.classList.contains('dark')).toBe(true);
-    setTheme('matrix');
+    setTheme('matrix', activeProfileId);
     expect(document.documentElement.classList.contains('dark')).toBe(true);
   });
 

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,8 +12,11 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import { useProfiles } from "../../hooks/useProfiles";
 
 export default function Settings() {
+  const { activeProfileId } = useProfiles();
+  const profileId = activeProfileId ?? null;
   const {
     accent,
     setAccent,
@@ -56,7 +59,7 @@ export default function Settings() {
   const changeBackground = (name: string) => setWallpaper(name);
 
   const handleExport = async () => {
-    const data = await exportSettingsData();
+    const data = await exportSettingsData(profileId);
     const blob = new Blob([data], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -68,7 +71,7 @@ export default function Settings() {
 
   const handleImport = async (file: File) => {
     const text = await file.text();
-    await importSettingsData(text);
+    await importSettingsData(text, profileId);
     try {
       const parsed = JSON.parse(text);
       if (parsed.accent !== undefined) setAccent(parsed.accent);
@@ -92,8 +95,11 @@ export default function Settings() {
       )
     )
       return;
-    await resetSettings();
-    window.localStorage.clear();
+    await resetSettings(profileId);
+    const sessionKey = profileId
+      ? `desktop-session:${profileId}`
+      : "desktop-session";
+    window.localStorage.removeItem(sessionKey);
     setAccent(defaults.accent);
     setWallpaper(defaults.wallpaper);
     setDensity(defaults.density as any);

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,47 +1,121 @@
-import React, { Component } from 'react';
+import React, { useMemo, useState } from 'react';
 import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
+import { useProfiles } from '../../hooks/useProfiles';
 
-export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+const Navbar = () => {
+  const [showStatus, setShowStatus] = useState(false);
+  const [showProfiles, setShowProfiles] = useState(false);
+  const { profiles, activeProfileId, createProfile, deleteProfile, setActiveProfile, isSwitching } = useProfiles();
 
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
-                                <WhiskerMenu />
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
-                                >
-                                        <Clock />
-                                </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
-			</div>
-		);
-	}
-}
+  const activeProfile = useMemo(
+    () => profiles.find((profile) => profile.id === activeProfileId),
+    [activeProfileId, profiles],
+  );
+
+  const handleSelectProfile = async (id) => {
+    setShowProfiles(false);
+    await setActiveProfile(id);
+  };
+
+  const handleCreateProfile = async () => {
+    await createProfile();
+    setShowProfiles(false);
+  };
+
+  const handleDeleteProfile = async (id) => {
+    await deleteProfile(id);
+  };
+
+  return (
+    <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+      <div className="pl-3 pr-1">
+        <Image
+          src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg"
+          alt="network icon"
+          width={16}
+          height={16}
+          className="w-4 h-4"
+        />
+      </div>
+      <WhiskerMenu />
+      <div className="flex items-center space-x-2">
+        <div className="relative">
+          <button
+            type="button"
+            className="px-3 py-1 rounded hover:bg-ub-cool-grey transition-colors"
+            aria-haspopup="menu"
+            aria-expanded={showProfiles}
+            onClick={() => setShowProfiles((prev) => !prev)}
+          >
+            {activeProfile ? activeProfile.name : 'Profiles'}
+          </button>
+          {showProfiles && (
+            <div className="absolute right-0 mt-2 w-56 bg-ub-cool-grey border border-black border-opacity-20 rounded shadow-lg z-50">
+              <div className="px-4 py-2 border-b border-black border-opacity-10 text-xs uppercase tracking-wide text-ubt-light">
+                Profiles
+              </div>
+              <ul className="max-h-64 overflow-y-auto">
+                {profiles.map((profile) => {
+                  const isActive = profile.id === activeProfileId;
+                  return (
+                    <li key={profile.id} className="flex items-center justify-between px-4 py-2 text-left">
+                      <button
+                        type="button"
+                        className={`flex-1 text-left truncate ${isActive ? 'font-semibold text-white' : 'text-ubt-grey'} hover:text-white`}
+                        onClick={() => handleSelectProfile(profile.id)}
+                        disabled={isActive || isSwitching}
+                      >
+                        {profile.name}
+                        {isActive && <span className="ml-2 text-xs text-ubt-light">(active)</span>}
+                      </button>
+                      {profiles.length > 1 && !isActive && (
+                        <button
+                          type="button"
+                          className="ml-2 text-xs text-red-300 hover:text-red-200"
+                          onClick={() => handleDeleteProfile(profile.id)}
+                          disabled={isSwitching}
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+              <div className="border-t border-black border-opacity-10 px-4 py-2 flex items-center justify-between">
+                <button
+                  type="button"
+                  className="text-sm text-ubt-grey hover:text-white"
+                  onClick={handleCreateProfile}
+                  disabled={isSwitching}
+                >
+                  Add profile
+                </button>
+                {isSwitching && <span className="text-xs text-ubt-light">Switching…</span>}
+              </div>
+            </div>
+          )}
+        </div>
+        <div className="pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1">
+          <Clock />
+        </div>
+      </div>
+      <button
+        type="button"
+        id="status-bar"
+        aria-label="System status"
+        onClick={() => setShowStatus((prev) => !prev)}
+        className="relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1"
+      >
+        <Status />
+        <QuickSettings open={showStatus} />
+      </button>
+    </div>
+  );
+};
+
+export default Navbar;

--- a/hooks/useProfiles.tsx
+++ b/hooks/useProfiles.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  deleteProfile,
+  getProfile,
+  listProfiles,
+  saveProfile,
+  type ProfileMetadata,
+} from '../utils/safeIDB';
+
+export const ACTIVE_PROFILE_STORAGE_KEY = 'desktop-active-profile';
+
+interface ProfilesContextValue {
+  profiles: ProfileMetadata[];
+  activeProfileId: string | null;
+  activeProfile: ProfileMetadata | null;
+  ready: boolean;
+  isSwitching: boolean;
+  createProfile: (name?: string) => Promise<ProfileMetadata>;
+  deleteProfile: (id: string) => Promise<void>;
+  renameProfile: (id: string, name: string) => Promise<void>;
+  setActiveProfile: (id: string) => Promise<void>;
+  refreshProfiles: () => Promise<void>;
+}
+
+const ProfilesContext = createContext<ProfilesContextValue | undefined>(undefined);
+
+const PROFILE_NAME_BASE = 'Profile';
+
+const generateId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `profile-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+const createMetadata = (name: string): ProfileMetadata => {
+  const now = Date.now();
+  return {
+    id: generateId(),
+    name,
+    createdAt: now,
+    updatedAt: now,
+    lastUsed: now,
+  };
+};
+
+const pickDefaultName = (existing: ProfileMetadata[]) => {
+  const used = new Set(existing.map((profile) => profile.name.toLowerCase()));
+  if (!used.has('primary profile')) {
+    return 'Primary Profile';
+  }
+  if (!used.has(PROFILE_NAME_BASE.toLowerCase())) {
+    return PROFILE_NAME_BASE;
+  }
+  let suffix = existing.length + 1;
+  let candidate = `${PROFILE_NAME_BASE} ${suffix}`;
+  while (used.has(candidate.toLowerCase())) {
+    suffix += 1;
+    candidate = `${PROFILE_NAME_BASE} ${suffix}`;
+  }
+  return candidate;
+};
+
+export const ProfilesProvider = ({ children }: { children: ReactNode }) => {
+  const [profiles, setProfiles] = useState<ProfileMetadata[]>([]);
+  const [activeProfileId, setActiveProfileId] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null;
+    return window.localStorage.getItem(ACTIVE_PROFILE_STORAGE_KEY);
+  });
+  const [ready, setReady] = useState(false);
+  const [isSwitching, setIsSwitching] = useState(false);
+
+  const persistActiveId = useCallback((id: string) => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(ACTIVE_PROFILE_STORAGE_KEY, id);
+  }, []);
+
+  const loadProfiles = useCallback(async () => {
+    const stored = await listProfiles();
+    const uniqueProfiles = stored.reduce<ProfileMetadata[]>((acc, profile) => {
+      if (!profile?.id) {
+        return acc;
+      }
+      if (acc.some((existing) => existing.id === profile.id)) {
+        return acc;
+      }
+      acc.push(profile);
+      return acc;
+    }, []);
+
+    let data = uniqueProfiles;
+    if (!data.length) {
+      const defaultProfile = createMetadata('Primary Profile');
+      await saveProfile(defaultProfile);
+      data = [defaultProfile];
+    }
+    data.sort((a, b) => a.createdAt - b.createdAt);
+    setProfiles(data);
+
+    let storedActive: string | null = null;
+    if (typeof window !== 'undefined') {
+      const fromStorage = window.localStorage.getItem(
+        ACTIVE_PROFILE_STORAGE_KEY,
+      );
+      if (fromStorage && data.some((profile) => profile.id === fromStorage)) {
+        storedActive = fromStorage;
+      } else {
+        storedActive = data[0]?.id ?? null;
+      }
+    } else {
+      storedActive = data[0]?.id ?? null;
+    }
+
+    if (storedActive) {
+      setActiveProfileId(storedActive);
+      persistActiveId(storedActive);
+    } else {
+      setActiveProfileId(null);
+      if (typeof window !== 'undefined') {
+        window.localStorage.removeItem(ACTIVE_PROFILE_STORAGE_KEY);
+      }
+    }
+  }, [persistActiveId]);
+
+  const refreshProfiles = useCallback(async () => {
+    await loadProfiles();
+  }, [loadProfiles]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      await loadProfiles();
+      if (!cancelled) {
+        setReady(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadProfiles]);
+
+  const setActiveProfile = useCallback(
+    async (id: string) => {
+      if (!id || id === activeProfileId) {
+        return;
+      }
+      setIsSwitching(true);
+      setActiveProfileId(id);
+      persistActiveId(id);
+      const now = Date.now();
+      setProfiles((prev) =>
+        prev.map((profile) =>
+          profile.id === id
+            ? { ...profile, lastUsed: now, updatedAt: now }
+            : profile,
+        ),
+      );
+      const profile =
+        profiles.find((p) => p.id === id) || (await getProfile(id)) || null;
+      if (profile) {
+        await saveProfile({ ...profile, lastUsed: now, updatedAt: now });
+      }
+      setIsSwitching(false);
+    },
+    [activeProfileId, persistActiveId, profiles],
+  );
+
+  const createProfile = useCallback(
+    async (name?: string) => {
+      const profileName =
+        name?.trim() && name.trim().length
+          ? name.trim()
+          : pickDefaultName(profiles);
+      const profile = createMetadata(profileName);
+      await saveProfile(profile);
+      setProfiles((prev) => [...prev, profile].sort((a, b) => a.createdAt - b.createdAt));
+      await setActiveProfile(profile.id);
+      return profile;
+    },
+    [profiles, setActiveProfile],
+  );
+
+  const renameProfile = useCallback(
+    async (id: string, name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      setProfiles((prev) =>
+        prev.map((profile) =>
+          profile.id === id
+            ? { ...profile, name: trimmed, updatedAt: Date.now() }
+            : profile,
+        ),
+      );
+      const target = profiles.find((p) => p.id === id) || (await getProfile(id));
+      if (target) {
+        await saveProfile({ ...target, name: trimmed, updatedAt: Date.now() });
+      }
+    },
+    [profiles],
+  );
+
+  const deleteProfileById = useCallback(
+    async (id: string) => {
+      if (profiles.length <= 1) return;
+      await deleteProfile(id);
+      const remaining = profiles.filter((profile) => profile.id !== id);
+      setProfiles(remaining);
+      if (activeProfileId === id) {
+        const fallback = remaining[0]?.id ?? null;
+        if (fallback) {
+          await setActiveProfile(fallback);
+        } else {
+          setActiveProfileId(null);
+          if (typeof window !== 'undefined') {
+            window.localStorage.removeItem(ACTIVE_PROFILE_STORAGE_KEY);
+          }
+        }
+      }
+    },
+    [activeProfileId, profiles, setActiveProfile],
+  );
+
+  const activeProfile = useMemo(
+    () => profiles.find((profile) => profile.id === activeProfileId) ?? null,
+    [activeProfileId, profiles],
+  );
+
+  const value = useMemo<ProfilesContextValue>(
+    () => ({
+      profiles,
+      activeProfileId,
+      activeProfile,
+      ready,
+      isSwitching,
+      createProfile,
+      deleteProfile: deleteProfileById,
+      renameProfile,
+      setActiveProfile,
+      refreshProfiles,
+    }),
+    [
+      activeProfile,
+      activeProfileId,
+      createProfile,
+      deleteProfileById,
+      isSwitching,
+      profiles,
+      ready,
+      refreshProfiles,
+      renameProfile,
+      setActiveProfile,
+    ],
+  );
+
+  return <ProfilesContext.Provider value={value}>{children}</ProfilesContext.Provider>;
+};
+
+export const useProfiles = () => {
+  const context = useContext(ProfilesContext);
+  if (!context) {
+    throw new Error('useProfiles must be used within a ProfilesProvider');
+  }
+  return context;
+};

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -1,5 +1,6 @@
 import usePersistentState from './usePersistentState';
 import { defaults } from '../utils/settingsStore';
+import { useProfiles } from './useProfiles';
 
 export interface SessionWindow {
   id: string;
@@ -30,8 +31,12 @@ function isSession(value: unknown): value is DesktopSession {
 }
 
 export default function useSession() {
+  const { activeProfileId } = useProfiles();
+  const storageKey = activeProfileId
+    ? `desktop-session:${activeProfileId}`
+    : 'desktop-session';
   const [session, setSession, _reset, clear] = usePersistentState<DesktopSession>(
-    'desktop-session',
+    storageKey,
     initialSession,
     isSession,
   );

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,25 +1,34 @@
 import { useEffect, useState } from 'react';
-import { THEME_KEY, getTheme, setTheme as applyTheme } from '../utils/theme';
+import { THEME_KEY, getTheme, getThemeStorageKey, setTheme as applyTheme } from '../utils/theme';
+import { useProfiles } from './useProfiles';
 
 export const useTheme = () => {
-  const [theme, setThemeState] = useState<string>(() => getTheme());
+  const { activeProfileId } = useProfiles();
+  const [theme, setThemeState] = useState<string>(() => getTheme(activeProfileId));
 
   useEffect(() => {
     const handleStorage = (e: StorageEvent) => {
-      if (e.key === THEME_KEY) {
-        const next = getTheme();
+      const key = getThemeStorageKey(activeProfileId);
+      if (e.key === key || (!activeProfileId && e.key === THEME_KEY)) {
+        const next = getTheme(activeProfileId);
         setThemeState(next);
-        applyTheme(next);
+        applyTheme(next, activeProfileId);
 
       }
     };
     window.addEventListener('storage', handleStorage);
     return () => window.removeEventListener('storage', handleStorage);
-  }, []);
+  }, [activeProfileId]);
+
+  useEffect(() => {
+    const next = getTheme(activeProfileId);
+    setThemeState(next);
+    applyTheme(next, activeProfileId);
+  }, [activeProfileId]);
 
   const setTheme = (next: string) => {
     setThemeState(next);
-    applyTheme(next);
+    applyTheme(next, activeProfileId);
 
   };
 

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,7 @@ import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { ProfilesProvider } from '../hooks/useProfiles';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
@@ -156,12 +157,13 @@ function MyApp(props) {
         >
           Skip to app grid
         </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
+        <ProfilesProvider>
+          <SettingsProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;
                 const evt = e;
@@ -170,9 +172,10 @@ function MyApp(props) {
               }}
             />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </SettingsProvider>
+        </ProfilesProvider>
       </div>
     </ErrorBoundary>
 

--- a/utils/profileKeys.ts
+++ b/utils/profileKeys.ts
@@ -1,0 +1,6 @@
+export const PROFILE_STORAGE_PREFIX = 'profile';
+
+export const getProfileScopedKey = (
+  profileId: string | null | undefined,
+  key: string,
+) => (profileId ? `${PROFILE_STORAGE_PREFIX}:${profileId}:${key}` : key);

--- a/utils/safeIDB.ts
+++ b/utils/safeIDB.ts
@@ -1,7 +1,112 @@
-import { openDB } from 'idb';
+import { openDB, type DBSchema, type IDBPDatabase, type OpenDBCallbacks } from 'idb';
 import { hasIndexedDB } from './isBrowser';
 
-export function getDb(name: string, version = 1, upgrade?: Parameters<typeof openDB>[2]) {
+export function getDb<Schema extends DBSchema = any>(
+  name: string,
+  version = 1,
+  callbacks?: OpenDBCallbacks<Schema>,
+): Promise<IDBPDatabase<Schema>> | null {
   if (!hasIndexedDB) return null;
-  return openDB(name, version, upgrade);
+  return openDB<Schema>(name, version, callbacks);
+}
+
+export interface ProfileMetadata {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+  lastUsed: number;
+}
+
+interface ProfilesDB extends DBSchema {
+  profiles: {
+    key: string;
+    value: ProfileMetadata;
+  };
+}
+
+const PROFILE_DB_NAME = 'kali-desktop';
+const PROFILE_STORE_NAME = 'profiles';
+const PROFILE_DB_VERSION = 1;
+
+let profileDbPromise: Promise<IDBPDatabase<ProfilesDB>> | null = null;
+let profileDbInstance: IDBPDatabase<ProfilesDB> | null = null;
+
+export function getProfilesDb() {
+  if (!profileDbPromise) {
+    profileDbPromise = getDb<ProfilesDB>(PROFILE_DB_NAME, PROFILE_DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(PROFILE_STORE_NAME)) {
+          db.createObjectStore(PROFILE_STORE_NAME, {
+            keyPath: 'id',
+          });
+        }
+      },
+    })?.then((db) => {
+      profileDbInstance = db;
+      return db;
+    }) ?? null;
+  }
+  return profileDbPromise;
+}
+
+export async function listProfiles(): Promise<ProfileMetadata[]> {
+  try {
+    const dbp = getProfilesDb();
+    if (!dbp) return [];
+    const db = await dbp;
+    const profiles = await db.transaction(PROFILE_STORE_NAME).store.getAll();
+    return (profiles ?? []).sort((a, b) => a.createdAt - b.createdAt);
+  } catch {
+    return [];
+  }
+}
+
+export async function getProfile(id: string): Promise<ProfileMetadata | undefined> {
+  try {
+    const dbp = getProfilesDb();
+    if (!dbp) return undefined;
+    const db = await dbp;
+    return db.transaction(PROFILE_STORE_NAME).store.get(id) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function saveProfile(profile: ProfileMetadata): Promise<void> {
+  try {
+    const dbp = getProfilesDb();
+    if (!dbp) return;
+    const db = await dbp;
+    const tx = db.transaction(PROFILE_STORE_NAME, 'readwrite');
+    await tx.store.put(profile);
+    await tx.done;
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export async function deleteProfile(id: string): Promise<void> {
+  try {
+    const dbp = getProfilesDb();
+    if (!dbp) return;
+    const db = await dbp;
+    const tx = db.transaction(PROFILE_STORE_NAME, 'readwrite');
+    await tx.store.delete(id);
+    await tx.done;
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function __resetProfilesDbForTests() {
+  if (profileDbInstance) {
+    try {
+      profileDbInstance.close();
+    } catch {
+      // ignore closing errors in tests
+    }
+    profileDbInstance = null;
+  }
+  profileDbPromise = null;
 }

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { get, set, del } from 'idb-keyval';
+import { getProfileScopedKey } from './profileKeys';
 import { getTheme, setTheme } from './theme';
 
 const DEFAULT_SETTINGS = {
@@ -16,130 +17,170 @@ const DEFAULT_SETTINGS = {
   haptics: true,
 };
 
-export async function getAccent() {
+export async function getAccent(profileId) {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
-  return (await get('accent')) || DEFAULT_SETTINGS.accent;
+  try {
+    const key = getProfileScopedKey(profileId, 'accent');
+    return (await get(key)) || DEFAULT_SETTINGS.accent;
+  } catch {
+    return DEFAULT_SETTINGS.accent;
+  }
 }
 
-export async function setAccent(accent) {
+export async function setAccent(accent, profileId) {
   if (typeof window === 'undefined') return;
-  await set('accent', accent);
+  try {
+    await set(getProfileScopedKey(profileId, 'accent'), accent);
+  } catch {
+    // ignore
+  }
 }
 
-export async function getWallpaper() {
+export async function getWallpaper(profileId) {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
-  return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
+  try {
+    const key = getProfileScopedKey(profileId, 'bg-image');
+    return (await get(key)) || DEFAULT_SETTINGS.wallpaper;
+  } catch {
+    return DEFAULT_SETTINGS.wallpaper;
+  }
 }
 
-export async function setWallpaper(wallpaper) {
+export async function setWallpaper(wallpaper, profileId) {
   if (typeof window === 'undefined') return;
-  await set('bg-image', wallpaper);
+  try {
+    await set(getProfileScopedKey(profileId, 'bg-image'), wallpaper);
+  } catch {
+    // ignore
+  }
 }
 
-export async function getDensity() {
+export async function getDensity(profileId) {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  const key = getProfileScopedKey(profileId, 'density');
+  return window.localStorage.getItem(key) || DEFAULT_SETTINGS.density;
 }
 
-export async function setDensity(density) {
+export async function setDensity(density, profileId) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
+  const key = getProfileScopedKey(profileId, 'density');
+  window.localStorage.setItem(key, density);
 }
 
-export async function getReducedMotion() {
+export async function getReducedMotion(profileId) {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  const stored = window.localStorage.getItem('reduced-motion');
+  const key = getProfileScopedKey(profileId, 'reduced-motion');
+  const stored = window.localStorage.getItem(key);
   if (stored !== null) {
     return stored === 'true';
   }
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
-export async function setReducedMotion(value) {
+export async function setReducedMotion(value, profileId) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+  const key = getProfileScopedKey(profileId, 'reduced-motion');
+  window.localStorage.setItem(key, value ? 'true' : 'false');
 }
 
-export async function getFontScale() {
+export async function getFontScale(profileId) {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
+  const key = getProfileScopedKey(profileId, 'font-scale');
+  const stored = window.localStorage.getItem(key);
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
-export async function setFontScale(scale) {
+export async function setFontScale(scale, profileId) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  const key = getProfileScopedKey(profileId, 'font-scale');
+  window.localStorage.setItem(key, String(scale));
 }
 
-export async function getHighContrast() {
+export async function getHighContrast(profileId) {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  const key = getProfileScopedKey(profileId, 'high-contrast');
+  return window.localStorage.getItem(key) === 'true';
 }
 
-export async function setHighContrast(value) {
+export async function setHighContrast(value, profileId) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+  const key = getProfileScopedKey(profileId, 'high-contrast');
+  window.localStorage.setItem(key, value ? 'true' : 'false');
 }
 
-export async function getLargeHitAreas() {
+export async function getLargeHitAreas(profileId) {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
+  const key = getProfileScopedKey(profileId, 'large-hit-areas');
+  return window.localStorage.getItem(key) === 'true';
 }
 
-export async function setLargeHitAreas(value) {
+export async function setLargeHitAreas(value, profileId) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
+  const key = getProfileScopedKey(profileId, 'large-hit-areas');
+  window.localStorage.setItem(key, value ? 'true' : 'false');
 }
 
-export async function getHaptics() {
+export async function getHaptics(profileId) {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
-  const val = window.localStorage.getItem('haptics');
+  const key = getProfileScopedKey(profileId, 'haptics');
+  const val = window.localStorage.getItem(key);
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
-export async function setHaptics(value) {
+export async function setHaptics(value, profileId) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('haptics', value ? 'true' : 'false');
+  const key = getProfileScopedKey(profileId, 'haptics');
+  window.localStorage.setItem(key, value ? 'true' : 'false');
 }
 
-export async function getPongSpin() {
+export async function getPongSpin(profileId) {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
+  const key = getProfileScopedKey(profileId, 'pong-spin');
+  const val = window.localStorage.getItem(key);
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
-export async function setPongSpin(value) {
+export async function setPongSpin(value, profileId) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
+  const key = getProfileScopedKey(profileId, 'pong-spin');
+  window.localStorage.setItem(key, value ? 'true' : 'false');
 }
 
-export async function getAllowNetwork() {
+export async function getAllowNetwork(profileId) {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
+  const key = getProfileScopedKey(profileId, 'allow-network');
+  return window.localStorage.getItem(key) === 'true';
 }
 
-export async function setAllowNetwork(value) {
+export async function setAllowNetwork(value, profileId) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+  const key = getProfileScopedKey(profileId, 'allow-network');
+  window.localStorage.setItem(key, value ? 'true' : 'false');
 }
 
-export async function resetSettings() {
+export async function resetSettings(profileId) {
   if (typeof window === 'undefined') return;
   await Promise.all([
-    del('accent'),
-    del('bg-image'),
+    del(getProfileScopedKey(profileId, 'accent')),
+    del(getProfileScopedKey(profileId, 'bg-image')),
   ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
+  const keys = [
+    'density',
+    'reduced-motion',
+    'font-scale',
+    'high-contrast',
+    'large-hit-areas',
+    'pong-spin',
+    'allow-network',
+    'haptics',
+  ];
+  keys.forEach((name) => {
+    const scoped = getProfileScopedKey(profileId, name);
+    window.localStorage.removeItem(scoped);
+  });
 }
 
-export async function exportSettings() {
+export async function exportSettings(profileId) {
   const [
     accent,
     wallpaper,
@@ -152,18 +193,18 @@ export async function exportSettings() {
     allowNetwork,
     haptics,
   ] = await Promise.all([
-    getAccent(),
-    getWallpaper(),
-    getDensity(),
-    getReducedMotion(),
-    getFontScale(),
-    getHighContrast(),
-    getLargeHitAreas(),
-    getPongSpin(),
-    getAllowNetwork(),
-    getHaptics(),
+    getAccent(profileId),
+    getWallpaper(profileId),
+    getDensity(profileId),
+    getReducedMotion(profileId),
+    getFontScale(profileId),
+    getHighContrast(profileId),
+    getLargeHitAreas(profileId),
+    getPongSpin(profileId),
+    getAllowNetwork(profileId),
+    getHaptics(profileId),
   ]);
-  const theme = getTheme();
+  const theme = getTheme(profileId);
   return JSON.stringify({
     accent,
     wallpaper,
@@ -179,7 +220,7 @@ export async function exportSettings() {
   });
 }
 
-export async function importSettings(json) {
+export async function importSettings(json, profileId) {
   if (typeof window === 'undefined') return;
   let settings;
   try {
@@ -201,17 +242,17 @@ export async function importSettings(json) {
     haptics,
     theme,
   } = settings;
-  if (accent !== undefined) await setAccent(accent);
-  if (wallpaper !== undefined) await setWallpaper(wallpaper);
-  if (density !== undefined) await setDensity(density);
-  if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
-  if (fontScale !== undefined) await setFontScale(fontScale);
-  if (highContrast !== undefined) await setHighContrast(highContrast);
-  if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
-  if (pongSpin !== undefined) await setPongSpin(pongSpin);
-  if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
-  if (haptics !== undefined) await setHaptics(haptics);
-  if (theme !== undefined) setTheme(theme);
+  if (accent !== undefined) await setAccent(accent, profileId);
+  if (wallpaper !== undefined) await setWallpaper(wallpaper, profileId);
+  if (density !== undefined) await setDensity(density, profileId);
+  if (reducedMotion !== undefined) await setReducedMotion(reducedMotion, profileId);
+  if (fontScale !== undefined) await setFontScale(fontScale, profileId);
+  if (highContrast !== undefined) await setHighContrast(highContrast, profileId);
+  if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas, profileId);
+  if (pongSpin !== undefined) await setPongSpin(pongSpin, profileId);
+  if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork, profileId);
+  if (haptics !== undefined) await setHaptics(haptics, profileId);
+  if (theme !== undefined) setTheme(theme, profileId);
 }
 
 export const defaults = DEFAULT_SETTINGS;

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,4 +1,9 @@
+import { getProfileScopedKey } from './profileKeys';
+
 export const THEME_KEY = 'app:theme';
+
+export const getThemeStorageKey = (profileId?: string | null) =>
+  getProfileScopedKey(profileId ?? null, THEME_KEY);
 
 // Score required to unlock each theme
 export const THEME_UNLOCKS: Record<string, number> = {
@@ -13,10 +18,10 @@ const DARK_THEMES = ['dark', 'neon', 'matrix'] as const;
 export const isDarkTheme = (theme: string): boolean =>
   DARK_THEMES.includes(theme as (typeof DARK_THEMES)[number]);
 
-export const getTheme = (): string => {
+export const getTheme = (profileId?: string | null): string => {
   if (typeof window === 'undefined') return 'default';
   try {
-    const stored = window.localStorage.getItem(THEME_KEY);
+    const stored = window.localStorage.getItem(getThemeStorageKey(profileId));
     if (stored) return stored;
     const prefersDark = window.matchMedia?.(
       '(prefers-color-scheme: dark)'
@@ -27,14 +32,17 @@ export const getTheme = (): string => {
   }
 };
 
-export const setTheme = (theme: string): void => {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(THEME_KEY, theme);
+export const setTheme = (theme: string, profileId?: string | null): void => {
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(getThemeStorageKey(profileId), theme);
+    } catch {
+      /* ignore storage errors */
+    }
+  }
+  if (typeof document !== 'undefined') {
     document.documentElement.dataset.theme = theme;
     document.documentElement.classList.toggle('dark', isDarkTheme(theme));
-  } catch {
-    /* ignore storage errors */
   }
 };
 


### PR DESCRIPTION
## Summary
- add a ProfilesProvider backed by IndexedDB, including dedupe/reset helpers, and wire it through the app shell
- scope settings, session, and theme persistence by active profile and expose new profile utility helpers
- add navbar UI for switching/creating/deleting profiles and update settings flows accordingly
- add tests covering profile creation/switching and theme persistence for profile-aware storage

## Testing
- yarn test __tests__/profiles.test.tsx --runInBand
- yarn test __tests__/themePersistence.test.tsx --runInBand
- yarn test --runInBand *(fails: existing window.test.tsx TypeError on preventDefault and nmapNse.test.tsx missing alert role)*
- yarn lint *(hangs without completing on repo-wide ESLint run; manually aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68cce5eb51c0832891694948b60074a1