### PR TITLE
[privacy] add consent data export

### DIFF
--- a/__tests__/dataExport.test.ts
+++ b/__tests__/dataExport.test.ts
@@ -1,0 +1,96 @@
+import { gatherDataExport } from '../lib/dataExport';
+import { runDataExport } from '../workers/data-export.worker';
+
+describe('data export aggregation', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  const profiles = [
+    {
+      deviceId: 'device-1',
+      name: 'Adapter',
+      services: [],
+    },
+    {
+      deviceId: 'device-2',
+      name: 'Sensor',
+      services: [
+        {
+          uuid: '1234',
+          characteristics: [{ uuid: 'abcd', value: 'ready' }],
+        },
+      ],
+    },
+  ];
+
+  const seedStorage = () => {
+    window.localStorage.setItem(
+      'desktop-session',
+      JSON.stringify({ windows: [], wallpaper: 'wall-2', dock: [] }),
+    );
+    window.localStorage.setItem('hydra/session', JSON.stringify({ tasks: [1, 2, 3] }));
+    window.localStorage.setItem('openvas/session', JSON.stringify({ target: '1.2.3.4' }));
+    window.localStorage.setItem('app:theme', 'dark');
+    window.localStorage.setItem('reduced-motion', 'true');
+    window.localStorage.setItem('density', 'compact');
+    window.localStorage.setItem('snap-enabled', 'false');
+  };
+
+  it('collects sections with size metadata and invokes progress callbacks', async () => {
+    seedStorage();
+    const stages: string[] = [];
+    const archive = await gatherDataExport({
+      storage: window.localStorage,
+      profileLoader: async () => profiles,
+      now: () => new Date('2024-01-01T00:00:00.000Z'),
+      onStageComplete: (stage, summary) => {
+        stages.push(stage);
+        expect(summary.items).toBeGreaterThanOrEqual(0);
+        expect(summary.bytes).toBeGreaterThanOrEqual(0);
+      },
+    });
+
+    expect(stages).toEqual(['profiles', 'sessions', 'flags']);
+    expect(archive.generatedAt).toBe('2024-01-01T00:00:00.000Z');
+    expect(archive.sections.profiles.items).toHaveLength(2);
+    expect(archive.sections.sessions.items.map((item) => item.key)).toEqual([
+      'desktop-session',
+      'hydra/session',
+      'openvas/session',
+    ]);
+    expect(archive.sections.flags.items.find((item) => item.key === 'app:theme')?.data).toBe(
+      'dark',
+    );
+
+    const encoder = new TextEncoder();
+    const hydraRaw = window.localStorage.getItem('hydra/session') as string;
+    expect(
+      archive.sections.sessions.items.find((item) => item.key === 'hydra/session')?.size,
+    ).toBe(encoder.encode(hydraRaw).byteLength);
+
+    const totalSizes =
+      archive.sections.profiles.totalSize +
+      archive.sections.sessions.totalSize +
+      archive.sections.flags.totalSize;
+    expect(archive.totals.bytes).toBe(totalSizes);
+  });
+
+  it('serializes via the worker helper and returns a matching archive', async () => {
+    seedStorage();
+    const result = await runDataExport({
+      storage: window.localStorage,
+      profileLoader: async () => profiles,
+      now: () => new Date('2024-01-02T00:00:00.000Z'),
+    });
+
+    expect(result.bytes).toBe(result.buffer.byteLength);
+    const text = new TextDecoder().decode(new Uint8Array(result.buffer));
+    const parsed = JSON.parse(text);
+    expect(parsed).toEqual(result.archive);
+
+    expect(result.archive.sections.flags.totalSize).toBe(
+      result.archive.sections.flags.items.reduce((sum, item) => sum + item.size, 0),
+    );
+  });
+});

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,75 @@
+# Privacy & Consent Center
+
+The settings app includes a dedicated **Privacy** tab that acts as the consent
+center for the desktop experience. It summarises every category of data the UI
+stores locally and provides tooling to review or export that information.
+
+## Stored data categories
+
+The export workflow groups persisted data into three high-level sections:
+
+- **Profiles** – device or tool profiles saved via OPFS, such as Bluetooth
+  captures from the BLE sensor simulator. Each entry includes its full
+  definition (`deviceId`, friendly name, characteristic values) and the byte
+  size of the stored JSON file.
+- **Sessions** – resumable workflows held in `localStorage` including the
+  desktop layout (`desktop-session`) and app specific sessions such as Hydra and
+  OpenVAS. Values are parsed back into JSON objects when possible and carry the
+  size of the original payload.
+- **Flags & preferences** – feature toggles and accessibility settings (reduced
+  motion, high contrast, haptics, theme, density, router profiles, etc.). The
+  export keeps the raw value alongside its byte footprint so you can gauge how
+  much storage each flag consumes.
+
+## Exporting a privacy archive
+
+1. Open **Settings → Privacy**.
+2. Press **Export Data Archive**. The button triggers the
+   `data-export.worker.ts` worker which gathers each category without blocking
+   the UI.
+3. Watch the inline status indicator. It reports the current stage
+   (profiles/sessions/flags), how many records were bundled, and the cumulative
+   byte size for that stage. The message uses `aria-live="polite"` so screen
+   readers hear updates automatically.
+4. When the worker finishes a JSON archive named
+   `kali-portfolio-export-<timestamp>.json` downloads automatically. The
+   summary line confirms how many profiles, sessions, and flags were exported
+   plus the total archive size.
+
+The worker streams progress messages back to the UI, allowing the consent center
+to show real-time feedback and to surface any errors (for example when workers
+are unsupported). Every run generates a fresh request identifier so stale
+messages from earlier exports are ignored.
+
+## Archive format
+
+The downloaded file is a readable JSON document with this structure:
+
+```json
+{
+  "generatedAt": "2024-01-01T00:00:00.000Z",
+  "totals": {
+    "bytes": 1234,
+    "counts": {
+      "profiles": 2,
+      "sessions": 3,
+      "flags": 10
+    }
+  },
+  "sections": {
+    "profiles": {
+      "totalSize": 456,
+      "items": [
+        { "key": "device-id", "size": 123, "data": { /* profile */ } }
+      ]
+    },
+    "sessions": { /* ... */ },
+    "flags": { /* ... */ }
+  }
+}
+```
+
+Each item includes the original serialized value (`raw`), the parsed representation, the
+source (`opfs` or `localStorage`), and a `size` property measured in bytes. This
+keeps the archive human readable while still providing enough metadata for
+troubleshooting or for honouring user data requests.

--- a/lib/dataExport.ts
+++ b/lib/dataExport.ts
@@ -1,0 +1,241 @@
+import { loadProfiles, SavedProfile } from '../utils/bleProfiles';
+
+export type DataExportStage = 'profiles' | 'sessions' | 'flags';
+
+export const DATA_EXPORT_STAGES: DataExportStage[] = [
+  'profiles',
+  'sessions',
+  'flags',
+];
+
+const SESSION_KEYS = ['desktop-session', 'hydra/session', 'openvas/session'] as const;
+
+const FLAG_KEYS = [
+  'app:theme',
+  'density',
+  'font-scale',
+  'reduced-motion',
+  'high-contrast',
+  'large-hit-areas',
+  'pong-spin',
+  'allow-network',
+  'haptics',
+  'snap-enabled',
+  'reaver-router-profile',
+] as const;
+
+type SessionKey = (typeof SESSION_KEYS)[number];
+type FlagKey = (typeof FLAG_KEYS)[number];
+
+type LocalStorageKey = SessionKey | FlagKey;
+
+type DataSource = 'localStorage' | 'opfs';
+
+export interface ExportItem<T = unknown> {
+  key: string;
+  size: number;
+  source: DataSource;
+  data: T;
+  raw: string;
+}
+
+export interface ExportSection<T = unknown> {
+  items: ExportItem<T>[];
+  totalSize: number;
+}
+
+export interface DataExportArchive {
+  generatedAt: string;
+  totals: {
+    bytes: number;
+    counts: Record<DataExportStage, number>;
+  };
+  sections: {
+    profiles: ExportSection<SavedProfile>;
+    sessions: ExportSection<unknown>;
+    flags: ExportSection<unknown>;
+  };
+}
+
+export interface StageSummary {
+  items: number;
+  bytes: number;
+}
+
+export type StageCallback = (stage: DataExportStage, summary: StageSummary) => void;
+
+export interface DataExportOptions {
+  storage?: Storage;
+  profileLoader?: () => Promise<SavedProfile[]>;
+  now?: () => Date;
+  onStageComplete?: StageCallback;
+}
+
+export interface DataExportWorkerRequest {
+  type: 'start';
+  requestId?: string;
+}
+
+export interface DataExportWorkerProgressEvent {
+  type: 'progress';
+  stage: DataExportStage;
+  completed: number;
+  total: number;
+  items: number;
+  bytes: number;
+  requestId?: string;
+}
+
+export interface DataExportWorkerCompleteEvent {
+  type: 'complete';
+  archive: DataExportArchive;
+  buffer: ArrayBuffer;
+  bytes: number;
+  mime: string;
+  suggestedName: string;
+  requestId?: string;
+}
+
+export interface DataExportWorkerErrorEvent {
+  type: 'error';
+  error: string;
+  requestId?: string;
+}
+
+export type DataExportWorkerEvent =
+  | DataExportWorkerProgressEvent
+  | DataExportWorkerCompleteEvent
+  | DataExportWorkerErrorEvent;
+
+export const DATA_EXPORT_DEFAULT_MIME = 'application/json';
+
+const encoder = new TextEncoder();
+
+const getDefaultStorage = (): Storage | undefined => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return window.localStorage;
+  }
+  if (typeof globalThis !== 'undefined' && (globalThis as any).localStorage) {
+    return (globalThis as any).localStorage as Storage;
+  }
+  return undefined;
+};
+
+const parseValue = (value: string): unknown => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+};
+
+const buildLocalStorageItems = (
+  keys: readonly LocalStorageKey[],
+  storage?: Storage,
+): ExportItem[] => {
+  if (!storage) return [];
+  const items: ExportItem[] = [];
+  for (const key of keys) {
+    const raw = storage.getItem(key);
+    if (raw === null) continue;
+    items.push({
+      key,
+      raw,
+      data: parseValue(raw),
+      size: encoder.encode(raw).byteLength,
+      source: 'localStorage',
+    });
+  }
+  return items.sort((a, b) => a.key.localeCompare(b.key));
+};
+
+const buildProfiles = async (
+  loader: () => Promise<SavedProfile[]>,
+): Promise<ExportItem<SavedProfile>[]> => {
+  const profiles = await loader();
+  return profiles
+    .map((profile) => {
+      const raw = JSON.stringify(profile);
+      return {
+        key: profile.deviceId,
+        raw,
+        data: profile,
+        size: encoder.encode(raw).byteLength,
+        source: 'opfs' as const,
+      } satisfies ExportItem<SavedProfile>;
+    })
+    .sort((a, b) => a.key.localeCompare(b.key));
+};
+
+const buildSection = <T,>(items: ExportItem<T>[]): ExportSection<T> => ({
+  items,
+  totalSize: items.reduce((acc, item) => acc + item.size, 0),
+});
+
+export const gatherDataExport = async (
+  options: DataExportOptions = {},
+): Promise<DataExportArchive> => {
+  const storage = options.storage ?? getDefaultStorage();
+  const profileLoader = options.profileLoader ?? loadProfiles;
+  const now = options.now ?? (() => new Date());
+
+  const profiles = buildSection(await buildProfiles(profileLoader));
+  options.onStageComplete?.('profiles', {
+    items: profiles.items.length,
+    bytes: profiles.totalSize,
+  });
+
+  const sessions = buildSection(buildLocalStorageItems(SESSION_KEYS, storage));
+  options.onStageComplete?.('sessions', {
+    items: sessions.items.length,
+    bytes: sessions.totalSize,
+  });
+
+  const flags = buildSection(buildLocalStorageItems(FLAG_KEYS, storage));
+  options.onStageComplete?.('flags', {
+    items: flags.items.length,
+    bytes: flags.totalSize,
+  });
+
+  const totalBytes = profiles.totalSize + sessions.totalSize + flags.totalSize;
+
+  return {
+    generatedAt: now().toISOString(),
+    totals: {
+      bytes: totalBytes,
+      counts: {
+        profiles: profiles.items.length,
+        sessions: sessions.items.length,
+        flags: flags.items.length,
+      },
+    },
+    sections: {
+      profiles,
+      sessions,
+      flags,
+    },
+  };
+};
+
+export const serializeArchive = (archive: DataExportArchive): Uint8Array => {
+  const json = JSON.stringify(archive, null, 2);
+  return encoder.encode(json);
+};
+
+export const toArrayBuffer = (view: Uint8Array): ArrayBuffer => {
+  if (view.byteOffset === 0 && view.byteLength === view.buffer.byteLength) {
+    return view.buffer;
+  }
+  return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength);
+};
+
+export const formatExportFileName = (date: Date | string = new Date()): string => {
+  const value = typeof date === 'string' ? new Date(date) : date;
+  const safe = value.toISOString().replace(/[:.]/g, '-');
+  return `kali-portfolio-export-${safe}.json`;
+};
+
+export const __TEST__ = {
+  SESSION_KEYS,
+  FLAG_KEYS,
+};

--- a/workers/data-export.worker.ts
+++ b/workers/data-export.worker.ts
@@ -1,0 +1,120 @@
+import {
+  DATA_EXPORT_DEFAULT_MIME,
+  DATA_EXPORT_STAGES,
+  DataExportArchive,
+  DataExportOptions,
+  DataExportStage,
+  DataExportWorkerCompleteEvent,
+  DataExportWorkerErrorEvent,
+  DataExportWorkerProgressEvent,
+  DataExportWorkerRequest,
+  formatExportFileName,
+  gatherDataExport,
+  serializeArchive,
+  StageCallback,
+  toArrayBuffer,
+} from '../lib/dataExport';
+
+export interface RunDataExportOptions extends Omit<DataExportOptions, 'onStageComplete'> {
+  onStageComplete?: StageCallback;
+}
+
+export interface RunDataExportResult {
+  archive: DataExportArchive;
+  buffer: ArrayBuffer;
+  bytes: number;
+}
+
+export const runDataExport = async (
+  options: RunDataExportOptions = {},
+): Promise<RunDataExportResult> => {
+  const { onStageComplete, ...rest } = options;
+  const archive = await gatherDataExport({
+    ...rest,
+    onStageComplete: (stage, summary) => {
+      onStageComplete?.(stage, summary);
+    },
+  });
+  const encoded = serializeArchive(archive);
+  const buffer = toArrayBuffer(encoded);
+  return {
+    archive,
+    buffer,
+    bytes: encoded.byteLength,
+  };
+};
+
+const emitProgress = (
+  stage: DataExportStage,
+  summary: Parameters<StageCallback>[1],
+  requestId: string | undefined,
+): DataExportWorkerProgressEvent => ({
+  type: 'progress',
+  stage,
+  completed: DATA_EXPORT_STAGES.indexOf(stage) + 1,
+  total: DATA_EXPORT_STAGES.length,
+  items: summary.items,
+  bytes: summary.bytes,
+  requestId,
+});
+
+const emitComplete = (
+  archive: DataExportArchive,
+  buffer: ArrayBuffer,
+  bytes: number,
+  requestId: string | undefined,
+): DataExportWorkerCompleteEvent => ({
+  type: 'complete',
+  archive,
+  buffer,
+  bytes,
+  mime: DATA_EXPORT_DEFAULT_MIME,
+  suggestedName: formatExportFileName(archive.generatedAt),
+  requestId,
+});
+
+const emitError = (
+  error: unknown,
+  requestId: string | undefined,
+): DataExportWorkerErrorEvent => ({
+  type: 'error',
+  error: error instanceof Error ? error.message : String(error),
+  requestId,
+});
+
+const isWorkerScope =
+  typeof self !== 'undefined' && typeof (self as any).importScripts === 'function';
+
+if (isWorkerScope) {
+  const scope = self as DedicatedWorkerGlobalScope;
+  scope.onmessage = async ({ data }) => {
+    const message = data as DataExportWorkerRequest;
+    if (!message || message.type !== 'start') return;
+    const { requestId } = message;
+    try {
+      const result = await runDataExport({
+        onStageComplete: (stage, summary) => {
+          const progress: DataExportWorkerProgressEvent = emitProgress(
+            stage,
+            summary,
+            requestId,
+          );
+          scope.postMessage(progress);
+        },
+      });
+      const complete: DataExportWorkerCompleteEvent = emitComplete(
+        result.archive,
+        result.buffer,
+        result.bytes,
+        requestId,
+      );
+      scope.postMessage(complete, [result.buffer]);
+    } catch (err) {
+      scope.postMessage(emitError(err, requestId));
+    }
+  };
+}
+
+export type { DataExportWorkerRequest } from '../lib/dataExport';
+
+export type { DataExportWorkerEvent } from '../lib/dataExport';


### PR DESCRIPTION
## Summary
- add a reusable data export helper and worker that groups profiles, sessions, and flags with size metadata
- integrate a consent-center export button with progress feedback in the Settings privacy tab
- document the privacy export flow and cover the aggregator with unit tests

## Testing
- CI=1 yarn lint *(fails: repository has hundreds of pre-existing jsx-a11y/no-top-level-window violations)*
- yarn eslint workers/data-export.worker.ts
- yarn eslint apps/settings/index.tsx
- yarn test __tests__/dataExport.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cce5c6653c832881895748ea7e3b46