### PR TITLE
[desktop] Harden window keyboard focus handling

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -77,3 +77,8 @@ html[data-theme='matrix'] {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
+
+.opened-window:focus-within {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- add keyboard trap coverage and focusable rect shims to the window test suite so tab cycling expectations work in jsdom
- expose window chrome elements with ARIA roles and test IDs and support the new focus ring styling
- keep the enhanced keyboard handlers that close on Escape, trap Tab, and snap with arrow keys

## Testing
- yarn lint (fails: pre-existing jsx-a11y/control-has-associated-label and no-top-level-window violations)
- yarn test window.test.tsx --watch=false
- yarn test --watch=false (fails: legacy suites such as nmapNse.test.tsx alert lookup and jsdom localStorage origin errors)


------
https://chatgpt.com/codex/tasks/task_e_68d3562538288328944bbe63b9ca51cf