### PR TITLE
[ci] add lighthouse performance gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,96 @@ jobs:
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+
+  performance:
+    runs-on: ubuntu-latest
+    needs: install
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn build
+      - name: Run Lighthouse with budgets
+        run: |
+          set -euo pipefail
+          mkdir -p .lighthouse
+          PORT=3000 yarn start --hostname 0.0.0.0 --port 3000 > .lighthouse/next.log 2>&1 &
+          server_pid=$!
+          cleanup() {
+            if ps -p "$server_pid" > /dev/null 2>&1; then
+              kill "$server_pid" 2>/dev/null || true
+              wait "$server_pid" 2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
+          npx wait-on http://127.0.0.1:3000
+          npx --yes lighthouse@12.8.2 http://127.0.0.1:3000/ \
+            --preset=desktop \
+            --output=json \
+            --output=html \
+            --output-path=.lighthouse/report \
+            --save-assets \
+            --budgets-path=./lighthouse-budgets.json \
+            --chrome-flags="--headless=new --no-sandbox --disable-gpu"
+      - name: Summarize Lighthouse results
+        id: summarize_lighthouse
+        run: |
+          set +e
+          node scripts/perf/generate-lighthouse-summary.mjs \
+            .lighthouse/report.report.json \
+            .lighthouse/summary.md \
+            .lighthouse/summary.json
+          status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Upload Lighthouse artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-reports
+          path: |
+            .lighthouse/report.report.html
+            .lighthouse/report.report.json
+            .lighthouse/report.report.assets/**
+            .lighthouse/summary.md
+            .lighthouse/summary.json
+            .lighthouse/next.log
+      - name: Add summary to job summary
+        if: ${{ always() }}
+        run: |
+          if [ -f .lighthouse/summary.md ]; then
+            cat .lighthouse/summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Comment with Lighthouse summary
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const summaryPath = path.join(process.cwd(), '.lighthouse/summary.md');
+            if (!fs.existsSync(summaryPath)) {
+              core.warning('No Lighthouse summary found to comment with.');
+              return;
+            }
+            const body = `<!-- lighthouse-performance-gate -->\n${fs.readFileSync(summaryPath, 'utf8')}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find((comment) => comment.body && comment.body.startsWith('<!-- lighthouse-performance-gate -->'));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+      - name: Enforce Lighthouse budgets
+        if: ${{ steps.summarize_lighthouse.outputs.exit_code != '0' }}
+        run: |
+          echo 'Lighthouse budgets or runtime checks failed.' >&2
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dist
 # misc
 .DS_Store
 *.pem
+.lighthouse/
 
 # debug
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ See Vercel's [Speed Insights Quickstart](https://vercel.com/docs/speed-insights/
 
 ---
 
+## Performance budgets
+
+- Pull requests run a Lighthouse gate that enforces [`lighthouse-budgets.json`](./lighthouse-budgets.json).
+- CI uploads the HTML report, JSON payload, Chrome trace, and a markdown summary comment on failure or success.
+- Follow the remediation and local reproduction steps documented in [`docs/performance-gate.md`](./docs/performance-gate.md).
+
+---
+
 ## Tech Stack
 
 - **Next.js 15** (app uses `/pages` routing) + **TypeScript** in parts

--- a/docs/performance-gate.md
+++ b/docs/performance-gate.md
@@ -1,0 +1,75 @@
+# Lighthouse performance gate
+
+The repository now enforces a performance workflow on every pull request. The `performance`
+job in [`ci.yml`](../.github/workflows/ci.yml) builds the application, launches the
+production server, and runs Lighthouse against `http://127.0.0.1:3000/` with the budgets
+defined in [`lighthouse-budgets.json`](../lighthouse-budgets.json). The run captures the
+Lighthouse HTML report, JSON payload, Chrome trace, and a human-readable summary that is
+posted back to the pull request.
+
+## What the workflow enforces
+
+- **Resource budgets** – scripts must stay under 350 KB and the total transfer under 2 MB.
+  Third-party requests and script counts are also capped to keep the desktop responsive.
+- **Timing budgets** – Largest Contentful Paint must stay under 4 s and Time to Interactive
+  under 5 s for the desktop profile.
+- **Runtime checks** – any Lighthouse runtime error or missing audit is treated as a build
+  failure so the gate never silently skips a run.
+
+When budgets are exceeded the `performance` job fails and the pull request receives an
+updated comment summarising the metrics, budget overages, and a link to the `lighthouse-
+reports` artifact.
+
+## Reproducing locally
+
+1. Install dependencies and build the production bundle.
+
+   ```bash
+   yarn install
+   yarn build
+   ```
+
+2. Launch the production server and keep it running.
+
+   ```bash
+   PORT=3000 yarn start --hostname 0.0.0.0 --port 3000
+   ```
+
+3. In another terminal run Lighthouse with the same settings used in CI.
+
+   ```bash
+   npx --yes lighthouse@12.8.2 http://127.0.0.1:3000/ \
+     --preset=desktop \
+     --output=json \
+     --output=html \
+     --output-path=.lighthouse/report \
+     --save-assets \
+     --budgets-path=./lighthouse-budgets.json \
+     --chrome-flags="--headless=new --no-sandbox --disable-gpu"
+   node scripts/perf/generate-lighthouse-summary.mjs \
+     .lighthouse/report.report.json \
+     .lighthouse/summary.md \
+     .lighthouse/summary.json
+   ```
+
+4. Inspect `.lighthouse/summary.md` for the same markdown used in the PR comment. The
+   `.lighthouse/report.report.assets/` directory contains the Chrome trace
+   (`lighthouse-0.trace.json`) that can be loaded into Chrome DevTools Performance panel.
+
+## Remediation checklist
+
+When the gate fails:
+
+- **Script or total size over budget** – split heavy apps with `next/dynamic`, lazy-load
+  third-party libraries, remove unused dependencies, or compress large JSON/assets.
+- **Third-party request count over budget** – audit analytics and embeds; defer or disable
+  integrations that run on the desktop shell by default.
+- **Timing budgets breached** – open the generated trace in Chrome DevTools and inspect the
+  long tasks around LCP/TTI. Optimise render-blocking resources, preconnect critical
+  origins, and move heavy work behind user interaction or web workers.
+- **Runtime error** – rerun the command locally to reproduce. Common causes are the server
+  failing to start or the page returning an HTTP error. Fix the underlying issue before
+  re-running Lighthouse.
+
+Clear the regression and push a new commit; the workflow comment will update automatically
+and the job will pass once budgets are respected again.

--- a/lighthouse-budgets.json
+++ b/lighthouse-budgets.json
@@ -1,0 +1,17 @@
+[
+  {
+    "path": "/",
+    "resourceSizes": [
+      { "resourceType": "script", "budget": 350 },
+      { "resourceType": "total", "budget": 2000 }
+    ],
+    "resourceCounts": [
+      { "resourceType": "script", "budget": 30 },
+      { "resourceType": "third-party", "budget": 20 }
+    ],
+    "timings": [
+      { "metric": "interactive", "budget": 5000 },
+      { "metric": "largest-contentful-paint", "budget": 4000 }
+    ]
+  }
+]

--- a/scripts/perf/generate-lighthouse-summary.mjs
+++ b/scripts/perf/generate-lighthouse-summary.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [reportPath, summaryPath, jsonPath] = process.argv.slice(2);
+
+if (!reportPath || !summaryPath || !jsonPath) {
+  console.error('Usage: node generate-lighthouse-summary.mjs <report.json> <summary.md> <summary.json>');
+  process.exit(1);
+}
+
+function readReport(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(content);
+  } catch (error) {
+    console.error(`Failed to read Lighthouse report at ${filePath}:`, error);
+    process.exit(1);
+  }
+}
+
+function ensureDir(filePath) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function parseNumber(value) {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const normalized = value.replace(/[^0-9.-]+/g, '');
+    if (normalized.length === 0) return Number.NaN;
+    return Number.parseFloat(normalized);
+  }
+  return Number.NaN;
+}
+
+function formatMs(value) {
+  if (!Number.isFinite(value)) return 'n/a';
+  return `${Math.round(value)} ms`;
+}
+
+function formatKb(value) {
+  if (!Number.isFinite(value)) return 'n/a';
+  return `${Math.round(value)} KB`;
+}
+
+const report = readReport(reportPath);
+const categories = report.categories ?? {};
+
+const metricsConfig = [
+  { id: 'first-contentful-paint', label: 'First Contentful Paint', formatter: formatMs },
+  { id: 'largest-contentful-paint', label: 'Largest Contentful Paint', formatter: formatMs },
+  { id: 'speed-index', label: 'Speed Index', formatter: formatMs },
+  { id: 'total-blocking-time', label: 'Total Blocking Time', formatter: formatMs },
+  { id: 'interactive', label: 'Time to Interactive', formatter: formatMs },
+  { id: 'cumulative-layout-shift', label: 'Cumulative Layout Shift', formatter: (value) => (Number.isFinite(value) ? value.toFixed(3) : 'n/a') },
+];
+
+const metrics = metricsConfig
+  .map((metric) => {
+    const audit = report.audits?.[metric.id];
+    const numericValue = audit && typeof audit.numericValue === 'number' ? audit.numericValue : Number.NaN;
+    return {
+      id: metric.id,
+      label: metric.label,
+      rawValue: numericValue,
+      displayValue: metric.formatter(numericValue),
+    };
+  })
+  .filter((metric) => metric.rawValue || metric.displayValue !== 'n/a');
+
+const performanceScoreRaw = categories.performance?.score;
+const performanceScore = typeof performanceScoreRaw === 'number' ? Math.round(performanceScoreRaw * 100) : null;
+
+function evaluateBudget(auditId, { label, unitFormatter, overBudgetKey }) {
+  const audit = report.audits?.[auditId];
+  if (!audit) {
+    return {
+      id: auditId,
+      label,
+      status: 'error',
+      message: `Missing Lighthouse audit: ${auditId}`,
+      items: [],
+    };
+  }
+
+  if (audit.scoreDisplayMode === 'notApplicable') {
+    return {
+      id: auditId,
+      label,
+      status: 'error',
+      message: 'Audit was marked not applicable. Check your budgets configuration.',
+      items: [],
+    };
+  }
+
+  const items = Array.isArray(audit.details?.items) ? audit.details.items : [];
+  const normalizedItems = items.map((item) => {
+    const budget = parseNumber(item.budget ?? item.budgetMiB ?? item.budgetMs);
+    const actual = parseNumber(item.usage ?? item.actual ?? item.value);
+    const overBudget = parseNumber(item[overBudgetKey] ?? item.overBudget ?? item.overBudgetMs);
+    const identifier = item.resourceType || item.metric || item.label || item.url || 'unknown';
+    return {
+      identifier,
+      budget,
+      actual,
+      overBudget,
+      displayBudget: unitFormatter(budget),
+      displayActual: unitFormatter(actual),
+      displayOverBudget: unitFormatter(overBudget),
+    };
+  });
+
+  const failingItems = normalizedItems.filter((item) => Number.isFinite(item.overBudget) && item.overBudget > 0);
+  const status = failingItems.length > 0 || audit.score === 0 ? 'fail' : 'pass';
+
+  return {
+    id: auditId,
+    label,
+    status,
+    message: failingItems.length ? `${failingItems.length} budget${failingItems.length > 1 ? 's' : ''} exceeded.` : undefined,
+    items: normalizedItems,
+    failingItems,
+  };
+}
+
+const performanceBudget = evaluateBudget('performance-budget', {
+  label: 'Resource budgets',
+  unitFormatter: formatKb,
+  overBudgetKey: 'overBudget',
+});
+
+const timingBudget = evaluateBudget('timing-budget', {
+  label: 'Timing budgets',
+  unitFormatter: formatMs,
+  overBudgetKey: 'overBudgetMs',
+});
+
+const budgetResults = [performanceBudget, timingBudget];
+const runtimeErrors = [];
+
+if (report.runtimeError && report.runtimeError.message) {
+  runtimeErrors.push(report.runtimeError.message);
+}
+
+const runWarnings = Array.isArray(report.runWarnings) ? report.runWarnings : [];
+
+const hasBudgetFailures = budgetResults.some((result) => result.status === 'fail' || result.status === 'error');
+const hasRuntimeErrors = runtimeErrors.length > 0;
+const hasWarnings = runWarnings.length > 0;
+
+let summary = '# Lighthouse performance gate\n\n';
+
+if (performanceScore !== null) {
+  summary += `- **Performance score:** ${performanceScore}/100\n`;
+}
+
+if (metrics.length > 0) {
+  summary += '\n## Key metrics\n\n';
+  summary += '| Metric | Value |\n';
+  summary += '| --- | --- |\n';
+  for (const metric of metrics) {
+    summary += `| ${metric.label} | ${metric.displayValue} |\n`;
+  }
+}
+
+summary += '\n## Budget checks\n\n';
+for (const result of budgetResults) {
+  if (result.status === 'pass') {
+    summary += `- ✅ ${result.label} met\n`;
+  } else if (result.status === 'fail') {
+    summary += `- ❌ ${result.label} exceeded\n`;
+    for (const item of result.failingItems) {
+      summary += `  - ${item.identifier}: ${item.displayActual} (budget ${item.displayBudget})\n`;
+    }
+  } else {
+    summary += `- ⚠️ ${result.label}: ${result.message ?? 'Audit unavailable'}\n`;
+  }
+}
+
+if (hasRuntimeErrors || hasWarnings) {
+  summary += '\n## Alerts\n\n';
+  for (const warning of runWarnings) {
+    summary += `- ⚠️ ${warning}\n`;
+  }
+  for (const error of runtimeErrors) {
+    summary += `- ❌ ${error}\n`;
+  }
+}
+
+summary += '\nArtifacts include the HTML report, JSON payload, trace, and summary JSON.\n';
+
+ensureDir(summaryPath);
+ensureDir(jsonPath);
+fs.writeFileSync(summaryPath, summary, 'utf8');
+
+const output = {
+  performanceScore,
+  metrics,
+  budgets: budgetResults.map((result) => ({
+    id: result.id,
+    label: result.label,
+    status: result.status,
+    message: result.message,
+    failingItems: result.failingItems?.map((item) => ({
+      identifier: item.identifier,
+      budget: item.budget,
+      actual: item.actual,
+      overBudget: item.overBudget,
+    })) ?? [],
+  })),
+  warnings: runWarnings,
+  runtimeErrors,
+};
+
+fs.writeFileSync(jsonPath, JSON.stringify(output, null, 2));
+
+if (hasBudgetFailures || hasRuntimeErrors) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add a `performance` job to the CI workflow that runs Lighthouse with budgets, uploads artifacts, and comments on pull requests
- add a reusable summary generator plus Lighthouse budget configuration to enforce resource and timing limits
- document the new gate, remediation guidance, and link it from the README while ignoring local `.lighthouse/` outputs

## Testing
- yarn lint *(fails: repository already contains numerous jsx-a11y and no-top-level-window violations)*
- yarn test *(fails/hangs: existing suites such as window, nmap, and pdf viewer fail and Jest does not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25af42988328b76f62e8f14fac63