### PR TITLE
[ci] enforce test stability gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   install:
@@ -48,7 +51,37 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: yarn test --coverage
+      - name: Run Jest stability suite
+        run: |
+          set -euo pipefail
+
+          attempts=1
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            attempts=3
+          fi
+
+          passes=0
+          summary="### Jest stability report\\n\\n"
+          for i in $(seq 1 "$attempts"); do
+            echo "::group::Jest run #$i of $attempts"
+            if yarn test --coverage; then
+              passes=$((passes + 1))
+              summary="${summary}- ✅ Run #$i\\n"
+            else
+              summary="${summary}- ❌ Run #$i\\n"
+              printf '%b' "$summary" >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
+            echo "::endgroup::"
+          done
+
+          if [ "$attempts" -gt 1 ]; then
+            summary="${summary}\\nAll ${passes}/${attempts} runs passed. Merge is unblocked."
+          else
+            summary="${summary}\\nMain branch run completed without retries."
+          fi
+
+          printf '%b' "$summary" >> "$GITHUB_STEP_SUMMARY"
 
   security:
     runs-on: ubuntu-latest
@@ -79,3 +112,37 @@ jobs:
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+
+  playwright-main:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx playwright install --with-deps
+      - name: Run Playwright (no retries) on main
+        env:
+          PLAYWRIGHT_HTML_REPORT: playwright-report
+        run: |
+          set -euo pipefail
+
+          yarn dev &
+          DEV_PID=$!
+          trap 'kill $DEV_PID' EXIT
+
+          npx wait-on http://127.0.0.1:3000
+
+          summary="### Playwright report (main push)\\n\\n"
+          if npx playwright test --retries=0; then
+            summary="${summary}- ✅ Playwright run passed without retries"
+            printf '%b' "$summary" >> "$GITHUB_STEP_SUMMARY"
+          else
+            summary="${summary}- ❌ Playwright run failed"
+            printf '%b' "$summary" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,8 @@ yarn smoke     # Manual smoke script that crawls /apps/* during dev
 npx playwright test
 ```
 
+> **CI stability policy:** Pull requests must show three consecutive passing runs of `yarn test --coverage`. Pushes to `main` execute `yarn test` and `npx playwright test --retries=0` without retries, and the workflow summary records any failure for investigation.
+
 Notes
 
 * Keep unit tests close to code in `__tests__/` or the project’s test folders.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ See `.env.local.example` for the full list.
 - Run `yarn lint` and `yarn test` before committing changes.
 - For manual smoke tests, start `yarn dev` and in another terminal run `yarn smoke` to visit every `/apps/*` route.
 
+## Test Stability Policy
+
+- Pull requests must demonstrate Jest stability by passing `yarn test` (with coverage) three consecutive times in CI. The workflow summary records each attempt, and merges are blocked until all three succeed.
+- Pushes to `main` run `yarn test` once and `npx playwright test --retries=0` without automatic retries. Any failure is captured in the workflow summary so flaky behavior can be investigated immediately.
+- To mirror CI locally, run `yarn test --coverage` multiple times or execute `npx playwright test --retries=0` against a dev server before submitting a PR.
+
 ---
 
 ## Speed Insights

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,3 +22,9 @@ yarn dev
 See the [Architecture](./architecture.md) document for an overview of how the project is organized.
 
 For app contributions, see the [New App Checklist](./new-app-checklist.md).
+
+## CI Stability Policy
+
+- Every pull request must produce three consecutive green runs of `yarn test --coverage` in CI. The GitHub Actions summary for the Jest job records each attempt and blocks merge if stability is not achieved.
+- When code lands on `main`, CI executes `yarn test` and `npx playwright test --retries=0` without retries. Any failure is preserved in the workflow summary so contributors can investigate flakiness immediately.
+- Before opening a PR, mimic the policy locally by looping `yarn test --coverage` (e.g., `for i in {1..3}; do yarn test --coverage || break; done`) and running Playwright against a dev server with `npx playwright test --retries=0`.


### PR DESCRIPTION
## Summary
- add a Jest stability loop and main-branch Playwright run to CI so flakiness is surfaced
- push stability results into the GitHub Actions job summary and trigger the workflow on `main`
- document the three-pass requirement in the README, getting started guide, and AGENTS instructions

## Testing
- yarn lint *(fails: repo has hundreds of pre-existing jsx-a11y and no-top-level-window violations in apps and public game scripts)*
- yarn test *(fails: existing suites such as `__tests__/window.test.tsx`, `__tests__/nmapNse.test.tsx`, and `__tests__/Modal.test.tsx` break without new changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25dec2b0832890eee94481859388