### PR TITLE
[docs] document layered module boundaries

### DIFF
--- a/docs/adr/0001-layered-architecture.md
+++ b/docs/adr/0001-layered-architecture.md
@@ -1,0 +1,78 @@
+# ADR 0001: Layered module boundaries
+
+## Status
+Accepted
+
+## Context
+The portfolio mixes desktop chrome, dozens of simulated security tools, retro games, API stubs, and shared utilities. Over time
+these areas began to reference one another without guardrails, making it harder to reason about dependencies and to reuse
+behaviour across apps without dragging in UI concerns. A documented layer model keeps imports predictable so new contributors can
+extend a feature or replace a data source without breaking unrelated surfaces.
+
+## Decision
+### Layer definitions
+- **Presentation layer** — user-facing shells and layout scaffolding.
+  - `app/`: Next.js App Router entries and layout wrappers.
+  - `pages/` (excluding `pages/api/`): legacy route components that render windows and app launchers.
+  - `components/`: shared UI chrome, app wrappers, menus, and window controls.
+  - `styles/`: global Tailwind extensions and CSS modules consumed directly by presentation components.
+- **Feature layer** — domain-specific experiences that power each window.
+  - `apps/`: implementations of simulated tools, utilities, and games rendered inside desktop windows.
+  - `games/`: standalone game logic consumed by feature apps such as the arcade launcher.
+  - `modules/`: reusable domain bundles (for example, Metasploit module metadata) that feature apps import.
+  - `plugins/`, `workers/`, `player/`, `templates/`, and `pages/api/`: orchestrators, background workers, and API routes that
+    deliver feature behaviour to the UI.
+- **Data layer** — data access, validation, and service integrations.
+  - `lib/`: analytics clients, database shims, fetch utilities, and validation helpers used to talk to external services.
+  - `data/`: static JSON, content indexes, and leaderboard payloads shipped with the site.
+  - `sql/`: reference SQL queries and schema snapshots.
+- **Shared layer** — cross-cutting helpers with no knowledge of upper layers.
+  - `hooks/`: reusable state management and platform hooks (focus trap, persisted state, notifications, etc.).
+  - `utils/`: generic utilities (storage wrappers, feature flags, analytics helpers) that any layer can adopt.
+  - `types/` and `filters/`: shared TypeScript declarations and filter presets consumed throughout the stack.
+
+### Allowed imports
+- **Presentation ➜ Feature**: presentation files may import feature modules but not the reverse.
+  - Example: `components/apps/terminal.tsx` imports `apps/terminal/tabs` to render the terminal UI.
+- **Presentation ➜ Shared**: UI layers rely on hooks and helpers from the shared layer.
+  - Example: `components/menu/*` can import `hooks/useFocusTrap` for keyboard navigation.
+- **Feature ➜ Data**: feature modules obtain data or service clients from the data layer.
+  - Example: `apps/terminal/index.tsx` may import `modules/metadata` for simulated command metadata.
+- **Feature ➜ Shared**: feature modules can consume shared hooks and utilities, but shared code must not import feature logic.
+  - Example: `apps/terminal/tabs/index.tsx` can use `utils/pubsub` for app-wide events.
+- **Data ➜ Shared**: data-layer utilities may depend on shared helpers (for example, logging), but must not import presentation
+  or feature code.
+  - Example: `lib/service-client.ts` can import `utils/env` for configuration.
+- **Shared layer**: shared utilities must remain dependency-free relative to higher layers. They may only import other shared
+  assets (for example, `utils/feature.ts` consuming `types/feature.ts`).
+
+Any import that points from a lower layer back up to a higher layer (for example, a hook importing from `components/`) violates
+this ADR. Cross-feature imports should route through shared utilities when behaviour must be reused.
+
+### Layer dependency diagram
+```mermaid
+flowchart LR
+  subgraph Shared
+    shared[Shared utilities]
+  end
+  subgraph Data
+    data[Data providers]
+  end
+  subgraph Feature
+    feature[Feature modules]
+  end
+  subgraph Presentation
+    presentation[Presentation components]
+  end
+
+  presentation --> feature
+  presentation --> shared
+  feature --> data
+  feature --> shared
+  data --> shared
+```
+
+## Consequences
+- New code reviews will reject imports that climb "up" the stack (for example, `hooks/` pulling from `components/`).
+- Shared utilities remain lightweight because they cannot depend on feature or presentation concerns.
+- Documentation and tooling (ESLint rules, code mods) can rely on the explicit mapping of directories to layers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,8 +2,34 @@
 
 The project is a desktop-style portfolio built with Next.js.
 
-- **pages/** wraps applications using Next.js routing and dynamic imports.
-- **components/apps/** contains the individual app implementations.
-- **pages/api/** exposes serverless functions for backend features.
+## Layered module boundaries
+We follow the layered module policy defined in [ADR 0001](./adr/0001-layered-architecture.md) to keep UI chrome, feature
+simulations, and data adapters isolated.
+
+### Layers at a glance
+- **Presentation**: `app/`, `pages/` (excluding `pages/api/`), `components/`, and `styles/` render the desktop shell and window
+  layouts.
+- **Feature**: `apps/`, `games/`, `modules/`, `player/`, `plugins/`, `templates/`, `workers/`, and `pages/api/` implement the
+  simulations, utilities, and background behaviour that power each window.
+- **Data**: `lib/`, `data/`, and `sql/` provide service clients, validation helpers, and bundled datasets.
+- **Shared**: `hooks/`, `utils/`, `types/`, and `filters/` expose reusable primitives that stay free of presentation concerns.
+
+The dependency flow between these layers is illustrated in the [layer dependency diagram](./adr/0001-layered-architecture.md#layer-dependency-diagram).
+Presentation modules may depend on feature and shared code, features may depend on data and shared code, data modules may depend
+on shared helpers, and shared code must avoid importing from higher layers.
+
+### Example compliant imports
+```tsx
+// components/apps/terminal.tsx — Presentation importing Feature code
+import dynamic from "next/dynamic";
+
+const TerminalApp = dynamic(() => import("@/apps/terminal/tabs"), { ssr: false });
+```
+
+```tsx
+// apps/contact/index.tsx — Feature importing Data and Shared helpers
+import { trackEvent } from "@/lib/analytics-client";
+import { contactSchema } from "@/utils/contactSchema";
+```
 
 For setup instructions, see the [Getting Started](./getting-started.md) guide.


### PR DESCRIPTION
## Summary
- add ADR 0001 describing presentation, feature, data, and shared layers with allowed import directions and a dependency diagram
- update the architecture overview to summarize the ADR and show example import snippets that match the new layering rules

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window errors across legacy apps and public assets)*
- yarn test *(fails: existing unit test issues in window keyboard handling, nmap NSE demo, and modal escape behavior)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25f329cc8328b1db8162d5fd6a54