### PR TITLE
[deps] configure renovate automation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,3 +22,14 @@ yarn dev
 See the [Architecture](./architecture.md) document for an overview of how the project is organized.
 
 For app contributions, see the [New App Checklist](./new-app-checklist.md).
+
+## Dependency updates
+
+Automated dependency maintenance is handled by [Renovate](https://docs.renovatebot.com/).
+
+- Renovate runs once a week after 02:00 UTC on Mondays to batch dependency checks.
+- All devDependencies are bundled into a single "Dev dependencies" pull request to simplify reviews.
+- Patch and minor updates auto-merge once the required CI checks pass, so keep the main branch green.
+- Renovate pull requests are labeled `dependencies` and `renovate`. Use those labels when referencing or triaging them.
+
+If Renovate opens a pull request that needs manual intervention (for example, a major update), leave the labels in place and add context about what blocks the upgrade. Renovate will rebase automatically when changes land on the target branch.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "UTC",
+  "schedule": ["after 02:00 on Monday"],
+  "labels": ["dependencies", "renovate"],
+  "onboarding": false,
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "Dev dependencies",
+      "groupSlug": "dev-deps"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a repository-level renovate.json that runs weekly, groups devDependencies, and auto-merges green patch/minor updates
- document renovate labels and expectations in the contributor getting started guide

## Testing
- npm_config_progress=false RENOVATE_CONFIG_FILE=renovate.json npx --yes renovate --dry-run --platform=local

------
https://chatgpt.com/codex/tasks/task_e_68cd25d1f35483289d75131834f833fe