### PR TITLE
ci: cache dependencies and build artifacts

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -11,7 +11,16 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node20-node-modules-${{ hashFiles('yarn.lock') }}
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-node20-next-cache-${{ hashFiles('yarn.lock') }}
       - run: yarn install --immutable
       - run: npx playwright install --with-deps
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node20-node-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --immutable --immutable-cache
 
   lint:
@@ -22,7 +26,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node20-node-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --immutable --immutable-cache
       - run: npm run lint
 
@@ -34,7 +42,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node20-node-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --immutable --immutable-cache
       - run: npm run tsc -- --noEmit
 
@@ -46,7 +58,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node20-node-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --immutable --immutable-cache
       - run: yarn test --coverage
 
@@ -58,7 +74,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node20-node-modules-${{ hashFiles('yarn.lock') }}
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
@@ -74,7 +94,16 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node20-node-modules-${{ hashFiles('yarn.lock') }}
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-node20-next-cache-${{ hashFiles('yarn.lock') }}
       - run: yarn install --immutable --immutable-cache
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -10,12 +10,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'yarn'
-          cache-dependency-path: 'yarn.lock'
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node20-node-modules-${{ hashFiles('yarn.lock') }}
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-node20-next-cache-${{ hashFiles('yarn.lock') }}
       - name: Installing Packages
         run: yarn install --immutable
 


### PR DESCRIPTION
## Summary
- add explicit actions/cache steps keyed by the yarn.lock hash to share node_modules across CI jobs
- restore and persist the Next.js build cache for preview, accessibility, and deploy workflows while keeping keys node-version scoped

## Testing
- not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68cd25bdb8c483289e1383ce0507d0b9