### PR TITLE
[window] add snap debugging overlay

### DIFF
--- a/docs/window-manager.md
+++ b/docs/window-manager.md
@@ -1,0 +1,22 @@
+# Window Manager Debugging
+
+The desktop window manager includes a debug overlay that helps visualize snap targets and window state while you are iterating on drag interactions.
+
+## Enabling the overlay
+
+You can enable the overlay with either of the following options:
+
+- Set the environment variable before starting the dev server:
+  
+  ```bash
+  NEXT_PUBLIC_WINDOW_DEBUG=1 yarn dev
+  ```
+- Append `?snap-debug=1` to the URL while the app is running.
+
+Once enabled, the overlay renders colored regions for the available snap targets and a HUD showing the current cursor coordinates and snap state.
+
+## Runtime toggle
+
+While the app is running you can press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd> (or <kbd>⌘</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd> on macOS) to toggle the overlay on or off without reloading the page.
+
+Use this tool when tuning drag thresholds or investigating snap behaviors. Remember to disable the flag before shipping production builds.


### PR DESCRIPTION
## Summary
- add a feature-flagged debug overlay to the Window component that exposes snap zones, cursor coordinates, and snap state
- enable toggling the overlay at runtime via Ctrl+Shift+D and highlight the active snap zone
- document how to enable the snap debug tools in `docs/window-manager.md`

## Testing
- yarn lint *(fails: repository contains pre-existing accessibility and lint violations across many apps)*
- yarn test --watch=false *(fails: repository has pre-existing failing suites such as `__tests__/nmapNse.test.tsx` and `__tests__/Modal.test.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68cd757516148328829b68a723fdec66