### PR TITLE
[ci] split workflow jobs and upload artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,19 +4,9 @@ on:
   pull_request:
 
 jobs:
-  install:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: yarn
-      - run: yarn install --immutable --immutable-cache
-
   lint:
+    name: Lint
     runs-on: ubuntu-latest
-    needs: install
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -24,11 +14,11 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: npm run lint
+      - run: yarn lint
 
   typecheck:
+    name: Typecheck
     runs-on: ubuntu-latest
-    needs: install
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -36,11 +26,11 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: npm run tsc -- --noEmit
+      - run: yarn typecheck
 
-  test:
+  unit:
+    name: Unit Tests
     runs-on: ubuntu-latest
-    needs: install
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -49,10 +39,75 @@ jobs:
           cache: yarn
       - run: yarn install --immutable --immutable-cache
       - run: yarn test --coverage
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage
+          if-no-files-found: warn
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - typecheck
+      - unit
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn build
+      - name: Upload Next.js build
+        uses: actions/upload-artifact@v4
+        with:
+          name: next-build
+          path: .next
+          if-no-files-found: error
+
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - uses: actions/download-artifact@v4
+        with:
+          name: next-build
+          path: .
+      - run: npx playwright install --with-deps
+      - run: npx playwright test
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: warn
+      - name: Upload Playwright traces
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results
+          if-no-files-found: warn
 
   security:
+    name: Security Audit
     runs-on: ubuntu-latest
-    needs: install
+    needs:
+      - lint
+      - typecheck
+      - unit
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -63,8 +118,12 @@ jobs:
       - run: yarn npm audit
 
   vercel-preview:
+    name: Vercel Preview
     runs-on: ubuntu-latest
-    needs: install
+    needs:
+      - lint
+      - typecheck
+      - unit
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,36 @@
-# Kali Linux Portfolio 
+# Kali Linux Portfolio
+
+[![Lint Status](https://github.com/Alex-Unnippillil/kali-linux-portfolio/actions/workflows/ci.yml/badge.svg?branch=main&job=Lint)](https://github.com/Alex-Unnippillil/kali-linux-portfolio/actions/workflows/ci.yml?query=workflow%3ACI)
+[![Typecheck Status](https://github.com/Alex-Unnippillil/kali-linux-portfolio/actions/workflows/ci.yml/badge.svg?branch=main&job=Typecheck)](https://github.com/Alex-Unnippillil/kali-linux-portfolio/actions/workflows/ci.yml?query=workflow%3ACI)
+[![Unit Test Status](https://github.com/Alex-Unnippillil/kali-linux-portfolio/actions/workflows/ci.yml/badge.svg?branch=main&job=Unit%20Tests)](https://github.com/Alex-Unnippillil/kali-linux-portfolio/actions/workflows/ci.yml?query=workflow%3ACI)
+[![Build Status](https://github.com/Alex-Unnippillil/kali-linux-portfolio/actions/workflows/ci.yml/badge.svg?branch=main&job=Build)](https://github.com/Alex-Unnippillil/kali-linux-portfolio/actions/workflows/ci.yml?query=workflow%3ACI)
+[![E2E Status](https://github.com/Alex-Unnippillil/kali-linux-portfolio/actions/workflows/ci.yml/badge.svg?branch=main&job=E2E)](https://github.com/Alex-Unnippillil/kali-linux-portfolio/actions/workflows/ci.yml?query=workflow%3ACI)
 
 A desktop-style portfolio built with Next.js and Tailwind that emulates a Kali/Ubuntu UI with windows, a dock, context menus, and a rich catalog of **security-tool simulations**, **utilities**, and **retro games**. This README is tailored for a professional full-stack engineer preparing **production deployment** and ongoing maintenance.
 
 > Repo homepage: https://unnippillil.com/
+
+---
+
+## Continuous Integration
+
+The CI pipeline runs discrete quality gates with explicit dependencies so that build and end-to-end tests only execute after fast feedback checks succeed.
+
+| Job | Description | Depends on |
+| --- | --- | --- |
+| Lint | Runs `yarn lint` with ESLint. | — |
+| Typecheck | Runs `yarn typecheck` for TypeScript coverage. | — |
+| Unit Tests | Executes `yarn test --coverage` and uploads the Jest `coverage/` report as `coverage-report`. | — |
+| Build | Builds the production bundle and uploads the `.next/` directory as the `next-build` artifact. | Lint, Typecheck, Unit Tests |
+| E2E | Downloads the production build artifact, starts `yarn start`, runs Playwright specs, and uploads both the HTML report and trace bundles. | Build |
+| Security Audit | Executes `yarn npm audit` to surface vulnerable packages. | Lint, Typecheck, Unit Tests |
+| Vercel Preview | Runs the Vercel CLI preview deployment flow. | Lint, Typecheck, Unit Tests |
+
+Artifacts exposed by CI:
+
+- **Coverage report** (`coverage-report`) – Jest LCOV/HTML output from the unit test job.
+- **Next build** (`next-build`) – Production `.next` directory for debugging or reuse in downstream jobs.
+- **Playwright results** (`playwright-report`, `playwright-traces`) – HTML report plus raw trace archives for failed E2E runs.
 
 ---
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,24 @@
 import { defineConfig } from '@playwright/test';
 
+const baseURL = process.env.BASE_URL ?? 'http://127.0.0.1:3000';
+
 export default defineConfig({
   testDir: './tests',
   testMatch: /.*\.spec\.ts/,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+  ],
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    baseURL,
+    trace: 'retain-on-failure',
   },
+  webServer: process.env.BASE_URL
+    ? undefined
+    : {
+        command: 'yarn start --hostname 0.0.0.0 --port 3000',
+        url: baseURL,
+        timeout: 120_000,
+        reuseExistingServer: !process.env.CI,
+      },
 });


### PR DESCRIPTION
## Summary
- split the CI workflow into lint, typecheck, unit, build, E2E, security, and preview stages with explicit dependencies
- upload Jest coverage, Next.js build output, and Playwright reports/traces as build artifacts
- enable Playwright HTML reporting, trace retention, and auto-starting the production server while updating README badges/docs for the new layout

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint violations)*
- yarn test *(fails: repository has pre-existing failing suites and long-running jobs; interrupted after failures surfaced)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25bcbda88328ba023c1c18cca139