### PR TITLE
[desktop] Sync favorites with local storage

### DIFF
--- a/utils/favorites.ts
+++ b/utils/favorites.ts
@@ -1,0 +1,91 @@
+import { safeLocalStorage } from './safeStorage';
+
+const FAVORITES_KEY = 'kali-favorites';
+const LEGACY_KEY = 'pinnedApps';
+export const FAVORITES_EVENT = 'kali-favorites-updated';
+
+type FavoriteId = string;
+
+const isStringArray = (value: unknown): value is FavoriteId[] =>
+  Array.isArray(value) && value.every(item => typeof item === 'string');
+
+const parseStoredIds = (raw: string | null): FavoriteId[] => {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return isStringArray(parsed) ? parsed : [];
+  } catch (e) {
+    return [];
+  }
+};
+
+const dispatchUpdate = () => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(FAVORITES_EVENT));
+};
+
+const writeIds = (ids: FavoriteId[]) => {
+  if (!safeLocalStorage) return;
+  const payload = JSON.stringify(ids);
+  safeLocalStorage.setItem(FAVORITES_KEY, payload);
+  safeLocalStorage.setItem(LEGACY_KEY, payload);
+};
+
+export const readFavoriteIds = (): FavoriteId[] => {
+  const primary = parseStoredIds(safeLocalStorage?.getItem(FAVORITES_KEY) || null);
+  if (primary.length > 0) {
+    if (safeLocalStorage) {
+      safeLocalStorage.setItem(FAVORITES_KEY, JSON.stringify(primary));
+      safeLocalStorage.setItem(LEGACY_KEY, JSON.stringify(primary));
+    }
+    return primary;
+  }
+  const legacy = parseStoredIds(safeLocalStorage?.getItem(LEGACY_KEY) || null);
+  if (legacy.length > 0 && safeLocalStorage) {
+    safeLocalStorage.setItem(FAVORITES_KEY, JSON.stringify(legacy));
+    safeLocalStorage.setItem(LEGACY_KEY, JSON.stringify(legacy));
+  }
+  return legacy;
+};
+
+export const setFavoriteIds = (ids: FavoriteId[]) => {
+  if (!safeLocalStorage) return;
+  const unique = Array.from(new Set(ids.filter(id => typeof id === 'string')));
+  writeIds(unique);
+  dispatchUpdate();
+};
+
+export const addFavoriteId = (id: FavoriteId) => {
+  if (!safeLocalStorage) return;
+  const ids = readFavoriteIds();
+  if (ids.includes(id)) {
+    dispatchUpdate();
+    return;
+  }
+  ids.push(id);
+  writeIds(ids);
+  dispatchUpdate();
+};
+
+export const removeFavoriteId = (id: FavoriteId) => {
+  if (!safeLocalStorage) return;
+  const ids = readFavoriteIds().filter(existingId => existingId !== id);
+  writeIds(ids);
+  dispatchUpdate();
+};
+
+export const subscribeToFavoriteChanges = (callback: () => void) => {
+  if (typeof window === 'undefined') return () => {};
+  const handler = () => callback();
+  const storageHandler = (event: StorageEvent) => {
+    if (!event.key || event.key === FAVORITES_KEY || event.key === LEGACY_KEY) {
+      callback();
+    }
+  };
+  window.addEventListener(FAVORITES_EVENT, handler);
+  window.addEventListener('storage', storageHandler);
+  return () => {
+    window.removeEventListener(FAVORITES_EVENT, handler);
+    window.removeEventListener('storage', storageHandler);
+  };
+};


### PR DESCRIPTION
## Summary
- load saved favourite ids from localStorage when building the whisker menu favourites list
- centralise favourite storage helpers that mirror data between the new key and the legacy dock key
- update desktop pin/unpin handlers to persist favourites through the shared helpers

## Testing
- yarn eslint components/menu/WhiskerMenu.tsx components/screen/desktop.js utils/favorites.ts *(fails: existing jsx-a11y/control-has-associated-label errors in WhiskerMenu and desktop)*

------
https://chatgpt.com/codex/tasks/task_e_68d659d488c8832897912314d96439f5