### PR TITLE
[ci] capture preview source maps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      NEXT_PUBLIC_VERCEL_ENV: preview
+      NEXT_DISABLE_SOURCEMAP_GENERATION: '0'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -77,5 +79,16 @@ jobs:
           cache: yarn
       - run: yarn install --immutable --immutable-cache
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-      - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build preview with source maps
+        run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Upload preview source maps
+        if: ${{ env.NEXT_PUBLIC_VERCEL_ENV == 'preview' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-source-maps
+          path: |
+            .vercel/output/static/**/*.map
+            .vercel/output/functions/**/*.map
+          if-no-files-found: ignore
+          retention-days: 7
       - run: npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
- enable preview builds to set the Vercel environment and re-enable source-map generation
- upload generated map files as an artifact so they can be reviewed from pull requests

## Testing
- [ ] `yarn lint`
- [ ] `yarn test`
- [x] not applicable (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d61baa7e1c8328bbd903e592a3d22c