### PR TITLE
[config] update vercel yarn commands

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,7 @@
   "functions": {
     "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
     "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
-  }
+  },
+  "installCommand": "corepack enable && corepack prepare yarn@4.9.2 --activate && yarn install --immutable",
+  "buildCommand": "yarn build"
 }


### PR DESCRIPTION
## Summary
- set Vercel's install command to activate Yarn 4.9.2 via Corepack before installing dependencies
- configure the deployment build command to run `yarn build`

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d61b867ed08328a6edc49f068596c4