### PR TITLE
[apps] lazy-load Monaco mini editor

### DIFF
--- a/__tests__/projectGallery.test.tsx
+++ b/__tests__/projectGallery.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, waitFor, within } from '@testing-library/rea
 import ProjectGallery from '../components/apps/project-gallery';
 
 jest.mock('react-ga4', () => ({ event: jest.fn() }));
-jest.mock('@monaco-editor/react', () => function MonacoEditorMock() {
+jest.mock('../components/apps/mini-editor', () => function MonacoEditorMock() {
   return <div />;
 });
 

--- a/components/apps/mini-editor/MonacoEditor.tsx
+++ b/components/apps/mini-editor/MonacoEditor.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import Editor, { loader } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+
+import 'monaco-editor/esm/vs/language/typescript/monaco.contribution';
+
+loader.config({ monaco });
+
+export default Editor;

--- a/components/apps/mini-editor/index.tsx
+++ b/components/apps/mini-editor/index.tsx
@@ -1,0 +1,40 @@
+import dynamic from 'next/dynamic';
+import type { FC } from 'react';
+import type { EditorProps } from '@monaco-editor/react';
+
+const Monaco = dynamic(() => import('./MonacoEditor'), {
+  ssr: false,
+  loading: () => (
+    <div
+      className="h-full w-full animate-pulse bg-black/40"
+      aria-hidden="true"
+    />
+  ),
+});
+
+const baseOptions: EditorProps['options'] = {
+  tabSize: 2,
+  minimap: { enabled: false },
+  automaticLayout: true,
+  scrollBeyondLastLine: false,
+};
+
+type MiniEditorProps = Omit<EditorProps, 'options'> & {
+  options?: EditorProps['options'];
+};
+
+const MiniEditor: FC<MiniEditorProps> = ({ options, ...props }) => {
+  const mergedOptions: EditorProps['options'] = {
+    ...baseOptions,
+    ...options,
+    minimap: {
+      ...baseOptions?.minimap,
+      ...(options?.minimap ?? {}),
+    },
+  };
+
+  return <Monaco {...props} options={mergedOptions} />;
+};
+
+export type { MiniEditorProps };
+export default MiniEditor;

--- a/components/apps/project-gallery.tsx
+++ b/components/apps/project-gallery.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import dynamic from 'next/dynamic';
 import projectsData from '../../data/projects.json';
+import MiniEditor from './mini-editor';
 
 interface Project {
   id: number;
@@ -20,8 +20,6 @@ interface Project {
 interface Props {
   openApp?: (id: string) => void;
 }
-
-const Editor = dynamic(() => import('@monaco-editor/react'), { ssr: false });
 
 const STORAGE_KEY = 'project-gallery-filters';
 const STORAGE_FILE = 'project-gallery-filters.json';
@@ -229,8 +227,10 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
         <div className="mb-4 overflow-auto">
           <table className="w-full text-sm text-left" role="table">
             <thead>
-              <tr>
-                <th />
+                <tr>
+                  <th scope="col">
+                    <span className="sr-only">Project attribute</span>
+                  </th>
                 {selected.map((p) => (
                   <th key={p.id}>{p.title}</th>
                 ))}
@@ -267,12 +267,12 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
                 loading="lazy"
               />
               <div className="w-full md:w-1/2 h-48">
-                <Editor
+                <MiniEditor
                   height="100%"
                   theme="vs-dark"
                   language={project.language}
                   value={project.snippet}
-                  options={{ readOnly: true, minimap: { enabled: false } }}
+                  options={{ readOnly: true }}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add a dedicated mini editor wrapper that lazy-loads Monaco and only registers the TypeScript/JavaScript worker
- update the project gallery to use the shared mini editor and improve the comparison table header accessibility
- adjust the project gallery unit test to mock the new wrapper

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window errors across legacy apps)*
- npx eslint components/apps/project-gallery.tsx components/apps/mini-editor/index.tsx components/apps/mini-editor/MonacoEditor.tsx __tests__/projectGallery.test.tsx
- yarn test *(fails: existing window keyboard handling test)*
- yarn test projectGallery


------
https://chatgpt.com/codex/tasks/task_e_68d3564c95908328b65fad3f3d734e14