### PR TITLE
[config] update vercel runtime schema

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "functions": {
-    "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
-    "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }
+    "pages/api/**/*.{js,ts}": { "runtime": "nodejs20.x" },
+    "app/api/**/route.{js,ts}": { "runtime": "nodejs20.x" }
   }
 }


### PR DESCRIPTION
## Summary
- update the Vercel functions runtime definitions to use the supported nodejs20.x runtime

## Testing
- npx vercel pull --yes --environment=preview --cwd . --local-config vercel.json *(fails: ENETUNREACH while attempting to reach vercel.com)*

------
https://chatgpt.com/codex/tasks/task_e_68d61b8961948328bc859f78f9e68cbe