### PR TITLE
[docs] add contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: "Bug report"
+description: "Report a defect or regression in the Kali Linux Portfolio"
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug! Please include as much detail as possible so we can reproduce the issue locally and in CI.
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened?
+      placeholder: "Window manager locks up when opening the terminal app"
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        Provide a numbered list of steps that consistently reproduce the problem. Include sample input or links if relevant.
+      placeholder: |
+        1. …
+        2. …
+        3. …
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened, including error messages or screenshots.
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, device, build SHA, or any other context needed to reproduce.
+      placeholder: "Chrome 131 on macOS 15, yarn dev"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Screenshots
+      description: Paste stack traces, console logs, or attach images that help illustrate the issue.
+  - type: checkboxes
+    id: regression
+    attributes:
+      label: Regression Check
+      description: Let us know if this used to work.
+      options:
+        - label: I confirmed this worked in a previous release/build
+        - label: I am not sure if this ever worked

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: "Feature request"
+description: "Suggest a new capability or improvement"
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share the use case and how the portfolio should behave after this feature ships. Include links to design references if available.
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: What is the concise title of this feature?
+      placeholder: "Add dark terminal theme toggle"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What user problem or workflow gap does this feature solve?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Current Behavior / Reproduction
+      description: |
+        Describe the current steps or flows that highlight the gap. Include screenshots, URLs, or commands that reproduce the limitation.
+      placeholder: |
+        1. Open …
+        2. Attempt …
+        3. Observe …
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: Describe the change, including affected apps/modules and any feature flags.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Bullet list of conditions that must be met for this feature to be considered complete.
+  - type: checkboxes
+    id: dependencies
+    attributes:
+      label: Dependencies & Risks
+      description: Call out any considerations that could block delivery.
+      options:
+        - label: Requires new environment variables or secrets
+        - label: Impacts analytics, monitoring, or alerting
+        - label: Introduces third-party services or APIs
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Links, mockups, or anything else that will help scope the work.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+- _List the key changes and the apps or modules they touch._
+- _Call out any feature flags or toggles updated in this PR._
+
+## Testing
+_Select all that apply and add details if needed._
+- [ ] `yarn lint`
+- [ ] `yarn test`
+- [ ] `yarn smoke`
+- [ ] `npx playwright test`
+- [ ] Other (explain):
+
+## Screenshots / Recordings
+_Attach updated UI captures or mark as not applicable._
+- [ ] Screenshots or recordings are attached below
+- [ ] Not applicable (no visual changes)
+
+## Risk Assessment
+_How risky is this change once deployed?_
+- [ ] Low — isolated UI/content change or docs only
+- [ ] Medium — touches shared components, APIs, or build config
+- [ ] High — migrations, data mutations, or core window manager updates
+
+## Gating Questions
+_Confirm each item before requesting review._
+- [ ] Have environment variables or secrets changed? (document updates if yes)
+- [ ] Are follow-up issues required? (link or create them)
+- [ ] Does this PR impact production monitoring or analytics?
+- [ ] Were docs updated for user-facing or operational changes?

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ See `.env.local.example` for the full list.
 - Run `yarn lint` and `yarn test` before committing changes.
 - For manual smoke tests, start `yarn dev` and in another terminal run `yarn smoke` to visit every `/apps/*` route.
 
+## Contribution & Issue Templates
+
+- Use the [pull request template](.github/PULL_REQUEST_TEMPLATE.md) to document your changes, test coverage, risk assessment, and required gating questions before requesting review.
+- When filing issues, choose the **Bug report** template to capture reproduction steps, expected vs. actual behavior, and environment details.
+- For feature ideas, open an issue with the **Feature request** template to describe the problem, current reproduction flow, and proposed solution.
+
 ---
 
 ## Speed Insights


### PR DESCRIPTION
## Summary
- add a pull request template covering tests, screenshots, risk, and gating questions
- add issue forms for bug reports and feature requests with required reproduction details
- update the README to point contributors to the new templates

## Testing
- [ ] `yarn lint` *(fails: existing accessibility lint errors across legacy app files)*
- [ ] `yarn test` *(fails: existing Jest suites such as Modal.test.tsx and nmapNse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25ece4a48328bac04d65d5da262a