### PR TITLE
[infra] align vercel runtime with node 20

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,3 +22,9 @@ yarn dev
 See the [Architecture](./architecture.md) document for an overview of how the project is organized.
 
 For app contributions, see the [New App Checklist](./new-app-checklist.md).
+
+## Vercel runtime configuration
+
+- Node.js 20 is pinned in `.nvmrc`, `package.json#engines`, and `vercel.json`. No extra runtime overrides should be added in Vercel project settings.
+- Vercel automatically applies this configuration to preview and production deployments, so both environments report the same runtime.
+- To verify, run `vercel inspect <deployment-url> --target preview` and `vercel inspect <deployment-url> --target production`; both should list **Node.js 20** as the runtime.

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
-    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
+    "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
+    "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
   }
 }


### PR DESCRIPTION
## Summary
- update the Vercel functions runtime to use `nodejs20.x` so both preview and production builds use the same Node version
- document the runtime configuration and verification steps in the getting started guide

## Testing
- [ ] Not run (not required for this change)


------
https://chatgpt.com/codex/tasks/task_e_68d61b883894832892bdc92523cbaeb1