### PR TITLE
[api] add flags health endpoint

### DIFF
--- a/__tests__/flags-health.api.test.ts
+++ b/__tests__/flags-health.api.test.ts
@@ -1,0 +1,65 @@
+import { createMocks } from 'node-mocks-http';
+import handler, { snapshotFlags } from '../pages/api/flags/health';
+
+describe('flags health api', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('produces a snapshot of feature flags', () => {
+    const env = {
+      FEATURE_TOOL_APIS: 'enabled',
+      FEATURE_HYDRA: 'disabled',
+      FEATURE_EXPERIMENTAL: 'enabled',
+    } as NodeJS.ProcessEnv;
+
+    const snapshot = snapshotFlags(env);
+
+    expect(snapshot.flags).toEqual({
+      FEATURE_EXPERIMENTAL: { enabled: true, value: 'enabled' },
+      FEATURE_HYDRA: { enabled: false, value: 'disabled' },
+      FEATURE_TOOL_APIS: { enabled: true, value: 'enabled' },
+    });
+    expect(snapshot.enabledGates).toEqual([
+      'FEATURE_EXPERIMENTAL',
+      'FEATURE_TOOL_APIS',
+    ]);
+  });
+
+  it('returns the current flag state over HTTP', async () => {
+    process.env.FEATURE_TOOL_APIS = 'enabled';
+    process.env.FEATURE_HYDRA = 'disabled';
+
+    const { req, res } = createMocks({ method: 'GET' });
+    await handler(req as any, res as any);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeaders()).toMatchObject({ 'cache-control': 'no-store' });
+
+    const body = res._getJSONData();
+    expect(body.ok).toBe(true);
+    expect(typeof body.timestamp).toBe('string');
+    expect(new Date(body.timestamp).toString()).not.toBe('Invalid Date');
+    expect(body.enabledGates).toEqual(['FEATURE_TOOL_APIS']);
+    expect(body.flags).toMatchObject({
+      FEATURE_TOOL_APIS: { enabled: true, value: 'enabled' },
+      FEATURE_HYDRA: { enabled: false, value: 'disabled' },
+    });
+  });
+
+  it('rejects non-GET methods', async () => {
+    const { req, res } = createMocks({ method: 'POST' });
+
+    await handler(req as any, res as any);
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(res._getJSONData()).toEqual({ error: 'Method Not Allowed' });
+  });
+});

--- a/pages/api/flags/health.ts
+++ b/pages/api/flags/health.ts
@@ -1,0 +1,61 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const FEATURE_PREFIX = 'FEATURE_';
+const KNOWN_FLAGS = ['FEATURE_TOOL_APIS', 'FEATURE_HYDRA'];
+
+type FlagSnapshot = {
+  enabled: boolean;
+  value: string | null;
+};
+
+type FlagsHealthResponse = {
+  ok: true;
+  timestamp: string;
+  enabledGates: string[];
+  flags: Record<string, FlagSnapshot>;
+};
+
+export function snapshotFlags(env: NodeJS.ProcessEnv) {
+  const candidates = new Set<string>(KNOWN_FLAGS);
+  for (const key of Object.keys(env)) {
+    if (key.startsWith(FEATURE_PREFIX)) {
+      candidates.add(key);
+    }
+  }
+
+  const sortedKeys = Array.from(candidates).sort();
+  const flags: Record<string, FlagSnapshot> = {};
+  const enabledGates: string[] = [];
+
+  for (const key of sortedKeys) {
+    const rawValue = env[key];
+    const normalized = typeof rawValue === 'string' ? rawValue.toLowerCase() : '';
+    const enabled = normalized === 'enabled';
+    flags[key] = { enabled, value: rawValue ?? null };
+    if (enabled) {
+      enabledGates.push(key);
+    }
+  }
+
+  return { flags, enabledGates };
+}
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<FlagsHealthResponse | { error: string }>,
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  const { flags, enabledGates } = snapshotFlags(process.env);
+  res.setHeader('Cache-Control', 'no-store');
+  res.status(200).json({
+    ok: true,
+    timestamp: new Date().toISOString(),
+    enabledGates,
+    flags,
+  });
+}


### PR DESCRIPTION
## Summary
- add a feature-flag health endpoint under `/api/flags/health`
- surface env-backed gates and mark which are enabled via the existing flag scheme
- cover the snapshot helper and API contract with unit tests

## Testing
- [x] yarn test flags-health.api.test.ts

## Flags
- [x] FEATURE_TOOL_APIS (enabled in tests)
- [x] FEATURE_HYDRA (disabled in tests)


------
https://chatgpt.com/codex/tasks/task_e_68d61ba3d36c83289745db48fe380a8b