### PR TITLE
[chore] enforce dependency constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,18 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: npm run lint
 
+  constraints:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn constraints
+
   typecheck:
     runs-on: ubuntu-latest
     needs: install

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 !.yarn/plugins
 !.yarn/sdks
 !.yarn/versions
+!.yarn/constraints.pro
 /.pnp
 .pnp.cjs
 .pnp.loader.mjs

--- a/.yarn/constraints.pro
+++ b/.yarn/constraints.pro
@@ -1,0 +1,7 @@
+% Ensure key React/Next dependencies resolve to a single version across the workspace.
+gen_enforcedDependency("workspace:*", "react", "19.1.1").
+gen_enforcedDependency("workspace:*", "react-dom", "19.1.1").
+gen_enforcedDependency("workspace:*", "@types/react", "19.1.12").
+gen_enforcedDependency("workspace:*", "@types/react-dom", "19.1.9").
+gen_enforcedDependency("workspace:*", "next", "15.5.2").
+gen_enforcedDependency("workspace:*", "typescript", "5.8.2").

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint . --max-warnings=0",
     "tsc": "tsc",
     "typecheck": "tsc --noEmit",
+    "constraints": "yarn constraints",
     "a11y": "node scripts/a11y.mjs",
     "smoke": "node scripts/smoke-all-apps.mjs",
     "module-report": "node scripts/generate-module-report.mjs",


### PR DESCRIPTION
## Summary
- add a Yarn constraints file to pin the React/Next stack to a single version
- expose a `yarn constraints` script and ensure the constraints file is committed
- run the constraints check in CI to surface multi-version issues early

## Testing
- yarn constraints
- yarn lint *(fails: repository currently reports hundreds of existing accessibility lint errors)*
- yarn test *(fails: suite already contains failing integration tests; run interrupted after repeated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25d1d1d88328a810052a924cdea0