### PR TITLE
ci: add gitleaks and header verify jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,22 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Gitleaks scan
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          args: detect --source . --report-format sarif --report-path gitleaks-report.sarif --redact
+      - name: Upload Gitleaks report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report
+          path: gitleaks-report.sarif
+          if-no-files-found: warn
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install
@@ -79,3 +95,25 @@ jobs:
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+
+  verify-headers:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - name: Build and verify response headers
+        run: |
+          set -o pipefail
+          node scripts/verify.mjs | tee header-verification.log
+      - name: Upload header verification log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: header-verification-log
+          path: header-verification.log
+          if-no-files-found: warn

--- a/next.config.js
+++ b/next.config.js
@@ -125,9 +125,9 @@ module.exports = withBundleAnalyzer(
     ...(isStaticExport && { output: 'export' }),
     webpack: configureWebpack,
 
-    // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
+    // Allow faster local builds but enforce ESLint (and its zero-warning policy) whenever CI runs `next build`
     eslint: {
-      ignoreDuringBuilds: true,
+      ignoreDuringBuilds: !process.env.CI,
     },
     images: {
       unoptimized: true,


### PR DESCRIPTION
## Summary
- add a Gitleaks scan to CI and upload the SARIF report for auditing
- run the existing header verification script after building the Next.js app and store the log as an artifact
- ensure `next build` enforces ESLint in CI instead of skipping it

## Testing
- yarn lint *(fails: repo already contains numerous `jsx-a11y/control-has-associated-label` violations)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25d3352c8328bc53ca55883dbd47