### PR TITLE
[config] add hsts header

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -55,6 +55,10 @@ const securityHeaders = [
     key: 'X-Frame-Options',
     value: 'SAMEORIGIN',
   },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
 ];
 
 const withBundleAnalyzer = require('@next/bundle-analyzer')({


### PR DESCRIPTION
## Summary
- add an HSTS directive to the shared security headers so production responses emit Strict-Transport-Security

## Testing
- CI=1 yarn build
- curl -I http://localhost:3000 | grep -i strict-transport-security
- CI=1 yarn lint *(fails: existing accessibility violations in apps and public game scripts)*
- yarn test *(fails: existing failing suites such as window keyboard handling, nmap NSE alert role, and modal focus management)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d801532c83288e7f8c17d8aa6e2d