### PR TITLE
[config] enforce lint and type checks during build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -125,9 +125,11 @@ module.exports = withBundleAnalyzer(
     ...(isStaticExport && { output: 'export' }),
     webpack: configureWebpack,
 
-    // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI
     eslint: {
-      ignoreDuringBuilds: true,
+      ignoreDuringBuilds: false,
+    },
+    typescript: {
+      ignoreBuildErrors: false,
     },
     images: {
       unoptimized: true,


### PR DESCRIPTION
## Summary
- re-enable Next.js build-time ESLint enforcement by restoring `ignoreDuringBuilds: false`
- add explicit TypeScript build gate so compilation stops on type errors

## Testing
- CI=1 yarn build *(fails as expected because existing lint violations now stop the build)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d7fac9ec8328907bd984cb2005b1