### PR TITLE
[accessibility] Respect reduced motion in application menus

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -217,9 +217,19 @@ dialog {
     }
 }
 
-/* Show Applications overlay animation */
+/* Show Applications/Places overlay animation */
 .all-apps-anim {
     animation: allAppsScale 200ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .all-apps-anim {
+        animation: none !important;
+    }
+}
+
+html.reduce-motion .all-apps-anim {
+    animation: none !important;
 }
 
 @keyframes allAppsScale {


### PR DESCRIPTION
## Summary
- disable the all apps/places overlay entrance animation when reduced motion is requested via media query
- honor the quick settings reduced motion toggle by skipping the animation when the class is applied

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d659edc7d083288dc723f4337dd7d6