### PR TITLE
[menu] Dynamically load legacy menus

### DIFF
--- a/components/menu/ApplicationsMenu.tsx
+++ b/components/menu/ApplicationsMenu.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import Image from 'next/image';
+import UbuntuApp from '../base/ubuntu_app';
+import apps, { utilities, games } from '../../apps.config';
+import { safeLocalStorage } from '../../utils/safeStorage';
+
+interface AppMeta {
+  id: string;
+  title: string;
+  icon: string;
+  disabled?: boolean;
+  favourite?: boolean;
+}
+
+const CATEGORIES = [
+  { id: 'all', label: 'All Applications' },
+  { id: 'favorites', label: 'Favorites' },
+  { id: 'recent', label: 'Recent' },
+  { id: 'utilities', label: 'Utilities' },
+  { id: 'games', label: 'Games' },
+];
+
+const ApplicationsMenu: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [category, setCategory] = useState('all');
+  const [query, setQuery] = useState('');
+  const [highlight, setHighlight] = useState(0);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const allApps: AppMeta[] = apps as unknown as AppMeta[];
+  const favoriteApps = useMemo(() => allApps.filter((app) => app.favourite), [allApps]);
+  const recentApps = useMemo(() => {
+    if (!open) return [] as AppMeta[];
+    try {
+      const stored = safeLocalStorage?.getItem('recentApps');
+      const ids: string[] = stored ? JSON.parse(stored) : [];
+      return ids
+        .map((id) => allApps.find((app) => app.id === id))
+        .filter(Boolean) as AppMeta[];
+    } catch {
+      return [];
+    }
+  }, [allApps, open]);
+  const utilityApps: AppMeta[] = utilities as unknown as AppMeta[];
+  const gameApps: AppMeta[] = games as unknown as AppMeta[];
+
+  const currentApps = useMemo(() => {
+    let list: AppMeta[];
+    switch (category) {
+      case 'favorites':
+        list = favoriteApps;
+        break;
+      case 'recent':
+        list = recentApps;
+        break;
+      case 'utilities':
+        list = utilityApps;
+        break;
+      case 'games':
+        list = gameApps;
+        break;
+      default:
+        list = allApps;
+    }
+    if (query) {
+      const lower = query.toLowerCase();
+      list = list.filter((app) => app.title.toLowerCase().includes(lower));
+    }
+    return list;
+  }, [allApps, favoriteApps, gameApps, query, recentApps, utilityApps, category]);
+
+  useEffect(() => {
+    if (!open) return;
+    setHighlight(0);
+  }, [open, category, query]);
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (!open) return;
+      const target = event.target as Node;
+      if (!menuRef.current?.contains(target) && !buttonRef.current?.contains(target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  useEffect(() => {
+    const handleKey = (event: KeyboardEvent) => {
+      if (!open) return;
+      if (event.key === 'Escape') {
+        setOpen(false);
+        return;
+      }
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setHighlight((prev) => Math.min(prev + 1, currentApps.length - 1));
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setHighlight((prev) => Math.max(prev - 1, 0));
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
+        const app = currentApps[highlight];
+        if (app) openSelectedApp(app.id);
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open, currentApps, highlight]);
+
+  const openSelectedApp = (id: string) => {
+    window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+      >
+        <Image
+          src="/themes/Yaru/status/view-app-grid-symbolic.svg"
+          alt="Applications"
+          width={16}
+          height={16}
+          className="inline mr-1"
+        />
+        Applications
+      </button>
+      {open && (
+        <div
+          ref={menuRef}
+          className="absolute left-0 mt-1 z-50 flex bg-ub-grey text-white shadow-lg"
+          tabIndex={-1}
+          onBlur={(event) => {
+            if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+              setOpen(false);
+            }
+          }}
+        >
+          <div className="flex flex-col bg-gray-800 p-2 min-w-[10rem]">
+            {CATEGORIES.map((cat) => (
+              <button
+                key={cat.id}
+                type="button"
+                className={`text-left px-2 py-1 rounded mb-1 rtl:text-right ${
+                  category === cat.id ? 'bg-gray-700 text-white' : 'text-ubt-grey'
+                }`}
+                onClick={() => setCategory(cat.id)}
+              >
+                {cat.label}
+              </button>
+            ))}
+          </div>
+          <div className="p-3">
+            <input
+              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+              placeholder="Search applications"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              autoFocus
+            />
+            <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
+              {currentApps.map((app, index) => (
+                <div key={app.id} className={index === highlight ? 'ring-2 ring-ubb-orange rounded' : ''}>
+                  <UbuntuApp
+                    id={app.id}
+                    icon={app.icon}
+                    name={app.title}
+                    openApp={() => openSelectedApp(app.id)}
+                    disabled={app.disabled}
+                  />
+                </div>
+              ))}
+              {!currentApps.length && (
+                <p className="col-span-3 text-sm text-ubt-grey text-center">No applications found.</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ApplicationsMenu;

--- a/components/panel/PlacesMenu.tsx
+++ b/components/panel/PlacesMenu.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import React, { useState } from 'react';
+
+const DEFAULT_PLACES = [
+  { label: 'Home', path: '/home/kali' },
+  { label: 'Desktop', path: '/home/kali/Desktop' },
+  { label: 'Documents', path: '/home/kali/Documents' },
+  { label: 'Downloads', path: '/home/kali/Downloads' },
+  { label: 'Removable', path: '/media/removable' },
+];
+
+interface PlacesMenuProps {
+  openApp?: (id: string) => void;
+}
+
+const PlacesMenu: React.FC<PlacesMenuProps> = ({ openApp }) => {
+  const [open, setOpen] = useState(false);
+
+  const handleSelect = (path: string) => {
+    try {
+      if (typeof window !== 'undefined') {
+        sessionStorage.setItem('file-explorer-path', path);
+      }
+    } catch {
+      // ignore sessionStorage failures
+    }
+    if (openApp) {
+      openApp('file-explorer');
+    } else {
+      window.dispatchEvent(new CustomEvent('open-app', { detail: 'file-explorer' }));
+    }
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        onClick={() => setOpen((value) => !value)}
+      >
+        Places
+      </button>
+      {open && (
+        <ul
+          className="absolute left-0 mt-1 w-40 bg-ub-grey text-ubt-grey border border-black border-opacity-50 rounded shadow-md z-50"
+          onMouseLeave={() => setOpen(false)}
+        >
+          {DEFAULT_PLACES.map((item) => (
+            <li key={item.label}>
+              <button
+                type="button"
+                className="w-full text-left px-4 py-1 hover:bg-white hover:bg-opacity-10"
+                title={item.path}
+                onClick={() => handleSelect(item.path)}
+              >
+                {item.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default PlacesMenu;

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,21 +1,56 @@
 import React, { Component } from 'react';
+import dynamic from 'next/dynamic';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
 
-export default class Navbar extends Component {
-	constructor() {
-		super();
-		this.state = {
-			status_card: false
-		};
-	}
+const ApplicationsMenu = dynamic(
+        () => import('../menu/ApplicationsMenu'),
+        {
+                ssr: false,
+                loading: () => (
+                        <button
+                                type="button"
+                                className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 opacity-60"
+                                disabled
+                        >
+                                Applications
+                        </button>
+                ),
+        }
+);
 
-	render() {
-		return (
+const PlacesMenu = dynamic(
+        () => import('../panel/PlacesMenu'),
+        {
+                ssr: false,
+                loading: () => (
+                        <span className="pl-3 pr-3 py-1 text-ubt-grey text-sm opacity-70">Places</span>
+                ),
+        }
+);
+
+export default class Navbar extends Component {
+        constructor(props) {
+                super(props);
+                this.state = {
+                        status_card: false
+                };
+                this.useWhiskerMenu = process.env.NEXT_PUBLIC_UI_EXPERIMENTS === 'true';
+        }
+
+        render() {
+                return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-                                <WhiskerMenu />
+                                {this.useWhiskerMenu ? (
+                                        <WhiskerMenu />
+                                ) : (
+                                        <div className="flex items-center space-x-1">
+                                                <ApplicationsMenu />
+                                                <PlacesMenu openApp={this.props.openApp} />
+                                        </div>
+                                )}
                                 <div
                                         className={
                                                 'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -9,15 +9,16 @@ import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
 
 export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
-			screen_locked: false,
-			bg_image_name: 'wall-2',
-			booting_screen: true,
-			shutDownScreen: false
-		};
-	}
+        constructor(props) {
+                super(props);
+                this.desktopRef = React.createRef();
+                this.state = {
+                        screen_locked: false,
+                        bg_image_name: 'wall-2',
+                        booting_screen: true,
+                        shutDownScreen: false
+                };
+        }
 
 	componentDidMount() {
 		this.getLocalData();
@@ -113,22 +114,30 @@ export default class Ubuntu extends Component {
                 safeLocalStorage?.setItem('shut-down', false);
 	};
 
-	render() {
-		return (
-			<div className="w-screen h-screen overflow-hidden" id="monitor-screen">
-				<LockScreen
-					isLocked={this.state.screen_locked}
-					bgImgName={this.state.bg_image_name}
+        openApp = (id) => {
+                this.desktopRef?.current?.openApp?.(id);
+        };
+
+        render() {
+                return (
+                        <div className="w-screen h-screen overflow-hidden" id="monitor-screen">
+                                <LockScreen
+                                        isLocked={this.state.screen_locked}
+                                        bgImgName={this.state.bg_image_name}
 					unLockScreen={this.unLockScreen}
 				/>
-				<BootingScreen
-					visible={this.state.booting_screen}
-					isShutDown={this.state.shutDownScreen}
-					turnOn={this.turnOn}
-				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+                                <BootingScreen
+                                        visible={this.state.booting_screen}
+                                        isShutDown={this.state.shutDownScreen}
+                                        turnOn={this.turnOn}
+                                />
+                                <Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} openApp={this.openApp} />
+                                <Desktop
+                                        ref={this.desktopRef}
+                                        bg_image_name={this.state.bg_image_name}
+                                        changeBackgroundImage={this.changeBackgroundImage}
+                                />
+                        </div>
+                );
+        }
 }


### PR DESCRIPTION
## Summary
- add a client-only Applications menu component that mirrors the legacy launcher behaviour
- add a Places menu shortcut list and dynamically import both menus in the navbar behind the UI experiments flag
- expose the desktop openApp handler through the navbar so the legacy menus can launch apps when selected

## Testing
- yarn lint *(fails: pre-existing jsx-a11y/control-has-associated-label violations across apps and public bundles)*

------
https://chatgpt.com/codex/tasks/task_e_68d659ee73c483288ac81ed1f5b249a7