### PR TITLE
build: externalize heavy SSR packages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -124,6 +124,10 @@ module.exports = withBundleAnalyzer(
   withPWA({
     ...(isStaticExport && { output: 'export' }),
     webpack: configureWebpack,
+    serverExternalPackages: [
+      '@supabase/supabase-js',
+      '@tinyhttp/cookie-signature',
+    ],
 
     // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
     eslint: {


### PR DESCRIPTION
## Summary
- add a `serverExternalPackages` allow-list so Next.js keeps Supabase and cookie-signature out of the server bundle
- verified the compiled API route now requires the Supabase client at runtime instead of bundling it

## Testing
- ❌ `yarn lint` *(fails: repository already has numerous jsx-a11y violations unrelated to this change)*
- ❌ `yarn test` *(fails: existing suites trip act/localStorage issues; command aborted after failures)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d7f81dcc8328b3fb8f4f2fb964cc