### PR TITLE
[deps] fix missing peer dependencies

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,3 +13,19 @@ logFilters:
   - pattern: "Resolution field \"magic-string@*\" is incompatible with requested version"
     level: info
 
+packageExtensions:
+  "3d-force-graph-ar@*":
+    peerDependencies:
+      aframe: "*"
+      three: "*"
+  "3d-force-graph-vr@*":
+    peerDependencies:
+      three: "*"
+  "aframe-forcegraph-component@*":
+    peerDependencies:
+      three: "*"
+  "react-force-graph@*":
+    peerDependencies:
+      aframe: "*"
+      three: "*"
+


### PR DESCRIPTION
## Summary
- add Yarn package extensions for the 3d-force-graph packages to supply their aframe and three peer dependencies
- eliminate the Yarn peer dependency warnings during install

## Testing
- yarn install --immutable
- yarn lint *(fails: existing accessibility and custom lint rule violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d13e43e40c83289f6c1992c2779adc