### PR TITLE
[ci] use yarn lint in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: npm run lint
+      - run: yarn lint
 
   typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- switch the lint job in the CI workflow to run `yarn lint` so the Yarn script enforces `--max-warnings=0`

## Testing
- `yarn lint` *(fails: existing lint errors in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d7f0ad1c832898e3f35101e859fa