### PR TITLE
[settings] Add tabbed desktop settings panel

### DIFF
--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import Tabs from "../Tabs";
 import ToggleSwitch from "../ToggleSwitch";
-
-const PANEL_PREFIX = "xfce.panel.";
+import { useSettings } from "../../hooks/useSettings";
 
 export default function Preferences() {
   type TabId = "display" | "measurements" | "appearance" | "opacity" | "items";
@@ -17,48 +16,16 @@ export default function Preferences() {
   ];
 
   const [active, setActive] = useState<TabId>("display");
-
-  const [size, setSize] = useState(() => {
-    if (typeof window === "undefined") return 24;
-    const stored = localStorage.getItem(`${PANEL_PREFIX}size`);
-    return stored ? parseInt(stored, 10) : 24;
-  });
-  const [length, setLength] = useState(() => {
-    if (typeof window === "undefined") return 100;
-    const stored = localStorage.getItem(`${PANEL_PREFIX}length`);
-    return stored ? parseInt(stored, 10) : 100;
-  });
-  const [orientation, setOrientation] = useState<"horizontal" | "vertical">(() => {
-    if (typeof window === "undefined") return "horizontal";
-    return (localStorage.getItem(`${PANEL_PREFIX}orientation`) as
-      | "horizontal"
-      | "vertical"
-      | null) || "horizontal";
-  });
-  const [autohide, setAutohide] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return localStorage.getItem(`${PANEL_PREFIX}autohide`) === "true";
-  });
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}size`, String(size));
-  }, [size]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}length`, String(length));
-  }, [length]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}orientation`, orientation);
-  }, [orientation]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}autohide`, autohide ? "true" : "false");
-  }, [autohide]);
+  const {
+    panelPosition,
+    setPanelPosition,
+    panelSize,
+    setPanelSize,
+    panelOpacity,
+    setPanelOpacity,
+    panelAutohide,
+    setPanelAutohide,
+  } = useSettings();
 
   return (
     <div>
@@ -68,25 +35,25 @@ export default function Preferences() {
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <label htmlFor="orientation" className="text-ubt-grey">
-                Orientation
+                Dock position
               </label>
               <select
                 id="orientation"
-                value={orientation}
+                value={panelPosition}
                 onChange={(e) =>
-                  setOrientation(e.target.value as "horizontal" | "vertical")
+                  setPanelPosition(e.target.value as "top" | "bottom")
                 }
                 className="bg-ub-cool-grey text-white px-2 py-1 rounded"
               >
-                <option value="horizontal">Horizontal</option>
-                <option value="vertical">Vertical</option>
+                <option value="bottom">Bottom</option>
+                <option value="top">Top</option>
               </select>
             </div>
             <div className="flex items-center justify-between">
               <span className="text-ubt-grey">Autohide</span>
               <ToggleSwitch
-                checked={autohide}
-                onChange={setAutohide}
+                checked={panelAutohide}
+                onChange={setPanelAutohide}
                 ariaLabel="Autohide panel"
               />
             </div>
@@ -96,44 +63,51 @@ export default function Preferences() {
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <label htmlFor="panel-size" className="text-ubt-grey">
-                Size: {size}px
+                Size: {panelSize}px
               </label>
               <input
                 id="panel-size"
                 type="range"
                 min="16"
                 max="128"
-                value={size}
-                onChange={(e) => setSize(parseInt(e.target.value, 10))}
+                value={panelSize}
+                onChange={(e) => setPanelSize(parseInt(e.target.value, 10))}
                 className="ubuntu-slider"
                 aria-label="Panel size"
-              />
-            </div>
-            <div className="flex items-center justify-between">
-              <label htmlFor="panel-length" className="text-ubt-grey">
-                Length: {length}%
-              </label>
-              <input
-                id="panel-length"
-                type="range"
-                min="10"
-                max="100"
-                value={length}
-                onChange={(e) => setLength(parseInt(e.target.value, 10))}
-                className="ubuntu-slider"
-                aria-label="Panel length"
               />
             </div>
           </div>
         )}
         {active === "appearance" && (
-          <p className="text-ubt-grey">Appearance settings are not available yet.</p>
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <label htmlFor="panel-opacity" className="text-ubt-grey">
+                Opacity: {Math.round(panelOpacity * 100)}%
+              </label>
+              <input
+                id="panel-opacity"
+                type="range"
+                min="0.1"
+                max="1"
+                step="0.05"
+                value={panelOpacity}
+                onChange={(e) => setPanelOpacity(parseFloat(e.target.value))}
+                className="ubuntu-slider"
+                aria-label="Panel opacity"
+              />
+            </div>
+          </div>
         )}
         {active === "opacity" && (
-          <p className="text-ubt-grey">Opacity settings are not available yet.</p>
+          <p className="text-ubt-grey">
+            Additional opacity controls are managed from the main Settings app.
+          </p>
         )}
         {active === "items" && (
-          <p className="text-ubt-grey">Item settings are not available yet.</p>
+          <p className="text-ubt-grey">
+            Item management is coming soon. Use the desktop favorites menu to
+            pin or remove applications.
+          </p>
         )}
       </div>
     </div>

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,8 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Image from 'next/image';
+import { useSettings } from '../../hooks/useSettings';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const {
+        panelPosition,
+        panelSize,
+        panelOpacity,
+        panelAutohide,
+        workspaceCount,
+        workspaceNames,
+    } = useSettings();
+    const [hovered, setHovered] = useState(false);
 
     const handleClick = (app) => {
         const id = app.id;
@@ -15,8 +25,27 @@ export default function Taskbar(props) {
         }
     };
 
+    const translate = panelAutohide && !hovered
+        ? (panelPosition === 'top' ? 'translateY(calc(-100% + 8px))' : 'translateY(calc(100% - 8px))')
+        : 'translateY(0)';
+
+    const panelStyle = {
+        height: `${panelSize}px`,
+        backgroundColor: `rgba(0, 0, 0, ${panelOpacity})`,
+        transform: translate,
+        transition: 'transform var(--motion-medium)',
+    };
+
+    const indicatorNames = workspaceNames.slice(0, workspaceCount);
+
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div
+            className={`desktop-panel absolute left-0 w-full flex items-center z-40 ${panelPosition === 'top' ? 'top-0' : 'bottom-0'}`}
+            style={panelStyle}
+            role="toolbar"
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+        >
             {runningApps.map(app => (
                 <button
                     key={app.id}
@@ -42,6 +71,20 @@ export default function Taskbar(props) {
                     )}
                 </button>
             ))}
+            {indicatorNames.length > 0 && (
+                <div className="ml-auto flex items-center gap-2 pr-3">
+                    {indicatorNames.map((name, index) => (
+                        <span
+                            key={`${name}-${index}`}
+                            title={name}
+                            className="px-2 py-1 text-xs rounded bg-white bg-opacity-10 text-white"
+                            aria-label={`Workspace ${index + 1}: ${name}`}
+                        >
+                            {index + 1}
+                        </span>
+                    ))}
+                </div>
+            )}
         </div>
     );
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -60,6 +60,10 @@
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
+  /* Desktop controls */
+  --panel-size: 40px;
+  --panel-opacity: 0.5;
+  --workspace-count: 4;
 }
 
 /* High contrast theme */

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { get, set, del } from 'idb-keyval';
+import { safeLocalStorage } from './safeStorage';
 import { getTheme, setTheme } from './theme';
 
 const DEFAULT_SETTINGS = {
@@ -14,41 +15,79 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  panelPosition: 'bottom',
+  panelSize: 40,
+  panelOpacity: 0.5,
+  panelAutohide: false,
+  workspaceCount: 4,
+  workspaceNames: ['Desktop 1', 'Desktop 2', 'Desktop 3', 'Desktop 4'],
 };
 
 export async function getAccent() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
-  return (await get('accent')) || DEFAULT_SETTINGS.accent;
+  const localValue = safeLocalStorage?.getItem('accent');
+  if (localValue) return localValue;
+  try {
+    const idbValue = await get('accent');
+    if (idbValue) {
+      safeLocalStorage?.setItem('accent', idbValue);
+      return idbValue;
+    }
+  } catch {
+    /* ignore */
+  }
+  return DEFAULT_SETTINGS.accent;
 }
 
 export async function setAccent(accent) {
   if (typeof window === 'undefined') return;
-  await set('accent', accent);
+  safeLocalStorage?.setItem('accent', accent);
+  try {
+    await set('accent', accent);
+  } catch {
+    /* ignore */
+  }
 }
 
 export async function getWallpaper() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
-  return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
+  const localValue = safeLocalStorage?.getItem('bg-image');
+  if (localValue) return localValue;
+  try {
+    const idbValue = await get('bg-image');
+    if (idbValue) {
+      safeLocalStorage?.setItem('bg-image', idbValue);
+      return idbValue;
+    }
+  } catch {
+    /* ignore */
+  }
+  return DEFAULT_SETTINGS.wallpaper;
 }
 
 export async function setWallpaper(wallpaper) {
   if (typeof window === 'undefined') return;
-  await set('bg-image', wallpaper);
+  safeLocalStorage?.setItem('bg-image', wallpaper);
+  try {
+    await set('bg-image', wallpaper);
+  } catch {
+    /* ignore */
+  }
 }
 
 export async function getDensity() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  return safeLocalStorage?.getItem('density') || DEFAULT_SETTINGS.density;
 }
 
 export async function setDensity(density) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
+  safeLocalStorage?.setItem('density', density);
 }
 
 export async function getReducedMotion() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  const stored = window.localStorage.getItem('reduced-motion');
+  const stored = safeLocalStorage?.getItem('reduced-motion');
   if (stored !== null) {
     return stored === 'true';
   }
@@ -57,70 +96,142 @@ export async function getReducedMotion() {
 
 export async function setReducedMotion(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+  safeLocalStorage?.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
+  const stored = safeLocalStorage?.getItem('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  safeLocalStorage?.setItem('font-scale', String(scale));
 }
 
 export async function getHighContrast() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  return safeLocalStorage?.getItem('high-contrast') === 'true';
 }
 
 export async function setHighContrast(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+  safeLocalStorage?.setItem('high-contrast', value ? 'true' : 'false');
 }
 
 export async function getLargeHitAreas() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
+  return safeLocalStorage?.getItem('large-hit-areas') === 'true';
 }
 
 export async function setLargeHitAreas(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
+  safeLocalStorage?.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
 export async function getHaptics() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
-  const val = window.localStorage.getItem('haptics');
+  const val = safeLocalStorage?.getItem('haptics');
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
 export async function setHaptics(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('haptics', value ? 'true' : 'false');
+  safeLocalStorage?.setItem('haptics', value ? 'true' : 'false');
 }
 
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
+  const val = safeLocalStorage?.getItem('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
 export async function setPongSpin(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
+  safeLocalStorage?.setItem('pong-spin', value ? 'true' : 'false');
 }
 
 export async function getAllowNetwork() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
+  return safeLocalStorage?.getItem('allow-network') === 'true';
 }
 
 export async function setAllowNetwork(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+  safeLocalStorage?.setItem('allow-network', value ? 'true' : 'false');
+}
+
+export async function getPanelPosition() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.panelPosition;
+  return (
+    safeLocalStorage?.getItem('panel-position') || DEFAULT_SETTINGS.panelPosition
+  );
+}
+
+export async function setPanelPosition(value) {
+  if (typeof window === 'undefined') return;
+  safeLocalStorage?.setItem('panel-position', value);
+}
+
+export async function getPanelSize() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.panelSize;
+  const stored = safeLocalStorage?.getItem('panel-size');
+  return stored ? parseInt(stored, 10) : DEFAULT_SETTINGS.panelSize;
+}
+
+export async function setPanelSize(value) {
+  if (typeof window === 'undefined') return;
+  safeLocalStorage?.setItem('panel-size', String(value));
+}
+
+export async function getPanelOpacity() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.panelOpacity;
+  const stored = safeLocalStorage?.getItem('panel-opacity');
+  return stored ? parseFloat(stored) : DEFAULT_SETTINGS.panelOpacity;
+}
+
+export async function setPanelOpacity(value) {
+  if (typeof window === 'undefined') return;
+  safeLocalStorage?.setItem('panel-opacity', String(value));
+}
+
+export async function getPanelAutohide() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.panelAutohide;
+  return safeLocalStorage?.getItem('panel-autohide') === 'true';
+}
+
+export async function setPanelAutohide(value) {
+  if (typeof window === 'undefined') return;
+  safeLocalStorage?.setItem('panel-autohide', value ? 'true' : 'false');
+}
+
+export async function getWorkspaceCount() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.workspaceCount;
+  const stored = safeLocalStorage?.getItem('workspace-count');
+  return stored ? parseInt(stored, 10) : DEFAULT_SETTINGS.workspaceCount;
+}
+
+export async function setWorkspaceCount(value) {
+  if (typeof window === 'undefined') return;
+  safeLocalStorage?.setItem('workspace-count', String(value));
+}
+
+export async function getWorkspaceNames() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.workspaceNames;
+  try {
+    const stored = safeLocalStorage?.getItem('workspace-names');
+    if (!stored) return DEFAULT_SETTINGS.workspaceNames;
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : DEFAULT_SETTINGS.workspaceNames;
+  } catch {
+    return DEFAULT_SETTINGS.workspaceNames;
+  }
+}
+
+export async function setWorkspaceNames(value) {
+  if (typeof window === 'undefined') return;
+  safeLocalStorage?.setItem('workspace-names', JSON.stringify(value));
 }
 
 export async function resetSettings() {
@@ -129,14 +240,20 @@ export async function resetSettings() {
     del('accent'),
     del('bg-image'),
   ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
+  safeLocalStorage?.removeItem('density');
+  safeLocalStorage?.removeItem('reduced-motion');
+  safeLocalStorage?.removeItem('font-scale');
+  safeLocalStorage?.removeItem('high-contrast');
+  safeLocalStorage?.removeItem('large-hit-areas');
+  safeLocalStorage?.removeItem('pong-spin');
+  safeLocalStorage?.removeItem('allow-network');
+  safeLocalStorage?.removeItem('haptics');
+  safeLocalStorage?.removeItem('panel-position');
+  safeLocalStorage?.removeItem('panel-size');
+  safeLocalStorage?.removeItem('panel-opacity');
+  safeLocalStorage?.removeItem('panel-autohide');
+  safeLocalStorage?.removeItem('workspace-count');
+  safeLocalStorage?.removeItem('workspace-names');
 }
 
 export async function exportSettings() {
@@ -151,6 +268,12 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    panelPosition,
+    panelSize,
+    panelOpacity,
+    panelAutohide,
+    workspaceCount,
+    workspaceNames,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -162,6 +285,12 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getPanelPosition(),
+    getPanelSize(),
+    getPanelOpacity(),
+    getPanelAutohide(),
+    getWorkspaceCount(),
+    getWorkspaceNames(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -175,6 +304,12 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    panelPosition,
+    panelSize,
+    panelOpacity,
+    panelAutohide,
+    workspaceCount,
+    workspaceNames,
     theme,
   });
 }
@@ -199,6 +334,12 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    panelPosition,
+    panelSize,
+    panelOpacity,
+    panelAutohide,
+    workspaceCount,
+    workspaceNames,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -211,6 +352,12 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (panelPosition !== undefined) await setPanelPosition(panelPosition);
+  if (panelSize !== undefined) await setPanelSize(panelSize);
+  if (panelOpacity !== undefined) await setPanelOpacity(panelOpacity);
+  if (panelAutohide !== undefined) await setPanelAutohide(panelAutohide);
+  if (workspaceCount !== undefined) await setWorkspaceCount(workspaceCount);
+  if (workspaceNames !== undefined) await setWorkspaceNames(workspaceNames);
   if (theme !== undefined) setTheme(theme);
 }
 

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,3 +1,5 @@
+import { safeLocalStorage } from './safeStorage';
+
 export const THEME_KEY = 'app:theme';
 
 // Score required to unlock each theme
@@ -16,7 +18,7 @@ export const isDarkTheme = (theme: string): boolean =>
 export const getTheme = (): string => {
   if (typeof window === 'undefined') return 'default';
   try {
-    const stored = window.localStorage.getItem(THEME_KEY);
+    const stored = safeLocalStorage?.getItem(THEME_KEY);
     if (stored) return stored;
     const prefersDark = window.matchMedia?.(
       '(prefers-color-scheme: dark)'
@@ -30,7 +32,7 @@ export const getTheme = (): string => {
 export const setTheme = (theme: string): void => {
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(THEME_KEY, theme);
+    safeLocalStorage?.setItem(THEME_KEY, theme);
     document.documentElement.dataset.theme = theme;
     document.documentElement.classList.toggle('dark', isDarkTheme(theme));
   } catch {


### PR DESCRIPTION
## Summary
- rebuild the Settings app with tabbed sections for appearance, panel, workspaces, wallpaper, and accessibility controls
- extend the shared settings context and persistence layer to cover new panel/workspace preferences using safeLocalStorage
- refresh the panel preferences dialog, taskbar behaviour, and design tokens so desktop changes apply immediately

## Testing
- yarn lint *(fails: repository has numerous pre-existing jsx-a11y and no-top-level-window violations outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d66821b4c88328ae0e59505a71dece