### PR TITLE
[menu] share launcher helper and persistence events

### DIFF
--- a/components/menu/ApplicationsMenu.tsx
+++ b/components/menu/ApplicationsMenu.tsx
@@ -1,0 +1,87 @@
+import React, { Dispatch, SetStateAction } from 'react';
+import UbuntuApp from '../base/ubuntu_app';
+
+export type AppMeta = {
+  id: string;
+  title: string;
+  icon: string;
+  disabled?: boolean;
+  favourite?: boolean;
+};
+
+const CATEGORIES = [
+  { id: 'all', label: 'All' },
+  { id: 'favorites', label: 'Favorites' },
+  { id: 'recent', label: 'Recent' },
+  { id: 'utilities', label: 'Utilities' },
+  { id: 'games', label: 'Games' },
+];
+
+interface ApplicationsMenuProps {
+  menuRef: React.RefObject<HTMLDivElement>;
+  category: string;
+  onCategoryChange: Dispatch<SetStateAction<string>>;
+  query: string;
+  onQueryChange: Dispatch<SetStateAction<string>>;
+  apps: AppMeta[];
+  highlight: number;
+  onOpenApp: (id: string) => void;
+  onBlur: React.FocusEventHandler<HTMLDivElement>;
+}
+
+const ApplicationsMenu = ({
+  menuRef,
+  category,
+  onCategoryChange,
+  query,
+  onQueryChange,
+  apps,
+  highlight,
+  onOpenApp,
+  onBlur,
+}: ApplicationsMenuProps) => (
+  <div
+    ref={menuRef}
+    className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+    tabIndex={-1}
+    onBlur={onBlur}
+  >
+    <div className="flex flex-col bg-gray-800 p-2">
+      {CATEGORIES.map(cat => (
+        <button
+          key={cat.id}
+          className={`text-left px-2 py-1 rounded mb-1 ${
+            category === cat.id ? 'bg-gray-700' : ''
+          }`}
+          onClick={() => onCategoryChange(cat.id)}
+        >
+          {cat.label}
+        </button>
+      ))}
+    </div>
+    <div className="p-3">
+      <input
+        className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+        placeholder="Search"
+        value={query}
+        onChange={e => onQueryChange(e.target.value)}
+        autoFocus
+      />
+      <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
+        {apps.map((app, idx) => (
+          <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>
+            <UbuntuApp
+              id={app.id}
+              icon={app.icon}
+              name={app.title}
+              openApp={() => onOpenApp(app.id)}
+              disabled={app.disabled}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+export default ApplicationsMenu;

--- a/hooks/useFavoriteApps.ts
+++ b/hooks/useFavoriteApps.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import {
+  getFavoriteAppIds,
+  FAVORITE_APPS_EVENT,
+  FAVORITE_APPS_KEY,
+} from '../utils/appPersistence';
+
+const useFavoriteApps = () => {
+  const [favorites, setFavorites] = useState<string[]>(() => getFavoriteAppIds());
+
+  useEffect(() => {
+    const handleUpdate = (event: Event) => {
+      const detail = (event as CustomEvent<string[]>).detail;
+      if (Array.isArray(detail)) {
+        setFavorites(detail);
+      } else {
+        setFavorites(getFavoriteAppIds());
+      }
+    };
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === FAVORITE_APPS_KEY) {
+        setFavorites(getFavoriteAppIds());
+      }
+    };
+
+    window.addEventListener(FAVORITE_APPS_EVENT, handleUpdate as EventListener);
+    window.addEventListener('storage', handleStorage);
+
+    return () => {
+      window.removeEventListener(FAVORITE_APPS_EVENT, handleUpdate as EventListener);
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  return favorites;
+};
+
+export default useFavoriteApps;

--- a/hooks/useRecentApps.ts
+++ b/hooks/useRecentApps.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import {
+  getRecentAppIds,
+  RECENT_APPS_EVENT,
+  RECENT_APPS_KEY,
+} from '../utils/appPersistence';
+
+const useRecentApps = () => {
+  const [recent, setRecent] = useState<string[]>(() => getRecentAppIds());
+
+  useEffect(() => {
+    const handleUpdate = (event: Event) => {
+      const detail = (event as CustomEvent<string[]>).detail;
+      if (Array.isArray(detail)) {
+        setRecent(detail);
+      } else {
+        setRecent(getRecentAppIds());
+      }
+    };
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === RECENT_APPS_KEY) {
+        setRecent(getRecentAppIds());
+      }
+    };
+
+    window.addEventListener(RECENT_APPS_EVENT, handleUpdate as EventListener);
+    window.addEventListener('storage', handleStorage);
+
+    return () => {
+      window.removeEventListener(RECENT_APPS_EVENT, handleUpdate as EventListener);
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  return recent;
+};
+
+export default useRecentApps;

--- a/utils/appPersistence.ts
+++ b/utils/appPersistence.ts
@@ -1,0 +1,75 @@
+import { safeLocalStorage } from './safeStorage';
+
+export const OPEN_APP_EVENT = 'open-app';
+export const RECENT_APPS_KEY = 'recentApps';
+export const RECENT_APPS_EVENT = 'recent-apps-updated';
+export const FAVORITE_APPS_KEY = 'pinnedApps';
+export const FAVORITE_APPS_EVENT = 'favorite-apps-updated';
+
+const MAX_RECENT_APPS = 10;
+
+const parseStoredIds = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+  return value.filter((id): id is string => typeof id === 'string');
+};
+
+const readIds = (key: string): string[] => {
+  if (!safeLocalStorage) return [];
+  try {
+    const raw = safeLocalStorage.getItem(key);
+    if (!raw) return [];
+    return parseStoredIds(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+};
+
+const writeIds = (key: string, ids: string[], eventName: string) => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(key, JSON.stringify(ids));
+  } catch {
+    // ignore write errors
+  }
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(eventName, { detail: ids }));
+  }
+};
+
+export const getRecentAppIds = () => readIds(RECENT_APPS_KEY);
+
+export const setRecentAppIds = (ids: string[]) =>
+  writeIds(RECENT_APPS_KEY, ids, RECENT_APPS_EVENT);
+
+export const recordRecentApp = (id: string, limit = MAX_RECENT_APPS) => {
+  if (!id) return getRecentAppIds();
+  const existing = getRecentAppIds().filter(appId => appId !== id);
+  existing.unshift(id);
+  const next = existing.slice(0, Math.max(limit, 0));
+  setRecentAppIds(next);
+  return next;
+};
+
+export const getFavoriteAppIds = () => readIds(FAVORITE_APPS_KEY);
+
+export const setFavoriteAppIds = (ids: string[]) =>
+  writeIds(FAVORITE_APPS_KEY, ids, FAVORITE_APPS_EVENT);
+
+export const addFavoriteApp = (id: string) => {
+  if (!id) return getFavoriteAppIds();
+  const next = [...new Set([...getFavoriteAppIds(), id])];
+  setFavoriteAppIds(next);
+  return next;
+};
+
+export const removeFavoriteApp = (id: string) => {
+  if (!id) return getFavoriteAppIds();
+  const next = getFavoriteAppIds().filter(appId => appId !== id);
+  setFavoriteAppIds(next);
+  return next;
+};
+
+export const dispatchOpenApp = (id: string) => {
+  if (!id || typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(OPEN_APP_EVENT, { detail: id }));
+};


### PR DESCRIPTION
## Summary
- add an app persistence utility that dispatches the shared open-app event and keeps recent and favorite ids in sync
- expose `useRecentApps` and `useFavoriteApps` so menus can react to persistence updates
- refactor the Whisker menu to render a dedicated `ApplicationsMenu` panel and rely on the shared helper while desktop pin/open flows emit the same events

## Testing
- ❌ `yarn lint` *(fails due to numerous pre-existing accessibility and no-top-level-window warnings unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d659d192588328a3155b07e753ed07