### PR TITLE
[styles] Add Kali theme tokens

### DIFF
--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -27,6 +27,17 @@
   --color-text: #F5F5F5;
   --kali-bg: rgba(15, 19, 23, 0.85);
 
+  /* Kali theme tokens */
+  --kali-blue: #1793d1;
+  --kali-blue-dark: #0f6fa1;
+  --kali-blue-glow: rgba(23, 147, 209, 0.35);
+  --kali-bg-solid: #0f1317;
+  --kali-panel: rgba(26, 31, 38, 0.9);
+  --kali-panel-border: rgba(255, 255, 255, 0.08);
+  --kali-panel-highlight: rgba(255, 255, 255, 0.05);
+  --kali-terminal-green: #00ff00;
+  --kali-terminal-text: #f5f5f5;
+
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
   --game-color-success: #15803d;


### PR DESCRIPTION
## Summary
- add Kali-specific theme variables to the shared design tokens so future components can reference them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d659b3b1388328994b0d8b1148f901