### PR TITLE
[config] tighten tsconfig include paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,46 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
-
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts"],
-  "exclude": ["node_modules", "__tests__", "components/apps/archive", "components/apps/kismet"]
+  "include": [
+    "next-env.d.ts",
+    "app/**/*",
+    "apps/**/*",
+    "calc/**/*",
+    "components/**/*",
+    "filters/**/*",
+    "games/**/*",
+    "hooks/**/*",
+    "lib/**/*",
+    "modules/**/*",
+    "pages/**/*",
+    "player/**/*",
+    "plugins/**/*",
+    "scanner/**/*",
+    "src/**/*",
+    "styles/**/*",
+    "types/**/*",
+    "utils/**/*",
+    "workers/**/*",
+    "middleware.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "__tests__",
+    "__mocks__",
+    "tests",
+    "playwright",
+    "docs",
+    "templates",
+    "scripts/examples",
+    "components/apps/archive",
+    "components/apps/kismet",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/*.stories.*",
+    "**/*.e2e.*",
+    "**/__tests__/**",
+    "**/__mocks__/**"
+  ]
 }


### PR DESCRIPTION
## Summary
- restrict the TypeScript include globs to the app and supporting source directories
- exclude test, Storybook, and archived app code so type checking skips non-production files

## Testing
- yarn tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d61b94252c8328a5793ff42060c4a4