### PR TITLE
[build] Prepare Yarn 4.9.2 via Corepack

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -12,6 +12,11 @@ jobs:
         with:
           node-version: 20
           cache: yarn
+      - name: Prepare Yarn 4.9.2
+        run: |
+          corepack enable
+          corepack prepare yarn@4.9.2 --activate
+          yarn -v
       - run: yarn install --immutable
       - run: npx playwright install --with-deps
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
         with:
           node-version: 20
           cache: yarn
+      - name: Prepare Yarn 4.9.2
+        run: |
+          corepack enable
+          corepack prepare yarn@4.9.2 --activate
+          yarn -v
       - run: yarn install --immutable --immutable-cache
 
   lint:
@@ -23,6 +28,11 @@ jobs:
         with:
           node-version: 20
           cache: yarn
+      - name: Prepare Yarn 4.9.2
+        run: |
+          corepack enable
+          corepack prepare yarn@4.9.2 --activate
+          yarn -v
       - run: yarn install --immutable --immutable-cache
       - run: npm run lint
 
@@ -35,6 +45,11 @@ jobs:
         with:
           node-version: 20
           cache: yarn
+      - name: Prepare Yarn 4.9.2
+        run: |
+          corepack enable
+          corepack prepare yarn@4.9.2 --activate
+          yarn -v
       - run: yarn install --immutable --immutable-cache
       - run: npm run tsc -- --noEmit
 
@@ -47,6 +62,11 @@ jobs:
         with:
           node-version: 20
           cache: yarn
+      - name: Prepare Yarn 4.9.2
+        run: |
+          corepack enable
+          corepack prepare yarn@4.9.2 --activate
+          yarn -v
       - run: yarn install --immutable --immutable-cache
       - run: yarn test --coverage
 
@@ -59,6 +79,11 @@ jobs:
         with:
           node-version: 20
           cache: yarn
+      - name: Prepare Yarn 4.9.2
+        run: |
+          corepack enable
+          corepack prepare yarn@4.9.2 --activate
+          yarn -v
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
@@ -75,6 +100,11 @@ jobs:
         with:
           node-version: 20
           cache: yarn
+      - name: Prepare Yarn 4.9.2
+        run: |
+          corepack enable
+          corepack prepare yarn@4.9.2 --activate
+          yarn -v
       - run: yarn install --immutable --immutable-cache
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -16,6 +16,11 @@ jobs:
           node-version: 20
           cache: 'yarn'
           cache-dependency-path: 'yarn.lock'
+      - name: Prepare Yarn 4.9.2
+        run: |
+          corepack enable
+          corepack prepare yarn@4.9.2 --activate
+          yarn -v
       - name: Installing Packages
         run: yarn install --immutable
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Always test inside controlled labs and obtain written permission before performi
 
 ### Requirements
 - **Node.js 20.19.5** (repo includes `.nvmrc`; run `nvm use`)
-- **Yarn** or **npm**
+- **Yarn 4.9.2** (managed via [Corepack](https://nodejs.org/docs/latest/api/corepack.html))
 - Recommended: **pnpm** if you prefer stricter hoisting; update lock/config accordingly.
 
 ### Install & Run (Dev)
@@ -31,6 +31,9 @@ Always test inside controlled labs and obtain written permission before performi
 cp .env.local.example .env.local  # populate with required keys
 nvm install  # installs Node 20.19.5 from .nvmrc if needed
 nvm use
+corepack enable
+corepack prepare yarn@4.9.2 --activate
+yarn -v  # confirm 4.9.2
 yarn install
 yarn dev
 ```

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
+  "installCommand": "corepack enable && corepack prepare yarn@4.9.2 --activate && yarn -v && yarn install",
   "functions": {
     "pages/api/**/*.{js,ts}": { "runtime": "@vercel/node@5.3.20" },
     "app/api/**/route.{js,ts}": { "runtime": "@vercel/node@5.3.20" }


### PR DESCRIPTION
## Summary
- add README guidance for enabling Corepack and activating Yarn 4.9.2 locally
- run Corepack activation in CI workflows and Vercel install command before dependency installs
- echo `yarn -v` in automation to confirm the expected 4.9.2 runtime

## Testing
- [ ] yarn lint
- [ ] yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d61bab34248328aba86546da533c99