### PR TITLE
[build] quiet magic-string resolution warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,6 +10,10 @@ logFilters:
     level: discard
   - pattern: "The engine \"bare\" appears to be invalid."
     level: discard
+  - pattern: "Resolution field \"magic-string@npm:^0.25.0\" is incompatible with requested version \"magic-string@npm:^0.25.7\""
+    level: discard
+  - pattern: "Resolution field \"magic-string@npm:^0.25.7\" is incompatible with requested version \"magic-string@npm:^0.25.0\""
+    level: discard
   - pattern: "Resolution field \"magic-string@*\" is incompatible with requested version"
     level: info
 


### PR DESCRIPTION
## Summary
- add log filters in .yarnrc.yml to downgrade noisy magic-string resolution messages

## Testing
- [x] yarn install

------
https://chatgpt.com/codex/tasks/task_e_68d61bac47188328b48db909814661cd