### PR TITLE
[public] add placeholder my-app icon

### DIFF
--- a/public/themes/Yaru/apps/my-app.svg
+++ b/public/themes/Yaru/apps/my-app.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Sample app icon">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#77216F" />
+      <stop offset="100%" stop-color="#2C001E" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="12" fill="url(#bg)" />
+  <path
+    d="M32 17a3 3 0 0 1 2.66 1.66l15 30A3 3 0 0 1 47 52H17a3 3 0 0 1-2.66-4.34l15-30A3 3 0 0 1 32 17Zm0 8.12L21.9 49h20.2Z"
+    fill="#F6F5F4"
+  />
+  <circle cx="32" cy="44" r="4" fill="#E95420" />
+</svg>


### PR DESCRIPTION
## Summary
- add a sample my-app icon under public/themes/Yaru/apps so documentation references resolve

## Testing
- `node -e "require('glob'); const fs=require('fs'); const path=require('path'); const dir=path.join(process.cwd(),'public','themes','Yaru','apps'); const files=new Set(fs.readdirSync(dir)); const regex=/\/themes\/Yaru\/apps\/([A-Za-z0-9._-]+)/g; const referenced=new Set(); for (const file of require('glob').sync('**/*.{js,jsx,ts,tsx,json,md}', { cwd: process.cwd(), nodir: true, ignore: ['node_modules/**', '.next/**'] })) { const content=fs.readFileSync(path.join(process.cwd(), file), 'utf8'); let match; while ((match = regex.exec(content))) { referenced.add(match[1]); } } const missing=[...referenced].filter((icon)=>!files.has(icon)); if (missing.length) { console.error('Missing icons:', missing); process.exit(1); } console.log('All referenced icons exist. Total:', referenced.size);"`


------
https://chatgpt.com/codex/tasks/task_e_68d5d82a18748328913bf0289f57a5f3