### PR TITLE
[ci] run playwright smoke suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,21 @@ jobs:
       - run: yarn install --immutable --immutable-cache
       - run: yarn npm audit
 
+  smoke:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - name: Install Playwright browsers
+        run: yarn playwright install --with-deps
+      - name: Run Playwright smoke tests
+        run: yarn playwright test
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,17 @@
 import { defineConfig } from '@playwright/test';
 
+const baseURL = process.env.BASE_URL || 'http://127.0.0.1:3000';
+
 export default defineConfig({
   testDir: './tests',
   testMatch: /.*\.spec\.ts/,
+  webServer: {
+    command: 'yarn dev --hostname 127.0.0.1 --port 3000',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    baseURL,
   },
 });


### PR DESCRIPTION
## Summary
- install Playwright browser dependencies in CI using `yarn playwright install --with-deps`
- add a CI job that executes the Playwright smoke tests covering the app routes
- configure Playwright to launch the Next.js dev server automatically for the smoke suite

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d61bbe428c8328a2b2e0c9c58c3da0