### PR TITLE
[config] Simplify headers configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -156,24 +156,6 @@ module.exports = withBundleAnalyzer(
                 source: '/(.*)',
                 headers: securityHeaders,
               },
-              {
-                source: '/fonts/(.*)',
-                headers: [
-                  {
-                    key: 'Cache-Control',
-                    value: 'public, max-age=31536000, immutable',
-                  },
-                ],
-              },
-              {
-                source: '/images/(.*)',
-                headers: [
-                  {
-                    key: 'Cache-Control',
-                    value: 'public, max-age=86400',
-                  },
-                ],
-              },
             ];
           },
         }),


### PR DESCRIPTION
## Summary
- remove custom font and image cache-control entries from next.config.js headers configuration
- keep only the global security headers so the response headers remain deterministic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d61ba61fc48328b55816feaef6622e