### PR TITLE
[taskbar] Add tooltip for running apps

### DIFF
--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const [hoveredAppId, setHoveredAppId] = React.useState(null);
 
     const handleClick = (app) => {
         const id = app.id;
@@ -22,9 +23,14 @@ export default function Taskbar(props) {
                     key={app.id}
                     type="button"
                     aria-label={app.title}
+                    aria-describedby={hoveredAppId === app.id ? `taskbar-tooltip-${app.id}` : undefined}
                     data-context="taskbar"
                     data-app-id={app.id}
                     onClick={() => handleClick(app)}
+                    onMouseEnter={() => setHoveredAppId(app.id)}
+                    onMouseLeave={() => setHoveredAppId(null)}
+                    onFocus={() => setHoveredAppId(app.id)}
+                    onBlur={() => setHoveredAppId(null)}
                     className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
                         'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
                 >
@@ -39,6 +45,15 @@ export default function Taskbar(props) {
                     <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
                     {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
                         <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
+                    )}
+                    {hoveredAppId === app.id && (
+                        <div
+                            id={`taskbar-tooltip-${app.id}`}
+                            role="tooltip"
+                            className="absolute -top-8 left-1/2 -translate-x-1/2 rounded bg-gray-900 bg-opacity-90 px-2 py-1 text-xs text-white shadow-lg"
+                        >
+                            {app.title}
+                        </div>
                     )}
                 </button>
             ))}


### PR DESCRIPTION
## Summary
- add a hover and focus driven tooltip for each running taskbar app button
- track the hovered app id to render a popover that mirrors XFCE styling cues

## Testing
- [ ] yarn lint *(hangs in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d659e2e53883288ea5c87339737812