### PR TITLE
[config] conditionally unoptimize images for static export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -130,7 +130,7 @@ module.exports = withBundleAnalyzer(
       ignoreDuringBuilds: true,
     },
     images: {
-      unoptimized: true,
+      unoptimized: isStaticExport,
       domains: [
         'opengraph.githubassets.com',
         'raw.githubusercontent.com',


### PR DESCRIPTION
## Summary
- tie Next.js image optimization to the static export environment flag so static builds skip optimization while dynamic builds keep it enabled
- keep the existing remote image domain allowlist aligned with the CSP guidance

## Testing
- [ ] `yarn lint` *(fails: existing accessibility labeling errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3561928688328bd6dc4be245bc100