### PR TITLE
[tests] Fix window snapping keyboard mock

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -198,8 +198,15 @@ describe('Window snapping finalize and release', () => {
 
     expect(ref.current!.state.snapped).toBe('left');
 
+    const keyboardEvent = {
+      key: 'ArrowDown',
+      altKey: true,
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn()
+    } as unknown as KeyboardEvent;
+
     act(() => {
-      ref.current!.handleKeyDown({ key: 'ArrowDown', altKey: true } as any);
+      ref.current!.handleKeyDown(keyboardEvent);
     });
 
     expect(ref.current!.state.snapped).toBeNull();


### PR DESCRIPTION
## Summary
- ensure the window snapping Alt+ArrowDown test supplies a keyboard event with preventDefault/stopPropagation

## Testing
- yarn test window

------
https://chatgpt.com/codex/tasks/task_e_68d61bbdb990832899fb5186b89a40ea