### PR TITLE
[ux] Improve toast notifications

### DIFF
--- a/__tests__/liveRegion.test.tsx
+++ b/__tests__/liveRegion.test.tsx
@@ -5,7 +5,9 @@ import FormError from '../components/ui/FormError';
 
 describe('live region components', () => {
   it('Toast uses polite live region', () => {
-    const { unmount } = render(<Toast message="Saved" />);
+    const { unmount } = render(
+      <Toast id="test" message="Saved" onDismiss={() => {}} />,
+    );
     const region = screen.getByRole('status');
     expect(region).toHaveAttribute('aria-live', 'polite');
     unmount();

--- a/__tests__/metasploitPage.test.tsx
+++ b/__tests__/metasploitPage.test.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import MetasploitPage from '../apps/metasploit';
+import NotificationCenter from '../components/common/NotificationCenter';
+
+const renderWithNotifications = (ui: React.ReactElement) =>
+  render(<NotificationCenter>{ui}</NotificationCenter>);
 
 describe('Metasploit page module filtering', () => {
   it('filters modules by search and shows tags', () => {
-    render(<MetasploitPage />);
+    renderWithNotifications(<MetasploitPage />);
 
     // expand tree to reveal a known module
     fireEvent.click(screen.getAllByText('auxiliary')[0]);

--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import NmapNSEApp from '../components/apps/nmap-nse';
+import NotificationCenter from '../components/common/NotificationCenter';
+
+const renderWithNotifications = (ui: React.ReactElement) =>
+  render(<NotificationCenter>{ui}</NotificationCenter>);
 
 describe('NmapNSEApp', () => {
   it('shows example output for selected script', async () => {
@@ -18,7 +22,7 @@ describe('NmapNSEApp', () => {
         })
       );
 
-    render(<NmapNSEApp />);
+    renderWithNotifications(<NmapNSEApp />);
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
 
     await userEvent.click(screen.getByLabelText(/ftp-anon/i));
@@ -44,7 +48,7 @@ describe('NmapNSEApp', () => {
     // @ts-ignore
     navigator.clipboard = { writeText };
 
-    render(<NmapNSEApp />);
+    renderWithNotifications(<NmapNSEApp />);
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
     await userEvent.click(
       screen.getByRole('button', { name: /copy command/i })
@@ -73,7 +77,7 @@ describe('NmapNSEApp', () => {
     // @ts-ignore
     navigator.clipboard = { writeText };
 
-    render(<NmapNSEApp />);
+    renderWithNotifications(<NmapNSEApp />);
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
 
     await userEvent.click(
@@ -82,7 +86,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });
@@ -120,7 +124,7 @@ describe('NmapNSEApp', () => {
         })
       );
 
-    render(<NmapNSEApp />);
+    renderWithNotifications(<NmapNSEApp />);
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
 
     const hostNode = await screen.findByText('192.0.2.1');

--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import FormError from "../../components/ui/FormError";
-import Toast from "../../components/ui/Toast";
 import { processContactForm } from "../../components/apps/contact";
 import { contactSchema } from "../../utils/contactSchema";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openMailto } from "../../utils/mailto";
 import { trackEvent } from "@/lib/analytics-client";
+import useNotifications from "../../hooks/useNotifications";
 
 const DRAFT_KEY = "contact-draft";
 const EMAIL = "alex.unnippillil@hotmail.com";
@@ -29,11 +29,15 @@ const ContactApp: React.FC = () => {
   const [message, setMessage] = useState("");
   const [honeypot, setHoneypot] = useState("");
   const [error, setError] = useState("");
-  const [toast, setToast] = useState("");
   const [csrfToken, setCsrfToken] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [emailError, setEmailError] = useState("");
   const [messageError, setMessageError] = useState("");
+  const { pushNotification } = useNotifications();
+  const notify = useCallback(
+    (message: string) => pushNotification("Contact", message),
+    [pushNotification]
+  );
 
   useEffect(() => {
     const saved = localStorage.getItem(DRAFT_KEY);
@@ -101,7 +105,7 @@ const ContactApp: React.FC = () => {
         recaptchaToken,
       });
       if (result.success) {
-        setToast("Message sent");
+        notify("Message sent");
         setName("");
         setEmail("");
         setMessage("");
@@ -261,7 +265,6 @@ const ContactApp: React.FC = () => {
           )}
         </button>
       </form>
-      {toast && <Toast message={toast} onClose={() => setToast("")} />}
     </div>
   );
 };

--- a/apps/metasploit/index.tsx
+++ b/apps/metasploit/index.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import React, { useState, useMemo, useRef, useEffect } from 'react';
+import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import modulesData from '../../components/apps/metasploit/modules.json';
 import MetasploitApp from '../../components/apps/metasploit';
-import Toast from '../../components/ui/Toast';
+import useNotifications from '../../hooks/useNotifications';
 
 interface Module {
   name: string;
@@ -47,9 +47,13 @@ const MetasploitPage: React.FC = () => {
   const [split, setSplit] = useState(60);
   const splitRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
-  const [toast, setToast] = useState('');
   const [query, setQuery] = useState('');
   const [tag, setTag] = useState('');
+  const { pushNotification } = useNotifications();
+  const notify = useCallback(
+    (message: string) => pushNotification('Metasploit', message),
+    [pushNotification],
+  );
 
   const allTags = useMemo(
     () =>
@@ -99,7 +103,7 @@ const MetasploitPage: React.FC = () => {
     };
   }, []);
 
-  const handleGenerate = () => setToast('Payload generated');
+  const handleGenerate = () => notify('Payload generated');
 
   const renderTree = (node: TreeNode) => (
     <ul className="ml-2">
@@ -209,7 +213,6 @@ const MetasploitPage: React.FC = () => {
           </div>
         </div>
       </div>
-      {toast && <Toast message={toast} onClose={() => setToast('')} />}
     </div>
   );
 };

--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
-import Toast from '../../ui/Toast';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import useNotifications from '../../../hooks/useNotifications';
 import DiscoveryMap from './DiscoveryMap';
 
 // Basic script metadata. Example output is loaded from public/demo/nmap-nse.json
@@ -84,9 +84,13 @@ const NmapNSEApp = () => {
   const [scriptOptions, setScriptOptions] = useState({});
   const [activeScript, setActiveScript] = useState(scripts[0].name);
   const [phaseStep, setPhaseStep] = useState(0);
-  const [toast, setToast] = useState('');
   const outputRef = useRef(null);
   const phases = ['prerule', 'hostrule', 'portrule'];
+  const { pushNotification } = useNotifications();
+  const notify = useCallback(
+    (message) => pushNotification('Nmap NSE', message),
+    [pushNotification],
+  );
 
   useEffect(() => {
     fetch('/demo/nmap-nse.json')
@@ -134,7 +138,7 @@ const NmapNSEApp = () => {
     if (typeof window !== 'undefined') {
       try {
         await navigator.clipboard.writeText(command);
-        setToast('Command copied');
+        notify('Command copied');
       } catch (e) {
         // ignore
       }
@@ -148,7 +152,7 @@ const NmapNSEApp = () => {
     if (!text.trim()) return;
     try {
       await navigator.clipboard.writeText(text);
-      setToast('Output copied');
+      notify('Output copied');
     } catch (e) {
       // ignore
     }
@@ -162,7 +166,7 @@ const NmapNSEApp = () => {
     const sel = window.getSelection();
     sel.removeAllRanges();
     sel.addRange(range);
-    setToast('Output selected');
+    notify('Output selected');
   };
 
   const handleOutputKey = (e) => {
@@ -435,7 +439,6 @@ const NmapNSEApp = () => {
           </button>
         </div>
       </div>
-      {toast && <Toast message={toast} onClose={() => setToast('')} />}
     </div>
   );
 };

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,4 +1,11 @@
-import React, { createContext, useCallback, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import Toast from '../ui/Toast';
 
 export interface AppNotification {
   id: string;
@@ -16,22 +23,45 @@ export const NotificationsContext = createContext<NotificationsContextValue | nu
 
 export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const [notifications, setNotifications] = useState<Record<string, AppNotification[]>>({});
+  const [visibleToasts, setVisibleToasts] = useState<(AppNotification & { appId: string })[]>([]);
+  const queueRef = useRef<(AppNotification & { appId: string })[]>([]);
+
+  const fillVisibleToasts = useCallback(
+    (current: (AppNotification & { appId: string })[]) => {
+      let next = [...current];
+      while (next.length < 4 && queueRef.current.length > 0) {
+        const toast = queueRef.current.shift();
+        if (toast) {
+          next = [...next, toast];
+        }
+      }
+      return next;
+    },
+    [],
+  );
 
   const pushNotification = useCallback((appId: string, message: string) => {
+    const now = Date.now();
+    const toast = {
+      id: `${now}-${Math.random()}`,
+      message,
+      date: now,
+      appId,
+    };
     setNotifications(prev => {
       const list = prev[appId] ?? [];
       const next = {
         ...prev,
-        [appId]: [
-          ...list,
-          {
-            id: `${Date.now()}-${Math.random()}`,
-            message,
-            date: Date.now(),
-          },
-        ],
+        [appId]: [...list, { id: toast.id, message, date: toast.date }],
       };
       return next;
+    });
+    setVisibleToasts(prev => {
+      if (prev.length >= 4) {
+        queueRef.current = [...queueRef.current, toast];
+        return prev;
+      }
+      return [...prev, toast];
     });
   }, []);
 
@@ -42,7 +72,21 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
       delete next[appId];
       return next;
     });
-  }, []);
+    if (!appId) {
+      queueRef.current = [];
+      setVisibleToasts([]);
+      return;
+    }
+    queueRef.current = queueRef.current.filter(toast => toast.appId !== appId);
+    setVisibleToasts(prev => fillVisibleToasts(prev.filter(toast => toast.appId !== appId)));
+  }, [fillVisibleToasts]);
+
+  const dismissToast = useCallback(
+    (id: string) => {
+      setVisibleToasts(prev => fillVisibleToasts(prev.filter(toast => toast.id !== id)));
+    },
+    [fillVisibleToasts],
+  );
 
   const totalCount = Object.values(notifications).reduce(
     (sum, list) => sum + list.length,
@@ -62,6 +106,20 @@ export const NotificationCenter: React.FC<{ children?: React.ReactNode }> = ({ c
       value={{ notifications, pushNotification, clearNotifications }}
     >
       {children}
+      {visibleToasts.length > 0 && (
+        <div className="pointer-events-none fixed bottom-4 right-4 z-[1000] flex flex-col gap-2">
+          {visibleToasts.map(toast => (
+            <Toast
+              key={toast.id}
+              id={toast.id}
+              message={toast.message}
+              appId={toast.appId}
+              onDismiss={dismissToast}
+              duration={5000}
+            />
+          ))}
+        </div>
+      )}
       <div className="notification-center">
         {Object.entries(notifications).map(([appId, list]) => (
           <section key={appId} className="notification-group">

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,48 +1,95 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 interface ToastProps {
+  id: string;
   message: string;
-  actionLabel?: string;
-  onAction?: () => void;
-  onClose?: () => void;
+  appId?: string;
+  onDismiss: (id: string) => void;
   duration?: number;
 }
 
 const Toast: React.FC<ToastProps> = ({
+  id,
   message,
-  actionLabel,
-  onAction,
-  onClose,
-  duration = 6000,
+  appId,
+  onDismiss,
+  duration = 5000,
 }) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const [visible, setVisible] = useState(false);
+  const startRef = useRef<number | null>(null);
+  const remainingRef = useRef(duration);
+  const [hovering, setHovering] = useState(false);
+
+  const clearTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const startTimer = useCallback(() => {
+    if (remainingRef.current <= 0) {
+      onDismiss(id);
+      return;
+    }
+    clearTimer();
+    startRef.current = Date.now();
+    timeoutRef.current = setTimeout(() => {
+      onDismiss(id);
+    }, remainingRef.current);
+  }, [clearTimer, id, onDismiss]);
 
   useEffect(() => {
-    setVisible(true);
-    timeoutRef.current = setTimeout(() => {
-      onClose && onClose();
-    }, duration);
+    remainingRef.current = duration;
+    startTimer();
     return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      clearTimer();
     };
-  }, [duration, onClose]);
+  }, [clearTimer, duration, startTimer]);
+
+  const handleMouseEnter = () => {
+    setHovering(true);
+    if (startRef.current == null) return;
+    const elapsed = Date.now() - startRef.current;
+    remainingRef.current = Math.max(0, remainingRef.current - elapsed);
+    clearTimer();
+  };
+
+  const handleMouseLeave = () => {
+    setHovering(false);
+    if (remainingRef.current <= 0) {
+      onDismiss(id);
+      return;
+    }
+    startTimer();
+  };
+
+  const handleDismiss = () => {
+    clearTimer();
+    onDismiss(id);
+  };
 
   return (
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      className="pointer-events-auto flex w-80 max-w-full items-start gap-3 rounded-md border border-gray-700 bg-gray-900/95 p-4 text-white shadow-lg backdrop-blur transition duration-150 ease-in-out"
     >
-      <span>{message}</span>
-      {onAction && actionLabel && (
-        <button
-          onClick={onAction}
-          className="ml-4 underline focus:outline-none"
-        >
-          {actionLabel}
-        </button>
-      )}
+      <div className="flex-1 space-y-1">
+        {appId && <p className="text-xs uppercase text-gray-400">{appId}</p>}
+        <p className="text-sm leading-snug">{message}</p>
+      </div>
+      <button
+        type="button"
+        aria-label="Dismiss notification"
+        onClick={handleDismiss}
+        className="rounded p-1 text-gray-400 transition hover:bg-gray-800 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-yellow"
+      >
+        <span aria-hidden="true">×</span>
+      </button>
+      {hovering && <span className="sr-only">Timer paused</span>}
     </div>
   );
 };

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -13,6 +13,7 @@ import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import PipPortalProvider from '../components/common/PipPortal';
+import NotificationCenter from '../components/common/NotificationCenter';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
@@ -157,11 +158,12 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <PipPortalProvider>
-            <div aria-live="polite" id="live-region" />
-            <Component {...pageProps} />
-            <ShortcutOverlay />
-            <Analytics
+          <NotificationCenter>
+            <PipPortalProvider>
+              <div aria-live="polite" id="live-region" />
+              <Component {...pageProps} />
+              <ShortcutOverlay />
+              <Analytics
               beforeSend={(e) => {
                 if (e.url.includes('/admin') || e.url.includes('/private')) return null;
                 const evt = e;
@@ -170,8 +172,9 @@ function MyApp(props) {
               }}
             />
 
-            {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-          </PipPortalProvider>
+              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+            </PipPortalProvider>
+          </NotificationCenter>
         </SettingsProvider>
       </div>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- upgrade the shared Toast component with hover-pausing timers and bottom-right styling so multiple messages can stack
- extend NotificationCenter to queue up to four concurrent toasts while keeping historical notifications, and wrap the app plus hooks-based features to publish through it
- migrate contact, Metasploit, Nmap NSE, and game overlays to push notifications and update related tests to render within the provider

## Testing
- `yarn lint` *(fails: repository contains hundreds of existing jsx-a11y label errors and public JS globals flagged by the custom no-top-level-window rule)*
- `yarn test --watch=false` *(fails: existing suites access localStorage in jsdom and emit act() warnings unrelated to the toast changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d6681c31fc83289e02b2151d3b96f2