### PR TITLE
[api] add CVE feed endpoint

### DIFF
--- a/data/cve-feed.json
+++ b/data/cve-feed.json
@@ -1,0 +1,352 @@
+{
+  "generated": "2024-10-05T14:00:00Z",
+  "summary": {
+    "total": 15,
+    "critical": 4,
+    "high": 6,
+    "medium": 4,
+    "low": 1,
+    "exploited": 3
+  },
+  "trending": [
+    {
+      "cve": "CVE-2024-40521",
+      "title": "Apache Struts OGNL Remote Code Execution",
+      "cvss": 9.8,
+      "epss": 0.97,
+      "published": "2024-09-27",
+      "updated": "2024-10-02",
+      "summary": "Crafted OGNL expressions allow unauthenticated remote code execution when Struts is configured with the default interceptor stack.",
+      "affected": [
+        {
+          "vendor": "Apache",
+          "product": "Struts 2",
+          "versions": [
+            "2.5.33",
+            "2.6.0"
+          ]
+        }
+      ],
+      "tags": [
+        "rce",
+        "java",
+        "web"
+      ],
+      "references": [
+        "https://nvd.nist.gov/vuln/detail/CVE-2024-40521",
+        "https://struts.apache.org/security/#s2-40521"
+      ],
+      "detection": [
+        "Look for unusual process launches owned by the web container user.",
+        "Monitor web server logs for OGNL payload patterns containing %{ or ${ sequences."
+      ],
+      "mitigation": "Upgrade to Struts 2.5.34 or apply the vendor patch."
+    },
+    {
+      "cve": "CVE-2024-37654",
+      "title": "Cisco IOS XE Web UI Privilege Escalation",
+      "cvss": 9.6,
+      "epss": 0.94,
+      "published": "2024-09-14",
+      "updated": "2024-09-30",
+      "summary": "A crafted HTTP request chain bypasses authentication in the web UI and allows attackers to execute privileged CLI commands.",
+      "affected": [
+        {
+          "vendor": "Cisco",
+          "product": "IOS XE",
+          "versions": [
+            "17.9.x",
+            "17.10.x"
+          ]
+        }
+      ],
+      "tags": [
+        "network",
+        "priv-esc",
+        "zero-day"
+      ],
+      "references": [
+        "https://nvd.nist.gov/vuln/detail/CVE-2024-37654",
+        "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-iosxe-webui-2024"
+      ],
+      "detection": [
+        "Review HTTP access logs for repeated requests to /%25%25/ path segments.",
+        "Monitor configuration changes originating from unknown administrator sessions."
+      ],
+      "mitigation": "Disable the web UI and restrict management plane access until patched firmware is applied."
+    },
+    {
+      "cve": "CVE-2024-32988",
+      "title": "Fortinet FortiOS SSL VPN Command Injection",
+      "cvss": 8.8,
+      "epss": 0.88,
+      "published": "2024-08-31",
+      "updated": "2024-09-25",
+      "summary": "Improper input validation in the SSL VPN portal allows remote attackers to execute shell commands as root.",
+      "affected": [
+        {
+          "vendor": "Fortinet",
+          "product": "FortiOS",
+          "versions": [
+            "7.0.0-7.0.14",
+            "7.2.0-7.2.7"
+          ]
+        }
+      ],
+      "tags": [
+        "vpn",
+        "command-injection"
+      ],
+      "references": [
+        "https://nvd.nist.gov/vuln/detail/CVE-2024-32988",
+        "https://www.fortiguard.com/psirt/FG-IR-24-32988"
+      ],
+      "detection": [
+        "Inspect wvsd logs for suspicious parameter values in /remote/login endpoints.",
+        "Monitor for abnormal processes spawned by sslvpnd."
+      ],
+      "mitigation": "Upgrade to the fixed FortiOS release or disable SSL VPN access."
+    },
+    {
+      "cve": "CVE-2024-31812",
+      "title": "Microsoft Exchange Server Outlook Web Access Remote Code Execution",
+      "cvss": 8.7,
+      "epss": 0.82,
+      "published": "2024-09-10",
+      "updated": "2024-10-01",
+      "summary": "An encoding flaw in Outlook Web Access allows authenticated attackers to upload arbitrary ASPX payloads that execute with SYSTEM privileges.",
+      "affected": [
+        {
+          "vendor": "Microsoft",
+          "product": "Exchange Server",
+          "versions": [
+            "2019 CU15",
+            "2016 CU24"
+          ]
+        }
+      ],
+      "tags": [
+        "exchange",
+        "authenticated"
+      ],
+      "references": [
+        "https://nvd.nist.gov/vuln/detail/CVE-2024-31812",
+        "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-31812"
+      ],
+      "detection": [
+        "Alert on unexpected ASPX uploads in the \"FrontEnd\" virtual directories.",
+        "Monitor event logs for w3wp.exe child processes executing cmd.exe or powershell.exe."
+      ],
+      "mitigation": "Apply the October cumulative update or restrict OWA to trusted networks."
+    },
+    {
+      "cve": "CVE-2024-31701",
+      "title": "Progress MOVEit Transfer Authentication Bypass",
+      "cvss": 8.5,
+      "epss": 0.79,
+      "published": "2024-09-05",
+      "updated": "2024-09-29",
+      "summary": "A logic error in the SFTP module allows attackers to reuse expired session tokens to gain administrative access.",
+      "affected": [
+        {
+          "vendor": "Progress",
+          "product": "MOVEit Transfer",
+          "versions": [
+            "2023.1",
+            "2023.0"
+          ]
+        }
+      ],
+      "tags": [
+        "file-transfer",
+        "auth-bypass"
+      ],
+      "references": [
+        "https://nvd.nist.gov/vuln/detail/CVE-2024-31701",
+        "https://community.progress.com/s/article/moveit-transfer-hotfix-september-2024"
+      ],
+      "detection": [
+        "Audit MOVEit system logs for repeated token reuse from the same IP within seconds.",
+        "Monitor for newly created administrative accounts without corresponding change tickets."
+      ],
+      "mitigation": "Install the vendor hotfix and enforce short-lived access tokens."
+    }
+  ],
+  "exploited": [
+    {
+      "cve": "CVE-2024-37654",
+      "title": "Cisco IOS XE Web UI Privilege Escalation",
+      "cvss": 9.6,
+      "epss": 0.94,
+      "published": "2024-09-14",
+      "updated": "2024-09-30",
+      "summary": "In-the-wild exploitation chains use the web UI flaw to create local admin accounts and pivot deeper into campus networks.",
+      "affected": [
+        {
+          "vendor": "Cisco",
+          "product": "IOS XE",
+          "versions": [
+            "17.9.x",
+            "17.10.x"
+          ]
+        }
+      ],
+      "tags": [
+        "network",
+        "priv-esc",
+        "zero-day"
+      ],
+      "references": [
+        "https://nvd.nist.gov/vuln/detail/CVE-2024-37654",
+        "https://www.cisa.gov/known-exploited-vulnerabilities-catalog"
+      ],
+      "detection": [
+        "Correlate new local user creation logs with web UI access events.",
+        "Monitor for configuration changes initiated via RESTCONF from unusual IP ranges."
+      ],
+      "mitigation": "Disable the web UI and apply Cisco's interim engineering build.",
+      "firstSeen": "2024-09-17",
+      "observedIn": [
+        "Managed campus networks",
+        "Shadowserver honeypots"
+      ]
+    },
+    {
+      "cve": "CVE-2024-32988",
+      "title": "Fortinet FortiOS SSL VPN Command Injection",
+      "cvss": 8.8,
+      "epss": 0.88,
+      "published": "2024-08-31",
+      "updated": "2024-09-25",
+      "summary": "Attackers deploy custom webshells after exploiting the SSL VPN injection issue, enabling long-term persistence on edge appliances.",
+      "affected": [
+        {
+          "vendor": "Fortinet",
+          "product": "FortiOS",
+          "versions": [
+            "7.0.0-7.0.14",
+            "7.2.0-7.2.7"
+          ]
+        }
+      ],
+      "tags": [
+        "vpn",
+        "command-injection"
+      ],
+      "references": [
+        "https://nvd.nist.gov/vuln/detail/CVE-2024-32988",
+        "https://www.fortiguard.com/psirt/FG-IR-24-32988"
+      ],
+      "detection": [
+        "Inspect temporary directories for unexpected webshell artifacts.",
+        "Review VPN portal access logs for POST requests containing base64-encoded payloads."
+      ],
+      "mitigation": "Upgrade FortiOS and restrict VPN portal exposure.",
+      "firstSeen": "2024-09-08",
+      "observedIn": [
+        "Managed detection service sensors",
+        "Multiple MSSP incident reports"
+      ]
+    },
+    {
+      "cve": "CVE-2024-31701",
+      "title": "Progress MOVEit Transfer Authentication Bypass",
+      "cvss": 8.5,
+      "epss": 0.79,
+      "published": "2024-09-05",
+      "updated": "2024-09-29",
+      "summary": "Attackers reuse expired session tokens to stage mass file theft campaigns, often pairing the exploit with data extortion.",
+      "affected": [
+        {
+          "vendor": "Progress",
+          "product": "MOVEit Transfer",
+          "versions": [
+            "2023.1",
+            "2023.0"
+          ]
+        }
+      ],
+      "tags": [
+        "file-transfer",
+        "auth-bypass"
+      ],
+      "references": [
+        "https://nvd.nist.gov/vuln/detail/CVE-2024-31701",
+        "https://community.progress.com/s/article/moveit-transfer-hotfix-september-2024"
+      ],
+      "detection": [
+        "Alert on large bursts of file downloads initiated by service accounts.",
+        "Correlate MOVEit audit events for reused tokens across different IP addresses."
+      ],
+      "mitigation": "Install the vendor hotfix and enforce MFA for administrators.",
+      "firstSeen": "2024-09-11",
+      "observedIn": [
+        "Threat intelligence sharing feeds",
+        "CISA KEV catalog"
+      ]
+    }
+  ],
+  "vendorBreakdown": [
+    {
+      "vendor": "Cisco",
+      "count": 3
+    },
+    {
+      "vendor": "Microsoft",
+      "count": 3
+    },
+    {
+      "vendor": "Fortinet",
+      "count": 2
+    },
+    {
+      "vendor": "VMware",
+      "count": 2
+    },
+    {
+      "vendor": "Progress",
+      "count": 1
+    }
+  ],
+  "weeklyActivity": [
+    {
+      "week": "2024-09-02",
+      "critical": 1,
+      "high": 2,
+      "medium": 2,
+      "low": 1
+    },
+    {
+      "week": "2024-09-09",
+      "critical": 0,
+      "high": 3,
+      "medium": 2,
+      "low": 0
+    },
+    {
+      "week": "2024-09-16",
+      "critical": 2,
+      "high": 1,
+      "medium": 1,
+      "low": 0
+    },
+    {
+      "week": "2024-09-23",
+      "critical": 1,
+      "high": 2,
+      "medium": 2,
+      "low": 0
+    },
+    {
+      "week": "2024-09-30",
+      "critical": 0,
+      "high": 2,
+      "medium": 1,
+      "low": 1
+    }
+  ],
+  "metadata": {
+    "source": "Simulated portfolio dataset",
+    "disclaimer": "Demo CVE feed for educational use. Not an authoritative security advisory."
+  }
+}

--- a/hooks/useCveFeed.ts
+++ b/hooks/useCveFeed.ts
@@ -1,0 +1,26 @@
+import useSWR from 'swr';
+import type { CveFeed } from '../types/cve';
+import { CVE_CACHE_MS, CVE_STALE_MS } from '../lib/cache/cve';
+
+const fetcher = async (url: string): Promise<CveFeed> => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error('Failed to fetch CVE feed');
+  }
+  return response.json();
+};
+
+export default function useCveFeed() {
+  const swr = useSWR<CveFeed>('/api/cve', fetcher, {
+    dedupingInterval: CVE_CACHE_MS,
+    focusThrottleInterval: CVE_STALE_MS,
+    keepPreviousData: true,
+  });
+
+  return {
+    data: swr.data,
+    error: swr.error,
+    isLoading: swr.isLoading,
+    mutate: swr.mutate,
+  };
+}

--- a/lib/cache/cve.ts
+++ b/lib/cache/cve.ts
@@ -1,0 +1,5 @@
+export const CVE_CACHE_SECONDS = 3600;
+export const CVE_STALE_SECONDS = 3600;
+
+export const CVE_CACHE_MS = CVE_CACHE_SECONDS * 1000;
+export const CVE_STALE_MS = CVE_STALE_SECONDS * 1000;

--- a/pages/api/cve.ts
+++ b/pages/api/cve.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import data from '../../data/cve-feed.json';
+import type { CveFeed } from '../../types/cve';
+import { CVE_CACHE_SECONDS, CVE_STALE_SECONDS } from '../../lib/cache/cve';
+
+const cveFeed = data as CveFeed;
+
+type ErrorResponse = { error: string };
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CveFeed | ErrorResponse>,
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  res.setHeader(
+    'Cache-Control',
+    `public, s-maxage=${CVE_CACHE_SECONDS}, stale-while-revalidate=${CVE_STALE_SECONDS}`,
+  );
+
+  return res.status(200).json(cveFeed);
+}

--- a/types/cve.ts
+++ b/types/cve.ts
@@ -1,0 +1,61 @@
+export interface CveProduct {
+  vendor: string;
+  product: string;
+  versions?: string[];
+}
+
+export interface CveItem {
+  cve: string;
+  title: string;
+  cvss: number;
+  epss?: number;
+  published: string;
+  updated?: string;
+  summary: string;
+  affected: CveProduct[];
+  tags?: string[];
+  references: string[];
+  detection?: string[];
+  mitigation?: string;
+}
+
+export interface ExploitedCve extends CveItem {
+  firstSeen: string;
+  observedIn?: string[];
+  mitigation: string;
+}
+
+export interface VendorStat {
+  vendor: string;
+  count: number;
+}
+
+export interface WeeklyActivity {
+  week: string;
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+}
+
+export interface CveSummary {
+  total: number;
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  exploited: number;
+}
+
+export interface CveFeed {
+  generated: string;
+  summary: CveSummary;
+  trending: CveItem[];
+  exploited: ExploitedCve[];
+  vendorBreakdown: VendorStat[];
+  weeklyActivity: WeeklyActivity[];
+  metadata: {
+    source: string;
+    disclaimer: string;
+  };
+}


### PR DESCRIPTION
## Summary
- add a static CVE feed dataset and TypeScript types
- expose a cached `/api/cve` route and SWR hook that share cache timings

## Testing
- yarn lint *(fails: existing accessibility and window/document lint issues)*
- yarn test *(fails: legacy window manager, Nmap NSE, and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d80cac408328970cfae0ad08e236