### PR TITLE
[config] update vercel node runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
-    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
+    "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
+    "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
   }
 }


### PR DESCRIPTION
## Summary
- set both pages and app route functions to use the Node.js 20 runtime in `vercel.json`

## Testing
- not run (config change only)


------
https://chatgpt.com/codex/tasks/task_e_68d5d7ecdf248328a290c2f4179089da