### PR TITLE
[a11y] Focus accessibility scan on critical issues

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -17,5 +17,5 @@ jobs:
       - run: |
           yarn dev &
           npx wait-on http://localhost:3000
-      - run: npx pa11y-ci --config pa11yci.json
+      - run: yarn a11y
       - run: npx playwright test playwright/a11y.spec.ts

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ See `.env.local.example` for the full list.
 
 ---
 
+## Accessibility Workflow
+
+- Start the dev server with `yarn dev` in one terminal, then run `yarn a11y` in another to execute the Pa11y scan defined in [`pa11yci.json`](./pa11yci.json).
+- The scan covers the desktop shell (`/`), the launcher (`/apps`), and key productivity apps (`/apps/contact`, `/apps/settings`) under both default and high-contrast themes.
+- Findings are grouped by severity using Axe impact levels; the script exits with a non-zero status only when **critical** issues are detected so that moderate gaps remain visible without blocking deployments.
+- The **Accessibility** GitHub Actions workflow runs the same command on every pull request and will fail the check if critical issues are reported.
+
+---
+
 ## Local Development Tips
 
 - Run `yarn lint` and `yarn test` before committing changes.

--- a/pa11yci.json
+++ b/pa11yci.json
@@ -13,7 +13,9 @@
   },
   "urls": [
     "http://localhost:3000",
-    "http://localhost:3000/apps"
+    "http://localhost:3000/apps",
+    "http://localhost:3000/apps/contact",
+    "http://localhost:3000/apps/settings"
   ],
   "scenarios": [
     {},

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -6,26 +6,72 @@ const { defaults = {}, urls = [], scenarios = [{}] } = JSON.parse(
   fs.readFileSync(configPath),
 );
 
+const severityRank = {
+  minor: 0,
+  moderate: 1,
+  serious: 2,
+  critical: 3,
+};
+
+const getImpact = issue => {
+  if (issue.runnerExtras?.impact) {
+    return issue.runnerExtras.impact;
+  }
+
+  switch (issue.type) {
+    case 'error':
+      return 'serious';
+    case 'warning':
+      return 'moderate';
+    default:
+      return 'minor';
+  }
+};
+
 (async () => {
-  let hasErrors = false;
+  let hasCritical = false;
   for (const url of urls) {
     for (const scenario of scenarios) {
       const options = { ...defaults, ...scenario };
       const label = scenario.label ? ` (${scenario.label})` : '';
       console.log(`Testing ${url}${label}`);
       const results = await pa11y(url, options);
-      if (results.issues.length > 0) {
-        hasErrors = true;
-        for (const issue of results.issues) {
-          console.log(`  [${issue.code}] ${issue.message} (${issue.selector})`);
-        }
-      } else {
+
+      if (results.issues.length === 0) {
         console.log('  No issues found');
+        continue;
+      }
+
+      const buckets = new Map();
+      for (const issue of results.issues) {
+        const impact = getImpact(issue);
+        const bucketKey = impact in severityRank ? impact : 'minor';
+        if (!buckets.has(bucketKey)) {
+          buckets.set(bucketKey, []);
+        }
+        buckets.get(bucketKey).push(issue);
+      }
+
+      const orderedBuckets = Array.from(buckets.entries()).sort(
+        (a, b) => (severityRank[b[0]] ?? 0) - (severityRank[a[0]] ?? 0),
+      );
+
+      for (const [impact, issues] of orderedBuckets) {
+        console.log(`  ${impact.toUpperCase()}: ${issues.length}`);
+        for (const issue of issues) {
+          console.log(
+            `    [${issue.code}] ${issue.message} (${issue.selector})`,
+          );
+        }
+        if (impact === 'critical') {
+          hasCritical = true;
+        }
       }
     }
   }
 
-  if (hasErrors) {
+  if (hasCritical) {
+    console.log('\nCritical accessibility violations detected.');
     process.exitCode = 1;
   }
 })();


### PR DESCRIPTION
## Summary
- extend the Pa11y routes to cover the desktop, launcher, contact, and settings screens in both default and high-contrast themes
- update the accessibility runner to bucket findings by impact and fail CI only on critical violations
- document the workflow in the README and route the GitHub Action through the new script

## Testing
- [ ] `yarn lint`
- [x] `yarn a11y`

------
https://chatgpt.com/codex/tasks/task_e_68d61bbf02548328ae2bc92ea7d9117e