### PR TITLE
[lib] tighten server env validation

### DIFF
--- a/__tests__/contact.api.test.ts
+++ b/__tests__/contact.api.test.ts
@@ -2,10 +2,27 @@ import handler, { rateLimit, RATE_LIMIT_WINDOW_MS } from '../pages/api/contact';
 import { createMocks } from 'node-mocks-http';
 
 describe('contact api', () => {
+  const requiredEnv = {
+    JWT_SECRET: 'jwt-secret',
+    JWT_REFRESH_SECRET: 'jwt-refresh-secret',
+    RATE_LIMIT_SECRET: 'rate-limit-secret',
+    ADMIN_READ_KEY: 'admin-key',
+    SUPABASE_URL: 'https://example.com',
+    SUPABASE_SERVICE_ROLE_KEY: 'service-role',
+    SUPABASE_ANON_KEY: 'anon-key',
+  };
+
+  beforeEach(() => {
+    Object.assign(process.env, requiredEnv);
+  });
+
   afterEach(() => {
     rateLimit.clear();
     jest.restoreAllMocks();
     delete (global as any).fetch;
+    for (const key of Object.keys(requiredEnv)) {
+      delete process.env[key];
+    }
     delete process.env.RECAPTCHA_SECRET;
   });
 

--- a/__tests__/contactRateLimit.test.ts
+++ b/__tests__/contactRateLimit.test.ts
@@ -1,10 +1,27 @@
 import handler, { rateLimit, RATE_LIMIT_WINDOW_MS } from '../pages/api/contact';
 
 describe('contact api rate limiter', () => {
+  const requiredEnv = {
+    JWT_SECRET: 'jwt-secret',
+    JWT_REFRESH_SECRET: 'jwt-refresh-secret',
+    RATE_LIMIT_SECRET: 'rate-limit-secret',
+    ADMIN_READ_KEY: 'admin-key',
+    SUPABASE_URL: 'https://example.com',
+    SUPABASE_SERVICE_ROLE_KEY: 'service-role',
+    SUPABASE_ANON_KEY: 'anon-key',
+  };
+
+  beforeEach(() => {
+    Object.assign(process.env, requiredEnv);
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
     rateLimit.clear();
     delete (global as any).fetch;
+    for (const key of Object.keys(requiredEnv)) {
+      delete process.env[key];
+    }
     delete process.env.RECAPTCHA_SECRET;
   });
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -19,9 +19,13 @@ const publicEnvSchema = z.object({
 
 const serverEnvSchema = publicEnvSchema.extend({
   RECAPTCHA_SECRET: z.string(),
-  SUPABASE_URL: z.string().optional(),
-  SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
-  SUPABASE_ANON_KEY: z.string().optional(),
+  JWT_SECRET: z.string(),
+  JWT_REFRESH_SECRET: z.string(),
+  RATE_LIMIT_SECRET: z.string(),
+  ADMIN_READ_KEY: z.string(),
+  SUPABASE_URL: z.string(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string(),
+  SUPABASE_ANON_KEY: z.string(),
 });
 
 function validatePublicEnv(env) {

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -19,9 +19,13 @@ const publicEnvSchema = z.object({
 
 const serverEnvSchema = publicEnvSchema.extend({
   RECAPTCHA_SECRET: z.string(),
-  SUPABASE_URL: z.string().optional(),
-  SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
-  SUPABASE_ANON_KEY: z.string().optional(),
+  JWT_SECRET: z.string(),
+  JWT_REFRESH_SECRET: z.string(),
+  RATE_LIMIT_SECRET: z.string(),
+  ADMIN_READ_KEY: z.string(),
+  SUPABASE_URL: z.string(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string(),
+  SUPABASE_ANON_KEY: z.string(),
 });
 
 export function validatePublicEnv(env: NodeJS.ProcessEnv) {


### PR DESCRIPTION
## Summary
- require JWT, rate-limit, admin, and Supabase server credentials in the shared validation schema
- mirror the stricter validation in the TypeScript definition
- seed contact API tests with the mandatory environment variables before invoking the handler

## Testing
- yarn lint *(fails: repository has numerous pre-existing jsx-a11y and lint violations)*
- yarn test *(fails: suite already contains failing window/contact UI tests under jest)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d82df4a08328adf3f22497f0fccb