### PR TITLE
chore(security): remove remote Google Fonts from CSP

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -11,8 +11,8 @@ export function middleware(req: NextRequest) {
   const csp = [
     "default-src 'self'",
     "img-src 'self' https: data:",
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "font-src 'self' https://fonts.gstatic.com",
+    "style-src 'self' 'unsafe-inline'",
+    "font-src 'self'",
     `script-src 'self' 'unsafe-inline' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
     "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com",
     "frame-src 'self' https://vercel.live https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",


### PR DESCRIPTION
## Summary
- remove the Google Fonts hosts from the middleware CSP style-src and font-src directives
- confirmed the codebase no longer references external Google Fonts URLs

## Testing
- yarn lint *(fails: pre-existing jsx-a11y/control-has-associated-label violations across many apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d805f4e88328a30dbaa8fe05a6df