### PR TITLE
[api] add hibp password check endpoint

### DIFF
--- a/__tests__/hibp-check.api.test.ts
+++ b/__tests__/hibp-check.api.test.ts
@@ -1,0 +1,73 @@
+import crypto from 'crypto';
+import { createMocks } from 'node-mocks-http';
+import handler, { MIN_PASSWORD_LENGTH } from '../pages/api/hibp-check';
+
+describe('hibp-check api', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (global as any).fetch;
+  });
+
+  it('returns breach count when password is found', async () => {
+    const password = 'hunter' + 'x'.repeat(MIN_PASSWORD_LENGTH - 6 + 1);
+    const hash = crypto.createHash('sha1').update(password, 'utf8').digest('hex').toUpperCase();
+    const prefix = hash.slice(0, 5);
+    const suffix = hash.slice(5);
+
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(`${suffix}:42\nOTHERHASH:1`),
+    });
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { password },
+    });
+
+    await handler(req as any, res as any);
+
+    expect((global as any).fetch).toHaveBeenCalledWith(
+      `https://api.pwnedpasswords.com/range/${prefix}`,
+      expect.objectContaining({
+        method: 'GET',
+        headers: { 'Add-Padding': 'true' },
+      }),
+    );
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ ok: true, count: 42, breached: true });
+  });
+
+  it('rejects invalid payloads', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { password: 'short' },
+    });
+
+    await handler(req as any, res as any);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({ ok: false, code: 'invalid_password' });
+    expect((global as any).fetch).toBeUndefined();
+  });
+
+  it('returns throttled response when hibp responds with 429', async () => {
+    const password = 'validPassword123';
+
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: () => Promise.resolve(''),
+    });
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { password },
+    });
+
+    await handler(req as any, res as any);
+
+    expect(res._getStatusCode()).toBe(429);
+    expect(res._getJSONData()).toEqual({ ok: false, code: 'hibp_throttled' });
+  });
+});

--- a/pages/api/hibp-check.ts
+++ b/pages/api/hibp-check.ts
@@ -1,0 +1,88 @@
+import crypto from 'crypto';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const HIBP_ENDPOINT = 'https://api.pwnedpasswords.com/range/';
+export const MIN_PASSWORD_LENGTH = 8;
+const MAX_PASSWORD_LENGTH = 1024;
+
+function getPasswordFromBody(body: unknown): string | null {
+  if (!body || typeof body !== 'object') {
+    return null;
+  }
+  const value = (body as Record<string, unknown>).password;
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.normalize('NFKC');
+  if (normalized.length < MIN_PASSWORD_LENGTH || normalized.length > MAX_PASSWORD_LENGTH) {
+    return null;
+  }
+  return normalized;
+}
+
+async function lookupPassword(hashSuffix: string, hashPrefix: string) {
+  const response = await fetch(`${HIBP_ENDPOINT}${hashPrefix}`, {
+    method: 'GET',
+    headers: {
+      'Add-Padding': 'true',
+    },
+  });
+
+  if (response.status === 429) {
+    return { ok: false as const, status: 429 };
+  }
+
+  if (!response.ok) {
+    return { ok: false as const, status: 502 };
+  }
+
+  const payload = await response.text();
+  const lines = payload.split('\n');
+  const match = lines
+    .map((line) => line.trim())
+    .find((line) => line.toUpperCase().startsWith(`${hashSuffix}:`));
+
+  const count = match ? Number.parseInt(match.split(':')[1] ?? '0', 10) || 0 : 0;
+
+  return { ok: true as const, count };
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ ok: false });
+    return;
+  }
+
+  const password = getPasswordFromBody(req.body);
+  if (!password) {
+    res.status(400).json({ ok: false, code: 'invalid_password' });
+    return;
+  }
+
+  const hash = crypto.createHash('sha1').update(password, 'utf8').digest('hex').toUpperCase();
+  const hashPrefix = hash.slice(0, 5);
+  const hashSuffix = hash.slice(5);
+
+  try {
+    const result = await lookupPassword(hashSuffix, hashPrefix);
+
+    if (!result.ok) {
+      if (result.status === 429) {
+        res.status(429).json({ ok: false, code: 'hibp_throttled' });
+        return;
+      }
+      res.status(502).json({ ok: false, code: 'hibp_unavailable' });
+      return;
+    }
+
+    res.setHeader('Cache-Control', 'no-store');
+    res.status(200).json({ ok: true, count: result.count, breached: result.count > 0 });
+  } catch (error) {
+    console.error('hibp lookup failed', error);
+    res.status(502).json({ ok: false, code: 'hibp_unavailable' });
+  }
+}


### PR DESCRIPTION
## Summary
- add a Have I Been Pwned password check API route with payload validation and throttle handling
- return structured success/error responses including minimum length enforcement
- cover success, validation failure, and upstream throttle cases with API tests

## Testing
- yarn test hibp-check
- yarn lint *(fails: existing accessibility and lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d80e034c8328b8b4b3bc25c78540