### PR TITLE
[theme] Add Kali icon subsets

### DIFF
--- a/public/themes/Kali/Places/folder-documents.svg
+++ b/public/themes/Kali/Places/folder-documents.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4.5 7.5h5l1.5 2h8.5a1.5 1.5 0 0 1 1.5 1.5v7a1.5 1.5 0 0 1-1.5 1.5h-14a1.5 1.5 0 0 1-1.5-1.5v-9a1.5 1.5 0 0 1 1.5-1.5z" fill="#1793d1" fill-opacity="0.15" />
+  <rect x="9.5" y="12" width="5" height="4.5" rx="0.8" />
+  <path d="M9.5 13.8h5" />
+  <path d="M9.5 15.7h5" />
+</svg>

--- a/public/themes/Kali/Places/folder-download.svg
+++ b/public/themes/Kali/Places/folder-download.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4.5 7.5h5l1.5 2h8.5a1.5 1.5 0 0 1 1.5 1.5v7a1.5 1.5 0 0 1-1.5 1.5h-14a1.5 1.5 0 0 1-1.5-1.5v-9a1.5 1.5 0 0 1 1.5-1.5z" fill="#1793d1" fill-opacity="0.15" />
+  <path d="M12 10.5v5" />
+  <path d="M9.5 13.5L12 16l2.5-2.5" />
+</svg>

--- a/public/themes/Kali/Places/folder.svg
+++ b/public/themes/Kali/Places/folder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4.5 7.5h5l1.5 2h8.5a1.5 1.5 0 0 1 1.5 1.5v7a1.5 1.5 0 0 1-1.5 1.5h-14a1.5 1.5 0 0 1-1.5-1.5v-9a1.5 1.5 0 0 1 1.5-1.5z" fill="#1793d1" fill-opacity="0.15" />
+  <path d="M4 10.5h16" opacity="0.6" />
+</svg>

--- a/public/themes/Kali/Places/user-desktop.svg
+++ b/public/themes/Kali/Places/user-desktop.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="6" width="16" height="11" rx="1.5" fill="#1793d1" fill-opacity="0.15" />
+  <path d="M10 17v2.5h4V17" />
+  <path d="M4 13h16" />
+</svg>

--- a/public/themes/Kali/Places/user-home.svg
+++ b/public/themes/Kali/Places/user-home.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4.5 11.5L12 5l7.5 6.5v7a1.5 1.5 0 0 1-1.5 1.5h-12a1.5 1.5 0 0 1-1.5-1.5z" fill="#1793d1" fill-opacity="0.15" />
+  <path d="M9.5 19V13h5v6" />
+</svg>

--- a/public/themes/Kali/Places/user-trash-full.svg
+++ b/public/themes/Kali/Places/user-trash-full.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M7.5 8.5h9l-.7 10.2a1.5 1.5 0 0 1-1.5 1.3H9.7a1.5 1.5 0 0 1-1.5-1.3z" fill="#1793d1" fill-opacity="0.3" />
+  <path d="M6 8.5h12" />
+  <path d="M10 11v5.5" />
+  <path d="M14 11v5.5" />
+  <path d="M9 6h6l.8 1.5H8.2z" />
+  <path d="M8.7 10.5l.8-1.5h4.9l.9 1.5z" fill="#1793d1" opacity="0.5" />
+</svg>

--- a/public/themes/Kali/Places/user-trash-symbolic.svg
+++ b/public/themes/Kali/Places/user-trash-symbolic.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M7.5 8.5h9l-.7 10.2a1.5 1.5 0 0 1-1.5 1.3H9.7a1.5 1.5 0 0 1-1.5-1.3z" fill="#1793d1" fill-opacity="0.15" />
+  <path d="M6 8.5h12" />
+  <path d="M10 11v5.5" />
+  <path d="M14 11v5.5" />
+  <path d="M9 6h6l.8 1.5H8.2z" />
+</svg>

--- a/public/themes/Kali/Places/user-trash.svg
+++ b/public/themes/Kali/Places/user-trash.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M7.5 8.5h9l-.7 10.2a1.5 1.5 0 0 1-1.5 1.3H9.7a1.5 1.5 0 0 1-1.5-1.3z" fill="#1793d1" fill-opacity="0.15" />
+  <path d="M6 8.5h12" />
+  <path d="M10 11v5.5" />
+  <path d="M14 11v5.5" />
+  <path d="M9 6h6l.8 1.5H8.2z" />
+</svg>

--- a/public/themes/Kali/categories/applications-all.svg
+++ b/public/themes/Kali/categories/applications-all.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="4" width="6" height="6" rx="1.2" fill="#1793d1" fill-opacity="0.2" />
+  <rect x="14" y="4" width="6" height="6" rx="1.2" fill="#1793d1" fill-opacity="0.2" />
+  <rect x="4" y="14" width="6" height="6" rx="1.2" fill="#1793d1" fill-opacity="0.2" />
+  <rect x="14" y="14" width="6" height="6" rx="1.2" fill="#1793d1" fill-opacity="0.2" />
+  <rect x="4" y="4" width="6" height="6" rx="1.2" />
+  <rect x="14" y="4" width="6" height="6" rx="1.2" />
+  <rect x="4" y="14" width="6" height="6" rx="1.2" />
+  <rect x="14" y="14" width="6" height="6" rx="1.2" />
+</svg>

--- a/public/themes/Kali/categories/applications-favorites.svg
+++ b/public/themes/Kali/categories/applications-favorites.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 6.2l1.9 3.8 4.2.6-3 3 0.7 4.3L12 16l-3.8 1.9 0.7-4.3-3-3 4.2-.6z" fill="#1793d1" fill-opacity="0.2" />
+  <path d="M12 6.2l1.9 3.8 4.2.6-3 3 0.7 4.3L12 16l-3.8 1.9 0.7-4.3-3-3 4.2-.6z" />
+</svg>

--- a/public/themes/Kali/categories/applications-games.svg
+++ b/public/themes/Kali/categories/applications-games.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6.5 15.5a3.5 3.5 0 0 1 0-7h11a3.5 3.5 0 0 1 0 7l-2.2-2.2H8.7z" fill="#1793d1" fill-opacity="0.2" />
+  <path d="M10 10v3" />
+  <path d="M8.5 11.5h3" />
+  <circle cx="14.8" cy="11.3" r="0.8" fill="#1793d1" />
+  <circle cx="16.9" cy="12.7" r="0.8" fill="#1793d1" />
+</svg>

--- a/public/themes/Kali/categories/applications-recent.svg
+++ b/public/themes/Kali/categories/applications-recent.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="7" fill="#1793d1" fill-opacity="0.2" />
+  <path d="M12 8v4l3 2" />
+  <path d="M8.5 8.5L7 7" />
+  <path d="M15.5 15.5L17 17" />
+</svg>

--- a/public/themes/Kali/categories/applications-utilities.svg
+++ b/public/themes/Kali/categories/applications-utilities.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9.5 6.5a3 3 0 0 1 4.2 3.6l4.8 4.8-2.1 2.1-4.8-4.8a3 3 0 0 1-3.6-4.2l-2.4 2.4-1.8-1.8 3.4-3.4z" fill="#1793d1" fill-opacity="0.2" />
+  <path d="M13 10.5l4.5 4.5-2.1 2.1-4.5-4.5" />
+</svg>

--- a/public/themes/Kali/panel/audio-volume-medium-symbolic.svg
+++ b/public/themes/Kali/panel/audio-volume-medium-symbolic.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="#1793d1" stroke-width="1.75" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4.5 9.5h3.25L12 6v12l-4.25-3.5H4.5z" fill="#1793d1" opacity="0.2" />
+  <path d="M15 9.5c1 .75 1.5 1.75 1.5 2.5s-.5 1.75-1.5 2.5" />
+  <path d="M17.75 7.25c1.75 1.25 2.75 2.75 2.75 4.75s-1 3.5-2.75 4.75" opacity="0.7" />
+</svg>

--- a/public/themes/Kali/panel/battery-good-symbolic.svg
+++ b/public/themes/Kali/panel/battery-good-symbolic.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 24" fill="none" stroke="#1793d1" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.7">
+  <rect x="3" y="6.5" width="17" height="11" rx="2" ry="2" fill="#1793d1" fill-opacity="0.15" />
+  <rect x="5.5" y="9" width="9" height="6" rx="1" ry="1" fill="#1793d1" />
+  <rect x="15.5" y="9" width="2.5" height="6" rx="1" ry="1" fill="#1793d1" opacity="0.5" />
+  <path d="M21.5 10v4" />
+</svg>

--- a/public/themes/Kali/panel/decompiler-symbolic.svg
+++ b/public/themes/Kali/panel/decompiler-symbolic.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 7.5h6l3 3-3 3H6z" fill="#1793d1" fill-opacity="0.2" />
+  <path d="M15 6v12" />
+</svg>

--- a/public/themes/Kali/panel/display-brightness-symbolic.svg
+++ b/public/themes/Kali/panel/display-brightness-symbolic.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="4" fill="#1793d1" fill-opacity="0.2" />
+  <path d="M12 4.5v2.5" />
+  <path d="M12 17v2.5" />
+  <path d="M4.5 12H7" />
+  <path d="M17 12h2.5" />
+  <path d="M7.1 7.1l1.7 1.7" />
+  <path d="M15.2 15.2l1.7 1.7" />
+  <path d="M16.9 7.1l-1.7 1.7" />
+  <path d="M8.8 15.2l-1.7 1.7" />
+</svg>

--- a/public/themes/Kali/panel/emblem-system-symbolic.svg
+++ b/public/themes/Kali/panel/emblem-system-symbolic.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="6.5" opacity="0.25" fill="#1793d1" />
+  <path d="M12 7.5v3" />
+  <path d="M12 13.5v3" />
+  <path d="M7.5 12h3" />
+  <path d="M13.5 12h3" />
+</svg>

--- a/public/themes/Kali/panel/network-wireless-signal-good-symbolic.svg
+++ b/public/themes/Kali/panel/network-wireless-signal-good-symbolic.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 10.5c2.4-2.4 5.2-3.6 8-3.6s5.6 1.2 8 3.6" opacity="0.4" />
+  <path d="M7 13c1.6-1.6 3.4-2.4 5-2.4s3.4.8 5 2.4" opacity="0.7" />
+  <path d="M10.2 15.5c.5-.5 1.1-.8 1.8-.8s1.3.3 1.8.8" />
+  <circle cx="12" cy="18" r="1.6" fill="#1793d1" />
+</svg>

--- a/public/themes/Kali/panel/network-wireless-signal-none-symbolic.svg
+++ b/public/themes/Kali/panel/network-wireless-signal-none-symbolic.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 10.5c2.4-2.4 5.2-3.6 8-3.6 1.8 0 3.5.5 5 1.5" opacity="0.25" />
+  <path d="M7.2 13.3c1.4-1.3 3-2 4.8-2" opacity="0.25" />
+  <line x1="6" y1="18" x2="18" y2="6" />
+  <circle cx="9" cy="18" r="1.4" fill="#1793d1" />
+</svg>

--- a/public/themes/Kali/panel/power-button.svg
+++ b/public/themes/Kali/panel/power-button.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 4.5v6" />
+  <path d="M7.5 6.5a7 7 0 1 0 9 0" />
+</svg>

--- a/public/themes/Kali/panel/process-working-symbolic.svg
+++ b/public/themes/Kali/panel/process-working-symbolic.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 4.5a7.5 7.5 0 1 1-7.2 5.6" opacity="0.25" />
+  <path d="M12 2v6" />
+</svg>


### PR DESCRIPTION
## Summary
- add a Kali theme asset tree with panel status glyphs for power, battery, volume, and network
- provide Kali-flavored SVGs for Whisker-style category buttons and common Places destinations

## Testing
- not run (static asset update)

------
https://chatgpt.com/codex/tasks/task_e_68d659e94b848328a5946e49f9058755