### PR TITLE
[a11y] Improve navbar menu accessibility

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -31,9 +31,11 @@ export class UbuntuApp extends Component {
     }
 
     render() {
+        const ariaRole = this.props.role || 'button';
+
         return (
             <div
-                role="button"
+                role={ariaRole}
                 aria-label={this.props.name}
                 aria-disabled={this.props.disabled}
                 data-context="app"

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useId } from 'react';
 import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
@@ -27,6 +27,8 @@ const WhiskerMenu: React.FC = () => {
   const [highlight, setHighlight] = useState(0);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
+  const triggerId = useId();
 
   const allApps: AppMeta[] = apps as any;
   const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
@@ -115,12 +117,17 @@ const WhiskerMenu: React.FC = () => {
   }, [open]);
 
   return (
-    <div className="relative">
+    <div className="relative" role="none">
       <button
         ref={buttonRef}
         type="button"
         onClick={() => setOpen(o => !o)}
         className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        id={triggerId}
+        role="menuitem"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={menuId}
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"
@@ -141,6 +148,9 @@ const WhiskerMenu: React.FC = () => {
               setOpen(false);
             }
           }}
+          id={menuId}
+          role="menu"
+          aria-labelledby={triggerId}
         >
           <div className="flex flex-col bg-gray-800 p-2">
             {CATEGORIES.map(cat => (
@@ -148,6 +158,8 @@ const WhiskerMenu: React.FC = () => {
                 key={cat.id}
                 className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
                 onClick={() => setCategory(cat.id)}
+                role="menuitem"
+                aria-pressed={category === cat.id}
               >
                 {cat.label}
               </button>
@@ -170,6 +182,7 @@ const WhiskerMenu: React.FC = () => {
                     name={app.title}
                     openApp={() => openSelectedApp(app.id)}
                     disabled={app.disabled}
+                    role="menuitem"
                   />
                 </div>
               ))}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -15,7 +15,13 @@ export default class Navbar extends Component {
 	render() {
 		return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <WhiskerMenu />
+                                <div
+                                        role="menubar"
+                                        aria-label="Primary menu"
+                                        className="flex items-center"
+                                >
+                                        <WhiskerMenu />
+                                </div>
                                 <div
                                         className={
                                                 'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'


### PR DESCRIPTION
## Summary
- wrap the navbar's left menu triggers in a menubar container
- add aria metadata to the Applications menu trigger and list so it exposes menu/menuitem semantics
- allow UbuntuApp tiles to adopt a menuitem role when rendered inside menus

## Testing
- [ ] yarn lint
- [ ] yarn test

## Flags
- [ ] None

------
https://chatgpt.com/codex/tasks/task_e_68d659ebd0188328b59eb5ff08665857