### PR TITLE
[workspace] add dynamic manager and overflow UI

### DIFF
--- a/__tests__/workspaceManager.test.ts
+++ b/__tests__/workspaceManager.test.ts
@@ -1,0 +1,58 @@
+import WorkspaceManager from '../utils/workspaceManager';
+
+describe('WorkspaceManager', () => {
+  it('clamps workspace count between 1 and 8', () => {
+    const manager = new WorkspaceManager({ initialCount: 0 });
+    expect(manager.getWorkspaces()).toHaveLength(1);
+
+    manager.setWorkspaceCount(20);
+    expect(manager.getWorkspaces()).toHaveLength(8);
+
+    manager.setWorkspaceCount(-5);
+    expect(manager.getWorkspaces()).toHaveLength(1);
+  });
+
+  it('migrates windows when shrinking workspace count', () => {
+    const manager = new WorkspaceManager({ initialCount: 4 });
+    const workspaces = manager.getWorkspaces();
+
+    manager.registerWindow('alpha', workspaces[0].id);
+    manager.registerWindow('bravo', workspaces[1].id);
+    manager.registerWindow('charlie', workspaces[2].id);
+    manager.registerWindow('delta', workspaces[3].id);
+
+    manager.setActiveWorkspace(workspaces[3].id);
+    manager.setWorkspaceCount(2);
+
+    const resized = manager.getWorkspaces();
+    expect(resized).toHaveLength(2);
+
+    expect(resized[0].windows).toEqual(['alpha']);
+    expect(resized[1].windows).toEqual(['bravo', 'charlie', 'delta']);
+
+    const deltaWorkspace = manager.getWorkspaceForWindow('delta');
+    expect(deltaWorkspace?.id).toBe(resized[1].id);
+    expect(deltaWorkspace?.name).toBe('Workspace 2');
+
+    expect(manager.activeWorkspaceId).toBe(resized[1].id);
+  });
+
+  it('preserves unique window assignments when migrating', () => {
+    const manager = new WorkspaceManager({ initialCount: 3 });
+    const [first, second, third] = manager.getWorkspaces();
+
+    manager.registerWindow('win-1', first.id);
+    manager.registerWindow('win-2', second.id);
+    manager.registerWindow('win-3', third.id);
+
+    manager.moveWindow('win-1', third.id);
+    expect(manager.getWorkspaceForWindow('win-1')?.id).toBe(third.id);
+
+    manager.setWorkspaceCount(2);
+    const reduced = manager.getWorkspaces();
+    expect(reduced[1].windows).toEqual(['win-2', 'win-3', 'win-1']);
+
+    const unique = new Set(reduced[1].windows);
+    expect(unique.size).toBe(reduced[1].windows.length);
+  });
+});

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -1,17 +1,56 @@
 import React, { useEffect, useState, useRef } from 'react';
 
-export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
+const MAX_VISIBLE_WORKSPACES = 4;
+
+export default function WindowSwitcher({
+  windows = [],
+  onSelect,
+  onClose,
+  workspaces = [],
+  activeWorkspaceId,
+  onWorkspaceSelect,
+}) {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(0);
+  const [visibleStart, setVisibleStart] = useState(0);
   const inputRef = useRef(null);
 
   const filtered = windows.filter((w) =>
     w.title.toLowerCase().includes(query.toLowerCase())
   );
 
+  const hasOverflow = workspaces.length > MAX_VISIBLE_WORKSPACES;
+  const resolvedActiveId =
+    activeWorkspaceId || workspaces[0]?.id || null;
+  const visibleWorkspaces = hasOverflow
+    ? workspaces.slice(visibleStart, visibleStart + MAX_VISIBLE_WORKSPACES)
+    : workspaces;
+
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
+
+  useEffect(() => {
+    if (!hasOverflow) {
+      if (visibleStart !== 0) setVisibleStart(0);
+      return;
+    }
+    const activeIndex = workspaces.findIndex(
+      (ws) => ws.id === resolvedActiveId,
+    );
+    if (activeIndex === -1) return;
+    let nextStart = visibleStart;
+    if (activeIndex < visibleStart) {
+      nextStart = activeIndex;
+    } else if (activeIndex >= visibleStart + MAX_VISIBLE_WORKSPACES) {
+      nextStart = activeIndex - MAX_VISIBLE_WORKSPACES + 1;
+    }
+    const maxStart = Math.max(0, workspaces.length - MAX_VISIBLE_WORKSPACES);
+    nextStart = Math.min(Math.max(nextStart, 0), maxStart);
+    if (nextStart !== visibleStart) {
+      setVisibleStart(nextStart);
+    }
+  }, [hasOverflow, visibleStart, workspaces, resolvedActiveId]);
 
   useEffect(() => {
     const handleKeyUp = (e) => {
@@ -56,9 +95,76 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
     setSelected(0);
   };
 
+  const handleWorkspaceClick = (workspaceId) => {
+    if (typeof onWorkspaceSelect === 'function') {
+      onWorkspaceSelect(workspaceId);
+    }
+  };
+
+  const handlePrev = () => {
+    setVisibleStart((start) => Math.max(0, start - 1));
+  };
+
+  const handleNext = () => {
+    const maxStart = Math.max(0, workspaces.length - MAX_VISIBLE_WORKSPACES);
+    setVisibleStart((start) => Math.min(maxStart, start + 1));
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white">
       <div className="bg-ub-grey p-4 rounded w-3/4 md:w-1/3">
+        {workspaces.length > 0 && (
+          <div className="mb-3">
+            <div className="flex items-center gap-2">
+              {hasOverflow && (
+                <button
+                  type="button"
+                  className="px-2 py-1 bg-black bg-opacity-30 rounded disabled:opacity-40"
+                  onClick={handlePrev}
+                  disabled={visibleStart === 0}
+                  aria-label="Previous workspace"
+                >
+                  ‹
+                </button>
+              )}
+              <div
+                className={
+                  hasOverflow
+                    ? 'flex-1 overflow-hidden'
+                    : 'flex-1'
+                }
+              >
+                <div className="flex gap-2">
+                  {visibleWorkspaces.map((ws) => (
+                    <button
+                      key={ws.id}
+                      type="button"
+                      onClick={() => handleWorkspaceClick(ws.id)}
+                      className={`px-2 py-1 rounded transition-colors ${
+                        ws.id === resolvedActiveId
+                          ? 'bg-ub-orange text-black'
+                          : 'bg-black bg-opacity-30 hover:bg-opacity-50'
+                      }`}
+                    >
+                      {ws.name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              {hasOverflow && (
+                <button
+                  type="button"
+                  className="px-2 py-1 bg-black bg-opacity-30 rounded disabled:opacity-40"
+                  onClick={handleNext}
+                  disabled={visibleStart >= workspaces.length - MAX_VISIBLE_WORKSPACES}
+                  aria-label="Next workspace"
+                >
+                  ›
+                </button>
+              )}
+            </div>
+          </div>
+        )}
         <input
           ref={inputRef}
           value={query}
@@ -66,6 +172,7 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
           onKeyDown={handleKeyDown}
           className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
           placeholder="Search windows"
+          aria-label="Search windows"
         />
         <ul>
           {filtered.map((w, i) => (

--- a/utils/workspaceManager.ts
+++ b/utils/workspaceManager.ts
@@ -1,0 +1,197 @@
+export interface WorkspaceSnapshot {
+  id: string;
+  name: string;
+  windows: string[];
+  index: number;
+}
+
+interface WorkspaceInternal {
+  id: string;
+  title?: string;
+  windows: string[];
+}
+
+export interface WorkspaceManagerOptions {
+  initialCount?: number;
+  minCount?: number;
+  maxCount?: number;
+}
+
+const DEFAULT_MIN = 1;
+const DEFAULT_MAX = 8;
+
+export default class WorkspaceManager {
+  private workspaces: WorkspaceInternal[] = [];
+
+  private assignments = new Map<string, string>();
+
+  private activeId: string | null = null;
+
+  private idCounter = 0;
+
+  private readonly minCount: number;
+
+  private readonly maxCount: number;
+
+  constructor(options: WorkspaceManagerOptions = {}) {
+    const { initialCount = DEFAULT_MIN, minCount = DEFAULT_MIN, maxCount = DEFAULT_MAX } = options;
+    this.minCount = Math.max(1, minCount);
+    this.maxCount = Math.max(this.minCount, maxCount);
+
+    const startCount = this.clampCount(initialCount);
+    this.ensureWorkspaceCount(startCount);
+  }
+
+  get activeWorkspaceId() {
+    return this.activeId;
+  }
+
+  getWorkspaces(): WorkspaceSnapshot[] {
+    return this.workspaces.map((ws, index) => ({
+      id: ws.id,
+      name: ws.title || `Workspace ${index + 1}`,
+      windows: [...ws.windows],
+      index,
+    }));
+  }
+
+  getWorkspaceForWindow(windowId: string): WorkspaceSnapshot | undefined {
+    const workspaceId = this.assignments.get(windowId);
+    if (!workspaceId) return undefined;
+    const index = this.workspaces.findIndex((ws) => ws.id === workspaceId);
+    if (index === -1) return undefined;
+    const workspace = this.workspaces[index];
+    return {
+      id: workspace.id,
+      name: workspace.title || `Workspace ${index + 1}`,
+      windows: [...workspace.windows],
+      index,
+    };
+  }
+
+  setActiveWorkspace(workspaceId: string) {
+    if (this.workspaces.some((ws) => ws.id === workspaceId)) {
+      this.activeId = workspaceId;
+    }
+  }
+
+  setWorkspaceTitle(workspaceId: string, title: string) {
+    const workspace = this.workspaces.find((ws) => ws.id === workspaceId);
+    if (workspace) {
+      workspace.title = title.trim();
+    }
+  }
+
+  registerWindow(windowId: string, workspaceId?: string) {
+    if (!windowId) return;
+    const target = this.resolveWorkspace(workspaceId ?? this.activeId ?? this.workspaces[0]?.id);
+    if (!target) return;
+
+    const currentId = this.assignments.get(windowId);
+    if (currentId === target.id) return;
+
+    if (currentId) {
+      this.removeWindowFromWorkspace(windowId, currentId);
+    }
+    this.addWindowToWorkspace(windowId, target.id);
+  }
+
+  moveWindow(windowId: string, workspaceId: string) {
+    const target = this.resolveWorkspace(workspaceId);
+    if (!target) return;
+
+    const currentId = this.assignments.get(windowId);
+    if (currentId === target.id) return;
+
+    if (currentId) {
+      this.removeWindowFromWorkspace(windowId, currentId);
+    }
+    this.addWindowToWorkspace(windowId, target.id);
+  }
+
+  removeWindow(windowId: string) {
+    const workspaceId = this.assignments.get(windowId);
+    if (!workspaceId) return;
+    this.removeWindowFromWorkspace(windowId, workspaceId);
+  }
+
+  setWorkspaceCount(requestedCount: number) {
+    const count = this.clampCount(requestedCount);
+    this.ensureWorkspaceCount(count);
+  }
+
+  private clampCount(count: number) {
+    if (!Number.isFinite(count)) return this.minCount;
+    const rounded = Math.round(count);
+    return Math.min(this.maxCount, Math.max(this.minCount, rounded));
+  }
+
+  private ensureWorkspaceCount(count: number) {
+    if (count === this.workspaces.length) return;
+
+    if (count > this.workspaces.length) {
+      while (this.workspaces.length < count) {
+        this.createWorkspace();
+      }
+      return;
+    }
+
+    // shrinking: migrate windows from removed workspaces into the last remaining workspace
+    while (this.workspaces.length > count) {
+      const removed = this.workspaces.pop();
+      if (!removed) break;
+      const fallback = this.workspaces[this.workspaces.length - 1];
+      if (!fallback) {
+        // Should not happen thanks to minCount >= 1, but guard just in case
+        const created = this.createWorkspace();
+        removed.windows.forEach((win) => this.attachWindowToWorkspace(win, created));
+        continue;
+      }
+      removed.windows.forEach((win) => this.attachWindowToWorkspace(win, fallback));
+    }
+
+    if (this.activeId && !this.workspaces.some((ws) => ws.id === this.activeId)) {
+      this.activeId = this.workspaces[this.workspaces.length - 1]?.id ?? null;
+    }
+  }
+
+  private createWorkspace() {
+    const workspace: WorkspaceInternal = {
+      id: `workspace-${++this.idCounter}`,
+      windows: [],
+    };
+    this.workspaces.push(workspace);
+    if (!this.activeId) {
+      this.activeId = workspace.id;
+    }
+    return workspace;
+  }
+
+  private resolveWorkspace(workspaceId?: string | null) {
+    if (!workspaceId) return undefined;
+    return this.workspaces.find((ws) => ws.id === workspaceId);
+  }
+
+  private addWindowToWorkspace(windowId: string, workspaceId: string) {
+    const workspace = this.resolveWorkspace(workspaceId);
+    if (!workspace) return;
+    if (!workspace.windows.includes(windowId)) {
+      workspace.windows.push(windowId);
+    }
+    this.assignments.set(windowId, workspace.id);
+  }
+
+  private removeWindowFromWorkspace(windowId: string, workspaceId: string) {
+    const workspace = this.resolveWorkspace(workspaceId);
+    if (!workspace) return;
+    workspace.windows = workspace.windows.filter((id) => id !== windowId);
+    this.assignments.delete(windowId);
+  }
+
+  private attachWindowToWorkspace(windowId: string, workspace: WorkspaceInternal) {
+    if (!workspace.windows.includes(windowId)) {
+      workspace.windows.push(windowId);
+    }
+    this.assignments.set(windowId, workspace.id);
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable WorkspaceManager that clamps the workspace count between 1 and 8 while migrating window assignments safely
- update the window switcher to render workspace controls with overflow navigation and an accessible search field
- cover workspace count changes and migration behaviour with dedicated tests

## Testing
- npx eslint utils/workspaceManager.ts components/screen/window-switcher.js
- yarn test workspaceManager

------
https://chatgpt.com/codex/tasks/task_e_68d66823ab408328a10ba4a710759609