### PR TITLE
[config] Reformat Vercel functions config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,11 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
-    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
+    "pages/api/**/*.{js,ts}": {
+      "runtime": "@vercel/node@5.3.20"
+    },
+    "app/api/**/route.{js,ts}": {
+      "runtime": "@vercel/node@5.3.20"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- confirm the Vercel configuration no longer declares the deprecated `nodeVersion` property
- reformat the function runtime entries for readability

## Testing
- npx vercel pull --yes --environment=preview *(fails: ENETUNREACH contacting vercel.com in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d61b8451a88328a2bbd7ef2d68fc9c