### PR TITLE
[events] add typed domain event bus

### DIFF
--- a/components/apps/Games/common/perf/PerfOverlay.tsx
+++ b/components/apps/Games/common/perf/PerfOverlay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef } from 'react';
-import { publish } from '../../../../../utils/pubsub';
+import { publish } from '../../../../../events';
 import { hasOffscreenCanvas } from '../../../../../utils/feature';
 
 interface PerfSample {
@@ -53,7 +53,13 @@ const PerfOverlay: React.FC = () => {
       const loop = (now: number) => {
         if (lastRef.current) {
           const dt = now - lastRef.current;
-          publish('fps', 1000 / dt);
+          publish({
+            type: 'perf/fps-sampled',
+            payload: {
+              fps: 1000 / dt,
+              frameTimeMs: dt,
+            },
+          });
           worker.postMessage({ type: 'frame', dt });
         }
         lastRef.current = now;
@@ -84,7 +90,13 @@ const PerfOverlay: React.FC = () => {
         const samples = samplesRef.current;
         samples.push({ t: now, dt });
         if (samples.length > MAX_SAMPLES) samples.shift();
-        publish('fps', 1000 / dt);
+        publish({
+          type: 'perf/fps-sampled',
+          payload: {
+            fps: 1000 / dt,
+            frameTimeMs: dt,
+          },
+        });
         if (ctx) {
           const w = canvas.width;
           const h = canvas.height;

--- a/events/events.typecheck.ts
+++ b/events/events.typecheck.ts
@@ -1,0 +1,69 @@
+import { publish, subscribe } from '.';
+
+publish({
+  type: 'perf/fps-sampled',
+  payload: {
+    fps: 60,
+    frameTimeMs: 16.67,
+  },
+});
+
+subscribe('perf/fps-sampled', (payload) => {
+  const fps: number = payload.fps;
+  const frameTime: number = payload.frameTimeMs;
+  fps.toFixed(2);
+  frameTime.toFixed(2);
+});
+
+const invalidTypeEvent = {
+  type: 'perf/unknown',
+  payload: {
+    fps: 60,
+    frameTimeMs: 16.67,
+  },
+} as const;
+
+const invalidTypePublish = () => {
+  // @ts-expect-error - event type must exist in DomainEvent
+  publish(invalidTypeEvent);
+};
+
+const missingFrameTimeEvent = {
+  type: 'perf/fps-sampled',
+  payload: {
+    fps: 60,
+  },
+} as const;
+
+const missingFrameTimePublish = () => {
+  // @ts-expect-error - payload must include frameTimeMs
+  publish(missingFrameTimeEvent);
+};
+
+const invalidPayloadEvent = {
+  type: 'perf/fps-sampled',
+  payload: {
+    fps: 'fast',
+    frameTimeMs: 16,
+  },
+} as const;
+
+const invalidPayloadPublish = () => {
+  // @ts-expect-error - payload types must match DomainEvent definition
+  publish(invalidPayloadEvent);
+};
+
+void invalidTypePublish;
+void missingFrameTimePublish;
+void invalidPayloadPublish;
+
+subscribe('perf/fps-sampled', (payload) => {
+  payload.fps.toFixed(0);
+  payload.frameTimeMs.toFixed(2);
+  // @ts-expect-error - payload should not expose arbitrary properties
+  payload.nonexistent;
+});
+
+// @ts-expect-error - cannot subscribe to unknown event topics
+subscribe('perf/unknown', () => {});
+

--- a/events/index.ts
+++ b/events/index.ts
@@ -1,0 +1,41 @@
+import { createPubSub, type EventOfType, type EventPayload } from '../utils/pubsub';
+
+export type FpsSampledEvent = {
+  type: 'perf/fps-sampled';
+  payload: {
+    fps: number;
+    frameTimeMs: number;
+  };
+};
+
+export type DomainEvent = FpsSampledEvent;
+
+export type DomainEventType = DomainEvent['type'];
+
+export type DomainEventPayload<Type extends DomainEventType> = EventPayload<DomainEvent, Type>;
+
+const eventBus = createPubSub<DomainEvent>();
+
+export const publish = eventBus.publish;
+export const subscribe = eventBus.subscribe;
+
+export type Publish = typeof publish;
+export type Subscribe = typeof subscribe;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __domainEvents: {
+    publish: Publish;
+    subscribe: Subscribe;
+  } | undefined;
+}
+
+if (typeof globalThis !== 'undefined') {
+  globalThis.__domainEvents = {
+    publish,
+    subscribe,
+  };
+}
+
+export type EventOfTypeWithPayload<Type extends DomainEventType> = EventOfType<DomainEvent, Type>;
+


### PR DESCRIPTION
## Summary
- add a typed `DomainEvent` union and publish/subscribe helpers in a new `events` module
- refactor the shared pub/sub utility and perf overlay to emit strongly typed FPS events
- add a TypeScript typecheck file to enforce invalid event payloads at compile time

## Testing
- yarn lint *(fails: repository already contains hundreds of accessibility lint violations across apps and public assets)*
- yarn typecheck
- yarn test *(fails: existing window, nmap NSE, and related suites in the repository are currently red)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25ef7f408328a7ad526495868c14