### PR TITLE
[menu] add memoized ApplicationsMenu filtering

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
-import WhiskerMenu from '../menu/WhiskerMenu';
+import ApplicationsMenu from '../menu/ApplicationsMenu';
 
 export default class Navbar extends Component {
 	constructor() {
@@ -15,7 +15,7 @@ export default class Navbar extends Component {
 	render() {
 		return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <WhiskerMenu />
+                                <ApplicationsMenu />
                                 <div
                                         className={
                                                 'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'


### PR DESCRIPTION
## Summary
- replace the WhiskerMenu implementation with an ApplicationsMenu that normalizes app metadata with `useMemo`
- hydrate favorites and recent entries from localStorage, persist the active Kali category, and filter search results accordingly
- point the navbar to the new ApplicationsMenu component

## Testing
- yarn lint *(fails: existing repo lint errors about missing control labels and top-level window usage)*

------
https://chatgpt.com/codex/tasks/task_e_68d659c8bc888328814d3d6bb7630eb8