### PR TITLE
[tests] add About Alex resume coverage

### DIFF
--- a/tests/about-alex.spec.ts
+++ b/tests/about-alex.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import aboutData from '../components/apps/alex/data.json';
+import resumeData from '../components/apps/alex/resume.json';
+
+test.describe('About Alex desktop shortcut', () => {
+  test('opens resume view with dynamic data', async ({ page }) => {
+    await page.goto('/');
+
+    const aboutShortcut = page.getByRole('button', { name: 'About Alex' });
+    await expect(aboutShortcut).toBeVisible();
+
+    await aboutShortcut.dblclick();
+
+    const aboutWindow = page.locator('#about');
+    await expect(aboutWindow).toBeVisible();
+
+    await aboutWindow.locator('#resume').click();
+
+    const resumeSection = aboutWindow.locator('#resume-content');
+    await expect(resumeSection).toBeVisible();
+
+    const expectedStrings = [
+      ...resumeData.skills,
+      ...resumeData.projects.map((project) => project.name),
+      ...resumeData.experience.flatMap((entry) => [entry.date, entry.description]),
+      ...aboutData.milestones.flatMap((milestone) => [milestone.year, milestone.description]),
+    ];
+
+    for (const text of expectedStrings) {
+      await expect(resumeSection, `Missing resume content: ${text}`).toContainText(text);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add an end-to-end Playwright test that opens the About Alex desktop shortcut and verifies resume data renders from JSON sources

## Testing
- yarn lint *(fails: existing accessibility and lint violations in unrelated files)*
- yarn test *(fails: existing jest suite failures in unrelated areas)*
- npx playwright test tests/about-alex.spec.ts *(fails: browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d82b483083289b3ffe181ff76017