### PR TITLE
[infra] align Vercel Node version configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Workflow: `.github/workflows/gh-deploy.yml`:
   - `NEXT_PUBLIC_RECAPTCHA_SITE_KEY`
   - `RECAPTCHA_SECRET`
   - `ADMIN_READ_KEY` (set manually in Vercel or your host)
+  - `NODE_VERSION=20.19.5` (keeps Vercel builds and serverless functions aligned with `.nvmrc`/`package.json`)
 - Build command: `yarn build`
 - Output: Next.js (serverless by default on Vercel).
 - If you keep API routes, Vercel deploys them as serverless functions. For a static build, disable API routes or feature-flag those apps.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This project is built with [Next.js](https://nextjs.org/).
 
 ## Prerequisites
 
-- Node.js 20
+- Node.js 20.19.5 (install via `.nvmrc` to match CI and Vercel)
 - yarn or npm
 
 ## Installation

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,13 @@
   "functions": {
     "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
     "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
+  },
+  "env": {
+    "NODE_VERSION": "20.19.5"
+  },
+  "build": {
+    "env": {
+      "NODE_VERSION": "20.19.5"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- pin Vercel build/runtime to Node 20.19.5 via vercel.json env configuration
- document the NODE_VERSION requirement for Vercel deployments and onboarding docs

## Testing
- [ ] `yarn lint` *(fails: existing repo-wide accessibility lint errors)*
- [ ] `yarn test` *(fails: existing failing suites in repository; jest left two suites failing and hung waiting to exit)*

------
https://chatgpt.com/codex/tasks/task_e_68d355d55d0c8328b85c3cd1f143be14