### PR TITLE
[components] Add Applications and Places navbar buttons

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -7,14 +7,44 @@ import WhiskerMenu from '../menu/WhiskerMenu';
 export default class Navbar extends Component {
 	constructor() {
 		super();
-		this.state = {
-			status_card: false
-		};
-	}
+                this.state = {
+                        status_card: false,
+                        applicationsMenuOpen: false,
+                        placesMenuOpen: false
+                };
+        }
 
-	render() {
-		return (
+        render() {
+                return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                <button
+                                        type="button"
+                                        aria-haspopup="true"
+                                        aria-expanded={this.state.applicationsMenuOpen}
+                                        onClick={() =>
+                                                this.setState((prevState) => ({
+                                                        applicationsMenuOpen: !prevState.applicationsMenuOpen,
+                                                        placesMenuOpen: false
+                                                }))
+                                        }
+                                        className="px-3 h-8 flex items-center hover:bg-kali-menu-hover focus-ring"
+                                >
+                                        Applications
+                                </button>
+                                <button
+                                        type="button"
+                                        aria-haspopup="true"
+                                        aria-expanded={this.state.placesMenuOpen}
+                                        onClick={() =>
+                                                this.setState((prevState) => ({
+                                                        placesMenuOpen: !prevState.placesMenuOpen,
+                                                        applicationsMenuOpen: false
+                                                }))
+                                        }
+                                        className="px-3 h-8 flex items-center hover:bg-kali-menu-hover focus-ring"
+                                >
+                                        Places
+                                </button>
                                 <WhiskerMenu />
                                 <div
                                         className={


### PR DESCRIPTION
## Summary
- add Applications and Places controls to the navbar ahead of the launcher
- introduce local state toggles for future Applications and Places menus

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d659be51a48328b696d573bfeb38db