### PR TITLE
Add permission preflight flow for device-dependent apps

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -214,6 +214,7 @@ const utilityList = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayQr,
+    permissions: ['camera'],
   },
   {
     id: 'ascii-art',
@@ -711,6 +712,7 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayFileExplorer,
+    permissions: ['fileSystemAccess'],
   },
   {
     id: 'resource-monitor',
@@ -729,6 +731,7 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayScreenRecorder,
+    permissions: ['screenCapture'],
   },
   {
     id: 'ettercap',

--- a/components/common/PermissionDialog.tsx
+++ b/components/common/PermissionDialog.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import {
+  getPermissionDetails,
+  type PermissionKind,
+  type PermissionState,
+} from '../../utils/permissionHandler';
+
+interface PermissionDialogProps {
+  appTitle: string;
+  appIcon?: string;
+  requirements: PermissionKind[];
+  statuses: Record<PermissionKind, PermissionState>;
+  busy?: boolean;
+  error?: string | null;
+  onGrant: () => void;
+  onCancel: () => void;
+  onContinue?: () => void;
+}
+
+const statusCopy: Record<PermissionState, { label: string; className: string }> = {
+  granted: {
+    label: 'Granted',
+    className: 'text-green-400',
+  },
+  prompt: {
+    label: 'Needs approval',
+    className: 'text-yellow-300',
+  },
+  denied: {
+    label: 'Blocked',
+    className: 'text-red-400',
+  },
+  unsupported: {
+    label: 'Unsupported',
+    className: 'text-red-300',
+  },
+};
+
+const PermissionDialog: React.FC<PermissionDialogProps> = ({
+  appTitle,
+  appIcon,
+  requirements,
+  statuses,
+  busy = false,
+  error,
+  onGrant,
+  onCancel,
+  onContinue,
+}) => {
+  const showContinue = typeof onContinue === 'function';
+  const disableGrant =
+    busy || requirements.every((kind) => statuses[kind] === 'unsupported');
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="permission-dialog-title"
+        className="w-full max-w-lg rounded-lg bg-ub-cool-grey text-white shadow-xl border border-black/40"
+      >
+        <div className="flex items-center gap-3 border-b border-white/10 px-5 py-4">
+          {appIcon && (
+            <img src={appIcon} alt="" className="h-10 w-10 rounded" aria-hidden="true" />
+          )}
+          <div>
+            <h2 id="permission-dialog-title" className="text-lg font-semibold">
+              {appTitle} needs your permission
+            </h2>
+            <p className="text-sm text-white/70">
+              Enable the following capabilities to unlock the full experience.
+            </p>
+          </div>
+        </div>
+        <div className="max-h-[50vh] overflow-y-auto px-5 py-4 space-y-3">
+          <ul className="space-y-3">
+            {requirements.map((requirement) => {
+              const details = getPermissionDetails(requirement);
+              const status = statuses[requirement];
+              const statusMeta = statusCopy[status];
+              return (
+                <li
+                  key={requirement}
+                  className="flex items-start gap-3 rounded-md border border-white/10 bg-black/30 px-3 py-2"
+                >
+                  <div className="flex-1">
+                    <p className="font-medium">{details.title}</p>
+                    <p className="text-sm text-white/70">{details.description}</p>
+                  </div>
+                  <span className={`text-sm font-semibold ${statusMeta.className}`}>
+                    {statusMeta.label}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+          {error && (
+            <p className="rounded-md border border-red-500/40 bg-red-900/40 px-3 py-2 text-sm text-red-200">
+              {error}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-col gap-2 border-t border-white/10 px-5 py-4 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md border border-white/20 px-4 py-2 text-sm hover:bg-white/10"
+          >
+            Not now
+          </button>
+          {showContinue && (
+            <button
+              type="button"
+              onClick={onContinue}
+              className="rounded-md border border-white/20 px-4 py-2 text-sm hover:bg-white/10"
+            >
+              Open anyway
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onGrant}
+            disabled={disableGrant}
+            className={`rounded-md px-4 py-2 text-sm font-semibold transition ${
+              disableGrant
+                ? 'cursor-not-allowed bg-white/10 text-white/40'
+                : 'bg-blue-500 text-white hover:bg-blue-600'
+            }`}
+          >
+            {busy ? 'Requesting…' : 'Allow access'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PermissionDialog;

--- a/utils/permissionHandler.ts
+++ b/utils/permissionHandler.ts
@@ -1,0 +1,200 @@
+export type PermissionKind = 'camera' | 'microphone' | 'screenCapture' | 'fileSystemAccess';
+export type PermissionState = 'granted' | 'prompt' | 'denied' | 'unsupported';
+
+type NavigatorPermissionState = 'granted' | 'denied' | 'prompt';
+
+type GlobalWithFileSystem = typeof globalThis & {
+  showDirectoryPicker?: () => Promise<unknown>;
+  showOpenFilePicker?: () => Promise<unknown[]>;
+  showSaveFilePicker?: (options?: unknown) => Promise<unknown>;
+};
+
+const getGlobalObject = (): GlobalWithFileSystem | undefined =>
+  typeof globalThis === 'undefined' ? undefined : (globalThis as GlobalWithFileSystem);
+
+const getNavigator = (): Navigator | undefined => getGlobalObject()?.navigator as Navigator | undefined;
+
+interface PermissionDetails {
+  title: string;
+  description: string;
+}
+
+const PERMISSION_DETAILS: Record<PermissionKind, PermissionDetails> = {
+  camera: {
+    title: 'Camera',
+    description: 'Used to scan QR codes or capture images.',
+  },
+  microphone: {
+    title: 'Microphone',
+    description: 'Required for apps that capture audio.',
+  },
+  screenCapture: {
+    title: 'Screen capture',
+    description: 'Needed to record or share your screen.',
+  },
+  fileSystemAccess: {
+    title: 'File system access',
+    description: 'Allows selecting folders and saving files.',
+  },
+};
+
+const mapPermissionState = (state: NavigatorPermissionState | undefined): PermissionState => {
+  if (!state) return 'prompt';
+  if (state === 'granted') return 'granted';
+  if (state === 'denied') return 'denied';
+  return 'prompt';
+};
+
+export const getPermissionDetails = (kind: PermissionKind): PermissionDetails =>
+  PERMISSION_DETAILS[kind];
+
+type ExtendedPermissionDescriptor = PermissionDescriptor | { name: 'camera' | 'microphone' | 'file-system' };
+
+const queryPermission = async (
+  descriptor: ExtendedPermissionDescriptor,
+): Promise<PermissionStatus | null> => {
+  const navigatorRef = getNavigator();
+  try {
+    if (!navigatorRef?.permissions?.query) return null;
+    return await navigatorRef.permissions.query(descriptor as PermissionDescriptor);
+  } catch {
+    return null;
+  }
+};
+
+export const getPermissionStatus = async (kind: PermissionKind): Promise<PermissionState> => {
+  try {
+    const navigatorRef = getNavigator();
+    const globalRef = getGlobalObject();
+
+    switch (kind) {
+      case 'camera': {
+        if (!navigatorRef?.mediaDevices?.getUserMedia) return 'unsupported';
+        const status = await queryPermission({ name: 'camera' });
+        return mapPermissionState(status?.state as NavigatorPermissionState | undefined);
+      }
+      case 'microphone': {
+        if (!navigatorRef?.mediaDevices?.getUserMedia) return 'unsupported';
+        const status = await queryPermission({ name: 'microphone' });
+        return mapPermissionState(status?.state as NavigatorPermissionState | undefined);
+      }
+      case 'screenCapture': {
+        if (!navigatorRef?.mediaDevices?.getDisplayMedia) return 'unsupported';
+        // Permissions API does not expose display capture yet.
+        return 'prompt';
+      }
+      case 'fileSystemAccess': {
+        if (!globalRef?.showOpenFilePicker && !globalRef?.showDirectoryPicker) {
+          return 'unsupported';
+        }
+        const status = await queryPermission({ name: 'file-system' });
+        return mapPermissionState(status?.state as NavigatorPermissionState | undefined);
+      }
+      default:
+        return 'unsupported';
+    }
+  } catch {
+    return 'denied';
+  }
+};
+
+const stopStream = (stream: MediaStream | null | undefined) => {
+  if (!stream) return;
+  stream.getTracks().forEach((track) => {
+    try {
+      track.stop();
+    } catch {
+      // ignore
+    }
+  });
+};
+
+const ensureHandlePermission = async (handle: unknown): Promise<PermissionState> => {
+  const permissionFn = (handle as { requestPermission?: (options: { mode: 'read' | 'readwrite' }) => Promise<'granted' | 'denied' | 'prompt'> })?.requestPermission;
+  if (typeof permissionFn !== 'function') return 'granted';
+  try {
+    const result = await permissionFn.call(handle, { mode: 'read' });
+    return result === 'granted' ? 'granted' : 'denied';
+  } catch {
+    return 'denied';
+  }
+};
+
+export const requestPermission = async (kind: PermissionKind): Promise<PermissionState> => {
+  try {
+    const navigatorRef = getNavigator();
+    const globalRef = getGlobalObject();
+
+    switch (kind) {
+      case 'camera': {
+        if (!navigatorRef?.mediaDevices?.getUserMedia) return 'unsupported';
+        const stream = await navigatorRef.mediaDevices.getUserMedia({ video: true });
+        stopStream(stream);
+        return 'granted';
+      }
+      case 'microphone': {
+        if (!navigatorRef?.mediaDevices?.getUserMedia) return 'unsupported';
+        const stream = await navigatorRef.mediaDevices.getUserMedia({ audio: true });
+        stopStream(stream);
+        return 'granted';
+      }
+      case 'screenCapture': {
+        if (!navigatorRef?.mediaDevices?.getDisplayMedia) return 'unsupported';
+        const stream = await navigatorRef.mediaDevices
+          .getDisplayMedia({ video: true, audio: true })
+          .catch(async () => navigatorRef.mediaDevices?.getDisplayMedia({ video: true }).catch(() => null));
+        if (!stream) return 'denied';
+        stopStream(stream);
+        return 'granted';
+      }
+      case 'fileSystemAccess': {
+        const directoryPicker = typeof globalRef?.showDirectoryPicker === 'function'
+          ? await globalRef.showDirectoryPicker()
+          : undefined;
+        if (directoryPicker) {
+          const status = await ensureHandlePermission(directoryPicker);
+          if (status !== 'granted') return 'denied';
+          return 'granted';
+        }
+
+        const filePicker = typeof globalRef?.showOpenFilePicker === 'function'
+          ? await globalRef.showOpenFilePicker()
+          : undefined;
+        const handle = Array.isArray(filePicker) ? filePicker[0] : undefined;
+        if (handle) {
+          const status = await ensureHandlePermission(handle);
+          if (status !== 'granted') return 'denied';
+          return 'granted';
+        }
+
+        return 'unsupported';
+      }
+      default:
+        return 'unsupported';
+    }
+  } catch (err) {
+    if (err instanceof DOMException && (err.name === 'NotAllowedError' || err.name === 'SecurityError')) {
+      return 'denied';
+    }
+    return 'denied';
+  }
+};
+
+export const checkPermissions = async (
+  kinds: PermissionKind[],
+): Promise<Record<PermissionKind, PermissionState>> => {
+  const entries = await Promise.all(
+    kinds.map(async (kind) => [kind, await getPermissionStatus(kind)] as const),
+  );
+  return Object.fromEntries(entries) as Record<PermissionKind, PermissionState>;
+};
+
+export const requestPermissions = async (
+  kinds: PermissionKind[],
+): Promise<Record<PermissionKind, PermissionState>> => {
+  const result: Partial<Record<PermissionKind, PermissionState>> = {};
+  for (const kind of kinds) {
+    result[kind] = await requestPermission(kind);
+  }
+  return result as Record<PermissionKind, PermissionState>;
+};


### PR DESCRIPTION
## Summary
- add permission metadata to apps that require camera, file system, or screen capture access
- implement a shared permission handler and preflight dialog to request capabilities up front
- gate app launches behind the dialog with graceful fallback messaging when permissions are denied

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint violations across many files)*
- npx eslint utils/permissionHandler.ts


------
https://chatgpt.com/codex/tasks/task_e_68d6682724848328b4f2eed7610903dd