### PR TITLE
[desktop] add guest profile switcher

### DIFF
--- a/__mocks__/idb-keyval.js
+++ b/__mocks__/idb-keyval.js
@@ -1,0 +1,21 @@
+const store = new Map();
+
+const asyncValue = (value) => Promise.resolve(value);
+
+export const get = jest.fn((key) => asyncValue(store.get(key)));
+
+export const set = jest.fn((key, value) => {
+  store.set(key, value);
+  return asyncValue(undefined);
+});
+
+export const del = jest.fn((key) => {
+  store.delete(key);
+  return asyncValue(undefined);
+});
+
+export const __reset = () => {
+  store.clear();
+};
+
+export const __store = store;

--- a/__tests__/profileSwitcher.test.tsx
+++ b/__tests__/profileSwitcher.test.tsx
@@ -1,0 +1,220 @@
+jest.mock('idb-keyval');
+
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import usePersistentState from '../hooks/usePersistentState';
+import { ProfileProvider, useProfileSwitcher } from '../hooks/useProfileSwitcher';
+import useSession from '../hooks/useSession';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+import { defaults } from '../utils/settingsStore';
+
+const idbKeyval = require('idb-keyval');
+
+const ProfileWrapper = ({ children }: { children: ReactNode }) => (
+  <ProfileProvider>{children}</ProfileProvider>
+);
+
+const SettingsWrapper = ({ children }: { children: ReactNode }) => (
+  <ProfileProvider>
+    <SettingsProvider>{children}</SettingsProvider>
+  </ProfileProvider>
+);
+
+describe('profile switcher and guest mode', () => {
+  let uuidCounter = 0;
+
+  beforeEach(() => {
+    uuidCounter = 0;
+    Object.defineProperty(global, 'crypto', {
+      value: {
+        randomUUID: jest.fn(() => `uuid-${++uuidCounter}`),
+      },
+      configurable: true,
+    });
+    window.localStorage.clear();
+    document.documentElement.dataset.theme = '';
+    document.documentElement.className = '';
+    idbKeyval.__reset();
+    idbKeyval.get.mockClear();
+    idbKeyval.set.mockClear();
+    idbKeyval.del.mockClear();
+    window.matchMedia = jest.fn().mockReturnValue({
+      matches: false,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      onchange: null,
+      dispatchEvent: jest.fn(),
+    });
+    // @ts-ignore
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
+  });
+
+  test('persistent state scoped per profile and ignored for guests', () => {
+    const { result } = renderHook(
+      () => {
+        const [value, setValue] = usePersistentState('demo-key', 'initial');
+        const profile = useProfileSwitcher();
+        return { value, setValue, profile };
+      },
+      { wrapper: ProfileWrapper },
+    );
+
+    act(() => {
+      result.current.setValue('primary');
+    });
+    expect(result.current.value).toBe('primary');
+    expect(window.localStorage.getItem('profile:default:demo-key')).toBe('"primary"');
+
+    let workProfileId: string;
+    act(() => {
+      const profile = result.current.profile.createProfile('Work');
+      workProfileId = profile.id;
+    });
+
+    act(() => {
+      result.current.profile.switchProfile(workProfileId);
+    });
+    expect(result.current.value).toBe('initial');
+
+    act(() => {
+      result.current.setValue('work');
+    });
+    expect(window.localStorage.getItem(`profile:${workProfileId}:demo-key`)).toBe('"work"');
+
+    act(() => {
+      result.current.profile.switchProfile('default');
+    });
+    expect(result.current.value).toBe('primary');
+
+    act(() => {
+      result.current.profile.enterGuestMode();
+    });
+    const guestProfileId = result.current.profile.activeProfileId;
+
+    act(() => {
+      result.current.setValue('guest-temp');
+    });
+    expect(window.localStorage.getItem(`profile:${guestProfileId}:demo-key`)).toBeNull();
+
+    act(() => {
+      result.current.profile.exitGuestMode();
+    });
+    expect(result.current.value).toBe('primary');
+    expect(result.current.profile.isGuest).toBe(false);
+  });
+
+  test('session resets to defaults after exiting guest mode', async () => {
+    const { result } = renderHook(
+      () => {
+        const session = useSession();
+        const profile = useProfileSwitcher();
+        return { ...session, profile };
+      },
+      { wrapper: ProfileWrapper },
+    );
+
+    act(() => {
+      result.current.setSession({
+        windows: [{ id: 'win-1', x: 10, y: 20 }],
+        wallpaper: 'wall-5',
+        dock: ['terminal'],
+      });
+    });
+
+    await waitFor(() => {
+      const stored = window.localStorage.getItem('profile:default:desktop-session');
+      expect(stored).not.toBeNull();
+      const parsed = JSON.parse(stored!);
+      expect(parsed.wallpaper).toBe('wall-5');
+      expect(parsed.windows).toHaveLength(1);
+    });
+
+    act(() => {
+      result.current.profile.enterGuestMode();
+    });
+    const guestProfileId = result.current.profile.activeProfileId;
+
+    act(() => {
+      result.current.setSession({
+        windows: [{ id: 'win-guest', x: 0, y: 0 }],
+        wallpaper: 'wall-1',
+        dock: [],
+      });
+    });
+
+    expect(window.localStorage.getItem(`profile:${guestProfileId}:desktop-session`)).toBeNull();
+
+    act(() => {
+      result.current.profile.exitGuestMode();
+    });
+
+    await waitFor(() => {
+      expect(result.current.session.wallpaper).toBe(defaults.wallpaper);
+      const stored = window.localStorage.getItem('profile:default:desktop-session');
+      expect(stored).not.toBeNull();
+      const parsed = JSON.parse(stored!);
+      expect(parsed.wallpaper).toBe(defaults.wallpaper);
+      expect(parsed.windows).toHaveLength(0);
+    });
+  });
+
+  test('settings are cleared and restored to defaults after guest sessions', async () => {
+    const { result } = renderHook(
+      () => {
+        const settings = useSettings();
+        const profile = useProfileSwitcher();
+        return { settings, profile };
+      },
+      { wrapper: SettingsWrapper },
+    );
+
+    await act(async () => {
+      result.current.settings.setAccent('#e53e3e');
+      result.current.settings.setTheme('dark');
+      result.current.settings.setReducedMotion(true);
+    });
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem('app:theme:default')).toBe('dark');
+      expect(idbKeyval.set).toHaveBeenCalledWith('default:accent', '#e53e3e');
+    });
+
+    act(() => {
+      result.current.profile.enterGuestMode();
+    });
+
+    await waitFor(() => {
+      expect(result.current.settings.theme).toBe('default');
+      expect(result.current.settings.accent).toBe(defaults.accent);
+    });
+
+    const guestProfileId = result.current.profile.activeProfileId;
+
+    await act(async () => {
+      result.current.settings.setTheme('neon');
+      result.current.settings.setAccent('#ed64a6');
+    });
+
+    expect(window.localStorage.getItem(`app:theme:${guestProfileId}`)).toBeNull();
+    const accentCalls = idbKeyval.set.mock.calls.filter(
+      (call: [string, ...unknown[]]) => (call[0] as string).endsWith(':accent'),
+    );
+    expect(accentCalls.some((call) => call[0] === `${guestProfileId}:accent`)).toBe(false);
+
+    act(() => {
+      result.current.profile.exitGuestMode();
+    });
+
+    await waitFor(() => {
+      expect(result.current.settings.theme).toBe('default');
+      expect(result.current.settings.accent).toBe(defaults.accent);
+      const storedTheme = window.localStorage.getItem('app:theme:default');
+      expect(storedTheme).toBe('default');
+      expect(idbKeyval.del).toHaveBeenCalledWith('default:accent');
+      expect(idbKeyval.set).toHaveBeenCalledWith('default:accent', defaults.accent);
+    });
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import { useProfileSwitcher } from "../../hooks/useProfileSwitcher";
 
 export default function Settings() {
   const {
@@ -32,6 +33,7 @@ export default function Settings() {
     theme,
     setTheme,
   } = useSettings();
+  const { persistentProfileId } = useProfileSwitcher();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const tabs = [
@@ -56,7 +58,7 @@ export default function Settings() {
   const changeBackground = (name: string) => setWallpaper(name);
 
   const handleExport = async () => {
-    const data = await exportSettingsData();
+    const data = await exportSettingsData(persistentProfileId);
     const blob = new Blob([data], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -68,7 +70,7 @@ export default function Settings() {
 
   const handleImport = async (file: File) => {
     const text = await file.text();
-    await importSettingsData(text);
+    await importSettingsData(text, persistentProfileId);
     try {
       const parsed = JSON.parse(text);
       if (parsed.accent !== undefined) setAccent(parsed.accent);
@@ -92,8 +94,7 @@ export default function Settings() {
       )
     )
       return;
-    await resetSettings();
-    window.localStorage.clear();
+    await resetSettings(persistentProfileId);
     setAccent(defaults.accent);
     setWallpaper(defaults.wallpaper);
     setDensity(defaults.density as any);

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,9 +1,16 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
-import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import {
+    resetSettings,
+    defaults,
+    exportSettings as exportSettingsData,
+    importSettings as importSettingsData,
+} from '../../utils/settingsStore';
+import { useProfileSwitcher } from '../../hooks/useProfileSwitcher';
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { persistentProfileId } = useProfileSwitcher();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -222,7 +229,7 @@ export function Settings() {
             <div className="flex justify-center my-4 border-t border-gray-900 pt-4 space-x-4">
                 <button
                     onClick={async () => {
-                        const data = await exportSettingsData();
+                        const data = await exportSettingsData(persistentProfileId);
                         const blob = new Blob([data], { type: 'application/json' });
                         const url = URL.createObjectURL(blob);
                         const a = document.createElement('a');
@@ -243,7 +250,7 @@ export function Settings() {
                 </button>
                 <button
                     onClick={async () => {
-                        await resetSettings();
+                        await resetSettings(persistentProfileId);
                         setAccent(defaults.accent);
                         setWallpaper(defaults.wallpaper);
                         setDensity(defaults.density);
@@ -251,6 +258,9 @@ export function Settings() {
                         setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
+                        setPongSpin(defaults.pongSpin);
+                        setAllowNetwork(defaults.allowNetwork);
+                        setHaptics(defaults.haptics);
                         setTheme('default');
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
@@ -266,7 +276,7 @@ export function Settings() {
                     const file = e.target.files && e.target.files[0];
                     if (!file) return;
                     const text = await file.text();
-                    await importSettingsData(text);
+                    await importSettingsData(text, persistentProfileId);
                     try {
                         const parsed = JSON.parse(text);
                         if (parsed.accent !== undefined) setAccent(parsed.accent);
@@ -275,6 +285,9 @@ export function Settings() {
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
+                        if (parsed.pongSpin !== undefined) setPongSpin(parsed.pongSpin);
+                        if (parsed.allowNetwork !== undefined) setAllowNetwork(parsed.allowNetwork);
+                        if (parsed.haptics !== undefined) setHaptics(parsed.haptics);
                         if (parsed.theme !== undefined) { setTheme(parsed.theme); }
                     } catch (err) {
                         console.error('Invalid settings', err);

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { useCallback, useEffect, useMemo } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import { useProfileSwitcher } from '../../hooks/useProfileSwitcher';
 
 interface Props {
   open: boolean;
@@ -12,6 +13,17 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const {
+    profiles,
+    activeProfileId,
+    persistentProfileId,
+    isGuest,
+    switchProfile,
+    createProfile,
+    renameProfile,
+    enterGuestMode,
+    exitGuestMode,
+  } = useProfileSwitcher();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -21,36 +33,157 @@ const QuickSettings = ({ open }: Props) => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
 
+  const selectedProfileId = useMemo(
+    () => (isGuest ? persistentProfileId : activeProfileId),
+    [activeProfileId, isGuest, persistentProfileId],
+  );
+
+  const handleCreateProfile = useCallback(() => {
+    const name = window.prompt('Name this profile?', 'Profile');
+    const trimmed = name?.trim();
+    const profile = createProfile(trimmed || undefined);
+    switchProfile(profile.id);
+  }, [createProfile, switchProfile]);
+
+  const handleRenameProfile = useCallback(
+    (id: string, currentName: string) => {
+      const name = window.prompt('Rename profile', currentName);
+      const trimmed = name?.trim();
+      if (!trimmed || trimmed === currentName) return;
+      renameProfile(id, trimmed);
+    },
+    [renameProfile],
+  );
+
+  const handleGuestToggle = useCallback(() => {
+    if (isGuest) {
+      exitGuestMode();
+    } else {
+      enterGuestMode();
+    }
+  }, [enterGuestMode, exitGuestMode, isGuest]);
+
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 w-64 ${
         open ? '' : 'hidden'
       }`}
     >
-      <div className="px-4 pb-2">
+      <div className="px-4 pb-3 border-b border-black/30">
+        <div className="flex items-center justify-between">
+          <span className="font-semibold">Profiles</span>
+          <button
+            type="button"
+            className="text-xs text-ubt-grey hover:text-white"
+            onClick={(event) => {
+              event.stopPropagation();
+              handleCreateProfile();
+            }}
+          >
+            + New
+          </button>
+        </div>
+        <ul className="mt-2 space-y-1" aria-label="Available profiles">
+          {profiles.map((profile) => {
+            const isActiveProfile = selectedProfileId === profile.id;
+            const willRestore = isGuest && profile.id === persistentProfileId;
+            return (
+              <li key={profile.id}>
+                <button
+                  type="button"
+                  className={`w-full flex items-center justify-between rounded px-2 py-1 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-ub-orange ${
+                    isActiveProfile ? 'bg-ub-dark text-white' : 'hover:bg-ub-mid'
+                  }`}
+                  onClick={() => switchProfile(profile.id)}
+                >
+                  <span className="truncate">{profile.name}</span>
+                  <span className="text-[0.65rem] uppercase tracking-wide text-ubt-grey">
+                    {isGuest && profile.id === activeProfileId
+                      ? 'Guest'
+                      : isActiveProfile
+                        ? 'Active'
+                        : willRestore
+                          ? 'Saved'
+                          : ''}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="mt-1 text-[0.65rem] uppercase tracking-wide text-ubt-grey hover:text-white"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleRenameProfile(profile.id, profile.name);
+                  }}
+                >
+                  Rename
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      <div className="px-4 py-3 border-b border-black/30">
         <button
+          type="button"
+          className="w-full rounded bg-ub-orange px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-ubt-orange"
+          onClick={(event) => {
+            event.stopPropagation();
+            handleGuestToggle();
+          }}
+        >
+          {isGuest ? 'Exit Guest Session' : 'Browse as Guest'}
+        </button>
+        <p className="mt-2 text-xs leading-snug text-ubt-grey">
+          Guest sessions use in-memory storage and wipe preferences when you exit.
+        </p>
+      </div>
+
+      <div className="px-4 pt-3 space-y-2">
+        <button
+          type="button"
           className="w-full flex justify-between"
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          onClick={(event) => {
+            event.stopPropagation();
+            setTheme(theme === 'light' ? 'dark' : 'light');
+          }}
         >
           <span>Theme</span>
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
-        <input
-          type="checkbox"
-          checked={reduceMotion}
-          onChange={() => setReduceMotion(!reduceMotion)}
-        />
+        <label className="flex items-center justify-between">
+          <span>Sound</span>
+          <input
+            type="checkbox"
+            checked={sound}
+            onChange={(event) => {
+              event.stopPropagation();
+              setSound(!sound);
+            }}
+          />
+        </label>
+        <label className="flex items-center justify-between">
+          <span>Network</span>
+          <input
+            type="checkbox"
+            checked={online}
+            onChange={(event) => {
+              event.stopPropagation();
+              setOnline(!online);
+            }}
+          />
+        </label>
+        <label className="flex items-center justify-between">
+          <span>Reduced motion</span>
+          <input
+            type="checkbox"
+            checked={reduceMotion}
+            onChange={(event) => {
+              event.stopPropagation();
+              setReduceMotion(!reduceMotion);
+            }}
+          />
+        </label>
       </div>
     </div>
   );

--- a/hooks/usePersistentState.js
+++ b/hooks/usePersistentState.js
@@ -1,15 +1,25 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useProfileSwitcher } from './useProfileSwitcher';
 
 // Persist state in localStorage with validation and helpers.
 export default function usePersistentState(key, initial, validator) {
-  const getInitial = () => (typeof initial === "function" ? initial() : initial);
+  const { storageKey, isGuest } = useProfileSwitcher();
+  const storageKeyRef = useRef(null);
+  const getInitial = useCallback(
+    () => (typeof initial === 'function' ? initial() : initial),
+    [initial],
+  );
+
+  const computeKey = useCallback(() => (isGuest ? null : storageKey(key)), [isGuest, key, storageKey]);
+  storageKeyRef.current = computeKey();
 
   const [state, setState] = useState(() => {
-    if (typeof window === "undefined") return getInitial();
+    const currentKey = storageKeyRef.current;
+    if (typeof window === 'undefined' || !currentKey) return getInitial();
     try {
-      const stored = window.localStorage.getItem(key);
+      const stored = window.localStorage.getItem(currentKey);
       if (stored !== null) {
         const parsed = JSON.parse(stored);
         if (!validator || validator(parsed)) {
@@ -23,22 +33,49 @@ export default function usePersistentState(key, initial, validator) {
   });
 
   useEffect(() => {
+    const currentKey = computeKey();
+    storageKeyRef.current = currentKey;
+    if (typeof window === 'undefined' || !currentKey) {
+      setState(getInitial());
+      return;
+    }
     try {
-      window.localStorage.setItem(key, JSON.stringify(state));
+      const stored = window.localStorage.getItem(currentKey);
+      if (stored !== null) {
+        const parsed = JSON.parse(stored);
+        if (!validator || validator(parsed)) {
+          setState(parsed);
+          return;
+        }
+      }
+    } catch {
+      // ignore errors and fall back to initial
+    }
+    setState(getInitial());
+  }, [computeKey, getInitial, validator]);
+
+  useEffect(() => {
+    const currentKey = storageKeyRef.current;
+    if (!currentKey || typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(currentKey, JSON.stringify(state));
     } catch {
       // ignore write errors
     }
-  }, [key, state]);
+  }, [state]);
 
-  const reset = () => setState(getInitial());
-  const clear = () => {
-    try {
-      window.localStorage.removeItem(key);
-    } catch {
-      // ignore remove errors
+  const reset = useCallback(() => setState(getInitial()), [getInitial]);
+  const clear = useCallback(() => {
+    const currentKey = storageKeyRef.current;
+    if (currentKey && typeof window !== 'undefined') {
+      try {
+        window.localStorage.removeItem(currentKey);
+      } catch {
+        // ignore remove errors
+      }
     }
     reset();
-  };
+  }, [reset]);
 
   return [state, setState, reset, clear];
 }

--- a/hooks/useProfileSwitcher.tsx
+++ b/hooks/useProfileSwitcher.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+interface Profile {
+  id: string;
+  name: string;
+}
+
+interface ProfileContextValue {
+  profiles: Profile[];
+  activeProfileId: string;
+  persistentProfileId: string;
+  isGuest: boolean;
+  switchProfile: (id: string) => void;
+  createProfile: (name?: string) => Profile;
+  renameProfile: (id: string, name: string) => void;
+  storageKey: (key: string) => string;
+  enterGuestMode: () => void;
+  exitGuestMode: () => void;
+}
+
+const STORAGE_KEY = 'profile-switcher';
+const DEFAULT_PROFILE: Profile = { id: 'default', name: 'Personal' };
+
+interface StoredState {
+  profiles: Profile[];
+  activeProfileId: string;
+}
+
+const ProfileContext = createContext<ProfileContextValue | undefined>(undefined);
+
+const generateId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `profile-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const readStoredState = (): StoredState => {
+  if (typeof window === 'undefined') {
+    return { profiles: [DEFAULT_PROFILE], activeProfileId: DEFAULT_PROFILE.id };
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return { profiles: [DEFAULT_PROFILE], activeProfileId: DEFAULT_PROFILE.id };
+    }
+    const parsed = JSON.parse(raw) as StoredState;
+    if (!parsed.profiles?.length) {
+      return { profiles: [DEFAULT_PROFILE], activeProfileId: DEFAULT_PROFILE.id };
+    }
+    const hasActive = parsed.profiles.some((p) => p.id === parsed.activeProfileId);
+    return {
+      profiles: parsed.profiles,
+      activeProfileId: hasActive ? parsed.activeProfileId : parsed.profiles[0].id,
+    };
+  } catch {
+    return { profiles: [DEFAULT_PROFILE], activeProfileId: DEFAULT_PROFILE.id };
+  }
+};
+
+export function ProfileProvider({ children }: { children: ReactNode }) {
+  const initial = useMemo(readStoredState, []);
+  const [profiles, setProfiles] = useState<Profile[]>(initial.profiles);
+  const [activeProfileId, setActiveProfileId] = useState(initial.activeProfileId);
+  const [guestProfileId, setGuestProfileId] = useState<string | null>(null);
+  const [isGuest, setIsGuest] = useState(false);
+  const lastPersistentId = useRef(initial.activeProfileId);
+
+  useEffect(() => {
+    if (isGuest || typeof window === 'undefined') return;
+    try {
+      const state: StoredState = { profiles, activeProfileId };
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch {
+      /* ignore storage failures */
+    }
+  }, [profiles, activeProfileId, isGuest]);
+
+  const switchProfile = useCallback(
+    (id: string) => {
+      const exists = profiles.some((profile) => profile.id === id);
+      if (!exists) return;
+      setIsGuest(false);
+      setGuestProfileId(null);
+      lastPersistentId.current = id;
+      setActiveProfileId(id);
+    },
+    [profiles],
+  );
+
+  const createProfile = useCallback(
+    (name?: string) => {
+      const profile: Profile = {
+        id: generateId(),
+        name:
+          name ||
+          `Profile ${profiles.reduce(
+            (count, p) => (p.name.startsWith('Profile ') ? count + 1 : count),
+            1,
+          )}`,
+      };
+      setProfiles((prev) => [...prev, profile]);
+      return profile;
+    },
+    [profiles],
+  );
+
+  const renameProfile = useCallback((id: string, name: string) => {
+    setProfiles((prev) =>
+      prev.map((profile) => (profile.id === id ? { ...profile, name } : profile)),
+    );
+  }, []);
+
+  const enterGuestMode = useCallback(() => {
+    const guestId = `guest-${generateId()}`;
+    setGuestProfileId(guestId);
+    setIsGuest(true);
+    lastPersistentId.current = activeProfileId;
+    setActiveProfileId(guestId);
+  }, [activeProfileId]);
+
+  const exitGuestMode = useCallback(() => {
+    setIsGuest(false);
+    setGuestProfileId(null);
+    const target = lastPersistentId.current;
+    const fallback = profiles[0]?.id ?? DEFAULT_PROFILE.id;
+    const next = profiles.some((profile) => profile.id === target) ? target : fallback;
+    setActiveProfileId(next);
+  }, [profiles]);
+
+  const storageKey = useCallback(
+    (key: string) => `profile:${activeProfileId}:${key}`,
+    [activeProfileId],
+  );
+
+  const value = useMemo<ProfileContextValue>(
+    () => ({
+      profiles,
+      activeProfileId,
+      persistentProfileId: isGuest ? lastPersistentId.current : activeProfileId,
+      isGuest,
+      switchProfile,
+      createProfile,
+      renameProfile,
+      storageKey,
+      enterGuestMode,
+      exitGuestMode,
+    }),
+    [
+      profiles,
+      activeProfileId,
+      isGuest,
+      switchProfile,
+      createProfile,
+      renameProfile,
+      storageKey,
+      enterGuestMode,
+      exitGuestMode,
+    ],
+  );
+
+  return <ProfileContext.Provider value={value}>{children}</ProfileContext.Provider>;
+}
+
+export function useProfileSwitcher() {
+  const ctx = useContext(ProfileContext);
+  if (!ctx) {
+    throw new Error('useProfileSwitcher must be used within a ProfileProvider');
+  }
+  return ctx;
+}
+

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -1,5 +1,7 @@
+import { useEffect, useRef } from 'react';
 import usePersistentState from './usePersistentState';
 import { defaults } from '../utils/settingsStore';
+import { useProfileSwitcher } from './useProfileSwitcher';
 
 export interface SessionWindow {
   id: string;
@@ -30,11 +32,20 @@ function isSession(value: unknown): value is DesktopSession {
 }
 
 export default function useSession() {
+  const { isGuest } = useProfileSwitcher();
   const [session, setSession, _reset, clear] = usePersistentState<DesktopSession>(
     'desktop-session',
     initialSession,
     isSession,
   );
+  const wasGuest = useRef(isGuest);
+
+  useEffect(() => {
+    if (wasGuest.current && !isGuest) {
+      clear();
+    }
+    wasGuest.current = isGuest;
+  }, [isGuest, clear]);
 
   const resetSession = () => {
     clear();

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,25 +1,43 @@
 import { useEffect, useState } from 'react';
-import { THEME_KEY, getTheme, setTheme as applyTheme } from '../utils/theme';
+import { THEME_KEY, getTheme, setTheme as applyTheme, isDarkTheme } from '../utils/theme';
+import { useProfileSwitcher } from './useProfileSwitcher';
 
 export const useTheme = () => {
-  const [theme, setThemeState] = useState<string>(() => getTheme());
+  const { activeProfileId, isGuest } = useProfileSwitcher();
+  const profileId = activeProfileId;
+  const persist = !isGuest;
+  const [theme, setThemeState] = useState<string>(() => (persist ? getTheme(profileId) : 'default'));
 
   useEffect(() => {
     const handleStorage = (e: StorageEvent) => {
-      if (e.key === THEME_KEY) {
-        const next = getTheme();
+      const key = `${THEME_KEY}:${profileId}`;
+      if (e.key === key) {
+        const next = getTheme(profileId);
         setThemeState(next);
-        applyTheme(next);
+        applyTheme(profileId, next);
 
       }
     };
     window.addEventListener('storage', handleStorage);
     return () => window.removeEventListener('storage', handleStorage);
-  }, []);
+  }, [profileId]);
+
+  useEffect(() => {
+    if (!persist) {
+      setThemeState('default');
+      return;
+    }
+    setThemeState(getTheme(profileId));
+  }, [persist, profileId]);
 
   const setTheme = (next: string) => {
     setThemeState(next);
-    applyTheme(next);
+    if (persist) {
+      applyTheme(profileId, next);
+    } else {
+      document.documentElement.dataset.theme = next;
+      document.documentElement.classList.toggle('dark', isDarkTheme(next));
+    }
 
   };
 

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,7 @@ import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { ProfileProvider } from '../hooks/useProfileSwitcher';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
@@ -156,23 +157,25 @@ function MyApp(props) {
         >
           Skip to app grid
         </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+        <ProfileProvider>
+          <SettingsProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </SettingsProvider>
+        </ProfileProvider>
       </div>
     </ErrorBoundary>
 

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { get, set, del } from 'idb-keyval';
-import { getTheme, setTheme } from './theme';
+import { getTheme, setTheme, clearTheme } from './theme';
 
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
@@ -16,130 +16,143 @@ const DEFAULT_SETTINGS = {
   haptics: true,
 };
 
-export async function getAccent() {
+const idbKey = (profileId, key) => `${profileId}:${key}`;
+const localKey = (profileId, key) => `profile:${profileId}:${key}`;
+
+export async function getAccent(profileId = 'default') {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
-  return (await get('accent')) || DEFAULT_SETTINGS.accent;
+  return (await get(idbKey(profileId, 'accent'))) || DEFAULT_SETTINGS.accent;
 }
 
-export async function setAccent(accent) {
+export async function setAccent(profileId = 'default', accent) {
   if (typeof window === 'undefined') return;
-  await set('accent', accent);
+  await set(idbKey(profileId, 'accent'), accent);
 }
 
-export async function getWallpaper() {
+export async function getWallpaper(profileId = 'default') {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
-  return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
+  return (await get(idbKey(profileId, 'bg-image'))) || DEFAULT_SETTINGS.wallpaper;
 }
 
-export async function setWallpaper(wallpaper) {
+export async function setWallpaper(profileId = 'default', wallpaper) {
   if (typeof window === 'undefined') return;
-  await set('bg-image', wallpaper);
+  await set(idbKey(profileId, 'bg-image'), wallpaper);
 }
 
-export async function getDensity() {
+export async function getDensity(profileId = 'default') {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  return window.localStorage.getItem(localKey(profileId, 'density')) || DEFAULT_SETTINGS.density;
 }
 
-export async function setDensity(density) {
+export async function setDensity(profileId = 'default', density) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
+  window.localStorage.setItem(localKey(profileId, 'density'), density);
 }
 
-export async function getReducedMotion() {
+export async function getReducedMotion(profileId = 'default') {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  const stored = window.localStorage.getItem('reduced-motion');
+  const stored = window.localStorage.getItem(localKey(profileId, 'reduced-motion'));
   if (stored !== null) {
     return stored === 'true';
   }
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
-export async function setReducedMotion(value) {
+export async function setReducedMotion(profileId = 'default', value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+  window.localStorage.setItem(localKey(profileId, 'reduced-motion'), value ? 'true' : 'false');
 }
 
-export async function getFontScale() {
+export async function getFontScale(profileId = 'default') {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
+  const stored = window.localStorage.getItem(localKey(profileId, 'font-scale'));
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
-export async function setFontScale(scale) {
+export async function setFontScale(profileId = 'default', scale) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  window.localStorage.setItem(localKey(profileId, 'font-scale'), String(scale));
 }
 
-export async function getHighContrast() {
+export async function getHighContrast(profileId = 'default') {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  return window.localStorage.getItem(localKey(profileId, 'high-contrast')) === 'true';
 }
 
-export async function setHighContrast(value) {
+export async function setHighContrast(profileId = 'default', value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+  window.localStorage.setItem(localKey(profileId, 'high-contrast'), value ? 'true' : 'false');
 }
 
-export async function getLargeHitAreas() {
+export async function getLargeHitAreas(profileId = 'default') {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
+  return window.localStorage.getItem(localKey(profileId, 'large-hit-areas')) === 'true';
 }
 
-export async function setLargeHitAreas(value) {
+export async function setLargeHitAreas(profileId = 'default', value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
+  window.localStorage.setItem(localKey(profileId, 'large-hit-areas'), value ? 'true' : 'false');
 }
 
-export async function getHaptics() {
+export async function getHaptics(profileId = 'default') {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
-  const val = window.localStorage.getItem('haptics');
+  const val = window.localStorage.getItem(localKey(profileId, 'haptics'));
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
-export async function setHaptics(value) {
+export async function setHaptics(profileId = 'default', value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('haptics', value ? 'true' : 'false');
+  window.localStorage.setItem(localKey(profileId, 'haptics'), value ? 'true' : 'false');
 }
 
-export async function getPongSpin() {
+export async function getPongSpin(profileId = 'default') {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
+  const val = window.localStorage.getItem(localKey(profileId, 'pong-spin'));
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
-export async function setPongSpin(value) {
+export async function setPongSpin(profileId = 'default', value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
+  window.localStorage.setItem(localKey(profileId, 'pong-spin'), value ? 'true' : 'false');
 }
 
-export async function getAllowNetwork() {
+export async function getAllowNetwork(profileId = 'default') {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
+  return window.localStorage.getItem(localKey(profileId, 'allow-network')) === 'true';
 }
 
-export async function setAllowNetwork(value) {
+export async function setAllowNetwork(profileId = 'default', value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+  window.localStorage.setItem(localKey(profileId, 'allow-network'), value ? 'true' : 'false');
 }
 
-export async function resetSettings() {
+export async function resetSettings(profileId = 'default') {
   if (typeof window === 'undefined') return;
   await Promise.all([
-    del('accent'),
-    del('bg-image'),
+    del(idbKey(profileId, 'accent')),
+    del(idbKey(profileId, 'bg-image')),
   ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
+  const keys = [
+    'density',
+    'reduced-motion',
+    'font-scale',
+    'high-contrast',
+    'large-hit-areas',
+    'pong-spin',
+    'allow-network',
+    'haptics',
+  ];
+  keys.forEach((name) => {
+    try {
+      window.localStorage.removeItem(localKey(profileId, name));
+    } catch {
+      /* ignore */
+    }
+  });
+  clearTheme(profileId);
 }
 
-export async function exportSettings() {
+export async function exportSettings(profileId = 'default') {
   const [
     accent,
     wallpaper,
@@ -152,18 +165,18 @@ export async function exportSettings() {
     allowNetwork,
     haptics,
   ] = await Promise.all([
-    getAccent(),
-    getWallpaper(),
-    getDensity(),
-    getReducedMotion(),
-    getFontScale(),
-    getHighContrast(),
-    getLargeHitAreas(),
-    getPongSpin(),
-    getAllowNetwork(),
-    getHaptics(),
+    getAccent(profileId),
+    getWallpaper(profileId),
+    getDensity(profileId),
+    getReducedMotion(profileId),
+    getFontScale(profileId),
+    getHighContrast(profileId),
+    getLargeHitAreas(profileId),
+    getPongSpin(profileId),
+    getAllowNetwork(profileId),
+    getHaptics(profileId),
   ]);
-  const theme = getTheme();
+  const theme = getTheme(profileId);
   return JSON.stringify({
     accent,
     wallpaper,
@@ -179,7 +192,7 @@ export async function exportSettings() {
   });
 }
 
-export async function importSettings(json) {
+export async function importSettings(json, profileId = 'default') {
   if (typeof window === 'undefined') return;
   let settings;
   try {
@@ -201,17 +214,17 @@ export async function importSettings(json) {
     haptics,
     theme,
   } = settings;
-  if (accent !== undefined) await setAccent(accent);
-  if (wallpaper !== undefined) await setWallpaper(wallpaper);
-  if (density !== undefined) await setDensity(density);
-  if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
-  if (fontScale !== undefined) await setFontScale(fontScale);
-  if (highContrast !== undefined) await setHighContrast(highContrast);
-  if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
-  if (pongSpin !== undefined) await setPongSpin(pongSpin);
-  if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
-  if (haptics !== undefined) await setHaptics(haptics);
-  if (theme !== undefined) setTheme(theme);
+  if (accent !== undefined) await setAccent(profileId, accent);
+  if (wallpaper !== undefined) await setWallpaper(profileId, wallpaper);
+  if (density !== undefined) await setDensity(profileId, density);
+  if (reducedMotion !== undefined) await setReducedMotion(profileId, reducedMotion);
+  if (fontScale !== undefined) await setFontScale(profileId, fontScale);
+  if (highContrast !== undefined) await setHighContrast(profileId, highContrast);
+  if (largeHitAreas !== undefined) await setLargeHitAreas(profileId, largeHitAreas);
+  if (pongSpin !== undefined) await setPongSpin(profileId, pongSpin);
+  if (allowNetwork !== undefined) await setAllowNetwork(profileId, allowNetwork);
+  if (haptics !== undefined) await setHaptics(profileId, haptics);
+  if (theme !== undefined) setTheme(profileId, theme);
 }
 
 export const defaults = DEFAULT_SETTINGS;

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,5 +1,7 @@
 export const THEME_KEY = 'app:theme';
 
+const themeStorageKey = (profileId: string) => `${THEME_KEY}:${profileId}`;
+
 // Score required to unlock each theme
 export const THEME_UNLOCKS: Record<string, number> = {
   default: 0,
@@ -13,10 +15,10 @@ const DARK_THEMES = ['dark', 'neon', 'matrix'] as const;
 export const isDarkTheme = (theme: string): boolean =>
   DARK_THEMES.includes(theme as (typeof DARK_THEMES)[number]);
 
-export const getTheme = (): string => {
+export const getTheme = (profileId = 'default'): string => {
   if (typeof window === 'undefined') return 'default';
   try {
-    const stored = window.localStorage.getItem(THEME_KEY);
+    const stored = window.localStorage.getItem(themeStorageKey(profileId));
     if (stored) return stored;
     const prefersDark = window.matchMedia?.(
       '(prefers-color-scheme: dark)'
@@ -27,14 +29,23 @@ export const getTheme = (): string => {
   }
 };
 
-export const setTheme = (theme: string): void => {
+export const setTheme = (profileId: string, theme: string): void => {
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(THEME_KEY, theme);
+    window.localStorage.setItem(themeStorageKey(profileId), theme);
     document.documentElement.dataset.theme = theme;
     document.documentElement.classList.toggle('dark', isDarkTheme(theme));
   } catch {
     /* ignore storage errors */
+  }
+};
+
+export const clearTheme = (profileId: string): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(themeStorageKey(profileId));
+  } catch {
+    /* ignore */
   }
 };
 


### PR DESCRIPTION
## Summary
- add a profile switcher provider that supports ephemeral guest sessions and profile-scoped storage keys
- integrate the new profile switcher into Quick Settings and both settings UIs so import/export/reset operate on the active profile only
- expand theme persistence coverage and add regression tests to ensure guest sessions never persist data

## Testing
- yarn lint *(fails: pre-existing accessibility and no-top-level-window violations in unrelated files)*
- yarn test --runTestsByPath __tests__/profileSwitcher.test.tsx
- yarn test --runTestsByPath __tests__/themePersistence.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cce5e830548328a7430cfdd348b75d