### PR TITLE
[ui] Add Kali gradient wallpaper option

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
+import KaliWallpaper from "../../components/util-components/kali-wallpaper";
 
 export default function Settings() {
   const {
@@ -19,6 +20,8 @@ export default function Settings() {
     setAccent,
     wallpaper,
     setWallpaper,
+    useKaliWallpaper,
+    setUseKaliWallpaper,
     density,
     setDensity,
     reducedMotion,
@@ -54,6 +57,7 @@ export default function Settings() {
   ];
 
   const changeBackground = (name: string) => setWallpaper(name);
+  const wallpaperIndex = Math.max(0, wallpapers.indexOf(wallpaper));
 
   const handleExport = async () => {
     const data = await exportSettingsData();
@@ -112,15 +116,17 @@ export default function Settings() {
       </div>
       {activeTab === "appearance" && (
         <>
-          <div
-            className="md:w-2/5 w-2/3 h-1/3 m-auto my-4"
-            style={{
-              backgroundImage: `url(/wallpapers/${wallpaper}.webp)`,
-              backgroundSize: "cover",
-              backgroundRepeat: "no-repeat",
-              backgroundPosition: "center center",
-            }}
-          ></div>
+          <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4 relative overflow-hidden rounded-lg shadow-inner">
+            {useKaliWallpaper ? (
+              <KaliWallpaper />
+            ) : (
+              <div
+                className="absolute inset-0 bg-cover bg-center"
+                style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)` }}
+                aria-hidden="true"
+              />
+            )}
+          </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Theme:</label>
             <select
@@ -151,6 +157,22 @@ export default function Settings() {
             </div>
           </div>
           <div className="flex justify-center my-4">
+            <label className="mr-2 text-ubt-grey flex items-center">
+              <input
+                type="checkbox"
+                checked={useKaliWallpaper}
+                onChange={(e) => setUseKaliWallpaper(e.target.checked)}
+                className="mr-2"
+              />
+              Kali Gradient Wallpaper
+            </label>
+          </div>
+          {useKaliWallpaper && (
+            <p className="text-center text-xs text-ubt-grey/70 px-6 -mt-2 mb-4">
+              Your previous wallpaper selection is preserved for when you turn this off.
+            </p>
+          )}
+          <div className="flex justify-center my-4">
             <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
             <input
               id="wallpaper-slider"
@@ -158,7 +180,7 @@ export default function Settings() {
               min="0"
               max={wallpapers.length - 1}
               step="1"
-              value={wallpapers.indexOf(wallpaper)}
+              value={wallpaperIndex}
               onChange={(e) =>
                 changeBackground(wallpapers[parseInt(e.target.value, 10)])
               }

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import KaliWallpaper from '../util-components/kali-wallpaper';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -57,7 +58,16 @@ export function Settings() {
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
-            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4" style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}>
+            <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4 relative overflow-hidden rounded-lg shadow-inner">
+                {useKaliWallpaper ? (
+                    <KaliWallpaper />
+                ) : (
+                    <div
+                        className="absolute inset-0 bg-cover bg-center"
+                        style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)` }}
+                        aria-hidden="true"
+                    />
+                )}
             </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Theme:</label>
@@ -72,6 +82,22 @@ export function Settings() {
                     <option value="matrix">Matrix</option>
                 </select>
             </div>
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={useKaliWallpaper}
+                        onChange={(e) => setUseKaliWallpaper(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Kali Gradient Wallpaper
+                </label>
+            </div>
+            {useKaliWallpaper && (
+                <p className="text-center text-xs text-ubt-grey/70 px-6 -mt-2 mb-4">
+                    Your previous wallpaper selection is preserved for when you turn this off.
+                </p>
+            )}
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Accent:</label>
                 <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
+import KaliWallpaper from '../util-components/kali-wallpaper';
 
 export default function LockScreen(props) {
 
-    const { wallpaper } = useSettings();
+    const { bgImageName, useKaliWallpaper } = useSettings();
+    const useKaliTheme = useKaliWallpaper || bgImageName === 'kali-gradient';
 
     if (props.isLocked) {
         window.addEventListener('click', props.unLockScreen);
@@ -16,11 +18,17 @@ export default function LockScreen(props) {
             id="ubuntu-lock-screen"
             style={{ zIndex: "100", contentVisibility: 'auto' }}
             className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
-            <img
-                src={`/wallpapers/${wallpaper}.webp`}
-                alt=""
-                className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
-            />
+            {useKaliTheme ? (
+                <KaliWallpaper
+                    className={`absolute top-0 left-0 h-full w-full transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                />
+            ) : (
+                <img
+                    src={`/wallpapers/${bgImageName}.webp`}
+                    alt=""
+                    className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                />
+            )}
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
                 <div className=" text-7xl">
                     <Clock onlyTime={true} />

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -2,14 +2,19 @@
 
 import React, { useEffect, useState } from 'react'
 import { useSettings } from '../../hooks/useSettings';
+import KaliWallpaper from './kali-wallpaper';
 
 export default function BackgroundImage() {
-    const { wallpaper } = useSettings();
+    const { bgImageName, useKaliWallpaper } = useSettings();
     const [needsOverlay, setNeedsOverlay] = useState(false);
 
     useEffect(() => {
+        if (useKaliWallpaper || bgImageName === 'kali-gradient') {
+            setNeedsOverlay(false);
+            return;
+        }
         const img = new Image();
-        img.src = `/wallpapers/${wallpaper}.webp`;
+        img.src = `/wallpapers/${bgImageName}.webp`;
         img.onload = () => {
             const canvas = document.createElement('canvas');
             canvas.width = img.width;
@@ -34,17 +39,23 @@ export default function BackgroundImage() {
             const contrast = (1.05) / (lum + 0.05); // white text luminance is 1
             setNeedsOverlay(contrast < 4.5);
         };
-    }, [wallpaper]);
+    }, [bgImageName, useKaliWallpaper]);
 
     return (
         <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
-            <img
-                src={`/wallpapers/${wallpaper}.webp`}
-                alt=""
-                className="w-full h-full object-cover"
-            />
-            {needsOverlay && (
-                <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>
+            {useKaliWallpaper || bgImageName === 'kali-gradient' ? (
+                <KaliWallpaper />
+            ) : (
+                <>
+                    <img
+                        src={`/wallpapers/${bgImageName}.webp`}
+                        alt=""
+                        className="w-full h-full object-cover"
+                    />
+                    {needsOverlay && (
+                        <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>
+                    )}
+                </>
             )}
         </div>
     )

--- a/components/util-components/kali-wallpaper.js
+++ b/components/util-components/kali-wallpaper.js
@@ -1,0 +1,56 @@
+"use client";
+
+import React from 'react';
+
+const BASE_GRADIENT_STYLE = {
+  background: 'radial-gradient(circle at 20% 20%, rgba(16, 80, 122, 0.9) 0%, rgba(3, 20, 33, 0.94) 45%, rgba(0, 7, 14, 0.98) 100%)',
+};
+
+const ACCENT_GLOW_STYLE = {
+  background: 'radial-gradient(circle at center, rgba(23, 147, 209, 0.4) 0%, rgba(3, 20, 33, 0) 60%)',
+  mixBlendMode: 'screen',
+};
+
+const GRID_LAYER_STYLE = {
+  backgroundImage:
+    'linear-gradient(120deg, rgba(23,147,209,0.15) 25%, transparent 25%), linear-gradient(240deg, rgba(23,147,209,0.08) 25%, transparent 25%)',
+  backgroundSize: '60px 60px',
+  opacity: 0.18,
+};
+
+const DRAGON_PATH = "M256 62c-63 0-117 31-152 80 69-21 121 12 150 38 23 21 29 44 12 79-22 41-85 41-132 19 19 63 86 112 166 112 101 0 178-77 178-178 0-14-1-29-5-43 25 20 42 49 50 81 18 76-29 163-113 208l50 26-14 36-112-60c-101-12-187-84-212-174-28-102 26-216 132-246 34-10 70-14 102-4l-36 74c-4-1-9-2-14-2z";
+
+function KaliDragon({ className = '' }) {
+  return (
+    <svg
+      className={`pointer-events-none text-cyan-300/80 drop-shadow-[0_0_25px_rgba(23,147,209,0.55)] ${className}`}
+      viewBox="0 0 512 512"
+      role="img"
+      aria-label="Stylized Kali dragon"
+      focusable="false"
+    >
+      <path fill="currentColor" d={DRAGON_PATH} />
+    </svg>
+  );
+}
+
+export function KaliWallpaper({ className = '', showDragon = true }) {
+  return (
+    <div className={`relative h-full w-full overflow-hidden ${className}`} aria-hidden="true">
+      <div className="absolute inset-0" style={BASE_GRADIENT_STYLE} />
+      <div className="absolute inset-0" style={GRID_LAYER_STYLE} />
+      <div className="absolute inset-0" style={ACCENT_GLOW_STYLE} />
+      {showDragon && (
+        <KaliDragon className="absolute left-1/2 top-1/2 h-[55%] max-h-[420px] w-auto -translate-x-1/2 -translate-y-1/2" />
+      )}
+      <div
+        className="absolute inset-0"
+        style={{
+          background: 'linear-gradient(to bottom, rgba(3, 8, 15, 0.35) 0%, rgba(3, 8, 15, 0.75) 100%)',
+        }}
+      />
+    </div>
+  );
+}
+
+export default KaliWallpaper;

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -4,6 +4,8 @@ import {
   setAccent as saveAccent,
   getWallpaper as loadWallpaper,
   setWallpaper as saveWallpaper,
+  getUseKaliWallpaper as loadUseKaliWallpaper,
+  setUseKaliWallpaper as saveUseKaliWallpaper,
   getDensity as loadDensity,
   setDensity as saveDensity,
   getReducedMotion as loadReducedMotion,
@@ -54,6 +56,8 @@ const shadeColor = (color: string, percent: number): string => {
 interface SettingsContextValue {
   accent: string;
   wallpaper: string;
+  bgImageName: string;
+  useKaliWallpaper: boolean;
   density: Density;
   reducedMotion: boolean;
   fontScale: number;
@@ -65,6 +69,7 @@ interface SettingsContextValue {
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
+  setUseKaliWallpaper: (value: boolean) => void;
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
   setFontScale: (value: number) => void;
@@ -79,6 +84,8 @@ interface SettingsContextValue {
 export const SettingsContext = createContext<SettingsContextValue>({
   accent: defaults.accent,
   wallpaper: defaults.wallpaper,
+  bgImageName: defaults.wallpaper,
+  useKaliWallpaper: defaults.useKaliWallpaper,
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
@@ -90,6 +97,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
+  setUseKaliWallpaper: () => {},
   setDensity: () => {},
   setReducedMotion: () => {},
   setFontScale: () => {},
@@ -104,6 +112,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [accent, setAccent] = useState<string>(defaults.accent);
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
+  const [useKaliWallpaper, setUseKaliWallpaper] = useState<boolean>(defaults.useKaliWallpaper);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
@@ -119,6 +128,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     (async () => {
       setAccent(await loadAccent());
       setWallpaper(await loadWallpaper());
+      setUseKaliWallpaper(await loadUseKaliWallpaper());
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
@@ -155,6 +165,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     saveWallpaper(wallpaper);
   }, [wallpaper]);
+
+  useEffect(() => {
+    saveUseKaliWallpaper(useKaliWallpaper);
+  }, [useKaliWallpaper]);
 
   useEffect(() => {
     const spacing: Record<Density, Record<string, string>> = {
@@ -236,11 +250,15 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  const bgImageName = useKaliWallpaper ? 'kali-gradient' : wallpaper;
+
   return (
     <SettingsContext.Provider
       value={{
         accent,
         wallpaper,
+        bgImageName,
+        useKaliWallpaper,
         density,
         reducedMotion,
         fontScale,
@@ -252,6 +270,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         theme,
         setAccent,
         setWallpaper,
+        setUseKaliWallpaper,
         setDensity,
         setReducedMotion,
         setFontScale,

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -6,6 +6,7 @@ import { getTheme, setTheme } from './theme';
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
   wallpaper: 'wall-2',
+  useKaliWallpaper: false,
   density: 'regular',
   reducedMotion: false,
   fontScale: 1,
@@ -34,6 +35,17 @@ export async function getWallpaper() {
 export async function setWallpaper(wallpaper) {
   if (typeof window === 'undefined') return;
   await set('bg-image', wallpaper);
+}
+
+export async function getUseKaliWallpaper() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.useKaliWallpaper;
+  const stored = window.localStorage.getItem('use-kali-wallpaper');
+  return stored === null ? DEFAULT_SETTINGS.useKaliWallpaper : stored === 'true';
+}
+
+export async function setUseKaliWallpaper(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('use-kali-wallpaper', value ? 'true' : 'false');
 }
 
 export async function getDensity() {
@@ -137,12 +149,14 @@ export async function resetSettings() {
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
+  window.localStorage.removeItem('use-kali-wallpaper');
 }
 
 export async function exportSettings() {
   const [
     accent,
     wallpaper,
+    useKaliWallpaper,
     density,
     reducedMotion,
     fontScale,
@@ -154,6 +168,7 @@ export async function exportSettings() {
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
+    getUseKaliWallpaper(),
     getDensity(),
     getReducedMotion(),
     getFontScale(),
@@ -175,6 +190,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    useKaliWallpaper,
     theme,
   });
 }
@@ -191,6 +207,7 @@ export async function importSettings(json) {
   const {
     accent,
     wallpaper,
+    useKaliWallpaper,
     density,
     reducedMotion,
     fontScale,
@@ -203,6 +220,7 @@ export async function importSettings(json) {
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
+  if (useKaliWallpaper !== undefined) await setUseKaliWallpaper(useKaliWallpaper);
   if (density !== undefined) await setDensity(density);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
   if (fontScale !== undefined) await setFontScale(fontScale);


### PR DESCRIPTION
## Summary
- add a reusable Kali gradient wallpaper component and render it for the desktop and lock screen when selected
- persist a new wallpaper toggle in settings so the gradient can be enabled without losing the user’s chosen image
- update wallpaper persistence utilities and export/import logic to remember the gradient preference

## Testing
- yarn lint *(fails: existing accessibility and lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d659dd26508328b6f1888391c52fcc