### PR TITLE
[ui] Remove duplicate wifi icon from navbar

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
@@ -16,9 +15,6 @@ export default class Navbar extends Component {
 	render() {
 		return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <div className="pl-3 pr-1">
-                                        <Image src="/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" alt="network icon" width={16} height={16} className="w-4 h-4" />
-                                </div>
                                 <WhiskerMenu />
                                 <div
                                         className={


### PR DESCRIPTION
## Summary
- remove the redundant Wi-Fi icon from the navbar so the status indicator only appears once

## Testing
- yarn lint *(fails: existing repo lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d32ade24a0832895f2e11f5534853c