### PR TITLE
[middleware] Guard middleware subrequests

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,73 @@
+class HeaderCollection {
+  private store = new Map<string, string>();
+
+  constructor(init?: Record<string, string>) {
+    if (init) {
+      for (const [key, value] of Object.entries(init)) {
+        this.set(key, value);
+      }
+    }
+  }
+
+  set(key: string, value: string) {
+    this.store.set(key.toLowerCase(), value);
+  }
+
+  get(key: string) {
+    return this.store.get(key.toLowerCase()) ?? null;
+  }
+}
+
+jest.mock('next/server', () => {
+  class MockNextResponse {
+    public status: number;
+    public headers: HeaderCollection;
+    public body?: string;
+
+    constructor(body?: string, init?: { status?: number; headers?: Record<string, string> }) {
+      this.body = body;
+      this.status = init?.status ?? 200;
+      this.headers = new HeaderCollection(init?.headers);
+    }
+
+    static next() {
+      return new MockNextResponse(undefined);
+    }
+  }
+
+  return {
+    NextResponse: MockNextResponse,
+  };
+});
+
+import { middleware } from '../middleware';
+
+type NextRequestLike = Parameters<typeof middleware>[0];
+
+describe('middleware', () => {
+  function createRequest(headersInit?: Record<string, string>): NextRequestLike {
+    const headers = new HeaderCollection(headersInit);
+    return {
+      headers: headers as unknown as Headers,
+    } as NextRequestLike;
+  }
+
+  it('blocks middleware subrequests with a 403 response', () => {
+    const req = createRequest({ 'x-middleware-subrequest': '1' });
+
+    const res = middleware(req);
+
+    expect(res.status).toBe(403);
+    expect(res.headers.get('x-csp-nonce')).toBeNull();
+  });
+
+  it('adds CSP headers for normal requests', () => {
+    const req = createRequest();
+
+    const res = middleware(req);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-csp-nonce')).toBeTruthy();
+    expect(res.headers.get('Content-Security-Policy')).toContain("default-src 'self'");
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,15 @@ function nonce() {
 }
 
 export function middleware(req: NextRequest) {
+  if (req.headers.get('x-middleware-subrequest')) {
+    return new NextResponse(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+  }
+
   const n = nonce();
   const csp = [
     "default-src 'self'",


### PR DESCRIPTION
## Summary
- add a guard in the middleware to reject subrequests flagged by `x-middleware-subrequest`
- keep CSP and nonce headers applied for regular requests and cover behavior with unit tests

## Testing
- yarn test --watch=false --runTestsByPath __tests__/middleware.test.ts
- yarn lint *(fails: repo has existing accessibility and window/document lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d80448888328a3180ab46811e082