### PR TITLE
[security] align permissions policy headers

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -25,5 +25,9 @@ export function middleware(req: NextRequest) {
   const res = NextResponse.next();
   res.headers.set('x-csp-nonce', n);
   res.headers.set('Content-Security-Policy', csp);
+  res.headers.set(
+    'Permissions-Policy',
+    'camera=(), microphone=(), geolocation=(), interest-cohort=()'
+  );
   return res;
 }

--- a/next.config.js
+++ b/next.config.js
@@ -48,7 +48,7 @@ const securityHeaders = [
   },
   {
     key: 'Permissions-Policy',
-    value: 'camera=(), microphone=(), geolocation=*',
+    value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()',
   },
   {
     // Allow same-origin framing so the PDF resume renders in an <object>


### PR DESCRIPTION
## Summary
- disable geolocation and interest cohort tracking in the Next.js permissions policy header
- mirror the updated permissions policy in the middleware response headers so edge and node outputs stay aligned

## Testing
- yarn lint *(fails: repository contains existing accessibility lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d8000e448328a183af6c9b18ac3b