### PR TITLE
[config] Restore legacy tool rewrites

### DIFF
--- a/__tests__/rewrites.test.ts
+++ b/__tests__/rewrites.test.ts
@@ -1,0 +1,28 @@
+jest.mock('@next/bundle-analyzer', () => () => (config: unknown) => config);
+jest.mock('@ducanh2912/next-pwa', () => ({
+  __esModule: true,
+  default: () => (config: unknown) => config,
+}));
+
+describe('Next.js rewrites', () => {
+  it('rewrites legacy tool routes to the new app locations', async () => {
+    const config = require('../next.config.js');
+
+    expect(config.rewrites).toBeDefined();
+
+    const rewrites = await config.rewrites();
+
+    expect(rewrites).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: '/tools',
+          destination: '/apps',
+        }),
+        expect.objectContaining({
+          source: '/tools/:path*',
+          destination: '/apps/:path*',
+        }),
+      ]),
+    );
+  });
+});

--- a/next.config.js
+++ b/next.config.js
@@ -146,6 +146,18 @@ module.exports = withBundleAnalyzer(
       deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
       imageSizes: [16, 32, 48, 64, 96, 128, 256],
     },
+    async rewrites() {
+      return [
+        {
+          source: '/tools',
+          destination: '/apps',
+        },
+        {
+          source: '/tools/:path*',
+          destination: '/apps/:path*',
+        },
+      ];
+    },
     // Security headers are skipped outside production; remove !isProd check to restore them for development.
     ...(isStaticExport || !isProd
       ? {}


### PR DESCRIPTION
## Summary
- ensure `/tools` routes rewrite to their `/apps` counterparts so legacy links keep working
- add a Jest regression test that verifies the rewrite mapping stays in place

## Testing
- yarn test rewrites

------
https://chatgpt.com/codex/tasks/task_e_68d61b9ebd908328a16db16c4fbfe59f