### PR TITLE
[docs] add backlog of portfolio tasks

### DIFF
--- a/docs/task-backlog.md
+++ b/docs/task-backlog.md
@@ -1,0 +1,65 @@
+# Project Task Backlog
+
+The following numbered backlog captures incremental improvements and investigations for the Kali Linux Portfolio experience.
+
+1. Audit the desktop window manager to ensure focus handling works consistently with keyboard navigation and screen readers.
+2. Refactor the dock component to lazy-load icons and reduce initial bundle size without regressing hover previews.
+3. Implement a global theming toggle that lets users switch between light, dark, and high-contrast variants of the desktop skin.
+4. Add persistent window layout saving so reopened sessions restore window positions and sizes using local storage.
+5. Improve drag-and-drop performance on touch devices by debouncing pointer events and adding tactile feedback animations.
+6. Create a contextual help overlay that explains the desktop controls and can be summoned with a keyboard shortcut.
+7. Expand the right-click context menu with shortcuts for "Open in New Window" and "Add to Favorites" actions.
+8. Build a notification center widget that aggregates simulated system alerts and recent activity logs.
+9. Optimize the background wallpaper loader to support responsive sources and blur-up placeholders.
+10. Add multi-monitor simulation by allowing the desktop canvas to pan across an extended virtual workspace.
+11. Update the terminal app simulation with additional canned commands that teach common Kali Linux workflows.
+12. Enhance the file explorer app with sortable table columns and breadcrumb navigation for nested directories.
+13. Introduce a package manager simulation that lists curated security tools with descriptions and mock install logs.
+14. Build a clipboard manager utility app showing recent copied snippets and allowing pinned entries.
+15. Add a screenshot tool that captures the current desktop state and downloads an image locally.
+16. Create a process monitor simulation visualizing CPU, memory, and network graphs sourced from mock data.
+17. Implement a task scheduler UI that lets users configure reminders and timed demo tasks within the desktop.
+18. Expand the retro game catalog with a pixel-art puzzle game that teaches cybersecurity concepts.
+19. Update the music player app with playlist support and waveform visualizations using client-side audio APIs.
+20. Add a markdown notes app featuring syntax highlighting, export options, and simulated collaborative editing.
+21. Write an interactive tutorial that guides newcomers through launching, resizing, and closing desktop apps.
+22. Produce a walkthrough for configuring the simulated VPN app, highlighting best practices without real network calls.
+23. Create an in-app changelog viewer that surfaces recent release notes pulled from the repo's data directory.
+24. Design a security awareness quiz app with randomized questions and shareable results.
+25. Build a phishing email analyzer simulation that teaches users how to spot malicious indicators in sample messages.
+26. Add a "Red Team vs Blue Team" scenario selector that launches curated sets of simulated tools and logs.
+27. Implement a vulnerability management dashboard with mock CVE feeds and prioritization filters.
+28. Create a forensics lab simulation where users inspect disk images through guided steps and canned evidence.
+29. Develop a wireless auditing tutorial that explains terminology and shows simulated scan outputs.
+30. Add a password cracking workshop that visualizes entropy, cracking speeds, and defense strategies without real attacks.
+31. Perform an accessibility audit of all interactive components and document fixes in an actionable checklist.
+32. Add focus-visible styling to every desktop control to improve navigation clarity for keyboard users.
+33. Implement reduced-motion preferences that disable non-essential animations when the OS setting is detected.
+34. Ensure high-contrast themes meet WCAG color contrast ratios across window chrome and content areas.
+35. Localize core UI strings into at least two additional languages with a language switcher accessible from the dock.
+36. Provide RTL layout support for applicable languages by adjusting desktop alignment and window chrome.
+37. Optimize bundle splitting to isolate rarely used apps from the primary desktop shell chunk.
+38. Replace large raster assets with vector or responsive alternatives to improve Lighthouse performance scores.
+39. Instrument performance markers around window creation and report metrics to the analytics wrapper when enabled.
+40. Implement service worker caching strategies tailored for app shell assets versus dynamic data JSON files.
+41. Expand unit test coverage for window management reducers and ensure edge cases are captured.
+42. Add integration tests that verify app launch sequences, focus transitions, and dock pinning behaviors.
+43. Configure automated visual regression tests for key desktop states using Playwright and percy-like snapshots.
+44. Create smoke test scripts that crawl every `/apps/*` route and validate essential elements render in static export.
+45. Set up Git hooks that run linting and unit tests on staged files to prevent regressions entering the repo.
+46. Document the process for generating mock data so contributors can extend simulations without live services.
+47. Draft contributor guidelines that highlight coding conventions, testing requirements, and review expectations.
+48. Build a status dashboard page summarizing test coverage, bundle sizes, and recent deployment health.
+49. Integrate Lighthouse CI in the pipeline to track performance and accessibility budgets over time.
+50. Automate changelog generation from conventional commits to streamline release notes.
+51. Produce marketing copy for each flagship app and surface it in the portfolio's projects section.
+52. Add storytelling content that contextualizes Kali Linux's role in ethical hacking and cybersecurity education.
+53. Refresh the hero section of the public landing page with updated visuals and a concise value proposition.
+54. Create case-study pages describing how different personas might use the simulated desktop environment.
+55. Prepare a media kit with downloadable screenshots, logos, and brand guidelines for press outreach.
+56. Draft a blog post series covering behind-the-scenes architecture decisions and technical learnings.
+57. Build a mailing list signup module that integrates with a static-friendly provider via client-side API calls.
+58. Design a release roadmap graphic that can be embedded on the site or shared externally.
+59. Capture and document user feedback from playtests, synthesizing insights into actionable improvements.
+60. Plan a community livestream event showcasing new features, complete with demo scripts and Q&A resources.
+


### PR DESCRIPTION
## Summary
- add a documentation page that enumerates 60 prospective improvements for the Kali Linux Portfolio experience
- cover desktop shell, application simulations, accessibility, testing, and content initiatives in the backlog

## Testing
- yarn lint *(fails: repository has hundreds of pre-existing accessibility lint violations)*
- yarn test *(partially executes then hangs; multiple suites already fail in the current baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68d376fc583c83288d6918e70a4a6d6c