### PR TITLE
[menu] Highlight active whisker category

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -143,15 +143,27 @@ const WhiskerMenu: React.FC = () => {
           }}
         >
           <div className="flex flex-col bg-gray-800 p-2">
-            {CATEGORIES.map(cat => (
-              <button
-                key={cat.id}
-                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
-                onClick={() => setCategory(cat.id)}
-              >
-                {cat.label}
-              </button>
-            ))}
+            {CATEGORIES.map(cat => {
+              const isActive = category === cat.id;
+              return (
+                <button
+                  key={cat.id}
+                  type="button"
+                  className={`relative text-left px-2 py-1 rounded mb-1 transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 ${
+                    isActive ? 'bg-kali-menu-hover' : 'hover:bg-kali-menu-hover'
+                  }`}
+                  onClick={() => setCategory(cat.id)}
+                >
+                  {isActive && (
+                    <span
+                      aria-hidden="true"
+                      className="pointer-events-none absolute left-0 top-0 bottom-0 w-0.5 rounded-full bg-[var(--color-primary)]"
+                    />
+                  )}
+                  {cat.label}
+                </button>
+              );
+            })}
           </div>
           <div className="p-3">
             <input

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,6 +9,7 @@
   --color-primary: #1793d1; /* kali blue accent */
   --color-secondary: #1a1f26; /* complementary dark */
   --color-accent: #1793d1; /* accent matches primary */
+  --color-menu-hover: rgba(23, 147, 209, 0.18); /* subtle accent wash for menus */
   /* Utility colors */
   --color-muted: #2a2e36; /* muted surfaces */
   --color-surface: #1a1f26; /* panel surfaces */
@@ -29,6 +30,7 @@ html[data-theme='dark'] {
   --color-primary: #1e88e5;
   --color-secondary: #121212;
   --color-accent: #bb86fc;
+  --color-menu-hover: rgba(30, 136, 229, 0.28);
   --color-muted: #1f1f1f;
   --color-surface: #121212;
   --color-inverse: #ffffff;
@@ -44,6 +46,7 @@ html[data-theme='neon'] {
   --color-primary: #39ff14;
   --color-secondary: #1a1a1a;
   --color-accent: #ff00ff;
+  --color-menu-hover: rgba(57, 255, 20, 0.22);
   --color-muted: #222222;
   --color-surface: #111111;
   --color-inverse: #ffffff;
@@ -59,6 +62,7 @@ html[data-theme='matrix'] {
   --color-primary: #00ff00;
   --color-secondary: #001100;
   --color-accent: #00ff00;
+  --color-menu-hover: rgba(0, 255, 0, 0.18);
   --color-muted: #003300;
   --color-surface: #001100;
   --color-inverse: #ffffff;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,6 +36,7 @@ module.exports = {
         'ubt-gedit-dark': 'var(--color-ubt-gedit-dark)',
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
+        'kali-menu-hover': 'var(--color-menu-hover)',
       },
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],


### PR DESCRIPTION
## Summary
- restyle Whisker menu category buttons with the Kali hover fill and focus states
- add a left-edge accent bar for the active category using the theme accent color
- expose a reusable CSS variable for the Kali menu hover wash and register it with Tailwind

## Testing
- yarn lint *(fails: existing jsx-a11y control-has-associated-label and no-top-level-window errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d659cb3cec8328b48327bbeaa295d8