### PR TITLE
chore: verify static export toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ yarn export && npx serve out
 ```
 Verify that features relying on `/api/*` return 404 or other placeholders when served statically.
 
+> `NEXT_PUBLIC_STATIC_EXPORT=true` switches `next.config.js` to `output: 'export'` and causes `next build` to populate `.next/export/` and `export-detail.json`. Keep the flag unset when running the serverful build so `/api/*` routes remain available.
+
 ### Install as PWA for Sharing
 
 To send text or links directly into the Sticky Notes app:
@@ -215,7 +217,7 @@ Copy `.env.local.example` to `.env.local` and fill in required values.
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public Supabase anonymous key used on the client. |
 | `ADMIN_READ_KEY` | Secret key required by admin message APIs. Configure this directly as an environment variable (e.g., in the Vercel dashboard). |
 | `NEXT_PUBLIC_UI_EXPERIMENTS` | Enable experimental UI heuristics. |
-| `NEXT_PUBLIC_STATIC_EXPORT` | Set to `'true'` during `yarn export` to disable server APIs. |
+| `NEXT_PUBLIC_STATIC_EXPORT` | Set to `'true'` during `yarn export` so Next.js enables `output: 'export'` and writes `.next/export`; leave unset for serverful builds so API routes stay active. |
 | `NEXT_PUBLIC_SHOW_BETA` | Set to `1` to display a small beta badge in the UI. |
 | `FEATURE_TOOL_APIS` | Enable server-side tool API routes like Hydra and John; set to `enabled` to allow. |
 | `FEATURE_HYDRA` | Allow the Hydra API (`/api/hydra`); requires `FEATURE_TOOL_APIS`. |

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1,12 +1,18 @@
 import { execSync, spawn } from 'child_process';
+import { existsSync, rmSync } from 'fs';
 import { createRequire } from 'module';
 import net from 'net';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import waitOn from 'wait-on';
 
 const require = createRequire(import.meta.url);
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+
 const run = (cmd, args = [], opts = {}) => new Promise((resolve, reject) => {
-  const child = spawn(cmd, args, { stdio: 'inherit', ...opts });
+  const child = spawn(cmd, args, { stdio: 'inherit', cwd: rootDir, ...opts });
   child.on('exit', (code) => {
     if (code === 0) {
       resolve();
@@ -26,7 +32,40 @@ const getPort = () =>
     srv.on('error', reject);
   });
 
+const getOutputSetting = (env = {}) => {
+  const mergedEnv = { ...process.env, ...env };
+  if (!('NEXT_PUBLIC_STATIC_EXPORT' in env)) {
+    delete mergedEnv.NEXT_PUBLIC_STATIC_EXPORT;
+  }
+  return execSync("node -e \"console.log(require('./next.config.js').output || '')\"", {
+    cwd: rootDir,
+    env: mergedEnv,
+    encoding: 'utf8',
+  }).trim();
+};
+
+const cleanNextDir = () => {
+  const nextDir = path.join(rootDir, '.next');
+  if (existsSync(nextDir)) {
+    rmSync(nextDir, { recursive: true, force: true });
+  }
+};
+
+const assertExportArtifacts = (expected) => {
+  const exportDir = path.join(rootDir, '.next', 'export');
+  const detailFile = path.join(rootDir, '.next', 'export-detail.json');
+  const hasExportDir = existsSync(exportDir);
+  const hasDetailFile = existsSync(detailFile);
+  if (expected && (!hasExportDir || !hasDetailFile)) {
+    throw new Error('Static export build missing .next/export artifacts');
+  }
+  if (!expected && (hasExportDir || hasDetailFile)) {
+    throw new Error('Serverful build unexpectedly generated static export artifacts');
+  }
+};
+
 (async () => {
+  let server;
   try {
     const yarnVersion = execSync('yarn --version', { encoding: 'utf8' }).trim();
     const nextVersion = require('next/package.json').version;
@@ -34,14 +73,22 @@ const getPort = () =>
     console.log(`yarn: ${yarnVersion}`);
     console.log(`next: ${nextVersion}`);
 
+    const serverOutput = getOutputSetting();
+    if (serverOutput === 'export') {
+      throw new Error('NEXT_PUBLIC_STATIC_EXPORT should be unset for serverful builds');
+    }
+
     await run('yarn', ['install', '--immutable']);
     await run('yarn', ['lint']);
     await run('yarn', ['tsc', '--noEmit']);
+
+    cleanNextDir();
     await run('yarn', ['build']);
+    assertExportArtifacts(false);
 
     const port = await getPort();
-    const server = spawn('yarn', ['start', '-p', String(port)], { stdio: 'inherit' });
-    process.on('exit', () => server.kill());
+    server = spawn('yarn', ['start', '-p', String(port)], { stdio: 'inherit', cwd: rootDir });
+    process.on('exit', () => server?.kill());
     await waitOn({ resources: [`http://localhost:${port}`], timeout: 60000 });
 
     const routes = ['/', '/dummy-form', '/video-gallery', '/profile'];
@@ -54,12 +101,30 @@ const getPort = () =>
       console.log(`✓ ${route}`);
     }
 
-    console.log('verify: PASS');
     server.kill();
+    await new Promise((resolve) => server.on('exit', resolve));
+    server = undefined;
+    cleanNextDir();
+
+    const exportOutput = getOutputSetting({ NEXT_PUBLIC_STATIC_EXPORT: 'true' });
+    if (exportOutput !== 'export') {
+      throw new Error('Static export flag did not enable output: "export"');
+    }
+
+    await run('yarn', ['build'], {
+      env: { ...process.env, NEXT_PUBLIC_STATIC_EXPORT: 'true' },
+    });
+    assertExportArtifacts(true);
+
+    console.log('✓ Static export build generated .next/export and export-detail.json');
+    console.log('verify: PASS');
   } catch (err) {
     console.error('verify: FAIL');
     console.error(err);
     process.exit(1);
+  } finally {
+    server?.kill();
+    cleanNextDir();
   }
 })();
 


### PR DESCRIPTION
## Summary
- extend scripts/verify.mjs to assert serverful vs static export builds and ensure output: 'export' toggles only when NEXT_PUBLIC_STATIC_EXPORT is set
- add documentation describing how the flag changes Next.js build output

## Testing
- yarn lint *(fails: existing repo accessibility/lint errors)*
- yarn test *(fails: existing Jest suite issues under watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d7fcffa48328a4bb286ca7123ea2