### PR TITLE
[styles] align kali global colors

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,7 +19,13 @@
   --color-focus-ring: var(--color-accent);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
+  --kali-text: #f5f5f5;
   accent-color: var(--color-control-accent);
+}
+
+body {
+  background: var(--kali-bg);
+  color: var(--kali-text);
 }
 
 /* Dark theme */
@@ -69,8 +75,8 @@ html[data-theme='matrix'] {
 }
 
 ::selection {
-  background: var(--color-selection);
-  color: var(--color-inverse);
+  background: color-mix(in srgb, var(--color-primary) 65%, var(--kali-bg));
+  color: var(--kali-text);
 }
 
 *:focus-visible {


### PR DESCRIPTION
## Summary
- set the body background and text color to reuse kali theme tokens
- adjust the selection highlight to use the kali color mix blend
- expose a kali text token so the selection and body colors stay in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d659b5d48c83289f58431a72b0c611