### PR TITLE
[desktop] Update panel behavior and messaging badges

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -657,6 +657,7 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displayX,
+    category: 'messaging',
   },
   {
     id: 'spotify',
@@ -926,6 +927,7 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayContact,
+    category: 'messaging',
   },
   {
     id: 'hydra',

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,47 +1,103 @@
-import React from 'react';
+import React, { useContext, useMemo } from 'react';
 import Image from 'next/image';
+import { NotificationsContext } from '../common/NotificationCenter';
 
 export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const notificationsCtx = useContext(NotificationsContext);
+    const notifications = notificationsCtx?.notifications || {};
 
-    const handleClick = (app) => {
+    const pinnedApps = useMemo(
+        () => props.apps.filter(app => props.favourite_apps?.[app.id]),
+        [props.apps, props.favourite_apps]
+    );
+
+    const runningUnpinned = useMemo(
+        () => props.apps.filter(app => props.closed_windows[app.id] === false && !props.favourite_apps?.[app.id]),
+        [props.apps, props.closed_windows, props.favourite_apps]
+    );
+
+    const messagingAppIds = useMemo(
+        () => new Set(props.apps.filter(app => app.category === 'messaging').map(app => app.id)),
+        [props.apps]
+    );
+
+    const panelApps = [...pinnedApps, ...runningUnpinned];
+
+    const handleClick = (event, app) => {
         const id = app.id;
+
+        if (event.shiftKey) {
+            props.openApp(id, { spawnNew: true });
+            return;
+        }
+
+        if (event.altKey && props.closed_windows[id] === false) {
+            props.minimize(id);
+            return;
+        }
+
         if (props.minimized_windows[id]) {
             props.openApp(id);
-        } else if (props.focused_windows[id]) {
-            props.minimize(id);
-        } else {
-            props.openApp(id);
+            return;
         }
+
+        if (props.closed_windows[id] === false) {
+            if (!props.focused_windows[id]) {
+                props.openApp(id);
+            }
+            return;
+        }
+
+        props.openApp(id);
     };
 
     return (
         <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => (
-                <button
-                    key={app.id}
-                    type="button"
-                    aria-label={app.title}
-                    data-context="taskbar"
-                    data-app-id={app.id}
-                    onClick={() => handleClick(app)}
-                    className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                >
-                    <Image
-                        width={24}
-                        height={24}
-                        className="w-5 h-5"
-                        src={app.icon.replace('./', '/')}
-                        alt=""
-                        sizes="24px"
-                    />
-                    <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                    {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                    )}
-                </button>
-            ))}
+            {panelApps.map(app => {
+                const isRunning = props.closed_windows[app.id] === false;
+                const isMinimized = !!props.minimized_windows[app.id];
+                const isFocused = isRunning && !isMinimized && props.focused_windows[app.id];
+                const badgeCount = messagingAppIds.has(app.id)
+                    ? (notifications[app.id]?.length || 0)
+                    : 0;
+                const className = `${
+                    isFocused ? 'bg-white bg-opacity-20 ' : ''
+                }relative flex items-center mx-1 px-2 py-1 rounded transition-colors duration-150 hover:bg-white hover:bg-opacity-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-40`;
+                const labelClass = `ml-1 text-sm whitespace-nowrap ${
+                    isRunning ? 'text-white' : 'text-white text-opacity-70'
+                }`;
+
+                return (
+                    <button
+                        key={app.id}
+                        type="button"
+                        aria-label={app.title}
+                        data-context="taskbar"
+                        data-app-id={app.id}
+                        onClick={(event) => handleClick(event, app)}
+                        className={className}
+                        aria-pressed={isFocused}
+                    >
+                        <Image
+                            width={24}
+                            height={24}
+                            className="w-5 h-5"
+                            src={app.icon.replace('./', '/')}
+                            alt=""
+                            sizes="24px"
+                        />
+                        <span className={labelClass}>{app.title}</span>
+                        {isFocused && (
+                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-3/4 h-0.5 bg-white rounded-full" />
+                        )}
+                        {badgeCount > 0 && (
+                            <span className="absolute -top-1 -right-1 min-w-[1.25rem] px-1 py-0.5 rounded-full bg-red-500 text-white text-xs leading-none text-center">
+                                {badgeCount > 99 ? '99+' : badgeCount}
+                            </span>
+                        )}
+                    </button>
+                );
+            })}
         </div>
     );
 }

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import NotificationCenter from '../components/common/NotificationCenter';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -156,23 +157,25 @@ function MyApp(props) {
         >
           Skip to app grid
         </a>
-        <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
-              beforeSend={(e) => {
-                if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                const evt = e;
-                if (evt.metadata?.email) delete evt.metadata.email;
-                return e;
-              }}
-            />
+        <NotificationCenter>
+          <SettingsProvider>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
+                beforeSend={(e) => {
+                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                  const evt = e;
+                  if (evt.metadata?.email) delete evt.metadata.email;
+                  return e;
+                }}
+              />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
-        </SettingsProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </SettingsProvider>
+        </NotificationCenter>
       </div>
     </ErrorBoundary>
 


### PR DESCRIPTION
## Summary
- ensure the taskbar shows pinned apps alongside running windows with clear active indicators
- allow click-to-focus, Alt+click minimize, and Shift+click to relaunch an app instance from the taskbar
- surface messaging app badge counts by wiring the notification context into the shell and tagging relevant apps

## Testing
- npx eslint components/screen/taskbar.js components/screen/desktop.js pages/_app.jsx apps.config.js

------
https://chatgpt.com/codex/tasks/task_e_68d6681a4c5c8328901d7697e3bab796