### PR TITLE
[ci] align typecheck command with yarn script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: npm run tsc -- --noEmit
+      - run: yarn typecheck
 
   test:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:watch": "jest --watch",
     "lint": "eslint . --max-warnings=0",
     "tsc": "tsc",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "a11y": "node scripts/a11y.mjs",
     "smoke": "node scripts/smoke-all-apps.mjs",
     "module-report": "node scripts/generate-module-report.mjs",


### PR DESCRIPTION
## Summary
- point the typecheck script at tsconfig.json while disabling emit
- update the CI workflow to run the yarn typecheck script

## Testing
- yarn typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5d7f1cb1c832888222d53d9e8d4e6