### PR TITLE
[apps] add toggle controls for launcher tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,24 @@ export const displaySudoku = () => <SudokuApp />;
 ```
 Heavy apps are wrapped with **dynamic import** and most games share a `GameLayout` with a help overlay.
 
+### App toggles
+
+Every entry exported from `apps.config.js` now carries a boolean toggle so tiles can be hidden without removing their metadata.
+To disable an app globally, update the `toggleOverrides` map and set the relevant id to `false`:
+
+```ts
+const toggleOverrides = {
+  apps: {
+    'metasploit': false,
+  },
+  utilities: {},
+  games: {},
+};
+```
+
+Toggles apply to the desktop, Whisker menu, and `/apps` index. The effective state is exported as `appToggleConfig`
+if you need to surface toggle status elsewhere in the UI or tests.
+
 ### Prefetching dynamic apps
 Dynamic app modules include a `webpackPrefetch` hint and expose a `prefetch()` helper. Desktop tiles call this helper on hover or
 keyboard focus so bundles are warmed before launch. When adding a new app, export a default component and register it with

--- a/apps.config.js
+++ b/apps.config.js
@@ -204,6 +204,18 @@ const displayHashcat = createDisplay(HashcatApp);
 
 const displayKismet = createDisplay(KismetApp);
 
+const toggleOverrides = {
+  apps: {
+    // 'metasploit': false,
+  },
+  utilities: {
+    // 'qr': false,
+  },
+  games: {
+    // '2048': false,
+  },
+};
+
 // Utilities list used for the "Utilities" folder on the desktop
 const utilityList = [
   {
@@ -279,8 +291,6 @@ const utilityList = [
     screen: displaySubnetCalculator,
   },
 ];
-
-export const utilities = utilityList;
 
 // Default window sizing for games to prevent oversized frames
 export const gameDefaults = {
@@ -603,9 +613,7 @@ const gameList = [
   },
 ];
 
-export const games = gameList.map((game) => ({ ...gameDefaults, ...game }));
-
-const apps = [
+const primaryAppList = [
   {
     id: 'chrome',
     title: 'Google Chrome',
@@ -1062,10 +1070,40 @@ const apps = [
     desktop_shortcut: false,
     screen: displaySecurityTools,
   },
-  // Utilities are grouped separately
-  ...utilities,
-  // Games are included so they appear alongside apps
-  ...games,
 ];
 
+const applyToggleConfig = (items, category) => {
+  const overrides = toggleOverrides[category] ?? {};
+  const toggles = {};
+  const enabledItems = [];
+
+  items.forEach((item) => {
+    const enabled = overrides[item.id] ?? true;
+    toggles[item.id] = enabled;
+    if (enabled) {
+      enabledItems.push({ ...item, enabled });
+    }
+  });
+
+  return { enabledItems, toggles };
+};
+
+const { enabledItems: enabledUtilities, toggles: utilityToggleState } = applyToggleConfig(utilityList, 'utilities');
+export const utilities = enabledUtilities;
+
+const gamesWithDefaults = gameList.map((game) => ({ ...gameDefaults, ...game }));
+const { enabledItems: enabledGames, toggles: gameToggleState } = applyToggleConfig(gamesWithDefaults, 'games');
+export const games = enabledGames;
+
+const { enabledItems: enabledPrimaryApps, toggles: appToggleState } = applyToggleConfig(primaryAppList, 'apps');
+
+const apps = [...enabledPrimaryApps, ...utilities, ...games];
+
+export const appToggleConfig = {
+  apps: appToggleState,
+  utilities: utilityToggleState,
+  games: gameToggleState,
+};
+
 export default apps;
+

--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -26,15 +26,17 @@ export default function AppGrid({ openApp }) {
   const columnCountRef = useRef(1);
   const [focusedIndex, setFocusedIndex] = useState(0);
 
+  const availableApps = apps.filter((app) => app.enabled !== false);
+
   const filtered = useMemo(() => {
-    if (!query) return apps.map((app) => ({ ...app, nodes: app.title }));
-    return apps
+    if (!query) return availableApps.map((app) => ({ ...app, nodes: app.title }));
+    return availableApps
       .map((app) => {
         const { matched, nodes } = fuzzyHighlight(app.title, query);
         return matched ? { ...app, nodes } : null;
       })
       .filter(Boolean);
-  }, [query]);
+  }, [query, availableApps]);
 
   useEffect(() => {
     if (focusedIndex >= filtered.length) {

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -10,6 +10,7 @@ type AppMeta = {
   icon: string;
   disabled?: boolean;
   favourite?: boolean;
+  enabled?: boolean;
 };
 
 const CATEGORIES = [
@@ -28,7 +29,7 @@ const WhiskerMenu: React.FC = () => {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  const allApps: AppMeta[] = apps as any;
+  const allApps: AppMeta[] = (apps as any).filter((app: AppMeta) => app.enabled !== false);
   const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
   const recentApps = useMemo(() => {
     try {
@@ -38,8 +39,8 @@ const WhiskerMenu: React.FC = () => {
       return [];
     }
   }, [allApps, open]);
-  const utilityApps: AppMeta[] = utilities as any;
-  const gameApps: AppMeta[] = games as any;
+  const utilityApps: AppMeta[] = (utilities as any).filter((app: AppMeta) => app.enabled !== false);
+  const gameApps: AppMeta[] = (games as any).filter((app: AppMeta) => app.enabled !== false);
 
   const currentApps = useMemo(() => {
     let list: AppMeta[];

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -19,7 +19,7 @@ const AppsPage = () => {
   }, []);
 
   const filteredApps = apps.filter(
-    (app) => !app.disabled && app.title.toLowerCase().includes(query.toLowerCase()),
+    (app) => app.enabled !== false && !app.disabled && app.title.toLowerCase().includes(query.toLowerCase()),
   );
 
   return (


### PR DESCRIPTION
## Summary
- add toggle overrides and toggle state exports in `apps.config.js`
- filter the desktop launcher, Whisker menu, and /apps listing against disabled toggles
- document how to control app toggles in the README

## Testing
- yarn lint *(fails: existing no-top-level-window violations in legacy game assets)*

------
https://chatgpt.com/codex/tasks/task_e_68d61bc15de08328ae1bf301d6be199e