### PR TITLE
[apps] add ops dashboard status tiles

### DIFF
--- a/__tests__/opsDashboard.test.tsx
+++ b/__tests__/opsDashboard.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import OpsDashboard, { REFRESH_INTERVAL_MS } from '../apps/ops-dashboard';
+
+const createResponse = <T,>(data: T) =>
+  ({
+    ok: true,
+    json: async () => data,
+  }) as Response;
+
+const advanceAndFlush = async () => {
+  await act(async () => {
+    jest.advanceTimersByTime(REFRESH_INTERVAL_MS);
+    await Promise.resolve();
+  });
+};
+
+describe('OpsDashboard', () => {
+  const originalFetch = global.fetch;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete (global as typeof global & { fetch?: typeof fetch }).fetch;
+    }
+  });
+
+  it('transitions tile status when metrics cross thresholds', async () => {
+    const pingGood = {
+      updatedAt: '2024-05-17T10:00:00.000Z',
+      regions: [
+        { name: 'us-east', latencyMs: 150, slaMs: 220 },
+        { name: 'eu-central', latencyMs: 160, slaMs: 210 },
+      ],
+    };
+    const errorsGood = {
+      updatedAt: '2024-05-17T10:00:00.000Z',
+      services: [
+        { name: 'api-gateway', errorRate: 0.01, target: 0.02 },
+        { name: 'auth-service', errorRate: 0.008, target: 0.02 },
+      ],
+    };
+    const versionInfo = {
+      version: '2024.05.17',
+      build: 'ops-dashboard-demo',
+      commit: 'opsdemo123',
+      releasedAt: '2024-05-17T08:00:00.000Z',
+      notes: 'Mock metadata',
+    };
+    const pingWarning = {
+      updatedAt: '2024-05-17T10:00:15.000Z',
+      regions: [
+        { name: 'us-east', latencyMs: 280, slaMs: 220 },
+        { name: 'eu-central', latencyMs: 260, slaMs: 210 },
+      ],
+    };
+    const errorsWarning = {
+      updatedAt: '2024-05-17T10:00:15.000Z',
+      services: [
+        { name: 'api-gateway', errorRate: 0.035, target: 0.02 },
+        { name: 'auth-service', errorRate: 0.015, target: 0.02 },
+      ],
+    };
+    const pingCritical = {
+      updatedAt: '2024-05-17T10:00:30.000Z',
+      regions: [
+        { name: 'us-east', latencyMs: 380, slaMs: 220 },
+        { name: 'eu-central', latencyMs: 360, slaMs: 210 },
+      ],
+    };
+    const errorsCritical = {
+      updatedAt: '2024-05-17T10:00:30.000Z',
+      services: [
+        { name: 'api-gateway', errorRate: 0.08, target: 0.02 },
+        { name: 'auth-service', errorRate: 0.03, target: 0.02 },
+      ],
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(createResponse(pingGood))
+      .mockResolvedValueOnce(createResponse(errorsGood))
+      .mockResolvedValueOnce(createResponse(versionInfo))
+      .mockResolvedValueOnce(createResponse(pingWarning))
+      .mockResolvedValueOnce(createResponse(errorsWarning))
+      .mockResolvedValueOnce(createResponse(pingCritical))
+      .mockResolvedValueOnce(createResponse(errorsCritical));
+
+    render(<OpsDashboard />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('tile-pings')).toHaveAttribute(
+        'data-status',
+        'good',
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('tile-errors')).toHaveAttribute(
+        'data-status',
+        'good',
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('tile-version')).toHaveAttribute(
+        'data-status',
+        'good',
+      ),
+    );
+
+    await advanceAndFlush();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('tile-pings')).toHaveAttribute(
+        'data-status',
+        'warning',
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('tile-errors')).toHaveAttribute(
+        'data-status',
+        'warning',
+      ),
+    );
+
+    await advanceAndFlush();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('tile-pings')).toHaveAttribute(
+        'data-status',
+        'critical',
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('tile-errors')).toHaveAttribute(
+        'data-status',
+        'critical',
+      ),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/status/pings', {
+      cache: 'no-store',
+    });
+    expect(fetchMock).toHaveBeenCalledWith('/api/status/errors', {
+      cache: 'no-store',
+    });
+    expect(fetchMock).toHaveBeenCalledWith('/version.json', { cache: 'no-store' });
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -65,6 +65,7 @@ const CandyCrushApp = createDynamicApp('candy-crush', 'Candy Crush');
 const FileExplorerApp = createDynamicApp('file-explorer', 'Files');
 const Radare2App = createDynamicApp('radare2', 'Radare2');
 const AboutAlexApp = createDynamicApp('alex', 'About Alex');
+const OpsDashboardApp = createDynamicApp('ops-dashboard', 'Ops Dashboard');
 
 const QrApp = createDynamicApp('qr', 'QR Tool');
 const AsciiArtApp = createDynamicApp('ascii_art', 'ASCII Art');
@@ -156,6 +157,7 @@ const displayCandyCrush = createDisplay(CandyCrushApp);
 const displayFileExplorer = createDisplay(FileExplorerApp);
 const displayRadare2 = createDisplay(Radare2App);
 const displayAboutAlex = createDisplay(AboutAlexApp);
+const displayOpsDashboard = createDisplay(OpsDashboardApp);
 
 const displayQr = createDisplay(QrApp);
 const displayAsciiArt = createDisplay(AsciiArtApp);
@@ -720,6 +722,17 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayResourceMonitor,
+  },
+  {
+    id: 'ops-dashboard',
+    title: 'Ops Dashboard',
+    icon: '/themes/Yaru/apps/ops-dashboard.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayOpsDashboard,
+    defaultWidth: 70,
+    defaultHeight: 60,
   },
   {
     id: 'screen-recorder',

--- a/apps/ops-dashboard/index.tsx
+++ b/apps/ops-dashboard/index.tsx
@@ -1,0 +1,398 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+export const REFRESH_INTERVAL_MS = 15000;
+
+type TileStatus = 'loading' | 'good' | 'warning' | 'critical';
+
+interface PingRegion {
+  name: string;
+  latencyMs: number;
+  slaMs: number;
+}
+
+interface PingResponse {
+  updatedAt: string;
+  regions: PingRegion[];
+}
+
+interface ErrorService {
+  name: string;
+  errorRate: number;
+  target: number;
+}
+
+interface ErrorResponse {
+  updatedAt: string;
+  services: ErrorService[];
+}
+
+interface VersionInfo {
+  version: string;
+  build?: string;
+  commit?: string;
+  releasedAt: string;
+  notes?: string;
+}
+
+interface TileDescriptor {
+  id: string;
+  title: string;
+  status: TileStatus;
+  value: string;
+  meta?: string;
+  description: string;
+  tooltip: string;
+}
+
+const statusThemes: Record<TileStatus, string> = {
+  loading: 'border-slate-600 bg-slate-900/60',
+  good: 'border-green-400 bg-green-500/20',
+  warning: 'border-yellow-400 bg-yellow-500/20',
+  critical: 'border-red-500 bg-red-500/20',
+};
+
+const statusAccent: Record<TileStatus, string> = {
+  loading: 'text-slate-300',
+  good: 'text-green-300',
+  warning: 'text-yellow-200',
+  critical: 'text-red-300',
+};
+
+const statusLabels: Record<TileStatus, string> = {
+  loading: 'Loading',
+  good: 'Operational',
+  warning: 'Investigate',
+  critical: 'Critical',
+};
+
+const FETCH_OPTIONS: RequestInit = { cache: 'no-store' };
+
+const safeFormatDateTime = (iso: string) => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown time';
+  }
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })}`;
+};
+
+const formatLatency = (value: number) => `${Math.round(value)} ms`;
+const formatPercent = (value: number) => `${(value * 100).toFixed(2)}%`;
+
+const classifyLatency = (latency: number, slo: number): Exclude<TileStatus, 'loading'> => {
+  if (latency <= slo) {
+    return 'good';
+  }
+  if (latency <= slo * 1.5) {
+    return 'warning';
+  }
+  return 'critical';
+};
+
+const classifyErrorRate = (rate: number, target: number): Exclude<TileStatus, 'loading'> => {
+  if (rate <= target) {
+    return 'good';
+  }
+  if (rate <= target * 2) {
+    return 'warning';
+  }
+  return 'critical';
+};
+
+const toTitleCase = (value: string) =>
+  value
+    .split(/[-_]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, FETCH_OPTIONS);
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return (await response.json()) as T;
+}
+
+function StatusTile({ tile }: { tile: TileDescriptor }) {
+  return (
+    <article
+      role="listitem"
+      data-testid={`tile-${tile.id}`}
+      data-status={tile.status}
+      className={`border rounded-lg px-4 py-5 shadow-lg transition-colors duration-300 ${statusThemes[tile.status]}`}
+      title={tile.tooltip}
+      aria-live="polite"
+    >
+      <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-300">
+        <span>{tile.title}</span>
+        <span className={`font-semibold ${statusAccent[tile.status]}`}>
+          {statusLabels[tile.status]}
+        </span>
+      </div>
+      <div className="mt-3 text-3xl font-mono">{tile.value}</div>
+      {tile.meta ? <div className="mt-2 text-sm text-slate-200">{tile.meta}</div> : null}
+      <div className="mt-2 text-xs text-slate-400 whitespace-pre-line leading-snug">
+        {tile.description}
+      </div>
+    </article>
+  );
+}
+
+export default function OpsDashboard() {
+  const [pingData, setPingData] = useState<PingResponse | null>(null);
+  const [pingError, setPingError] = useState<string | null>(null);
+  const [errorData, setErrorData] = useState<ErrorResponse | null>(null);
+  const [errorRateError, setErrorRateError] = useState<string | null>(null);
+  const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
+  const [versionError, setVersionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    const loadMetrics = async () => {
+      const [pingResult, errorResult] = await Promise.allSettled(
+        [
+          fetchJson<PingResponse>('/api/status/pings'),
+          fetchJson<ErrorResponse>('/api/status/errors'),
+        ] as [Promise<PingResponse>, Promise<ErrorResponse>],
+      );
+
+      if (!active) {
+        return;
+      }
+
+      if (pingResult.status === 'fulfilled') {
+        setPingData(pingResult.value);
+        setPingError(null);
+      } else {
+        setPingData(null);
+        setPingError('Unable to retrieve latency metrics.');
+      }
+
+      if (errorResult.status === 'fulfilled') {
+        setErrorData(errorResult.value);
+        setErrorRateError(null);
+      } else {
+        setErrorData(null);
+        setErrorRateError('Unable to retrieve error rates.');
+      }
+    };
+
+    loadMetrics();
+    const intervalId = setInterval(loadMetrics, REFRESH_INTERVAL_MS);
+
+    return () => {
+      active = false;
+      clearInterval(intervalId);
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    const loadVersion = async () => {
+      try {
+        const data = await fetchJson<VersionInfo>('/version.json');
+        if (!active) {
+          return;
+        }
+        setVersionInfo(data);
+        setVersionError(null);
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+        setVersionInfo(null);
+        setVersionError('Unable to load build metadata.');
+      }
+    };
+
+    loadVersion();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const tiles = useMemo<TileDescriptor[]>(() => {
+    const latencyTile: TileDescriptor = (() => {
+      if (pingError) {
+        return {
+          id: 'pings',
+          title: 'Global latency',
+          status: 'critical',
+          value: 'Offline',
+          description: pingError,
+          tooltip: pingError,
+        };
+      }
+      if (!pingData || pingData.regions.length === 0) {
+        return {
+          id: 'pings',
+          title: 'Global latency',
+          status: 'loading',
+          value: '--',
+          description: 'Waiting for telemetry from edge locations.',
+          tooltip: 'Awaiting the first ping sample from each region.',
+        };
+      }
+
+      const averageLatency =
+        pingData.regions.reduce((sum, region) => sum + region.latencyMs, 0) /
+        pingData.regions.length;
+      const worstRegion = pingData.regions.reduce((worst, region) =>
+        region.latencyMs > worst.latencyMs ? region : worst,
+      pingData.regions[0]);
+      const slo = pingData.regions.reduce(
+        (max, region) => Math.max(max, region.slaMs),
+        200,
+      );
+      const status = classifyLatency(worstRegion.latencyMs, slo);
+
+      const tooltip = pingData.regions
+        .map(
+          (region) =>
+            `${region.name.toUpperCase()}: ${formatLatency(region.latencyMs)} (SLA ${region.slaMs}ms)`,
+        )
+        .join('\n');
+
+      return {
+        id: 'pings',
+        title: 'Global latency',
+        status,
+        value: formatLatency(averageLatency),
+        meta: `Slowest region: ${worstRegion.name.toUpperCase()} (${formatLatency(
+          worstRegion.latencyMs,
+        )})`,
+        description: `Updated ${safeFormatDateTime(pingData.updatedAt)}`,
+        tooltip,
+      };
+    })();
+
+    const errorsTile: TileDescriptor = (() => {
+      if (errorRateError) {
+        return {
+          id: 'errors',
+          title: 'Error budget',
+          status: 'critical',
+          value: 'Unavailable',
+          description: errorRateError,
+          tooltip: errorRateError,
+        };
+      }
+      if (!errorData || errorData.services.length === 0) {
+        return {
+          id: 'errors',
+          title: 'Error budget',
+          status: 'loading',
+          value: '--',
+          description: 'Collecting error telemetry from services.',
+          tooltip: 'Awaiting error rate samples from core services.',
+        };
+      }
+
+      const worstService = errorData.services.reduce((worst, service) =>
+        service.errorRate > worst.errorRate ? service : worst,
+      errorData.services[0]);
+      const status = classifyErrorRate(
+        worstService.errorRate,
+        worstService.target || 0.01,
+      );
+      const tooltip = errorData.services
+        .map(
+          (service) =>
+            `${toTitleCase(service.name)}: ${formatPercent(service.errorRate)} (SLO ${formatPercent(
+              service.target,
+            )})`,
+        )
+        .join('\n');
+
+      return {
+        id: 'errors',
+        title: 'Error budget',
+        status,
+        value: formatPercent(worstService.errorRate),
+        meta: `${toTitleCase(worstService.name)} target ${formatPercent(
+          worstService.target,
+        )}`,
+        description: `Updated ${safeFormatDateTime(errorData.updatedAt)}`,
+        tooltip,
+      };
+    })();
+
+    const versionTile: TileDescriptor = (() => {
+      if (versionError) {
+        return {
+          id: 'version',
+          title: 'Release',
+          status: 'critical',
+          value: 'Unknown',
+          description: versionError,
+          tooltip: versionError,
+        };
+      }
+      if (!versionInfo) {
+        return {
+          id: 'version',
+          title: 'Release',
+          status: 'loading',
+          value: '--',
+          description: 'Fetching build metadata…',
+          tooltip: 'Waiting for release metadata from version.json.',
+        };
+      }
+
+      const metaParts = [
+        versionInfo.build ? `Build ${versionInfo.build}` : null,
+        versionInfo.commit ? `Commit ${versionInfo.commit}` : null,
+      ].filter(Boolean);
+      const descriptionParts = [
+        `Released ${safeFormatDateTime(versionInfo.releasedAt)}`,
+        versionInfo.notes ?? null,
+      ].filter(Boolean);
+
+      return {
+        id: 'version',
+        title: 'Release',
+        status: 'good',
+        value: versionInfo.version,
+        meta: metaParts.join(' • ') || undefined,
+        description: descriptionParts.join('\n'),
+        tooltip:
+          [
+            `Version ${versionInfo.version}`,
+            metaParts.join(' • ') || undefined,
+            versionInfo.notes || undefined,
+          ]
+            .filter(Boolean)
+            .join('\n'),
+      };
+    })();
+
+    return [latencyTile, errorsTile, versionTile];
+  }, [pingData, pingError, errorData, errorRateError, versionInfo, versionError]);
+
+  return (
+    <div className="h-full w-full bg-ub-cool-grey text-white overflow-auto">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6 p-6">
+        <header className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-wide">Operations Dashboard</h1>
+          <p className="text-sm text-slate-200/80">
+            Live telemetry from demo status endpoints. Data refreshes every{' '}
+            {REFRESH_INTERVAL_MS / 1000} seconds.
+          </p>
+        </header>
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3" role="list">
+          {tiles.map((tile) => (
+            <StatusTile key={tile.id} tile={tile} />
+          ))}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/pages/api/status/errors.ts
+++ b/pages/api/status/errors.ts
@@ -1,0 +1,41 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface ErrorService {
+  name: string;
+  errorRate: number;
+  target: number;
+}
+
+interface ErrorResponse {
+  updatedAt: string;
+  services: ErrorService[];
+}
+
+const SERVICES: Array<Pick<ErrorService, 'name' | 'target'> & { baseline: number; variance: number }> = [
+  { name: 'api-gateway', target: 0.015, baseline: 0.008, variance: 0.01 },
+  { name: 'auth-service', target: 0.02, baseline: 0.012, variance: 0.015 },
+  { name: 'job-processor', target: 0.025, baseline: 0.018, variance: 0.02 },
+];
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+const drift = (baseline: number, variance: number) => {
+  const offset = (Math.random() - 0.5) * variance * 2;
+  return clamp(baseline + offset, 0, 0.25);
+};
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse<ErrorResponse>,
+) {
+  const services: ErrorService[] = SERVICES.map((service) => ({
+    name: service.name,
+    target: service.target,
+    errorRate: parseFloat(drift(service.baseline, service.variance).toFixed(4)),
+  }));
+
+  res.status(200).json({
+    updatedAt: new Date().toISOString(),
+    services,
+  });
+}

--- a/pages/api/status/pings.ts
+++ b/pages/api/status/pings.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface PingRegion {
+  name: string;
+  latencyMs: number;
+  slaMs: number;
+}
+
+interface PingResponse {
+  updatedAt: string;
+  regions: PingRegion[];
+}
+
+const BASELINE_REGIONS: Array<Pick<PingRegion, 'name' | 'slaMs'> & { baseline: number; variance: number }> = [
+  { name: 'us-east', slaMs: 220, baseline: 140, variance: 40 },
+  { name: 'us-west', slaMs: 240, baseline: 160, variance: 60 },
+  { name: 'eu-central', slaMs: 210, baseline: 150, variance: 45 },
+  { name: 'ap-southeast', slaMs: 260, baseline: 190, variance: 70 },
+];
+
+const jitter = (baseline: number, variance: number) => {
+  const offset = (Math.random() - 0.5) * variance * 2;
+  return Math.max(45, Math.round(baseline + offset));
+};
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse<PingResponse>,
+) {
+  const regions: PingRegion[] = BASELINE_REGIONS.map((region) => ({
+    name: region.name,
+    slaMs: region.slaMs,
+    latencyMs: jitter(region.baseline, region.variance),
+  }));
+
+  res.status(200).json({
+    updatedAt: new Date().toISOString(),
+    regions,
+  });
+}

--- a/public/themes/Yaru/apps/ops-dashboard.svg
+++ b/public/themes/Yaru/apps/ops-dashboard.svg
@@ -1,0 +1,8 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="12" fill="#0F172A"/>
+  <rect x="10" y="38" width="10" height="16" rx="2" fill="#38BDF8"/>
+  <rect x="24" y="28" width="10" height="26" rx="2" fill="#22D3EE"/>
+  <rect x="38" y="20" width="10" height="34" rx="2" fill="#34D399"/>
+  <path d="M12 26L20 34L28 18L36 36L44 14L52 22" stroke="#FBBF24" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="52" cy="22" r="3" fill="#F87171"/>
+</svg>

--- a/public/version.json
+++ b/public/version.json
@@ -1,0 +1,7 @@
+{
+  "version": "2024.05.17",
+  "build": "ops-dashboard-demo",
+  "commit": "opsdemo123",
+  "releasedAt": "2024-05-17T08:00:00.000Z",
+  "notes": "Mock build metadata served to the Ops Dashboard for demo purposes."
+}


### PR DESCRIPTION
## Summary
- add an Ops Dashboard app that polls the demo status endpoints and surfaces release metadata
- create mocked status APIs, dashboard icon, and version manifest consumed by the new app
- register the app in the desktop config and cover severity transitions with a focused test

## Testing
- yarn lint *(fails: pre-existing accessibility violations across legacy apps)*
- yarn test --runTestsByPath __tests__/opsDashboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cce5c2cb848328bc87085e7ec1036c