### PR TITLE
[api] add blackjack user guard

### DIFF
--- a/__tests__/blackjackUser.api.test.ts
+++ b/__tests__/blackjackUser.api.test.ts
@@ -1,0 +1,54 @@
+import handler from '../pages/api/users/[id]/blackjack';
+import { rateLimit } from '../pages/api/contact';
+import { createMocks } from 'node-mocks-http';
+
+function createToken(sub: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' }))
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  const payload = Buffer.from(JSON.stringify({ sub }))
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  return `${header}.${payload}.signature`;
+}
+
+describe('users/[id]/blackjack api', () => {
+  beforeEach(() => {
+    rateLimit.clear();
+  });
+
+  test('rejects mismatched subject', async () => {
+    const token = createToken('user-123');
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      query: { id: 'user-456' },
+    });
+    (req.socket as any).remoteAddress = '9.9.9.9';
+
+    await handler(req as any, res as any);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({ ok: false, code: 'forbidden' });
+  });
+
+  test('allows matching subject', async () => {
+    const token = createToken('user-123');
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      query: { id: 'user-123' },
+    });
+    (req.socket as any).remoteAddress = '8.8.8.8';
+
+    await handler(req as any, res as any);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ ok: true });
+  });
+});
+

--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -5,7 +5,7 @@ import { getServiceSupabase } from '../../lib/supabase';
 
 // Simple in-memory rate limiter. Not suitable for distributed environments.
 export const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX = 5;
+export const RATE_LIMIT_MAX = 5;
 
 export const rateLimit = new Map();
 

--- a/pages/api/users/[id]/blackjack.ts
+++ b/pages/api/users/[id]/blackjack.ts
@@ -1,0 +1,141 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  RATE_LIMIT_MAX,
+  RATE_LIMIT_WINDOW_MS,
+  rateLimit,
+} from '../../contact';
+
+type BlackjackResponse = {
+  ok: boolean;
+  code?:
+    | 'method_not_allowed'
+    | 'invalid_user'
+    | 'missing_token'
+    | 'invalid_token'
+    | 'forbidden'
+    | 'rate_limit';
+};
+
+function getClientIp(req: NextApiRequest): string {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    return forwarded.split(',')[0]?.trim() ?? '';
+  }
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    return forwarded[0];
+  }
+  return req.socket.remoteAddress ?? '';
+}
+
+function enforceRateLimit(
+  req: NextApiRequest,
+  res: NextApiResponse<BlackjackResponse>,
+): boolean {
+  const ip = getClientIp(req);
+  const now = Date.now();
+  const entry = rateLimit.get(ip) ?? { count: 0, start: now };
+
+  if (now - entry.start > RATE_LIMIT_WINDOW_MS) {
+    entry.count = 0;
+    entry.start = now;
+  }
+
+  entry.count += 1;
+  rateLimit.set(ip, entry);
+
+  for (const [key, value] of rateLimit.entries()) {
+    if (now - value.start > RATE_LIMIT_WINDOW_MS) {
+      rateLimit.delete(key);
+    }
+  }
+
+  if (entry.count > RATE_LIMIT_MAX) {
+    res
+      .status(429)
+      .json({ ok: false, code: 'rate_limit' });
+    return true;
+  }
+
+  return false;
+}
+
+function extractBearerToken(req: NextApiRequest): string | null {
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  const auth = req.headers.authorization ?? headers['Authorization'];
+  if (!auth) {
+    return null;
+  }
+
+  const value = Array.isArray(auth) ? auth[0] : auth;
+  if (!value || typeof value !== 'string') {
+    return null;
+  }
+
+  const [scheme, token] = value.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) {
+    return null;
+  }
+
+  return token;
+}
+
+function decodeJwtSubject(token: string): string | null {
+  const parts = token.split('.');
+  if (parts.length < 2) {
+    return null;
+  }
+
+  const payload = parts[1];
+  try {
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padding = normalized.length % 4;
+    const base64 =
+      padding === 0 ? normalized : normalized.padEnd(normalized.length + 4 - padding, '=');
+    const json = Buffer.from(base64, 'base64').toString('utf8');
+    const parsed = JSON.parse(json);
+    return typeof parsed.sub === 'string' ? parsed.sub : null;
+  } catch {
+    return null;
+  }
+}
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<BlackjackResponse>,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ ok: false, code: 'method_not_allowed' });
+    return;
+  }
+
+  if (enforceRateLimit(req, res)) {
+    return;
+  }
+
+  const userId = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
+  if (!userId || typeof userId !== 'string') {
+    res.status(400).json({ ok: false, code: 'invalid_user' });
+    return;
+  }
+
+  const token = extractBearerToken(req);
+  if (!token) {
+    res.status(401).json({ ok: false, code: 'missing_token' });
+    return;
+  }
+
+  const subject = decodeJwtSubject(token);
+  if (!subject) {
+    res.status(401).json({ ok: false, code: 'invalid_token' });
+    return;
+  }
+
+  if (subject !== userId) {
+    res.status(403).json({ ok: false, code: 'forbidden' });
+    return;
+  }
+
+  res.status(200).json({ ok: true });
+}
+


### PR DESCRIPTION
## Summary
- add a users/[id]/blackjack API route that checks the JWT subject, reuses the shared rate limiter, and returns an auth-gated response
- cover the new route with tests that ensure mismatched subjects are rejected

## Testing
- [ ] yarn lint *(fails: pre-existing accessibility/document globals issues in unrelated files)*
- [x] yarn test blackjackUser.api.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d5d80ff97c832890a1fb10ef771ac1