### PR TITLE
[ci] fail yarn installs on warnings

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: 20
           cache: yarn
-      - run: yarn install --immutable
+      - run: ./scripts/ci/yarn-install.sh
       - run: npx playwright install --with-deps
       - run: |
           yarn dev &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: 20
           cache: yarn
-      - run: yarn install --immutable --immutable-cache
+      - run: ./scripts/ci/yarn-install.sh
 
   lint:
     runs-on: ubuntu-latest
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: 20
           cache: yarn
-      - run: yarn install --immutable --immutable-cache
+      - run: ./scripts/ci/yarn-install.sh
       - run: npm run lint
 
   typecheck:
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: 20
           cache: yarn
-      - run: yarn install --immutable --immutable-cache
+      - run: ./scripts/ci/yarn-install.sh
       - run: npm run tsc -- --noEmit
 
   test:
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: 20
           cache: yarn
-      - run: yarn install --immutable --immutable-cache
+      - run: ./scripts/ci/yarn-install.sh
       - run: yarn test --coverage
 
   security:
@@ -59,7 +59,7 @@ jobs:
         with:
           node-version: 20
           cache: yarn
-      - run: yarn install --immutable --immutable-cache
+      - run: ./scripts/ci/yarn-install.sh
       - run: yarn npm audit
 
   vercel-preview:
@@ -75,7 +75,7 @@ jobs:
         with:
           node-version: 20
           cache: yarn
-      - run: yarn install --immutable --immutable-cache
+      - run: ./scripts/ci/yarn-install.sh
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -17,7 +17,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: 'yarn.lock'
       - name: Installing Packages
-        run: yarn install --immutable
+        run: ./scripts/ci/yarn-install.sh
 
       - name: Test
         run: yarn jest -w=1

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,3 +13,14 @@ logFilters:
   - pattern: "Resolution field \"magic-string@*\" is incompatible with requested version"
     level: info
 
+packageExtensions:
+  "3d-force-graph-ar@*":
+    dependencies:
+      aframe: "^1.7.1"
+  "aframe-forcegraph-component@*":
+    dependencies:
+      three: "^0.180.0"
+  "react-force-graph@*":
+    dependencies:
+      aframe: "^1.7.1"
+

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@xterm/xterm": "^5.5.0",
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",
-    "aframe": "^1.5.0",
+    "aframe": "^1.7.1",
     "antd": "5.27.2",
     "autoprefixer": "^10.4.13",
     "bad-words": "^3.0.4",
@@ -99,7 +99,7 @@
     "stockfish": "^16.0.0",
     "swr": "^2.2.5",
     "tailwindcss": "^3.2.4",
-    "three": "^0.179.1",
+    "three": "^0.180.0",
     "turndown": "^7.2.1",
     "zod": "^3.23.8"
   },

--- a/scripts/ci/yarn-install.sh
+++ b/scripts/ci/yarn-install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMP_LOG="$(mktemp)"
+trap 'rm -f "$TMP_LOG"' EXIT
+
+if yarn install --immutable --immutable-cache --inline-builds | tee "$TMP_LOG"; then
+  :
+else
+  status=$?
+  exit "$status"
+fi
+
+if grep -q "Done with warnings" "$TMP_LOG"; then
+  echo "::error::Yarn install completed with warnings"
+  exit 1
+fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -4527,7 +4527,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aframe@npm:^1.5.0":
+"aframe@npm:^1.7.1":
   version: 1.7.1
   resolution: "aframe@npm:1.7.1"
   dependencies:
@@ -13395,7 +13395,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"three@npm:>=0.118 <1":
+"three@npm:>=0.118 <1, three@npm:^0.180.0":
   version: 0.180.0
   resolution: "three@npm:0.180.0"
   checksum: 10c0/2b5954b3e0946676cd606f126b1fbbe337ab6e72ae5a25b3eadbf1b8c502c17f21d851b9f5fe035edd48736306e339f143b5ee9cd4e91a2e614681abacef08de
@@ -13406,13 +13406,6 @@ __metadata:
   version: 0.164.1
   resolution: "three@npm:0.164.1"
   checksum: 10c0/f34dc945444fba814be542a907a2f6f2bed3189315604b8ef936d95513b2a4030807df63dcbb48b658bbe3d3e77a446cf2d164c1c08465578c23d4c278d76bb3
-  languageName: node
-  linkType: hard
-
-"three@npm:^0.179.1":
-  version: 0.179.1
-  resolution: "three@npm:0.179.1"
-  checksum: 10c0/563ba6d6a79b761b0a19b35141999edeec534cfef07e4ed2d480e2b7c30c290cb27bff0f43d81eaf60849af25b19a7950607db3ccf4aaa90a68d1394a2563f73
   languageName: node
   linkType: hard
 
@@ -13891,7 +13884,7 @@ __metadata:
     "@xterm/xterm": "npm:^5.5.0"
     "@zxing/browser": "npm:^0.1.5"
     "@zxing/library": "npm:^0.21.3"
-    aframe: "npm:^1.5.0"
+    aframe: "npm:^1.7.1"
     antd: "npm:5.27.2"
     autoprefixer: "npm:^10.4.13"
     bad-words: "npm:^3.0.4"
@@ -13960,7 +13953,7 @@ __metadata:
     swr: "npm:^2.2.5"
     tailwindcss: "npm:^3.2.4"
     test-exclude: "npm:7.0.1"
-    three: "npm:^0.179.1"
+    three: "npm:^0.180.0"
     turndown: "npm:^7.2.1"
     typescript: "npm:5.8.2"
     wait-on: "npm:^8.0.4"


### PR DESCRIPTION
## Summary
- replace all workflow yarn install invocations with a shared script that enforces immutable installs and fails when logs contain "Done with warnings"
- extend the Yarn configuration and dependency versions so missing peer dependencies are satisfied without warnings

## Testing
- `./scripts/ci/yarn-install.sh`
- `bash -c 'set -euo pipefail; tmp=$(mktemp); trap "rm -f "$tmp"" EXIT; printf "Done with warnings\n" | tee "$tmp" >/dev/null; if grep -q "Done with warnings" "$tmp"; then echo "::error::Detected warnings"; exit 1; fi'` *(expected failure to prove warning detection)*

------
https://chatgpt.com/codex/tasks/task_e_68d61b855c008328bdc56103a6a190a6