### PR TITLE
[utils] Add hover prefetch for dynamic apps

### DIFF
--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -2,22 +2,27 @@ import React from 'react';
 import dynamic from 'next/dynamic';
 import { logEvent } from './analytics';
 
-export const createDynamicApp = (id, title) =>
-  dynamic(
+export const createDynamicApp = (id, title) => {
+  const loadModule = () =>
+    import(
+      /* webpackPrefetch: true */ `../components/apps/${id}`
+    );
+
+  const DynamicComponent = dynamic(
     async () => {
       try {
-        const mod = await import(
-          /* webpackPrefetch: true */ `../components/apps/${id}`
-        );
+        const mod = await loadModule();
         logEvent({ category: 'Application', action: `Loaded ${title}` });
         return mod.default;
       } catch (err) {
         console.error(`Failed to load ${title}`, err);
-        return () => (
+        const ErrorFallback = () => (
           <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
             {`Unable to load ${title}`}
           </div>
         );
+        ErrorFallback.displayName = `${title}LoadError`;
+        return ErrorFallback;
       }
     },
     {
@@ -30,6 +35,14 @@ export const createDynamicApp = (id, title) =>
     }
   );
 
+  DynamicComponent.prefetch = () =>
+    loadModule().catch((err) => {
+      console.error(`Failed to prefetch ${title}`, err);
+    });
+
+  return DynamicComponent;
+};
+
 export const createDisplay = (Component) => {
   const DynamicComponent = dynamic(() => Promise.resolve({ default: Component }), {
     ssr: false,
@@ -39,9 +52,15 @@ export const createDisplay = (Component) => {
   );
 
   Display.prefetch = () => {
-    if (typeof Component.preload === 'function') {
-      Component.preload();
+    if (typeof Component.prefetch === 'function') {
+      return Component.prefetch();
     }
+
+    if (typeof Component.preload === 'function') {
+      return Component.preload();
+    }
+
+    return undefined;
   };
 
   return Display;


### PR DESCRIPTION
## Summary
- reuse a shared loader in `createDynamicApp` so each dynamic app can expose a `prefetch` helper
- attach the helper to both the dynamic component and `createDisplay` so tiles can trigger hover prefetch
- give the load-error fallback a display name to satisfy eslint

## Testing
- yarn lint *(fails: repository has 570+ existing accessibility lint errors)*
- yarn eslint utils/createDynamicApp.js
- yarn test *(fails: existing suites like `__tests__/nmapNse.test.tsx` still fail)*

------
https://chatgpt.com/codex/tasks/task_e_68d356f47750832884f8da2399e2b4c7