### PR TITLE
[api] Add edge rate limiter to tool endpoints

### DIFF
--- a/__tests__/rateLimitEdge.test.ts
+++ b/__tests__/rateLimitEdge.test.ts
@@ -1,0 +1,74 @@
+import rateLimitEdge, { clearRateLimitEdgeStore } from '@/lib/rateLimitEdge';
+
+describe('rateLimitEdge helper', () => {
+  const createRes = () => {
+    const res: any = {
+      statusCode: 200,
+      body: undefined as unknown,
+      headers: {} as Record<string, string>,
+    };
+    res.setHeader = (name: string, value: string) => {
+      res.headers[name] = value;
+    };
+    res.status = (code: number) => {
+      res.statusCode = code;
+      return res;
+    };
+    res.json = (payload: unknown) => {
+      res.body = payload;
+      return res;
+    };
+    return res;
+  };
+
+  afterEach(() => {
+    clearRateLimitEdgeStore();
+  });
+
+  it('allows requests under the limit and annotates headers', async () => {
+    const handler = jest.fn((_, res) => {
+      res.status(200).json({ ok: true });
+    });
+    const limited = rateLimitEdge(handler, {
+      limit: 2,
+      keyGenerator: () => 'test-client',
+      scopeGenerator: () => '/api/demo',
+    });
+
+    const res1 = createRes();
+    await limited({ headers: {} }, res1);
+    expect(res1.statusCode).toBe(200);
+    expect(res1.headers['X-RateLimit-Limit']).toBe('2');
+    expect(res1.headers['X-RateLimit-Remaining']).toBe('1');
+    expect(res1.headers['X-RateLimit-Reset']).toBeDefined();
+
+    const res2 = createRes();
+    await limited({ headers: {} }, res2);
+    expect(res2.statusCode).toBe(200);
+    expect(res2.headers['X-RateLimit-Remaining']).toBe('0');
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('blocks when the limit is exceeded and returns 429', async () => {
+    const handler = jest.fn((_, res) => {
+      res.status(200).json({ ok: true });
+    });
+    const limited = rateLimitEdge(handler, {
+      limit: 1,
+      keyGenerator: () => 'client',
+      scopeGenerator: () => '/api/demo',
+    });
+
+    const res1 = createRes();
+    await limited({ headers: {} }, res1);
+    expect(res1.statusCode).toBe(200);
+    expect(res1.headers['X-RateLimit-Remaining']).toBe('0');
+
+    const res2 = createRes();
+    await limited({ headers: {} }, res2);
+    expect(res2.statusCode).toBe(429);
+    expect(res2.body).toEqual({ error: 'rate_limit' });
+    expect(res2.headers['Retry-After']).toBeDefined();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/rateLimitEdge.ts
+++ b/lib/rateLimitEdge.ts
@@ -1,0 +1,231 @@
+const RATE_LIMIT_STORE_SYMBOL = Symbol.for('kali.rateLimitEdgeStore');
+
+type RateLimitEntry = {
+  count: number;
+  start: number;
+};
+
+type RateLimitEdgeOptions = {
+  limit?: number;
+  windowMs?: number;
+  keyGenerator?: (req: unknown) => string;
+  scopeGenerator?: (req: unknown) => string;
+};
+
+type RateLimitResult = {
+  limited: boolean;
+  limit: number;
+  remaining: number;
+  resetMs: number;
+  retryAfterSeconds: number;
+};
+
+type NodeResponseLike = {
+  setHeader?: (name: string, value: string) => void;
+  status: (code: number) => NodeResponseLike;
+  json: (data: unknown) => NodeResponseLike;
+};
+
+const globalObj = globalThis as typeof globalThis & {
+  [RATE_LIMIT_STORE_SYMBOL]?: Map<string, RateLimitEntry>;
+};
+
+const store: Map<string, RateLimitEntry> =
+  globalObj[RATE_LIMIT_STORE_SYMBOL] ?? new Map();
+
+globalObj[RATE_LIMIT_STORE_SYMBOL] = store;
+
+const DEFAULT_LIMIT = 10;
+const DEFAULT_WINDOW_MS = 60_000;
+
+function pruneStore(now: number, windowMs: number) {
+  for (const [key, entry] of store) {
+    if (now - entry.start > windowMs) {
+      store.delete(key);
+    }
+  }
+}
+
+function getHeader(req: any, name: string): string {
+  const headers = req?.headers;
+  if (!headers) return '';
+  if (typeof headers.get === 'function') {
+    return headers.get(name) ?? headers.get(name.toLowerCase()) ?? '';
+  }
+  if (typeof headers === 'object') {
+    const entries = Object.entries(headers);
+    for (const [key, value] of entries) {
+      if (key.toLowerCase() === name.toLowerCase()) {
+        if (Array.isArray(value)) {
+          return value[0] ?? '';
+        }
+        return value ?? '';
+      }
+    }
+  }
+  return '';
+}
+
+function defaultScope(req: any): string {
+  if (req?.nextUrl?.pathname) {
+    return req.nextUrl.pathname;
+  }
+  const rawUrl = req?.url;
+  if (typeof rawUrl === 'string') {
+    try {
+      const url = new URL(rawUrl, 'http://localhost');
+      return url.pathname;
+    } catch {
+      const [pathPart] = rawUrl.split('?');
+      return pathPart || 'global';
+    }
+  }
+  return 'global';
+}
+
+function defaultKey(req: any): string {
+  const header =
+    getHeader(req, 'x-forwarded-for') ||
+    getHeader(req, 'x-real-ip') ||
+    getHeader(req, 'cf-connecting-ip');
+  if (header) {
+    const [first] = String(header).split(',');
+    if (first && first.trim()) {
+      return first.trim();
+    }
+  }
+  if (typeof req?.ip === 'string' && req.ip) {
+    return req.ip;
+  }
+  const socket = req?.socket;
+  if (socket && typeof socket.remoteAddress === 'string') {
+    return socket.remoteAddress;
+  }
+  return 'anonymous';
+}
+
+function applyRateLimit(
+  key: string,
+  limit: number,
+  windowMs: number,
+): RateLimitResult {
+  const now = Date.now();
+  const entry = store.get(key);
+  if (!entry || now - entry.start >= windowMs) {
+    const fresh: RateLimitEntry = { count: 1, start: now };
+    store.set(key, fresh);
+    pruneStore(now, windowMs);
+    const resetMs = fresh.start + windowMs;
+    return {
+      limited: false,
+      limit,
+      remaining: Math.max(0, limit - fresh.count),
+      resetMs,
+      retryAfterSeconds: Math.max(0, Math.ceil((resetMs - now) / 1000)),
+    };
+  }
+
+  entry.count += 1;
+  store.set(key, entry);
+  pruneStore(now, windowMs);
+  const resetMs = entry.start + windowMs;
+  const limited = entry.count > limit;
+  const remaining = limited ? 0 : Math.max(0, limit - entry.count);
+  return {
+    limited,
+    limit,
+    remaining,
+    resetMs,
+    retryAfterSeconds: Math.max(0, Math.ceil((resetMs - now) / 1000)),
+  };
+}
+
+function setNodeHeaders(
+  res: NodeResponseLike,
+  result: RateLimitResult,
+  limited: boolean,
+) {
+  if (typeof res?.setHeader === 'function') {
+    res.setHeader('X-RateLimit-Limit', String(result.limit));
+    res.setHeader('X-RateLimit-Remaining', String(result.remaining));
+    res.setHeader('X-RateLimit-Reset', String(Math.ceil(result.resetMs / 1000)));
+    if (limited) {
+      res.setHeader('Retry-After', String(result.retryAfterSeconds || 0));
+    }
+  }
+}
+
+function applyEdgeHeaders(
+  response: Response,
+  result: RateLimitResult,
+  limited: boolean,
+): Response {
+  const headers = new Headers(response.headers);
+  headers.set('X-RateLimit-Limit', String(result.limit));
+  headers.set('X-RateLimit-Remaining', String(result.remaining));
+  headers.set('X-RateLimit-Reset', String(Math.ceil(result.resetMs / 1000)));
+  if (limited) {
+    headers.set('Retry-After', String(result.retryAfterSeconds || 0));
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export function clearRateLimitEdgeStore() {
+  store.clear();
+}
+
+export default function rateLimitEdge<Req = any, Res = any>(
+  handler: (req: Req, res?: Res) => any,
+  options: RateLimitEdgeOptions = {},
+) {
+  const limit = options.limit ?? DEFAULT_LIMIT;
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const keyGenerator = options.keyGenerator ?? defaultKey;
+  const scopeGenerator = options.scopeGenerator ?? defaultScope;
+
+  return async function rateLimitedHandler(req: Req, res?: Res) {
+    const scope = scopeGenerator(req);
+    const keyBase = keyGenerator(req);
+    const key = `${scope}:${keyBase || 'anonymous'}`;
+    const result = applyRateLimit(key, limit, windowMs);
+
+    const isNodeResponse = res && typeof (res as any).status === 'function';
+
+    if (isNodeResponse) {
+      setNodeHeaders(res as unknown as NodeResponseLike, result, result.limited);
+      if (result.limited) {
+        (res as any)
+          .status(429)
+          .json({ error: 'rate_limit' });
+        return;
+      }
+      return handler(req, res);
+    }
+
+    if (result.limited) {
+      if (typeof Response === 'undefined') {
+        return handler(req, res);
+      }
+      return new Response(JSON.stringify({ error: 'rate_limit' }), {
+        status: 429,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'X-RateLimit-Limit': String(result.limit),
+          'X-RateLimit-Remaining': String(result.remaining),
+          'X-RateLimit-Reset': String(Math.ceil(result.resetMs / 1000)),
+          'Retry-After': String(result.retryAfterSeconds || 0),
+        },
+      });
+    }
+
+    const response = await handler(req, res);
+    if (typeof Response !== 'undefined' && response instanceof Response) {
+      return applyEdgeHeaders(response, result, false);
+    }
+    return response;
+  };
+}

--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -4,10 +4,12 @@ import { randomUUID } from 'crypto';
 import { promisify } from 'util';
 import path from 'path';
 
+import rateLimitEdge from '@/lib/rateLimitEdge';
+
 const execFileAsync = promisify(execFile);
 const allowed = new Set(['http', 'https', 'ssh', 'ftp', 'smtp']);
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   if (
     process.env.FEATURE_TOOL_APIS !== 'enabled' ||
     process.env.FEATURE_HYDRA !== 'enabled'
@@ -107,3 +109,5 @@ export default async function handler(req, res) {
     await fs.copyFile(restoreFile, sessionFile).catch(() => {});
   }
 }
+
+export default rateLimitEdge(handler, { limit: 5 });

--- a/pages/api/john.js
+++ b/pages/api/john.js
@@ -4,9 +4,11 @@ import { tmpdir } from 'os';
 import path from 'path';
 import { promisify } from 'util';
 
+import rateLimitEdge from '@/lib/rateLimitEdge';
+
 const execAsync = promisify(exec);
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });
     return;
@@ -42,3 +44,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: e.stderr || e.message });
   }
 }
+
+export default rateLimitEdge(handler, { limit: 5 });

--- a/pages/api/metasploit.js
+++ b/pages/api/metasploit.js
@@ -1,6 +1,7 @@
 import modules from '../../components/apps/metasploit/modules.json';
+import rateLimitEdge from '@/lib/rateLimitEdge';
 
-export default function handler(req, res) {
+function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });
     return;
@@ -54,3 +55,5 @@ export default function handler(req, res) {
 
   return res.status(200).json({ output: 'Command not supported in mock environment.' });
 }
+
+export default rateLimitEdge(handler);

--- a/pages/api/mimikatz.js
+++ b/pages/api/mimikatz.js
@@ -1,6 +1,7 @@
 import modules from '../../components/apps/mimikatz/modules.json';
+import rateLimitEdge from '@/lib/rateLimitEdge';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });
     return;
@@ -24,3 +25,5 @@ export default async function handler(req, res) {
   res.setHeader('Allow', ['GET', 'POST']);
   return res.status(405).end('Method Not Allowed');
 }
+
+export default rateLimitEdge(handler);

--- a/pages/api/modules/update.js
+++ b/pages/api/modules/update.js
@@ -1,4 +1,5 @@
 import versionData from '../../../data/module-version.json';
+import rateLimitEdge from '@/lib/rateLimitEdge';
 
 const REMOTE_VERSION_URL =
   'https://raw.githubusercontent.com/unnipillil/kali-linux-portfolio/main/data/module-version.json';
@@ -13,7 +14,7 @@ function compareSemver(a, b) {
   return 0;
 }
 
-export default async function handler(
+async function handler(
   req,
   res,
 ) {
@@ -40,3 +41,5 @@ export default async function handler(
   const needsUpdate = compareSemver(current, latest) < 0;
   res.status(200).json({ current, latest, needsUpdate });
 }
+
+export default rateLimitEdge(handler);

--- a/pages/api/nse/update.js
+++ b/pages/api/nse/update.js
@@ -1,7 +1,9 @@
 import { readFile } from 'fs/promises';
 import path from 'path';
 
-export default async function handler(_req, res) {
+import rateLimitEdge from '@/lib/rateLimitEdge';
+
+async function handler(_req, res) {
   try {
     const versionPath = path.join(process.cwd(), 'public', 'demo-data', 'nmap', 'script-db-version.json');
     const raw = await readFile(versionPath, 'utf8');
@@ -23,3 +25,5 @@ export default async function handler(_req, res) {
     res.status(500).json({ error: 'Unable to check script versions' });
   }
 }
+
+export default rateLimitEdge(handler);

--- a/pages/api/radare2.js
+++ b/pages/api/radare2.js
@@ -4,9 +4,11 @@ import os from 'os';
 import path from 'path';
 import { promisify } from 'util';
 
+import rateLimitEdge from '@/lib/rateLimitEdge';
+
 const execFileAsync = promisify(execFile);
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });
     return;
@@ -65,4 +67,6 @@ export default async function handler(req, res) {
     return res.status(500).json({ error: e.message });
   }
 }
+
+export default rateLimitEdge(handler, { limit: 5 });
 


### PR DESCRIPTION
## Summary
- add a reusable rateLimitEdge helper that attaches rate-limit headers and optionally falls back to Response for edge handlers
- wrap the remaining tool API routes (mimikatz, metasploit, hydra, john, radare2, module/nse updates) with the new limiter
- cover the helper with unit tests and keep existing hydra/mimikatz API tests green

## Testing
- yarn lint *(fails: existing repo-wide accessibility and window/document lint violations)*
- CI=1 yarn test __tests__/hydra.api.test.ts __tests__/hydra-api.test.js
- CI=1 yarn test __tests__/rateLimitEdge.test.ts
- CI=1 yarn test __tests__/mimikatz.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d5d809923c8328a262c0c17ed1d0a1