### PR TITLE
[ci] expand verify pipeline gating

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "next start",
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build",
     "test": "jest",
+    "dedupe:check": "yarn dedupe --check",
     "test:watch": "jest --watch",
     "lint": "eslint . --max-warnings=0",
     "tsc": "tsc",

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1,32 +1,66 @@
 import { execSync, spawn } from 'child_process';
+import fs from 'fs';
 import { createRequire } from 'module';
-import net from 'net';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import waitOn from 'wait-on';
 
 const require = createRequire(import.meta.url);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
 
-const run = (cmd, args = [], opts = {}) => new Promise((resolve, reject) => {
-  const child = spawn(cmd, args, { stdio: 'inherit', ...opts });
-  child.on('exit', (code) => {
-    if (code === 0) {
-      resolve();
-    } else {
-      reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
-    }
-  });
-});
-
-const getPort = () =>
+const run = (cmd, args = [], opts = {}) =>
   new Promise((resolve, reject) => {
-    const srv = net.createServer();
-    srv.listen(0, () => {
-      const { port } = srv.address();
-      srv.close(() => resolve(port));
+    const child = spawn(cmd, args, { stdio: 'inherit', ...opts });
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      }
     });
-    srv.on('error', reject);
   });
+
+const scriptExists = (name) => Boolean(packageJson.scripts?.[name]);
+
+const runYarnScript = async (scriptNames, { optional = false, fallbackArgs, env = {} } = {}) => {
+  const names = Array.isArray(scriptNames) ? scriptNames : [scriptNames];
+  const scriptName = names.find((name) => scriptExists(name));
+
+  if (scriptName) {
+    await run('yarn', [scriptName], { env: { ...process.env, ...env } });
+    return true;
+  }
+
+  if (fallbackArgs) {
+    await run('yarn', fallbackArgs, { env: { ...process.env, ...env } });
+    return true;
+  }
+
+  if (optional) {
+    console.log(`Skipping ${names.join(' / ')} (no script configured)`);
+    return false;
+  }
+
+  throw new Error(`Required script not found: ${names[0]}`);
+};
+
+const runStage = async (label, fn) => {
+  console.log(`\n=== ${label} ===`);
+  try {
+    await fn();
+    console.log(`✓ ${label}`);
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    err.message = `${label}: ${err.message}`;
+    throw err;
+  }
+};
 
 (async () => {
+  let server;
   try {
     const yarnVersion = execSync('yarn --version', { encoding: 'utf8' }).trim();
     const nextVersion = require('next/package.json').version;
@@ -34,32 +68,78 @@ const getPort = () =>
     console.log(`yarn: ${yarnVersion}`);
     console.log(`next: ${nextVersion}`);
 
-    await run('yarn', ['install', '--immutable']);
-    await run('yarn', ['lint']);
-    await run('yarn', ['tsc', '--noEmit']);
-    await run('yarn', ['build']);
+    await runStage('Install dependencies', () => run('yarn', ['install', '--immutable']));
+    await runStage('Check dependency dedupe', () =>
+      runYarnScript('dedupe:check', { fallbackArgs: ['dedupe', '--check'] }),
+    );
+    await runStage('Lint', () => runYarnScript('lint'));
+    await runStage('Typecheck', () => runYarnScript('typecheck', { fallbackArgs: ['tsc', '--noEmit'] }));
+    await runStage('Unit tests', () => runYarnScript('test', { env: { CI: '1' } }));
+    await runStage('Build', () => runYarnScript('build'));
 
-    const port = await getPort();
-    const server = spawn('yarn', ['start', '-p', String(port)], { stdio: 'inherit' });
-    process.on('exit', () => server.kill());
-    await waitOn({ resources: [`http://localhost:${port}`], timeout: 60000 });
+    const port = Number(process.env.VERIFY_PORT ?? 3000);
+    const baseUrl = `http://localhost:${port}`;
+
+    await runStage('Start production server', async () => {
+      server = spawn('yarn', ['start', '-p', String(port)], { stdio: 'inherit' });
+      process.on('exit', () => {
+        if (server) {
+          server.kill();
+        }
+      });
+      await waitOn({ resources: [baseUrl], timeout: 60000 });
+    });
+
+    await runStage('Smoke tests', () =>
+      runYarnScript('smoke', { env: { BASE_URL: baseUrl } }),
+    );
+
+    await runStage('Pa11y accessibility scan', () =>
+      runYarnScript('a11y', { env: { BASE_URL: baseUrl } }),
+    );
+
+    await runStage('Bundle budget checks', async () => {
+      const executed = await runYarnScript(['bundle-budget', 'bundle:budget', 'budget:check'], {
+        optional: true,
+        env: { BASE_URL: baseUrl },
+      });
+      if (!executed) {
+        console.log('No bundle budget script configured; skipping.');
+      }
+    });
+
+    await runStage('Lighthouse audit', async () => {
+      const executed = await runYarnScript(['lighthouse', 'lhci', 'perf:lighthouse'], {
+        optional: true,
+        env: { BASE_URL: baseUrl },
+      });
+      if (!executed) {
+        console.log('No Lighthouse script configured; skipping.');
+      }
+    });
 
     const routes = ['/', '/dummy-form', '/video-gallery', '/profile'];
-    for (const route of routes) {
-      const res = await fetch(`http://localhost:${port}${route}`);
-      const header = res.headers.get('x-powered-by');
-      if (res.status !== 200 || header !== 'Next.js') {
-        throw new Error(`Route ${route} failed: status ${res.status}, header ${header}`);
+    await runStage('Route smoke check', async () => {
+      for (const route of routes) {
+        const url = `${baseUrl}${route}`;
+        const res = await fetch(url);
+        const header = res.headers.get('x-powered-by');
+        if (res.status !== 200 || header !== 'Next.js') {
+          throw new Error(`Route ${route} failed: status ${res.status}, header ${header}`);
+        }
+        console.log(`✓ ${route}`);
       }
-      console.log(`✓ ${route}`);
-    }
+    });
 
-    console.log('verify: PASS');
-    server.kill();
+    console.log('\nverify: PASS');
   } catch (err) {
-    console.error('verify: FAIL');
+    console.error('\nverify: FAIL');
     console.error(err);
-    process.exit(1);
+    process.exitCode = 1;
+  } finally {
+    if (server) {
+      server.kill();
+    }
   }
 })();
 


### PR DESCRIPTION
## Summary
- expand `scripts/verify.mjs` to orchestrate dependency install, linting, type checks, tests, build, server smoke checks, Pa11y, and optional bundle budget/Lighthouse stages with fail-fast handling
- add a `dedupe:check` yarn script so the pipeline can enforce dependency deduplication

## Testing
- yarn verify:all *(fails: existing lint errors around missing control labels and window/document usage in public app bundles)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d7f283608328ac61d17d074aced5