### PR TITLE
[build] align tsconfig with Next linting

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 /// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "export": "NEXT_PUBLIC_STATIC_EXPORT=true next build",
     "test": "jest",
     "test:watch": "jest --watch",
-    "lint": "eslint . --max-warnings=0",
+    "lint": "next lint --max-warnings=0",
     "tsc": "tsc",
     "typecheck": "tsc --noEmit",
     "a11y": "node scripts/a11y.mjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "strictNullChecks": true,
     "noImplicitAny": true,
+    "noEmit": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "module": "esnext",
@@ -19,9 +20,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
-
-    }
+    },
+    "plugins": [{ "name": "next" }]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts", ".next/types/**/*.ts"],
   "exclude": ["node_modules", "__tests__", "components/apps/archive", "components/apps/kismet"]
 }


### PR DESCRIPTION
## Summary
- enable noEmit and the Next.js TypeScript plugin in the root tsconfig while tracking generated route types
- switch the lint script to use `next lint` so local automation exercises Next.js TypeScript checks
- accept Next.js' navigation type references in next-env.d.ts

## Testing
- yarn lint *(fails: existing jsx-a11y control-has-associated-label violations and a missing @typescript-eslint/no-var-requires rule definition)*

------
https://chatgpt.com/codex/tasks/task_e_68d61b9854a483288244276272236391