### PR TITLE
[terminal] offload fake hash command to worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ play/pause and track controls include keyboard hotkeys.
 ### Terminal Commands
 - `clear` – clears the terminal display.
 - `help` – lists available commands.
+- `hash <text>` – simulates a long-running hashing routine in a worker.
 
 ### Games
 | Game | Route | Category |

--- a/apps/terminal/commands/index.ts
+++ b/apps/terminal/commands/index.ts
@@ -9,6 +9,7 @@ async function man(args: string, ctx: CommandContext) {
   const loaders: Record<string, () => Promise<string>> = {
     alias: () => fetch(new URL('../man/alias.txt', import.meta.url)).then((r) => r.text()),
     cat: () => fetch(new URL('../man/cat.txt', import.meta.url)).then((r) => r.text()),
+    hash: () => fetch(new URL('../man/hash.txt', import.meta.url)).then((r) => r.text()),
     grep: () => fetch(new URL('../man/grep.txt', import.meta.url)).then((r) => r.text()),
     history: () => fetch(new URL('../man/history.txt', import.meta.url)).then((r) => r.text()),
     jq: () => fetch(new URL('../man/jq.txt', import.meta.url)).then((r) => r.text()),
@@ -44,6 +45,8 @@ const registry: Record<string, CommandHandler> = {
   cat: (args, ctx) => ctx.runWorker(`cat ${args}`),
   grep: (args, ctx) => ctx.runWorker(`grep ${args}`),
   jq: (args, ctx) => ctx.runWorker(`jq ${args}`),
+  hash: (args, ctx) =>
+    ctx.runWorker(args.trim() ? `hash ${args}` : 'hash'),
 };
 
 export default registry;

--- a/apps/terminal/man/hash.txt
+++ b/apps/terminal/man/hash.txt
@@ -1,0 +1,15 @@
+HASH
+    Simulate a CPU-intensive hashing run without blocking the UI.
+
+SYNOPSIS
+    hash <text>
+    <command> | hash
+
+DESCRIPTION
+    Runs a fake hashing routine inside a Web Worker. The worker performs
+    heavy computation in chunks and streams progress back to the terminal,
+    demonstrating how long-running tasks can stay responsive.
+
+EXAMPLES
+    hash secret
+    cat payload.txt | hash


### PR DESCRIPTION
## Summary
- add a hash manual entry and route the command through the terminal worker
- extend the terminal worker with a CPU-bound hash simulation that streams progress
- document the new command in the README

## Testing
- yarn lint *(fails: existing accessibility and window globals errors)*
- yarn test *(fails: pre-existing act/localStorage/contact suite issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d35655f78c8328a60ab12d0980f875