### PR TITLE
[docs] log wasm build matrix

### DIFF
--- a/test-log.md
+++ b/test-log.md
@@ -32,3 +32,12 @@ Attempted to load each route under `/apps` in Chromium, Firefox, and WebKit. All
 - `yarn why bare-fs` shows the module is required by `tar-fs@3.1.0` via `@puppeteer/browsers@2.10.7`.
 - Latest versions (`@puppeteer/browsers@2.10.8`, `tar-fs@3.1.0`) still depend on `bare-fs@4.2.1`, so the warning remains.
 - `puppeteer` and `puppeteer-core` require this chain; removing them would break existing tooling, so the warning is ignored.
+
+## WASM build matrix (2025-09-26)
+
+- **Node 22.20.0:** `yarn build` hung during the static generation phase and required manual termination after emitting the initial PWA compilation output.【8cfa87†L1-L14】【22fe03†L1-L2】
+- **Node 22.20.0:** `npx vercel build` could not run because the CLI prompts for linked project settings and exits when none are supplied in this offline environment.【e111b0†L1-L8】
+- **Node 22.20.0:** Capstone WASM smoke test (`node -e ...`) succeeds, showing WebAssembly instructions decode correctly.【d45db3†L1-L12】
+- **Node 20.19.5:** `yarn build` completes with full static output summaries, confirming production builds work on this release line.【341583†L1-L20】
+- **Node 20.19.5:** `npx vercel build` encounters the same missing-project prompt, so preview builds cannot be exercised locally without credentials.【10fef6†L1-L2】
+- **Node 20.19.5:** Capstone WASM smoke test passes, matching the successful output observed on Node 22.【06a5e9†L1-L12】


### PR DESCRIPTION
## Summary
- record the Node 22 vs 20 WebAssembly build outcomes in `test-log.md`
- note that Vercel preview builds require linked project settings before they can run locally

## Testing
- [ ] `yarn build` (Node 22.20.0) *(hung during static generation)*
- [x] `node -e "(async () => { const cap = require('capstone-wasm'); await cap.loadCapstone(); const cs = new cap.Capstone(cap.Const.ARCH_X86, cap.Const.MODE_32); const insns = cs.disasm(Buffer.from('b800000000c3', 'hex'), { address: 0x1000 }); console.log(insns[0]); cs.close(); })();"` (Node 22.20.0)
- [ ] `npx --yes vercel build` (Node 22.20.0) *(blocked: missing linked project settings)*
- [x] `yarn build` (Node 20.19.5)
- [x] `node -e "(async () => { const cap = require('capstone-wasm'); await cap.loadCapstone(); const cs = new cap.Capstone(cap.Const.ARCH_X86, cap.Const.MODE_32); const insns = cs.disasm(Buffer.from('b800000000c3', 'hex'), { address: 0x1000 }); console.log(insns[0]); cs.close(); })();"` (Node 20.19.5)
- [ ] `npx --yes vercel build` (Node 20.19.5) *(blocked: missing linked project settings)*

------
https://chatgpt.com/codex/tasks/task_e_68d61b80e4c88328985e7af059d22b8a