### PR TITLE
[security] allow resume PDF embed

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -17,7 +17,7 @@ export function middleware(req: NextRequest) {
     "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com",
     "frame-src 'self' https://vercel.live https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
     "frame-ancestors 'self'",
-    "object-src 'none'",
+    "object-src 'self'",
     "base-uri 'self'",
     "form-action 'self'"
   ].join('; ');

--- a/next.config.js
+++ b/next.config.js
@@ -10,8 +10,8 @@ const ContentSecurityPolicy = [
   "base-uri 'self'",
   // Restrict form submissions to same origin
   "form-action 'self'",
-  // Disallow all plugins and other embedded objects
-  "object-src 'none'",
+  // Allow same-origin PDF embedding for the resume while blocking external plugins
+  "object-src 'self'",
   // Allow external images and data URIs for badges/icons
   "img-src 'self' https: data:",
   // Allow inline styles


### PR DESCRIPTION
## Summary
- allow the resume PDF to load by permitting same-origin object embeds in the global CSP
- mirror the CSP change in the middleware so development and production headers stay in sync

## Testing
- `curl -I http://localhost:3000/apps/index`
- `curl -I http://localhost:3000/assets/Alex-Unnippillil-Resume.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68d61bc2f664832885fb559d07aad660