### PR TITLE
[config] tighten remote image host allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ play/pause and track controls include keyboard hotkeys.
    ```
 3. Add metadata (icon, title) where appropriate.
 4. If the app needs persistent state, use `usePersistentState(key, initial, validator)`.
-5. If the app embeds external sites, **whitelist** the domain in `next.config.js` CSP (`connect-src`, `frame-src`, `img-src`) and `images.domains`.
+5. If the app embeds external sites, **whitelist** the domain in `next.config.js` CSP (`connect-src`, `frame-src`, `img-src`) and `images.remotePatterns`.
 
 ---
 

--- a/docs/TASKS_UI_POLISH.md
+++ b/docs/TASKS_UI_POLISH.md
@@ -216,7 +216,7 @@ This document tracks UI polish tasks for the Kali/Ubuntu inspired desktop experi
     - **Where:** Gedit app; env vars already specified in README.
 
 51. **Chrome app permissions UI**
-    - **Accept:** Explicit message about sandboxed iframes and limited capabilities; tighten CSP and image domains for embeds.
+    - **Accept:** Explicit message about sandboxed iframes and limited capabilities; tighten CSP and image remote patterns for embeds.
     - **Where:** Chrome app; `next.config.js` CSP list.
 
 52. **Project Gallery lazy loading**

--- a/docs/new-app-checklist.md
+++ b/docs/new-app-checklist.md
@@ -22,7 +22,7 @@ export const displayMyApp = () => <MyApp />;
 ## Content Security Policy
 
 - Apps that fetch data or embed external sites must whitelist their domains in `next.config.js`.
-- Update the appropriate directives (`connect-src`, `frame-src`, `img-src`) and `images.domains` when needed.
+- Update the appropriate directives (`connect-src`, `frame-src`, `img-src`) and `images.remotePatterns` when needed.
 
 ## Playwright smoke test
 

--- a/next.config.js
+++ b/next.config.js
@@ -131,17 +131,57 @@ module.exports = withBundleAnalyzer(
     },
     images: {
       unoptimized: true,
-      domains: [
-        'opengraph.githubassets.com',
-        'raw.githubusercontent.com',
-        'avatars.githubusercontent.com',
-        'i.ytimg.com',
-        'yt3.ggpht.com',
-        'i.scdn.co',
-        'www.google.com',
-        'example.com',
-        'developer.mozilla.org',
-        'en.wikipedia.org',
+      remotePatterns: [
+        {
+          protocol: 'https',
+          hostname: 'opengraph.githubassets.com',
+          pathname: '/**',
+        },
+        {
+          protocol: 'https',
+          hostname: 'raw.githubusercontent.com',
+          pathname: '/**',
+        },
+        {
+          protocol: 'https',
+          hostname: 'avatars.githubusercontent.com',
+          pathname: '/**',
+        },
+        {
+          protocol: 'https',
+          hostname: 'i.ytimg.com',
+          pathname: '/**',
+        },
+        {
+          protocol: 'https',
+          hostname: 'yt3.ggpht.com',
+          pathname: '/**',
+        },
+        {
+          protocol: 'https',
+          hostname: 'i.scdn.co',
+          pathname: '/**',
+        },
+        {
+          protocol: 'https',
+          hostname: 'www.google.com',
+          pathname: '/**',
+        },
+        {
+          protocol: 'https',
+          hostname: 'example.com',
+          pathname: '/**',
+        },
+        {
+          protocol: 'https',
+          hostname: 'developer.mozilla.org',
+          pathname: '/**',
+        },
+        {
+          protocol: 'https',
+          hostname: 'en.wikipedia.org',
+          pathname: '/**',
+        },
       ],
       deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
       imageSizes: [16, 32, 48, 64, 96, 128, 256],


### PR DESCRIPTION
## Summary
- replace the Next.js image domain allowlist with equivalent `remotePatterns` entries for each approved host
- refresh contributor docs to reference `images.remotePatterns` instead of the legacy `images.domains`

## Testing
- `yarn lint` *(fails: existing accessibility warnings across many legacy apps)*
- `yarn test --watch=false` *(fails: existing unit test failures such as window focus handling and nmap NSE output assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d7f6dd7c8328bcc8c4e666f76ba6