### PR TITLE
[build] clarify node engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
     "verify:all": "node scripts/verify.mjs"
   },
-  "engines": {
-    "node": "20.19.5"
-  },
+  "engines": { "node": "20.19.5" },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",
     "@emailjs/browser": "^3.10.0",


### PR DESCRIPTION
## Summary
- inline the Node engine declaration so the manifest continues to require Node 20.19.5

## Testing
- [x] `yarn install` (Node v20.19.4 to observe the mismatched runtime behavior)

## Flags
- none

------
https://chatgpt.com/codex/tasks/task_e_68d61b82f24c8328b72b3b55240217f9