### PR TITLE
[build] register file system access types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": [],
+    "types": ["node", "web-bluetooth", "file-system-access"],
+    "typeRoots": ["./types", "./node_modules/@types"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]

--- a/types/file-system-access/index.d.ts
+++ b/types/file-system-access/index.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="wicg-file-system-access" />
+
+export {};


### PR DESCRIPTION
## Summary
- include Node, Web Bluetooth, and file-system-access entries in the TypeScript configuration
- add a local type root that references the WICG File System Access definitions

## Testing
- yarn tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d61b92259c83289b2560cab12136a5