### PR TITLE
[ci] enforce yarn patch absence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: node scripts/check-no-patches.mjs
 
   lint:
     runs-on: ubuntu-latest
@@ -24,6 +25,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: node scripts/check-no-patches.mjs
       - run: npm run lint
 
   typecheck:
@@ -36,6 +38,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: node scripts/check-no-patches.mjs
       - run: npm run tsc -- --noEmit
 
   test:
@@ -48,6 +51,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: node scripts/check-no-patches.mjs
       - run: yarn test --coverage
 
   security:
@@ -60,6 +64,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: node scripts/check-no-patches.mjs
       - run: yarn npm audit
 
   vercel-preview:
@@ -76,6 +81,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: node scripts/check-no-patches.mjs
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/scripts/check-no-patches.mjs
+++ b/scripts/check-no-patches.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { readdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const patchesDir = resolve(__dirname, '../.yarn/patches');
+
+try {
+  const entries = await readdir(patchesDir);
+
+  if (entries.length > 0) {
+    console.error(
+      'Yarn patches detected in .yarn/patches. Please remove them before committing.'
+    );
+    console.error(`Found entries: ${entries.join(', ')}`);
+    process.exitCode = 1;
+  }
+} catch (error) {
+  if (error.code === 'ENOENT') {
+    process.exit(0);
+  } else {
+    console.error('Unable to inspect .yarn/patches directory.');
+    console.error(error);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable script that fails when `.yarn/patches` contains files
- run the script in every CI job immediately after installing dependencies

## Testing
- node scripts/check-no-patches.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d5d7f57e248328b44520cbd382a5c4