### PR TITLE
[config] Update Vercel runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
-    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
+    "pages/api/**/*.{js,ts}": { "runtime": "nodejs22.x" },
+    "app/api/**/route.{js,ts}": { "runtime": "nodejs22.x" }
   }
 }


### PR DESCRIPTION
## Summary
- update the Vercel configuration to use the Node.js 22 runtime for API routes in both the pages and app directories

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d61b8391e48328b56566cd236b263c