### PR TITLE
[ui] Update window chrome styling

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -635,12 +635,26 @@ export class Window extends Component {
                 >
                     <div
                         style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        className={[
+                            this.state.cursorType,
+                            this.state.closed ? 'closed-window' : '',
+                            this.state.maximized ? 'duration-300' : '',
+                            this.props.minimized ? 'opacity-0 invisible duration-200' : '',
+                            this.state.grabbed ? 'opacity-70' : '',
+                            this.state.snapPreview ? 'ring-2 ring-blue-400' : '',
+                            this.props.isFocused ? 'z-30' : 'z-20',
+                            'opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute flex flex-col window-shadow',
+                            styles.windowFrame,
+                            this.props.isFocused ? styles.windowFrameActive : styles.windowFrameInactive,
+                            this.state.maximized ? styles.windowFrameMaximized : '',
+                        ].filter(Boolean).join(' ')}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
                         tabIndex={0}
                         onKeyDown={this.handleKeyDown}
+                        onPointerDown={this.focusWindow}
+                        onFocus={this.focusWindow}
                     >
                         {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}
@@ -649,6 +663,7 @@ export class Window extends Component {
                             onKeyDown={this.handleTitleBarKeyDown}
                             onBlur={this.releaseGrab}
                             grabbed={this.state.grabbed}
+                            onPointerDown={this.focusWindow}
                         />
                         <WindowEditButtons
                             minimize={this.minimizeWindow}
@@ -674,15 +689,16 @@ export class Window extends Component {
 export default Window
 
 // Window's title bar
-export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
+export function WindowTopBar({ title, onKeyDown, onBlur, grabbed, onPointerDown }) {
     return (
         <div
-            className={" relative bg-ub-window-title border-t-2 border-white border-opacity-5 px-3 text-white w-full select-none rounded-b-none flex items-center h-11"}
+            className={`${styles.windowTitlebar} relative bg-ub-window-title px-3 text-white w-full select-none flex items-center`}
             tabIndex={0}
             role="button"
             aria-grabbed={grabbed}
             onKeyDown={onKeyDown}
             onBlur={onBlur}
+            onPointerDown={onPointerDown}
         >
             <div className="flex justify-center w-full text-sm font-bold">{title}</div>
         </div>
@@ -734,7 +750,7 @@ export function WindowEditButtons(props) {
     const { togglePin } = useDocPiP(props.pip || (() => null));
     const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
     return (
-        <div className="absolute select-none right-0 top-0 mt-1 mr-1 flex justify-center items-center h-11 min-w-[8.25rem]">
+        <div className={`${styles.windowControls} absolute select-none right-0 top-0 mr-1 flex justify-center items-center min-w-[8.25rem]`}>
             {pipSupported && props.pip && (
                 <button
                     type="button"

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -1,3 +1,56 @@
+.windowFrame {
+  position: relative;
+  border: 1px solid var(--color-window-border);
+  border-radius: var(--radius-6);
+  box-shadow: var(--shadow-2);
+  overflow: hidden;
+  transition: filter var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+}
+
+.windowFrame::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--color-window-accent);
+  opacity: 0;
+  pointer-events: none;
+  border-top-left-radius: calc(var(--radius-6) - 1px);
+  border-top-right-radius: calc(var(--radius-6) - 1px);
+  transition: opacity var(--motion-fast) ease;
+  z-index: 2;
+}
+
+.windowFrameActive::before {
+  opacity: 1;
+}
+
+.windowFrameInactive {
+  filter: brightness(0.85);
+}
+
+.windowFrameMaximized {
+  border-radius: 0;
+}
+
+.windowFrameMaximized::before {
+  border-radius: 0;
+}
+
+.windowTitlebar {
+  height: 28px;
+  border-top-left-radius: calc(var(--radius-6) - 1px);
+  border-top-right-radius: calc(var(--radius-6) - 1px);
+  position: relative;
+  z-index: 1;
+}
+
+.windowControls {
+  height: 28px;
+}
+
 .windowYBorder {
   height: calc(100% - 10px);
   width: calc(100% + 10px);

--- a/styles/index.css
+++ b/styles/index.css
@@ -94,7 +94,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .notFocused {
-    filter: brightness(90%);
+    filter: brightness(0.85);
 }
 
 .root,
@@ -105,9 +105,9 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 }
 
 .window-shadow {
-    box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -webkit-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
-    -moz-box-shadow: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+    box-shadow: var(--shadow-2);
+    -webkit-box-shadow: var(--shadow-2);
+    -moz-box-shadow: var(--shadow-2);
 }
 
 .closed-window {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -45,7 +45,15 @@
   --radius-sm: 2px;
   --radius-md: 4px;
   --radius-lg: 8px;
+  --radius-6: 12px;
   --radius-round: 9999px;
+
+  /* Elevation */
+  --shadow-2: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+
+  /* Window chrome */
+  --color-window-border: #0d1a2a;
+  --color-window-accent: var(--color-primary);
 
   /* Motion durations */
   --motion-fast: 150ms;


### PR DESCRIPTION
## Summary
- restyle the window frame to use the new 28px header, tokenized radius, and elevation
- add an active window accent and inactive dimming driven by desktop focus state
- extend shared design tokens with window border, accent, and shadow values

## Testing
- `yarn lint` *(fails: pre-existing accessibility violations in unrelated app fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68d66802b9f08328a6446fbd915e6124