### PR TITLE
[a11y] add focus ring utility

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -120,7 +120,7 @@ const WhiskerMenu: React.FC = () => {
         ref={buttonRef}
         type="button"
         onClick={() => setOpen(o => !o)}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 focus-ring"
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,6 +19,7 @@
   --color-focus-ring: var(--color-accent);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
+  --kali-focus: var(--color-focus-ring);
   accent-color: var(--color-control-accent);
 }
 
@@ -75,5 +76,10 @@ html[data-theme='matrix'] {
 
 *:focus-visible {
   outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.focus-ring {
+  outline: 2px solid var(--kali-focus);
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- add a reusable `.focus-ring` utility that uses the Kali focus color token
- apply the focus outline to the Applications menu trigger in the navigation menu

## Testing
- yarn lint *(fails: repository already contains numerous jsx-a11y/control-has-associated-label and no-top-level-window errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d659b6dbe4832896c450b63a0dac36