### PR TITLE
[apps] Add accessible label for Kismet upload input

### DIFF
--- a/__tests__/kismet.test.tsx
+++ b/__tests__/kismet.test.tsx
@@ -5,6 +5,6 @@ import KismetApp from '../components/apps/kismet.jsx';
 describe('KismetApp', () => {
   it('renders file input', () => {
     render(<KismetApp />);
-    expect(screen.getByLabelText(/pcap file/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/upload pcap file/i)).toBeInTheDocument();
   });
 });

--- a/components/apps/kismet.jsx
+++ b/components/apps/kismet.jsx
@@ -152,13 +152,21 @@ const KismetApp = ({ onNetworkDiscovered }) => {
 
   return (
     <div className="p-4 text-white space-y-4">
-      <input
-        type="file"
-        accept=".pcap"
-        onChange={handleFile}
-        aria-label="pcap file"
-        className="block"
-      />
+      <div>
+        <label
+          htmlFor="kismet-pcap-upload"
+          className="block text-sm font-semibold text-gray-200"
+        >
+          Upload PCAP file
+        </label>
+        <input
+          id="kismet-pcap-upload"
+          type="file"
+          accept=".pcap"
+          onChange={handleFile}
+          className="mt-1 block"
+        />
+      </div>
 
       {networks.length > 0 && (
         <>


### PR DESCRIPTION
## Summary
- add a visible label for the Kismet PCAP upload control to improve accessibility
- update the Kismet unit test to assert against the new label

## Testing
- yarn test kismet

------
https://chatgpt.com/codex/tasks/task_e_68d61bbd376083289f9b8f59ae1ae8cd