### PR TITLE
[desktop] Update snap preview highlight

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -617,8 +617,15 @@ export class Window extends Component {
                 {this.state.snapPreview && (
                     <div
                         data-testid="snap-preview"
-                        className="fixed border-2 border-dashed border-white bg-white bg-opacity-10 pointer-events-none z-40 transition-opacity"
-                        style={{ left: this.state.snapPreview.left, top: this.state.snapPreview.top, width: this.state.snapPreview.width, height: this.state.snapPreview.height }}
+                        className="fixed pointer-events-none z-40 transition-opacity"
+                        style={{
+                            left: this.state.snapPreview.left,
+                            top: this.state.snapPreview.top,
+                            width: this.state.snapPreview.width,
+                            height: this.state.snapPreview.height,
+                            backgroundColor: 'var(--kali-blue)',
+                            opacity: 0.35
+                        }}
                     />
                 )}
                 <Draggable

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,6 +9,7 @@
   --color-primary: #1793d1; /* kali blue accent */
   --color-secondary: #1a1f26; /* complementary dark */
   --color-accent: #1793d1; /* accent matches primary */
+  --kali-blue: var(--color-primary);
   /* Utility colors */
   --color-muted: #2a2e36; /* muted surfaces */
   --color-surface: #1a1f26; /* panel surfaces */


### PR DESCRIPTION
## Summary
- replace the snap preview dashed border with a semi-transparent fill that matches the Kali blue palette
- expose a `--kali-blue` CSS variable so the snap preview can follow the theme accent

## Testing
- [ ] yarn lint
- [ ] yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d659e68ba88328af075ad71df32c19