### PR TITLE
[tests] guard icon assets with jest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - run: yarn test --runTestsByPath __tests__/iconAssets.test.ts
       - run: yarn test --coverage
 
   security:

--- a/__tests__/iconAssets.test.ts
+++ b/__tests__/iconAssets.test.ts
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import path from 'path';
+
+import apps from '../apps.config';
+
+type AppEntry = {
+  id?: string;
+  title?: string;
+  icon?: string;
+};
+
+describe('icon asset availability', () => {
+  it('ensures every icon path resolves inside public/', () => {
+    expect(Array.isArray(apps)).toBe(true);
+
+    const appEntries: AppEntry[] = Array.isArray(apps) ? (apps as AppEntry[]) : [];
+
+    const icons = appEntries
+      .filter((entry) => entry && typeof entry === 'object' && typeof entry.icon === 'string' && entry.icon.trim().length > 0)
+      .map((entry) => ({
+        icon: entry.icon as string,
+        label: entry.id ?? entry.title ?? entry.icon ?? 'unknown',
+      }));
+
+    expect(icons.length).toBeGreaterThan(0);
+
+    const publicDir = path.join(__dirname, '..', 'public');
+    const missing: string[] = [];
+    const outside: string[] = [];
+
+    for (const { icon, label } of icons) {
+      const normalized = icon.replace(/^\/+/, '');
+      const resolved = path.resolve(publicDir, normalized);
+      const relative = path.relative(publicDir, resolved);
+
+      if (relative.startsWith('..') || path.isAbsolute(relative)) {
+        outside.push(`${label}: ${icon}`);
+        continue;
+      }
+
+      if (!fs.existsSync(resolved)) {
+        missing.push(`${label}: ${icon}`);
+      }
+    }
+
+    expect(outside).toEqual([]);
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Jest check that loads the dynamic app registry and confirms every icon path resolves inside `public/`
- ensure the CI test job executes the icon asset check before the full coverage run

## Testing
- yarn test --runTestsByPath __tests__/iconAssets.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d5d8194ae08328aa0fa4bd8a1803d2