### PR TITLE
[docs] align app checklist with theme icon paths

### DIFF
--- a/docs/new-app-checklist.md
+++ b/docs/new-app-checklist.md
@@ -6,7 +6,8 @@ Use this checklist when adding a new app to the portfolio.
 
 - Place a **64x64** SVG or PNG icon in `public/themes/Yaru/apps/`.
 - Name the file after the app id (e.g. `my-app.svg`).
-- Reference the icon in `apps.config.js` with `icon: './themes/Yaru/apps/my-app.svg'`.
+- Reference the icon in `apps.config.js` with `icon: '/themes/Yaru/apps/my-app.svg'` so the runtime loads it from `public/themes/...`.
+- Run the icon existence test (`yarn test icon-existence`) to confirm the new `/themes/...` asset is present before committing.
 
 ## Dynamic import pattern
 


### PR DESCRIPTION
## Summary
- update the new app checklist to reference the /themes-based icon paths
- document the icon existence test contributors should run when adding icons

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d5d827c9988328ab04bcad0fa1fc10