### PR TITLE
[menu] Add Kali-style category rail

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
-import apps, { utilities, games } from '../../apps.config';
+import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 
 type AppMeta = {
@@ -12,12 +12,102 @@ type AppMeta = {
   favourite?: boolean;
 };
 
-const CATEGORIES = [
-  { id: 'all', label: 'All' },
-  { id: 'favorites', label: 'Favorites' },
-  { id: 'recent', label: 'Recent' },
-  { id: 'utilities', label: 'Utilities' },
-  { id: 'games', label: 'Games' }
+type CategorySource =
+  | { type: 'all' }
+  | { type: 'favorites' }
+  | { type: 'recent' }
+  | { type: 'ids'; appIds: readonly string[] };
+
+type CategoryDefinition = {
+  id: string;
+  label: string;
+  icon: string;
+} & CategorySource;
+
+type CategoryConfig = CategoryDefinition & { apps: AppMeta[] };
+
+const CATEGORY_DEFINITIONS: readonly CategoryDefinition[] = [
+  {
+    id: 'all',
+    label: 'All Applications',
+    icon: '/themes/Yaru/system/view-app-grid-symbolic.svg',
+    type: 'all',
+  },
+  {
+    id: 'favorites',
+    label: 'Favorites',
+    icon: '/themes/Yaru/status/projects.svg',
+    type: 'favorites',
+  },
+  {
+    id: 'recent',
+    label: 'Recent',
+    icon: '/themes/Yaru/status/process-working-symbolic.svg',
+    type: 'recent',
+  },
+  {
+    id: 'information-gathering',
+    label: 'Information Gathering',
+    icon: '/themes/Yaru/apps/radar-symbolic.svg',
+    type: 'ids',
+    appIds: ['nmap-nse', 'reconng', 'kismet', 'wireshark'],
+  },
+  {
+    id: 'vulnerability-analysis',
+    label: 'Vulnerability Analysis',
+    icon: '/themes/Yaru/apps/nessus.svg',
+    type: 'ids',
+    appIds: ['nessus', 'openvas', 'nikto'],
+  },
+  {
+    id: 'web-app-analysis',
+    label: 'Web App Analysis',
+    icon: '/themes/Yaru/apps/http.svg',
+    type: 'ids',
+    appIds: ['http', 'beef', 'metasploit'],
+  },
+  {
+    id: 'password-attacks',
+    label: 'Password Attacks',
+    icon: '/themes/Yaru/apps/john.svg',
+    type: 'ids',
+    appIds: ['john', 'hashcat', 'hydra'],
+  },
+  {
+    id: 'wireless-attacks',
+    label: 'Wireless Attacks',
+    icon: '/themes/Yaru/status/network-wireless-signal-good-symbolic.svg',
+    type: 'ids',
+    appIds: ['kismet', 'reaver', 'wireshark'],
+  },
+  {
+    id: 'exploitation-tools',
+    label: 'Exploitation Tools',
+    icon: '/themes/Yaru/apps/metasploit.svg',
+    type: 'ids',
+    appIds: ['metasploit', 'security-tools', 'beef'],
+  },
+  {
+    id: 'sniffing-spoofing',
+    label: 'Sniffing & Spoofing',
+    icon: '/themes/Yaru/apps/ettercap.svg',
+    type: 'ids',
+    appIds: ['dsniff', 'ettercap', 'wireshark'],
+  },
+  {
+    id: 'post-exploitation',
+    label: 'Post Exploitation',
+    icon: '/themes/Yaru/apps/msf-post.svg',
+    type: 'ids',
+    appIds: ['msf-post', 'mimikatz', 'volatility'],
+  },
+  {
+    id: 'forensics-reporting',
+    label: 'Forensics & Reporting',
+    icon: '/themes/Yaru/apps/autopsy.svg',
+    type: 'ids',
+    appIds: ['autopsy', 'evidence-vault', 'project-gallery'],
+  },
 ];
 
 const WhiskerMenu: React.FC = () => {
@@ -25,8 +115,11 @@ const WhiskerMenu: React.FC = () => {
   const [category, setCategory] = useState('all');
   const [query, setQuery] = useState('');
   const [highlight, setHighlight] = useState(0);
+  const [categoryHighlight, setCategoryHighlight] = useState(0);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const categoryListRef = useRef<HTMLDivElement>(null);
+  const categoryButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
   const allApps: AppMeta[] = apps as any;
   const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
@@ -38,38 +131,72 @@ const WhiskerMenu: React.FC = () => {
       return [];
     }
   }, [allApps, open]);
-  const utilityApps: AppMeta[] = utilities as any;
-  const gameApps: AppMeta[] = games as any;
+  const categoryConfigs = useMemo<CategoryConfig[]>(() => {
+    const mapById = new Map(allApps.map(app => [app.id, app] as const));
+
+    return CATEGORY_DEFINITIONS.map((definition) => {
+      let appsForCategory: AppMeta[] = [];
+      switch (definition.type) {
+        case 'all':
+          appsForCategory = allApps;
+          break;
+        case 'favorites':
+          appsForCategory = favoriteApps;
+          break;
+        case 'recent':
+          appsForCategory = recentApps;
+          break;
+        case 'ids':
+          appsForCategory = definition.appIds
+            .map(appId => mapById.get(appId))
+            .filter((app): app is AppMeta => Boolean(app));
+          break;
+        default:
+          appsForCategory = allApps;
+      }
+      return {
+        ...definition,
+        apps: appsForCategory,
+      } as CategoryConfig;
+    });
+  }, [allApps, favoriteApps, recentApps]);
+
+  const currentCategory = useMemo(() => {
+    const found = categoryConfigs.find(cat => cat.id === category);
+    return found ?? categoryConfigs[0];
+  }, [category, categoryConfigs]);
 
   const currentApps = useMemo(() => {
-    let list: AppMeta[];
-    switch (category) {
-      case 'favorites':
-        list = favoriteApps;
-        break;
-      case 'recent':
-        list = recentApps;
-        break;
-      case 'utilities':
-        list = utilityApps;
-        break;
-      case 'games':
-        list = gameApps;
-        break;
-      default:
-        list = allApps;
-    }
+    let list = currentCategory?.apps ?? [];
     if (query) {
       const q = query.toLowerCase();
       list = list.filter(a => a.title.toLowerCase().includes(q));
     }
     return list;
-  }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
+  }, [currentCategory, query]);
+
+  useEffect(() => {
+    const storedCategory = safeLocalStorage?.getItem('whisker-menu-category');
+    if (!storedCategory) return;
+    if (CATEGORY_DEFINITIONS.some(cat => cat.id === storedCategory)) {
+      setCategory(storedCategory);
+    }
+  }, []);
+
+  useEffect(() => {
+    safeLocalStorage?.setItem('whisker-menu-category', currentCategory.id);
+  }, [currentCategory.id]);
 
   useEffect(() => {
     if (!open) return;
     setHighlight(0);
   }, [open, category, query]);
+
+  useEffect(() => {
+    if (!open) return;
+    const index = categoryConfigs.findIndex(cat => cat.id === currentCategory.id);
+    setCategoryHighlight(index === -1 ? 0 : index);
+  }, [open, currentCategory.id, categoryConfigs]);
 
   const openSelectedApp = (id: string) => {
     window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
@@ -84,6 +211,10 @@ const WhiskerMenu: React.FC = () => {
         return;
       }
       if (!open) return;
+      const target = e.target as Node | null;
+      if (target && categoryListRef.current?.contains(target)) {
+        return;
+      }
       if (e.key === 'Escape') {
         setOpen(false);
       } else if (e.key === 'ArrowDown') {
@@ -114,6 +245,41 @@ const WhiskerMenu: React.FC = () => {
     return () => document.removeEventListener('mousedown', handleClick);
   }, [open]);
 
+  const focusCategoryButton = (index: number) => {
+    const btn = categoryButtonRefs.current[index];
+    if (btn) {
+      btn.focus();
+    }
+  };
+
+  const handleCategoryNavigation = (direction: 1 | -1) => {
+    setCategoryHighlight((current) => {
+      const nextIndex = (current + direction + categoryConfigs.length) % categoryConfigs.length;
+      const nextCategory = categoryConfigs[nextIndex];
+      if (nextCategory) {
+        setCategory(nextCategory.id);
+        focusCategoryButton(nextIndex);
+      }
+      return nextIndex;
+    });
+  };
+
+  const handleCategoryKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      handleCategoryNavigation(1);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      handleCategoryNavigation(-1);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      const selected = categoryConfigs[categoryHighlight];
+      if (selected) {
+        setCategory(selected.id);
+      }
+    }
+  };
+
   return (
     <div className="relative">
       <button
@@ -142,26 +308,55 @@ const WhiskerMenu: React.FC = () => {
             }
           }}
         >
-          <div className="flex flex-col bg-gray-800 p-2">
-            {CATEGORIES.map(cat => (
+          <div
+            ref={categoryListRef}
+            className="flex max-h-80 w-64 flex-col gap-1 overflow-y-auto bg-gray-900 p-3"
+            role="listbox"
+            aria-label="Application categories"
+            tabIndex={0}
+            onKeyDown={handleCategoryKeyDown}
+          >
+            {categoryConfigs.map((cat, index) => (
               <button
                 key={cat.id}
-                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
-                onClick={() => setCategory(cat.id)}
+                ref={(el) => {
+                  categoryButtonRefs.current[index] = el;
+                }}
+                type="button"
+                className={`flex items-center gap-3 rounded px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-ubb-orange focus:ring-offset-2 focus:ring-offset-gray-900 ${
+                  category === cat.id ? 'bg-gray-700/80' : 'hover:bg-gray-700/60'
+                }`}
+                role="option"
+                aria-selected={category === cat.id}
+                onClick={() => {
+                  setCategory(cat.id);
+                  setCategoryHighlight(index);
+                }}
               >
-                {cat.label}
+                <span className="w-8 font-mono text-xs text-gray-300">{String(index + 1).padStart(2, '0')}</span>
+                <span className="flex items-center gap-2">
+                  <Image
+                    src={cat.icon}
+                    alt=""
+                    width={20}
+                    height={20}
+                    className="h-5 w-5"
+                    sizes="20px"
+                  />
+                  <span className="text-sm">{cat.label}</span>
+                </span>
               </button>
             ))}
           </div>
-          <div className="p-3">
+          <div className="flex flex-col p-3">
             <input
-              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+              className="mb-3 w-64 rounded bg-black bg-opacity-20 px-2 py-1 focus:outline-none"
               placeholder="Search"
               value={query}
               onChange={e => setQuery(e.target.value)}
               autoFocus
             />
-            <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
+            <div className="grid max-h-64 grid-cols-3 gap-2 overflow-y-auto">
               {currentApps.map((app, idx) => (
                 <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>
                   <UbuntuApp


### PR DESCRIPTION
## Summary
- replace the Whisker menu category rail with Kali-style numbered entries and tool icons
- wire the left rail to context-aware filters, keyboard navigation, and stored selection state
- prevent arrow key conflicts with the application grid highlight while navigating the category list

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d6681352908328a498293ed020e7b5