### PR TITLE
[security] add Referrer-Policy middleware header

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,41 @@
+import { webcrypto } from 'node:crypto';
+
+type HeaderMap = Map<string, string>;
+
+const headers: HeaderMap = new Map();
+
+const response = {
+  headers: {
+    set: jest.fn((key: string, value: string) => {
+      headers.set(key, value);
+    }),
+    get: jest.fn((key: string) => headers.get(key) ?? null),
+  },
+};
+
+globalThis.crypto = webcrypto as unknown as Crypto;
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    next: jest.fn(() => response),
+  },
+}));
+
+// eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+const { middleware } = require('../middleware');
+
+describe('middleware', () => {
+  beforeEach(() => {
+    headers.clear();
+    jest.clearAllMocks();
+  });
+
+  it('sets security headers including Referrer-Policy', () => {
+    const result = middleware({} as any);
+
+    expect(result).toBe(response);
+    expect(headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+    expect(headers.get('Content-Security-Policy')).toContain("default-src 'self'");
+    expect(headers.get('x-csp-nonce')).toBeTruthy();
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -25,5 +25,6 @@ export function middleware(req: NextRequest) {
   const res = NextResponse.next();
   res.headers.set('x-csp-nonce', n);
   res.headers.set('Content-Security-Policy', csp);
+  res.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   return res;
 }


### PR DESCRIPTION
## Summary
- add a strict-origin-when-cross-origin Referrer-Policy header in the middleware
- cover the middleware security headers with a dedicated unit test

## Testing
- yarn lint *(fails: repository contains pre-existing accessibility lint violations)*
- yarn test --runTestsByPath __tests__/middleware.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d5d7ff066c8328a0c7e558d4111516