### PR TITLE
[build] block node core modules in browser code

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,81 @@
 import { FlatCompat } from '@eslint/eslintrc';
 import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
 
+const nodeCoreModules = [
+  'assert',
+  'async_hooks',
+  'buffer',
+  'child_process',
+  'cluster',
+  'console',
+  'constants',
+  'crypto',
+  'dgram',
+  'diagnostics_channel',
+  'dns',
+  'domain',
+  'events',
+  'fs',
+  'fs/promises',
+  'http',
+  'http2',
+  'https',
+  'inspector',
+  'module',
+  'net',
+  'os',
+  'path',
+  'perf_hooks',
+  'process',
+  'punycode',
+  'querystring',
+  'readline',
+  'repl',
+  'stream',
+  'string_decoder',
+  'timers',
+  'tls',
+  'tty',
+  'url',
+  'util',
+  'v8',
+  'vm',
+  'worker_threads',
+  'zlib',
+];
+
+const browserOnlyGlobs = [
+  'apps/**/*.{js,jsx,ts,tsx}',
+  'calc/**/*.{js,jsx,ts,tsx}',
+  'components/**/*.{js,jsx,ts,tsx}',
+  'filters/**/*.{js,jsx,ts,tsx}',
+  'games/**/*.{js,jsx,ts,tsx}',
+  'hooks/**/*.{js,jsx,ts,tsx}',
+  'modules/**/*.{js,jsx,ts,tsx}',
+  'pages/**/*.{js,jsx,ts,tsx}',
+  'player/**/*.{js,jsx,ts,tsx}',
+  'src/**/*.{js,jsx,ts,tsx}',
+  'styles/**/*.{js,jsx,ts,tsx}',
+  'templates/**/*.{js,jsx,ts,tsx}',
+  'utils/**/*.{js,jsx,ts,tsx}',
+  'workers/**/*.{js,jsx,ts,tsx}',
+];
+
+const nodeImportRestriction = [
+  'error',
+  {
+    paths: nodeCoreModules.flatMap((moduleName) => {
+      const message =
+        'Node.js core modules are not available in browser bundles. Move this logic to a server entry point or replace it with a browser-safe API.';
+      const entries = [{ name: moduleName, message }];
+      if (!moduleName.startsWith('node:')) {
+        entries.push({ name: `node:${moduleName}`, message });
+      }
+      return entries;
+    }),
+  },
+];
+
 const compat = new FlatCompat();
 
 const config = [
@@ -17,6 +92,21 @@ const config = [
     files: ['utils/qrStorage.ts', 'utils/safeStorage.ts', 'utils/sync.ts'],
     rules: {
       'no-restricted-globals': ['error', 'window', 'document'],
+    },
+  },
+  {
+    files: browserOnlyGlobs,
+    ignores: [
+      'pages/api/**',
+      'pages/**/api/**',
+      'app/api/**',
+      'app/**/route.{js,ts}',
+      '**/__tests__/**',
+      '**/*.test.{js,jsx,ts,tsx}',
+      '**/*.spec.{js,jsx,ts,tsx}',
+    ],
+    rules: {
+      'no-restricted-imports': nodeImportRestriction,
     },
   },
   ...compat.config({

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,52 @@
 
 const { validateServerEnv: validateEnv } = require('./lib/validate.js');
 
+const NODE_CORE_MODULE_FALLBACKS = [
+  'assert',
+  'async_hooks',
+  'buffer',
+  'child_process',
+  'cluster',
+  'console',
+  'constants',
+  'crypto',
+  'dgram',
+  'diagnostics_channel',
+  'dns',
+  'domain',
+  'events',
+  'fs',
+  'fs/promises',
+  'http',
+  'http2',
+  'https',
+  'inspector',
+  'module',
+  'net',
+  'os',
+  'path',
+  'perf_hooks',
+  'process',
+  'punycode',
+  'querystring',
+  'readline',
+  'repl',
+  'stream',
+  'string_decoder',
+  'timers',
+  'tls',
+  'tty',
+  'url',
+  'util',
+  'v8',
+  'vm',
+  'worker_threads',
+  'zlib',
+].reduce((acc, moduleName) => {
+  acc[moduleName] = false;
+  return acc;
+}, {});
+
 const ContentSecurityPolicy = [
   "default-src 'self'",
   // Prevent injection of external base URIs
@@ -96,11 +142,12 @@ function configureWebpack(config, { isServer }) {
   };
   // Prevent bundling of server-only modules in the browser
   config.resolve = config.resolve || {};
-  config.resolve.fallback = {
-    ...(config.resolve.fallback || {}),
-    module: false,
-    async_hooks: false,
-  };
+  if (!isServer) {
+    config.resolve.fallback = {
+      ...(config.resolve.fallback || {}),
+      ...NODE_CORE_MODULE_FALLBACKS,
+    };
+  }
   config.resolve.alias = {
     ...(config.resolve.alias || {}),
     'react-dom$': require('path').resolve(__dirname, 'lib/react-dom-shim.js'),


### PR DESCRIPTION
## Summary
- add a reusable list of Node.js core modules and apply no-restricted-imports to browser-targeted source trees
- ensure the Webpack client build marks Node core modules as unavailable so they are never bundled

## Testing
- `yarn lint` *(fails: existing jsx-a11y and no-top-level-window violations in legacy files)*
- `yarn test --watch=false` *(fails: existing suites such as window.test.tsx and Modal.test.tsx; run aborted after >160s)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d8135e0c8328a4a31b2cc34ae0e5