### PR TITLE
[ui] Align quick settings dropdown with kali theme

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -23,7 +23,7 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute rounded-md shadow-kali-panel border border-kali-border bg-kali-menu py-4 top-full right-3 mt-2 ${
         open ? '' : 'hidden'
       }`}
     >


### PR DESCRIPTION
## Summary
- swap the quick settings panel wrapper to the kali panel styling tokens
- position the dropdown relative to the trigger so it aligns with the taller navbar

## Testing
- [ ] yarn lint
- [ ] yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d659c347048328aaa73b13abc851c0