### PR TITLE
[styles] align font stacks with brief

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,6 +19,11 @@
   --color-focus-ring: var(--color-accent);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
+  /* Typography */
+  --font-ui: "Ubuntu", "Cantarell", "Noto Sans", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "Ubuntu Mono", "Fira Code", "Fira Mono", "Liberation Mono", Menlo, Consolas,
+    monospace;
   accent-color: var(--color-control-accent);
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -53,7 +53,7 @@
   --motion-slow: 500ms;
 
   /* Fonts */
-  --font-family-base: 'Ubuntu', sans-serif;
+  --font-family-base: var(--font-ui);
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 const plugin = require('tailwindcss/plugin');
+const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
   darkMode: 'class',
@@ -38,7 +39,9 @@ module.exports = {
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
       },
       fontFamily: {
-        ubuntu: ['Ubuntu', 'sans-serif'],
+        sans: ['var(--font-ui)', ...defaultTheme.fontFamily.sans],
+        mono: ['var(--font-mono)', ...defaultTheme.fontFamily.mono],
+        ubuntu: ['var(--font-ui)', ...defaultTheme.fontFamily.sans],
       },
       minWidth: {
         '0': '0',


### PR DESCRIPTION
## Summary
- add `--font-ui` and `--font-mono` custom properties that match the brief's font stacks
- point Tailwind's `font-sans`/`font-mono` utilities and the Ubuntu helper class at those variables
- reuse `--font-ui` for the shared base font token so global styles stay consistent

## Testing
- [ ] yarn lint *(timed out in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d659b7fc4883289d6a023036e854fb