### PR TITLE
feat(flags): add override fetching and debug controls

### DIFF
--- a/__tests__/featureFlagOverrides.test.ts
+++ b/__tests__/featureFlagOverrides.test.ts
@@ -1,0 +1,200 @@
+import { renderHook, act } from '@testing-library/react';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+import {
+  useFeatureFlags,
+  defaultFeatureFlags,
+  __resetFeatureFlagStoreForTests,
+} from '../hooks/useFeatureFlags';
+
+const nativeFetch = global.fetch;
+const originalLocalStorage = window.localStorage;
+const originalSessionStorage = window.sessionStorage;
+
+const createStorage = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+};
+
+describe('feature flag overrides', () => {
+  beforeEach(() => {
+    __resetFeatureFlagStoreForTests();
+    const local = createStorage();
+    const session = createStorage();
+    Object.defineProperty(window, 'localStorage', {
+      value: local,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(window, 'sessionStorage', {
+      value: session,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (nativeFetch) {
+      global.fetch = nativeFetch;
+    } else {
+      // @ts-ignore
+      delete global.fetch;
+    }
+    if (originalLocalStorage) {
+      Object.defineProperty(window, 'localStorage', {
+        value: originalLocalStorage,
+        configurable: true,
+        writable: true,
+      });
+    } else {
+      // @ts-ignore
+      delete window.localStorage;
+    }
+    if (originalSessionStorage) {
+      Object.defineProperty(window, 'sessionStorage', {
+        value: originalSessionStorage,
+        configurable: true,
+        writable: true,
+      });
+    } else {
+      // @ts-ignore
+      delete window.sessionStorage;
+    }
+    jest.restoreAllMocks();
+  });
+
+  test('applies overrides and notifies subscribers on refresh', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          toolApis: true,
+          hydra: true,
+          labsUnlocked: true,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          toolApis: false,
+          hydra: true,
+        }),
+      });
+
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const { result } = renderHook(
+      () => {
+        const settings = useSettings();
+        const featureFlags = useFeatureFlags();
+        return { settings, featureFlags };
+      },
+      { wrapper: SettingsProvider }
+    );
+
+    expect(result.current.featureFlags.flags).toEqual(
+      expect.objectContaining(defaultFeatureFlags)
+    );
+
+    await act(async () => {
+      result.current.settings.setAllowNetwork(true);
+    });
+
+    await act(async () => {
+      await result.current.featureFlags.setOverrideUrl('/mock/flags.json');
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result.current.featureFlags.status).toBe('ready');
+    expect(result.current.featureFlags.flags.toolApis).toBe(true);
+    expect(result.current.featureFlags.flags.hydra).toBe(true);
+    expect(result.current.featureFlags.flags.labsUnlocked).toBe(true);
+
+    act(() => {
+      result.current.featureFlags.setFlag('toolApis', false);
+    });
+    expect(result.current.featureFlags.flags.toolApis).toBe(false);
+
+    act(() => {
+      result.current.featureFlags.resetFlag('toolApis');
+    });
+    expect(result.current.featureFlags.flags.toolApis).toBe(true);
+
+    await act(async () => {
+      await result.current.featureFlags.refreshOverrides();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result.current.featureFlags.flags.toolApis).toBe(false);
+    expect(result.current.featureFlags.flags.hydra).toBe(true);
+  });
+
+  test('falls back to defaults when overrides are unavailable', async () => {
+    const mockFetch = jest.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const { result } = renderHook(
+      () => {
+        const settings = useSettings();
+        const featureFlags = useFeatureFlags();
+        return { settings, featureFlags };
+      },
+      { wrapper: SettingsProvider }
+    );
+
+    expect(result.current.featureFlags.flags).toEqual(
+      expect.objectContaining(defaultFeatureFlags)
+    );
+
+    await act(async () => {
+      await result.current.featureFlags.setOverrideUrl('/mock/flags.json');
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.featureFlags.status).toBe('blocked');
+    expect(result.current.featureFlags.flags).toEqual(
+      expect.objectContaining(defaultFeatureFlags)
+    );
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      });
+
+    await act(async () => {
+      result.current.settings.setAllowNetwork(true);
+    });
+
+    await act(async () => {
+      await result.current.featureFlags.refreshOverrides();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result.current.featureFlags.status).toBe('error');
+    expect(result.current.featureFlags.flags).toEqual(
+      expect.objectContaining(defaultFeatureFlags)
+    );
+  });
+});

--- a/hooks/useFeatureFlags.ts
+++ b/hooks/useFeatureFlags.ts
@@ -1,0 +1,226 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { useSettings } from './useSettings';
+
+export type FeatureFlagValue = boolean | number | string;
+export type FeatureFlagOverrides = Record<string, FeatureFlagValue>;
+export type FeatureFlagStatus = 'idle' | 'loading' | 'ready' | 'blocked' | 'error';
+
+type FeatureFlagState = {
+  overrides: FeatureFlagOverrides;
+  manualOverrides: FeatureFlagOverrides;
+  source: string | null;
+  status: FeatureFlagStatus;
+  error: string | null;
+};
+
+const isValidValue = (value: unknown): value is FeatureFlagValue =>
+  typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string';
+
+export const defaultFeatureFlags: Readonly<FeatureFlagOverrides> = Object.freeze({
+  toolApis: false,
+  hydra: false,
+  john: false,
+  developerMenu: false,
+});
+
+let state: FeatureFlagState = {
+  overrides: {},
+  manualOverrides: {},
+  source: null,
+  status: 'idle',
+  error: null,
+};
+
+let allowNetwork = false;
+let fetchVersion = 0;
+let snapshotVersion = 0;
+let cachedSnapshot: FeatureFlagSnapshot | null = null;
+let cachedSnapshotVersion = -1;
+
+const listeners = new Set<() => void>();
+
+const emit = () => {
+  listeners.forEach((listener) => listener());
+};
+
+const sanitizePayload = (payload: unknown): FeatureFlagOverrides => {
+  if (!payload || typeof payload !== 'object') return {};
+  const result: FeatureFlagOverrides = {};
+  Object.entries(payload as Record<string, unknown>).forEach(([key, value]) => {
+    if (isValidValue(value)) {
+      result[key] = value;
+    }
+  });
+  return result;
+};
+
+const computeFlags = (): FeatureFlagOverrides => ({
+  ...defaultFeatureFlags,
+  ...state.overrides,
+  ...state.manualOverrides,
+});
+
+type FeatureFlagSnapshot = {
+  flags: FeatureFlagOverrides;
+  overrides: FeatureFlagOverrides;
+  manualOverrides: FeatureFlagOverrides;
+  source: string | null;
+  status: FeatureFlagStatus;
+  error: string | null;
+};
+
+const getSnapshot = (): FeatureFlagSnapshot => {
+  if (!cachedSnapshot || cachedSnapshotVersion !== snapshotVersion) {
+    cachedSnapshot = {
+      flags: computeFlags(),
+      overrides: state.overrides,
+      manualOverrides: state.manualOverrides,
+      source: state.source,
+      status: state.status,
+      error: state.error,
+    };
+    cachedSnapshotVersion = snapshotVersion;
+  }
+  return cachedSnapshot;
+};
+
+const getServerSnapshot = getSnapshot;
+
+const updateState = (partial: Partial<FeatureFlagState>) => {
+  state = { ...state, ...partial };
+  snapshotVersion += 1;
+  cachedSnapshot = null;
+  emit();
+};
+
+const setManualOverrideValue = (key: string, value: FeatureFlagValue) => {
+  if (!isValidValue(value)) return;
+  updateState({ manualOverrides: { ...state.manualOverrides, [key]: value } });
+};
+
+const clearManualOverrideValue = (key: string) => {
+  if (!(key in state.manualOverrides)) return;
+  const { [key]: _removed, ...rest } = state.manualOverrides;
+  updateState({ manualOverrides: rest });
+};
+
+const clearAllManualOverrideValues = () => {
+  if (Object.keys(state.manualOverrides).length === 0) return;
+  updateState({ manualOverrides: {} });
+};
+
+const fetchOverrides = async (): Promise<void> => {
+  const source = state.source;
+  if (!source) return;
+
+  const currentVersion = ++fetchVersion;
+
+  if (!allowNetwork) {
+    updateState({ status: 'blocked', error: 'Network access disabled by settings.' });
+    return;
+  }
+
+  updateState({ status: 'loading', error: null });
+
+  try {
+    const response = await fetch(source, { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+    const data = await response.json();
+    if (currentVersion !== fetchVersion) return;
+    const overrides = sanitizePayload(data);
+    updateState({ overrides, status: 'ready', error: null });
+  } catch (error) {
+    if (currentVersion !== fetchVersion) return;
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    updateState({ overrides: {}, status: 'error', error: message });
+  }
+};
+
+const setSource = async (url: string | null): Promise<void> => {
+  const normalized = url && url.trim().length > 0 ? url.trim() : null;
+  fetchVersion += 1;
+  updateState({ source: normalized });
+  if (!normalized) {
+    updateState({ overrides: {}, status: 'idle', error: null });
+    return;
+  }
+  await fetchOverrides();
+};
+
+const refresh = async (): Promise<void> => {
+  await fetchOverrides();
+};
+
+const updateAllowNetworkSetting = (value: boolean) => {
+  if (allowNetwork === value) return;
+  allowNetwork = value;
+  if (!value) {
+    if (state.source) {
+      updateState({ status: 'blocked', error: 'Network access disabled by settings.' });
+    } else {
+      updateState({ status: 'idle', error: null });
+    }
+    return;
+  }
+  updateState({ status: 'idle', error: null });
+  if (state.source) {
+    void fetchOverrides();
+  }
+};
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export function useFeatureFlags() {
+  const { allowNetwork } = useSettings();
+
+  useEffect(() => {
+    updateAllowNetworkSetting(allowNetwork);
+  }, [allowNetwork]);
+
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const setOverrideUrl = useCallback((url: string | null) => setSource(url), []);
+  const refreshOverrides = useCallback(() => refresh(), []);
+  const setFlag = useCallback((key: string, value: FeatureFlagValue) => {
+    setManualOverrideValue(key, value);
+  }, []);
+  const resetFlag = useCallback((key: string) => {
+    clearManualOverrideValue(key);
+  }, []);
+  const clearAllFlags = useCallback(() => {
+    clearAllManualOverrideValues();
+  }, []);
+
+  return {
+    ...snapshot,
+    defaults: defaultFeatureFlags,
+    setOverrideUrl,
+    refreshOverrides,
+    setFlag,
+    resetFlag,
+    clearAllFlags,
+  };
+}
+
+export const __resetFeatureFlagStoreForTests = () => {
+  state = {
+    overrides: {},
+    manualOverrides: {},
+    source: null,
+    status: 'idle',
+    error: null,
+  };
+  allowNetwork = false;
+  fetchVersion = 0;
+  snapshotVersion = 0;
+  cachedSnapshot = null;
+  cachedSnapshotVersion = -1;
+  emit();
+};

--- a/public/mock/flags.json
+++ b/public/mock/flags.json
@@ -1,0 +1,7 @@
+{
+  "toolApis": true,
+  "hydra": true,
+  "john": true,
+  "developerMenu": true,
+  "labsUnlocked": true
+}


### PR DESCRIPTION
## Summary
- add a dedicated feature flag store that merges remote overrides with defaults and respects the Allow Network setting
- expose a debug panel in Desktop Settings to load override URLs, use the mock flags JSON, and flip flags live
- document mock overrides in public/mock/flags.json and cover live update + fallback behaviour with Jest tests

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window violations)*
- yarn test --watch=false __tests__/featureFlagOverrides.test.ts
- CI=true yarn test --watch=false *(fails: existing suite errors such as window snapping test and jsdom localStorage origin issues)*

------
https://chatgpt.com/codex/tasks/task_e_68cce5f769e8832884c204031de07482