### PR TITLE
[ui] Add high contrast quick setting toggle

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 interface Props {
   open: boolean;
@@ -12,6 +12,8 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [highContrast, setHighContrast] = usePersistentState('qs-high-contrast', false);
+  const previousThemeRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -20,6 +22,20 @@ const QuickSettings = ({ open }: Props) => {
   useEffect(() => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
+
+  useEffect(() => {
+    if (highContrast) {
+      previousThemeRef.current = document.documentElement.dataset.theme;
+      document.documentElement.dataset.theme = 'contrast';
+    } else {
+      if (previousThemeRef.current) {
+        document.documentElement.dataset.theme = previousThemeRef.current;
+      } else {
+        delete document.documentElement.dataset.theme;
+      }
+      previousThemeRef.current = undefined;
+    }
+  }, [highContrast]);
 
   return (
     <div
@@ -43,6 +59,14 @@ const QuickSettings = ({ open }: Props) => {
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
         <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+      </div>
+      <div className="px-4 pb-2 flex justify-between">
+        <span>High contrast</span>
+        <input
+          type="checkbox"
+          checked={highContrast}
+          onChange={() => setHighContrast(!highContrast)}
+        />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -68,6 +68,25 @@ html[data-theme='matrix'] {
 
 }
 
+/* High contrast theme */
+html[data-theme='contrast'] {
+  --color-bg: #000000;
+  --color-text: #ffffff;
+  --color-primary: #ffff00;
+  --color-secondary: #000000;
+  --color-accent: #ff9900;
+  --color-muted: #1a1a1a;
+  --color-surface: #000000;
+  --color-inverse: #000000;
+  --color-border: #ffffff;
+  --color-terminal: #00ffff;
+  --color-dark: #000000;
+  --color-focus-ring: #ffff00;
+  --color-selection: #ff9900;
+  --color-control-accent: #ffff00;
+  accent-color: var(--color-control-accent);
+}
+
 ::selection {
   background: var(--color-selection);
   color: var(--color-inverse);


### PR DESCRIPTION
## Summary
- add a persistent high contrast toggle to the quick settings panel
- sync the toggle with the document theme dataset while restoring the previous theme when disabled
- define the high contrast palette overrides so the mode has distinct colors

## Testing
- yarn lint *(fails: existing accessibility rules across apps trigger 572 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d659ecf9b483289f4a77c37ba495f6