### PR TITLE
[build] register web platform types for TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,10 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": [],
+    "types": [
+      "web-bluetooth",
+      "wicg-file-system-access"
+    ],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]


### PR DESCRIPTION
## Summary
- add the Web Bluetooth and File System Access type packages to the global compiler options so related globals are resolved without local imports

## Testing
- yarn typecheck
- yarn lint *(fails: pre-existing accessibility and window/document lint rules across legacy apps)*
- yarn test *(fails: existing suites such as `__tests__/window.test.tsx`, `__tests__/nmapNse.test.tsx`, and jsdom localStorage access)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d8122e288328b5ef51134571625c