### PR TITLE
[styles] Add Kali panel box shadow utility

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,6 +37,9 @@ module.exports = {
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
       },
+      boxShadow: {
+        'kali-panel': '0 6px 20px rgba(0,0,0,.35)',
+      },
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],
       },


### PR DESCRIPTION
## Summary
- add the `kali-panel` box shadow preset to the Tailwind theme so it can be used throughout the UI

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d659b9fed483289e8e43379d7309c1