### PR TITLE
[apps] Harden QR validation and offline caching

### DIFF
--- a/__tests__/qrValidation.test.ts
+++ b/__tests__/qrValidation.test.ts
@@ -1,0 +1,36 @@
+import {
+  MAX_QR_PAYLOAD_LENGTH,
+  parseBatchCsv,
+  validateQrText,
+} from '../utils/qrValidation';
+
+describe('QR validation helpers', () => {
+  it('validates non-empty payloads', () => {
+    const result = validateQrText('hello world');
+    expect(result.ok).toBe(true);
+    expect(result.sanitized).toBe('hello world');
+  });
+
+  it('rejects empty or whitespace payloads', () => {
+    const result = validateQrText('   ');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Enter text to encode.');
+  });
+
+  it('rejects payloads longer than the maximum', () => {
+    const input = 'x'.repeat(MAX_QR_PAYLOAD_LENGTH + 1);
+    const result = validateQrText(input);
+    expect(result.ok).toBe(false);
+    expect(result?.error).toContain(`${MAX_QR_PAYLOAD_LENGTH}`);
+  });
+
+  it('parses CSV batches with errors', () => {
+    const csv = ['good,first', ',', 'bad'].join('\n');
+    const { items, errors } = parseBatchCsv(csv);
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({ name: 'first', value: 'good' });
+    expect(items[1]).toMatchObject({ name: 'code-3', value: 'bad' });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Line 2');
+  });
+});

--- a/next.config.js
+++ b/next.config.js
@@ -78,8 +78,45 @@ const withPWA = require('@ducanh2912/next-pwa').default({
       { url: '/apps/weather', revision: null },
       { url: '/apps/terminal', revision: null },
       { url: '/apps/checkers', revision: null },
+      { url: '/apps/qr', revision: null },
+      { url: '/apps/converter', revision: null },
       { url: '/offline.html', revision: null },
       { url: '/manifest.webmanifest', revision: null },
+      { url: '/qr', revision: null },
+      { url: '/qr/vcard', revision: null },
+    ],
+    runtimeCaching: [
+      {
+        urlPattern: ({ url }) => {
+          const path = url.pathname;
+          return (
+            path.startsWith('/_next/static/chunks/pages/apps/qr') ||
+            path.startsWith('/_next/static/chunks/pages/qr') ||
+            path.startsWith('/_next/static/chunks/pages/apps/converter')
+          );
+        },
+        handler: 'CacheFirst',
+        options: {
+          cacheName: 'qr-and-converter-bundles',
+          expiration: {
+            maxEntries: 6,
+            maxAgeSeconds: 7 * 24 * 60 * 60,
+          },
+        },
+      },
+      {
+        urlPattern: ({ url }) =>
+          url.pathname.startsWith('/apps/qr') ||
+          url.pathname.startsWith('/apps/converter'),
+        handler: 'StaleWhileRevalidate',
+        options: {
+          cacheName: 'app-shell-pages',
+          expiration: {
+            maxEntries: 8,
+            maxAgeSeconds: 7 * 24 * 60 * 60,
+          },
+        },
+      },
     ],
   },
 });

--- a/utils/qrValidation.ts
+++ b/utils/qrValidation.ts
@@ -1,0 +1,80 @@
+export const MAX_QR_PAYLOAD_LENGTH = 1200;
+export const MAX_BATCH_ITEMS = 50;
+
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001F\u007F]/g;
+const FILENAME_SAFE = /[^a-z0-9-_]+/gi;
+
+export interface ValidationResult {
+  ok: boolean;
+  sanitized: string;
+  error?: string;
+}
+
+export const normalizeInput = (value: string): string => value.replace(/\r\n?/g, '\n');
+
+export const sanitizeInput = (value: string): string =>
+  normalizeInput(value).replace(CONTROL_CHAR_PATTERN, '');
+
+export const validateQrText = (raw: string): ValidationResult => {
+  const sanitized = sanitizeInput(raw);
+  const hasContent = sanitized.trim().length > 0;
+  if (!hasContent) {
+    return { ok: false, sanitized, error: 'Enter text to encode.' };
+  }
+  if (sanitized.length > MAX_QR_PAYLOAD_LENGTH) {
+    return {
+      ok: false,
+      sanitized,
+      error: `Limit QR payloads to ${MAX_QR_PAYLOAD_LENGTH} characters.`,
+    };
+  }
+  return { ok: true, sanitized };
+};
+
+export const escapeWifiValue = (value: string): string =>
+  sanitizeInput(value).replace(/[\\;:,\"]/g, '\\$&');
+
+export interface ParsedBatchItem {
+  value: string;
+  name: string;
+  line: number;
+}
+
+export interface BatchParseResult {
+  items: ParsedBatchItem[];
+  errors: string[];
+}
+
+const sanitizeName = (raw: string, fallback: string): string => {
+  const cleaned = sanitizeInput(raw).trim();
+  if (!cleaned) return fallback;
+  return cleaned.replace(FILENAME_SAFE, '-').replace(/-+/g, '-').slice(0, 64);
+};
+
+export const parseBatchCsv = (csv: string): BatchParseResult => {
+  const lines = normalizeInput(csv)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const errors: string[] = [];
+  if (!lines.length) {
+    return { items: [], errors: ['Add at least one row in the batch CSV.'] };
+  }
+  if (lines.length > MAX_BATCH_ITEMS) {
+    errors.push(`Batch limit is ${MAX_BATCH_ITEMS} rows.`);
+  }
+  const limited = lines.slice(0, MAX_BATCH_ITEMS);
+  const items: ParsedBatchItem[] = [];
+  limited.forEach((line, index) => {
+    const lineNumber = index + 1;
+    const [valueCol, nameCol] = line.split(',', 2);
+    const { ok, sanitized, error } = validateQrText(valueCol || '');
+    if (!ok) {
+      errors.push(`Line ${lineNumber}: ${error ?? 'Invalid value.'}`);
+      return;
+    }
+    const name = sanitizeName(nameCol ?? '', `code-${lineNumber}`);
+    items.push({ value: sanitized, name, line: lineNumber });
+  });
+  return { items, errors };
+};


### PR DESCRIPTION
## Summary
- introduce shared QR validation utilities to sanitize payloads and parse batch CSV safely
- tighten QR tool, presets, and scanner UI with aggressive validation, accessible controls, and offline-friendly behavior
- add numeric range checks to the converter and precache QR/converter bundles for offline use

## Testing
- yarn lint *(fails: repo-wide jsx-a11y/no-top-level rules in existing apps)*
- npx eslint components/apps/qr_tool/index.tsx apps/qr/index.tsx apps/qr/components/Presets.tsx apps/qr/components/Scan.tsx apps/converter/index.tsx utils/qrValidation.ts __tests__/qrValidation.test.ts
- yarn test *(fails: existing window snapping and Nmap NSE tests in suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d3566b875483288f0edb7fe6703087