### PR TITLE
ci: verify next version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: node scripts/check-next-version.mjs
 
   lint:
     runs-on: ubuntu-latest
@@ -24,6 +25,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: node scripts/check-next-version.mjs
       - run: npm run lint
 
   typecheck:
@@ -36,6 +38,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: node scripts/check-next-version.mjs
       - run: npm run tsc -- --noEmit
 
   test:
@@ -48,6 +51,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: node scripts/check-next-version.mjs
       - run: yarn test --coverage
 
   security:
@@ -60,6 +64,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: node scripts/check-next-version.mjs
       - run: yarn npm audit
 
   vercel-preview:
@@ -76,6 +81,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: node scripts/check-next-version.mjs
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/scripts/check-next-version.mjs
+++ b/scripts/check-next-version.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const EXPECTED_VERSION = '15.5.2';
+
+const result = spawnSync('yarn', ['why', 'next'], { encoding: 'utf8' });
+
+if (result.error) {
+  console.error('Failed to execute "yarn why next":', result.error);
+  process.exit(1);
+}
+
+const output = `${result.stdout}${result.stderr}`;
+
+const match = output.match(/next@npm:([^\s]+)/);
+
+if (!match) {
+  console.error('Unable to determine the resolved Next.js version from "yarn why next" output.');
+  console.error('Command output:\n', output.trim());
+  process.exit(1);
+}
+
+const resolvedVersion = match[1];
+
+if (resolvedVersion !== EXPECTED_VERSION) {
+  console.error(
+    `Unexpected Next.js version resolved. Expected ${EXPECTED_VERSION}, but found ${resolvedVersion}.`
+  );
+  console.error('Command output:\n', output.trim());
+  process.exit(1);
+}
+
+console.log(`Next.js version check passed: ${resolvedVersion}`);


### PR DESCRIPTION
## Summary
- add a reusable script that asserts the resolved Next.js version
- hook the version check into every CI job immediately after dependency installation

## Testing
- node scripts/check-next-version.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d5d7eddb28832880b121ae24a8e6f7