### PR TITLE
[lint] expand storage lint coverage

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,7 @@ const config = [
     },
   },
   {
-    files: ['utils/qrStorage.ts', 'utils/safeStorage.ts', 'utils/sync.ts'],
+    files: ['utils/*{storage,Storage,IDB,idb}.ts', 'utils/sync.ts'],
     rules: {
       'no-restricted-globals': ['error', 'window', 'document'],
     },

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -10,38 +10,40 @@ export type ProgressData = Record<string, unknown>;
 export type Keybinds = Record<string, string>;
 export type Replay = { id: string; data: unknown };
 
+const canUsePersistentStorage = (): boolean => typeof indexedDB !== 'undefined';
+
 export const getProgress = async (): Promise<ProgressData> =>
-  (typeof window === 'undefined'
-    ? {}
-    : (await get<ProgressData>(PROGRESS_KEY)) || {});
+  (canUsePersistentStorage()
+    ? (await get<ProgressData>(PROGRESS_KEY)) || {}
+    : {});
 
 export const setProgress = async (progress: ProgressData): Promise<void> => {
-  if (typeof window === 'undefined') return;
+  if (!canUsePersistentStorage()) return;
   await set(PROGRESS_KEY, progress);
 };
 
 export const getKeybinds = async (): Promise<Keybinds> =>
-  (typeof window === 'undefined'
-    ? {}
-    : (await get<Keybinds>(KEYBINDS_KEY)) || {});
+  (canUsePersistentStorage()
+    ? (await get<Keybinds>(KEYBINDS_KEY)) || {}
+    : {});
 
 export const setKeybinds = async (keybinds: Keybinds): Promise<void> => {
-  if (typeof window === 'undefined') return;
+  if (!canUsePersistentStorage()) return;
   await set(KEYBINDS_KEY, keybinds);
 };
 
 export const getReplays = async (): Promise<Replay[]> =>
-  (typeof window === 'undefined'
-    ? []
-    : (await get<Replay[]>(REPLAYS_KEY)) || []);
+  (canUsePersistentStorage()
+    ? (await get<Replay[]>(REPLAYS_KEY)) || []
+    : []);
 
 export const saveReplay = async (replay: Replay): Promise<void> => {
-  if (typeof window === 'undefined') return;
+  if (!canUsePersistentStorage()) return;
   await update<Replay[]>(REPLAYS_KEY, (replays = []) => [...replays, replay]);
 };
 
 export const clearReplays = async (): Promise<void> => {
-  if (typeof window === 'undefined') return;
+  if (!canUsePersistentStorage()) return;
   await set(REPLAYS_KEY, []);
 };
 


### PR DESCRIPTION
## Summary
- expand the no-restricted-globals lint rule to cover all storage utilities via a glob
- update the storage helper to gate IndexedDB access without referencing window

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label and no-top-level-window issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d817f54483288ee267215f555daa