### PR TITLE
[desktop] Add disk quota banner with cleanup shortcut

### DIFF
--- a/__tests__/diskQuota.test.tsx
+++ b/__tests__/diskQuota.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import DiskQuotaBanner from '../components/DiskQuotaBanner';
+
+type Estimate = { usage?: number; quota?: number; usageDetails?: StorageEstimate['usageDetails'] };
+
+const setNavigatorEstimate = (estimate: Estimate) => {
+  Object.defineProperty(window.navigator, 'storage', {
+    configurable: true,
+    value: {
+      estimate: jest.fn().mockResolvedValue(estimate),
+    },
+  });
+};
+
+const clearNavigatorEstimate = () => {
+  try {
+    // @ts-ignore - allow deleting the mocked property
+    delete window.navigator.storage;
+  } catch {
+    /* ignore */
+  }
+};
+
+describe('DiskQuotaBanner', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    clearNavigatorEstimate();
+    jest.restoreAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('renders a warning when usage exceeds 80%', async () => {
+    setNavigatorEstimate({ usage: 900 * 1024 * 1024, quota: 1000 * 1024 * 1024 });
+    render(<DiskQuotaBanner />);
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByText(/90% used/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Clear space/i })).toBeInTheDocument();
+  });
+
+  it('does not render when usage is below threshold', async () => {
+    setNavigatorEstimate({ usage: 100 * 1024 * 1024, quota: 1000 * 1024 * 1024 });
+    render(<DiskQuotaBanner />);
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  it('skips warnings in safe mode', async () => {
+    localStorage.setItem('safe-mode', 'true');
+    setNavigatorEstimate({ usage: 950 * 1024 * 1024, quota: 1000 * 1024 * 1024 });
+    render(<DiskQuotaBanner />);
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  it('persists dismissal per profile', async () => {
+    localStorage.setItem('active-profile', 'ops');
+    localStorage.setItem('disk-quota-dismissed:ops', 'true');
+    setNavigatorEstimate({ usage: 900 * 1024 * 1024, quota: 1000 * 1024 * 1024 });
+    const { unmount } = render(<DiskQuotaBanner />);
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    unmount();
+    clearNavigatorEstimate();
+    setNavigatorEstimate({ usage: 900 * 1024 * 1024, quota: 1000 * 1024 * 1024 });
+    localStorage.setItem('active-profile', 'qa');
+    render(<DiskQuotaBanner />);
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+  });
+
+  it('invokes the cleanup tool and marks dismissal when clearing space', async () => {
+    setNavigatorEstimate({ usage: 850 * 1024 * 1024, quota: 1000 * 1024 * 1024 });
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+    render(<DiskQuotaBanner />);
+    const alert = await screen.findByRole('alert');
+    expect(alert).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear space/i }));
+
+    expect(sessionStorage.getItem('trash-filter')).toBe('expiring');
+    expect(localStorage.getItem('disk-quota-dismissed:default')).toBe('true');
+    expect(dispatchSpy).toHaveBeenCalledWith(expect.objectContaining({ detail: 'trash' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import useTrashState from './state';
 import HistoryList from './components/HistoryList';
 
@@ -18,6 +18,7 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     restoreAllFromHistory,
   } = useTrashState();
   const [selected, setSelected] = useState<number | null>(null);
+  const [filter, setFilter] = useState<'all' | 'expiring'>('all');
   const [purgeDays, setPurgeDays] = useState(30);
   const [emptyCountdown, setEmptyCountdown] = useState<number | null>(null);
   const [, setTick] = useState(0);
@@ -39,6 +40,18 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     setPurgeDays(pd);
     const id = setInterval(() => setTick(t => t + 1), 60 * 1000);
     return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = sessionStorage.getItem('trash-filter');
+      if (stored) {
+        setFilter(stored === 'expiring' ? 'expiring' : 'all');
+        sessionStorage.removeItem('trash-filter');
+      }
+    } catch {
+      // ignore storage errors
+    }
   }, []);
 
   const notifyChange = () => window.dispatchEvent(new Event('trash-change'));
@@ -136,6 +149,26 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     notifyChange();
   }, [restoreAllFromHistory]);
 
+  const visibleItems = useMemo(
+    () => {
+      const entries = items.map((item, index) => ({ item, index }));
+      if (filter !== 'expiring') return entries;
+      const threshold = Math.min(purgeDays, 7);
+      return entries.filter(({ item }) => daysLeft(item.closedAt) <= threshold);
+    },
+    [items, filter, purgeDays, daysLeft],
+  );
+
+  useEffect(() => {
+    if (selected === null) return;
+    if (!visibleItems.some(entry => entry.index === selected)) {
+      setSelected(null);
+    }
+  }, [selected, visibleItems]);
+
+  const hasItems = items.length > 0;
+  const hasVisibleItems = visibleItems.length > 0;
+
   return (
     <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white select-none">
       <div className="flex items-center justify-between w-full bg-ub-warm-grey bg-opacity-40 text-sm">
@@ -180,6 +213,18 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
           </button>
         </div>
       </div>
+      {filter === 'expiring' && (
+        <div className="flex items-center justify-between bg-yellow-500/10 px-3 py-2 text-xs text-yellow-200">
+          <span>Showing items that purge within 7 days.</span>
+          <button
+            type="button"
+            onClick={() => setFilter('all')}
+            className="rounded border border-yellow-300/40 px-2 py-1 text-yellow-100 transition hover:bg-yellow-500/20 hover:text-yellow-50 focus:outline-none focus:ring-2 focus:ring-yellow-300/60"
+          >
+            Show all
+          </button>
+        </div>
+      )}
       <div className="flex-1 overflow-auto">
         <div className="flex flex-col items-center justify-center mt-12 space-y-1.5">
           <img
@@ -187,37 +232,39 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
             alt={items.length ? 'Full trash' : 'Empty trash'}
             className="h-16 w-16 opacity-60"
           />
-          {items.length === 0 && <span>Trash is empty</span>}
+          {!hasItems && <span>Trash is empty</span>}
+          {hasItems && filter === 'expiring' && !hasVisibleItems && (
+            <span>No items expiring soon.</span>
+          )}
         </div>
-        {items.length > 0 && (
+        {hasVisibleItems && (
           <ul className="p-2 space-y-1.5 mt-4">
-            {items.map((item, idx) => (
-              <li
-                key={item.closedAt}
-                tabIndex={0}
-                onClick={() => setSelected(idx)}
-                className={`flex items-center h-9 px-1 cursor-pointer ${selected === idx ? 'bg-ub-drk-abrgn' : ''}`}
-              >
-                <img
-                  src={item.icon || DEFAULT_ICON}
-                  alt=""
-                  className="h-4 w-4 mr-2"
-                />
-                <span className="truncate font-mono" title={item.title}>
-                  {item.title}
-                </span>
-                <span
-                  className="ml-auto text-xs opacity-70"
-                  aria-label={`Purges in ${daysLeft(item.closedAt)} day${
-                    daysLeft(item.closedAt) === 1 ? '' : 's'
-                  }`}
+            {visibleItems.map(({ item, index }) => {
+              const days = daysLeft(item.closedAt);
+              return (
+                <li
+                  key={item.closedAt}
+                  tabIndex={0}
+                  onClick={() => setSelected(index)}
+                  className={`flex items-center h-9 px-1 cursor-pointer ${selected === index ? 'bg-ub-drk-abrgn' : ''}`}
                 >
-                  {`${daysLeft(item.closedAt)} day${
-                    daysLeft(item.closedAt) === 1 ? '' : 's'
-                  } left`}
-                </span>
-              </li>
-            ))}
+                  <img
+                    src={item.icon || DEFAULT_ICON}
+                    alt=""
+                    className="h-4 w-4 mr-2"
+                  />
+                  <span className="truncate font-mono" title={item.title}>
+                    {item.title}
+                  </span>
+                  <span
+                    className="ml-auto text-xs opacity-70"
+                    aria-label={`Purges in ${days} day${days === 1 ? '' : 's'}`}
+                  >
+                    {`${days} day${days === 1 ? '' : 's'} left`}
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/components/DiskQuotaBanner.tsx
+++ b/components/DiskQuotaBanner.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import useDiskQuota from '../hooks/useDiskQuota';
+import { safeLocalStorage } from '../utils/safeStorage';
+
+const DISMISS_PREFIX = 'disk-quota-dismissed';
+const CLEANUP_FILTER_KEY = 'trash-filter';
+const PROFILE_KEYS = [
+  'active-profile',
+  'profile',
+  'profile-id',
+  'profileId',
+  'desktop-profile',
+  'profileName',
+  'user-profile',
+];
+const SAFE_MODE_KEYS = ['safe-mode', 'safeMode'];
+
+const readDismissed = (key: string): boolean => {
+  try {
+    return safeLocalStorage?.getItem(key) === 'true';
+  } catch {
+    return false;
+  }
+};
+
+const getProfileId = (): string => {
+  if (typeof window === 'undefined') return 'default';
+  for (const key of PROFILE_KEYS) {
+    try {
+      const value = safeLocalStorage?.getItem(key) ?? window.localStorage?.getItem(key);
+      if (value && value.trim()) return value;
+    } catch {
+      /* ignore */
+    }
+  }
+  return 'default';
+};
+
+const isTruthy = (value: string | null | undefined): boolean =>
+  value === 'true' || value === '1';
+
+const isSafeMode = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  try {
+    for (const key of SAFE_MODE_KEYS) {
+      if (isTruthy(safeLocalStorage?.getItem(key))) return true;
+      if (isTruthy(window.localStorage?.getItem(key))) return true;
+      if (isTruthy(window.sessionStorage?.getItem(key))) return true;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  if (typeof document !== 'undefined') {
+    const dataset = document.documentElement?.dataset;
+    if (dataset && isTruthy(dataset.safeMode ?? dataset.safemode)) {
+      return true;
+    }
+  }
+
+  const globalFlags = ['__SAFE_MODE__', '__KALI_SAFE_MODE__'];
+  for (const flag of globalFlags) {
+    if ((window as Record<string, unknown>)[flag] === true) {
+      return true;
+    }
+  }
+
+  try {
+    const params = new URLSearchParams(window.location.search || '');
+    if (isTruthy(params.get('safe-mode')) || isTruthy(params.get('safeMode'))) {
+      return true;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  return false;
+};
+
+const formatBytes = (bytes: number | null): string => {
+  if (bytes === null || bytes < 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const precision = value < 10 && unitIndex > 0 ? 1 : 0;
+  return `${value.toFixed(precision)} ${units[unitIndex]}`;
+};
+
+const DiskQuotaBanner: React.FC = () => {
+  const { supported, usage, quota, loading, error } = useDiskQuota();
+  const [profileId] = useState(() => getProfileId());
+  const dismissalKey = useMemo(
+    () => `${DISMISS_PREFIX}:${profileId}`,
+    [profileId],
+  );
+  const [dismissed, setDismissed] = useState(() => readDismissed(dismissalKey));
+
+  useEffect(() => {
+    setDismissed(readDismissed(dismissalKey));
+  }, [dismissalKey]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const handleStorage = (event: StorageEvent) => {
+      if (!event.key) return;
+      if (event.key === dismissalKey) {
+        setDismissed(readDismissed(dismissalKey));
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [dismissalKey]);
+
+  const percentUsed = quota && usage !== null ? Math.round((usage / quota) * 100) : 0;
+  const safeMode = isSafeMode();
+
+  const shouldShow =
+    supported &&
+    !loading &&
+    !error &&
+    !dismissed &&
+    !safeMode &&
+    usage !== null &&
+    quota !== null &&
+    quota > 0 &&
+    percentUsed >= 80;
+
+  const setDismissedFlag = useCallback(() => {
+    try {
+      safeLocalStorage?.setItem(dismissalKey, 'true');
+    } catch {
+      /* ignore */
+    }
+    setDismissed(true);
+  }, [dismissalKey]);
+
+  const handleDismiss = () => {
+    setDismissedFlag();
+  };
+
+  const handleClearSpace = () => {
+    try {
+      sessionStorage.setItem(CLEANUP_FILTER_KEY, 'expiring');
+    } catch {
+      /* ignore */
+    }
+    setDismissedFlag();
+    window.dispatchEvent(new CustomEvent('open-app', { detail: 'trash' }));
+  };
+
+  if (!shouldShow) return null;
+
+  const usageLabel = formatBytes(usage);
+  const quotaLabel = formatBytes(quota);
+
+  return (
+    <div
+      role="alert"
+      className="fixed left-1/2 top-4 z-[60] w-11/12 max-w-xl -translate-x-1/2 rounded-md border border-red-500 bg-red-900/90 text-sm text-white shadow-lg backdrop-blur"
+    >
+      <div className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:gap-4">
+        <div className="flex-1">
+          <p className="font-semibold">
+            Storage space is running low ({percentUsed}% used).
+          </p>
+          <p className="text-xs text-red-100">
+            Using {usageLabel} of {quotaLabel}. Clear unused files to keep the desktop responsive.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleClearSpace}
+            className="rounded bg-white/20 px-3 py-1 text-xs font-semibold text-white transition hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white"
+          >
+            Clear space
+          </button>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            className="rounded border border-transparent px-2 py-1 text-xs text-red-100 transition hover:border-red-200 hover:text-white focus:outline-none focus:ring-2 focus:ring-red-200"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DiskQuotaBanner;

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -7,6 +7,7 @@ import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
+import DiskQuotaBanner from './DiskQuotaBanner';
 
 export default class Ubuntu extends Component {
 	constructor() {
@@ -113,12 +114,13 @@ export default class Ubuntu extends Component {
                 safeLocalStorage?.setItem('shut-down', false);
 	};
 
-	render() {
-		return (
-			<div className="w-screen h-screen overflow-hidden" id="monitor-screen">
-				<LockScreen
-					isLocked={this.state.screen_locked}
-					bgImgName={this.state.bg_image_name}
+        render() {
+                return (
+                        <div className="w-screen h-screen overflow-hidden" id="monitor-screen">
+                                <DiskQuotaBanner />
+                                <LockScreen
+                                        isLocked={this.state.screen_locked}
+                                        bgImgName={this.state.bg_image_name}
 					unLockScreen={this.unLockScreen}
 				/>
 				<BootingScreen

--- a/hooks/useDiskQuota.ts
+++ b/hooks/useDiskQuota.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const DEFAULT_POLL_INTERVAL = 60000;
+
+export interface UseDiskQuotaOptions {
+  /**
+   * How frequently to refresh the storage estimate in milliseconds.
+   * Set to a non-positive value to disable polling.
+   */
+  interval?: number;
+}
+
+export interface DiskQuotaState {
+  supported: boolean;
+  usage: number | null;
+  quota: number | null;
+  usageRatio: number;
+  usageDetails: StorageEstimate['usageDetails'] | null;
+  loading: boolean;
+  error: boolean;
+}
+
+export interface UseDiskQuotaResult extends DiskQuotaState {
+  refresh: () => Promise<StorageEstimate | null>;
+}
+
+const readNumber = (value: number | undefined): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null;
+
+export default function useDiskQuota(
+  options: UseDiskQuotaOptions = {},
+): UseDiskQuotaResult {
+  const interval = options.interval ?? DEFAULT_POLL_INTERVAL;
+  const supported =
+    typeof navigator !== 'undefined' &&
+    typeof navigator.storage?.estimate === 'function';
+
+  const mountedRef = useRef(false);
+  const [state, setState] = useState<DiskQuotaState>(() => ({
+    supported,
+    usage: null,
+    quota: null,
+    usageRatio: 0,
+    usageDetails: null,
+    loading: supported,
+    error: false,
+  }));
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!supported) return null;
+    if (mountedRef.current) {
+      setState((prev) => ({ ...prev, loading: prev.usage === null }));
+    }
+    try {
+      const estimate = await navigator.storage.estimate();
+      if (!mountedRef.current) return estimate;
+      const usage = readNumber(estimate.usage);
+      const quota = readNumber(estimate.quota);
+      const usageRatio =
+        quota && quota > 0 && usage !== null
+          ? Math.min(usage / quota, 1)
+          : 0;
+      setState({
+        supported: true,
+        usage,
+        quota,
+        usageRatio,
+        usageDetails: estimate.usageDetails ?? null,
+        loading: false,
+        error: false,
+      });
+      return estimate;
+    } catch {
+      if (!mountedRef.current) return null;
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: true,
+      }));
+      return null;
+    }
+  }, [supported]);
+
+  useEffect(() => {
+    if (!supported) return undefined;
+    let cancelled = false;
+    const run = async () => {
+      if (cancelled) return;
+      setState((prev) => ({ ...prev, loading: prev.usage === null }));
+      await refresh();
+    };
+    run();
+
+    if (!Number.isFinite(interval) || interval <= 0) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const timer = window.setInterval(run, interval);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [interval, refresh, supported]);
+
+  return { ...state, refresh };
+}


### PR DESCRIPTION
## Summary
- add a disk quota polling hook that exposes usage ratios from navigator.storage.estimate
- render a dismissable low-space banner in the Ubuntu shell that links to the trash cleanup tool and honors safe mode
- teach the trash app to accept a sessionStorage filter and cover the quota banner behaviour with Jest tests

## Testing
- yarn lint *(fails: repository has pre-existing accessibility/window globals violations)*
- yarn test --watch=false *(aborted after numerous existing suite failures/hangs)*
- yarn test --watch=false __tests__/diskQuota.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cce5e4b880832882b25eea2b8fbd79