### PR TITLE
[desktop] centralize global shortcuts

### DIFF
--- a/__tests__/ShortcutOverlay.test.tsx
+++ b/__tests__/ShortcutOverlay.test.tsx
@@ -17,12 +17,12 @@ describe('ShortcutOverlay', () => {
     );
     render(<ShortcutOverlay />);
     fireEvent.keyDown(window, { key: 'a' });
-    expect(
-      screen.getByText('Show keyboard shortcuts')
-    ).toBeInTheDocument();
-    expect(screen.getByText('Open settings')).toBeInTheDocument();
-    const items = screen.getAllByRole('listitem');
-    expect(items[0]).toHaveAttribute('data-conflict', 'true');
-    expect(items[1]).toHaveAttribute('data-conflict', 'true');
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    const showRow = screen
+      .getByText('Show keyboard shortcuts')
+      .closest('tr');
+    const settingsRow = screen.getByText('Open settings').closest('tr');
+    expect(showRow).toHaveAttribute('data-conflict', 'true');
+    expect(settingsRow).toHaveAttribute('data-conflict', 'true');
   });
 });

--- a/__tests__/shortcutsConfig.test.ts
+++ b/__tests__/shortcutsConfig.test.ts
@@ -1,0 +1,29 @@
+import { GLOBAL_SHORTCUTS, resolveShortcuts } from '../hooks/useShortcuts';
+
+describe('shortcut registry', () => {
+  test('has unique identifiers and bindings', () => {
+    const ids = new Set<string>();
+    const bindings = new Set<string>();
+    for (const shortcut of GLOBAL_SHORTCUTS) {
+      expect(ids.has(shortcut.id)).toBe(false);
+      ids.add(shortcut.id);
+      expect(bindings.has(shortcut.binding)).toBe(false);
+      bindings.add(shortcut.binding);
+    }
+  });
+
+  test('surfacing overrides reveals potential conflicts', () => {
+    const overrides = new Map<string, string>([
+      ['system.settings', 'A'],
+      ['help.shortcuts', 'A'],
+    ]);
+    const resolved = resolveShortcuts(overrides);
+    const conflicts = resolved.filter((shortcut) =>
+      resolved.some(
+        (candidate) =>
+          candidate !== shortcut && candidate.keys === shortcut.keys
+      )
+    );
+    expect(conflicts).toHaveLength(2);
+  });
+});

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -519,46 +519,42 @@ export class Window extends Component {
     }
 
     handleKeyDown = (e) => {
+        const prevent = () => {
+            if (typeof e.preventDefault === 'function') e.preventDefault();
+            if (typeof e.stopPropagation === 'function') e.stopPropagation();
+        };
         if (e.key === 'Escape') {
             this.closeWindow();
         } else if (e.key === 'Tab') {
             this.focusWindow();
         } else if (e.altKey) {
             if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.unsnapWindow();
             } else if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.snapWindow('left');
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.snapWindow('right');
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.snapWindow('top');
             }
             this.focusWindow();
         } else if (e.shiftKey) {
             const step = 1;
             if (e.key === 'ArrowLeft') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ width: Math.max(prev.width - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowRight') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ width: Math.min(prev.width + step, 100) }), this.resizeBoundries);
             } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ height: Math.max(prev.height - step, 20) }), this.resizeBoundries);
             } else if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                e.stopPropagation();
+                prevent();
                 this.setState(prev => ({ height: Math.min(prev.height + step, 100) }), this.resizeBoundries);
             }
             this.focusWindow();

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { getShortcutById, matchesShortcut } from '../../hooks/useShortcuts';
 
 type AppMeta = {
   id: string;
@@ -77,8 +78,9 @@ const WhiskerMenu: React.FC = () => {
   };
 
   useEffect(() => {
+    const toggleShortcut = getShortcutById('launcher.toggle');
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Meta' && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+      if (toggleShortcut && matchesShortcut(e, toggleShortcut.binding)) {
         e.preventDefault();
         setOpen(o => !o);
         return;

--- a/hooks/useShortcuts.ts
+++ b/hooks/useShortcuts.ts
@@ -1,0 +1,320 @@
+import { useMemo } from 'react';
+
+export type ShortcutCategory =
+  | 'Launcher'
+  | 'Window management'
+  | 'Utilities'
+  | 'System'
+  | 'Help';
+
+export interface ShortcutDefinition {
+  /** Stable identifier used for lookups and overrides. */
+  id: string;
+  /** Human-readable description for UI surfaces. */
+  description: string;
+  /** Semantic category used to group shortcuts in help overlays. */
+  category: ShortcutCategory;
+  /** Canonical binding string using modifier+key syntax (e.g. `Ctrl+Shift+V`). */
+  binding: string;
+  /** Optional label override for displaying the binding. */
+  display?: string;
+  /** Whether the shortcut can be remapped by the user. */
+  customizable?: boolean;
+}
+
+export interface ResolvedShortcut extends ShortcutDefinition {
+  /** The active key combination after applying overrides. */
+  keys: string;
+  /** Formatted label that should be rendered to end users. */
+  label: string;
+}
+
+/**
+ * Canonical registry of desktop-level keyboard shortcuts. All other modules
+ * should import definitions from here so the bindings stay in sync.
+ */
+export const GLOBAL_SHORTCUTS: ShortcutDefinition[] = [
+  {
+    id: 'launcher.toggle',
+    description: 'Toggle application launcher',
+    category: 'Launcher',
+    binding: 'Meta',
+    display: 'Win',
+  },
+  {
+    id: 'launcher.slot1',
+    description: 'Open first dock item',
+    category: 'Launcher',
+    binding: 'Meta+Digit1',
+    display: 'Win+1',
+  },
+  {
+    id: 'launcher.slot2',
+    description: 'Open second dock item',
+    category: 'Launcher',
+    binding: 'Meta+Digit2',
+    display: 'Win+2',
+  },
+  {
+    id: 'launcher.slot3',
+    description: 'Open third dock item',
+    category: 'Launcher',
+    binding: 'Meta+Digit3',
+    display: 'Win+3',
+  },
+  {
+    id: 'launcher.slot4',
+    description: 'Open fourth dock item',
+    category: 'Launcher',
+    binding: 'Meta+Digit4',
+    display: 'Win+4',
+  },
+  {
+    id: 'window.switcher.forward',
+    description: 'Cycle windows forward',
+    category: 'Window management',
+    binding: 'Alt+Tab',
+  },
+  {
+    id: 'window.switcher.backward',
+    description: 'Cycle windows backward',
+    category: 'Window management',
+    binding: 'Shift+Alt+Tab',
+  },
+  {
+    id: 'window.switcher.sameApp',
+    description: 'Cycle windows of focused app',
+    category: 'Window management',
+    binding: 'Alt+Backquote',
+    display: 'Alt+`',
+  },
+  {
+    id: 'window.switcher.sameAppBackward',
+    description: 'Cycle windows of focused app backward',
+    category: 'Window management',
+    binding: 'Shift+Alt+Backquote',
+    display: 'Shift+Alt+`',
+  },
+  {
+    id: 'window.snap.left',
+    description: 'Snap focused window left',
+    category: 'Window management',
+    binding: 'Meta+ArrowLeft',
+    display: 'Win+←',
+  },
+  {
+    id: 'window.snap.right',
+    description: 'Snap focused window right',
+    category: 'Window management',
+    binding: 'Meta+ArrowRight',
+    display: 'Win+→',
+  },
+  {
+    id: 'window.snap.up',
+    description: 'Maximize focused window',
+    category: 'Window management',
+    binding: 'Meta+ArrowUp',
+    display: 'Win+↑',
+  },
+  {
+    id: 'window.snap.down',
+    description: 'Restore/minimize focused window',
+    category: 'Window management',
+    binding: 'Meta+ArrowDown',
+    display: 'Win+↓',
+  },
+  {
+    id: 'utilities.clipboard',
+    description: 'Open clipboard manager',
+    category: 'Utilities',
+    binding: 'Ctrl+Shift+V',
+  },
+  {
+    id: 'system.settings',
+    description: 'Open settings',
+    category: 'System',
+    binding: 'Ctrl+,',
+    customizable: true,
+  },
+  {
+    id: 'system.screenshot',
+    description: 'Capture desktop screenshot',
+    category: 'System',
+    binding: 'PrintScreen',
+  },
+  {
+    id: 'help.shortcuts',
+    description: 'Show keyboard shortcuts',
+    category: 'Help',
+    binding: '?',
+    customizable: true,
+  },
+];
+
+const SHORTCUT_LOOKUP = new Map(GLOBAL_SHORTCUTS.map((shortcut) => [shortcut.id, shortcut]));
+
+const DISPLAY_TOKEN_MAP: Record<string, string> = {
+  Alt: 'Alt',
+  Ctrl: 'Ctrl',
+  Meta: 'Win',
+  Shift: 'Shift',
+  ArrowLeft: '←',
+  ArrowRight: '→',
+  ArrowUp: '↑',
+  ArrowDown: '↓',
+  Backquote: '`',
+  PrintScreen: 'Print Screen',
+};
+
+const isCharacterKey = (token: string) => token.length === 1;
+
+const normaliseToken = (token: string) => {
+  if (token.startsWith('Digit')) {
+    return token.replace('Digit', '');
+  }
+  if (token.startsWith('Key')) {
+    return token.replace('Key', '').toUpperCase();
+  }
+  return DISPLAY_TOKEN_MAP[token] || token;
+};
+
+const modifierOrder = ['Ctrl', 'Shift', 'Alt', 'Meta'] as const;
+
+const parseBinding = (binding: string) => binding.split('+').filter(Boolean);
+
+const extractKey = (tokens: string[]) => {
+  const modifiers = new Set(modifierOrder);
+  for (const token of tokens) {
+    if (!modifiers.has(token as (typeof modifierOrder)[number])) {
+      return token;
+    }
+  }
+  // Modifier-only shortcut such as `Meta`
+  return tokens[tokens.length - 1] || '';
+};
+
+export const formatShortcutLabel = (binding: string) => {
+  const tokens = parseBinding(binding);
+  if (tokens.length === 0) return '';
+  const keyToken = extractKey(tokens);
+  const formatted = tokens.map((token) => {
+    if (token === keyToken) {
+      if (keyToken === 'Meta' && tokens.length === 1) {
+        return normaliseToken('Meta');
+      }
+      return normaliseToken(token);
+    }
+    return normaliseToken(token);
+  });
+  return formatted.join('+');
+};
+
+const modifierFlags: Record<string, keyof KeyboardEvent> = {
+  Alt: 'altKey',
+  Ctrl: 'ctrlKey',
+  Meta: 'metaKey',
+  Shift: 'shiftKey',
+};
+
+const normaliseEventKey = (event: KeyboardEvent) => {
+  if (event.key.length === 1) {
+    return event.key.toUpperCase();
+  }
+  return event.key;
+};
+
+const matchesKeyToken = (event: KeyboardEvent, token: string) => {
+  if (token === 'Meta' && event.key === 'Meta') return true;
+  if (token.startsWith('Digit')) {
+    return event.code === token || event.key === token.replace('Digit', '');
+  }
+  if (token.startsWith('Key')) {
+    return normaliseEventKey(event) === token.replace('Key', '').toUpperCase();
+  }
+  if (token === 'Backquote') {
+    return event.code === 'Backquote' || event.key === '`' || event.key === '~';
+  }
+  if (isCharacterKey(token)) {
+    return normaliseEventKey(event) === token.toUpperCase();
+  }
+  return normaliseEventKey(event) === token;
+};
+
+/**
+ * Determine whether the provided keyboard event matches the given binding.
+ */
+export const matchesShortcut = (event: KeyboardEvent, binding: string) => {
+  const tokens = parseBinding(binding);
+  if (tokens.length === 0) return false;
+  const requiredModifiers = new Set<string>();
+  tokens.forEach((token) => {
+    if (modifierFlags[token]) {
+      requiredModifiers.add(token);
+    }
+  });
+
+  for (const [token, flag] of Object.entries(modifierFlags)) {
+    const required = requiredModifiers.has(token);
+    if (event[flag] !== required) {
+      return false;
+    }
+  }
+
+  const keyToken = extractKey(tokens);
+  return matchesKeyToken(event, keyToken);
+};
+
+/**
+ * Resolve the shortcut bindings, applying any overrides.
+ */
+export const resolveShortcuts = (overrides?: Map<string, string>): ResolvedShortcut[] =>
+  GLOBAL_SHORTCUTS.map((shortcut) => {
+    const keys =
+      shortcut.customizable && overrides?.get(shortcut.id)
+        ? overrides.get(shortcut.id) || shortcut.binding
+        : shortcut.binding;
+    return {
+      ...shortcut,
+      keys,
+      label: shortcut.display || formatShortcutLabel(keys),
+    };
+  });
+
+export const useShortcuts = (overrides?: Map<string, string>) =>
+  useMemo(() => resolveShortcuts(overrides), [overrides]);
+
+export const getShortcutById = (id: string) => SHORTCUT_LOOKUP.get(id);
+
+export const getShortcutBinding = (id: string): string | undefined => {
+  const shortcut = SHORTCUT_LOOKUP.get(id);
+  if (!shortcut) return undefined;
+  if (!shortcut.customizable || typeof window === 'undefined') {
+    return shortcut.binding;
+  }
+  try {
+    const stored = window.localStorage.getItem('keymap');
+    if (stored) {
+      const parsed = JSON.parse(stored) as Record<string, unknown>;
+      const value = parsed?.[shortcut.description];
+      if (typeof value === 'string') {
+        return value;
+      }
+    }
+  } catch {
+    // ignore malformed storage values
+  }
+  return shortcut.binding;
+};
+
+export const groupShortcutsByCategory = (shortcuts: ResolvedShortcut[]) => {
+  const groups = new Map<ShortcutCategory, ResolvedShortcut[]>();
+  shortcuts.forEach((shortcut) => {
+    const list = groups.get(shortcut.category) || [];
+    list.push(shortcut);
+    groups.set(shortcut.category, list);
+  });
+  return Array.from(groups.entries()).map(([category, items]) => ({
+    category,
+    items,
+  }));
+};

--- a/pages/keyboard-reference.tsx
+++ b/pages/keyboard-reference.tsx
@@ -1,40 +1,57 @@
 import React from 'react';
+import {
+  groupShortcutsByCategory,
+  resolveShortcuts,
+} from '../hooks/useShortcuts';
 
-const KeyboardReference = () => (
-  <main className="min-h-screen bg-ub-cool-grey text-white p-4 space-y-4">
-    <h1 className="text-2xl font-bold">Keyboard Mapping Reference</h1>
-    <p className="mb-4">Common shortcuts for navigating and interacting with the desktop.</p>
-    <table className="w-full border-collapse">
-      <thead>
-        <tr>
-          <th className="p-2 text-left border border-ubt-grey">Key</th>
-          <th className="p-2 text-left border border-ubt-grey">Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Ctrl + C</td>
-          <td className="p-2 border border-ubt-grey">Copy selected text</td>
-        </tr>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Ctrl + V</td>
-          <td className="p-2 border border-ubt-grey">Paste from clipboard</td>
-        </tr>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Ctrl + X</td>
-          <td className="p-2 border border-ubt-grey">Cut selected text</td>
-        </tr>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Alt + Tab</td>
-          <td className="p-2 border border-ubt-grey">Switch between apps</td>
-        </tr>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Alt + F4</td>
-          <td className="p-2 border border-ubt-grey">Close current window</td>
-        </tr>
-      </tbody>
-    </table>
-  </main>
-);
+const KeyboardReference = () => {
+  const shortcuts = resolveShortcuts();
+  const grouped = groupShortcutsByCategory(shortcuts);
+
+  return (
+    <main className="min-h-screen bg-ub-cool-grey text-white p-4 space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-bold">Keyboard Mapping Reference</h1>
+        <p className="max-w-3xl text-sm text-gray-200">
+          These shortcuts mirror the desktop environment. Use them to quickly open
+          apps, manage windows, and capture screenshots.
+        </p>
+      </header>
+      <div className="space-y-6">
+        {grouped.map(({ category, items }) => (
+          <section key={category} aria-label={`${category} shortcuts`}>
+            <h2 className="text-xl font-semibold mb-3">{category}</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full border-separate border-spacing-y-1">
+                <thead>
+                  <tr className="text-left text-sm uppercase tracking-wider text-gray-300">
+                    <th scope="col" className="px-3 py-2">
+                      Keys
+                    </th>
+                    <th scope="col" className="px-3 py-2">
+                      Description
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((shortcut) => (
+                    <tr key={shortcut.id} className="bg-black/40">
+                      <td className="px-3 py-2 font-mono whitespace-nowrap align-middle">
+                        {shortcut.label}
+                      </td>
+                      <td className="px-3 py-2 align-middle">
+                        {shortcut.description}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+};
 
 export default KeyboardReference;


### PR DESCRIPTION
## Summary
- add a canonical `useShortcuts` registry for launcher, window management, utility and help bindings
- refactor the desktop shell, shortcut overlay, Whisker menu, keyboard reference, and keymap settings to consume the shared definitions
- document and test shortcut uniqueness while improving the overlay UI and safeguarding window keyboard handlers

## Testing
- yarn test __tests__/shortcutsConfig.test.ts
- yarn test __tests__/ShortcutOverlay.test.tsx
- yarn test __tests__/window.test.tsx
- yarn test *(fails in existing suites such as nmapNse and contact API due to upstream issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d6681e21e4832887f0cec794ea2ff1