### PR TITLE
[tests] quarantine flaky suites

### DIFF
--- a/.github/workflows/nightly-quarantine.yml
+++ b/.github/workflows/nightly-quarantine.yml
@@ -1,0 +1,29 @@
+name: Quarantined Jest suite
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  quarantine:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - name: Run quarantined tests
+        run: yarn test:quarantine
+      - name: Summarize quarantined run
+        if: ${{ always() }}
+        run: |
+          echo "## Quarantined Jest suite" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "All quarantined tests passed ✅" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Failures detected in quarantined tests ❌" >> "$GITHUB_STEP_SUMMARY"
+            echo "Review the logs above and remove flaky tags once stabilized." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/__tests__/beef.test.tsx
+++ b/__tests__/beef.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Beef from '../components/apps/beef';
 
-describe('BeEF app', () => {
+describeFlaky('BeEF app', () => {
   test('advances through lab steps to payload builder', () => {
     render(<Beef />);
     fireEvent.click(screen.getByRole('button', { name: /begin/i }));

--- a/__tests__/hashcat.test.tsx
+++ b/__tests__/hashcat.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import HashcatApp, { detectHashType } from '../components/apps/hashcat';
 import progressInfo from '../components/apps/hashcat/progress.json';
 
-describe('HashcatApp', () => {
+describeFlaky('HashcatApp', () => {
   it('auto-detects hash types', () => {
     expect(detectHashType('d41d8cd98f00b204e9800998ecf8427e')).toBe('0');
     expect(detectHashType('da39a3ee5e6b4b0d3255bfef95601890afd80709')).toBe('100');

--- a/__tests__/mimikatz.test.ts
+++ b/__tests__/mimikatz.test.ts
@@ -11,7 +11,7 @@ function mockRes() {
   return res;
 }
 
-describe('mimikatz api', () => {
+describeFlaky('mimikatz api', () => {
   beforeAll(() => {
     process.env.FEATURE_TOOL_APIS = 'enabled';
   });

--- a/docs/testing/quarantine.md
+++ b/docs/testing/quarantine.md
@@ -1,0 +1,67 @@
+# Quarantined Jest suites
+
+Flaky UI tests can make the main CI job unreliable. This guide explains how we quarantine
+problematic suites, keep them visible, and graduate them back into the primary pipeline once
+they stabilise.
+
+## Tagging flaky tests
+
+Use the Jest helpers registered in `jest.setup.ts` to flag unstable suites or individual cases:
+
+```ts
+// Entire suite is flaky
+describeFlaky('Hashcat app', () => {
+  it('...', () => {
+    // test body
+  });
+});
+
+// A single test is flaky
+itFlaky('recovers from transient API errors', async () => {
+  // test body
+});
+```
+
+`describeFlaky`, `itFlaky`, and `testFlaky` behave exactly like their Jest equivalents when the
+`RUN_FLAKY` environment variable is set to `true`. Otherwise they call through to `.skip`, so the
+main `yarn test` job no longer executes the quarantined code.
+
+## Running the quarantine suite locally
+
+```bash
+yarn test:quarantine
+```
+
+The helper script automatically scans for files that contain the `*Flaky` helpers and runs them in
+band with `RUN_FLAKY=true`. If no quarantined suites exist the script exits quickly.
+
+## Nightly GitHub Action
+
+The `Quarantined Jest suite` workflow (`.github/workflows/nightly-quarantine.yml`) runs every night
+at 06:00 UTC and can also be launched manually with **Run workflow**. It installs dependencies and
+executes `yarn test:quarantine`. The job writes a short success/failure message to the workflow
+summary so we have a quick signal without digging through the logs.
+
+## Current quarantined suites
+
+| Suite | Reason noted | Date added | Exit criteria |
+|-------|--------------|------------|---------------|
+| `__tests__/hashcat.test.tsx` | UI timing assertions occasionally flake under jsdom timers | 2025-02-13 | Five consecutive nightly passes |
+| `__tests__/beef.test.tsx` | Navigation wizard occasionally mis-syncs state updates | 2025-02-13 | Five consecutive nightly passes |
+| `__tests__/mimikatz.test.ts` | API handler can emit inconsistent responses in parallel runs | 2025-02-13 | Five consecutive nightly passes |
+
+Update this table whenever a suite is added or graduates back to the main run.
+
+## Triage process
+
+1. **Monitor the nightly workflow.** Subscribe to failure notifications or review the workflow
+   history during stand-up. Failures bubble up just like any other CI job.
+2. **Debug promptly.** Reproduce locally with `yarn test:quarantine` (optionally with
+   `RUN_FLAKY=true yarn jest --watch` for focused debugging).
+3. **Stabilise and graduate.** Once a suite has met its exit criteria, replace `describeFlaky` /
+   `itFlaky` with the standard Jest helpers and remove its entry from the table above.
+4. **Record outcomes.** Note significant changes in `test-log.md` or link to an issue/PR if the fix
+   required code changes outside the test itself.
+
+Keeping this loop tight ensures the quarantine remains a short-term holding pen rather than a place
+where broken tests linger indefinitely.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,16 @@ const config = [
     },
   },
   {
+    files: ['__tests__/**/*.{js,jsx,ts,tsx}', 'tests/**/*.{js,jsx,ts,tsx}'],
+    languageOptions: {
+      globals: {
+        describeFlaky: 'readonly',
+        itFlaky: 'readonly',
+        testFlaky: 'readonly',
+      },
+    },
+  },
+  {
     files: ['utils/qrStorage.ts', 'utils/safeStorage.ts', 'utils/sync.ts'],
     rules: {
       'no-restricted-globals': ['error', 'window', 'document'],

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:quarantine": "node scripts/run-quarantine-tests.mjs",
     "lint": "eslint . --max-warnings=0",
     "tsc": "tsc",
     "typecheck": "tsc --noEmit",

--- a/scripts/run-quarantine-tests.mjs
+++ b/scripts/run-quarantine-tests.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import fg from 'fast-glob';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '..');
+
+const patterns = ['**/*.{test,spec}.{js,jsx,ts,tsx}'];
+const ignore = [
+  'node_modules/**',
+  '.next/**',
+  'playwright/**',
+  'tests/playwright/**',
+];
+
+const flaggedSuites = [];
+for (const file of await fg(patterns, { cwd: repoRoot, ignore })) {
+  const absolute = resolve(repoRoot, file);
+  const source = await readFile(absolute, 'utf8');
+  if (
+    source.includes('describeFlaky(') ||
+    source.includes('testFlaky(') ||
+    source.includes('itFlaky(')
+  ) {
+    flaggedSuites.push(file);
+  }
+}
+
+flaggedSuites.sort();
+
+if (flaggedSuites.length === 0) {
+  console.log('No quarantined Jest suites were detected.');
+  process.exit(0);
+}
+
+console.log('Running quarantined Jest suites:\n');
+for (const suite of flaggedSuites) {
+  console.log(` • ${suite}`);
+}
+console.log('');
+
+const jestBin = resolve(repoRoot, 'node_modules', 'jest', 'bin', 'jest.js');
+const args = ['--runInBand', '--runTestsByPath', ...flaggedSuites];
+
+const child = spawn(process.execPath, [jestBin, ...args], {
+  stdio: 'inherit',
+  cwd: repoRoot,
+  env: { ...process.env, RUN_FLAKY: 'true' },
+});
+
+child.on('exit', (code) => {
+  process.exit(code ?? 1);
+});

--- a/types/jest.d.ts
+++ b/types/jest.d.ts
@@ -1,0 +1,10 @@
+import 'jest';
+
+declare global {
+  // Helpers that mark suites/tests as flaky so they can be quarantined.
+  var testFlaky: typeof test;
+  var itFlaky: typeof it;
+  var describeFlaky: typeof describe;
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add jest helpers to mark flaky suites and register globals
- skip quarantined suites on the main test job and add a nightly workflow to run them
- document the quarantine process and ship a helper script to run the flagged suites locally

## Testing
- `yarn lint` *(fails: repo has existing accessibility and window global violations)*
- `yarn test` *(fails: pre-existing suites such as window/nmap still red; run cancelled after confirming failures)*
- `yarn test:quarantine`


------
https://chatgpt.com/codex/tasks/task_e_68cd25defee083289adca9a2aa364034