### PR TITLE
[tests] ensure Speed Insights production coverage

### DIFF
--- a/playwright/speed-insights.spec.ts
+++ b/playwright/speed-insights.spec.ts
@@ -5,8 +5,31 @@ test.skip(
   'Speed Insights script is disabled during static export',
 );
 
-test('Speed Insights script is injected in production', async ({ page }) => {
+const mode = process.env.PLAYWRIGHT_SERVER_MODE ?? 'development';
+
+if (mode !== 'development' && mode !== 'production') {
+  throw new Error(
+    `Unsupported PLAYWRIGHT_SERVER_MODE "${mode}". Expected "development" or "production".`,
+  );
+}
+
+const isProd = mode === 'production';
+
+test(`Speed Insights script ${isProd ? 'loads' : 'stays disabled'} in ${mode}`, async ({
+  page,
+}) => {
   await page.goto('/');
   const script = page.locator('script[src*="/_vercel/speed-insights/script.js"]');
-  await expect(script).toHaveCount(1);
+
+  const response = await page.request.get('/_vercel/speed-insights/script.js');
+
+  if (isProd) {
+    await expect(script).toHaveCount(1);
+    expect(response.ok()).toBeTruthy();
+    const body = await response.text();
+    expect(body.length).toBeGreaterThan(0);
+  } else {
+    await expect(script).toHaveCount(0);
+    expect(response.status()).toBe(404);
+  }
 });

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -26,6 +26,17 @@ const getPort = () =>
     srv.on('error', reject);
   });
 
+const stopServer = (child) =>
+  new Promise((resolve) => {
+    if (!child) {
+      resolve();
+      return;
+    }
+    const done = () => resolve();
+    child.once('exit', done);
+    child.kill();
+  });
+
 (async () => {
   try {
     const yarnVersion = execSync('yarn --version', { encoding: 'utf8' }).trim();
@@ -35,27 +46,57 @@ const getPort = () =>
     console.log(`next: ${nextVersion}`);
 
     await run('yarn', ['install', '--immutable']);
+    await run('npx', ['playwright', 'install', 'chromium']);
     await run('yarn', ['lint']);
     await run('yarn', ['tsc', '--noEmit']);
+
+    const runSpeedInsightsCheck = (mode, port) =>
+      run('npx', ['playwright', 'test', 'playwright/speed-insights.spec.ts'], {
+        env: {
+          ...process.env,
+          BASE_URL: `http://localhost:${port}`,
+          PLAYWRIGHT_SERVER_MODE: mode,
+        },
+      });
+
+    const devPort = await getPort();
+    const devServer = spawn('yarn', ['dev', '-p', String(devPort)], { stdio: 'inherit' });
+    const devExit = () => devServer.kill();
+    process.on('exit', devExit);
+    try {
+      await waitOn({ resources: [`http://localhost:${devPort}`], timeout: 60000 });
+      await runSpeedInsightsCheck('development', devPort);
+    } finally {
+      process.off('exit', devExit);
+      await stopServer(devServer);
+    }
+
     await run('yarn', ['build']);
 
     const port = await getPort();
     const server = spawn('yarn', ['start', '-p', String(port)], { stdio: 'inherit' });
-    process.on('exit', () => server.kill());
-    await waitOn({ resources: [`http://localhost:${port}`], timeout: 60000 });
+    const serverExit = () => server.kill();
+    process.on('exit', serverExit);
+    try {
+      await waitOn({ resources: [`http://localhost:${port}`], timeout: 60000 });
 
-    const routes = ['/', '/dummy-form', '/video-gallery', '/profile'];
-    for (const route of routes) {
-      const res = await fetch(`http://localhost:${port}${route}`);
-      const header = res.headers.get('x-powered-by');
-      if (res.status !== 200 || header !== 'Next.js') {
-        throw new Error(`Route ${route} failed: status ${res.status}, header ${header}`);
+      const routes = ['/', '/dummy-form', '/video-gallery', '/profile'];
+      for (const route of routes) {
+        const res = await fetch(`http://localhost:${port}${route}`);
+        const header = res.headers.get('x-powered-by');
+        if (res.status !== 200 || header !== 'Next.js') {
+          throw new Error(`Route ${route} failed: status ${res.status}, header ${header}`);
+        }
+        console.log(`✓ ${route}`);
       }
-      console.log(`✓ ${route}`);
-    }
 
-    console.log('verify: PASS');
-    server.kill();
+      await runSpeedInsightsCheck('production', port);
+
+      console.log('verify: PASS');
+    } finally {
+      process.off('exit', serverExit);
+      await stopServer(server);
+    }
   } catch (err) {
     console.error('verify: FAIL');
     console.error(err);


### PR DESCRIPTION
## Summary
- teach the Playwright Speed Insights spec to assert the script stays absent in dev and is served after a production build based on `PLAYWRIGHT_SERVER_MODE`
- extend `scripts/verify.mjs` to install Playwright browsers, exercise the spec against `yarn dev` and `yarn start`, and reuse the result inside the verify pipeline

## Testing
- yarn lint *(fails: repository has hundreds of pre-existing accessibility lint errors)*
- yarn test *(aborted after repeated pre-existing failures across the suite)*
- yarn verify:all *(fails: stops at the same lint violations as above)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d822664c8328bf61d7dfa1022034