### PR TITLE
[ci] add gitleaks secret scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,16 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - name: Install gitleaks
+        run: |
+          GITLEAKS_VERSION=8.28.0
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o gitleaks.tar.gz
+          tar -xzf gitleaks.tar.gz gitleaks
+          mkdir -p "$HOME/bin"
+          install -m 755 gitleaks "$HOME/bin/gitleaks"
+          rm gitleaks.tar.gz gitleaks
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+      - run: yarn scan:secrets
       - run: yarn npm audit
 
   vercel-preview:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,20 @@
+title = "Kali Linux Portfolio Gitleaks Configuration"
+
+[extend]
+  useDefault = true
+
+[allowlist]
+  description = "Allow demo hashes and tokens used in simulated security tools"
+  regexes = [
+    '''5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8''',
+    '''8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92''',
+    '''1c8bfe8f801d79745c4631d09fff36c82aa37fc4cce4fc946683d7b336b63032''',
+    '''5f4dcc3b5aa765d61d8327deb882cf99''',
+    '''e10adc3949ba59abbe56e057f20f883e''',
+    '''ffffffffffffffffffffffffffffffff''',
+    '''0123456789ABCDEF0123456789ABCDEF''',
+    '''FEDCBA9876543210FEDCBA9876543210''',
+    '''5d41402abc4b2a76b9719d911017c592''',
+    '''05000000123456789abcdef''',
+    '''xfce4_shortcuts'''
+  ]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ See `.env.local.example` for the full list.
 - `yarn test` – run the test suite.
 - `yarn lint` – check code for linting issues.
 - `yarn export` – generate a static export in the `out/` directory.
+- `yarn scan:secrets` – run [Gitleaks](https://github.com/gitleaks/gitleaks) using the repo's `.gitleaks.toml` allowlist.
 
 ---
 
@@ -99,6 +100,14 @@ See `.env.local.example` for the full list.
 
 - Run `yarn lint` and `yarn test` before committing changes.
 - For manual smoke tests, start `yarn dev` and in another terminal run `yarn smoke` to visit every `/apps/*` route.
+
+## Secret Scanning
+
+1. Install the [Gitleaks CLI](https://github.com/gitleaks/gitleaks/releases) so the `gitleaks` binary is available in your `PATH`.
+   - macOS: `brew install gitleaks`
+   - Linux: `curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks_8.28.0_linux_x64.tar.gz -o gitleaks.tar.gz && tar -xzf gitleaks.tar.gz gitleaks && sudo install gitleaks /usr/local/bin/gitleaks && rm gitleaks.tar.gz gitleaks`
+2. Run `yarn scan:secrets` from the project root. The command redacts output and fails if any leak is detected.
+3. Only extend `.gitleaks.toml` when adding new, intentional demo values. Unexpected findings should be investigated and scrubbed rather than allowlisted.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
-    "verify:all": "node scripts/verify.mjs"
+    "verify:all": "node scripts/verify.mjs",
+    "scan:secrets": "gitleaks detect --config=.gitleaks.toml --no-banner --redact"
   },
   "engines": {
     "node": "20.19.5"


### PR DESCRIPTION
## Summary
- add a repository-level `.gitleaks.toml` that keeps demo hashes/tokens allowlisted while inheriting the default rule set
- expose a `yarn scan:secrets` helper and document how to run the scan locally
- install gitleaks in the CI security job and fail the workflow when the scan finds new leaks

## Testing
- `yarn scan:secrets`
- `yarn lint` *(fails: repo already has numerous jsx-a11y/no-top-level-window violations)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25d77910832882694f77e9ea18ec