### PR TITLE
[volatility] Harden demo data parsing

### DIFF
--- a/__tests__/volatilityResilience.test.tsx
+++ b/__tests__/volatilityResilience.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+jest.mock('../public/demo-data/volatility/plugins.json', () => []);
+
+describe('Volatility demo resilience', () => {
+  test('PluginBrowser renders with empty plugin dataset', () => {
+    const PluginBrowser = require('../components/apps/volatility/PluginBrowser').default;
+    render(<PluginBrowser />);
+
+    expect(screen.getByText(/educational use only/i)).toBeInTheDocument();
+    expect(screen.queryByText('pslist')).not.toBeInTheDocument();
+  });
+
+  test('PluginWalkthrough provides fallback content without plugins', () => {
+    const PluginWalkthrough =
+      require('../apps/volatility/components/PluginWalkthrough').default;
+    render(<PluginWalkthrough />);
+
+    expect(screen.getByText(/No plugin data available/i)).toBeInTheDocument();
+  });
+});

--- a/apps/volatility/components/PluginWalkthrough.tsx
+++ b/apps/volatility/components/PluginWalkthrough.tsx
@@ -11,11 +11,13 @@ interface PluginInfo {
 }
 
 const PluginWalkthrough: React.FC = () => {
-  const data = plugins as PluginInfo[];
+  const data = (Array.isArray(plugins) ? plugins : []) as PluginInfo[];
   const [index, setIndex] = useState(0);
-  const current = data[index];
+  const hasData = data.length > 0;
+  const current = hasData ? data[index % data.length] : undefined;
 
   useEffect(() => {
+    if (!hasData) return;
     data.forEach((p) => {
       if (p.minVersion && p.minVersion !== VOLATILITY_VERSION) {
         console.warn(
@@ -23,10 +25,22 @@ const PluginWalkthrough: React.FC = () => {
         );
       }
     });
-  }, [data]);
+  }, [data, hasData]);
 
-  const next = () => setIndex((i) => (i + 1) % data.length);
-  const prev = () => setIndex((i) => (i - 1 + data.length) % data.length);
+  const next = () => hasData && setIndex((i) => (i + 1) % data.length);
+  const prev = () =>
+    hasData && setIndex((i) => (i - 1 + data.length) % data.length);
+
+  if (!current) {
+    return (
+      <div className="space-y-2 text-xs">
+        <p>No plugin data available.</p>
+      </div>
+    );
+  }
+
+  const output = typeof current.output === 'string' ? current.output : '';
+  const description = typeof current.description === 'string' ? current.description : '';
 
   return (
     <div className="space-y-2 text-xs">
@@ -46,9 +60,9 @@ const PluginWalkthrough: React.FC = () => {
           Requires Volatility {current.minVersion}
         </p>
       )}
-      <p>{current.description}</p>
+      <p>{description}</p>
       <pre className="bg-black p-2 rounded overflow-auto whitespace-pre-wrap">
-        {current.output}
+        {output}
       </pre>
     </div>
   );

--- a/components/apps/volatility/MemoryHeatmap.js
+++ b/components/apps/volatility/MemoryHeatmap.js
@@ -14,6 +14,7 @@ const chipColors = {
 };
 
 const MemoryHeatmap = ({ data }) => {
+  const safeData = React.useMemo(() => (Array.isArray(data) ? data : []), [data]);
   const canvasRef = useRef(null);
   const [filters, setFilters] = useState({
     process: true,
@@ -31,9 +32,9 @@ const MemoryHeatmap = ({ data }) => {
   }, []);
 
   useEffect(() => {
-    const count = data.filter((d) => filters[d.type]).length;
+    const count = safeData.filter((d) => filters[d.type]).length;
     setAnnouncement(`Displaying ${count} memory segments`);
-  }, [filters, data]);
+  }, [filters, safeData]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -43,7 +44,7 @@ const MemoryHeatmap = ({ data }) => {
     const draw = () => {
       if (!ctx || !canvas) return;
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      const filtered = data.filter((d) => filters[d.type]);
+      const filtered = safeData.filter((d) => filters[d.type]);
       filtered.forEach((cell) => {
         const x = cell.x - offset.x;
         const y = cell.y - offset.y;
@@ -63,7 +64,7 @@ const MemoryHeatmap = ({ data }) => {
 
     draw();
     return () => cancelAnimationFrame(frame);
-  }, [data, filters, offset]);
+  }, [safeData, filters, offset]);
 
   useEffect(() => {
     const canvas = canvasRef.current;

--- a/components/apps/volatility/PluginBrowser.js
+++ b/components/apps/volatility/PluginBrowser.js
@@ -7,22 +7,29 @@ const PluginBrowser = () => {
   const [category, setCategory] = useState('All');
   const [selected, setSelected] = useState(null);
 
-  const categories = useMemo(
-    () => ['All', ...Array.from(new Set(plugins.map((p) => p.category)))],
-    []
-  );
+  const pluginList = useMemo(() => (Array.isArray(plugins) ? plugins : []), []);
+
+  const categories = useMemo(() => {
+    const unique = new Set();
+    pluginList.forEach((p) => {
+      if (p?.category) {
+        unique.add(p.category);
+      }
+    });
+    return ['All', ...Array.from(unique)];
+  }, [pluginList]);
 
   useEffect(() => {
-    plugins.forEach((p) => {
+    pluginList.forEach((p) => {
       if (p.minVersion && p.minVersion !== VOLATILITY_VERSION) {
         console.warn(
           `Plugin ${p.name} requires Volatility ${p.minVersion} but version ${VOLATILITY_VERSION} is loaded.`
         );
       }
     });
-  }, []);
+  }, [pluginList]);
 
-  const filtered = plugins.filter(
+  const filtered = pluginList.filter(
     (p) => category === 'All' || p.category === category
   );
 
@@ -84,7 +91,7 @@ const PluginBrowser = () => {
           </a>
         </div>
       ))}
-      {selected && (
+      {selected && typeof selected.output === 'string' && (
         <div className="text-xs bg-black rounded overflow-auto">
           {selected.output.split('\n').map((line, i) => (
             <div key={i} className={`px-2 ${i % 2 ? 'bg-gray-900' : 'bg-gray-800'}`}>

--- a/components/apps/volatility/index.js
+++ b/components/apps/volatility/index.js
@@ -12,9 +12,9 @@ const pstree = Array.isArray(memoryFixture.pstree)
   : [];
 const dlllist = memoryFixture.dlllist ?? {};
 const pslist = Array.isArray(pslistJson.rows) ? pslistJson.rows : [];
-const pslistColumns = pslistJson.columns ?? [];
+const pslistColumns = Array.isArray(pslistJson.columns) ? pslistJson.columns : [];
 const netscan = Array.isArray(netscanJson.rows) ? netscanJson.rows : [];
-const netscanColumns = netscanJson.columns ?? [];
+const netscanColumns = Array.isArray(netscanJson.columns) ? netscanJson.columns : [];
 const malfind = Array.isArray(memoryFixture.malfind)
   ? memoryFixture.malfind
   : [];
@@ -64,17 +64,19 @@ const glossary = {
 };
 
 const SortableTable = ({ columns, data, onRowClick }) => {
+  const safeColumns = Array.isArray(columns) ? columns : [];
+  const safeData = Array.isArray(data) ? data : [];
   const [sort, setSort] = useState({ key: null, dir: 'asc' });
 
   const sorted = React.useMemo(() => {
-    if (!sort.key) return data;
-    const sortedData = [...data].sort((a, b) => {
+    if (!sort.key) return safeData;
+    const sortedData = [...safeData].sort((a, b) => {
       if (a[sort.key] < b[sort.key]) return sort.dir === 'asc' ? -1 : 1;
       if (a[sort.key] > b[sort.key]) return sort.dir === 'asc' ? 1 : -1;
       return 0;
     });
     return sortedData;
-  }, [data, sort]);
+  }, [safeData, sort]);
 
   const toggleSort = (key) => {
     setSort((prev) => ({
@@ -87,7 +89,7 @@ const SortableTable = ({ columns, data, onRowClick }) => {
     <table className="w-full text-xs table-auto">
       <thead>
         <tr>
-          {columns.map((col) => (
+          {safeColumns.map((col) => (
             <th
               key={col.key}
               onClick={() => toggleSort(col.key)}
@@ -105,7 +107,7 @@ const SortableTable = ({ columns, data, onRowClick }) => {
             className="odd:bg-gray-800 cursor-pointer"
             onClick={() => onRowClick && onRowClick(row)}
           >
-            {columns.map((col) => (
+            {safeColumns.map((col) => (
               <td key={col.key} className="px-2 py-1 whitespace-nowrap">
                 {col.render ? col.render(row) : row[col.key]}
               </td>
@@ -215,7 +217,7 @@ const VolatilityApp = () => {
                             { key: 'base', label: 'Base' },
                             { key: 'name', label: 'Name' },
                           ]}
-                          data={dlllist[selectedPid] || []}
+                          data={Array.isArray(dlllist[selectedPid]) ? dlllist[selectedPid] : []}
                           onRowClick={() => setFinding(glossary.dlllist)}
                         />
                       </>


### PR DESCRIPTION
## Summary
- add defensive guards for Volatility demo JSON data before mapping
- show fallback content in the plugin walkthrough when fixtures are missing
- ensure the memory heatmap and tables only iterate safe arrays and strings

## Testing
- yarn test volatility

------
https://chatgpt.com/codex/tasks/task_e_68d61b9c49988328bc8d87f7c13430b9