### PR TITLE
[desktop] Increase icon size and grid spacing

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -42,7 +42,7 @@ export class UbuntuApp extends Component {
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
                 className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-24 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
@@ -51,14 +51,19 @@ export class UbuntuApp extends Component {
                 onFocus={this.handlePrefetch}
             >
                 <Image
-                    width={40}
-                    height={40}
-                    className="mb-1 w-10"
+                    width={64}
+                    height={64}
+                    className="mb-2 h-16 w-16"
                     src={this.props.icon.replace('./', '/')}
                     alt={"Kali " + this.props.name}
-                    sizes="40px"
+                    sizes="64px"
                 />
-                {this.props.displayName || this.props.name}
+                <span
+                    className="w-full truncate px-1"
+                    title={this.props.displayName || this.props.name}
+                >
+                    {this.props.displayName || this.props.name}
+                </span>
 
             </div>
         )

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -432,26 +432,32 @@ export class Desktop extends Component {
     }
 
     renderDesktopApps = () => {
-        if (Object.keys(this.state.closed_windows).length === 0) return;
-        let appsJsx = [];
-        apps.forEach((app, index) => {
-            if (this.state.desktop_apps.includes(app.id)) {
+        if (Object.keys(this.state.closed_windows).length === 0) return null;
 
-                const props = {
-                    name: app.title,
-                    id: app.id,
-                    icon: app.icon,
-                    openApp: this.openApp,
-                    disabled: this.state.disabled_apps[app.id],
-                    prefetch: app.screen?.prefetch,
-                }
+        const shortcuts = apps
+            .filter((app) => this.state.desktop_apps.includes(app.id))
+            .map((app) => (
+                <UbuntuApp
+                    key={app.id}
+                    name={app.title}
+                    id={app.id}
+                    icon={app.icon}
+                    openApp={this.openApp}
+                    disabled={this.state.disabled_apps[app.id]}
+                    prefetch={app.screen?.prefetch}
+                />
+            ));
 
-                appsJsx.push(
-                    <UbuntuApp key={app.id} {...props} />
-                );
-            }
-        });
-        return appsJsx;
+        if (!shortcuts.length) return null;
+
+        return (
+            <div
+                className="desktop-app-grid self-start flex flex-wrap content-start items-start gap-[96px] px-6 py-8"
+                data-context="desktop-area"
+            >
+                {shortcuts}
+            </div>
+        );
     }
 
     renderWindows = () => {


### PR DESCRIPTION
## Summary
- enlarge the UbuntuApp icon default to 64px and clamp labels to a single truncated line
- render desktop shortcuts inside a wrapped flex grid with 96px gaps while keeping context menu hooks intact

## Testing
- [ ] yarn lint *(fails: existing accessibility and no-top-level-window lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d659de27788328998697e6d73965d4