### PR TITLE
docs: document dependency management policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Thanks for helping keep the Kali Linux Portfolio healthy. This guide highlights the
+expectations for development, testing, and dependency management.
+
+## Development Workflow
+
+1. Install dependencies with `yarn install` (Node version is managed by `.nvmrc`).
+2. Create feature branches locally and keep commits scoped.
+3. Run the verification suite before pushing:
+   - `yarn lint`
+   - `yarn test`
+   - `yarn build`
+   - `yarn smoke` (when you touch app windows or routing)
+4. For UI changes include screenshots or recordings in your PR description.
+5. Never commit secrets. Use feature flags to guard experimental tooling.
+
+## Dependency Management
+
+All contributors should read and follow the
+[`docs/dependency-policy.md`](./docs/dependency-policy.md). It explains when to
+prefer caret (`^`) ranges, when to pin exact versions, and how to triage Renovate
+pull requests. Align your `package.json` edits and review comments with that
+policy so automated updates stay predictable.
+
+## Reviewing Renovate PRs
+
+Renovate is configured to:
+
+- Automerge low-risk patch upgrades for dependencies that use caret ranges.
+- Label framework and build-tool updates with `manual-review` and require human
+  approval.
+- Group TypeScript compiler updates with their accompanying `@types/*` packages.
+
+Follow the triage checklist in the dependency policy when Renovate opens a PR,
+and document any blockers directly in the PR discussion.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ See `.env.local.example` for the full list.
 
 ---
 
+## Dependency Management
+
+See [`docs/dependency-policy.md`](./docs/dependency-policy.md) for guidance on when
+to use caret versus exact version pins and how we triage Renovate updates. The
+Renovate configuration in this repository mirrors that policy so low-risk
+dependencies can automerge while framework and build upgrades receive manual
+review.
+
+---
+
 ## Local Development Tips
 
 - Run `yarn lint` and `yarn test` before committing changes.

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -1,0 +1,85 @@
+# Dependency Policy
+
+This document explains how we choose version ranges for dependencies and how to review
+Renovate pull requests. The goal is to let low‑risk updates land with minimal friction
+while protecting the build from unexpected breaking changes.
+
+## Version Range Strategy
+
+We use two range styles in `package.json`:
+
+### Use caret (`^`) ranges when
+
+- The package follows SemVer (v1.0.0 or later) and has a track record of backwards‑compatible
+  patch/minor releases.
+- The library is **not** part of the core build toolchain (no direct impact on
+  the Next.js/React runtime, bundling, or TypeScript transpilation).
+- The package is easy to roll back because it only affects isolated features
+  (for example UI widgets, analytics clients, most hooks/helpers).
+- The dependency is primarily consumed in the browser and ships prebuilt assets
+  that do not require a Node.js build step.
+
+Caret ranges let Renovate keep us on the latest compatible patch/minor release.
+Renovate is configured to automerge these patch updates once CI passes.
+
+### Use exact pins when
+
+- The package is part of the critical runtime or build chain (Next.js,
+  React/React DOM, TypeScript, Webpack, PostCSS/Tailwind, Jest/ESLint, Playwright).
+- The package provides CLI/build tooling that historically ships breaking changes
+  even in minor releases.
+- The package is pre‑1.0 or does not follow SemVer.
+- A downstream asset depends on a specific version (for example data files that
+  must match a binary format).
+
+Exact pins ensure Renovate opens a focused PR that we can schedule, test, and
+coordinate with deployment windows. Renovate applies a `manual-review` label to
+these updates so they are easy to triage.
+
+### Adding or adjusting dependencies
+
+1. Decide whether the dependency is runtime/build critical. Default to an exact
+   pin when uncertain, then revisit after a few release cycles.
+2. Prefer caret ranges for UI helpers and utility libraries that can accept
+   SemVer patch/minor upgrades.
+3. Avoid broad ranges like `*` or `latest`; they bypass Renovate’s safety rails.
+4. When switching a package from caret to an exact pin (or vice versa), update
+   this policy if the change represents a new category of dependency.
+
+## Triage Process for Renovate Updates
+
+Renovate runs continuously and respects this policy:
+
+- Patch updates for caret ranges can automerge once CI finishes.
+- Framework/toolchain updates stay open for humans, carry the `manual-review`
+  label, and never automerge.
+- Type definition packages (the `@types/*` family) are grouped so we can test
+  them alongside the TypeScript compiler version they target.
+
+Follow this checklist when Renovate proposes an update:
+
+1. **Read the release notes and changelog** linked in the Renovate PR. Look for
+   breaking changes, migration steps, or Node.js version bumps.
+2. **Run the verification suite locally**: `yarn lint`, `yarn test`, and
+   `yarn build`. For UI or framework updates also run the smoke crawler
+   (`yarn smoke`) against a `yarn dev` server.
+3. **Validate critical workflows** manually if the change touches rendering,
+   routing, asset bundling, or simulated tool APIs.
+4. **Stage the update** by deploying to the preview environment or a staging
+   branch when the change affects infrastructure (Next.js, React, build tools).
+5. **Document decisions** in the PR. If an update is blocked, leave a comment
+   summarizing the issue and create a follow‑up task if needed.
+
+## Responding to Risky Upgrades
+
+For upgrades that fail testing or carry breaking migrations:
+
+- Convert the Renovate PR to draft and add details about the failure.
+- File an issue describing the blocker and potential remediation steps.
+- If the breakage comes from a caret dependency, consider temporarily pinning it
+  until we have a fix.
+- Coordinate with maintainers before merging framework/toolchain upgrades near a
+  release window.
+
+Keeping this policy up to date ensures automated tooling and human reviews stay
+aligned.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "UTC",
+  "prConcurrentLimit": 5,
+  "rangeStrategy": "auto",
+  "packageRules": [
+    {
+      "description": "Automerge patch updates for caret-managed dependencies",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "matchUpdateTypes": ["patch"],
+      "matchCurrentValue": "/^\\^/",
+      "excludePackageNames": [
+        "tailwindcss",
+        "postcss",
+        "next",
+        "react",
+        "react-dom",
+        "typescript",
+        "webpack",
+        "jest",
+        "jest-environment-jsdom",
+        "eslint",
+        "eslint-config-next",
+        "@playwright/test",
+        "playwright-core",
+        "@ducanh2912/next-pwa",
+        "@next/bundle-analyzer"
+      ],
+      "excludePackagePatterns": ["^@types/"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "description": "Require manual review for framework and build chain updates",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "tailwindcss",
+        "postcss",
+        "next",
+        "react",
+        "react-dom",
+        "typescript",
+        "webpack",
+        "jest",
+        "jest-environment-jsdom",
+        "eslint",
+        "eslint-config-next",
+        "@playwright/test",
+        "playwright-core",
+        "@ducanh2912/next-pwa",
+        "@next/bundle-analyzer"
+      ],
+      "rangeStrategy": "pin",
+      "labels": ["dependencies", "manual-review"],
+      "automerge": false
+    },
+    {
+      "description": "Group TypeScript compiler and definitions",
+      "matchManagers": ["npm"],
+      "groupName": "TypeScript and types",
+      "matchPackageNames": ["typescript"],
+      "matchPackagePatterns": ["^@types/"],
+      "labels": ["dependencies", "manual-review"],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add docs/dependency-policy.md describing version pinning and Renovate triage expectations
- reference the new policy from the README and a freshly added CONTRIBUTING guide
- configure Renovate to automerge safe caret updates while flagging framework/toolchain bumps for manual review

## Testing
- `yarn lint` *(fails: existing accessibility and no-top-level-window lint violations in legacy apps)*
- `CI=1 yarn test` *(fails: existing window snapping, Nmap clipboard, and localStorage unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25d0dfec83288a51bb24861093f2