### PR TITLE
[ci] enforce TypeScript checks during builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable --immutable-cache
-      - run: npm run tsc -- --noEmit
+      - run: yarn typecheck
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn lint
 
       - name: Type Check
-        run: yarn tsc --noEmit
+        run: yarn typecheck
 
       - name: Building
         run: yarn build

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 /// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "homepage": "https://unnippillil.com/",
   "scripts": {
     "build:gamepad": "tsc -p tsconfig.gamepad.json",
-    "prebuild": "tsc -p tsconfig.gamepad.json",
+    "prebuild": "tsc --noEmit && tsc -p tsconfig.gamepad.json",
     "dev": "next dev",
     "build": "next build",
     "postbuild": "node scripts/safe-copy.mjs",
     "start": "next start",
+    "preexport": "tsc --noEmit && tsc -p tsconfig.gamepad.json",
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -36,7 +36,7 @@ const getPort = () =>
 
     await run('yarn', ['install', '--immutable']);
     await run('yarn', ['lint']);
-    await run('yarn', ['tsc', '--noEmit']);
+    await run('yarn', ['typecheck']);
     await run('yarn', ['build']);
 
     const port = await getPort();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,10 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
-
-    }
+    },
+    "noEmit": true,
+    "plugins": [{ "name": "next" }]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts", ".next/types/**/*.ts"],
   "exclude": ["node_modules", "__tests__", "components/apps/archive", "components/apps/kismet"]
 }


### PR DESCRIPTION
## Summary
- ensure CI workflows run `yarn typecheck`
- run TypeScript checks before build/export scripts and in the verification helper
- align TypeScript config and generated env types with Next.js expectations so builds fail fast on type errors

## Testing
- [x] yarn typecheck
- [x] CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d61bafc1188328804f1b056039456b