### PR TITLE
feat(menu): add tree view for whisker menu

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,8 +1,14 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import Image from 'next/image';
-import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import usePersistentState from '../../hooks/usePersistentState';
+import {
+  APP_REGISTRY,
+  AppRegistryNode,
+  createDefaultExpansionState,
+  isRegistryCategory,
+} from '../../data/app-registry';
 
 type AppMeta = {
   id: string;
@@ -10,6 +16,14 @@ type AppMeta = {
   icon: string;
   disabled?: boolean;
   favourite?: boolean;
+  screen?: { prefetch?: () => void };
+};
+
+type TreeNode = {
+  id: string;
+  label: string;
+  apps: AppMeta[];
+  children: TreeNode[];
 };
 
 const CATEGORIES = [
@@ -17,8 +31,59 @@ const CATEGORIES = [
   { id: 'favorites', label: 'Favorites' },
   { id: 'recent', label: 'Recent' },
   { id: 'utilities', label: 'Utilities' },
-  { id: 'games', label: 'Games' }
+  { id: 'games', label: 'Games' },
 ];
+
+const buildTree = (
+  nodes: AppRegistryNode[],
+  filteredApps: AppMeta[],
+  lookup: Map<string, AppMeta>,
+): TreeNode[] => {
+  const available = new Set(filteredApps.map((app) => app.id));
+  const assigned = new Set<string>();
+
+  const buildNodes = (registryNodes: AppRegistryNode[]): TreeNode[] => {
+    const result: TreeNode[] = [];
+    registryNodes.forEach((node) => {
+      const children = node.children ? buildNodes(node.children) : [];
+      const apps: AppMeta[] = [];
+
+      if (node.apps) {
+        node.apps.forEach((id) => {
+          if (assigned.has(id) || !available.has(id)) return;
+          const meta = lookup.get(id);
+          if (meta) {
+            apps.push(meta);
+            assigned.add(id);
+          }
+        });
+      }
+
+      if (apps.length === 0 && children.length === 0) return;
+
+      result.push({
+        id: node.id,
+        label: node.label,
+        apps,
+        children,
+      });
+    });
+    return result;
+  };
+
+  const built = buildNodes(nodes);
+  const unassigned = filteredApps.filter((app) => !assigned.has(app.id));
+  if (unassigned.length) {
+    built.push({
+      id: 'other-apps',
+      label: 'Other Apps',
+      apps: unassigned,
+      children: [],
+    });
+  }
+
+  return built;
+};
 
 const WhiskerMenu: React.FC = () => {
   const [open, setOpen] = useState(false);
@@ -29,11 +94,13 @@ const WhiskerMenu: React.FC = () => {
   const menuRef = useRef<HTMLDivElement>(null);
 
   const allApps: AppMeta[] = apps as any;
-  const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
+  const favoriteApps = useMemo(() => allApps.filter((a) => a.favourite), [allApps]);
   const recentApps = useMemo(() => {
     try {
       const ids: string[] = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]');
-      return ids.map(id => allApps.find(a => a.id === id)).filter(Boolean) as AppMeta[];
+      return ids
+        .map((id) => allApps.find((a) => a.id === id))
+        .filter(Boolean) as AppMeta[];
     } catch {
       return [];
     }
@@ -41,7 +108,14 @@ const WhiskerMenu: React.FC = () => {
   const utilityApps: AppMeta[] = utilities as any;
   const gameApps: AppMeta[] = games as any;
 
-  const currentApps = useMemo(() => {
+  const [expandedState, setExpandedState] = usePersistentState<Record<string, string[]>>(
+    'whisker-expanded',
+    createDefaultExpansionState,
+  );
+
+  const appLookup = useMemo(() => new Map(allApps.map((app) => [app.id, app])), [allApps]);
+
+  const filteredApps = useMemo(() => {
     let list: AppMeta[];
     switch (category) {
       case 'favorites':
@@ -59,17 +133,60 @@ const WhiskerMenu: React.FC = () => {
       default:
         list = allApps;
     }
+
     if (query) {
       const q = query.toLowerCase();
-      list = list.filter(a => a.title.toLowerCase().includes(q));
+      list = list.filter((a) => a.title.toLowerCase().includes(q));
     }
+
     return list;
   }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
+
+  const registryCategory = isRegistryCategory(category) ? category : undefined;
+  const registryNodes = registryCategory ? APP_REGISTRY[registryCategory] : undefined;
+
+  const treeNodes = useMemo(() => {
+    if (!registryNodes) return [];
+    return buildTree(registryNodes, filteredApps, appLookup);
+  }, [registryNodes, filteredApps, appLookup]);
+
+  const forceExpand = query.trim().length > 0;
+
+  const expandedIds = useMemo(() => new Set(expandedState[category] ?? []), [expandedState, category]);
+
+  const visibleApps = useMemo(() => {
+    if (!registryNodes) return filteredApps;
+
+    const list: AppMeta[] = [];
+    const visit = (nodes: TreeNode[]) => {
+      nodes.forEach((node) => {
+        const hasChildren = node.children.length > 0;
+        const isExpanded = forceExpand || !hasChildren || expandedIds.has(node.id);
+
+        if (!hasChildren || isExpanded) {
+          node.apps.forEach((app) => {
+            list.push(app);
+          });
+        }
+
+        if (hasChildren && isExpanded) {
+          visit(node.children);
+        }
+      });
+    };
+
+    visit(treeNodes);
+    return list;
+  }, [registryNodes, filteredApps, treeNodes, expandedIds, forceExpand]);
 
   useEffect(() => {
     if (!open) return;
     setHighlight(0);
   }, [open, category, query]);
+
+  useEffect(() => {
+    setHighlight((current) => Math.min(current, Math.max(visibleApps.length - 1, 0)));
+  }, [visibleApps.length]);
 
   const openSelectedApp = (id: string) => {
     window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
@@ -80,7 +197,7 @@ const WhiskerMenu: React.FC = () => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Meta' && !e.ctrlKey && !e.shiftKey && !e.altKey) {
         e.preventDefault();
-        setOpen(o => !o);
+        setOpen((o) => !o);
         return;
       }
       if (!open) return;
@@ -88,19 +205,19 @@ const WhiskerMenu: React.FC = () => {
         setOpen(false);
       } else if (e.key === 'ArrowDown') {
         e.preventDefault();
-        setHighlight(h => Math.min(h + 1, currentApps.length - 1));
+        setHighlight((h) => Math.min(h + 1, Math.max(visibleApps.length - 1, 0)));
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
-        setHighlight(h => Math.max(h - 1, 0));
+        setHighlight((h) => Math.max(h - 1, 0));
       } else if (e.key === 'Enter') {
         e.preventDefault();
-        const app = currentApps[highlight];
+        const app = visibleApps[highlight];
         if (app) openSelectedApp(app.id);
       }
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [open, currentApps, highlight]);
+  }, [open, visibleApps, highlight]);
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
@@ -114,12 +231,94 @@ const WhiskerMenu: React.FC = () => {
     return () => document.removeEventListener('mousedown', handleClick);
   }, [open]);
 
+  const toggleNode = (nodeId: string) => {
+    if (!registryCategory) return;
+    setExpandedState((prev) => {
+      const set = new Set(prev[registryCategory] ?? []);
+      if (set.has(nodeId)) set.delete(nodeId);
+      else set.add(nodeId);
+      return { ...prev, [registryCategory]: Array.from(set) };
+    });
+  };
+
+  const handlePrefetch = (app: AppMeta) => {
+    if (typeof app.screen?.prefetch === 'function') {
+      app.screen.prefetch();
+    }
+  };
+
+  const highlightedAppId = visibleApps[highlight]?.id;
+
+  const renderApp = (app: AppMeta) => {
+    const isHighlighted = highlightedAppId === app.id;
+    return (
+      <li key={app.id}>
+        <button
+          type="button"
+          onClick={() => openSelectedApp(app.id)}
+          onMouseEnter={() => handlePrefetch(app)}
+          onFocus={() => handlePrefetch(app)}
+          disabled={app.disabled}
+          className={`flex w-full items-center gap-2 rounded px-2 py-1 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-ub-orange ${
+            app.disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-gray-700'
+          } ${isHighlighted ? 'bg-ub-orange text-black' : ''}`}
+        >
+          <Image
+            src={app.icon.replace('./', '/')}
+            alt=""
+            width={20}
+            height={20}
+            sizes="20px"
+            className="h-5 w-5"
+          />
+          <span>{app.title}</span>
+        </button>
+      </li>
+    );
+  };
+
+  const renderTree = (nodes: TreeNode[], depth = 0): JSX.Element => (
+    <ul className={`space-y-2 ${depth > 0 ? 'border-l border-gray-700 pl-4 ml-3' : ''}`}>
+      {nodes.map((node) => {
+        const hasChildren = node.children.length > 0;
+        const isExpanded = forceExpand || !hasChildren || expandedIds.has(node.id);
+        return (
+          <li key={node.id}>
+            <div className={`flex items-center gap-2 ${depth > 0 ? 'mt-1' : ''}`}>
+              {hasChildren && (
+                <button
+                  type="button"
+                  onClick={() => toggleNode(node.id)}
+                  className="flex h-5 w-5 items-center justify-center rounded border border-gray-600 bg-gray-800 text-xs focus:outline-none focus:ring-2 focus:ring-ub-orange"
+                  aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${node.label}`}
+                >
+                  {isExpanded ? '▾' : '▸'}
+                </button>
+              )}
+              <span className="text-sm font-semibold">{node.label}</span>
+            </div>
+            {isExpanded && (
+              <div className="mt-2 space-y-2">
+                {node.apps.length > 0 && (
+                  <ul className="space-y-1 pl-6">{node.apps.map((app) => renderApp(app))}</ul>
+                )}
+                {hasChildren && renderTree(node.children, depth + 1)}
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+
+  const showTree = Boolean(registryNodes);
+
   return (
     <div className="relative">
       <button
         ref={buttonRef}
         type="button"
-        onClick={() => setOpen(o => !o)}
+        onClick={() => setOpen((o) => !o)}
         className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
       >
         <Image
@@ -143,9 +342,10 @@ const WhiskerMenu: React.FC = () => {
           }}
         >
           <div className="flex flex-col bg-gray-800 p-2">
-            {CATEGORIES.map(cat => (
+            {CATEGORIES.map((cat) => (
               <button
                 key={cat.id}
+                type="button"
                 className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
                 onClick={() => setCategory(cat.id)}
               >
@@ -153,26 +353,26 @@ const WhiskerMenu: React.FC = () => {
               </button>
             ))}
           </div>
-          <div className="p-3">
+          <div className="p-3 w-80">
             <input
-              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+              className="mb-3 w-full px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
               placeholder="Search"
               value={query}
-              onChange={e => setQuery(e.target.value)}
+              onChange={(e) => setQuery(e.target.value)}
               autoFocus
             />
-            <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
-              {currentApps.map((app, idx) => (
-                <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>
-                  <UbuntuApp
-                    id={app.id}
-                    icon={app.icon}
-                    name={app.title}
-                    openApp={() => openSelectedApp(app.id)}
-                    disabled={app.disabled}
-                  />
-                </div>
-              ))}
+            <div className="max-h-64 overflow-y-auto pr-2">
+              {showTree ? (
+                treeNodes.length > 0 ? (
+                  renderTree(treeNodes)
+                ) : (
+                  <div className="text-sm text-gray-300">No apps found.</div>
+                )
+              ) : visibleApps.length > 0 ? (
+                <ul className="space-y-1">{visibleApps.map((app) => renderApp(app))}</ul>
+              ) : (
+                <div className="text-sm text-gray-300">No apps found.</div>
+              )}
             </div>
           </div>
         </div>

--- a/data/app-registry.ts
+++ b/data/app-registry.ts
@@ -1,0 +1,220 @@
+export type AppRegistryNode = {
+  id: string;
+  label: string;
+  apps?: string[];
+  children?: AppRegistryNode[];
+  /** Expand this node by default when the menu is first opened */
+  defaultOpen?: boolean;
+};
+
+const GAME_TREE: AppRegistryNode[] = [
+  {
+    id: 'games-arcade',
+    label: 'Arcade & Action',
+    defaultOpen: true,
+    apps: [
+      'asteroids',
+      'car-racer',
+      'lane-runner',
+      'frogger',
+      'platformer',
+      'space-invaders',
+      'flappy-bird',
+      'pinball',
+    ],
+  },
+  {
+    id: 'games-retro',
+    label: 'Retro Classics',
+    apps: ['pacman', 'pong', 'breakout', 'snake'],
+  },
+  {
+    id: 'games-puzzle',
+    label: 'Puzzle & Logic',
+    apps: ['2048', 'minesweeper', 'nonogram', 'sudoku', 'tetris', 'sokoban', 'memory', 'candy-crush'],
+  },
+  {
+    id: 'games-word',
+    label: 'Word & Trivia',
+    apps: ['hangman', 'word-search', 'wordle'],
+  },
+  {
+    id: 'games-board',
+    label: 'Board & Strategy',
+    apps: [
+      'chess',
+      'checkers',
+      'reversi',
+      'battleship',
+      'tictactoe',
+      'gomoku',
+      'tower-defense',
+      'connect-four',
+    ],
+  },
+  {
+    id: 'games-card',
+    label: 'Cards & Tabletop',
+    apps: ['blackjack', 'solitaire'],
+  },
+  {
+    id: 'games-memory',
+    label: 'Memory & Rhythm',
+    apps: ['simon'],
+  },
+];
+
+export const APP_REGISTRY = {
+  all: [
+    {
+      id: 'workspace',
+      label: 'Workspace',
+      defaultOpen: true,
+      children: [
+        {
+          id: 'workspace-core',
+          label: 'Core Applications',
+          defaultOpen: true,
+          apps: [
+            'chrome',
+            'files',
+            'settings',
+            'resource-monitor',
+            'screen-recorder',
+            'plugin-manager',
+            'trash',
+            'about',
+          ],
+        },
+        {
+          id: 'workspace-developer',
+          label: 'Developer Tools',
+          defaultOpen: true,
+          apps: ['terminal', 'vscode', 'html-rewriter', 'input-lab', 'serial-terminal'],
+        },
+        {
+          id: 'workspace-productivity',
+          label: 'Productivity & Notes',
+          defaultOpen: true,
+          apps: [
+            'todoist',
+            'sticky_notes',
+            'clipboard-manager',
+            'gedit',
+            'contact',
+            'calculator',
+            'converter',
+            'quote',
+            'project-gallery',
+          ],
+        },
+        {
+          id: 'workspace-media',
+          label: 'Media & Social',
+          apps: ['spotify', 'youtube', 'x'],
+        },
+        {
+          id: 'workspace-weather',
+          label: 'Weather & Widgets',
+          apps: ['weather', 'weather-widget'],
+        },
+        {
+          id: 'workspace-creative',
+          label: 'Creative Extras',
+          apps: ['ascii-art', 'figlet'],
+        },
+      ],
+    },
+    {
+      id: 'security-lab',
+      label: 'Security Lab',
+      defaultOpen: true,
+      children: [
+        {
+          id: 'security-recon',
+          label: 'Recon & Scanning',
+          defaultOpen: true,
+          apps: ['wireshark', 'nmap-nse', 'openvas', 'nessus', 'recon-ng', 'kismet', 'dsniff', 'ble-sensor'],
+        },
+        {
+          id: 'security-exploitation',
+          label: 'Exploitation & Delivery',
+          defaultOpen: true,
+          apps: ['metasploit', 'msf-post', 'beef', 'ettercap', 'nikto', 'hydra', 'reaver'],
+        },
+        {
+          id: 'security-credentials',
+          label: 'Credentials & Access',
+          apps: ['john', 'hashcat', 'mimikatz', 'mimikatz/offline'],
+        },
+        {
+          id: 'security-forensics',
+          label: 'Post-Exploitation & Forensics',
+          apps: ['autopsy', 'volatility', 'radare2', 'ghidra', 'evidence-vault'],
+        },
+        {
+          id: 'security-utilities',
+          label: 'Builders & Utilities',
+          apps: ['subnet-calculator', 'qr', 'ssh', 'http', 'security-tools'],
+        },
+      ],
+    },
+    {
+      id: 'all-games',
+      label: 'Games',
+      children: GAME_TREE,
+    },
+  ],
+  utilities: [
+    {
+      id: 'utilities-productivity',
+      label: 'Productivity',
+      defaultOpen: true,
+      apps: ['clipboard-manager', 'sticky_notes', 'todoist', 'project-gallery', 'quote'],
+    },
+    {
+      id: 'utilities-creative',
+      label: 'Creative & Fun',
+      apps: ['ascii-art', 'figlet'],
+    },
+    {
+      id: 'utilities-networking',
+      label: 'Networking',
+      apps: ['qr', 'subnet-calculator'],
+    },
+    {
+      id: 'utilities-developer',
+      label: 'Developer Tools',
+      apps: ['input-lab'],
+    },
+  ],
+  games: GAME_TREE,
+} as const satisfies Record<string, AppRegistryNode[]>;
+
+export type RegistryCategory = keyof typeof APP_REGISTRY;
+
+export const isRegistryCategory = (value: string): value is RegistryCategory =>
+  Object.prototype.hasOwnProperty.call(APP_REGISTRY, value);
+
+const collectDefaultExpansion = (nodes: AppRegistryNode[]): string[] => {
+  const ids: string[] = [];
+  nodes.forEach((node) => {
+    if (node.defaultOpen) {
+      ids.push(node.id);
+    }
+    if (node.children) {
+      ids.push(...collectDefaultExpansion(node.children));
+    }
+  });
+  return ids;
+};
+
+export const DEFAULT_APP_EXPANSION: Record<string, string[]> = Object.fromEntries(
+  Object.entries(APP_REGISTRY).map(([category, nodes]) => [
+    category,
+    collectDefaultExpansion(nodes),
+  ]),
+);
+
+export const createDefaultExpansionState = (): Record<string, string[]> =>
+  JSON.parse(JSON.stringify(DEFAULT_APP_EXPANSION));


### PR DESCRIPTION
## Summary
- add a registry-driven category tree for the whisker menu and render apps in collapsible sections
- persist expansion state per category so the menu re-opens with the previous tree state
- define shared app/subcategory metadata in a central registry for the menu to consume

## Testing
- yarn lint *(fails: existing jsx-a11y control label violations and no-top-level-window warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d66813c8188328be4fcc9d24c6f185