### PR TITLE
[ci] add app module validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,18 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: npm run tsc -- --noEmit
 
+  validate-apps:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn validate:apps
+
   test:
     runs-on: ubuntu-latest
     needs: install

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "a11y": "node scripts/a11y.mjs",
     "smoke": "node scripts/smoke-all-apps.mjs",
     "module-report": "node scripts/generate-module-report.mjs",
+    "validate:apps": "node scripts/validate-apps.mjs",
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
     "verify:all": "node scripts/verify.mjs"

--- a/scripts/validate-apps.mjs
+++ b/scripts/validate-apps.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const configPath = path.join(rootDir, 'apps.config.js');
+const SEARCH_DIRS = [
+  path.join(rootDir, 'components', 'apps'),
+  path.join(rootDir, 'apps'),
+];
+
+const EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs'];
+
+async function ensureConfigReadable() {
+  try {
+    await fs.access(configPath);
+  } catch (error) {
+    console.error(`Unable to access apps.config.js at ${configPath}`);
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+async function readDynamicAppIds() {
+  const source = await fs.readFile(configPath, 'utf8');
+  const regex = /createDynamicApp\(\s*['"]([^'"\)]+)['"]/g;
+  const ids = new Set();
+  let match;
+  while ((match = regex.exec(source)) !== null) {
+    ids.add(match[1]);
+  }
+  return ids;
+}
+
+async function pathExists(candidate) {
+  try {
+    const stats = await fs.stat(candidate);
+    return stats.isFile();
+  } catch (error) {
+    return false;
+  }
+}
+
+async function resolveDynamicImport(id) {
+  const extInId = path.extname(id);
+
+  for (const root of SEARCH_DIRS) {
+    const basePath = path.join(root, id);
+    const candidates = new Set();
+
+    if (extInId) {
+      candidates.add(basePath);
+    } else {
+      for (const ext of EXTENSIONS) {
+        candidates.add(basePath + ext);
+      }
+      candidates.add(basePath);
+      const indexBase = path.join(basePath, 'index');
+      for (const ext of EXTENSIONS) {
+        candidates.add(indexBase + ext);
+      }
+    }
+
+    for (const candidate of candidates) {
+      if (await pathExists(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+async function main() {
+  await ensureConfigReadable();
+  const ids = await readDynamicAppIds();
+
+  if (ids.size === 0) {
+    console.warn('No dynamic applications were discovered in apps.config.js');
+    return;
+  }
+
+  const missing = [];
+  for (const id of ids) {
+    const resolved = await resolveDynamicImport(id);
+    if (!resolved) {
+      missing.push(id);
+    }
+  }
+
+  if (missing.length > 0) {
+    console.error('The following dynamic app modules could not be resolved:');
+    for (const id of missing) {
+      console.error(`  • ${id}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Validated ${ids.size} dynamic app modules.`);
+}
+
+main().catch((error) => {
+  console.error('Unexpected error while validating app modules:');
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a node script that scans `apps.config.js` for dynamic entries and verifies the referenced modules exist
- expose the validator through a `yarn validate:apps` script
- wire the validator into the CI workflow as a dedicated job

## Testing
- yarn validate:apps
- yarn lint *(fails: repository currently has hundreds of pre-existing accessibility rule violations)*
- yarn test *(fails: existing suites such as window and nmap NSE tests already fail under Jest)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d826ed8083288e92a1edb95cc96c