### PR TITLE
[desktop] Refine window hit targets

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -626,6 +626,7 @@ export class Window extends Component {
                     handle=".bg-ub-window-title"
                     grid={this.props.snapEnabled ? [8, 8] : [1, 1]}
                     scale={1}
+                    cancel=".windowMainScreen, .windowMainScreen *"
                     onStart={this.changeCursorToMove}
                     onStop={this.handleStop}
                     onDrag={this.handleDrag}
@@ -642,8 +643,12 @@ export class Window extends Component {
                         tabIndex={0}
                         onKeyDown={this.handleKeyDown}
                     >
-                        {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
-                        {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}
+                        {this.props.resizable !== false && (
+                            <WindowResizeHandles
+                                onHorizontalResize={this.handleHorizontalResize}
+                                onVerticalResize={this.handleVerticleResize}
+                            />
+                        )}
                         <WindowTopBar
                             title={this.props.title}
                             onKeyDown={this.handleTitleBarKeyDown}
@@ -689,45 +694,53 @@ export function WindowTopBar({ title, onKeyDown, onBlur, grabbed }) {
     )
 }
 
-// Window's Borders
-export class WindowYBorder extends Component {
+// Window resize handles
+export class WindowResizeHandles extends Component {
     componentDidMount() {
-        // Use the browser's Image constructor rather than the imported Next.js
-        // Image component to avoid runtime errors when running in tests.
-
         this.trpImg = new window.Image(0, 0);
         this.trpImg.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
         this.trpImg.style.opacity = 0;
     }
-    render() {
-            return (
-                <div
-                    className={`${styles.windowYBorder} cursor-[e-resize] border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2`}
-                    onDragStart={(e) => { e.dataTransfer.setDragImage(this.trpImg, 0, 0) }}
-                    onDrag={this.props.resize}
-                ></div>
-            )
-        }
-    }
 
-export class WindowXBorder extends Component {
-    componentDidMount() {
-        // Use the global Image constructor instead of Next.js Image component
-
-        this.trpImg = new window.Image(0, 0);
-        this.trpImg.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-        this.trpImg.style.opacity = 0;
-    }
-    render() {
-            return (
-                <div
-                    className={`${styles.windowXBorder} cursor-[n-resize] border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2`}
-                    onDragStart={(e) => { e.dataTransfer.setDragImage(this.trpImg, 0, 0) }}
-                    onDrag={this.props.resize}
-                ></div>
-            )
+    handleDragStart = (event) => {
+        if (event.dataTransfer && this.trpImg) {
+            event.dataTransfer.setDragImage(this.trpImg, 0, 0);
         }
+    };
+
+    render() {
+        const { onHorizontalResize, onVerticalResize } = this.props;
+
+        return (
+            <div className="pointer-events-none absolute inset-0 z-30">
+                <div
+                    draggable
+                    onDragStart={this.handleDragStart}
+                    onDrag={onHorizontalResize}
+                    className={`${styles.resizeHandle} ${styles.resizeHandleLeft}`}
+                />
+                <div
+                    draggable
+                    onDragStart={this.handleDragStart}
+                    onDrag={onHorizontalResize}
+                    className={`${styles.resizeHandle} ${styles.resizeHandleRight}`}
+                />
+                <div
+                    draggable
+                    onDragStart={this.handleDragStart}
+                    onDrag={onVerticalResize}
+                    className={`${styles.resizeHandle} ${styles.resizeHandleTop}`}
+                />
+                <div
+                    draggable
+                    onDragStart={this.handleDragStart}
+                    onDrag={onVerticalResize}
+                    className={`${styles.resizeHandle} ${styles.resizeHandleBottom}`}
+                />
+            </div>
+        );
     }
+}
 
 // Window's Edit Buttons
 export function WindowEditButtons(props) {

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -1,9 +1,38 @@
-.windowYBorder {
-  height: calc(100% - 10px);
-  width: calc(100% + 10px);
+.resizeHandle {
+  position: absolute;
+  pointer-events: auto;
+  user-select: none;
+  touch-action: none;
 }
 
-.windowXBorder {
-  height: calc(100% + 10px);
-  width: calc(100% - 10px);
+.resizeHandleLeft {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 6px;
+  cursor: ew-resize;
+}
+
+.resizeHandleRight {
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 6px;
+  cursor: ew-resize;
+}
+
+.resizeHandleTop {
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 6px;
+  cursor: ns-resize;
+}
+
+.resizeHandleBottom {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 6px;
+  cursor: ns-resize;
 }


### PR DESCRIPTION
## Summary
- prevent draggable hit testing from starting when interacting with window content by cancelling drags outside the titlebar
- replace the oversized resize overlays with dedicated 6px edge handles that expose the correct cursors
- add supporting styles so resize hit zones sit on each edge without blocking underlying content

## Testing
- [ ] yarn lint *(hangs in container before producing output)*

------
https://chatgpt.com/codex/tasks/task_e_68d6681745908328a730322b1ce73264