### PR TITLE
[config] Add Jest and Node types to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": [],
+    "types": ["node", "jest"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]


### PR DESCRIPTION
## Summary
- include Jest and Node type packages in the root TypeScript configuration to ensure test helpers resolve correctly

## Testing
- yarn tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d61b9562588328af0e9594331f268b