### PR TITLE
[desktop] centralize window z-order management

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -612,6 +612,16 @@ export class Window extends Component {
     }
 
     render() {
+        const isActive = this.props.isFocused && !this.props.minimized;
+        const ringClass = this.state.snapPreview
+            ? " ring-2 ring-blue-400 "
+            : (isActive ? " ring-2 ring-blue-400 " : "");
+        const focusStateClass = isActive ? "" : " notFocused";
+        const windowStyle = {
+            width: `${this.state.width}%`,
+            height: `${this.state.height}%`,
+            zIndex: this.props.zIndex ?? 100,
+        };
         return (
             <>
                 {this.state.snapPreview && (
@@ -634,13 +644,16 @@ export class Window extends Component {
                     bounds={{ left: 0, top: 0, right: this.state.parentSize.width, bottom: this.state.parentSize.height }}
                 >
                     <div
-                        style={{ width: `${this.state.width}%`, height: `${this.state.height}%` }}
-                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + (this.state.snapPreview ? " ring-2 ring-blue-400 " : "") + (this.props.isFocused ? " z-30 " : " z-20 notFocused") + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
+                        style={windowStyle}
+                        className={this.state.cursorType + " " + (this.state.closed ? " closed-window " : "") + (this.state.maximized ? " duration-300 rounded-none" : " rounded-lg rounded-b-none") + (this.props.minimized ? " opacity-0 invisible duration-200 " : "") + (this.state.grabbed ? " opacity-70 " : "") + ringClass + focusStateClass + " opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute window-shadow border-black border-opacity-40 border border-t-0 flex flex-col"}
                         id={this.id}
                         role="dialog"
                         aria-label={this.props.title}
                         tabIndex={0}
                         onKeyDown={this.handleKeyDown}
+                        onMouseDownCapture={this.focusWindow}
+                        onTouchStart={this.focusWindow}
+                        onFocusCapture={this.focusWindow}
                     >
                         {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -8,7 +8,7 @@ export default function Taskbar(props) {
         const id = app.id;
         if (props.minimized_windows[id]) {
             props.openApp(id);
-        } else if (props.focused_windows[id]) {
+        } else if (props.activeWindowId === id) {
             props.minimize(id);
         } else {
             props.openApp(id);
@@ -17,31 +17,37 @@ export default function Taskbar(props) {
 
     return (
         <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
+            {runningApps.map(app => {
+                const isActive = (props.activeWindowId ? props.activeWindowId === app.id : props.focused_windows[app.id]) && !props.minimized_windows[app.id];
+                const showBadge = !isActive && !props.minimized_windows[app.id];
+                return (
+                    <button
+                        key={app.id}
+                        type="button"
+                        aria-label={app.title}
+                        data-context="taskbar"
+                        data-app-id={app.id}
+                        onClick={() => handleClick(app)}
+                        aria-pressed={isActive}
+                        data-active={isActive || undefined}
+                        className={(isActive ? ' bg-white bg-opacity-20 ' : ' ') +
+                            'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                        {showBadge && (
+                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
+                        )}
+                    </button>
+                );
+            })}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- track window z-order and active focus state inside the desktop manager
- update window rendering to apply dynamic z-index and focus ring styling
- sync taskbar button highlights and badges with the active window order

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d66805ac9083288016eda4951a7146