### PR TITLE
test: add offline playwright coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,23 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  offline:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: npx playwright install --with-deps
+      - run: yarn build
+      - run: |
+          yarn start &
+          npx wait-on http://127.0.0.1:3000
+      - run: npx playwright test playwright/offline.spec.ts
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install

--- a/playwright/offline.spec.ts
+++ b/playwright/offline.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+const waitForServiceWorker = async (page: import('@playwright/test').Page) => {
+  await page.waitForFunction(async () => {
+    if (!('serviceWorker' in navigator)) {
+      return false;
+    }
+    const registration = await navigator.serviceWorker.ready;
+    return Boolean(registration?.active);
+  });
+
+  const hasController = await page.evaluate(() => Boolean(navigator.serviceWorker?.controller));
+  if (!hasController) {
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await page.waitForFunction(() => Boolean(navigator.serviceWorker?.controller));
+  }
+};
+
+test.describe('offline fallback', () => {
+  test('shows offline page with retry button when network is unavailable', async ({ page, context }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await waitForServiceWorker(page);
+
+    await context.setOffline(true);
+
+    try {
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await expect(page).toHaveURL(/\/offline\.html$/);
+      await expect(page.getByRole('heading', { name: 'Offline' })).toBeVisible();
+
+      const retryButton = page.getByRole('button', { name: /retry/i });
+      await expect(retryButton).toBeVisible();
+      await retryButton.click();
+      await expect(page.getByRole('heading', { name: 'Offline' })).toBeVisible();
+    } finally {
+      await context.setOffline(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add an end-to-end test that verifies the offline fallback page and retry control
- run the offline Playwright spec during CI against a production build

## Testing
- yarn lint *(fails: existing accessibility and lint violations in unrelated files)*
- yarn test *(fails: existing Jest failures in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d81c3884832882fd251a769688ba