### PR TITLE
[lint] add complexity limits and baseline overrides

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import { FlatCompat } from '@eslint/eslintrc';
 import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
+import baselineOverrides from './eslint.overrides.mjs';
 
 const compat = new FlatCompat();
 
@@ -27,6 +28,28 @@ const config = [
       'jsx-a11y/control-has-associated-label': 'error',
     },
   }),
+  {
+    files: [
+      'app/**/*.{js,jsx,ts,tsx}',
+      'components/**/*.{js,jsx,ts,tsx}',
+      'hooks/**/*.{js,jsx,ts,tsx}',
+      'lib/**/*.{js,jsx,ts,tsx}',
+      'modules/**/*.{js,jsx,ts,tsx}',
+      'pages/**/*.{js,jsx,ts,tsx}',
+      'src/**/*.{js,jsx,ts,tsx}',
+      'utils/**/*.{js,ts}',
+      'workers/**/*.{js,ts}',
+    ],
+    rules: {
+      complexity: ['error', 20],
+      'max-lines-per-function': [
+        'error',
+        { max: 200, skipBlankLines: true, skipComments: true },
+      ],
+      'max-nested-callbacks': ['error', 4],
+    },
+  },
+  ...baselineOverrides,
 ];
 
 export default config;

--- a/eslint.overrides.mjs
+++ b/eslint.overrides.mjs
@@ -1,0 +1,37 @@
+const overrides = [
+  // Mini-apps and retro games are intentionally verbose simulations.
+  // They pre-date the stricter lint rules and would require major rewrites.
+  {
+    files: ['components/apps/**/*.{js,jsx,ts,tsx}'],
+    rules: {
+      complexity: 'off',
+      'max-lines-per-function': 'off',
+      'max-nested-callbacks': 'off',
+    },
+  },
+  // Legacy static bundles under public/ rely on DOM globals and large functions.
+  {
+    files: ['public/apps/**/*.{js,jsx}', 'public/workbox-*.js'],
+    rules: {
+      complexity: 'off',
+      'max-lines-per-function': 'off',
+      'max-nested-callbacks': 'off',
+    },
+  },
+  // API stubs simulate complex tooling flows; track their complexity separately.
+  {
+    files: ['pages/api/contact.js', 'pages/api/hydra.js'],
+    rules: {
+      complexity: 'off',
+    },
+  },
+  // Long-form report pages intentionally mirror original documents.
+  {
+    files: ['pages/nessus-report.tsx', 'pages/nikto-report.tsx', 'pages/qr/index.tsx'],
+    rules: {
+      'max-lines-per-function': 'off',
+    },
+  },
+];
+
+export default overrides;

--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -9,6 +9,8 @@ const RATE_LIMIT_MAX = 5;
 
 export const rateLimit = new Map();
 
+// NOTE: Complexity baseline tracked in eslint.overrides.mjs while we evaluate
+// opportunities to split rate limiting, captcha, and storage flows.
 export default async function handler(req, res) {
   try {
     validateServerEnv(process.env);

--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -7,6 +7,8 @@ import path from 'path';
 const execFileAsync = promisify(execFile);
 const allowed = new Set(['http', 'https', 'ssh', 'ftp', 'smtp']);
 
+// NOTE: Complexity baseline recorded in eslint.overrides.mjs because this
+// simulation handles install checks, session resumption, and cleanup.
 export default async function handler(req, res) {
   if (
     process.env.FEATURE_TOOL_APIS !== 'enabled' ||

--- a/pages/nessus-report.tsx
+++ b/pages/nessus-report.tsx
@@ -23,6 +23,8 @@ interface Finding {
 const radius = 60;
 const circumference = 2 * Math.PI * radius;
 
+// NOTE: Length exceeds max-lines rule to preserve detailed Nessus report UI;
+// tracked in eslint.overrides.mjs for future modularization.
 const NessusReport: React.FC = () => {
   const [selected, setSelected] = useState<Finding | null>(null);
   const [severity, setSeverity] = useState<string>('All');

--- a/pages/nikto-report.tsx
+++ b/pages/nikto-report.tsx
@@ -17,6 +17,8 @@ const severityColors: Record<string, string> = {
   Info: '#4b5563',
 };
 
+// NOTE: Page mirrors Nikto report layout; tracked in eslint.overrides.mjs for
+// future decomposition into widgets.
 const NiktoReport: React.FC = () => {
   const [findings, setFindings] = useState<NiktoFinding[]>([]);
   const [severity, setSeverity] = useState('All');

--- a/pages/qr/index.tsx
+++ b/pages/qr/index.tsx
@@ -17,6 +17,8 @@ const tabs = [
 
 type TabId = (typeof tabs)[number]['id'];
 
+// NOTE: Page aggregates multiple QR workflows; tracked in eslint.overrides.mjs
+// until we break the UI into smaller flows.
 const QRPage: React.FC = () => {
   const [active, setActive] = useState<TabId>('text');
   const [text, setText] = useState('');

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -188,30 +188,29 @@ export async function importSettings(json) {
     console.error('Invalid settings', e);
     return;
   }
-  const {
-    accent,
-    wallpaper,
-    density,
-    reducedMotion,
-    fontScale,
-    highContrast,
-    largeHitAreas,
-    pongSpin,
-    allowNetwork,
-    haptics,
-    theme,
-  } = settings;
-  if (accent !== undefined) await setAccent(accent);
-  if (wallpaper !== undefined) await setWallpaper(wallpaper);
-  if (density !== undefined) await setDensity(density);
-  if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
-  if (fontScale !== undefined) await setFontScale(fontScale);
-  if (highContrast !== undefined) await setHighContrast(highContrast);
-  if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
-  if (pongSpin !== undefined) await setPongSpin(pongSpin);
-  if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
-  if (haptics !== undefined) await setHaptics(haptics);
-  if (theme !== undefined) setTheme(theme);
+  const setters = {
+    accent: setAccent,
+    wallpaper: setWallpaper,
+    density: setDensity,
+    reducedMotion: setReducedMotion,
+    fontScale: setFontScale,
+    highContrast: setHighContrast,
+    largeHitAreas: setLargeHitAreas,
+    pongSpin: setPongSpin,
+    allowNetwork: setAllowNetwork,
+    haptics: setHaptics,
+    theme: async (value) => {
+      setTheme(value);
+    },
+  };
+
+  const tasks = Object.entries(setters)
+    .filter(([key]) => settings[key] !== undefined)
+    .map(async ([key, setter]) => {
+      await setter(settings[key]);
+    });
+
+  await Promise.all(tasks);
 }
 
 export const defaults = DEFAULT_SETTINGS;

--- a/workers/checkersAI.ts
+++ b/workers/checkersAI.ts
@@ -13,6 +13,31 @@ const inBounds = (r: number, c: number) => r >= 0 && r < 8 && c >= 0 && c < 8;
 const cloneBoard = (board: Board): Board =>
   board.map((row) => row.map((cell) => (cell ? { ...cell } : null)));
 
+const addDirectionalMoves = (
+  board: Board,
+  piece: Piece,
+  origin: [number, number],
+  dr: number,
+  dc: number,
+  moves: Move[],
+  captures: Move[],
+) => {
+  const [r, c] = origin;
+  const r1 = r + dr;
+  const c1 = c + dc;
+  if (!inBounds(r1, c1)) return;
+  const target = board[r1][c1];
+  if (!target) {
+    moves.push({ from: origin, to: [r1, c1] });
+    return;
+  }
+  if (target.color === piece.color) return;
+  const r2 = r + dr * 2;
+  const c2 = c + dc * 2;
+  if (!inBounds(r2, c2) || board[r2][c2]) return;
+  captures.push({ from: origin, to: [r2, c2], captured: [r1, c1] });
+};
+
 const getPieceMoves = (
   board: Board,
   r: number,
@@ -28,19 +53,7 @@ const getPieceMoves = (
   const moves: Move[] = [];
   const captures: Move[] = [];
   for (const [dr, dc] of dirs) {
-    const r1 = r + dr;
-    const c1 = c + dc;
-    if (!inBounds(r1, c1)) continue;
-    const target = board[r1][c1];
-    if (!target) {
-      moves.push({ from: [r, c], to: [r1, c1] });
-    } else if (target.color !== piece.color) {
-      const r2 = r + dr * 2;
-      const c2 = c + dc * 2;
-      if (inBounds(r2, c2) && !board[r2][c2]) {
-        captures.push({ from: [r, c], to: [r2, c2], captured: [r1, c1] });
-      }
-    }
+    addDirectionalMoves(board, piece, [r, c], dr, dc, moves, captures);
   }
   return enforceCapture && captures.length ? captures : [...captures, ...moves];
 };

--- a/workers/hash-worker.ts
+++ b/workers/hash-worker.ts
@@ -40,142 +40,111 @@ export interface ResultMessage {
   results: Record<string, string>;
 }
 
+const hashFactories: Partial<Record<Algorithm, () => Promise<any>>> = {
+  MD5: createMD5,
+  'SHA-1': createSHA1,
+  'SHA-256': createSHA256,
+  'SHA-384': createSHA384,
+  'SHA-512': createSHA512,
+  'SHA3-256': () => createSHA3(256),
+  'SHA3-512': () => createSHA3(512),
+  BLAKE3: createBLAKE3,
+  CRC32: createCRC32,
+};
+
+const isHashAlgorithm = (alg: Algorithm) => alg in hashFactories;
+
+const instantiateHashers = async (algorithms: Algorithm[]) => {
+  const pairs = await Promise.all(
+    algorithms
+      .filter(isHashAlgorithm)
+      .map(async (alg) => {
+        const factory = hashFactories[alg];
+        if (!factory) return null;
+        return [alg, await factory()] as const;
+      }),
+  );
+  return Object.fromEntries(pairs.filter(Boolean) as Array<[Algorithm, any]>);
+};
+
+const digestHasher = (alg: string, hasher: any) => {
+  if (alg === 'CRC32') {
+    const num = hasher.digest();
+    return num.toString(16).padStart(8, '0');
+  }
+  return hasher.digest('hex');
+};
+
+const postProgress = (loaded: number, total: number) => {
+  (self as any).postMessage({
+    type: 'progress',
+    loaded,
+    total,
+  } as ProgressMessage);
+};
+
+const updateHashers = (hashers: Record<string, any>, chunk: Uint8Array) => {
+  for (const hasher of Object.values(hashers)) {
+    hasher.update(chunk);
+  }
+};
+
+const finalizeHashers = (hashers: Record<string, any>) => {
+  const results: Record<string, string> = {};
+  for (const [alg, hasher] of Object.entries(hashers)) {
+    results[alg] = digestHasher(alg, hasher);
+  }
+  return results;
+};
+
+const handleFile = async (file: File, algorithms: Algorithm[]) => {
+  const hashers = await instantiateHashers(algorithms);
+  const reader = file.stream().getReader();
+  let loaded = 0;
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    loaded += value.length;
+    updateHashers(hashers, value);
+    postProgress(loaded, file.size);
+  }
+
+  return finalizeHashers(hashers);
+};
+
+const applyTextEncodings = (text: string, algorithms: Algorithm[], results: Record<string, string>) => {
+  if (algorithms.includes('BASE64')) {
+    results.BASE64 = btoa(text);
+  }
+  if (algorithms.includes('BASE64URL')) {
+    results.BASE64URL = btoa(text).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+  if (algorithms.includes('URL')) {
+    results.URL = encodeURIComponent(text);
+  }
+};
+
+const handleText = async (text: string, algorithms: Algorithm[]) => {
+  const data = new TextEncoder().encode(text);
+  const hashers = await instantiateHashers(algorithms);
+  if (Object.keys(hashers).length) {
+    updateHashers(hashers, data);
+  }
+  const results = finalizeHashers(hashers);
+  applyTextEncodings(text, algorithms, results);
+  postProgress(data.length, data.length);
+  return results;
+};
+
 self.onmessage = async ({ data }: MessageEvent<HashWorkerRequest>) => {
   const { file, text, algorithms } = data;
   const results: Record<string, string> = {};
 
   if (file) {
-    const hashers: Record<string, any> = {};
-
-    for (const alg of algorithms) {
-      switch (alg) {
-        case 'MD5':
-          hashers[alg] = await createMD5();
-          break;
-        case 'SHA-1':
-          hashers[alg] = await createSHA1();
-          break;
-        case 'SHA-256':
-          hashers[alg] = await createSHA256();
-          break;
-        case 'SHA-384':
-          hashers[alg] = await createSHA384();
-          break;
-        case 'SHA-512':
-          hashers[alg] = await createSHA512();
-          break;
-        case 'SHA3-256':
-          hashers[alg] = await createSHA3(256);
-          break;
-        case 'SHA3-512':
-          hashers[alg] = await createSHA3(512);
-          break;
-        case 'BLAKE3':
-          hashers[alg] = await createBLAKE3();
-          break;
-        case 'CRC32':
-          hashers[alg] = await createCRC32();
-          break;
-        default:
-          break;
-      }
-    }
-
-    const reader = file.stream().getReader();
-    let loaded = 0;
-
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      loaded += value.length;
-      for (const hasher of Object.values(hashers)) {
-        hasher.update(value);
-      }
-      (self as any).postMessage({
-        type: 'progress',
-        loaded,
-        total: file.size,
-      } as ProgressMessage);
-    }
-
-    for (const [alg, hasher] of Object.entries(hashers)) {
-      if (alg === 'CRC32') {
-        const num = hasher.digest();
-        results[alg] = num.toString(16).padStart(8, '0');
-      } else {
-        results[alg] = hasher.digest('hex');
-      }
-    }
+    Object.assign(results, await handleFile(file, algorithms));
   } else if (typeof text === 'string') {
-    const data = new TextEncoder().encode(text);
-
-    // Hashing for text
-    const hashAlgs = algorithms.filter(
-      (a) => !['BASE64', 'BASE64URL', 'URL'].includes(a),
-    );
-    const hashers: Record<string, any> = {};
-    for (const alg of hashAlgs) {
-      switch (alg) {
-        case 'MD5':
-          hashers[alg] = await createMD5();
-          break;
-        case 'SHA-1':
-          hashers[alg] = await createSHA1();
-          break;
-        case 'SHA-256':
-          hashers[alg] = await createSHA256();
-          break;
-        case 'SHA-384':
-          hashers[alg] = await createSHA384();
-          break;
-        case 'SHA-512':
-          hashers[alg] = await createSHA512();
-          break;
-        case 'SHA3-256':
-          hashers[alg] = await createSHA3(256);
-          break;
-        case 'SHA3-512':
-          hashers[alg] = await createSHA3(512);
-          break;
-        case 'BLAKE3':
-          hashers[alg] = await createBLAKE3();
-          break;
-        case 'CRC32':
-          hashers[alg] = await createCRC32();
-          break;
-        default:
-          break;
-      }
-    }
-
-    for (const hasher of Object.values(hashers)) {
-      hasher.update(data);
-    }
-
-    for (const [alg, hasher] of Object.entries(hashers)) {
-      if (alg === 'CRC32') {
-        const num = hasher.digest();
-        results[alg] = num.toString(16).padStart(8, '0');
-      } else {
-        results[alg] = hasher.digest('hex');
-      }
-    }
-
-    if (algorithms.includes('BASE64')) {
-      results.BASE64 = btoa(text);
-    }
-    if (algorithms.includes('BASE64URL')) {
-      results.BASE64URL = btoa(text).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-    }
-    if (algorithms.includes('URL')) {
-      results.URL = encodeURIComponent(text);
-    }
-
-    (self as any).postMessage({
-      type: 'progress',
-      loaded: data.length,
-      total: data.length,
-    } as ProgressMessage);
+    Object.assign(results, await handleText(text, algorithms));
   }
 
   (self as any).postMessage({ type: 'result', results } as ResultMessage);


### PR DESCRIPTION
## Summary
- add complexity, max-lines-per-function, and max-nested-callbacks rules with scoped thresholds
- capture legacy exceptions in a dedicated eslint.overrides.mjs file and annotate affected modules
- refactor workers and utilities to satisfy the new limits while keeping existing behaviour

## Testing
- `yarn lint` *(fails: repository already has numerous jsx-a11y and window/document violations that predate this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25e77be883288dcc12134da0b55a