### PR TITLE
[desktop] refresh window chrome styling

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -612,6 +612,30 @@ export class Window extends Component {
     }
 
     render() {
+        const {
+            width,
+            height,
+            cursorType,
+            closed,
+            maximized,
+            grabbed,
+            snapPreview,
+        } = this.state;
+        const { minimized, isFocused } = this.props;
+        const handleSelector = `.${styles.windowTopBarHandle}`;
+        const windowClasses = [
+            cursorType,
+            closed ? 'closed-window' : '',
+            maximized ? 'duration-300 rounded-none' : 'rounded-lg rounded-b-none',
+            minimized ? 'opacity-0 invisible duration-200' : '',
+            grabbed ? 'opacity-70' : '',
+            snapPreview ? 'ring-2 ring-blue-400' : '',
+            isFocused ? 'z-30' : 'z-20',
+            'opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow flex flex-col',
+            styles.windowContainer,
+            isFocused ? '' : styles.windowContainerInactive,
+        ].filter(Boolean).join(' ');
+
         return (
             <>
                 {this.state.snapPreview && (
@@ -623,7 +647,7 @@ export class Window extends Component {
                 )}
                 <Draggable
                     axis="both"
-                    handle=".bg-ub-window-title"
+                    handle={handleSelector}
                     grid={this.props.snapEnabled ? [8, 8] : [1, 1]}
                     scale={1}
                     onStart={this.changeCursorToMove}
@@ -634,8 +658,8 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        style={{ width: `${width}%`, height: `${height}%` }}
+                        className={windowClasses}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
@@ -648,7 +672,8 @@ export class Window extends Component {
                             title={this.props.title}
                             onKeyDown={this.handleTitleBarKeyDown}
                             onBlur={this.releaseGrab}
-                            grabbed={this.state.grabbed}
+                            grabbed={grabbed}
+                            isFocused={isFocused}
                         />
                         <WindowEditButtons
                             minimize={this.minimizeWindow}
@@ -674,10 +699,17 @@ export class Window extends Component {
 export default Window
 
 // Window's title bar
-export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
+export function WindowTopBar({ title, onKeyDown, onBlur, grabbed, isFocused }) {
+    const topBarClasses = [
+        styles.windowTopBar,
+        styles.windowTopBarHandle,
+        'relative text-white w-full select-none flex items-center h-11',
+        isFocused ? '' : styles.windowTopBarInactive,
+    ].filter(Boolean).join(' ');
+
     return (
         <div
-            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
+            className={topBarClasses}
             tabIndex={0}
             role="button"
             aria-grabbed={grabbed}

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -1,3 +1,35 @@
+.windowContainer {
+  border: 1px solid var(--kali-border);
+  background: var(--kali-window-gradient-active);
+  background-clip: padding-box;
+}
+
+.windowContainerInactive {
+  background: var(--kali-window-gradient-inactive);
+}
+
+.windowTopBar {
+  border: 1px solid var(--kali-border);
+  border-bottom: 0;
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+  background: var(--kali-topbar-gradient-active);
+  margin: -1px -1px 0;
+  padding-inline: 0.75rem;
+}
+
+.windowTopBarInactive {
+  background: var(--kali-topbar-gradient-inactive);
+}
+
+.windowTopBarHandle {
+  cursor: grab;
+}
+
+.windowTopBar[aria-grabbed="true"] {
+  cursor: grabbing;
+}
+
 .windowYBorder {
   height: calc(100% - 10px);
   width: calc(100% + 10px);

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -26,6 +26,11 @@
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
   --kali-bg: rgba(15, 19, 23, 0.85);
+  --kali-border: rgba(255, 255, 255, 0.12);
+  --kali-window-gradient-active: linear-gradient(180deg, rgba(34, 38, 44, 0.92) 0%, rgba(17, 21, 26, 0.95) 100%);
+  --kali-window-gradient-inactive: linear-gradient(180deg, rgba(24, 28, 33, 0.9) 0%, rgba(11, 14, 18, 0.92) 100%);
+  --kali-topbar-gradient-active: linear-gradient(180deg, rgba(38, 45, 54, 0.95) 0%, rgba(18, 22, 29, 0.96) 100%);
+  --kali-topbar-gradient-inactive: linear-gradient(180deg, rgba(27, 33, 41, 0.92) 0%, rgba(12, 16, 22, 0.94) 100%);
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;


### PR DESCRIPTION
## Summary
- add Kali window chrome tokens for border and gradients
- refactor the window shell to apply gradient borders and focused/inactive styling
- update the top bar handle to use CSS modules and shared selectors

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window lint errors throughout the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d659e013bc8328b836b6535077608a