### PR TITLE
[build] align worker imports with JS outputs

### DIFF
--- a/apps/figlet/index.tsx
+++ b/apps/figlet/index.tsx
@@ -74,7 +74,7 @@ const FigletApp: React.FC = () => {
 
   useEffect(() => {
     if (typeof window !== "undefined" && typeof Worker === "function") {
-      workerRef.current = new Worker(new URL("./worker.ts", import.meta.url));
+      workerRef.current = new Worker(new URL("./worker.js", import.meta.url));
       workerRef.current.onmessage = (e: MessageEvent<any>) => {
         if (e.data?.type === "font") {
           setFonts((prev) => [

--- a/apps/terminal/components/PipeSandbox.tsx
+++ b/apps/terminal/components/PipeSandbox.tsx
@@ -12,7 +12,7 @@ export default function PipeSandbox() {
     setOutput('');
     if (typeof Worker !== 'undefined') {
       const worker = new Worker(
-        new URL('../workers/pipelineWorker.ts', import.meta.url),
+        new URL('../workers/pipelineWorker.js', import.meta.url),
       );
       worker.onmessage = (e: MessageEvent<any>) => {
         const { type, chunk } = e.data || {};

--- a/apps/terminal/components/Scripts.tsx
+++ b/apps/terminal/components/Scripts.tsx
@@ -10,7 +10,7 @@ interface ScriptEntry {
 }
 
 const examplesHref = new URL(
-  '../../../scripts/examples/terminal.ts',
+  '../../../scripts/examples/terminal.js',
   import.meta.url,
 ).href;
 

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -229,7 +229,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   useEffect(() => {
     if (typeof Worker === 'function') {
       workerRef.current = new Worker(
-        new URL('../../workers/terminal-worker.ts', import.meta.url),
+        new URL('../../workers/terminal-worker.js', import.meta.url),
       );
     }
     return () => workerRef.current?.terminate();

--- a/apps/timer_stopwatch/main.js
+++ b/apps/timer_stopwatch/main.js
@@ -51,7 +51,7 @@ function startTimer() {
   timerRemaining = mins * 60 + secs;
   timerEndTime = Date.now() + timerRemaining * 1000;
   updateTimerDisplay();
-  timerWorker = new Worker(new URL('../../workers/timer.worker.ts', import.meta.url));
+  timerWorker = new Worker(new URL('../../workers/timer.worker.js', import.meta.url));
   timerWorker.onmessage = () => {
     timerRemaining = Math.max(0, Math.ceil((timerEndTime - Date.now()) / 1000));
     updateTimerDisplay();
@@ -86,7 +86,7 @@ function updateStopwatchDisplay() {
 function startWatch() {
   if (stopwatchWorker || typeof Worker !== 'function') return;
   stopwatchStartTime = Date.now() - stopwatchElapsed * 1000;
-  stopwatchWorker = new Worker(new URL('../../workers/timer.worker.ts', import.meta.url));
+  stopwatchWorker = new Worker(new URL('../../workers/timer.worker.js', import.meta.url));
   stopwatchWorker.onmessage = () => {
     stopwatchElapsed = Math.floor((Date.now() - stopwatchStartTime) / 1000);
     updateStopwatchDisplay();

--- a/apps/x/components/ThreadComposer.tsx
+++ b/apps/x/components/ThreadComposer.tsx
@@ -42,7 +42,7 @@ export default function ThreadComposer() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const worker = new Worker(
-      new URL('../../../workers/postPublisher.ts', import.meta.url),
+      new URL('../../../workers/postPublisher.js', import.meta.url),
     );
     worker.onmessage = ({ data }) => {
       if (data.action === 'publish') {

--- a/components/FixturesLoader.tsx
+++ b/components/FixturesLoader.tsx
@@ -11,7 +11,7 @@ export default function FixturesLoader({ onData }: LoaderProps) {
   const [worker, setWorker] = useState<Worker | null>(null);
 
   useEffect(() => {
-    const w = new Worker(new URL('../workers/fixturesParser.ts', import.meta.url));
+    const w = new Worker(new URL('../workers/fixturesParser.js', import.meta.url));
     w.onmessage = (e) => {
       const { type, payload } = e.data;
       if (type === 'progress') setProgress(payload);

--- a/components/apps/Games/common/canvas/index.tsx
+++ b/components/apps/Games/common/canvas/index.tsx
@@ -32,7 +32,7 @@ const Canvas = forwardRef<CanvasHandle, CanvasProps>(
       // Prefer OffscreenCanvas with a worker when supported
       if (typeof Worker === 'function' && hasOffscreenCanvas()) {
         const worker = new Worker(
-          new URL('../../../../../workers/game-loop.worker.ts', import.meta.url)
+          new URL('../../../../../workers/game-loop.worker.js', import.meta.url)
         );
         workerRef.current = worker;
         const offscreen = canvas.transferControlToOffscreen();

--- a/components/apps/converter/HashConverter.js
+++ b/components/apps/converter/HashConverter.js
@@ -20,7 +20,7 @@ const HashConverter = () => {
 
   useEffect(() => {
     workerRef.current = new Worker(
-      new URL('../../../workers/hash-worker.ts', import.meta.url),
+      new URL('../../../workers/hash-worker.js', import.meta.url),
     );
 
     workerRef.current.onmessage = (e) => {

--- a/components/apps/nessus/index.js
+++ b/components/apps/nessus/index.js
@@ -73,7 +73,7 @@ const Nessus = () => {
     setJobs(loadJobDefinitions());
     setFalsePositives(loadFalsePositives());
     parserWorkerRef.current = new Worker(
-      new URL('../../../workers/nessus-parser.ts', import.meta.url)
+      new URL('../../../workers/nessus-parser.js', import.meta.url)
     );
       parserWorkerRef.current.onmessage = (e) => {
       const { findings: parsed = [], error: err } = e.data || {};

--- a/components/apps/qr_tool/index.tsx
+++ b/components/apps/qr_tool/index.tsx
@@ -29,7 +29,7 @@ const QRTool: React.FC = () => {
       typeof Worker === 'function'
     ) {
       workerRef.current = new Worker(
-        new URL('../../../workers/qrEncode.worker.ts', import.meta.url),
+        new URL('../../../workers/qrEncode.worker.js', import.meta.url),
       );
     }
     return workerRef.current;

--- a/components/simulator/index.tsx
+++ b/components/simulator/index.tsx
@@ -30,7 +30,7 @@ const Simulator: React.FC = () => {
 
   useEffect(() => {
     const worker = new Worker(
-      new URL('../../workers/simulatorParser.worker.ts', import.meta.url),
+      new URL('../../workers/simulatorParser.worker.js', import.meta.url),
     );
     workerRef.current = worker;
     worker.onmessage = (e: MessageEvent<SimulatorParserResponse>) => {

--- a/components/util-components/clock.js
+++ b/components/util-components/clock.js
@@ -15,7 +15,7 @@ export default class Clock extends Component {
         const update = () => this.setState({ current_time: new Date() });
         update();
         if (typeof window !== 'undefined' && typeof Worker === 'function') {
-            this.worker = new Worker(new URL('../../workers/timer.worker.ts', import.meta.url));
+            this.worker = new Worker(new URL('../../workers/timer.worker.js', import.meta.url));
             this.worker.onmessage = update;
             this.worker.postMessage({ action: 'start', interval: 10 * 1000 });
         } else {

--- a/next.config.js
+++ b/next.config.js
@@ -105,6 +105,10 @@ function configureWebpack(config, { isServer }) {
     ...(config.resolve.alias || {}),
     'react-dom$': require('path').resolve(__dirname, 'lib/react-dom-shim.js'),
   };
+  config.resolve.extensionAlias = {
+    ...(config.resolve.extensionAlias || {}),
+    '.js': ['.js', '.ts', '.tsx'],
+  };
   if (isProd) {
     config.optimization = {
       ...(config.optimization || {}),

--- a/scripts/examples/terminal-worker.ts
+++ b/scripts/examples/terminal-worker.ts
@@ -2,7 +2,7 @@
 
 export function uppercaseExample() {
   if (typeof Worker !== 'function') return;
-  const worker = new Worker(new URL('../../workers/terminal-worker.ts', import.meta.url));
+  const worker = new Worker(new URL('../../workers/terminal-worker.js', import.meta.url));
   worker.onmessage = (e: MessageEvent<any>) => {
     const { type, chunk } = e.data || {};
     if (type === 'data') {
@@ -14,7 +14,7 @@ export function uppercaseExample() {
 
 export function lineCountExample() {
   if (typeof Worker !== 'function') return;
-  const worker = new Worker(new URL('../../workers/terminal-worker.ts', import.meta.url));
+  const worker = new Worker(new URL('../../workers/terminal-worker.js', import.meta.url));
   const big = Array.from({ length: 1000 }, (_, i) => `line ${i}`).join('\n');
   worker.onmessage = (e: MessageEvent<any>) => {
     const { type, chunk } = e.data || {};

--- a/scripts/examples/terminal.ts
+++ b/scripts/examples/terminal.ts
@@ -2,7 +2,7 @@
 
 export function uppercaseExample() {
   if (typeof Worker !== 'function') return;
-  const worker = new Worker(new URL('../../workers/terminal-worker.ts', import.meta.url));
+  const worker = new Worker(new URL('../../workers/terminal-worker.js', import.meta.url));
   worker.onmessage = (e: MessageEvent<any>) => {
     const { type, chunk } = e.data || {};
     if (type === 'data') {
@@ -14,7 +14,7 @@ export function uppercaseExample() {
 
 export function lineCountExample() {
   if (typeof Worker !== 'function') return;
-  const worker = new Worker(new URL('../../workers/terminal-worker.ts', import.meta.url));
+  const worker = new Worker(new URL('../../workers/terminal-worker.js', import.meta.url));
   const big = Array.from({ length: 1000 }, (_, i) => `line ${i}`).join('\n');
   worker.onmessage = (e: MessageEvent<any>) => {
     const { type, chunk } = e.data || {};


### PR DESCRIPTION
## Summary
- update worker URLs and script links to point at their compiled .js bundles
- configure webpack extension aliasing so .js specifiers resolve to existing TypeScript sources

## Testing
- yarn tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d5d811130483289dcc562cc37d7a78