### PR TITLE
[api] centralize rate limiting for API routes

### DIFF
--- a/__tests__/contact.api.test.ts
+++ b/__tests__/contact.api.test.ts
@@ -1,9 +1,12 @@
-import handler, { rateLimit, RATE_LIMIT_WINDOW_MS } from '../pages/api/contact';
+import handler, {
+  contactRateLimiter,
+  RATE_LIMIT_WINDOW_MS,
+} from '../pages/api/contact';
 import { createMocks } from 'node-mocks-http';
 
 describe('contact api', () => {
   afterEach(() => {
-    rateLimit.clear();
+    contactRateLimiter.reset();
     jest.restoreAllMocks();
     delete (global as any).fetch;
     delete process.env.RECAPTCHA_SECRET;
@@ -40,11 +43,11 @@ describe('contact api', () => {
 
   test('removes stale ip entries', async () => {
     const currentTime = 1_000_000;
-    jest.spyOn(Date, 'now').mockReturnValue(currentTime);
-    rateLimit.set('1.1.1.1', {
-      count: 1,
-      start: currentTime - RATE_LIMIT_WINDOW_MS - 1,
-    });
+    const dateSpy = jest.spyOn(Date, 'now');
+    dateSpy
+      .mockReturnValueOnce(currentTime - RATE_LIMIT_WINDOW_MS - 1)
+      .mockReturnValue(currentTime);
+    contactRateLimiter.check('1.1.1.1');
 
     (global as any).fetch = jest
       .fn()
@@ -70,8 +73,8 @@ describe('contact api', () => {
 
     await handler(req as any, res as any);
 
-    expect(rateLimit.has('1.1.1.1')).toBe(false);
-    expect(rateLimit.has('2.2.2.2')).toBe(true);
+    expect(contactRateLimiter.has('1.1.1.1')).toBe(false);
+    expect(contactRateLimiter.has('2.2.2.2')).toBe(true);
     expect(res._getStatusCode()).toBe(200);
   });
 });

--- a/pages/api/dummy.js
+++ b/pages/api/dummy.js
@@ -1,7 +1,22 @@
+import {
+  createRateLimiter,
+  getRequestIp,
+  setRateLimitHeaders,
+} from '../../utils/rateLimiter';
+
+const limiter = createRateLimiter();
+
 export default function handler(req, res) {
   if (req.method === 'POST') {
+    const rate = limiter.check(getRequestIp(req));
+    setRateLimitHeaders(res, rate);
+    if (!rate.ok) {
+      res.status(429).json({ error: 'rate_limit_exceeded' });
+      return;
+    }
     res.status(200).json({ message: 'Received' });
-  } else {
-    res.status(405).json({ message: 'Method not allowed' });
+    return;
   }
+
+  res.status(405).json({ message: 'Method not allowed' });
 }

--- a/pages/api/figlet/fonts.js
+++ b/pages/api/figlet/fonts.js
@@ -1,7 +1,21 @@
 import fs from 'fs';
 import path from 'path';
+import {
+  createRateLimiter,
+  getRequestIp,
+  setRateLimitHeaders,
+} from '../../../utils/rateLimiter';
+
+const limiter = createRateLimiter();
 
 export default function handler(req, res) {
+  const rate = limiter.check(getRequestIp(req));
+  setRateLimitHeaders(res, rate);
+  if (!rate.ok) {
+    res.status(429).json({ error: 'rate_limit_exceeded' });
+    return;
+  }
+
   const fontsDir = path.join(process.cwd(), 'figlet', 'fonts');
   let fonts = [];
   try {

--- a/pages/api/leaderboard/top.js
+++ b/pages/api/leaderboard/top.js
@@ -1,4 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
+import {
+  createRateLimiter,
+  getRequestIp,
+  setRateLimitHeaders,
+} from '../../../utils/rateLimiter';
+
+const limiter = createRateLimiter();
 
 export default async function handler(
   req,
@@ -7,6 +14,13 @@ export default async function handler(
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');
     res.status(405).end('Method Not Allowed');
+    return;
+  }
+
+  const rate = limiter.check(getRequestIp(req));
+  setRateLimitHeaders(res, rate);
+  if (!rate.ok) {
+    res.status(429).json({ error: 'rate_limit_exceeded' });
     return;
   }
 

--- a/pages/api/mimikatz.js
+++ b/pages/api/mimikatz.js
@@ -1,8 +1,21 @@
 import modules from '../../components/apps/mimikatz/modules.json';
+import {
+  createRateLimiter,
+  getRequestIp,
+  setRateLimitHeaders,
+} from '../../utils/rateLimiter';
+
+const limiter = createRateLimiter();
 
 export default async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });
+    return;
+  }
+  const rate = limiter.check(getRequestIp(req));
+  setRateLimitHeaders(res, rate);
+  if (!rate.ok) {
+    res.status(429).json({ error: 'rate_limit_exceeded' });
     return;
   }
   if (req.method === 'GET') {

--- a/pages/api/quote.ts
+++ b/pages/api/quote.ts
@@ -1,5 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import quotesData from '../../public/quotes/quotes.json';
+import {
+  createRateLimiter,
+  getRequestIp,
+  setRateLimitHeaders,
+} from '../../utils/rateLimiter';
 
 interface Quote {
   content: string;
@@ -8,11 +13,19 @@ interface Quote {
 }
 
 const quotes = quotesData as Quote[];
+const limiter = createRateLimiter();
 
 export default function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
+  const rate = limiter.check(getRequestIp(req));
+  setRateLimitHeaders(res, rate);
+  if (!rate.ok) {
+    res.status(429).json({ error: 'rate_limit_exceeded' });
+    return;
+  }
+
   const tag = Array.isArray(req.query.tag) ? req.query.tag[0] : req.query.tag;
   const pool = tag ? quotes.filter((q) => q.tags?.includes(tag)) : quotes;
   const quote = pool[Math.floor(Math.random() * pool.length)];

--- a/pages/api/radare2.js
+++ b/pages/api/radare2.js
@@ -3,8 +3,14 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { promisify } from 'util';
+import {
+  createRateLimiter,
+  getRequestIp,
+  setRateLimitHeaders,
+} from '../../utils/rateLimiter';
 
 const execFileAsync = promisify(execFile);
+const limiter = createRateLimiter({ max: 5 });
 
 export default async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
@@ -16,6 +22,12 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
     return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const rate = limiter.check(getRequestIp(req));
+  setRateLimitHeaders(res, rate);
+  if (!rate.ok) {
+    return res.status(429).json({ error: 'rate_limit_exceeded' });
   }
 
   const { action, hex, file } = req.body || {};

--- a/pages/api/share.js
+++ b/pages/api/share.js
@@ -1,6 +1,21 @@
+import {
+  createRateLimiter,
+  getRequestIp,
+  setRateLimitHeaders,
+} from '../../utils/rateLimiter';
+
+const limiter = createRateLimiter();
+
 export default function handler(req, res) {
   if (req.method !== 'POST') {
     res.status(405).end();
+    return;
+  }
+
+  const rate = limiter.check(getRequestIp(req));
+  setRateLimitHeaders(res, rate);
+  if (!rate.ok) {
+    res.status(429).json({ error: 'rate_limit_exceeded' });
     return;
   }
 

--- a/pages/api/wallpapers.js
+++ b/pages/api/wallpapers.js
@@ -1,7 +1,21 @@
 import fs from 'fs';
 import path from 'path';
+import {
+  createRateLimiter,
+  getRequestIp,
+  setRateLimitHeaders,
+} from '../../utils/rateLimiter';
+
+const limiter = createRateLimiter();
 
 export default function handler(req, res) {
+  const rate = limiter.check(getRequestIp(req));
+  setRateLimitHeaders(res, rate);
+  if (!rate.ok) {
+    res.status(429).json({ error: 'rate_limit_exceeded' });
+    return;
+  }
+
   const dir = path.join(process.cwd(), 'public', 'images', 'wallpapers');
   try {
     const files = fs

--- a/utils/rateLimiter.d.ts
+++ b/utils/rateLimiter.d.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export interface RateLimitResult {
+  ok: boolean;
+  limit: number;
+  remaining: number;
+  reset: number;
+  retryAfter: number;
+}
+
+export interface RateLimiter {
+  check(key: string): RateLimitResult;
+  reset(): void;
+  has(key: string): boolean;
+}
+
+export interface RateLimitOptions {
+  windowMs?: number;
+  max?: number;
+}
+
+export function createRateLimiter(options?: RateLimitOptions): RateLimiter;
+
+export function getRequestIp(
+  req: Pick<NextApiRequest, 'headers' | 'socket'>,
+): string;
+
+export function setRateLimitHeaders(
+  res: { setHeader?: NextApiResponse['setHeader'] },
+  result: RateLimitResult,
+): void;
+

--- a/utils/rateLimiter.js
+++ b/utils/rateLimiter.js
@@ -1,0 +1,76 @@
+const DEFAULT_WINDOW_MS = 60_000;
+const DEFAULT_MAX = 30;
+
+function cleanupStore(store, windowMs, now) {
+  for (const [key, entry] of store) {
+    if (now - entry.start >= windowMs) {
+      store.delete(key);
+    }
+  }
+}
+
+export function createRateLimiter(options = {}) {
+  const { windowMs = DEFAULT_WINDOW_MS, max = DEFAULT_MAX } = options;
+  const store = new Map();
+
+  return {
+    check(key) {
+      const now = Date.now();
+      cleanupStore(store, windowMs, now);
+
+      const entry = store.get(key) || { count: 0, start: now };
+      if (now - entry.start >= windowMs) {
+        entry.count = 0;
+        entry.start = now;
+      }
+
+      entry.count += 1;
+      store.set(key, entry);
+
+      const limited = entry.count > max;
+      const remaining = limited ? 0 : Math.max(0, max - entry.count);
+      const reset = entry.start + windowMs;
+      const retryAfter = limited
+        ? Math.max(1, Math.ceil((reset - now) / 1000))
+        : 0;
+
+      return {
+        ok: !limited,
+        limit: max,
+        remaining,
+        reset,
+        retryAfter,
+      };
+    },
+    reset() {
+      store.clear();
+    },
+    has(key) {
+      return store.has(key);
+    },
+  };
+}
+
+export function getRequestIp(req) {
+  const forwarded = req.headers?.['x-forwarded-for'];
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    return forwarded[0];
+  }
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    return forwarded.split(',')[0].trim();
+  }
+  return req.socket?.remoteAddress || '';
+}
+
+export function setRateLimitHeaders(res, result) {
+  if (typeof res.setHeader !== 'function') {
+    return;
+  }
+  res.setHeader('X-RateLimit-Limit', String(result.limit));
+  res.setHeader('X-RateLimit-Remaining', String(result.remaining));
+  res.setHeader('X-RateLimit-Reset', String(Math.floor(result.reset / 1000)));
+  if (!result.ok && result.retryAfter > 0) {
+    res.setHeader('Retry-After', String(result.retryAfter));
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a reusable in-memory rate limiter helper that sets standard rate limit headers
- update the contact API and its tests to use the shared limiter
- apply the limiter to remaining API routes so they emit consistent 429 responses when throttled

## Testing
- yarn lint *(fails: existing accessibility lint issues in unrelated UI components)*
- yarn test contactRateLimit hydra.api

------
https://chatgpt.com/codex/tasks/task_e_68d5d80aa60c832895479b2c5a91cd85