### PR TITLE
[config] validate env at runtime

### DIFF
--- a/lib/runtime-env.js
+++ b/lib/runtime-env.js
@@ -1,0 +1,40 @@
+const { validateServerEnv } = require('./validate.js');
+
+let cachedEnv = null;
+let validationError = null;
+let attempted = false;
+
+function runValidation() {
+  if (attempted) return;
+  attempted = true;
+  try {
+    cachedEnv = validateServerEnv(process.env);
+  } catch (error) {
+    validationError = error;
+    console.warn('Missing env vars; running without validation');
+  }
+}
+
+function ensureServerEnv() {
+  runValidation();
+  return cachedEnv;
+}
+
+function assertServerEnv() {
+  runValidation();
+  if (validationError) {
+    throw validationError;
+  }
+  return cachedEnv;
+}
+
+function getServerEnvValidationError() {
+  runValidation();
+  return validationError;
+}
+
+module.exports = {
+  ensureServerEnv,
+  assertServerEnv,
+  getServerEnvValidationError,
+};

--- a/lib/runtime-env.ts
+++ b/lib/runtime-env.ts
@@ -1,0 +1,38 @@
+import { validateServerEnv } from './validate';
+
+type ValidationResult = ReturnType<typeof validateServerEnv> | null;
+
+type ValidationError = unknown;
+
+let cachedEnv: ValidationResult = null;
+let validationError: ValidationError = null;
+let attempted = false;
+
+function runValidation() {
+  if (attempted) return;
+  attempted = true;
+  try {
+    cachedEnv = validateServerEnv(process.env);
+  } catch (error) {
+    validationError = error;
+    console.warn('Missing env vars; running without validation');
+  }
+}
+
+export function ensureServerEnv() {
+  runValidation();
+  return cachedEnv;
+}
+
+export function assertServerEnv() {
+  runValidation();
+  if (validationError) {
+    throw validationError;
+  }
+  return cachedEnv;
+}
+
+export function getServerEnvValidationError() {
+  runValidation();
+  return validationError;
+}

--- a/lib/service-client.ts
+++ b/lib/service-client.ts
@@ -1,6 +1,8 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { ensureServerEnv } from './runtime-env';
 
 export function getServiceClient(): SupabaseClient | null {
+  ensureServerEnv();
   const url = process.env.SUPABASE_URL;
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !serviceKey) {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,4 +1,7 @@
+import { ensureServerEnv } from './runtime-env';
+
 export function getServiceSupabase() {
+  ensureServerEnv();
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) {
@@ -27,6 +30,7 @@ export function getServiceSupabase() {
 }
 
 export function getAnonSupabaseServer() {
+  ensureServerEnv();
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_ANON_KEY;
   if (!url || !key) {

--- a/next.config.js
+++ b/next.config.js
@@ -2,8 +2,6 @@
 // Allows external badges and same-origin PDF embedding.
 // Update README (section "CSP External Domains") when editing domains below.
 
-const { validateServerEnv: validateEnv } = require('./lib/validate.js');
-
 const ContentSecurityPolicy = [
   "default-src 'self'",
   // Prevent injection of external base URIs
@@ -112,12 +110,6 @@ function configureWebpack(config, { isServer }) {
     };
   }
   return config;
-}
-
-try {
-  validateEnv?.(process.env);
-} catch {
-  console.warn('Missing env vars; running without validation');
 }
 
 module.exports = withBundleAnalyzer(

--- a/pages/api/admin/messages.js
+++ b/pages/api/admin/messages.js
@@ -1,10 +1,12 @@
 import { getServiceClient } from '../../../lib/service-client';
 import { createLogger } from '../../../lib/logger';
+import { ensureServerEnv } from '../../../../lib/runtime-env';
 
 export default async function handler(
   req,
   res
 ) {
+  ensureServerEnv();
   const logger = createLogger(req.headers['x-correlation-id']);
   if (req.method !== 'GET') {
     logger.warn('method not allowed', { method: req.method });

--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -1,6 +1,6 @@
 import { randomBytes } from 'crypto';
 import { contactSchema } from '../../utils/contactSchema';
-import { validateServerEnv } from '../../lib/validate';
+import { assertServerEnv } from '../../lib/runtime-env';
 import { getServiceSupabase } from '../../lib/supabase';
 
 // Simple in-memory rate limiter. Not suitable for distributed environments.
@@ -11,7 +11,7 @@ export const rateLimit = new Map();
 
 export default async function handler(req, res) {
   try {
-    validateServerEnv(process.env);
+    assertServerEnv();
   } catch {
     if (!process.env.RECAPTCHA_SECRET) {
       res.status(503).json({ ok: false, code: 'recaptcha_disabled' });

--- a/pages/api/leaderboard/submit.js
+++ b/pages/api/leaderboard/submit.js
@@ -1,9 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
+import { ensureServerEnv } from '../../../../lib/runtime-env';
 
 export default async function handler(
   req,
   res,
 ) {
+  ensureServerEnv();
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
     res.status(405).end('Method Not Allowed');

--- a/pages/api/leaderboard/top.js
+++ b/pages/api/leaderboard/top.js
@@ -1,9 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
+import { ensureServerEnv } from '../../../../lib/runtime-env';
 
 export default async function handler(
   req,
   res,
 ) {
+  ensureServerEnv();
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');
     res.status(405).end('Method Not Allowed');

--- a/pages/api/track.js
+++ b/pages/api/track.js
@@ -1,9 +1,11 @@
 import { createClient } from "@supabase/supabase-js";
+import { ensureServerEnv } from "../../lib/runtime-env";
 
 export default async function handler(
   req,
   res,
 ) {
+  ensureServerEnv();
   if (req.method !== "POST") {
     res.status(405).json({ ok: false });
     return;


### PR DESCRIPTION
## Summary
- add a runtime validation helper and call it from server-side entrypoints instead of next.config.js
- keep Supabase helpers and API routes aligned with the deferred validation approach

## Testing
- [ ] yarn lint *(fails with existing repository accessibility and no-top-level-window lint errors)*
- [ ] yarn test *(fails with pre-existing test suite issues; run aborted after multiple failures)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d7f91a4c832887f18196257981aa