### PR TITLE
[build] Pin webpack 5.101.3 for async WASM

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,14 +141,14 @@
     "test-exclude": "7.0.1",
     "typescript": "5.8.2",
     "wait-on": "^8.0.4",
-    "webpack": "^5.92.0",
+    "webpack": "5.101.3",
     "workbox-build": "7.1.1",
     "ws": "^8.18.0"
   },
   "resolutions": {
     "source-map": "^0.7.6",
     "test-exclude": "7.0.1",
-    "webpack": "^5.92.0",
+    "webpack": "5.101.3",
     "glob@npm:^7.1.6": "npm:glob@^9.3.5",
     "workbox-build@npm:7.1.0": "npm:workbox-build@7.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13964,7 +13964,7 @@ __metadata:
     turndown: "npm:^7.2.1"
     typescript: "npm:5.8.2"
     wait-on: "npm:^8.0.4"
-    webpack: "npm:^5.92.0"
+    webpack: "npm:5.101.3"
     workbox-build: "npm:7.1.1"
     ws: "npm:^8.18.0"
     zod: "npm:^3.23.8"
@@ -14219,7 +14219,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.92.0":
+"webpack@npm:5.101.3":
   version: 5.101.3
   resolution: "webpack@npm:5.101.3"
   dependencies:


### PR DESCRIPTION
## Summary
- record webpack 5.101.3 as the async WASM-compatible version in package manifests
- update the Yarn lockfile to match the pinned webpack release

## Testing
- CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d61bae6a7c832895a294a4309554df