### PR TITLE
[menu] Add Kali category icons

### DIFF
--- a/components/menu/ApplicationsMenu.tsx
+++ b/components/menu/ApplicationsMenu.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
+
+export type KaliCategory = {
+  id: string;
+  label: string;
+};
+
+export const KALI_CATEGORIES: KaliCategory[] = [
+  { id: 'information-gathering', label: 'Information Gathering' },
+  { id: 'vulnerability-analysis', label: 'Vulnerability Analysis' },
+  { id: 'web-application-analysis', label: 'Web Application Analysis' },
+  { id: 'database-assessment', label: 'Database Assessment' },
+  { id: 'password-attacks', label: 'Password Attacks' },
+  { id: 'wireless-attacks', label: 'Wireless Attacks' },
+  { id: 'reverse-engineering', label: 'Reverse Engineering' },
+  { id: 'exploitation-tools', label: 'Exploitation Tools' },
+  { id: 'sniffing-spoofing', label: 'Sniffing & Spoofing' },
+  { id: 'post-exploitation', label: 'Post Exploitation' },
+  { id: 'forensics', label: 'Forensics' },
+  { id: 'reporting', label: 'Reporting' },
+  { id: 'social-engineering', label: 'Social Engineering' },
+  { id: 'hardware-hacking', label: 'Hardware Hacking' },
+  { id: 'extra', label: 'Extra' },
+  { id: 'top10', label: 'Top 10 Security Tools' },
+];
+
+const DEFAULT_CATEGORY_ICON = '/themes/Yaru/status/preferences-system-symbolic.svg';
+
+const CATEGORY_ICON_LOOKUP: Record<string, string> = {
+  'information-gathering': '/themes/kali/categories/information-gathering.svg',
+  'vulnerability-analysis': '/themes/kali/categories/vulnerability-analysis.svg',
+  'web-application-analysis': '/themes/kali/categories/web-application-analysis.svg',
+  'database-assessment': '/themes/kali/categories/database-assessment.svg',
+  'password-attacks': '/themes/kali/categories/password-attacks.svg',
+  'wireless-attacks': '/themes/kali/categories/wireless-attacks.svg',
+  'reverse-engineering': '/themes/kali/categories/reverse-engineering.svg',
+  'exploitation-tools': '/themes/kali/categories/exploitation-tools.svg',
+  'sniffing-spoofing': '/themes/kali/categories/sniffing-spoofing.svg',
+  'sniffing-and-spoofing': '/themes/kali/categories/sniffing-spoofing.svg',
+  'post-exploitation': '/themes/kali/categories/post-exploitation.svg',
+  'maintaining-access': '/themes/kali/categories/post-exploitation.svg',
+  'forensics': '/themes/kali/categories/forensics.svg',
+  'reporting': '/themes/kali/categories/reporting.svg',
+  'reporting-tools': '/themes/kali/categories/reporting.svg',
+  'social-engineering': '/themes/kali/categories/social-engineering.svg',
+  'social-engineering-tools': '/themes/kali/categories/social-engineering.svg',
+  'hardware-hacking': '/themes/kali/categories/hardware-hacking.svg',
+  'extra': '/themes/kali/categories/extra.svg',
+  'miscellaneous': '/themes/kali/categories/extra.svg',
+  'top10': '/themes/kali/categories/top10.svg',
+  'top-10-tools': '/themes/kali/categories/top10.svg',
+  'stress-testing': '/themes/kali/categories/exploitation-tools.svg',
+};
+
+type CategoryIconProps = {
+  categoryId: string;
+  label: string;
+};
+
+const CategoryIcon: React.FC<CategoryIconProps> = ({ categoryId, label }) => {
+  const [src, setSrc] = useState<string>(CATEGORY_ICON_LOOKUP[categoryId] ?? DEFAULT_CATEGORY_ICON);
+
+  useEffect(() => {
+    setSrc(CATEGORY_ICON_LOOKUP[categoryId] ?? DEFAULT_CATEGORY_ICON);
+  }, [categoryId]);
+
+  return (
+    <Image
+      src={src}
+      alt={`${label} category icon`}
+      width={20}
+      height={20}
+      className="h-5 w-5 flex-shrink-0"
+      onError={() => {
+        if (src !== DEFAULT_CATEGORY_ICON) {
+          setSrc(DEFAULT_CATEGORY_ICON);
+        }
+      }}
+    />
+  );
+};
+
+type ApplicationsMenuProps = {
+  activeCategory: string;
+  onSelect: (id: string) => void;
+};
+
+const ApplicationsMenu: React.FC<ApplicationsMenuProps> = ({ activeCategory, onSelect }) => {
+  return (
+    <nav aria-label="Kali application categories">
+      <ul className="space-y-1">
+        {KALI_CATEGORIES.map((category) => {
+          const isActive = category.id === activeCategory;
+          return (
+            <li key={category.id}>
+              <button
+                type="button"
+                onClick={() => onSelect(category.id)}
+                className={`flex w-full items-center gap-3 rounded px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
+                  isActive ? 'bg-gray-700 text-white' : 'bg-transparent hover:bg-gray-700/60'
+                }`}
+                aria-pressed={isActive}
+              >
+                <CategoryIcon categoryId={category.id} label={category.label} />
+                <span className="text-sm font-medium">{category.label}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+};
+
+export default ApplicationsMenu;

--- a/public/themes/kali/categories/database-assessment.svg
+++ b/public/themes/kali/categories/database-assessment.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <ellipse cx="16" cy="8" rx="9" ry="4" />
+  <path d="M7 8v8c0 2.2 4 4 9 4s9-1.8 9-4V8" />
+  <path d="M7 16v8c0 2.2 4 4 9 4s9-1.8 9-4v-8" />
+  <polyline points="12 18 15 21 21 15" />
+</svg>

--- a/public/themes/kali/categories/exploitation-tools.svg
+++ b/public/themes/kali/categories/exploitation-tools.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="16" cy="16" r="8" />
+  <line x1="16" y1="6" x2="16" y2="2" />
+  <line x1="16" y1="30" x2="16" y2="26" />
+  <line x1="6" y1="16" x2="2" y2="16" />
+  <line x1="30" y1="16" x2="26" y2="16" />
+  <circle cx="16" cy="16" r="3" />
+</svg>

--- a/public/themes/kali/categories/extra.svg
+++ b/public/themes/kali/categories/extra.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="16 4 19.5 12 28 12 21 17 24 26 16 20.5 8 26 11 17 4 12 12.5 12" />
+</svg>

--- a/public/themes/kali/categories/forensics.svg
+++ b/public/themes/kali/categories/forensics.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 21c0-6 8-6 8 0 0 5-2 7-4 7s-4-2-4-7" />
+  <path d="M10 18c0-8 12-8 12 0" />
+  <path d="M9 15c0-10 14-10 14 0" />
+  <path d="M16 2v4" />
+</svg>

--- a/public/themes/kali/categories/hardware-hacking.svg
+++ b/public/themes/kali/categories/hardware-hacking.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="8" y="8" width="12" height="12" rx="2" />
+  <path d="M20 12l4-4" />
+  <path d="M24 8l3 3-2 2" />
+  <path d="M10 4v3" />
+  <path d="M16 4v3" />
+  <path d="M22 4v3" />
+  <path d="M10 25v3" />
+  <path d="M16 25v3" />
+  <path d="M22 25v3" />
+</svg>

--- a/public/themes/kali/categories/information-gathering.svg
+++ b/public/themes/kali/categories/information-gathering.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="16" cy="16" r="5" />
+  <circle cx="7" cy="7" r="3" />
+  <circle cx="25" cy="8" r="3" />
+  <circle cx="9" cy="25" r="3" />
+  <line x1="9" y1="23" x2="13" y2="19" />
+  <line x1="10" y1="8" x2="14" y2="13" />
+  <line x1="22" y1="9" x2="18" y2="13" />
+</svg>

--- a/public/themes/kali/categories/password-attacks.svg
+++ b/public/themes/kali/categories/password-attacks.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="14" r="5" />
+  <path d="M15 17l7 7h4v-4l-5-5" />
+  <path d="M20 10l2-2 2 2 2-2" />
+</svg>

--- a/public/themes/kali/categories/post-exploitation.svg
+++ b/public/themes/kali/categories/post-exploitation.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="6" y="6" width="20" height="16" rx="2" />
+  <polyline points="10 14 13 16 10 18" />
+  <line x1="15" y1="19" x2="22" y2="19" />
+  <polyline points="20 11 23 11 23 14" />
+  <line x1="20" y1="14" x2="23" y2="11" />
+</svg>

--- a/public/themes/kali/categories/reporting.svg
+++ b/public/themes/kali/categories/reporting.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="8" y="6" width="16" height="20" rx="3" />
+  <path d="M12 6v-1a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v1" />
+  <line x1="12" y1="16" x2="12" y2="21" />
+  <line x1="16" y1="14" x2="16" y2="21" />
+  <line x1="20" y1="18" x2="20" y2="21" />
+</svg>

--- a/public/themes/kali/categories/reverse-engineering.svg
+++ b/public/themes/kali/categories/reverse-engineering.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M16 9a7 7 0 1 1-7 7" />
+  <path d="M9 13l-4-1 1-4" />
+  <circle cx="16" cy="16" r="3" />
+  <path d="M21.5 7.5l1.5-2 3 2" />
+</svg>

--- a/public/themes/kali/categories/sniffing-spoofing.svg
+++ b/public/themes/kali/categories/sniffing-spoofing.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="9" width="9" height="6" rx="2" />
+  <rect x="19" y="17" width="9" height="6" rx="2" />
+  <path d="M13 12h4l2-3" />
+  <path d="M13 12h4l2 3" />
+  <path d="M16 15v4l-2 3" />
+  <path d="M16 19l2 3" />
+</svg>

--- a/public/themes/kali/categories/social-engineering.svg
+++ b/public/themes/kali/categories/social-engineering.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M8 6h16a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-4l-6 6v-6H8a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2z" />
+  <circle cx="12" cy="11" r="1" />
+  <circle cx="16" cy="11" r="1" />
+  <circle cx="20" cy="11" r="1" />
+</svg>

--- a/public/themes/kali/categories/top10.svg
+++ b/public/themes/kali/categories/top10.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M10 4h12v4a6 6 0 0 1-6 6 6 6 0 0 1-6-6V4z" />
+  <path d="M8 4h-4v3a5 5 0 0 0 5 5" />
+  <path d="M24 4h4v3a5 5 0 0 1-5 5" />
+  <path d="M14 22h4" />
+  <path d="M12 26h8" />
+  <line x1="16" y1="18" x2="16" y2="22" />
+</svg>

--- a/public/themes/kali/categories/vulnerability-analysis.svg
+++ b/public/themes/kali/categories/vulnerability-analysis.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M16 4l10 4v6c0 6.5-4.5 12-10 14-5.5-2-10-7.5-10-14V8l10-4z" />
+  <path d="M13 12l3 3-2 3 5 5" />
+</svg>

--- a/public/themes/kali/categories/web-application-analysis.svg
+++ b/public/themes/kali/categories/web-application-analysis.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="5" y="6" width="22" height="16" rx="2" />
+  <line x1="5" y1="11" x2="27" y2="11" />
+  <circle cx="14" cy="18" r="4" />
+  <line x1="17" y1="21" x2="21" y2="25" />
+</svg>

--- a/public/themes/kali/categories/wireless-attacks.svg
+++ b/public/themes/kali/categories/wireless-attacks.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 14a15 15 0 0 1 22 0" />
+  <path d="M9 18a9 9 0 0 1 14 0" />
+  <path d="M13 22a3 3 0 0 1 6 0" />
+  <polyline points="16 4 14 8 18 8 16 12" />
+</svg>


### PR DESCRIPTION
## Summary
- map `KALI_CATEGORIES` entries to Kali-specific SVG icons in the applications menu with a runtime fallback to the gear glyph
- add a new Kali-themed category icon set under `public/themes/kali/categories`

## Testing
- yarn lint *(fails due to pre-existing accessibility warnings across legacy app components)*

------
https://chatgpt.com/codex/tasks/task_e_68d659eac3608328ac31eeb8f1babd07