### PR TITLE
[examples] add runnable API samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,27 @@ See `.env.local.example` for the full list.
 - `yarn install` – install project dependencies.
 - `yarn dev` – start the development server with hot reloading.
 - `yarn test` – run the test suite.
+- `yarn test:examples` – execute the sample code under `examples/`.
 - `yarn lint` – check code for linting issues.
 - `yarn export` – generate a static export in the `out/` directory.
+
+---
+
+## Examples
+
+The `examples/` directory contains minimal TypeScript and JavaScript snippets that demonstrate
+core utility APIs such as the structured logger, environment validation helpers, and the in-memory
+pub/sub bus. Each snippet exports a `run*Example` function so it can be executed from automated
+tests or a Node REPL.
+
+To run the examples locally and verify they stay up to date with the implementation, execute:
+
+```bash
+yarn test:examples
+```
+
+The command runs a focused Jest suite that imports every example and asserts the observed output.
+This ensures the samples compile and continue to reflect real behaviour in CI.
 
 ---
 

--- a/__tests__/examples.test.ts
+++ b/__tests__/examples.test.ts
@@ -1,0 +1,37 @@
+import { runLoggerExample } from '@/examples/logger';
+import { runPubSubExample } from '@/examples/pubsub';
+
+const { runEnvValidationExample } = require('@/examples/env-validation.js');
+
+describe('code examples', () => {
+  it('logger example redacts sensitive metadata', () => {
+    const entries = runLoggerExample();
+    expect(entries).toHaveLength(2);
+    const [infoEntry, errorEntry] = entries;
+
+    expect(infoEntry.level).toBe('info');
+    expect(infoEntry.message).toBe('Booting logger example');
+    expect(infoEntry.meta).toMatchObject({ user: 'alice' });
+    expect(infoEntry.meta).not.toHaveProperty('password');
+
+    expect(errorEntry.meta).toMatchObject({ reason: 'demo-only' });
+    expect(errorEntry.meta).not.toHaveProperty('token');
+  });
+
+  it('env validation example parses public and server envs', () => {
+    const { publicEnv, serverEnv } = runEnvValidationExample();
+    expect(publicEnv).toMatchObject({
+      NEXT_PUBLIC_ENABLE_ANALYTICS: 'true',
+      NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+    });
+    expect(serverEnv).toMatchObject({ RECAPTCHA_SECRET: 'dummy-secret' });
+  });
+
+  it('pubsub example stops emitting after unsubscribe', () => {
+    const payloads = runPubSubExample();
+    expect(payloads).toEqual([
+      { status: 'connected' },
+      { status: 'processing', detail: 'step-1' },
+    ]);
+  });
+});

--- a/examples/env-validation.js
+++ b/examples/env-validation.js
@@ -1,0 +1,22 @@
+const { validatePublicEnv, validateServerEnv } = require('../lib/validate.js');
+
+function runEnvValidationExample() {
+  const publicEnv = {
+    NEXT_PUBLIC_ENABLE_ANALYTICS: 'true',
+    NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: 'public-anon-key',
+  };
+
+  const parsedPublic = validatePublicEnv(publicEnv);
+
+  const serverEnv = {
+    ...publicEnv,
+    RECAPTCHA_SECRET: 'dummy-secret',
+  };
+
+  const parsedServer = validateServerEnv(serverEnv);
+
+  return { publicEnv: parsedPublic, serverEnv: parsedServer };
+}
+
+module.exports = { runEnvValidationExample };

--- a/examples/logger.ts
+++ b/examples/logger.ts
@@ -1,0 +1,57 @@
+import { createLogger } from '@/lib/logger';
+
+export interface LoggerExampleEntry {
+  level: string;
+  message: string;
+  correlationId: string;
+  meta: Record<string, unknown>;
+}
+
+export function runLoggerExample(): LoggerExampleEntry[] {
+  const captured: LoggerExampleEntry[] = [];
+  const originalConsoleLog = console.log;
+
+  console.log = (entry?: unknown, ...rest: unknown[]) => {
+    const parts = [entry, ...rest].filter((value) => value !== undefined);
+    for (const value of parts) {
+      if (typeof value === 'string') {
+        try {
+          const parsed = JSON.parse(value) as Record<string, unknown>;
+          const { level, message, correlationId, ...meta } = parsed;
+          captured.push({
+            level: String(level),
+            message: String(message),
+            correlationId: String(correlationId),
+            meta,
+          });
+          continue;
+        } catch {
+          // fall through to generic handling
+        }
+      }
+
+      captured.push({
+        level: 'unknown',
+        message: String(value),
+        correlationId: 'unknown',
+        meta: {},
+      });
+    }
+  };
+
+  try {
+    const logger = createLogger('examples-correlation-id');
+    logger.info('Booting logger example', {
+      user: 'alice',
+      password: 'super-secret',
+    });
+    logger.error('Example failure', {
+      reason: 'demo-only',
+      token: 'top-secret-token',
+    });
+  } finally {
+    console.log = originalConsoleLog;
+  }
+
+  return captured;
+}

--- a/examples/pubsub.ts
+++ b/examples/pubsub.ts
@@ -1,0 +1,22 @@
+import { publish, subscribe } from '@/utils/pubsub';
+
+type Message = {
+  status: string;
+  detail?: string;
+};
+
+export function runPubSubExample(): Message[] {
+  const received: Message[] = [];
+  const unsubscribe = subscribe('examples:pubsub', (payload) => {
+    received.push(payload as Message);
+  });
+
+  publish('examples:pubsub', { status: 'connected' });
+  publish('examples:pubsub', { status: 'processing', detail: 'step-1' });
+
+  unsubscribe();
+
+  publish('examples:pubsub', { status: 'ignored', detail: 'after-unsubscribe' });
+
+  return received;
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "next start",
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build",
     "test": "jest",
+    "test:examples": "jest __tests__/examples.test.ts",
     "test:watch": "jest --watch",
     "lint": "eslint . --max-warnings=0",
     "tsc": "tsc",


### PR DESCRIPTION
## Summary
- add TypeScript and JavaScript examples that exercise the logger, environment validation, and pub/sub helpers
- wire the examples into a dedicated Jest suite and package script for CI coverage
- document how to run the examples locally from the README

## Testing
- yarn lint *(fails: pre-existing accessibility and window/document lint errors across legacy apps)*
- yarn test *(fails: known flaky suites including window and nmap NSE integration tests)*
- yarn test:examples


------
https://chatgpt.com/codex/tasks/task_e_68cd25dc7cb883288256942fa2494ea2