### PR TITLE
[desktop] Add gradient wallpaper defaults and persistence

### DIFF
--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
+import { getWallpaperSrc } from '@/utils/wallpapers';
 
 export default function LockScreen(props) {
 
     const { wallpaper } = useSettings();
+    const wallpaperSrc = useMemo(() => getWallpaperSrc(wallpaper), [wallpaper]);
 
     if (props.isLocked) {
         window.addEventListener('click', props.unLockScreen);
@@ -17,7 +19,7 @@ export default function LockScreen(props) {
             style={{ zIndex: "100", contentVisibility: 'auto' }}
             className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
             <img
-                src={`/wallpapers/${wallpaper}.webp`}
+                src={wallpaperSrc}
                 alt=""
                 className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
             />

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -1,15 +1,18 @@
 "use client";
 
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useSettings } from '../../hooks/useSettings';
+import { getWallpaperSrc } from '@/utils/wallpapers';
 
 export default function BackgroundImage() {
     const { wallpaper } = useSettings();
     const [needsOverlay, setNeedsOverlay] = useState(false);
+    const wallpaperSrc = useMemo(() => getWallpaperSrc(wallpaper), [wallpaper]);
 
     useEffect(() => {
         const img = new Image();
-        img.src = `/wallpapers/${wallpaper}.webp`;
+        setNeedsOverlay(false);
+        img.src = wallpaperSrc;
         img.onload = () => {
             const canvas = document.createElement('canvas');
             canvas.width = img.width;
@@ -34,17 +37,49 @@ export default function BackgroundImage() {
             const contrast = (1.05) / (lum + 0.05); // white text luminance is 1
             setNeedsOverlay(contrast < 4.5);
         };
-    }, [wallpaper]);
+        img.onerror = () => {
+            setNeedsOverlay(false);
+        };
+    }, [wallpaperSrc]);
 
     return (
-        <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
+        <div
+            className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full"
+            style={{
+                '--wallpaper-object-fit': 'cover',
+                '--wallpaper-object-position': 'center',
+                '--wallpaper-vignette-color': 'rgba(15, 23, 42, 0.6)',
+                '--wallpaper-vignette-inner': '55%',
+                '--wallpaper-vignette-outer': '125%',
+                '--wallpaper-vignette-blend': 'soft-light',
+                '--wallpaper-contrast-gradient': 'rgba(15, 23, 42, 0.65)',
+            }}
+        >
             <img
-                src={`/wallpapers/${wallpaper}.webp`}
+                src={wallpaperSrc}
                 alt=""
-                className="w-full h-full object-cover"
+                className="w-full h-full"
+                style={{
+                    objectFit: 'var(--wallpaper-object-fit, cover)',
+                    objectPosition: 'var(--wallpaper-object-position, center)',
+                }}
             />
+            <div
+                className="pointer-events-none absolute inset-0"
+                aria-hidden="true"
+                style={{
+                    background: 'radial-gradient(circle at center, transparent var(--wallpaper-vignette-inner, 55%), var(--wallpaper-vignette-color, rgba(15, 23, 42, 0.6)) var(--wallpaper-vignette-outer, 125%))',
+                    mixBlendMode: 'var(--wallpaper-vignette-blend, soft-light)',
+                }}
+            ></div>
             {needsOverlay && (
-                <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>
+                <div
+                    className="pointer-events-none absolute inset-0"
+                    aria-hidden="true"
+                    style={{
+                        background: 'linear-gradient(to bottom, var(--wallpaper-contrast-gradient, rgba(0,0,0,0.6)), transparent)',
+                    }}
+                ></div>
             )}
         </div>
     )

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState, ReactNode, useRef } from 'react';
+import { createContext, useContext, useEffect, useState, ReactNode, useRef, useCallback } from 'react';
 import {
   getAccent as loadAccent,
   setAccent as saveAccent,
@@ -23,6 +23,7 @@ import {
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import { normalizeWallpaper } from '@/utils/wallpapers';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -103,7 +104,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [accent, setAccent] = useState<string>(defaults.accent);
-  const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
+  const [wallpaper, setWallpaperState] = useState<string>(defaults.wallpaper);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
@@ -118,7 +119,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     (async () => {
       setAccent(await loadAccent());
-      setWallpaper(await loadWallpaper());
+      setWallpaperState(await loadWallpaper());
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
@@ -155,6 +156,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     saveWallpaper(wallpaper);
   }, [wallpaper]);
+
+  const setWallpaper = useCallback((value: string) => {
+    setWallpaperState(normalizeWallpaper(value));
+  }, []);
 
   useEffect(() => {
     const spacing: Record<Density, Record<string, string>> = {

--- a/public/wallpapers/gradient-default.svg
+++ b/public/wallpapers/gradient-default.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="3840" height="2160" viewBox="0 0 3840 2160" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <radialGradient id="aurora" cx="20%" cy="15%" r="120%" fx="15%" fy="10%">
+      <stop offset="0%" stop-color="#1d4ed8" stop-opacity="0.95"/>
+      <stop offset="45%" stop-color="#2563eb" stop-opacity="0.85"/>
+      <stop offset="72%" stop-color="#7c3aed" stop-opacity="0.75"/>
+      <stop offset="100%" stop-color="#111827" stop-opacity="1"/>
+    </radialGradient>
+    <radialGradient id="glow" cx="78%" cy="70%" r="65%">
+      <stop offset="0%" stop-color="#22d3ee" stop-opacity="0.65"/>
+      <stop offset="55%" stop-color="#0ea5e9" stop-opacity="0.25"/>
+      <stop offset="100%" stop-color="#111827" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="horizon" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" stop-opacity="0"/>
+      <stop offset="55%" stop-color="#312e81" stop-opacity="0.55"/>
+      <stop offset="100%" stop-color="#020617" stop-opacity="0.95"/>
+    </linearGradient>
+  </defs>
+  <rect width="3840" height="2160" fill="#020617"/>
+  <rect width="3840" height="2160" fill="url(#aurora)"/>
+  <rect width="3840" height="2160" fill="url(#horizon)"/>
+  <rect width="3840" height="2160" fill="url(#glow)"/>
+  <g opacity="0.28">
+    <circle cx="640" cy="300" r="460" fill="#93c5fd"/>
+    <circle cx="3360" cy="1760" r="420" fill="#a855f7"/>
+    <circle cx="2320" cy="680" r="540" fill="#38bdf8"/>
+  </g>
+</svg>

--- a/types/wallpapers.d.ts
+++ b/types/wallpapers.d.ts
@@ -1,0 +1,19 @@
+declare module '@/utils/wallpapers' {
+  export interface WallpaperPreset {
+    id: string;
+    name: string;
+    src: string;
+  }
+
+  export const PRESET_PREFIX: string;
+  export const CUSTOM_PREFIX: string;
+  export const WALLPAPER_STORAGE_KEY: string;
+  export const LEGACY_WALLPAPER_STORAGE_KEY: string;
+  export const WALLPAPER_PRESETS: WallpaperPreset[];
+  export const DEFAULT_WALLPAPER: string;
+  export function makePresetWallpaper(id: string): string;
+  export function isCustomWallpaper(value: string | null | undefined): boolean;
+  export function getWallpaperId(value: string | null | undefined): string | null;
+  export function getWallpaperSrc(value: string | null | undefined): string;
+  export function normalizeWallpaper(value: string | null | undefined): string;
+}

--- a/utils/wallpapers.js
+++ b/utils/wallpapers.js
@@ -1,0 +1,58 @@
+export const PRESET_PREFIX = 'preset:';
+export const CUSTOM_PREFIX = 'custom:';
+export const WALLPAPER_STORAGE_KEY = 'wallpaper-selection';
+export const LEGACY_WALLPAPER_STORAGE_KEY = 'bg-image';
+
+export const WALLPAPER_PRESETS = [
+  {
+    id: 'gradient-default',
+    name: 'Aurora Gradient',
+    src: '/wallpapers/gradient-default.svg',
+  },
+  { id: 'wall-1', name: 'Wallpaper 1', src: '/wallpapers/wall-1.webp' },
+  { id: 'wall-2', name: 'Wallpaper 2', src: '/wallpapers/wall-2.webp' },
+  { id: 'wall-3', name: 'Wallpaper 3', src: '/wallpapers/wall-3.webp' },
+  { id: 'wall-4', name: 'Wallpaper 4', src: '/wallpapers/wall-4.webp' },
+  { id: 'wall-5', name: 'Wallpaper 5', src: '/wallpapers/wall-5.webp' },
+  { id: 'wall-6', name: 'Wallpaper 6', src: '/wallpapers/wall-6.webp' },
+  { id: 'wall-7', name: 'Wallpaper 7', src: '/wallpapers/wall-7.webp' },
+  { id: 'wall-8', name: 'Wallpaper 8', src: '/wallpapers/wall-8.webp' },
+];
+
+export const DEFAULT_WALLPAPER = makePresetWallpaper(WALLPAPER_PRESETS[0].id);
+
+export function makePresetWallpaper(id) {
+  return `${PRESET_PREFIX}${id}`;
+}
+
+export function isCustomWallpaper(value) {
+  return typeof value === 'string' && value.startsWith(CUSTOM_PREFIX);
+}
+
+export function getWallpaperId(value) {
+  if (!value) return WALLPAPER_PRESETS[0].id;
+  if (isCustomWallpaper(value)) return null;
+  if (value.startsWith(PRESET_PREFIX)) {
+    return value.slice(PRESET_PREFIX.length);
+  }
+  return value;
+}
+
+export function getWallpaperSrc(value) {
+  if (!value) return WALLPAPER_PRESETS[0].src;
+  if (isCustomWallpaper(value)) {
+    return value.slice(CUSTOM_PREFIX.length);
+  }
+  const id = getWallpaperId(value);
+  const preset = WALLPAPER_PRESETS.find((item) => item.id === id);
+  if (preset) return preset.src;
+  return `/wallpapers/${id}.webp`;
+}
+
+export function normalizeWallpaper(value) {
+  if (!value) return DEFAULT_WALLPAPER;
+  if (isCustomWallpaper(value) || value.startsWith(PRESET_PREFIX)) {
+    return value;
+  }
+  return makePresetWallpaper(value);
+}


### PR DESCRIPTION
## Summary
- add a gradient wallpaper asset and shared helpers to resolve preset and custom backgrounds
- persist wallpaper selection via safeLocalStorage and normalize it in the settings context/store
- refresh background rendering and settings UIs to support uploads, vignette overlay, and the new default option

## Testing
- `yarn lint components/util-components/background-image.js components/screen/lock_screen.js components/apps/settings.js apps/settings/index.tsx hooks/useSettings.tsx utils/settingsStore.js utils/wallpapers.js` *(hangs, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d668021bbc832895dac0368fe29903