### PR TITLE
[project-gallery] cache GitHub API requests and rate-limit banner

### DIFF
--- a/__tests__/GitHubStars.test.tsx
+++ b/__tests__/GitHubStars.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import GitHubStars from '../components/GitHubStars';
+
+const originalFetch = global.fetch;
+
+describe('GitHubStars', () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    fetchMock = jest.fn();
+    (global as any).fetch = fetchMock;
+    class IntersectionObserverMock implements IntersectionObserver {
+      readonly root: Element | Document | null = null;
+      readonly rootMargin: string = '0px';
+      readonly thresholds: ReadonlyArray<number> = [];
+      private callback: IntersectionObserverCallback;
+
+      constructor(callback: IntersectionObserverCallback) {
+        this.callback = callback;
+      }
+
+      observe(target: Element) {
+        this.callback([{ isIntersecting: true, target } as IntersectionObserverEntry], this);
+      }
+
+      unobserve() {}
+
+      disconnect() {}
+
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    }
+
+    (global as any).IntersectionObserver = IntersectionObserverMock;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    fetchMock.mockReset();
+    (global as any).fetch = originalFetch;
+    delete (global as any).IntersectionObserver;
+  });
+
+  it('backs off when the GitHub API returns 403 and shows a banner', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: jest.fn(),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({ stargazers_count: 42 }),
+      });
+
+    render(<GitHubStars user="alex" repo="portfolio" />);
+
+    const banner = await screen.findByRole('alert');
+    expect(banner).toHaveTextContent(/rate limited/i);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await screen.findByText('⭐ 42');
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+  });
+});

--- a/components/GitHubStars.js
+++ b/components/GitHubStars.js
@@ -1,25 +1,66 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import usePersistentState from '../hooks/usePersistentState';
 
+const BASE_BACKOFF = 1000;
+const MAX_BACKOFF = 60_000;
+
 const GitHubStars = ({ user, repo }) => {
   const ref = useRef(null);
   const [visible, setVisible] = useState(false);
   const [stars, setStars] = usePersistentState(`gh-stars-${user}/${repo}`, null);
   const [loading, setLoading] = useState(stars === null);
+  const [rateLimited, setRateLimited] = useState(false);
+  const retryTimer = useRef(null);
+  const retryAttempt = useRef(0);
+  const inFlight = useRef(false);
+
+  const scheduleRetry = useCallback(
+    (retryFn) => {
+      if (retryTimer.current) {
+        clearTimeout(retryTimer.current);
+      }
+      const attempt = retryAttempt.current;
+      const delay = Math.min(MAX_BACKOFF, BASE_BACKOFF * 2 ** attempt);
+      retryAttempt.current = attempt + 1;
+      retryTimer.current = setTimeout(() => {
+        retryTimer.current = null;
+        retryFn();
+      }, delay);
+    },
+    [],
+  );
 
   const fetchStars = useCallback(async () => {
+    if (!repo || inFlight.current) {
+      return;
+    }
+    inFlight.current = true;
     try {
       setLoading(true);
       const res = await fetch(`https://api.github.com/repos/${user}/${repo}`);
-      if (!res.ok) throw new Error('Request failed');
+      if (res.status === 403) {
+        setRateLimited(true);
+        scheduleRetry(fetchStars);
+        return;
+      }
+      if (!res.ok) {
+        throw new Error('Request failed');
+      }
       const data = await res.json();
       setStars(data.stargazers_count || 0);
+      setRateLimited(false);
+      retryAttempt.current = 0;
+      if (retryTimer.current) {
+        clearTimeout(retryTimer.current);
+        retryTimer.current = null;
+      }
     } catch (e) {
       console.error('Failed to fetch star count', e);
     } finally {
+      inFlight.current = false;
       setLoading(false);
     }
-  }, [user, repo, setStars]);
+  }, [user, repo, setStars, scheduleRetry]);
 
   useEffect(() => {
     const observer = new IntersectionObserver((entries) => {
@@ -41,24 +82,50 @@ const GitHubStars = ({ user, repo }) => {
     }
   }, [visible, stars, fetchStars]);
 
+  useEffect(() => () => {
+    if (retryTimer.current) {
+      clearTimeout(retryTimer.current);
+    }
+  }, []);
+
   if (!repo) return null;
 
+  const starValue = typeof stars === 'number' ? stars : '--';
+
   return (
-    <div ref={ref} className="inline-flex items-center text-xs text-gray-300">
-      {loading ? (
-        <div className="h-5 w-12 bg-gray-200 animate-pulse rounded" />
-      ) : (
-        <>
-          <span>⭐ {stars}</span>
-          <button
-            onClick={fetchStars}
-            aria-label="Refresh star count"
-            className="ml-2 text-gray-400 hover:text-white"
-          >
-            ↻
-          </button>
-        </>
+    <div
+      ref={ref}
+      className="inline-flex flex-col text-xs text-gray-300 space-y-1"
+    >
+      {rateLimited && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="flex items-center gap-2 rounded border border-amber-400/30 bg-amber-500/10 px-2 py-1 text-amber-200"
+        >
+          <span aria-hidden="true">⚠️</span>
+          <span>Rate limited by GitHub API. Retrying soon…</span>
+        </div>
       )}
+      <div className="inline-flex items-center">
+        {loading ? (
+          <div className="h-5 w-12 animate-pulse rounded bg-gray-200" />
+        ) : (
+          <>
+            <span>⭐ {starValue}</span>
+            <button
+              type="button"
+              onClick={fetchStars}
+              aria-label="Refresh star count"
+              className="ml-2 text-gray-400 transition hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={loading || rateLimited}
+              title={rateLimited ? 'GitHub API rate limited' : 'Refresh star count'}
+            >
+              ↻
+            </button>
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/next.config.js
+++ b/next.config.js
@@ -61,6 +61,22 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
 
+const githubApiRuntimeCaching = {
+  urlPattern: /^https:\/\/api\.github\.com\/repos\/.*/i,
+  handler: 'NetworkFirst',
+  options: {
+    cacheName: 'github-api',
+    networkTimeoutSeconds: 3,
+    cacheableResponse: {
+      statuses: [0, 200],
+    },
+    expiration: {
+      maxEntries: 32,
+      maxAgeSeconds: 60 * 60,
+    },
+  },
+};
+
 const withPWA = require('@ducanh2912/next-pwa').default({
   dest: 'public',
   sw: 'sw.js',
@@ -81,6 +97,7 @@ const withPWA = require('@ducanh2912/next-pwa').default({
       { url: '/offline.html', revision: null },
       { url: '/manifest.webmanifest', revision: null },
     ],
+    runtimeCaching: [githubApiRuntimeCaching],
   },
 });
 


### PR DESCRIPTION
## Summary
- add a Workbox runtime caching rule for GitHub repo requests with a 3 s NetworkFirst timeout
- enhance the GitHubStars widget with exponential backoff, retry cleanup, and a visible rate limit banner
- cover the new rate limit behaviour with a dedicated Jest test

## Testing
- yarn lint *(fails: existing accessibility and top-level window lint violations across unrelated files)*
- yarn test *(fails: pre-existing suite failures unrelated to this change)*
- yarn test __tests__/GitHubStars.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d356638b108328b2d42267ef7b995c