### PR TITLE
[menu] remember whisker category

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -67,6 +67,27 @@ const WhiskerMenu: React.FC = () => {
   }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
 
   useEffect(() => {
+    const storedCategory = safeLocalStorage?.getItem('kali-last-cat');
+    const defaultCategory = favoriteApps.length > 0 ? 'favorites' : 'all';
+    const isValidCategory = CATEGORIES.some(cat => cat.id === storedCategory);
+
+    if (isValidCategory && storedCategory) {
+      if (storedCategory === 'favorites' && favoriteApps.length === 0) {
+        setCategory(prev => (prev !== defaultCategory ? defaultCategory : prev));
+      } else {
+        setCategory(prev => (prev !== storedCategory ? storedCategory : prev));
+      }
+    } else {
+      setCategory(prev => (prev !== defaultCategory ? defaultCategory : prev));
+    }
+  }, [favoriteApps]);
+
+  useEffect(() => {
+    if (!safeLocalStorage) return;
+    safeLocalStorage.setItem('kali-last-cat', category);
+  }, [category]);
+
+  useEffect(() => {
     if (!open) return;
     setHighlight(0);
   }, [open, category, query]);


### PR DESCRIPTION
## Summary
- initialize the Whisker menu category from localStorage when available
- fall back to favorites when any exist and otherwise default to the all category
- persist category changes back to localStorage for future sessions

## Testing
- [ ] yarn lint *(fails: pre-existing jsx-a11y label errors across multiple apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d659cbd340832886474a3ac8986a00