### PR TITLE
[csp] tighten script policy

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import Head from 'next/head';
-import { getCspNonce } from '../../utils/csp';
+import { useCspNonce } from '../../utils/csp';
 
 export default function Meta() {
-    const nonce = getCspNonce();
+    const nonce = useCspNonce();
     return (
         <Head>
             {/* Primary Meta Tags */}

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -6,12 +6,16 @@ import GitHubStars from '../../GitHubStars';
 import Certs from '../certs';
 import data from '../alex/data.json';
 import SafetyNote from './SafetyNote';
-import { getCspNonce } from '../../../utils/csp';
+import { CspNonceContext, getCspNonce } from '../../../utils/csp';
 import AboutSlides from './slides';
 import ScrollableTimeline from '../../ScrollableTimeline';
 
 class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_screen: string; navbar: boolean }> {
   screens: Record<string, React.ReactNode> = {};
+
+  static contextType = CspNonceContext;
+
+  declare context: React.ContextType<typeof CspNonceContext>;
 
   constructor(props: unknown) {
     super(props);
@@ -107,7 +111,7 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
       name: 'Alex Unnippillil',
       url: 'https://unnippillil.com',
     };
-    const nonce = getCspNonce();
+    const nonce = this.context ?? getCspNonce();
 
     return (
       <main className="w-full h-full flex bg-ub-cool-grey text-white select-none relative">

--- a/middleware.ts
+++ b/middleware.ts
@@ -13,7 +13,7 @@ export function middleware(req: NextRequest) {
     "img-src 'self' https: data:",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
-    `script-src 'self' 'unsafe-inline' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
+    `script-src 'self' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
     "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com",
     "frame-src 'self' https://vercel.live https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
     "frame-ancestors 'self'",
@@ -22,7 +22,14 @@ export function middleware(req: NextRequest) {
     "form-action 'self'"
   ].join('; ');
 
-  const res = NextResponse.next();
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set('x-csp-nonce', n);
+
+  const res = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
   res.headers.set('x-csp-nonce', n);
   res.headers.set('Content-Security-Policy', csp);
   return res;

--- a/next.config.js
+++ b/next.config.js
@@ -21,7 +21,7 @@ const ContentSecurityPolicy = [
   // Restrict fonts to same origin
   "font-src 'self'",
   // External scripts required for embedded timelines
-  "script-src 'self' 'unsafe-inline' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+  "script-src 'self' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
   // Allow outbound connections for embeds and the in-browser Chrome app
   "connect-src 'self' https://example.com https://developer.mozilla.org https://en.wikipedia.org https://www.google.com https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
   // Allow iframes from specific providers so the Chrome and StackBlitz apps can load allowed content

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { CspNonceContext } from '../utils/csp';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -26,7 +27,7 @@ const ubuntu = Ubuntu({
 
 
 function MyApp(props) {
-  const { Component, pageProps } = props;
+  const { Component, pageProps, cspNonce } = props;
 
 
   useEffect(() => {
@@ -147,36 +148,36 @@ function MyApp(props) {
   }, []);
 
   return (
-    <ErrorBoundary>
-      <Script src="/a2hs.js" strategy="beforeInteractive" />
-      <div className={ubuntu.className}>
-        <a
-          href="#app-grid"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
-        >
-          Skip to app grid
-        </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+    <CspNonceContext.Provider value={cspNonce}>
+      <ErrorBoundary>
+        <Script src="/a2hs.js" strategy="beforeInteractive" />
+        <div className={ubuntu.className}>
+          <a
+            href="#app-grid"
+            className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+          >
+            Skip to app grid
+          </a>
+          <SettingsProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
-      </div>
-    </ErrorBoundary>
-
-
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </SettingsProvider>
+        </div>
+      </ErrorBoundary>
+    </CspNonceContext.Provider>
   );
 }
 

--- a/utils/csp.ts
+++ b/utils/csp.ts
@@ -1,6 +1,15 @@
+import { createContext, useContext } from 'react';
+
+export const CspNonceContext = createContext<string | undefined>(undefined);
+
 export function getCspNonce(): string | undefined {
   if (typeof document !== 'undefined') {
     return document.documentElement.dataset.cspNonce;
   }
   return undefined;
+}
+
+export function useCspNonce(): string | undefined {
+  const ctxNonce = useContext(CspNonceContext);
+  return ctxNonce ?? getCspNonce();
 }


### PR DESCRIPTION
## Summary
- remove the `unsafe-inline` allowance from the script-src directives emitted by the Next.js config and edge middleware
- propagate the middleware nonce through the request headers and a new context provider so inline scripts can use it during SSR and hydration
- update the Meta and About structured data scripts to consume the shared nonce hook/context

## Testing
- `yarn exec eslint . --max-warnings=0` *(fails: pre-existing accessibility violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d80379388328aeda23c353e4514b