### PR TITLE
[desktop] enhance network tray indicator

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,17 +1,40 @@
 "use client";
 
+import { useEffect, useMemo } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import {
+  NetworkStatusSnapshot,
+  useNetworkStatus,
+  NetworkSignalStrength,
+  NetworkStatusIcon,
+} from '../util-components/network-tray-icon';
+import { useSettings } from '../../hooks/useSettings';
 
 interface Props {
   open: boolean;
 }
 
+interface DemoNetwork {
+  id: string;
+  ssid: string;
+  status: string;
+  iconStatus: NetworkStatusSnapshot;
+  isActive?: boolean;
+}
+
+const signalDescription: Record<NetworkSignalStrength, string> = {
+  none: 'no signal',
+  weak: 'weak signal',
+  medium: 'fair signal',
+  strong: 'strong signal',
+};
+
 const QuickSettings = ({ open }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
-  const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const networkStatus = useNetworkStatus();
+  const { allowNetwork, setAllowNetwork } = useSettings();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -20,6 +43,68 @@ const QuickSettings = ({ open }: Props) => {
   useEffect(() => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
+
+  const connectionSummary = networkStatus.isOnline
+    ? networkStatus.connectionType === 'ethernet'
+      ? 'Ethernet connected'
+      : `Wi-Fi ${signalDescription[networkStatus.signalStrength]}`
+    : 'Offline mode';
+
+  const demoNetworks = useMemo<DemoNetwork[]>(() => {
+    const primarySsid = networkStatus.connectionType === 'ethernet' ? 'Wired connection 1' : 'Unnippillil HQ';
+    const primaryStatus = networkStatus.isOnline
+      ? allowNetwork
+        ? 'Connected'
+        : 'Connected (requests blocked)'
+      : 'Offline';
+
+    return [
+      {
+        id: 'primary',
+        ssid: primarySsid,
+        status: primaryStatus,
+        iconStatus: {
+          isOnline: networkStatus.isOnline,
+          connectionType: networkStatus.connectionType === 'ethernet' ? 'ethernet' : 'wifi',
+          signalStrength:
+            networkStatus.connectionType === 'ethernet'
+              ? 'strong'
+              : networkStatus.signalStrength,
+        },
+        isActive: true,
+      },
+      {
+        id: 'lab',
+        ssid: 'Kali Lab',
+        status: networkStatus.isOnline ? 'Saved network' : 'Available when online',
+        iconStatus: {
+          isOnline: true,
+          connectionType: 'wifi',
+          signalStrength: 'medium',
+        },
+      },
+      {
+        id: 'guest',
+        ssid: 'Guest Portal',
+        status: 'Captive portal',
+        iconStatus: {
+          isOnline: true,
+          connectionType: 'wifi',
+          signalStrength: 'weak',
+        },
+      },
+      {
+        id: 'field',
+        ssid: 'Field Kit',
+        status: networkStatus.isOnline ? 'Out of range' : 'Unavailable offline',
+        iconStatus: {
+          isOnline: false,
+          connectionType: 'wifi',
+          signalStrength: 'none',
+        },
+      },
+    ];
+  }, [networkStatus, allowNetwork]);
 
   return (
     <div
@@ -42,7 +127,11 @@ const QuickSettings = ({ open }: Props) => {
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+        <input
+          type="checkbox"
+          checked={allowNetwork}
+          onChange={() => setAllowNetwork(!allowNetwork)}
+        />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>
@@ -51,6 +140,43 @@ const QuickSettings = ({ open }: Props) => {
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
         />
+      </div>
+      <div className="mt-3 border-t border-ub-grey border-opacity-40 pt-3 text-left text-sm">
+        <div className="flex items-center justify-between px-4">
+          <div>
+            <p className="text-[10px] uppercase tracking-wide text-ubt-grey">Networks</p>
+            <p className="text-sm text-ubt-cream">{connectionSummary}</p>
+          </div>
+          <NetworkStatusIcon
+            allowNetwork={allowNetwork}
+            status={networkStatus}
+            size="small"
+            showOfflineBadge={false}
+          />
+        </div>
+        <ul className="mt-3 space-y-2 px-3">
+          {demoNetworks.map((network) => (
+            <li
+              key={network.id}
+              className={`flex items-center justify-between gap-3 rounded-md px-2 py-1.5 transition ${
+                network.isActive
+                  ? 'bg-white bg-opacity-10'
+                  : 'hover:bg-white hover:bg-opacity-5'
+              }`}
+            >
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-white truncate">{network.ssid}</p>
+                <p className="text-xs text-ubt-grey">{network.status}</p>
+              </div>
+              <NetworkStatusIcon
+                allowNetwork={network.isActive ? allowNetwork : true}
+                status={network.iconStatus}
+                size="small"
+                showOfflineBadge={false}
+              />
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/components/util-components/network-tray-icon.tsx
+++ b/components/util-components/network-tray-icon.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from 'react';
+
+export type NetworkConnectionType = 'wifi' | 'ethernet' | 'cellular' | 'unknown';
+export type NetworkSignalStrength = 'none' | 'weak' | 'medium' | 'strong';
+
+export interface NetworkStatusSnapshot {
+  isOnline: boolean;
+  connectionType: NetworkConnectionType;
+  signalStrength: NetworkSignalStrength;
+}
+
+const signalLabels: Record<NetworkSignalStrength, string> = {
+  none: 'No signal',
+  weak: 'Weak signal',
+  medium: 'Fair signal',
+  strong: 'Strong signal',
+};
+
+type NavigatorConnection = Navigator['connection'] & {
+  mozConnection?: Navigator['connection'];
+  webkitConnection?: Navigator['connection'];
+};
+
+const getNavigator = () => (typeof navigator !== 'undefined' ? navigator : undefined);
+
+const getConnection = (): NavigatorConnection | undefined => {
+  const nav = getNavigator() as Navigator & NavigatorConnection;
+  if (!nav) return undefined;
+  return nav.connection || nav.mozConnection || nav.webkitConnection;
+};
+
+const coerceConnectionType = (connection?: NavigatorConnection): NetworkConnectionType => {
+  if (!connection) return 'wifi';
+  const { type, effectiveType } = connection as NavigatorConnection & { effectiveType?: string };
+  if (type === 'ethernet') return 'ethernet';
+  if (type === 'wifi') return 'wifi';
+  if (typeof effectiveType === 'string' && effectiveType.toLowerCase().includes('ethernet')) {
+    return 'ethernet';
+  }
+  if (type === 'cellular' || (typeof effectiveType === 'string' && /(2g|3g|4g|5g)/i.test(effectiveType))) {
+    return 'cellular';
+  }
+  return 'wifi';
+};
+
+const coerceSignalStrength = (
+  connection: NavigatorConnection | undefined,
+  isOnline: boolean,
+): NetworkSignalStrength => {
+  if (!isOnline) return 'none';
+  if (!connection) return 'strong';
+  const downlink = typeof connection.downlink === 'number' ? connection.downlink : undefined;
+  if (downlink !== undefined) {
+    if (downlink >= 5) return 'strong';
+    if (downlink >= 2) return 'medium';
+    if (downlink > 0) return 'weak';
+    return 'none';
+  }
+  const effectiveType = (connection as NavigatorConnection & { effectiveType?: string }).effectiveType;
+  if (effectiveType) {
+    const normalized = effectiveType.toLowerCase();
+    if (normalized.includes('4g') || normalized.includes('5g')) return 'strong';
+    if (normalized.includes('3g')) return 'medium';
+    if (normalized.includes('2g')) return 'weak';
+  }
+  return 'strong';
+};
+
+const buildStatusSnapshot = (): NetworkStatusSnapshot => {
+  const nav = getNavigator();
+  const connection = getConnection();
+  const isOnline = nav?.onLine ?? true;
+  return {
+    isOnline,
+    connectionType: isOnline ? coerceConnectionType(connection) : 'wifi',
+    signalStrength: coerceSignalStrength(connection, isOnline),
+  };
+};
+
+export const useNetworkStatus = () => {
+  const [status, setStatus] = useState<NetworkStatusSnapshot>(() => buildStatusSnapshot());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return () => {};
+    const updateStatus = () => {
+      setStatus((prev) => {
+        const next = buildStatusSnapshot();
+        return prev.isOnline === next.isOnline &&
+          prev.connectionType === next.connectionType &&
+          prev.signalStrength === next.signalStrength
+          ? prev
+          : next;
+      });
+    };
+
+    const connection = getConnection();
+    updateStatus();
+
+    window.addEventListener('online', updateStatus);
+    window.addEventListener('offline', updateStatus);
+    connection?.addEventListener?.('change', updateStatus);
+
+    return () => {
+      window.removeEventListener('online', updateStatus);
+      window.removeEventListener('offline', updateStatus);
+      connection?.removeEventListener?.('change', updateStatus);
+    };
+  }, []);
+
+  return status;
+};
+
+interface SharedProps {
+  allowNetwork?: boolean;
+  showOfflineBadge?: boolean;
+  size?: 'default' | 'small';
+  className?: string;
+}
+
+interface IconProps extends SharedProps {
+  status: NetworkStatusSnapshot;
+}
+
+const NetworkIcon = ({
+  status,
+  allowNetwork = true,
+  showOfflineBadge = true,
+  size = 'default',
+  className,
+}: IconProps) => {
+  const iconSize = size === 'small' ? 12 : 16;
+  const iconClass = size === 'small' ? 'w-3 h-3' : 'w-4 h-4';
+  const title = useMemo(() => {
+    if (!status.isOnline) return 'Offline';
+    const baseLabel =
+      status.connectionType === 'ethernet'
+        ? 'Connected (Ethernet)'
+        : `Connected (${signalLabels[status.signalStrength]})`;
+    if (!allowNetwork) {
+      return `${baseLabel} – requests blocked`;
+    }
+    return baseLabel;
+  }, [status, allowNetwork]);
+
+  const renderWifiIcon = (strength: NetworkSignalStrength) => {
+    const levels: Record<NetworkSignalStrength, number> = {
+      none: 0,
+      weak: 1,
+      medium: 2,
+      strong: 3,
+    };
+    const level = levels[strength];
+    return (
+      <svg
+        viewBox="0 0 24 24"
+        width={iconSize}
+        height={iconSize}
+        className={`${iconClass} text-current`}
+        aria-hidden
+      >
+        {level >= 1 && (
+          <path
+            d="M9.5 16a3.5 3.5 0 015 0"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.8}
+            strokeLinecap="round"
+          />
+        )}
+        {level >= 2 && (
+          <path
+            d="M6.3 12.8a7.8 7.8 0 0111.4 0"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.8}
+            strokeLinecap="round"
+          />
+        )}
+        {level >= 3 && (
+          <path
+            d="M3.2 9.2a12.4 12.4 0 0117.6 0"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.8}
+            strokeLinecap="round"
+          />
+        )}
+        {level >= 1 && <circle cx={12} cy={19} r={1.4} fill="currentColor" />}
+      </svg>
+    );
+  };
+
+  const renderEthernetIcon = () => (
+    <svg
+      viewBox="0 0 24 24"
+      width={iconSize}
+      height={iconSize}
+      className={`${iconClass} text-current`}
+      aria-hidden
+    >
+      <rect
+        x={4.5}
+        y={3.5}
+        width={15}
+        height={9}
+        rx={1.5}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.8}
+      />
+      <rect x={7} y={6} width={3} height={4} fill="currentColor" rx={0.6} />
+      <rect x={14} y={6} width={3} height={4} fill="currentColor" rx={0.6} />
+      <path
+        d="M9 12.5V17a3 3 0 003 3 3 3 0 003-3v-4.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.8}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+
+  const renderOfflineIcon = () => (
+    <svg
+      viewBox="0 0 24 24"
+      width={iconSize}
+      height={iconSize}
+      className={`${iconClass} text-current`}
+      aria-hidden
+    >
+      <circle
+        cx={12}
+        cy={12}
+        r={7.5}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.8}
+      />
+      <line
+        x1={7}
+        y1={7}
+        x2={17}
+        y2={17}
+        stroke="currentColor"
+        strokeWidth={1.8}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+
+  const icon = !status.isOnline
+    ? renderOfflineIcon()
+    : status.connectionType === 'ethernet'
+    ? renderEthernetIcon()
+    : renderWifiIcon(status.signalStrength);
+
+  const containerClasses = [
+    'relative inline-flex items-center',
+    showOfflineBadge ? 'gap-1.5' : '',
+    className ?? '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <span className={containerClasses} title={title} aria-label={title}>
+      <span className="relative inline-flex items-center justify-center">
+        {icon}
+        {!allowNetwork && status.isOnline && (
+          <span
+            className={`${
+              size === 'small' ? 'w-1.5 h-1.5 -top-0.5 -right-0.5' : 'w-2 h-2 -top-1 -right-1'
+            } absolute rounded-full bg-red-500`}
+          />
+        )}
+      </span>
+      {showOfflineBadge && !status.isOnline && (
+        <span
+          className={`${
+            size === 'small'
+              ? 'px-1 py-0.5 text-[9px]'
+              : 'px-1.5 py-0.5 text-[11px]'
+          } rounded bg-red-600 text-white font-semibold uppercase tracking-wide`}
+        >
+          Offline
+        </span>
+      )}
+    </span>
+  );
+};
+
+const NetworkTrayIcon = (props: SharedProps) => {
+  const status = useNetworkStatus();
+  return <NetworkIcon status={status} {...props} />;
+};
+
+export const NetworkStatusIcon = (props: IconProps) => <NetworkIcon {...props} />;
+
+export default NetworkTrayIcon;

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,61 +1,17 @@
-import React, { useEffect, useState } from "react";
+import React from 'react';
 import Image from 'next/image';
-import SmallArrow from "./small_arrow";
+import SmallArrow from './small_arrow';
 import { useSettings } from '../../hooks/useSettings';
+import NetworkTrayIcon from './network-tray-icon';
 
-const VOLUME_ICON = "/themes/Yaru/status/audio-volume-medium-symbolic.svg";
+const VOLUME_ICON = '/themes/Yaru/status/audio-volume-medium-symbolic.svg';
 
 export default function Status() {
   const { allowNetwork } = useSettings();
-  const [online, setOnline] = useState(true);
-
-  useEffect(() => {
-    const pingServer = async () => {
-      if (!window?.location) return;
-      try {
-        const url = new URL('/favicon.ico', window.location.href).toString();
-        await fetch(url, { method: 'HEAD', cache: 'no-store' });
-        setOnline(true);
-      } catch (e) {
-        setOnline(false);
-      }
-    };
-
-    const updateStatus = () => {
-      const isOnline = navigator.onLine;
-      setOnline(isOnline);
-      if (isOnline) {
-        pingServer();
-      }
-    };
-
-    updateStatus();
-    window.addEventListener('online', updateStatus);
-    window.addEventListener('offline', updateStatus);
-    return () => {
-      window.removeEventListener('online', updateStatus);
-      window.removeEventListener('offline', updateStatus);
-    };
-  }, []);
 
   return (
     <div className="flex justify-center items-center">
-      <span
-        className="mx-1.5 relative"
-        title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
-      >
-        <Image
-          width={16}
-          height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
-          alt={online ? "online" : "offline"}
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
-        {!allowNetwork && (
-          <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
-        )}
-      </span>
+      <NetworkTrayIcon allowNetwork={allowNetwork} className="mx-1.5" />
       <span className="mx-1.5">
         <Image
           width={16}
@@ -71,7 +27,7 @@ export default function Status() {
           width={16}
           height={16}
           src="/themes/Yaru/status/battery-good-symbolic.svg"
-          alt="ubuntu battry"
+          alt="ubuntu battery"
           className="inline status-symbol w-4 h-4"
           sizes="16px"
         />


### PR DESCRIPTION
## Summary
- add a reusable network tray icon component that watches `navigator.onLine` and renders Wi-Fi, Ethernet, or offline states with feature-detection guards
- swap the desktop status bar to the new indicator and surface an offline badge plus the request-blocked overlay
- expand the quick settings popover with a mock network list and live connection summary sourced from the new network status hook

## Testing
- yarn lint *(fails: repository has pre-existing jsx-a11y control label violations and no-top-level-window warnings in legacy demos)*

------
https://chatgpt.com/codex/tasks/task_e_68d6680f0edc8328bd36f7bea19c37eb