### PR TITLE
[api] Add health endpoint

### DIFF
--- a/pages/api/health.ts
+++ b/pages/api/health.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  res.status(200).json({ status: 'ok' });
+}

--- a/tests/apps.smoke.spec.ts
+++ b/tests/apps.smoke.spec.ts
@@ -22,6 +22,13 @@ const routes = getRoutes(appDir)
   .filter((r) => r !== '/apps/index')
   .map((r) => r.replace(/\/index$/, ''));
 
+test('health endpoint returns ok', async ({ request }) => {
+  const response = await request.get('/api/health');
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body).toEqual({ status: 'ok' });
+});
+
 for (const route of routes) {
   test(`loads ${route}`, async ({ page }) => {
     await page.goto('/apps');


### PR DESCRIPTION
## Summary
- add a simple `/api/health` route that returns `{ status: 'ok' }`
- extend the Playwright smoke suite to verify the health endpoint responds successfully

## Testing
- npx playwright test tests/apps.smoke.spec.ts *(fails: Playwright browsers not installed in container)*
- yarn lint *(fails: existing jsx-a11y and no-top-level-window errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d80efa8c8328a1caf03964d70b0f