### PR TITLE
[ci] add renovate dependency gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,19 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  renovate-verify-deps:
+    runs-on: ubuntu-latest
+    needs: install
+    if: github.actor == 'renovate[bot]'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn verify:deps
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -1,0 +1,19 @@
+# Dependency Policy
+
+## Renovate dependency gate
+
+Automated dependency updates from Renovate must pass a dependency verification script before they can merge. Run the gate locally with:
+
+```bash
+yarn verify:deps
+```
+
+The script chains the following checks to ensure new packages do not break the workspace:
+
+1. `yarn install --check-files` to confirm the lockfile and installed modules stay in sync. When the flag is unavailable (Yarn Berry), the script falls back to `yarn install --immutable --immutable-cache --check-cache` for equivalent safety.
+2. `yarn tsc --noEmit` for a full TypeScript pass without emitting build output.
+3. `yarn lint` to enforce repository lint rules.
+4. `next build` to compile the Next.js application.
+5. `yarn npm audit --severity high` to surface high severity advisories.
+
+Continuous integration runs this script in the `renovate-verify-deps` job for Renovate pull requests and blocks merges on any failure. Keep this gate green when reviewing automated upgrades.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
-    "verify:all": "node scripts/verify.mjs"
+    "verify:all": "node scripts/verify.mjs",
+    "verify:deps": "node scripts/verify-deps.mjs"
   },
   "engines": {
     "node": "20.19.5"

--- a/scripts/verify-deps.mjs
+++ b/scripts/verify-deps.mjs
@@ -1,0 +1,72 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+const stripAnsi = (value) =>
+  typeof value === 'string' ? value.replace(/\u001B\[[0-9;]*m/g, '') : '';
+
+const run = (cmd, args) => {
+  const result = spawnSync(cmd, args, { stdio: 'inherit' });
+  if (result.status !== 0) {
+    const error = new Error(`${cmd} ${args.join(' ')} exited with code ${result.status}`);
+    error.code = result.status ?? 1;
+    throw error;
+  }
+};
+
+const runInstallCheck = () => {
+  const primary = spawnSync('yarn', ['install', '--check-files'], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+
+  if (primary.status === 0) {
+    if (primary.stdout) {
+      process.stdout.write(primary.stdout);
+    }
+    if (primary.stderr) {
+      process.stderr.write(primary.stderr);
+    }
+    return;
+  }
+
+  const unsupportedFlag = stripAnsi(primary.stdout).includes('Unsupported option name ("--check-files")') ||
+    stripAnsi(primary.stderr).includes('Unsupported option name ("--check-files")');
+
+  if (!unsupportedFlag) {
+    if (primary.stdout) {
+      process.stdout.write(primary.stdout);
+    }
+    if (primary.stderr) {
+      process.stderr.write(primary.stderr);
+    }
+    const error = new Error('yarn install --check-files failed');
+    error.code = primary.status ?? 1;
+    throw error;
+  }
+
+  console.log('`yarn install --check-files` is unavailable in this Yarn release; falling back to Berry immutable checks.');
+  run('yarn', ['install', '--immutable', '--immutable-cache', '--check-cache']);
+};
+
+try {
+  runInstallCheck();
+  run('yarn', ['tsc', '--noEmit']);
+  run('yarn', ['lint']);
+
+  const nextBinary = path.join(
+    process.cwd(),
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'next.cmd' : 'next',
+  );
+  run(nextBinary, ['build']);
+
+  run('yarn', ['npm', 'audit', '--severity', 'high']);
+} catch (error) {
+  if (error instanceof Error) {
+    console.error(error.message);
+  } else {
+    console.error(error);
+  }
+  process.exit(error?.code ?? 1);
+}


### PR DESCRIPTION
## Summary
- add a verify:deps script that runs install consistency checks, type checking, linting, build, and a high-severity audit
- run the verify:deps script in CI for Renovate pull requests to block merges on failures
- document the new dependency verification gate for automated dependency updates

## Testing
- yarn verify:deps *(fails: lint errors already present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25cc4a40832883b9bd40bcaf6851