### PR TITLE
[ci] add README parity verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,18 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  verify-full:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn verify:full
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ See `.env.local.example` for the full list.
 - `yarn test` – run the test suite.
 - `yarn lint` – check code for linting issues.
 - `yarn export` – generate a static export in the `out/` directory.
+- `yarn verify:full` – reproduce the README walkthrough end-to-end (install dependencies, lint with `--max-warnings=0`, run tests,
+  type-check with `tsc --noEmit`, build the production bundle, and execute the Playwright smoke suite without console warnings).
+  This command also runs in CI to ensure the documentation and automation stay in lockstep.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "module-report": "node scripts/generate-module-report.mjs",
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
-    "verify:all": "node scripts/verify.mjs"
+    "verify:all": "node scripts/verify.mjs",
+    "verify:full": "node scripts/verify-full.mjs"
   },
   "engines": {
     "node": "20.19.5"

--- a/scripts/verify-full.mjs
+++ b/scripts/verify-full.mjs
@@ -1,0 +1,111 @@
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import waitOn from 'wait-on';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const run = (cmd, args = [], options = {}) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: 'inherit', ...options });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Command failed: ${cmd} ${args.join(' ')}`));
+      }
+    });
+  });
+
+const getPort = () =>
+  new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, () => {
+      const address = server.address();
+      server.close(() => {
+        if (address && typeof address === 'object') {
+          resolve(address.port);
+        } else {
+          reject(new Error('Failed to allocate port'));
+        }
+      });
+    });
+  });
+
+let devServer;
+
+(async () => {
+  const stopServer = async () => {
+    if (devServer && devServer.exitCode === null) {
+      devServer.kill('SIGTERM');
+      await new Promise((resolve) => devServer.once('exit', resolve));
+    }
+    devServer = undefined;
+  };
+
+  try {
+    console.log('\n▶ yarn install');
+    await run('yarn', ['install']);
+
+    const tscBin = require.resolve('typescript/lib/tsc.js');
+    const nextBin = require.resolve('next/dist/bin/next');
+    const playwrightCli = require.resolve('@playwright/test/cli');
+
+    console.log('\n▶ playwright install --with-deps');
+    await run('node', [playwrightCli, 'install', '--with-deps']);
+
+    console.log('\n▶ yarn lint --max-warnings=0');
+    await run('yarn', ['lint', '--max-warnings=0']);
+
+    console.log('\n▶ yarn test');
+    await run('yarn', ['test'], { env: { ...process.env, CI: '1' } });
+
+    console.log('\n▶ tsc --noEmit');
+    await run('node', [tscBin, '--noEmit']);
+
+    console.log('\n▶ next build');
+    await run('node', [nextBin, 'build']);
+
+    const port = await getPort();
+    console.log(`\n▶ next start (port ${port})`);
+    devServer = spawn('node', [nextBin, 'start', '-p', String(port)], {
+      stdio: 'inherit',
+      env: { ...process.env, PORT: String(port) },
+    });
+
+    const shutdownSignals = ['SIGINT', 'SIGTERM', 'SIGQUIT'];
+    shutdownSignals.forEach((signal) => {
+      process.on(signal, () => {
+        if (devServer && devServer.exitCode === null) {
+          devServer.kill('SIGTERM');
+        }
+        process.exit(1);
+      });
+    });
+
+    process.on('exit', () => {
+      if (devServer && devServer.exitCode === null) {
+        devServer.kill('SIGTERM');
+      }
+    });
+
+    await waitOn({ resources: [`http://127.0.0.1:${port}`], timeout: 120000 });
+    console.log(`Server is ready at http://127.0.0.1:${port}`);
+
+    console.log('\n▶ Playwright smoke (tests/apps.smoke.spec.ts)');
+    await run('node', [playwrightCli, 'test', 'tests/apps.smoke.spec.ts', '--config=playwright.config.ts'], {
+      env: { ...process.env, BASE_URL: `http://127.0.0.1:${port}` },
+    });
+
+    console.log('\n✅ verify:full PASS');
+  } catch (error) {
+    console.error('\n❌ verify:full FAIL');
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    await stopServer();
+  }
+})();


### PR DESCRIPTION
## Summary
- add a `verify:full` runner that automates the README walkthrough, including Playwright smoke checks without console warnings
- wire the new runner into CI and document the workflow so automation mirrors the published steps

## Testing
- yarn lint *(fails: repo already reports numerous accessibility and window/document lint errors)*
- yarn test *(fails: existing suites such as window and nmap NSE tests fail under Jest)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25a1f5e8832897bff4fd8ddc8f6c