### PR TITLE
[screen] Align navbar styling with Kali theme

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -12,9 +12,9 @@ export default class Navbar extends Component {
 		};
 	}
 
-	render() {
-		return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+		render() {
+			return (
+                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-kali-panel h-8 border-b border-kali-border text-[13px] select-none z-50">
                                 <WhiskerMenu />
                                 <div
                                         className={


### PR DESCRIPTION
## Summary
- update the navbar container to use the Kali panel background, height, and border utilities
- remove the old Ubuntu-specific color classes from the navbar wrapper to prevent style conflicts

## Testing
- [ ] yarn lint
- [ ] yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d659bbeb9883289ae497c24bd2258d