### PR TITLE
[chess] Lazy Stockfish worker analysis

### DIFF
--- a/workers/stockfish.worker.ts
+++ b/workers/stockfish.worker.ts
@@ -1,0 +1,118 @@
+type StockfishCommandMessage = { type: 'command'; command: string };
+type StockfishAnalyzeMessage = {
+  type: 'analyze';
+  fen: string;
+  depth: number;
+  multiPv?: number;
+};
+type StockfishStopMessage = { type: 'stop' };
+type StockfishQuitMessage = { type: 'quit' };
+
+type StockfishStructuredMessage =
+  | StockfishCommandMessage
+  | StockfishAnalyzeMessage
+  | StockfishStopMessage
+  | StockfishQuitMessage;
+
+export type StockfishWorkerRequest = StockfishStructuredMessage | string;
+export type StockfishWorkerResponse = string;
+
+type StockfishInstance = {
+  postMessage: (command: string) => void;
+  addMessageListener: (listener: (line: string) => void) => void;
+};
+
+type StockfishFactory = () => Promise<StockfishInstance>;
+
+let enginePromise: Promise<StockfishInstance> | null = null;
+
+const loadEngine = async (): Promise<StockfishInstance> => {
+  if (!enginePromise) {
+    enginePromise = import('stockfish')
+      .then(async (module: unknown) => {
+        const resolved = module as { default?: StockfishFactory };
+        const factory: StockfishFactory =
+          typeof resolved.default === 'function'
+            ? resolved.default
+            : (resolved as unknown as StockfishFactory);
+        const instance = await factory();
+        instance.addMessageListener((line: string) => {
+          self.postMessage(line as StockfishWorkerResponse);
+        });
+        return instance;
+      })
+      .catch((error) => {
+        enginePromise = null;
+        throw error;
+      });
+  }
+  return enginePromise;
+};
+
+const forwardCommand = async (command: string) => {
+  if (!command) return;
+  try {
+    const engine = await loadEngine();
+    engine.postMessage(command);
+  } catch {
+    // Ignore errors during initialization.
+  }
+};
+
+self.onmessage = async ({ data }: MessageEvent<StockfishWorkerRequest>) => {
+  if (typeof data === 'string') {
+    await forwardCommand(data);
+    return;
+  }
+
+  if (!data) return;
+
+  if (data.type === 'quit') {
+    const promise = enginePromise;
+    enginePromise = null;
+    if (promise) {
+      try {
+        const engine = await promise;
+        engine.postMessage('quit');
+      } catch {
+        // Ignore errors while shutting down.
+      }
+    }
+    self.close();
+    return;
+  }
+
+  if (data.type === 'stop') {
+    if (enginePromise) {
+      try {
+        const engine = await enginePromise;
+        engine.postMessage('stop');
+      } catch {
+        // Ignore
+      }
+    }
+    return;
+  }
+
+  if (data.type === 'command') {
+    await forwardCommand(data.command);
+    return;
+  }
+
+  if (data.type === 'analyze') {
+    const { fen, depth, multiPv } = data;
+    try {
+      const engine = await loadEngine();
+      const cappedDepth = Number.isFinite(depth) ? Math.max(1, Math.floor(depth)) : 12;
+      const option = typeof multiPv === 'number' ? Math.max(1, Math.floor(multiPv)) : 3;
+      engine.postMessage('stop');
+      engine.postMessage(`setoption name MultiPV value ${option}`);
+      engine.postMessage(`position fen ${fen}`);
+      engine.postMessage(`go depth ${cappedDepth}`);
+    } catch {
+      // Ignore analysis errors
+    }
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- instantiate the Stockfish engine from a dedicated worker when the Chess app opens and forward engine output back to the UI
- drive run-time analysis from the worker so the move suggestions and evaluation bar use Stockfish scores, including mate announcements
- reset analysis state and stop the worker when the board resets

## Testing
- yarn lint *(fails: repository has pre-existing accessibility violations across many apps)*
- yarn test *(fails: known window and nmap suites fail locally)*

------
https://chatgpt.com/codex/tasks/task_e_68d356ad5190832899619cb6061a90e9