### PR TITLE
desktop: add undo manager integration

### DIFF
--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -1,6 +1,7 @@
 import React, { act } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import Ubuntu from '../components/ubuntu';
+import { undoManager } from '../hooks/useUndoManager';
 
 jest.mock('../components/screen/desktop', () => function DesktopMock() {
   return <div data-testid="desktop" />;
@@ -56,5 +57,15 @@ describe('Ubuntu component', () => {
       instance!.shutDown();
     });
     expect(instance!.state.shutDownScreen).toBe(true);
+  });
+
+  it('routes ctrl+alt+z to the global undo stack', () => {
+    const spy = jest.spyOn(undoManager, 'undoGlobal').mockReturnValue(true);
+    render(<Ubuntu />);
+
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true, altKey: true });
+
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
   });
 });

--- a/__tests__/undoManager.test.ts
+++ b/__tests__/undoManager.test.ts
@@ -1,0 +1,62 @@
+import { undoManager } from '../hooks/useUndoManager';
+import {
+  clearJournal,
+  recordJournalEntry,
+  resetJournal,
+} from '../utils/journal';
+
+describe('undoManager', () => {
+  beforeEach(() => {
+    resetJournal();
+  });
+
+  it('tracks per-app stacks alongside the global history', () => {
+    const first = jest.fn();
+    const second = jest.fn();
+
+    recordJournalEntry({ appId: 'app-a', undo: first });
+    recordJournalEntry({ appId: 'app-b', undo: second });
+
+    let snapshot = undoManager.getSnapshot();
+    expect(snapshot.global).toHaveLength(2);
+    expect(snapshot.apps['app-a']).toHaveLength(1);
+    expect(snapshot.apps['app-b']).toHaveLength(1);
+
+    expect(undoManager.undoApp('app-a')).toBe(true);
+    expect(first).toHaveBeenCalledTimes(1);
+
+    snapshot = undoManager.getSnapshot();
+    expect(snapshot.global).toHaveLength(1);
+    expect(snapshot.apps['app-a']).toBeUndefined();
+    expect(snapshot.apps['app-b']).toHaveLength(1);
+
+    expect(undoManager.undoGlobal()).toBe(true);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(undoManager.getSnapshot().global).toHaveLength(0);
+  });
+
+  it('clears stacks by app id and through reset events', () => {
+    const noop = jest.fn();
+    recordJournalEntry({ appId: 'app-a', undo: noop });
+    recordJournalEntry({ appId: 'app-b', undo: noop });
+
+    clearJournal('app-a');
+    let snapshot = undoManager.getSnapshot();
+    expect(snapshot.apps['app-a']).toBeUndefined();
+    expect(snapshot.global.every((entry) => entry.appId !== 'app-a')).toBe(true);
+
+    resetJournal();
+    snapshot = undoManager.getSnapshot();
+    expect(snapshot.global).toHaveLength(0);
+    expect(Object.keys(snapshot.apps)).toHaveLength(0);
+  });
+
+  it('handles desktop-scoped entries without an app id', () => {
+    const undoDesktop = jest.fn();
+    recordJournalEntry({ undo: undoDesktop });
+
+    expect(undoManager.undoGlobal()).toBe(true);
+    expect(undoDesktop).toHaveBeenCalledTimes(1);
+    expect(undoManager.getSnapshot().global).toHaveLength(0);
+  });
+});

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -6,6 +6,8 @@ import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
+import { undoManager } from '../../hooks/useUndoManager';
+import { isEditableElement } from '../../utils/dom';
 import styles from './window.module.css';
 
 export class Window extends Component {
@@ -68,6 +70,9 @@ export class Window extends Component {
         root?.removeEventListener('super-arrow', this.handleSuperArrow);
         if (this._usageTimeout) {
             clearTimeout(this._usageTimeout);
+        }
+        if (this.id) {
+            undoManager.clearApp(this.id);
         }
     }
 
@@ -542,6 +547,14 @@ export class Window extends Component {
                 this.snapWindow('top');
             }
             this.focusWindow();
+        } else if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey && (e.key?.toLowerCase?.() === 'z')) {
+            if (!isEditableElement(e.target)) {
+                const undone = undoManager.undoApp(this.id);
+                if (undone) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+            }
         } else if (e.shiftKey) {
             const step = 1;
             if (e.key === 'ArrowLeft') {

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -6,6 +6,8 @@ import Desktop from './screen/desktop';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
+import { undoManager } from '../hooks/useUndoManager';
+import { isEditableElement } from '../utils/dom';
 import { safeLocalStorage } from '../utils/safeStorage';
 
 export default class Ubuntu extends Component {
@@ -19,9 +21,26 @@ export default class Ubuntu extends Component {
 		};
 	}
 
-	componentDidMount() {
-		this.getLocalData();
-	}
+        componentDidMount() {
+                this.getLocalData();
+                window.addEventListener('keydown', this.handleGlobalUndo);
+        }
+
+        componentWillUnmount() {
+                window.removeEventListener('keydown', this.handleGlobalUndo);
+        }
+
+        handleGlobalUndo = (event) => {
+                if (!event) return;
+                const key = event.key?.toLowerCase?.();
+                if (!(event.ctrlKey || event.metaKey) || !event.altKey || key !== 'z') return;
+                if (event.shiftKey) return;
+                if (isEditableElement(event.target)) return;
+                if (undoManager.undoGlobal()) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                }
+        };
 
 	setTimeOutBootScreen = () => {
 		setTimeout(() => {

--- a/docs/new-app-checklist.md
+++ b/docs/new-app-checklist.md
@@ -35,3 +35,26 @@ test('My App launches', async ({ page }) => {
   await expect(page.locator('[data-testid="my-app"]')).toBeVisible();
 });
 ```
+
+## Undo history hooks
+
+- Register undoable actions with the journal so the desktop can surface them
+  for <kbd>Ctrl</kbd>+<kbd>Z</kbd> inside the app window and
+  <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Z</kbd> globally.
+- Import helpers from `utils/journal`:
+
+```ts
+import { recordJournalEntry, clearJournal } from '../../utils/journal';
+
+recordJournalEntry({
+  appId: 'my-app',
+  description: 'Added note',
+  undo: () => removeNote(id),
+});
+
+// Call when the app resets state (e.g. on restart) so stale undo stacks clear
+clearJournal('my-app');
+```
+
+- The window component automatically clears an app's stack on unmount, but
+  explicit `clearJournal` calls keep the history accurate after internal resets.

--- a/hooks/useUndoManager.ts
+++ b/hooks/useUndoManager.ts
@@ -1,0 +1,249 @@
+import { useMemo, useSyncExternalStore } from 'react';
+import logger from '../utils/logger';
+import { JournalEntry, JournalEvent, subscribeToJournal } from '../utils/journal';
+
+export type UndoStackEntry = {
+  id: string;
+  appId: string | null;
+  undo: JournalEntry['undo'];
+  redo?: JournalEntry['redo'];
+  description?: string;
+  metadata?: JournalEntry['metadata'];
+  timestamp: number;
+};
+
+interface UndoState {
+  global: UndoStackEntry[];
+  apps: Record<string, UndoStackEntry[]>;
+}
+
+export type UndoManagerSnapshot = {
+  global: ReadonlyArray<UndoStackEntry>;
+  apps: Readonly<Record<string, ReadonlyArray<UndoStackEntry>>>;
+};
+
+type Listener = () => void;
+
+type UndoResult = boolean;
+
+const listeners = new Set<Listener>();
+let state: UndoState = { global: [], apps: {} };
+let snapshot: UndoManagerSnapshot = createSnapshot(state);
+let idCounter = 0;
+
+function createSnapshot(value: UndoState): UndoManagerSnapshot {
+  const appsEntries = Object.entries(value.apps).reduce<
+    Record<string, ReadonlyArray<UndoStackEntry>>
+  >((acc, [key, stack]) => {
+    acc[key] = Object.freeze([...stack]);
+    return acc;
+  }, {});
+
+  return {
+    global: Object.freeze([...value.global]),
+    apps: Object.freeze(appsEntries),
+  };
+}
+
+function notify() {
+  listeners.forEach((listener) => listener());
+}
+
+function setState(updater: (prev: UndoState) => UndoState) {
+  const next = updater(state);
+  if (next.global === state.global && next.apps === state.apps) {
+    return;
+  }
+  state = next;
+  snapshot = createSnapshot(state);
+  notify();
+}
+
+const recordEntry = (entry: JournalEntry) => {
+  const undoEntry: UndoStackEntry = {
+    id: `undo-${Date.now()}-${++idCounter}`,
+    appId: entry.appId ?? null,
+    undo: entry.undo,
+    redo: entry.redo,
+    description: entry.description,
+    metadata: entry.metadata,
+    timestamp: Date.now(),
+  };
+
+  setState((prev) => {
+    const global = [...prev.global, undoEntry];
+    if (!undoEntry.appId) {
+      return { global, apps: prev.apps };
+    }
+
+    const current = prev.apps[undoEntry.appId] ?? [];
+    return {
+      global,
+      apps: {
+        ...prev.apps,
+        [undoEntry.appId]: [...current, undoEntry],
+      },
+    };
+  });
+};
+
+const clearAppEntries = (appId: string) => {
+  setState((prev) => {
+    const stack = prev.apps[appId];
+    if (!stack?.length) return prev;
+
+    const ids = new Set(stack.map((item) => item.id));
+    const global = prev.global.filter((item) => !ids.has(item.id));
+    const apps = { ...prev.apps };
+    delete apps[appId];
+
+    return { global, apps };
+  });
+};
+
+const clearGlobalOnly = () => {
+  setState((prev) => {
+    const global = prev.global.filter((item) => item.appId !== null);
+    if (global.length === prev.global.length) return prev;
+    return { global, apps: prev.apps };
+  });
+};
+
+const clearAllEntries = () => {
+  setState((prev) => {
+    if (!prev.global.length && !Object.keys(prev.apps).length) {
+      return prev;
+    }
+    return { global: [], apps: {} };
+  });
+};
+
+const removeEntry = (entry: UndoStackEntry) => {
+  setState((prev) => {
+    let changed = false;
+    const global = prev.global.filter((item) => {
+      if (item.id === entry.id) {
+        changed = true;
+        return false;
+      }
+      return true;
+    });
+
+    let apps = prev.apps;
+    if (entry.appId) {
+      const stack = prev.apps[entry.appId];
+      if (stack) {
+        const filtered = stack.filter((item) => item.id !== entry.id);
+        if (filtered.length !== stack.length) {
+          apps = { ...prev.apps };
+          if (filtered.length) {
+            apps[entry.appId] = filtered;
+          } else {
+            delete apps[entry.appId];
+          }
+          changed = true;
+        }
+      }
+    }
+
+    if (!changed) return prev;
+    return { global, apps };
+  });
+};
+
+const runUndo = (entry: UndoStackEntry) => {
+  try {
+    const result = entry.undo();
+    if (result && typeof (result as Promise<void>).then === 'function') {
+      (result as Promise<void>).catch((error) => {
+        logger.error('Undo handler rejected', error);
+      });
+    }
+  } catch (error) {
+    logger.error('Undo handler threw', error);
+  }
+};
+
+const undoApp = (appId: string): UndoResult => {
+  const stack = state.apps[appId];
+  if (!stack?.length) return false;
+  const entry = stack[stack.length - 1];
+  removeEntry(entry);
+  runUndo(entry);
+  return true;
+};
+
+const undoGlobal = (): UndoResult => {
+  const entry = state.global[state.global.length - 1];
+  if (!entry) return false;
+  removeEntry(entry);
+  runUndo(entry);
+  return true;
+};
+
+const clearApp = (appId: string): void => {
+  clearAppEntries(appId);
+};
+
+const clearAll = (): void => {
+  clearAllEntries();
+};
+
+const getSnapshot = (): UndoManagerSnapshot => snapshot;
+
+const subscribe = (listener: Listener): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const handleJournalEvent = (event: JournalEvent) => {
+  if (event.type === 'record') {
+    recordEntry(event.entry);
+  } else if (event.type === 'clear') {
+    if (event.appId === undefined) {
+      clearAllEntries();
+    } else if (event.appId === null) {
+      clearGlobalOnly();
+    } else {
+      clearAppEntries(event.appId);
+    }
+  } else if (event.type === 'reset') {
+    clearAllEntries();
+  }
+};
+
+subscribeToJournal(handleJournalEvent);
+
+export const undoManager = {
+  subscribe,
+  getSnapshot,
+  undoApp,
+  undoGlobal,
+  clearApp,
+  clearAll,
+  record: recordEntry,
+};
+
+export interface UseUndoManagerValue extends UndoManagerSnapshot {
+  undoApp: typeof undoApp;
+  undoGlobal: typeof undoGlobal;
+  clearApp: typeof clearApp;
+  clearAll: typeof clearAll;
+}
+
+export default function useUndoManager(): UseUndoManagerValue {
+  const snap = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return useMemo(
+    () => ({
+      global: snap.global,
+      apps: snap.apps,
+      undoApp,
+      undoGlobal,
+      clearApp,
+      clearAll,
+    }),
+    [snap],
+  );
+}

--- a/utils/dom.ts
+++ b/utils/dom.ts
@@ -1,0 +1,41 @@
+export const isEditableElement = (target: EventTarget | null): boolean => {
+  if (!target || typeof Element === 'undefined') return false;
+  if (!(target instanceof Element)) return false;
+
+  if (target.hasAttribute('contenteditable') && target.getAttribute('contenteditable') !== 'false') {
+    return true;
+  }
+
+  const editable = typeof target.closest === 'function'
+    ? target.closest('input, textarea, [contenteditable]')
+    : null;
+  if (!editable) {
+    return false;
+  }
+  if (editable instanceof HTMLTextAreaElement) {
+    return !editable.readOnly && !editable.disabled;
+  }
+  if (editable instanceof HTMLInputElement) {
+    if (editable.readOnly || editable.disabled) return false;
+    const type = editable.type ? editable.type.toLowerCase() : 'text';
+    const nonTextTypes = new Set([
+      'button',
+      'checkbox',
+      'color',
+      'date',
+      'datetime-local',
+      'file',
+      'hidden',
+      'image',
+      'month',
+      'radio',
+      'range',
+      'reset',
+      'submit',
+      'time',
+      'week',
+    ]);
+    return !nonTextTypes.has(type);
+  }
+  return editable.hasAttribute('contenteditable');
+};

--- a/utils/journal.ts
+++ b/utils/journal.ts
@@ -1,0 +1,75 @@
+export type UndoHandler = () => void | Promise<void>;
+
+export interface JournalEntry {
+  appId?: string | null;
+  undo: UndoHandler;
+  redo?: UndoHandler;
+  description?: string;
+  /**
+   * Optional metadata bag for app specific details. Consumers should treat this
+   * as read only data attached to the entry when it was recorded.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+export type JournalEvent =
+  | { type: 'record'; entry: JournalEntry }
+  | { type: 'clear'; appId?: string | null }
+  | { type: 'reset' };
+
+type Listener = (event: JournalEvent) => void;
+
+const listeners = new Set<Listener>();
+
+const emit = (event: JournalEvent) => {
+  listeners.forEach((listener) => {
+    try {
+      listener(event);
+    } catch (error) {
+      // Listeners should be resilient. Swallow errors so one faulty listener
+      // does not break the journal fan out.
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('journal listener failed', error);
+      }
+    }
+  });
+};
+
+export const recordJournalEntry = (entry: JournalEntry): void => {
+  // Clone the entry so downstream consumers do not accidentally mutate the
+  // reference provided by the caller.
+  emit({
+    type: 'record',
+    entry: {
+      appId: entry.appId ?? null,
+      undo: entry.undo,
+      redo: entry.redo,
+      description: entry.description,
+      metadata: entry.metadata,
+    },
+  });
+};
+
+export const clearJournal = (appId?: string | null): void => {
+  emit({ type: 'clear', appId });
+};
+
+export const resetJournal = (): void => {
+  emit({ type: 'reset' });
+};
+
+export const subscribeToJournal = (listener: Listener): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const journal = {
+  record: recordJournalEntry,
+  clear: clearJournal,
+  reset: resetJournal,
+  subscribe: subscribeToJournal,
+};
+
+export default journal;


### PR DESCRIPTION
## Summary
- add a journal utility and undo manager hook to track per-app and cross-desktop undo history
- wire window and desktop components to consume the undo manager for Ctrl+Z shortcuts
- document the new API for app authors and add targeted tests

## Testing
- yarn lint *(fails: repository already reports hundreds of accessibility violations in existing apps)*
- yarn test *(fails: existing suites emit act/localStorage errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cce5ce8b288328aff58b866dc8bfc3