### PR TITLE
[panel] Update dock icon sizing and tooltips

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -1,13 +1,14 @@
 import React, { Component } from "react";
 import Image from 'next/image';
 import { toCanvas } from 'html-to-image';
+import Tooltip from '../ui/Tooltip';
 
 export class SideBarApp extends Component {
     constructor() {
         super();
         this.id = null;
         this.state = {
-            showTitle: false,
+            previewVisible: false,
             scaleImage: false,
             thumbnail: null,
         };
@@ -57,7 +58,28 @@ export class SideBarApp extends Component {
             this.scaleImage();
         }
         this.props.openApp(this.id);
-        this.setState({ showTitle: false, thumbnail: null });
+        this.setState({ previewVisible: false, thumbnail: null });
+    };
+
+    handleTooltipToggle = (open) => {
+        if (open) {
+            this.captureThumbnail();
+            this.setState({ previewVisible: true });
+        } else {
+            this.setState({ previewVisible: false, thumbnail: null });
+        }
+    };
+
+    handleAuxClick = (event) => {
+        if (event.button !== 1) return;
+        event.preventDefault();
+        event.stopPropagation();
+        if (typeof window !== 'undefined') {
+            window.dispatchEvent(new CustomEvent('open-app', { detail: this.props.id }));
+        } else {
+            this.props.openApp(this.props.id);
+        }
+        this.setState({ previewVisible: false, thumbnail: null });
     };
 
     captureThumbnail = async () => {
@@ -87,73 +109,62 @@ export class SideBarApp extends Component {
 
     render() {
         return (
-            <button
-                type="button"
-                aria-label={this.props.title}
-                data-context="app"
-                data-app-id={this.props.id}
-                onClick={this.openApp}
-                onMouseEnter={() => {
-                    this.captureThumbnail();
-                    this.setState({ showTitle: true });
-                }}
-                onMouseLeave={() => {
-                    this.setState({ showTitle: false, thumbnail: null });
-                }}
-                className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
-                    " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
-                id={"sidebar-" + this.props.id}
+            <Tooltip
+                content={this.props.title}
+                placement="right"
+                onOpenChange={this.handleTooltipToggle}
+                className="w-full justify-center"
             >
-                <Image
-                    width={28}
-                    height={28}
-                    className="w-7"
-                    src={this.props.icon.replace('./', '/')}
-                    alt="Ubuntu App Icon"
-                    sizes="28px"
-                />
-                <Image
-                    width={28}
-                    height={28}
-                    className={(this.state.scaleImage ? " scale " : "") + " scalable-app-icon w-7 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"}
-                    src={this.props.icon.replace('./', '/')}
-                    alt=""
-                    sizes="28px"
-                />
-                {
-                    (
-                        this.props.isClose[this.id] === false
-                            ? <div className=" w-2 h-1 absolute bottom-0 left-1/2 transform -translate-x-1/2 bg-white rounded-md"></div>
-                            : null
-                    )
-                }
-                {this.state.thumbnail && (
-                    <div
-                        className={
-                            (this.state.showTitle ? " visible " : " invisible ") +
-                            " pointer-events-none absolute bottom-full mb-2 left-1/2 transform -translate-x-1/2" +
-                            " rounded border border-gray-400 border-opacity-40 shadow-lg overflow-hidden bg-black bg-opacity-50"
-                        }
-                    >
-                        <Image
-                            width={128}
-                            height={80}
-                            src={this.state.thumbnail}
-                            alt={`Preview of ${this.props.title}`}
-                            className="w-32 h-20 object-cover"
-                            sizes="128px"
-                        />
-                    </div>
-                )}
-                <div
-                    className={
-                        (this.state.showTitle ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1.5 left-full ml-3 m-1 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
-                    }
+                <button
+                    type="button"
+                    aria-label={this.props.title}
+                    data-context="app"
+                    data-app-id={this.props.id}
+                    onClick={this.openApp}
+                    onAuxClick={this.handleAuxClick}
+                    className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
+                        " relative flex items-center justify-center rounded transition-hover transition-active p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue/60"}
+                    id={"sidebar-" + this.props.id}
                 >
-                    {this.props.title}
-                </div>
-            </button>
+                    <Image
+                        width={24}
+                        height={24}
+                        className="h-6 w-6"
+                        src={this.props.icon.replace('./', '/')}
+                        alt="Ubuntu App Icon"
+                        sizes="24px"
+                    />
+                    <Image
+                        width={24}
+                        height={24}
+                        className={(this.state.scaleImage ? " scale " : "") + " scalable-app-icon h-6 w-6 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"}
+                        src={this.props.icon.replace('./', '/')}
+                        alt=""
+                        sizes="24px"
+                    />
+                    {
+                        (
+                            this.props.isClose[this.id] === false
+                                ? <div className="w-2 h-1 absolute bottom-0 left-1/2 transform -translate-x-1/2 bg-white rounded-md"></div>
+                                : null
+                        )
+                    }
+                    {this.state.thumbnail && (
+                        <div
+                            className={`pointer-events-none absolute bottom-full mb-2 left-1/2 -translate-x-1/2 rounded border border-gray-400 border-opacity-40 shadow-lg overflow-hidden bg-black bg-opacity-50 transition-opacity duration-150 ${this.state.previewVisible ? 'visible opacity-100' : 'invisible opacity-0'}`}
+                        >
+                            <Image
+                                width={128}
+                                height={80}
+                                src={this.state.thumbnail}
+                                alt={`Preview of ${this.props.title}`}
+                                className="h-20 w-32 object-cover"
+                                sizes="128px"
+                            />
+                        </div>
+                    )}
+                </button>
+            </Tooltip>
         );
     }
 }

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -519,46 +519,42 @@ export class Window extends Component {
     }
 
     handleKeyDown = (e) => {
+        const prevent = () => {
+            if (typeof e.preventDefault === 'function') e.preventDefault();
+            if (typeof e.stopPropagation === 'function') e.stopPropagation();
+        };
         if (e.key === 'Escape') {
             this.closeWindow();
         } else if (e.key === 'Tab') {
             this.focusWindow();
         } else if (e.altKey) {
             if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.unsnapWindow();
             } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.snapWindow('left');
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.snapWindow('right');
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.snapWindow('top');
             }
             this.focusWindow();
         } else if (e.shiftKey) {
             const step = 1;
             if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
             }
             this.focusWindow();

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,6 +1,7 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
+import Tooltip from '../ui/Tooltip';
 
 let renderApps = (props) => {
     let sideBarAppsJsx = [];
@@ -30,7 +31,7 @@ export default function SideBar(props) {
             <nav
                 aria-label="Dock"
                 className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center gap-3 pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
             >
                 {
                     (
@@ -47,39 +48,23 @@ export default function SideBar(props) {
 }
 
 export function AllApps(props) {
-
-    const [title, setTitle] = useState(false);
-
     return (
-        <div
-            className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
-            style={{ marginTop: 'auto' }}
-            onMouseEnter={() => {
-                setTitle(true);
-            }}
-            onMouseLeave={() => {
-                setTitle(false);
-            }}
-            onClick={props.showApps}
-        >
-            <div className="relative">
+        <Tooltip content="Show Applications" placement="right" className="w-full justify-center">
+            <button
+                type="button"
+                className="w-10 h-10 rounded hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active"
+                style={{ marginTop: 'auto' }}
+                onClick={props.showApps}
+            >
                 <Image
-                    width={28}
-                    height={28}
-                    className="w-7"
+                    width={24}
+                    height={24}
+                    className="h-6 w-6"
                     src="/themes/Yaru/system/view-app-grid-symbolic.svg"
                     alt="Ubuntu view app"
-                    sizes="28px"
+                    sizes="24px"
                 />
-                <div
-                    className={
-                        (title ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1 left-full ml-5 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
-                    }
-                >
-                    Show Applications
-                </div>
-            </div>
-        </div>
+            </button>
+        </Tooltip>
     );
 }

--- a/components/ui/Tooltip.tsx
+++ b/components/ui/Tooltip.tsx
@@ -1,0 +1,90 @@
+import React, {
+  ReactElement,
+  ReactNode,
+  cloneElement,
+  useId,
+  useState,
+} from 'react';
+
+export type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+interface TooltipProps {
+  content: ReactNode;
+  children: ReactElement;
+  placement?: TooltipPlacement;
+  className?: string;
+  onOpenChange?: (open: boolean) => void;
+}
+
+const placementClasses: Record<TooltipPlacement, string> = {
+  top: 'bottom-full mb-2 left-1/2 -translate-x-1/2',
+  bottom: 'top-full mt-2 left-1/2 -translate-x-1/2',
+  left: 'right-full mr-3 top-1/2 -translate-y-1/2',
+  right: 'left-full ml-3 top-1/2 -translate-y-1/2',
+};
+
+const Tooltip: React.FC<TooltipProps> = ({
+  content,
+  children,
+  placement = 'top',
+  className = '',
+  onOpenChange,
+}) => {
+  const [open, setOpen] = useState(false);
+  const id = useId();
+
+  const childProps = children.props as Record<string, any>;
+
+  const handleMouseEnter = (event: React.MouseEvent) => {
+    childProps.onMouseEnter?.(event);
+    if (!open) {
+      setOpen(true);
+      onOpenChange?.(true);
+    }
+  };
+
+  const handleMouseLeave = (event: React.MouseEvent) => {
+    childProps.onMouseLeave?.(event);
+    if (open) {
+      setOpen(false);
+      onOpenChange?.(false);
+    }
+  };
+
+  const handleFocus = (event: React.FocusEvent) => {
+    childProps.onFocus?.(event);
+    if (!open) {
+      setOpen(true);
+      onOpenChange?.(true);
+    }
+  };
+
+  const handleBlur = (event: React.FocusEvent) => {
+    childProps.onBlur?.(event);
+    if (open) {
+      setOpen(false);
+      onOpenChange?.(false);
+    }
+  };
+
+  const tooltipClass = `pointer-events-none absolute z-50 whitespace-nowrap rounded bg-black/80 px-2 py-1 text-xs text-white shadow transition-opacity duration-150 ${
+    placementClasses[placement]
+  } ${open ? 'opacity-100' : 'opacity-0'}`.trim();
+
+  return (
+    <span className={`relative inline-flex ${className}`.trim()}>
+      {cloneElement(children, {
+        onMouseEnter: handleMouseEnter,
+        onMouseLeave: handleMouseLeave,
+        onFocus: handleFocus,
+        onBlur: handleBlur,
+        'aria-describedby': open ? id : undefined,
+      })}
+      <span role="tooltip" id={id} className={tooltipClass} aria-hidden={!open}>
+        {content}
+      </span>
+    </span>
+  );
+};
+
+export default Tooltip;


### PR DESCRIPTION
## Summary
- render dock favorites with 24px icons and consistent 12px spacing
- add a reusable tooltip component and attach it to dock entries and the app grid button
- wire dock middle click through the window manager event and harden keyboard snap handlers

## Testing
- npx eslint components/base/side_bar_app.js components/screen/side_bar.js components/ui/Tooltip.tsx
- yarn test __tests__/window.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d668094ca883288abba0d016358bad