### PR TITLE
[desktop] Improve context menu states and debounce game right-clicks

### DIFF
--- a/components/apps/minesweeper.js
+++ b/components/apps/minesweeper.js
@@ -218,6 +218,7 @@ const Minesweeper = () => {
   const rightDown = useRef(false);
   const chorded = useRef(false);
   const flagAnim = useRef({});
+  const lastRightClickRef = useRef(0);
 
   useEffect(() => {
     initWorker();
@@ -828,7 +829,11 @@ const Minesweeper = () => {
         leftDown.current = false;
         chorded.current = true;
       } else if (!chorded.current) {
-        toggleFlag(x, y);
+        const now = Date.now();
+        if (now - lastRightClickRef.current >= 250) {
+          toggleFlag(x, y);
+          lastRightClickRef.current = now;
+        }
       }
       rightDown.current = false;
     }
@@ -853,6 +858,11 @@ const Minesweeper = () => {
 
   const handleContextMenu = (e) => {
     e.preventDefault();
+    const now = Date.now();
+    if (now - lastRightClickRef.current < 250) {
+      return;
+    }
+    lastRightClickRef.current = now;
     if (e.clientX === 0 && e.clientY === 0) {
       toggleFlag(cursor.x, cursor.y);
     }

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -7,6 +7,9 @@ function AppMenu(props) {
     useFocusTrap(menuRef, props.active)
     useRovingTabIndex(menuRef, props.active, 'vertical')
 
+    const hasContextApp = Boolean(props.contextApp)
+    const isPinnedActionDisabled = !hasContextApp || props.contextApp.disabled
+
     const handleKeyDown = (e) => {
         if (e.key === 'Escape') {
             props.onClose && props.onClose()
@@ -14,12 +17,19 @@ function AppMenu(props) {
     }
 
     const handlePin = () => {
+        if (isPinnedActionDisabled) {
+            return
+        }
         if (props.pinned) {
             props.unpinApp && props.unpinApp()
         } else {
             props.pinApp && props.pinApp()
         }
     }
+
+    const buttonClass = `w-full text-left cursor-default py-0.5 mb-1.5 ${
+        isPinnedActionDisabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-700'
+    }`
 
     return (
         <div
@@ -35,7 +45,9 @@ function AppMenu(props) {
                 onClick={handlePin}
                 role="menuitem"
                 aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                disabled={isPinnedActionDisabled}
+                aria-disabled={isPinnedActionDisabled}
+                className={buttonClass}
             >
                 <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
             </button>

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -7,6 +7,8 @@ function TaskbarMenu(props) {
     useFocusTrap(menuRef, props.active);
     useRovingTabIndex(menuRef, props.active, 'vertical');
 
+    const hasContextApp = Boolean(props.contextApp);
+
     const handleKeyDown = (e) => {
         if (e.key === 'Escape') {
             props.onCloseMenu && props.onCloseMenu();
@@ -14,14 +16,25 @@ function TaskbarMenu(props) {
     };
 
     const handleMinimize = () => {
+        if (!hasContextApp) {
+            return;
+        }
         props.onMinimize && props.onMinimize();
         props.onCloseMenu && props.onCloseMenu();
     };
 
     const handleClose = () => {
+        if (!hasContextApp) {
+            return;
+        }
         props.onClose && props.onClose();
         props.onCloseMenu && props.onCloseMenu();
     };
+
+    const buttonClass = (disabled) =>
+        `w-full text-left cursor-default py-0.5 mb-1.5 ${
+            disabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-700'
+        }`;
 
     return (
         <div
@@ -37,7 +50,9 @@ function TaskbarMenu(props) {
                 onClick={handleMinimize}
                 role="menuitem"
                 aria-label={props.minimized ? 'Restore Window' : 'Minimize Window'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                disabled={!hasContextApp}
+                aria-disabled={!hasContextApp}
+                className={buttonClass(!hasContextApp)}
             >
                 <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
             </button>
@@ -46,7 +61,9 @@ function TaskbarMenu(props) {
                 onClick={handleClose}
                 role="menuitem"
                 aria-label="Close Window"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                disabled={!hasContextApp}
+                aria-disabled={!hasContextApp}
+                className={buttonClass(!hasContextApp)}
             >
                 <span className="ml-5">Close</span>
             </button>

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -864,6 +864,9 @@ export class Desktop extends Component {
     }
 
     render() {
+        const contextApp = this.state.context_app
+            ? apps.find((app) => app.id === this.state.context_app)
+            : null;
         return (
             <main id="desktop" role="main" className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
 
@@ -916,13 +919,15 @@ export class Desktop extends Component {
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />
                 <AppMenu
                     active={this.state.context_menus.app}
-                    pinned={this.initFavourite[this.state.context_app]}
+                    pinned={Boolean(this.initFavourite[this.state.context_app])}
+                    contextApp={contextApp}
                     pinApp={() => this.pinApp(this.state.context_app)}
                     unpinApp={() => this.unpinApp(this.state.context_app)}
                     onClose={this.hideAllContextMenu}
                 />
                 <TaskbarMenu
                     active={this.state.context_menus.taskbar}
+                    contextApp={contextApp}
                     minimized={this.state.context_app ? this.state.minimized_windows[this.state.context_app] : false}
                     onMinimize={() => {
                         const id = this.state.context_app;

--- a/hooks/useRovingTabIndex.ts
+++ b/hooks/useRovingTabIndex.ts
@@ -15,16 +15,36 @@ export default function useRovingTabIndex(
     const node = ref.current;
     if (!node || !active) return;
 
-    const items = Array.from(
+    const allItems = Array.from(
       node.querySelectorAll<HTMLElement>(
         '[role="tab"], [role="menuitem"], [role="option"]'
       )
     );
-    if (items.length === 0) return;
+    if (allItems.length === 0) return;
+
+    const items = allItems.filter(
+      (el) =>
+        !el.hasAttribute('disabled') &&
+        el.getAttribute('aria-disabled') !== 'true'
+    );
+
+    if (items.length === 0) {
+      allItems.forEach((el) => {
+        el.tabIndex = -1;
+      });
+      return;
+    }
 
     let index = items.findIndex((el) => el.tabIndex === 0);
     if (index === -1) index = 0;
+    const enabledSet = new Set(items);
+
     items.forEach((el, i) => (el.tabIndex = i === index ? 0 : -1));
+    allItems.forEach((el) => {
+      if (!enabledSet.has(el)) {
+        el.tabIndex = -1;
+      }
+    });
 
     const handleKey = (e: KeyboardEvent) => {
       const forward = orientation === 'horizontal' ? ['ArrowRight', 'ArrowDown'] : ['ArrowDown'];


### PR DESCRIPTION
## Summary
- filter disabled elements out of the roving tab index hook so context menus skip ineligible options
- disable app and taskbar context menu actions when no selection is available and plumb the active app through the desktop shell
- debounce Minesweeper right-click flag toggles to avoid duplicate actions in fast-refresh scenarios

## Testing
- yarn lint *(fails: repository has pre-existing accessibility and no-top-level-window lint violations)*
- yarn test *(fails: existing Jest suites such as nmapNse.test.tsx and settingsStore hooks fail under jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68d356385ba88328a12b7bf4b69869da