### PR TITLE
[ui] add notification center panel

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
+import NotificationBell from '../ui/NotificationBell';
 import WhiskerMenu from '../menu/WhiskerMenu';
 
 export default class Navbar extends Component {
@@ -16,27 +17,30 @@ export default class Navbar extends Component {
 		return (
                         <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <WhiskerMenu />
-                                <div
-                                        className={
-                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-                                        }
-                                >
-                                        <Clock />
+                                <div className="flex items-center">
+                                        <div
+                                                className={
+                                                        'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                }
+                                        >
+                                                <Clock />
+                                        </div>
+                                        <NotificationBell />
+                                        <button
+                                                type="button"
+                                                id="status-bar"
+                                                aria-label="System status"
+                                                onClick={() => {
+                                                        this.setState({ status_card: !this.state.status_card });
+                                                }}
+                                                className={
+                                                        'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                                }
+                                        >
+                                                <Status />
+                                                <QuickSettings open={this.state.status_card} />
+                                        </button>
                                 </div>
-                                <button
-                                        type="button"
-                                        id="status-bar"
-                                        aria-label="System status"
-                                        onClick={() => {
-                                                this.setState({ status_card: !this.state.status_card });
-                                        }}
-                                        className={
-                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-                                        }
-                                >
-                                        <Status />
-                                        <QuickSettings open={this.state.status_card} />
-                                </button>
 			</div>
 		);
 	}

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useNotifications } from '../../hooks/useNotifications';
+
+const focusableSelector =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+const NotificationBell: React.FC = () => {
+  const {
+    notifications,
+    unreadCount,
+    clearNotifications,
+    markAllRead,
+  } = useNotifications();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const headingId = useId();
+  const panelId = `${headingId}-panel`;
+
+  const closePanel = useCallback(() => {
+    setIsOpen(false);
+    setTimeout(() => {
+      buttonRef.current?.focus({ preventScroll: true });
+    }, 0);
+  }, []);
+
+  const togglePanel = useCallback(() => {
+    setIsOpen(prev => {
+      if (prev) {
+        setTimeout(() => {
+          buttonRef.current?.focus({ preventScroll: true });
+        }, 0);
+      }
+      return !prev;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closePanel();
+      }
+      if (event.key === 'Tab') {
+        const panel = panelRef.current;
+        if (!panel) return;
+        const focusable = Array.from(
+          panel.querySelectorAll<HTMLElement>(focusableSelector),
+        );
+        if (focusable.length === 0) {
+          event.preventDefault();
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node | null;
+      const panel = panelRef.current;
+      const button = buttonRef.current;
+      if (!panel || !button) return;
+      if (panel.contains(target) || button.contains(target)) return;
+      closePanel();
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+    };
+  }, [closePanel, isOpen]);
+
+  const hasOpenedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      hasOpenedRef.current = false;
+      return;
+    }
+    if (hasOpenedRef.current) return;
+    hasOpenedRef.current = true;
+    const panel = panelRef.current;
+    if (panel) {
+      panel.focus({ preventScroll: true });
+      const firstFocusable = panel.querySelector<HTMLElement>(focusableSelector);
+      firstFocusable?.focus({ preventScroll: true });
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (notifications.some(notification => !notification.read)) {
+      markAllRead();
+    }
+  }, [isOpen, markAllRead, notifications]);
+
+  const timeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'short',
+        timeStyle: 'short',
+      }),
+    [],
+  );
+
+  const formattedNotifications = useMemo(
+    () =>
+      notifications.map(notification => ({
+        ...notification,
+        formattedTime: new Date(notification.timestamp).toISOString(),
+        readableTime: timeFormatter.format(new Date(notification.timestamp)),
+      })),
+    [notifications, timeFormatter],
+  );
+
+  const handleDismissAll = useCallback(() => {
+    if (notifications.length === 0) return;
+    clearNotifications();
+    closePanel();
+  }, [clearNotifications, closePanel, notifications.length]);
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        ref={buttonRef}
+        aria-label="Open notifications"
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        onClick={togglePanel}
+        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey transition focus:border-ubb-orange focus:outline-none focus:ring-0 hover:bg-white hover:bg-opacity-10"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          className="h-5 w-5"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path d="M10 2a4 4 0 00-4 4v1.09c0 .471-.158.93-.45 1.3L4.3 10.2A1 1 0 005 11.8h10a1 1 0 00.7-1.6l-1.25-1.81a2 2 0 01-.45-1.3V6a4 4 0 00-4-4z" />
+          <path d="M7 12a3 3 0 006 0H7z" />
+        </svg>
+        {unreadCount > 0 && (
+          <span className="absolute -top-1.5 -right-1.5 min-w-[1.5rem] rounded-full bg-ubb-orange px-1 text-center text-[0.65rem] font-semibold leading-5 text-white">
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        )}
+      </button>
+      {isOpen && (
+        <div
+          ref={panelRef}
+          id={panelId}
+          role="dialog"
+          aria-modal="false"
+          aria-labelledby={headingId}
+          tabIndex={-1}
+          className="absolute right-0 z-50 mt-2 w-72 max-h-96 overflow-hidden rounded-md border border-white/10 bg-ub-grey/95 text-ubt-grey shadow-xl backdrop-blur"
+        >
+          <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
+            <h2 id={headingId} className="text-sm font-semibold text-white">
+              Notifications
+            </h2>
+            <button
+              type="button"
+              onClick={handleDismissAll}
+              disabled={notifications.length === 0}
+              className="text-xs font-medium text-ubb-orange transition disabled:cursor-not-allowed disabled:text-ubt-grey disabled:text-opacity-50"
+            >
+              Dismiss all
+            </button>
+          </div>
+          <div className="max-h-80 overflow-y-auto">
+            {notifications.length === 0 ? (
+              <p className="px-4 py-6 text-center text-sm text-ubt-grey text-opacity-80">
+                You&apos;re all caught up.
+              </p>
+            ) : (
+              <ul role="list" className="divide-y divide-white/10">
+                {formattedNotifications.map(notification => (
+                  <li key={notification.id} className="px-4 py-3 text-sm text-white">
+                    <p className="font-medium">{notification.title}</p>
+                    {notification.body && (
+                      <p className="mt-1 text-xs text-ubt-grey text-opacity-80">
+                        {notification.body}
+                      </p>
+                    )}
+                    <div className="mt-2 flex items-center justify-between text-[0.65rem] uppercase tracking-wide text-ubt-grey text-opacity-70">
+                      <span>{notification.appId}</span>
+                      <time dateTime={notification.formattedTime}>{notification.readableTime}</time>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NotificationBell;
+

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -1,6 +1,11 @@
 import { useContext } from 'react';
 import { NotificationsContext } from '../components/common/NotificationCenter';
 
+export type {
+  AppNotification,
+  PushNotificationInput,
+} from '../components/common/NotificationCenter';
+
 export const useNotifications = () => {
   const ctx = useContext(NotificationsContext);
   if (!ctx) {

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -12,6 +12,7 @@ import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import NotificationCenter from '../components/common/NotificationCenter';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
@@ -157,21 +158,23 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+          <NotificationCenter>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </NotificationCenter>
         </SettingsProvider>
       </div>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- refactor the shared notification center into a provider that tracks per-app messages, unread counts, and bulk actions
- add a notification bell with badge counts and an accessible panel UI featuring timestamps and a dismiss-all control
- wrap the app shell and navbar with the notification context so desktop components can publish and surface toasts

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label and no-top-level-window violations in unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d66812629083288b8bd70422a557bb