### PR TITLE
[lint] add boundaries plugin

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import { FlatCompat } from '@eslint/eslintrc';
+import boundaries from 'eslint-plugin-boundaries';
 import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
 
 const compat = new FlatCompat();
@@ -7,10 +8,47 @@ const config = [
   { ignores: ['components/apps/Chrome/index.tsx'] },
   {
     plugins: {
+      boundaries,
       'no-top-level-window': noTopLevelWindow,
+    },
+    settings: {
+      'boundaries/elements': [
+        { type: 'ui', pattern: 'app/**', mode: 'full' },
+        { type: 'ui', pattern: 'pages/**', mode: 'full' },
+        { type: 'features', pattern: 'components/**', mode: 'full' },
+        { type: 'features', pattern: 'apps/**', mode: 'full' },
+        { type: 'features', pattern: 'games/**', mode: 'full' },
+        { type: 'features', pattern: 'calc/**', mode: 'full' },
+        { type: 'features', pattern: 'modules/**', mode: 'full' },
+        { type: 'features', pattern: 'hooks/**', mode: 'full' },
+        { type: 'features', pattern: 'utils/**', mode: 'full' },
+        { type: 'features', pattern: 'workers/**', mode: 'full' },
+        { type: 'features', pattern: 'player/**', mode: 'full' },
+        { type: 'core', pattern: 'lib/**', mode: 'full' },
+        { type: 'core', pattern: 'src/**', mode: 'full' },
+        { type: 'core', pattern: 'plugins/**', mode: 'full' },
+        { type: 'core', pattern: 'middleware.ts', mode: 'full' },
+        { type: 'shared', pattern: 'types/**', mode: 'full' },
+        { type: 'shared', pattern: 'data/**', mode: 'full' },
+        { type: 'shared', pattern: 'filters/**', mode: 'full' },
+        { type: 'shared', pattern: 'templates/**', mode: 'full' },
+        { type: 'shared', pattern: 'quotes/**', mode: 'full' },
+      ],
     },
     rules: {
       'no-top-level-window/no-top-level-window-or-document': 'error',
+      'boundaries/element-types': [
+        'error',
+        {
+          default: 'allow',
+          message: '${file.type} is not allowed to import ${dependency.type}',
+          rules: [
+            { from: ['features'], disallow: ['ui'] },
+            { from: ['core'], disallow: ['features', 'ui'] },
+            { from: ['shared'], disallow: ['core', 'features', 'ui'] },
+          ],
+        },
+      ],
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "@types/wicg-file-system-access": "^2023.10.6",
     "eslint": "^9.13.0",
     "eslint-config-next": "15.5.2",
+    "eslint-plugin-boundaries": "^5.0.1",
     "fake-indexeddb": "^6.1.0",
     "fast-glob": "^3.3.3",
     "jest": "30.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5463,7 +5463,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
+"chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -6824,7 +6824,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-node@npm:^0.3.6, eslint-import-resolver-node@npm:^0.3.9":
+"eslint-import-resolver-node@npm:0.3.9, eslint-import-resolver-node@npm:^0.3.6, eslint-import-resolver-node@npm:^0.3.9":
   version: 0.3.9
   resolution: "eslint-import-resolver-node@npm:0.3.9"
   dependencies:
@@ -6859,6 +6859,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-module-utils@npm:2.12.0":
+  version: 2.12.0
+  resolution: "eslint-module-utils@npm:2.12.0"
+  dependencies:
+    debug: "npm:^3.2.7"
+  peerDependenciesMeta:
+    eslint:
+      optional: true
+  checksum: 10c0/4d8b46dcd525d71276f9be9ffac1d2be61c9d54cc53c992e6333cf957840dee09381842b1acbbb15fc6b255ebab99cd481c5007ab438e5455a14abe1a0468558
+  languageName: node
+  linkType: hard
+
 "eslint-module-utils@npm:^2.12.1":
   version: 2.12.1
   resolution: "eslint-module-utils@npm:2.12.1"
@@ -6868,6 +6880,20 @@ __metadata:
     eslint:
       optional: true
   checksum: 10c0/6f4efbe7a91ae49bf67b4ab3644cb60bc5bd7db4cb5521de1b65be0847ffd3fb6bce0dd68f0995e1b312d137f768e2a1f842ee26fe73621afa05f850628fdc40
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-boundaries@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eslint-plugin-boundaries@npm:5.0.1"
+  dependencies:
+    chalk: "npm:4.1.2"
+    eslint-import-resolver-node: "npm:0.3.9"
+    eslint-module-utils: "npm:2.12.0"
+    micromatch: "npm:4.0.8"
+  peerDependencies:
+    eslint: ">=6.0.0"
+  checksum: 10c0/a63adfe918f96b61abec6a29a9bbee2e37435f6744c2cb635c453d3af98037d6e48f8d25dc7d5b63128bec99703485130730cf07141122e1bd30e5414115a5af
   languageName: node
   linkType: hard
 
@@ -9821,7 +9847,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.4, micromatch@npm:^4.0.8":
+"micromatch@npm:4.0.8, micromatch@npm:^4.0.4, micromatch@npm:^4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
   dependencies:
@@ -13907,6 +13933,7 @@ __metadata:
     dompurify: "npm:^3.2.6"
     eslint: "npm:^9.13.0"
     eslint-config-next: "npm:15.5.2"
+    eslint-plugin-boundaries: "npm:^5.0.1"
     fake-indexeddb: "npm:^6.1.0"
     fast-glob: "npm:^3.3.3"
     fast-xml-parser: "npm:^4.3.5"


### PR DESCRIPTION
## Summary
- add eslint-plugin-boundaries to the devDependencies and lockfile
- register the plugin in `eslint.config.mjs` with ui/features/core/shared groups and forbid upward imports

## Testing
- [x] yarn lint *(fails because of pre-existing accessibility and window/document lint errors in the codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25f1c1988328b9d9742f85a8420f