### PR TITLE
[ui] Add delayed metadata tooltips for app listings

### DIFF
--- a/components/ui/AppTooltipContent.tsx
+++ b/components/ui/AppTooltipContent.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+type AppTooltipContentProps = {
+  meta?: {
+    title?: string;
+    description?: string;
+    path?: string;
+    keyboard?: string[];
+  } | null;
+};
+
+const AppTooltipContent: React.FC<AppTooltipContentProps> = ({ meta }) => {
+  if (!meta) {
+    return <span className="text-xs text-gray-200">Metadata unavailable.</span>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {meta.title ? (
+        <p className="text-sm font-semibold text-white">{meta.title}</p>
+      ) : null}
+      {meta.description ? (
+        <p className="text-xs leading-relaxed text-gray-200">{meta.description}</p>
+      ) : null}
+      {meta.path ? (
+        <p className="text-[11px] text-gray-300">
+          <span className="font-semibold text-gray-100">Path:</span>{' '}
+          <code className="rounded bg-black/40 px-1 py-0.5 text-[11px] text-ubt-grey">
+            {meta.path}
+          </code>
+        </p>
+      ) : null}
+      {meta.keyboard?.length ? (
+        <ul className="list-disc space-y-1 pl-4 text-[11px] text-gray-200">
+          {meta.keyboard.map((hint) => (
+            <li key={hint}>{hint}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+};
+
+export default AppTooltipContent;

--- a/components/ui/DelayedTooltip.tsx
+++ b/components/ui/DelayedTooltip.tsx
@@ -1,0 +1,150 @@
+import React, {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+type TriggerProps = {
+  ref: (node: HTMLElement | null) => void;
+  onMouseEnter: (event: React.MouseEvent<HTMLElement>) => void;
+  onMouseLeave: (event: React.MouseEvent<HTMLElement>) => void;
+  onFocus: (event: React.FocusEvent<HTMLElement>) => void;
+  onBlur: (event: React.FocusEvent<HTMLElement>) => void;
+};
+
+type DelayedTooltipProps = {
+  content: ReactNode;
+  delay?: number;
+  children: (triggerProps: TriggerProps) => React.ReactElement;
+};
+
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+const DEFAULT_OFFSET = 8;
+
+const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
+  content,
+  delay = 300,
+  children,
+}) => {
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const [visible, setVisible] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const timerRef = useRef<number | null>(null);
+  const [portalEl, setPortalEl] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const el = document.createElement('div');
+    el.setAttribute('data-delayed-tooltip', 'true');
+    document.body.appendChild(el);
+    setPortalEl(el);
+    return () => {
+      document.body.removeChild(el);
+      setPortalEl(null);
+    };
+  }, []);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const show = useCallback(() => {
+    clearTimer();
+    timerRef.current = window.setTimeout(() => {
+      setVisible(true);
+    }, delay);
+  }, [clearTimer, delay]);
+
+  const hide = useCallback(() => {
+    clearTimer();
+    setVisible(false);
+  }, [clearTimer]);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!visible || !triggerRef.current || !tooltipRef.current) {
+      return;
+    }
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+    const tooltipRect = tooltipRef.current.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    let top = triggerRect.bottom + DEFAULT_OFFSET;
+    let left =
+      triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
+
+    if (left < DEFAULT_OFFSET) {
+      left = DEFAULT_OFFSET;
+    }
+    if (left + tooltipRect.width > viewportWidth - DEFAULT_OFFSET) {
+      left = viewportWidth - tooltipRect.width - DEFAULT_OFFSET;
+    }
+
+    if (top + tooltipRect.height > viewportHeight - DEFAULT_OFFSET) {
+      top = triggerRect.top - tooltipRect.height - DEFAULT_OFFSET;
+      if (top < DEFAULT_OFFSET) {
+        top = Math.max(
+          DEFAULT_OFFSET,
+          viewportHeight - tooltipRect.height - DEFAULT_OFFSET,
+        );
+      }
+    }
+
+    setPosition({ top, left });
+  }, [visible, content]);
+
+  const triggerProps: TriggerProps = {
+    ref: (node) => {
+      triggerRef.current = node;
+    },
+    onMouseEnter: () => {
+      show();
+    },
+    onMouseLeave: () => {
+      hide();
+    },
+    onFocus: () => {
+      show();
+    },
+    onBlur: () => {
+      hide();
+    },
+  };
+
+  return (
+    <>
+      {children(triggerProps)}
+      {portalEl && visible
+        ? createPortal(
+            <div
+              ref={tooltipRef}
+              style={{
+                position: 'fixed',
+                top: position.top,
+                left: position.left,
+                zIndex: 1000,
+              }}
+              className="pointer-events-none max-w-xs rounded-md border border-gray-500/60 bg-ub-grey/95 px-3 py-2 text-xs text-white shadow-xl backdrop-blur"
+            >
+              {content}
+            </div>,
+            portalEl,
+          )
+        : null}
+    </>
+  );
+};
+
+export default DelayedTooltip;

--- a/lib/appRegistry.ts
+++ b/lib/appRegistry.ts
@@ -1,0 +1,106 @@
+export type AppMetadata = {
+  title: string;
+  description: string;
+  path: string;
+  keyboard: string[];
+  icon?: string;
+};
+
+type AppEntry = {
+  id: string;
+  title: string;
+  icon?: string;
+};
+
+const DEFAULT_KEYBOARD_HINTS = [
+  'Enter — Launch app',
+  'Ctrl+, — Open settings',
+  'Alt+Tab — Switch apps',
+];
+
+const metadataOverrides: Partial<Record<string, Partial<AppMetadata>>> = {
+  terminal: {
+    description: 'Simulated shell with offline commands and command history.',
+    keyboard: [
+      'Enter — Execute command',
+      'Ctrl+L — Clear terminal output',
+      'Arrow keys — Navigate history',
+    ],
+  },
+  chrome: {
+    description: 'Sandboxed Chromium experience with curated demo sites and reader mode.',
+    keyboard: [
+      'Ctrl+L — Focus address bar',
+      'Ctrl+Tab — Switch tabs',
+      'Ctrl+W — Close active tab',
+    ],
+  },
+  vscode: {
+    description: 'VS Code remote workspace embedded via StackBlitz iframe for quick code editing.',
+    keyboard: [
+      'Ctrl+P — Quick open files',
+      'Ctrl+Shift+P — Command palette',
+      'Ctrl+B — Toggle sidebar',
+    ],
+  },
+  spotify: {
+    description: 'Spotify-inspired player that streams curated demo playlists without external calls.',
+    keyboard: [
+      'Space — Play or pause',
+      'ArrowRight — Skip forward',
+      'ArrowLeft — Skip backward',
+    ],
+  },
+  settings: {
+    description: 'Desktop settings hub with themes, key bindings, and personalization options.',
+  },
+  'security-tools': {
+    description: 'Unified console aggregating repeater, log viewers, and lab-only detection fixtures.',
+    keyboard: [
+      'Ctrl+F — Focus global search',
+      'Tab — Cycle tool tabs',
+      'Esc — Close overlays',
+    ],
+  },
+  wireshark: {
+    description: 'Packet capture viewer using bundled PCAP fixtures to demonstrate network analysis.',
+  },
+  metasploit: {
+    description: 'Module browser and log replay of the Metasploit framework for safe demonstrations.',
+  },
+  weather: {
+    description: 'Weather dashboard showing forecast data sourced from static fixtures.',
+  },
+  'mimikatz/offline': {
+    description: 'Offline walkthrough of mimikatz credential extraction stages with canned data.',
+  },
+};
+
+export const buildAppMetadata = (app: AppEntry): AppMetadata => {
+  const override = metadataOverrides[app.id] ?? {};
+  return {
+    title: app.title,
+    icon: app.icon,
+    description:
+      override.description ?? `Launch the ${app.title} demo environment.`,
+    path: override.path ?? `/apps/${app.id}`,
+    keyboard: override.keyboard ?? DEFAULT_KEYBOARD_HINTS,
+  };
+};
+
+export const createRegistryMap = (apps: AppEntry[]): Record<string, AppMetadata> =>
+  apps.reduce<Record<string, AppMetadata>>((acc, app) => {
+    acc[app.id] = buildAppMetadata(app);
+    return acc;
+  }, {});
+
+export const loadAppRegistry = async () => {
+  const mod = await import('../apps.config');
+  const list: AppEntry[] = Array.isArray(mod.default) ? mod.default : [];
+  return {
+    apps: list,
+    metadata: createRegistryMap(list),
+  };
+};
+
+export const defaultKeyboardHints = DEFAULT_KEYBOARD_HINTS;


### PR DESCRIPTION
## Summary
- add a reusable delayed tooltip component that renders via a portal to avoid viewport overflow
- derive description, route, and keyboard hint metadata from the app registry for tooltip content
- surface the metadata tooltips on the /apps catalog and virtualized desktop app grid

## Testing
- yarn lint *(fails: pre-existing jsx-a11y control-has-associated-label violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d66815105c832890283110f280fd6c