### PR TITLE
[test] add wasm smoke suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,17 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
-      - run: npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+      - id: deploy
+        run: |
+          url=$(npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} | tail -n 1)
+          echo "Preview deployment: ${url}"
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+      - name: Run WASM smoke suite
+        if: steps.deploy.outputs.url != ''
+        env:
+          BASE_URL: ${{ steps.deploy.outputs.url }}
+        run: npx playwright test playwright/wasm-routes.spec.ts

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,17 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
-  testMatch: /.*\.spec\.ts/,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
   },
+  projects: [
+    {
+      name: 'app-smoke',
+      testDir: './tests',
+    },
+    {
+      name: 'playwright-suite',
+      testDir: './playwright',
+    },
+  ],
 });

--- a/playwright/wasm-routes.spec.ts
+++ b/playwright/wasm-routes.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+type SmokeRoute = {
+  path: string;
+  check: (page: import('@playwright/test').Page) => Promise<void>;
+};
+
+const routes: SmokeRoute[] = [
+  {
+    path: '/apps/ghidra',
+    check: async (page) => {
+      const fallbackImage = page.locator('img[alt="Ghidra screenshot 1"]');
+      if ((await fallbackImage.count()) > 0) {
+        await expect(fallbackImage).toBeVisible();
+        await expect(page.locator('img[alt="Ghidra screenshot 2"]')).toBeVisible();
+        return;
+      }
+
+      const toggleButton = page.getByRole('button', {
+        name: /Use (?:Capstone|Ghidra)/i,
+      });
+      await expect(toggleButton).toBeVisible();
+      await expect(page.getByPlaceholder('Search symbols')).toBeVisible();
+    },
+  },
+  {
+    path: '/apps/wireshark',
+    check: async (page) => {
+      await expect(
+        page.getByRole('button', { name: 'Toggle protocol color legend' }),
+      ).toBeVisible();
+      await expect(page.locator('input[type="file"][accept=".pcap,.pcapng"]')).toBeVisible();
+      await expect(page.getByRole('option', { name: 'Open sample' })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'Sample sources' })).toBeVisible();
+    },
+  },
+];
+
+for (const route of routes) {
+  test(`wasm smoke test for ${route.path}`, async ({ baseURL, page }) => {
+    const origin = baseURL ?? 'http://localhost:3000';
+    await page.goto(new URL(route.path, origin).toString(), {
+      waitUntil: 'networkidle',
+    });
+    await route.check(page);
+  });
+}


### PR DESCRIPTION
## Summary
- add wasm smoke tests that cover the ghidra and wireshark routes
- allow the shared Playwright config to cover both /tests and /playwright suites
- execute the wasm smoke suite against the deployed preview in CI

## Testing
- npx playwright test --config=playwright.config.ts --project=playwright-suite playwright/wasm-routes.spec.ts *(fails locally because /apps/ghidra responds 404 in the dev server)*

------
https://chatgpt.com/codex/tasks/task_e_68d61ba017ec8328bc37410712eca125