### PR TITLE
[desktop] add bottom dock option

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -86,6 +86,9 @@ export class SideBarApp extends Component {
     };
 
     render() {
+        const position = this.props.position || 'left';
+        const isBottom = position === 'bottom';
+
         return (
             <button
                 type="button"
@@ -148,7 +151,9 @@ export class SideBarApp extends Component {
                 <div
                     className={
                         (this.state.showTitle ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1.5 left-full ml-3 m-1 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
+                        (isBottom
+                            ? " w-max py-0.5 px-1.5 absolute bottom-full mb-2 left-1/2 transform -translate-x-1/2 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
+                            : " w-max py-0.5 px-1.5 absolute top-1.5 left-full ml-3 m-1 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md")
                     }
                 >
                     {this.props.title}

--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from "react";
 import Tabs from "../Tabs";
 import ToggleSwitch from "../ToggleSwitch";
+import usePanelPosition from "../../hooks/usePanelPosition";
 
 const PANEL_PREFIX = "xfce.panel.";
 
@@ -28,13 +29,7 @@ export default function Preferences() {
     const stored = localStorage.getItem(`${PANEL_PREFIX}length`);
     return stored ? parseInt(stored, 10) : 100;
   });
-  const [orientation, setOrientation] = useState<"horizontal" | "vertical">(() => {
-    if (typeof window === "undefined") return "horizontal";
-    return (localStorage.getItem(`${PANEL_PREFIX}orientation`) as
-      | "horizontal"
-      | "vertical"
-      | null) || "horizontal";
-  });
+  const [panelPosition, setPanelPosition] = usePanelPosition();
   const [autohide, setAutohide] = useState(() => {
     if (typeof window === "undefined") return false;
     return localStorage.getItem(`${PANEL_PREFIX}autohide`) === "true";
@@ -52,11 +47,6 @@ export default function Preferences() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    localStorage.setItem(`${PANEL_PREFIX}orientation`, orientation);
-  }, [orientation]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
     localStorage.setItem(`${PANEL_PREFIX}autohide`, autohide ? "true" : "false");
   }, [autohide]);
 
@@ -67,19 +57,19 @@ export default function Preferences() {
         {active === "display" && (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <label htmlFor="orientation" className="text-ubt-grey">
-                Orientation
+              <label htmlFor="panel-position" className="text-ubt-grey">
+                Dock position
               </label>
               <select
-                id="orientation"
-                value={orientation}
+                id="panel-position"
+                value={panelPosition}
                 onChange={(e) =>
-                  setOrientation(e.target.value as "horizontal" | "vertical")
+                  setPanelPosition(e.target.value === "bottom" ? "bottom" : "left")
                 }
                 className="bg-ub-cool-grey text-white px-2 py-1 rounded"
               >
-                <option value="horizontal">Horizontal</option>
-                <option value="vertical">Vertical</option>
+                <option value="left">Left</option>
+                <option value="bottom">Bottom</option>
               </select>
             </div>
             <div className="flex items-center justify-between">

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,19 +1,34 @@
 import React, { useState } from 'react'
 import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
+import usePanelPosition from '../../hooks/usePanelPosition';
 
-let renderApps = (props) => {
+let renderApps = (props, position) => {
     let sideBarAppsJsx = [];
     props.apps.forEach((app, index) => {
         if (props.favourite_apps[app.id] === false) return;
         sideBarAppsJsx.push(
-            <SideBarApp key={app.id} id={app.id} title={app.title} icon={app.icon} isClose={props.closed_windows} isFocus={props.focused_windows} openApp={props.openAppByAppId} isMinimized={props.isMinimized} openFromMinimised={props.openFromMinimised} />
+            <SideBarApp
+                key={app.id}
+                id={app.id}
+                title={app.title}
+                icon={app.icon}
+                isClose={props.closed_windows}
+                isFocus={props.focused_windows}
+                openApp={props.openAppByAppId}
+                isMinimized={props.isMinimized}
+                openFromMinimised={props.openFromMinimised}
+                position={position}
+            />
         );
     });
     return sideBarAppsJsx;
 }
 
 export default function SideBar(props) {
+
+    const [position] = usePanelPosition();
+    const isBottom = position === 'bottom';
 
     function showSideBar() {
         props.hideSideBar(null, false);
@@ -25,23 +40,36 @@ export default function SideBar(props) {
         }, 2000);
     }
 
+    const navBaseClasses = "absolute transform duration-300 select-none z-40 border-black border-opacity-60 bg-black bg-opacity-50 flex";
+    const navOrientationClasses = isBottom
+        ? " left-1/2 -translate-x-1/2 bottom-12 h-16 px-2 py-2 rounded-t-xl shadow-lg flex-row items-center gap-1"
+        : " left-0 top-0 h-full min-h-screen w-16 flex-col justify-start items-center pt-7";
+    const navVisibilityClass = props.hide
+        ? (isBottom ? " translate-y-full" : " -translate-x-full")
+        : (isBottom ? " translate-y-0" : "");
+
     return (
         <>
             <nav
                 aria-label="Dock"
-                className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                className={navBaseClasses + navOrientationClasses + navVisibilityClass}
             >
                 {
                     (
                         Object.keys(props.closed_windows).length !== 0
-                            ? renderApps(props)
+                            ? renderApps(props, position)
                             : null
                     )
                 }
-                <AllApps showApps={props.showAllApps} />
+                <AllApps showApps={props.showAllApps} position={position} />
             </nav>
-            <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-50"}></div>
+            <div
+                onMouseEnter={showSideBar}
+                onMouseLeave={hideSideBar}
+                className={(isBottom
+                    ? "h-2 w-full bottom-12"
+                    : "w-1 h-full top-0") + " absolute left-0 bg-transparent z-50"}
+            ></div>
         </>
     )
 }
@@ -49,11 +77,11 @@ export default function SideBar(props) {
 export function AllApps(props) {
 
     const [title, setTitle] = useState(false);
+    const isBottom = props.position === 'bottom';
 
     return (
         <div
-            className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
-            style={{ marginTop: 'auto' }}
+            className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active ${isBottom ? 'ml-auto' : 'mt-auto'}`}
             onMouseEnter={() => {
                 setTitle(true);
             }}
@@ -74,7 +102,9 @@ export function AllApps(props) {
                 <div
                     className={
                         (title ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1 left-full ml-5 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
+                        (isBottom
+                            ? " w-max py-0.5 px-1.5 absolute bottom-full mb-2 left-1/2 transform -translate-x-1/2 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
+                            : " w-max py-0.5 px-1.5 absolute top-1 left-full ml-5 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md")
                     }
                 >
                     Show Applications

--- a/hooks/usePanelPosition.ts
+++ b/hooks/usePanelPosition.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect } from "react";
+import usePersistentState from "./usePersistentState";
+
+export type PanelPosition = "left" | "bottom";
+
+const PANEL_POSITION_KEY = "desktop:panel-position";
+const LEGACY_ORIENTATION_KEY = "xfce.panel.orientation";
+
+const isPanelPosition = (value: unknown): value is PanelPosition =>
+  value === "left" || value === "bottom";
+
+const readLegacyOrientation = (): PanelPosition => {
+  if (typeof window === "undefined") return "left";
+  try {
+    const legacy = window.localStorage.getItem(LEGACY_ORIENTATION_KEY);
+    if (legacy === "horizontal") return "bottom";
+    if (legacy === "vertical") return "left";
+  } catch {
+    // ignore and fall back to default
+  }
+  return "left";
+};
+
+export default function usePanelPosition() {
+  const [position, setPosition] = usePersistentState<PanelPosition>(
+    PANEL_POSITION_KEY,
+    readLegacyOrientation,
+    isPanelPosition,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const orientation = position === "bottom" ? "horizontal" : "vertical";
+      window.localStorage.setItem(LEGACY_ORIENTATION_KEY, orientation);
+    } catch {
+      // ignore persistence errors
+    }
+  }, [position]);
+
+  return [position, setPosition] as const;
+}

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -3,6 +3,7 @@
 import { ChangeEvent } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import { useSettings } from '../../../hooks/useSettings';
+import usePanelPosition from '../../../hooks/usePanelPosition';
 
 /** Simple Adwaita-like toggle switch */
 function Toggle({
@@ -35,6 +36,7 @@ export default function ThemeSettings() {
   const { theme, setTheme } = useSettings();
   const [panelSize, setPanelSize] = usePersistentState('app:panel-icons', 16);
   const [gridSize, setGridSize] = usePersistentState('app:grid-icons', 64);
+  const [panelPosition, setPanelPosition] = usePanelPosition();
 
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     setTheme(e.target.value);
@@ -89,6 +91,35 @@ export default function ThemeSettings() {
               style={{ width: panelSize, height: panelSize }}
             ></div>
           </div>
+        </div>
+
+        <div className="mt-6">
+          <h2 className="text-lg mb-2">Panel Position</h2>
+          <fieldset className="space-y-2" role="radiogroup" aria-label="Panel position">
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="panel-position"
+                value="left"
+                checked={panelPosition === 'left'}
+                onChange={() => setPanelPosition('left')}
+              />
+              <span>Left dock</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="panel-position"
+                value="bottom"
+                checked={panelPosition === 'bottom'}
+                onChange={() => setPanelPosition('bottom')}
+              />
+              <span>Bottom dock</span>
+            </label>
+          </fieldset>
+          <p className="mt-2 text-sm text-ubt-grey">
+            Choose where the dock is anchored so context menus and previews appear in the right spot.
+          </p>
         </div>
 
         <div className="mt-6">


### PR DESCRIPTION
## Summary
- add a shared `usePanelPosition` hook to persist dock placement and keep the legacy orientation key in sync
- allow the desktop dock, previews, and tooltips to adapt between left and bottom layouts
- expose the dock position selector in both panel preferences and the theme settings page

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint violations, e.g. `jsx-a11y/control-has-associated-label`)*
- yarn test --watch=false *(fails: existing modal/window tests interacting with localStorage in jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68d668242010832896599df8a2ee2993