### PR TITLE
[config] Gate production source maps behind flag

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -124,6 +124,9 @@ module.exports = withBundleAnalyzer(
   withPWA({
     ...(isStaticExport && { output: 'export' }),
     webpack: configureWebpack,
+    // Only emit browser source maps when explicitly enabled to keep production builds lean.
+    productionBrowserSourceMaps:
+      process.env.ENABLE_PRODUCTION_SOURCEMAPS === 'true',
 
     // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
     eslint: {


### PR DESCRIPTION
## Summary
- disable `productionBrowserSourceMaps` by default and allow opting in via the `ENABLE_PRODUCTION_SOURCEMAPS` env flag

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d61ba81c008328b6e83254f3d37f82