### PR TITLE
[ui] Add contextual help overlay and tests

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -19,6 +19,30 @@ export const chromeDefaultTiles = [
   { title: 'Example', url: 'https://example.com' },
 ];
 
+export const helpArticles = {
+  terminal: {
+    appId: 'terminal',
+    articleId: 'terminal',
+    title: 'Terminal',
+    docPath: '/docs/apps/terminal.md',
+  },
+  wireshark: {
+    appId: 'wireshark',
+    articleId: 'wireshark',
+    title: 'Wireshark',
+    docPath: '/docs/apps/wireshark.md',
+  },
+};
+
+const withHelpArticle = (config) => {
+  const help = helpArticles[config.id];
+  if (!help) return config;
+  return {
+    ...config,
+    helpArticleId: help.articleId,
+  };
+};
+
 // Dynamic applications and games
 const TerminalApp = createDynamicApp('terminal', 'Terminal');
 // VSCode app uses a Stack iframe, so no editor dependencies are required
@@ -1066,6 +1090,6 @@ const apps = [
   ...utilities,
   // Games are included so they appear alongside apps
   ...games,
-];
+].map(withHelpArticle);
 
 export default apps;

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -519,46 +519,63 @@ export class Window extends Component {
     }
 
     handleKeyDown = (e) => {
+        const stopEvent = () => {
+            if (typeof e.preventDefault === 'function') {
+                e.preventDefault();
+            }
+            if (typeof e.stopPropagation === 'function') {
+                e.stopPropagation();
+            }
+        };
+        if (
+            e.key === 'F1' &&
+            !e.shiftKey &&
+            !e.altKey &&
+            !e.ctrlKey &&
+            !e.metaKey
+        ) {
+            stopEvent();
+            if (typeof window !== 'undefined') {
+                window.dispatchEvent(
+                    new CustomEvent('open-help', {
+                        detail: { appId: this.id },
+                    })
+                );
+            }
+            return;
+        }
         if (e.key === 'Escape') {
             this.closeWindow();
         } else if (e.key === 'Tab') {
             this.focusWindow();
         } else if (e.altKey) {
             if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                stopEvent();
                 this.unsnapWindow();
             } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                stopEvent();
                 this.snapWindow('left');
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                stopEvent();
                 this.snapWindow('right');
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                stopEvent();
                 this.snapWindow('top');
             }
             this.focusWindow();
         } else if (e.shiftKey) {
             const step = 1;
             if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                stopEvent();
                 this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                stopEvent();
                 this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                stopEvent();
                 this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                stopEvent();
                 this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
             }
             this.focusWindow();

--- a/components/help/ContextualHelpPortal.tsx
+++ b/components/help/ContextualHelpPortal.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
+import { helpArticles } from '../../apps.config';
+
+interface HelpArticleMeta {
+  appId: string;
+  articleId: string;
+  title: string;
+  docPath: string;
+}
+
+type HelpArticlesMap = Record<string, HelpArticleMeta>;
+
+const articles = helpArticles as unknown as HelpArticlesMap;
+const DEFAULT_HTML = '<p>No help available for this app.</p>';
+
+const toHtml = async (markdown: string): Promise<string> => {
+  const raw = await marked.parse(markdown);
+  return DOMPurify.sanitize(typeof raw === 'string' ? raw : String(raw));
+};
+
+const getFallbackArticle = (appId: string): HelpArticleMeta => ({
+  appId,
+  articleId: appId,
+  title: 'Help',
+  docPath: '',
+});
+
+const isFocusableElement = (el: Element | null): el is HTMLElement => {
+  return !!el && 'focus' in el && typeof (el as HTMLElement).focus === 'function';
+};
+
+const ContextualHelpPortal = () => {
+  const [isMounted, setIsMounted] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [article, setArticle] = useState<HelpArticleMeta | null>(null);
+  const [content, setContent] = useState(DEFAULT_HTML);
+  const [loading, setLoading] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const lastFocusedRef = useRef<HTMLElement | null>(null);
+  const lastOpenedAppIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      const previous = lastFocusedRef.current;
+      const fallbackId = lastOpenedAppIdRef.current;
+      lastFocusedRef.current = null;
+
+      const focusFallback = () => {
+        if (!fallbackId) return;
+        const fallbackEl = document.getElementById(fallbackId);
+        if (fallbackEl && isFocusableElement(fallbackEl)) {
+          fallbackEl.focus();
+        }
+      };
+
+      if (previous && previous.isConnected) {
+        requestAnimationFrame(() => {
+          previous.focus();
+        });
+      } else if (fallbackId) {
+        requestAnimationFrame(focusFallback);
+      }
+      return;
+    }
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+      }
+    };
+
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [isOpen, close]);
+
+  useEffect(() => {
+    if (!isMounted) return undefined;
+
+    const handleOpen = (event: Event) => {
+      const customEvent = event as CustomEvent<{ appId?: string }>;
+      const appId = customEvent.detail?.appId;
+      if (!appId) {
+        return;
+      }
+
+      lastOpenedAppIdRef.current = appId;
+
+      const activeElement = document.activeElement;
+      if (isFocusableElement(activeElement)) {
+        lastFocusedRef.current = activeElement;
+      } else {
+        const fallback = document.getElementById(appId);
+        lastFocusedRef.current = fallback && isFocusableElement(fallback) ? fallback : null;
+      }
+
+      const meta = articles[appId] || getFallbackArticle(appId);
+      setArticle(meta);
+      setContent(DEFAULT_HTML);
+      setLoading(false);
+      setIsOpen(true);
+    };
+
+    window.addEventListener('open-help', handleOpen as EventListener);
+    return () => window.removeEventListener('open-help', handleOpen as EventListener);
+  }, [isMounted]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    if (!article?.docPath) {
+      setContent(DEFAULT_HTML);
+      setLoading(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    const load = async () => {
+      try {
+        const response = await fetch(article.docPath);
+        const markdown = response.ok ? await response.text() : '';
+        if (cancelled) return;
+        if (!markdown) {
+          setContent(DEFAULT_HTML);
+          return;
+        }
+        const html = await toHtml(markdown);
+        if (!cancelled) {
+          setContent(html);
+        }
+      } catch {
+        if (!cancelled) {
+          setContent(DEFAULT_HTML);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, article]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    requestAnimationFrame(() => {
+      closeButtonRef.current?.focus();
+    });
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [isOpen]);
+
+  const rendered = useMemo(() => {
+    if (loading) {
+      return '<p>Loading help…</p>';
+    }
+    return content || DEFAULT_HTML;
+  }, [content, loading]);
+
+  if (!isMounted) {
+    return null;
+  }
+
+  return createPortal(
+    isOpen ? (
+      <div
+        data-testid="contextual-help"
+        className="fixed inset-0 z-[100] flex items-center justify-center px-4 py-8"
+        role="presentation"
+        onClick={close}
+      >
+        <div className="absolute inset-0 bg-black/70" aria-hidden="true" />
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="contextual-help-title"
+          className="relative z-10 w-full max-w-3xl overflow-hidden rounded-lg bg-slate-900 text-slate-100 shadow-2xl"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="flex items-center justify-between border-b border-white/10 px-5 py-3">
+            <h2 id="contextual-help-title" className="text-lg font-semibold">
+              {(article && article.title) || 'Help'}
+            </h2>
+            <button
+              type="button"
+              ref={closeButtonRef}
+              data-testid="contextual-help-close"
+              onClick={close}
+              className="rounded bg-blue-500 px-3 py-1 text-sm font-medium text-white hover:bg-blue-400 focus:outline-none focus:ring"
+            >
+              Back to app
+            </button>
+          </div>
+          <div
+            data-testid="contextual-help-content"
+            className="max-h-[70vh] overflow-y-auto px-5 pb-6 pt-4 text-left text-sm leading-6"
+            dangerouslySetInnerHTML={{ __html: rendered }}
+          />
+        </div>
+      </div>
+    ) : null,
+    document.body
+  );
+};
+
+export default ContextualHelpPortal;
+

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,12 +8,31 @@ function nonce() {
 
 export function middleware(req: NextRequest) {
   const n = nonce();
+  const scriptSrc = [
+    "'self'",
+    "'unsafe-inline'",
+    `'nonce-${n}'`,
+    'https://vercel.live',
+    'https://platform.twitter.com',
+    'https://syndication.twitter.com',
+    'https://cdn.syndication.twimg.com',
+    'https://www.youtube.com',
+    'https://www.google.com',
+    'https://www.gstatic.com',
+    'https://cdn.jsdelivr.net',
+    'https://cdnjs.cloudflare.com',
+  ];
+
+  if (process.env.NODE_ENV !== 'production') {
+    scriptSrc.push("'unsafe-eval'");
+  }
+
   const csp = [
     "default-src 'self'",
     "img-src 'self' https: data:",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
-    `script-src 'self' 'unsafe-inline' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
+    `script-src ${scriptSrc.join(' ')}`,
     "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com",
     "frame-src 'self' https://vercel.live https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
     "frame-ancestors 'self'",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,6 +14,7 @@ import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
+import ContextualHelpPortal from '../components/help/ContextualHelpPortal';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
@@ -161,6 +162,7 @@ function MyApp(props) {
             <div aria-live="polite" id="live-region" />
             <Component {...pageProps} />
             <ShortcutOverlay />
+            <ContextualHelpPortal />
             <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;

--- a/pages/help/[appId].tsx
+++ b/pages/help/[appId].tsx
@@ -1,0 +1,88 @@
+import type { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'next';
+import Head from 'next/head';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { marked } from 'marked';
+import { helpArticles } from '../../apps.config';
+
+interface StaticArticleMeta {
+  appId: string;
+  title: string;
+  docPath: string;
+}
+
+interface HelpArticleProps {
+  article: {
+    appId: string;
+    title: string;
+    html: string;
+  };
+}
+
+const articles = helpArticles as unknown as Record<string, StaticArticleMeta>;
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const paths = Object.keys(articles).map((appId) => ({
+    params: { appId },
+  }));
+  return {
+    paths,
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<HelpArticleProps> = async ({ params }) => {
+  const appId = typeof params?.appId === 'string' ? params.appId : '';
+  const meta = appId ? articles[appId] : undefined;
+
+  if (!meta) {
+    return { notFound: true };
+  }
+
+  const filePath = path.join(process.cwd(), 'public', meta.docPath.replace(/^\//, ''));
+
+  try {
+    const markdown = await fs.readFile(filePath, 'utf8');
+    const parsed = await marked.parse(markdown);
+    const html = typeof parsed === 'string' ? parsed : String(parsed);
+
+    return {
+      props: {
+        article: {
+          appId: meta.appId,
+          title: meta.title,
+          html,
+        },
+      },
+    };
+  } catch {
+    return { notFound: true };
+  }
+};
+
+type HelpArticlePageProps = InferGetStaticPropsType<typeof getStaticProps>;
+
+const HelpArticlePage = ({ article }: HelpArticlePageProps) => {
+  return (
+    <>
+      <Head>
+        <title>{`${article.title} Help | Kali Linux Portfolio`}</title>
+        <meta name="description" content={`Help article for the ${article.title} app.`} />
+      </Head>
+      <main className="min-h-screen bg-slate-950 text-slate-100">
+        <div className="mx-auto max-w-3xl px-4 py-10">
+          <a href="/" className="text-sm text-blue-300 hover:underline">
+            ← Back to desktop
+          </a>
+          <h1 className="mt-4 text-3xl font-bold">{article.title} Help</h1>
+          <div
+            className="prose prose-invert mt-6 max-w-none space-y-4 text-base leading-7"
+            dangerouslySetInnerHTML={{ __html: article.html }}
+          />
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default HelpArticlePage;

--- a/public/docs/apps/wireshark.md
+++ b/public/docs/apps/wireshark.md
@@ -1,0 +1,7 @@
+# Wireshark Help
+
+The Wireshark simulator visualizes packet captures so you can explore flows without touching production networks.
+
+- Use the flow graph to follow conversations between hosts.
+- Apply display filters to highlight interesting traffic patterns.
+- Export summaries to share findings with your team.

--- a/tests/help.spec.ts
+++ b/tests/help.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('contextual help', () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  test('opens terminal help on F1 and restores focus', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 120_000 });
+
+    await page.evaluate(() => {
+      const targetId = 'terminal';
+      return new Promise<void>((resolve, reject) => {
+        const start = Date.now();
+        const waitForDesktop = () => {
+          const desktop = document.getElementById('desktop');
+          if (desktop) {
+            const fire = () => window.dispatchEvent(new CustomEvent('open-app', { detail: targetId }));
+            fire();
+            const interval = window.setInterval(() => {
+              const terminalWindow = document.getElementById(targetId);
+              if (terminalWindow) {
+                window.clearInterval(interval);
+                resolve();
+                return;
+              }
+              if (Date.now() - start > 60_000) {
+                window.clearInterval(interval);
+                reject(new Error('Timed out opening terminal'));
+                return;
+              }
+              fire();
+            }, 200);
+            return;
+          }
+
+          if (Date.now() - start > 60_000) {
+            reject(new Error('Desktop did not initialize'));
+            return;
+          }
+
+          window.setTimeout(waitForDesktop, 100);
+        };
+
+        waitForDesktop();
+      });
+    });
+
+    const terminal = page.locator('#terminal');
+    await expect(terminal).toBeVisible();
+
+    await terminal.focus();
+    await expect(terminal).toBeFocused();
+
+    await page.keyboard.press('F1');
+
+    const overlay = page.locator('[data-testid="contextual-help"]');
+    await expect(overlay).toBeVisible();
+    await expect(page.locator('[data-testid="contextual-help-content"]')).toContainText(
+      'This terminal emulates basic shell commands.'
+    );
+
+    await page.locator('[data-testid="contextual-help-close"]').click();
+    await expect(overlay).toBeHidden();
+    await expect(terminal).toBeFocused();
+  });
+
+  test('loads wireshark help article via deep link', async ({ page }) => {
+    await page.goto('/help/wireshark', { waitUntil: 'domcontentloaded', timeout: 120_000 });
+    await expect(page.locator('main h1').first()).toHaveText('Wireshark Help');
+    await expect(page.locator('main')).toContainText('The Wireshark simulator visualizes packet captures');
+  });
+});


### PR DESCRIPTION
## Summary
- dispatch an `open-help` window event when users press F1 and register available articles in the app config
- render a contextual help portal that loads markdown docs, restores focus, and expose static `/help/[appId]` deep links
- relax the dev CSP to allow React Refresh and add Playwright coverage for F1 help and direct article routes

## Testing
- BASE_URL=http://localhost:3001 npx playwright test tests/help.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cce5edda10832883e46d4be5f1630f