### PR TITLE
[build] disable async_hooks and module fallbacks in webpack

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -96,11 +96,9 @@ function configureWebpack(config, { isServer }) {
   };
   // Prevent bundling of server-only modules in the browser
   config.resolve = config.resolve || {};
-  config.resolve.fallback = {
-    ...(config.resolve.fallback || {}),
-    module: false,
-    async_hooks: false,
-  };
+  config.resolve.fallback = config.resolve.fallback || {};
+  config.resolve.fallback.module = false;
+  config.resolve.fallback.async_hooks = false;
   config.resolve.alias = {
     ...(config.resolve.alias || {}),
     'react-dom$': require('path').resolve(__dirname, 'lib/react-dom-shim.js'),


### PR DESCRIPTION
## Summary
- ensure the Next.js webpack config always disables the async_hooks and module fallbacks to avoid client bundle warnings

## Testing
- CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d61ba263c08328bb0b7b5c0ab00ee7