### PR TITLE
ci: add bundle analyzer workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,52 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  bundle-analyzer:
+    runs-on: ubuntu-latest
+    needs: install
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - name: Install Playwright dependencies
+        run: npx playwright install --with-deps chromium
+      - name: Build with bundle analyzer
+        run: yarn analyze:treemap
+        env:
+          NEXT_TELEMETRY_DISABLED: '1'
+      - name: Upload bundle analyzer artifacts
+        id: upload-bundle-analyzer
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle-analyzer
+          path: bundle-analyzer
+          if-no-files-found: error
+          retention-days: 30
+      - name: Build PR comment
+        run: node scripts/build-bundle-analyzer-comment.mjs
+        env:
+          ANALYZER_ARTIFACT_URL: ${{ steps.upload-bundle-analyzer.outputs.artifact-url }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+      - name: Publish job summary
+        run: cat bundle-analyzer/comment.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Update PR with bundle analyzer results
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: bundle-analyzer/comment.md
+          edit-mode: replace
+          comment-identifier: bundle-analyzer
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dist
 # misc
 .DS_Store
 *.pem
+bundle-analyzer/
 
 # debug
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ yarn export && npx serve out
 ```
 Verify that features relying on `/api/*` return 404 or other placeholders when served statically.
 
+### Bundle Analyzer Treemap
+
+Generate an updated bundle report (HTML + PNG) before large dependency changes to track bundle growth.
+
+```bash
+# Install the Playwright browser once per machine
+npx playwright install chromium
+
+# Build with ANALYZE enabled and capture the treemap screenshot
+yarn analyze:treemap
+```
+
+The outputs are written to `bundle-analyzer/`:
+
+- `client.html` / `server.html` – interactive webpack-bundle-analyzer reports.
+- `client-stats.json` / `server-stats.json` – raw stats for historical diffing.
+- `client-treemap.png` – static treemap used in CI comments.
+
+The CI workflow uploads the entire folder as an artifact on every pull request so you can download and compare it across runs.
+
 ### Install as PWA for Sharing
 
 To send text or links directly into the Sticky Notes app:

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "smoke": "node scripts/smoke-all-apps.mjs",
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
+    "analyze:treemap": "ANALYZE=true yarn build && node scripts/capture-bundle-analyzer.mjs",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
     "verify:all": "node scripts/verify.mjs"
   },
@@ -142,6 +143,7 @@
     "typescript": "5.8.2",
     "wait-on": "^8.0.4",
     "webpack": "^5.92.0",
+    "webpack-bundle-analyzer": "^4.10.2",
     "workbox-build": "7.1.1",
     "ws": "^8.18.0"
   },

--- a/scripts/build-bundle-analyzer-comment.mjs
+++ b/scripts/build-bundle-analyzer-comment.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const statsPath = path.resolve(process.argv[2] ?? 'bundle-analyzer/client-stats.json');
+const outputPath = path.resolve(process.argv[3] ?? 'bundle-analyzer/comment.md');
+
+function formatBytes(bytes) {
+  const kb = bytes / 1024;
+  return `${kb.toFixed(kb > 100 ? 0 : 1)} KB`;
+}
+
+async function loadStats() {
+  const raw = await fs.readFile(statsPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function buildComment() {
+  const stats = await loadStats();
+  const assets = Array.isArray(stats?.assets) ? stats.assets : [];
+  const filtered = assets
+    .filter((asset) => asset?.name && !asset.name.endsWith('.map') && /(js|css)$/i.test(asset.name))
+    .map((asset) => ({
+      name: asset.name,
+      size: typeof asset.size === 'number' ? asset.size : 0,
+    }))
+    .sort((a, b) => b.size - a.size);
+
+  const totalSize = filtered.reduce((sum, asset) => sum + asset.size, 0);
+  const topAssets = filtered.slice(0, 10);
+
+  const artifactUrl = process.env.ANALYZER_ARTIFACT_URL;
+  const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+  const lines = [
+    '### 📦 Bundle Analyzer',
+    '',
+    artifactUrl
+      ? `- 📁 [Download treemap & HTML report](${artifactUrl})`
+      : '- 📁 Treemap artifact failed to upload.',
+    `- 🔁 [View workflow run](${runUrl})`,
+    '',
+    `**Total JS/CSS (uncompressed):** ${formatBytes(totalSize)}`,
+  ];
+
+  if (topAssets.length > 0) {
+    lines.push('', '| Asset | Size |', '| --- | ---: |');
+    for (const asset of topAssets) {
+      lines.push(`| ${asset.name} | ${formatBytes(asset.size)} |`);
+    }
+  } else {
+    lines.push('', '_No bundle assets detected in stats file._');
+  }
+
+  lines.push('', '_Generated automatically by CI._');
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, `${lines.join('\n')}\n`, 'utf8');
+  console.log(`Bundle analyzer comment written to ${outputPath}`);
+}
+
+buildComment().catch((error) => {
+  console.error('Failed to build bundle analyzer comment.');
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/capture-bundle-analyzer.mjs
+++ b/scripts/capture-bundle-analyzer.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { chromium } from 'playwright-core';
+
+const [reportArg, outputArg] = process.argv.slice(2);
+const reportPath = path.resolve(reportArg ?? 'bundle-analyzer/client.html');
+const outputPath = path.resolve(outputArg ?? 'bundle-analyzer/client-treemap.png');
+
+async function ensureReportExists() {
+  try {
+    await fs.access(reportPath);
+  } catch (error) {
+    console.error(`Bundle analyzer report not found at ${reportPath}`);
+    throw error;
+  }
+}
+
+async function captureTreemap() {
+  await ensureReportExists();
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+
+  const browser = await chromium.launch({
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  });
+  try {
+    const page = await browser.newPage({ viewport: { width: 1600, height: 1200 } });
+    await page.goto(pathToFileURL(reportPath).toString(), { waitUntil: 'networkidle' });
+    // Allow charts and fonts to finish rendering before capturing the screenshot.
+    await page.waitForTimeout(1000);
+    await page.screenshot({ path: outputPath, fullPage: true });
+    console.log(`Saved treemap screenshot to ${outputPath}`);
+  } finally {
+    await browser.close();
+  }
+}
+
+captureTreemap().catch((error) => {
+  console.error('Failed to capture bundle analyzer treemap.');
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -13965,6 +13965,7 @@ __metadata:
     typescript: "npm:5.8.2"
     wait-on: "npm:^8.0.4"
     webpack: "npm:^5.92.0"
+    webpack-bundle-analyzer: "npm:^4.10.2"
     workbox-build: "npm:7.1.1"
     ws: "npm:^8.18.0"
     zod: "npm:^3.23.8"
@@ -14199,6 +14200,28 @@ __metadata:
   bin:
     webpack-bundle-analyzer: lib/bin/analyzer.js
   checksum: 10c0/6a94c8f6aa03296fb2eb00d6ad3b27bd5c551590fd253772bc61debf3177414d42701014079d4f85c74ba1ca685ae9f0cb4063812b58c21f294d108e9908e5cd
+  languageName: node
+  linkType: hard
+
+"webpack-bundle-analyzer@npm:^4.10.2":
+  version: 4.10.2
+  resolution: "webpack-bundle-analyzer@npm:4.10.2"
+  dependencies:
+    "@discoveryjs/json-ext": "npm:0.5.7"
+    acorn: "npm:^8.0.4"
+    acorn-walk: "npm:^8.0.0"
+    commander: "npm:^7.2.0"
+    debounce: "npm:^1.2.1"
+    escape-string-regexp: "npm:^4.0.0"
+    gzip-size: "npm:^6.0.0"
+    html-escaper: "npm:^2.0.2"
+    opener: "npm:^1.5.2"
+    picocolors: "npm:^1.0.0"
+    sirv: "npm:^2.0.3"
+    ws: "npm:^7.3.1"
+  bin:
+    webpack-bundle-analyzer: lib/bin/analyzer.js
+  checksum: 10c0/00603040e244ead15b2d92981f0559fa14216381349412a30070a7358eb3994cd61a8221d34a3b3fb8202dc3d1c5ee1fbbe94c5c52da536e5b410aa1cf279a48
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add a CI job that runs the Next.js bundle analyzer, captures a treemap image, uploads the results, and posts a sticky PR comment
- add scripts to screenshot the analyzer report and to generate a markdown summary for comments
- document how to run the analyzer locally and ignore generated artifacts

## Testing
- yarn analyze:treemap
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations across apps)*
- yarn test *(fails: existing jest environment/localStorage issues in multiple suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25af6984832895cea28eb144555a