### PR TITLE
[ui] Centralize navbar keyboard shortcuts

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -4,18 +4,91 @@ import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
 
-export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+const APPLICATIONS_MENU = 'applications';
+const STATUS_MENU = 'status';
 
-	render() {
-		return (
+export default class Navbar extends Component {
+        constructor() {
+                super();
+                this.state = {
+                        openMenu: null,
+                        focusSearchSignal: 0
+                };
+        }
+
+        componentDidMount() {
+                this.handleKeyDown = (event) => {
+                        if (event.key === 'Escape') {
+                                this.closeMenus();
+                                return;
+                        }
+
+                        if (event.repeat) return;
+
+                        if (event.altKey && event.key === 'F1') {
+                                event.preventDefault();
+                                this.toggleMenu(APPLICATIONS_MENU);
+                                return;
+                        }
+
+                        if (event.key === 'Meta' && !event.ctrlKey && !event.shiftKey && !event.altKey) {
+                                event.preventDefault();
+                                this.toggleMenu(APPLICATIONS_MENU);
+                                return;
+                        }
+
+                        if (event.altKey && event.key === 'F2') {
+                                event.preventDefault();
+                                this.focusApplicationsMenu();
+                        }
+                };
+
+                window.addEventListener('keydown', this.handleKeyDown);
+        }
+
+        componentWillUnmount() {
+                if (this.handleKeyDown) {
+                        window.removeEventListener('keydown', this.handleKeyDown);
+                }
+        }
+
+        toggleMenu = (menu) => {
+                this.setState((prevState) => {
+                        const isOpen = prevState.openMenu === menu;
+                        return {
+                                openMenu: isOpen ? null : menu,
+                                focusSearchSignal:
+                                        !isOpen && menu === APPLICATIONS_MENU
+                                                ? prevState.focusSearchSignal + 1
+                                                : prevState.focusSearchSignal
+                        };
+                });
+        };
+
+        closeMenus = () => {
+                this.setState({ openMenu: null });
+        };
+
+        focusApplicationsMenu = () => {
+                this.setState((prevState) => ({
+                        openMenu: APPLICATIONS_MENU,
+                        focusSearchSignal: prevState.focusSearchSignal + 1
+                }));
+        };
+
+        render() {
+                const { openMenu, focusSearchSignal } = this.state;
+                const isApplicationsMenuOpen = openMenu === APPLICATIONS_MENU;
+                const isStatusMenuOpen = openMenu === STATUS_MENU;
+
+                return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <WhiskerMenu />
+                                <WhiskerMenu
+                                        open={isApplicationsMenuOpen}
+                                        onToggle={() => this.toggleMenu(APPLICATIONS_MENU)}
+                                        onClose={this.closeMenus}
+                                        focusSearchSignal={focusSearchSignal}
+                                />
                                 <div
                                         className={
                                                 'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
@@ -27,17 +100,15 @@ export default class Navbar extends Component {
                                         type="button"
                                         id="status-bar"
                                         aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
+                                        onClick={() => this.toggleMenu(STATUS_MENU)}
                                         className={
                                                 'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
                                         }
                                 >
                                         <Status />
-                                        <QuickSettings open={this.state.status_card} />
+                                        <QuickSettings open={isStatusMenuOpen} />
                                 </button>
-			</div>
-		);
-	}
+                        </div>
+                );
+        }
 }


### PR DESCRIPTION
## Summary
- manage the navbar menus with a shared `openMenu` state and focus tracking
- hook global Alt+F1, Meta, Alt+F2, and Escape shortcuts to toggle or focus the Applications menu and close menus
- update `WhiskerMenu` to be a controlled component that respects the navbar state and focuses its search box on demand

## Testing
- yarn lint *(fails: repository has pre-existing jsx-a11y/no-top-level-window violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d659bef2548328a588954aca55bd77