### PR TITLE
[ci] run gamepad prebuild in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: yarn prebuild
       - run: npm run tsc -- --noEmit
 
   test:

--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Type Check
         run: yarn tsc --noEmit
 
+      - name: Prebuild gamepad project
+        run: yarn prebuild
+
       - name: Building
         run: yarn build
         env:


### PR DESCRIPTION
## Summary
- run the dedicated gamepad TypeScript build in the CI typecheck job
- execute yarn prebuild before the deployment workflow's yarn build step so failures surface early

## Testing
- yarn lint *(fails: existing repository lint errors about missing labels and no-top-level-window rule)*
- yarn test *(fails: existing repository test failures and jsdom localStorage error; command interrupted after long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d81673ac8328b24cc9955d4094bb