### PR TITLE
[docs] add codeowner mapping

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# This file controls the default reviewers requested by GitHub.
+# Maintainers: please confirm these assignments and keep them aligned with the current leads for each area.
+
+/apps/          @Alex-Unnippillil
+/components/    @Alex-Unnippillil
+/lib/           @Alex-Unnippillil
+/configs/       @Alex-Unnippillil

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing Guide
+
+Thanks for helping improve the Kali Linux Portfolio! This document highlights the review process so changes land smoothly.
+
+## Review expectations
+
+- **CODEOWNERS coverage.** Pull requests touching `/apps`, `/components`, `/lib`, or `/configs` will automatically request a review from the listed owners. Make sure those reviewers sign off before merging.
+- **Coordinate early.** If a change spans multiple areas or needs a different subject matter expert, @-mention the relevant owner in the PR description so they can reroute as needed.
+- **Provide context.** Include a short summary of the problem you are solving, screenshots for UI updates, and the test commands you executed (see `AGENTS.md` for the full checklist).
+- **Keep changes scoped.** Smaller, focused commits help owners review faster. Large refactors should be pre-discussed so maintainers can plan enough review time.
+- **Confirm ownership.** Share the CODEOWNERS assignments with the maintainers for confirmation and update the file whenever team responsibilities change or new owners join.
+
+If you are unsure who should review your contribution, start a discussion in the issue or pull request and tag @Alex-Unnippillil. They can confirm or reassign the correct owner.


### PR DESCRIPTION
## Summary
- add a CODEOWNERS file that assigns apps, components, lib, and configs to @Alex-Unnippillil
- document review expectations and CODEOWNERS coordination in a new contributing guide

## Testing
- yarn lint *(fails: repository contains numerous existing accessibility and no-top-level-window lint errors)*
- yarn test *(fails/interrupted: existing React act warnings in multiple suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25edd43c8328b51264b3a626f114