### PR TITLE
[simulations] add adapters for security tools

### DIFF
--- a/apps/simulations/hydra.ts
+++ b/apps/simulations/hydra.ts
@@ -1,0 +1,170 @@
+export interface HydraSimulationOptions {
+  target: string;
+  service: string;
+  userList: string;
+  passList: string;
+  resume?: boolean;
+}
+
+export interface HydraSimulationResult {
+  output: string;
+  attempts: number;
+  highlight?: {
+    user: string;
+    password: string;
+    reason: string;
+  };
+}
+
+export interface HydraStoryboardStep {
+  title: string;
+  command: string;
+  description: string;
+  takeaway: string;
+}
+
+export const hydraStoryboard: HydraStoryboardStep[] = [
+  {
+    title: 'Scenario briefing',
+    command: 'hydra -L analysts.txt -P seasons.txt ssh://lab-gateway',
+    description:
+      'Introduce the simulated engagement and stress-test a short user/password list to demonstrate how fast a spray can begin.',
+    takeaway:
+      'Explain scope and throttle plans to stakeholders before touching credentials.',
+  },
+  {
+    title: 'Controlled spray',
+    command: 'hydra -L vpn-users.txt -P top20.txt -t 4 ssh://192.0.2.50',
+    description:
+      'Highlight the importance of parallelism limits. In the canned output the fourth thread triggers a warning about rate limits.',
+    takeaway:
+      'Balance speed against account lockouts in a lab rather than on production hosts.',
+  },
+  {
+    title: 'Result review',
+    command: 'hydra -l a.turner -P shortlist.txt ftp://files.lab --resume',
+    description:
+      'Walk through the resume flag to show how a campaign can pick up after a break without reusing attempts.',
+    takeaway:
+      'Document any credentials surfaced by the simulation and immediately rotate them.',
+  },
+];
+
+export const hydraSampleScripts = [
+  {
+    name: 'SSH quick check',
+    command: 'hydra -L demo-users.txt -P small.txt ssh://192.0.2.10',
+    note: 'Targets a lab SSH endpoint with 16 attempts before simulated lockout.',
+  },
+  {
+    name: 'Web form POST',
+    command:
+      "hydra -L demo-users.txt -P passwords.txt -s 443 https-post-form \"/login:username=^USER^&password=^PASS^:F=invalid\" example.com",
+    note: 'Illustrates form-based attacks without sending live traffic.',
+  },
+];
+
+const COMMON_PATTERNS = [/spring/i, /summer/i, /2024/, /password/i, /welcome/i];
+
+const summarizeList = (values: string[], max = 3) => {
+  const preview = values.slice(0, max).join(', ');
+  const overflow = values.length > max ? ` … +${values.length - max} more` : '';
+  return values.length ? `${preview}${overflow}` : 'None provided';
+};
+
+export const runHydraSimulation = async (
+  options: HydraSimulationOptions
+): Promise<HydraSimulationResult> => {
+  const users = options.userList
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const passwords = options.passList
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const totalAttempts = users.length * passwords.length;
+  let highlight: HydraSimulationResult['highlight'];
+
+  for (const user of users) {
+    const match = passwords.find((password) =>
+      COMMON_PATTERNS.some((regex) => regex.test(password))
+    );
+    if (match) {
+      highlight = {
+        user,
+        password: match,
+        reason: 'Password matches a weak seasonal or common pattern.',
+      };
+      break;
+    }
+  }
+
+  const statusLines = [
+    'Hydra Simulation Report',
+    '=======================',
+    `Target: ${options.target || 'N/A'}`,
+    `Service: ${options.service || 'ssh'}`,
+    `Mode: ${options.resume ? 'Resumed session' : 'Fresh run'}`,
+    `User candidates: ${users.length} (${summarizeList(users)})`,
+    `Password candidates: ${passwords.length} (${summarizeList(passwords)})`,
+    `Total attempts (simulated): ${totalAttempts || 'n/a'}`,
+    '',
+    'No live network traffic is generated. Use this walkthrough to explain lockout and throttling strategies to clients.',
+  ];
+
+  if (highlight) {
+    statusLines.push(
+      '',
+      'Highlighted finding:',
+      `- ${highlight.user}:${highlight.password} — ${highlight.reason}`,
+      'Discuss credential hygiene with the stakeholder and plan a reset.',
+    );
+  } else {
+    statusLines.push(
+      '',
+      'No weak credentials were detected in the provided lists. Consider demonstrating password complexity by comparing against corporate policy examples.',
+    );
+  }
+
+  statusLines.push(
+    '',
+    'Storyboard reminder:',
+    ...hydraStoryboard.map(
+      (step, index) => `${index + 1}. ${step.title} → ${step.command}`
+    ),
+    '',
+    'End of simulation.',
+  );
+
+  return {
+    output: statusLines.join('\n'),
+    attempts: totalAttempts,
+    highlight,
+  };
+};
+
+export type HydraControlAction = 'pause' | 'resume' | 'cancel';
+
+export const controlHydraSimulation = async (
+  action: HydraControlAction
+): Promise<{ status: string }> => {
+  switch (action) {
+    case 'pause':
+      return { status: 'Simulation paused locally.' };
+    case 'resume':
+      return { status: 'Simulation resumed locally.' };
+    case 'cancel':
+      return { status: 'Simulation cancelled and state cleared.' };
+    default:
+      return { status: 'No action performed.' };
+  }
+};
+
+export default {
+  runHydraSimulation,
+  controlHydraSimulation,
+  hydraStoryboard,
+  hydraSampleScripts,
+};

--- a/apps/simulations/john.ts
+++ b/apps/simulations/john.ts
@@ -1,0 +1,96 @@
+export interface JohnSimulationOptions {
+  hash: string;
+  rules?: string;
+}
+
+export interface JohnSimulationResult {
+  output: string;
+  cracked: boolean;
+  password?: string;
+  hashType: string;
+}
+
+export interface JohnStoryboardStep {
+  title: string;
+  example: string;
+  description: string;
+  takeaway: string;
+}
+
+const demoPotfile: Array<{ hash: string; password: string; hashType: string }> = [
+  {
+    hash: '5f4dcc3b5aa765d61d8327deb882cf99',
+    password: 'password',
+    hashType: 'Raw-MD5',
+  },
+  {
+    hash: '$6$demo$L6A7nZC6LzKWu6HRfbBtvWNzoZeU7bawUCgTnMjfsorCej2bcqLC1/xwrzd0oPEfyYZl13SQ1SeDsICoZ6cFy0',
+    password: 'winter2024!',
+    hashType: 'sha512crypt',
+  },
+  {
+    hash: '$2y$05$abcdefghijklmnopqrstuvuvu0/MTTn6P0ZVqW8W9kM7.',
+    password: 'demo1234',
+    hashType: 'bcrypt',
+  },
+];
+
+const detectHashType = (hash: string) => {
+  if (hash.startsWith('$6$')) return 'sha512crypt';
+  if (hash.startsWith('$2') || hash.startsWith('$2y$')) return 'bcrypt';
+  if (/^[a-f0-9]{32}$/i.test(hash)) return 'Raw-MD5';
+  if (/^[a-f0-9]{40}$/i.test(hash)) return 'Raw-SHA1';
+  return 'Unknown';
+};
+
+export const runJohnSimulation = async (
+  options: JohnSimulationOptions
+): Promise<JohnSimulationResult> => {
+  const trimmed = options.hash.trim();
+  const match = demoPotfile.find((entry) => entry.hash === trimmed);
+  const hashType = match?.hashType || detectHashType(trimmed);
+
+  if (match) {
+    return {
+      output: `Simulated crack successful!\nHash: ${trimmed}\nPassword: ${match.password}\nHash type: ${hashType}\nRules applied: ${options.rules || 'default demo rules'}`,
+      cracked: true,
+      password: match.password,
+      hashType,
+    };
+  }
+
+  return {
+    output: `No match found in the demo potfile for hash ${trimmed}.\nHash type guess: ${hashType}.\nExplain to learners how you would extend the wordlist or tune rules to continue the exercise.`,
+    cracked: false,
+    hashType,
+  };
+};
+
+export const johnStoryboard: JohnStoryboardStep[] = [
+  {
+    title: 'Briefing',
+    example: 'Share a hashed password captured from a lab system and confirm permission to attempt cracking.',
+    description:
+      'Set expectations with stakeholders about why password cracking is part of the assessment and how results will be handled.',
+    takeaway: 'Always store hashes securely and destroy them after the engagement.',
+  },
+  {
+    title: 'Wordlist selection',
+    example: 'Discuss the difference between rockyou.txt and a custom employee-season list.',
+    description:
+      'Highlight why curated wordlists are more effective than blindly running every rule.',
+    takeaway: 'Quality of inputs beats quantity; tailor wordlists to the organisation.',
+  },
+  {
+    title: 'Result handling',
+    example: 'Demonstrate how to document cracked credentials and notify the blue team.',
+    description:
+      'The canned simulation focuses on communication, not exploitation.',
+    takeaway: 'Reset compromised accounts and enable MFA where possible.',
+  },
+];
+
+export default {
+  runJohnSimulation,
+  johnStoryboard,
+};

--- a/apps/simulations/metasploit.ts
+++ b/apps/simulations/metasploit.ts
@@ -1,0 +1,87 @@
+export interface MetasploitCommandResult {
+  output: string;
+}
+
+export interface MetasploitStoryboardStep {
+  title: string;
+  command: string;
+  description: string;
+  takeaway: string;
+}
+
+const cannedResponses: Array<{
+  match: RegExp;
+  response: (matches: RegExpExecArray) => string;
+}> = [
+  {
+    match: /^search\s+(.+)/i,
+    response: (m) => `[*] Searching modules for: ${m[1]}\n[*] 3 modules matched in the demo database.\n    auxiliary/scanner/http/title\n    exploit/multi/http/manage_engine_opmanager_auth_upload\n    post/multi/gather/aws_keys`,
+  },
+  {
+    match: /^use\s+(.+)/i,
+    response: (m) => `[*] Using module: ${m[1]}\n[*] Info: Simulated module selected for tabletop exercise.`,
+  },
+  {
+    match: /^set\s+([A-Z_]+)\s+(.+)/i,
+    response: (m) => `[*] ${m[1]} => ${m[2]} (simulation only)`,
+  },
+  {
+    match: /^run(?:\s+|$)/i,
+    response: () => `[*] Running module...\n[*] Demo target responded with mock vulnerability banner.\n[*] No sessions created because this is a teaching environment.`,
+  },
+  {
+    match: /^sessions\s+-i\s*(\d+)/i,
+    response: (m) => `[*] Interacting with session ${m[1]}\n[*] Session output: whoami -> demo\\analyst`,
+  },
+  {
+    match: /^help/i,
+    response: () => `Core help topics:\n  - search <term>\n  - use <module>\n  - set RHOSTS <target>\n  - run\nAll commands are intercepted and answered locally.`,
+  },
+];
+
+const defaultBanner = `No canned response matched that command. Describe what would happen next to keep the demo engaging.`;
+
+export const runMetasploitCommand = async (
+  command: string
+): Promise<MetasploitCommandResult> => {
+  const trimmed = command.trim();
+  for (const canned of cannedResponses) {
+    const matches = canned.match.exec(trimmed);
+    if (matches) {
+      return { output: canned.response(matches) };
+    }
+  }
+  return { output: defaultBanner };
+};
+
+export const metasploitStoryboard: MetasploitStoryboardStep[] = [
+  {
+    title: 'Recon and module search',
+    command: 'search struts',
+    description:
+      'Highlight how an operator narrows down modules that match a CVE or service fingerprint. The simulated response lists staged modules.',
+    takeaway:
+      'Emphasise responsible disclosure and change management before launching code.',
+  },
+  {
+    title: 'Configure safely',
+    command: 'set RHOSTS 192.0.2.42',
+    description:
+      'Demonstrate setting options without contacting the remote host. Pair it with documentation on why those values were chosen.',
+    takeaway:
+      'Keep a written record of every option changed for audit trails.',
+  },
+  {
+    title: 'Tabletop execution',
+    command: 'run',
+    description:
+      'Walk stakeholders through the expected console output. The canned text shows a vulnerability banner without opening a real session.',
+    takeaway:
+      'Discuss remediation steps immediately rather than attempting exploitation.',
+  },
+];
+
+export default {
+  runMetasploitCommand,
+  metasploitStoryboard,
+};

--- a/apps/simulations/nmap.ts
+++ b/apps/simulations/nmap.ts
@@ -1,0 +1,218 @@
+export interface NmapScript {
+  name: string;
+  description: string;
+  tags: string[];
+  example: string;
+  phase: 'prerule' | 'hostrule' | 'portrule';
+}
+
+export interface NmapScanHost {
+  ip: string;
+  ports: Array<{
+    port: number;
+    service: string;
+    cvss: number;
+    scripts?: Array<{
+      name: string;
+      output: string;
+    }>;
+  }>;
+}
+
+export interface NmapScanResult {
+  hosts: NmapScanHost[];
+}
+
+export interface NmapStoryboardStep {
+  title: string;
+  command: string;
+  description: string;
+  takeaway: string;
+}
+
+export const scriptCatalog: NmapScript[] = [
+  {
+    name: 'http-title',
+    description: 'Fetches page titles from HTTP services.',
+    tags: ['discovery', 'http'],
+    example: `PORT   STATE SERVICE VERSION\n80/tcp open  http\n| http-title: Example Domain\n|_Requested resource was /`,
+    phase: 'portrule',
+  },
+  {
+    name: 'ssl-cert',
+    description: 'Retrieves TLS certificate information.',
+    tags: ['ssl', 'discovery'],
+    example: `PORT    STATE SERVICE\n443/tcp open  https\n| ssl-cert: Subject: commonName=example.com\n| Not valid before: 2020-06-01T00:00:00\n|_Not valid after: 2022-06-01T12:00:00`,
+    phase: 'portrule',
+  },
+  {
+    name: 'smb-os-discovery',
+    description: 'Discovers remote OS information via SMB.',
+    tags: ['smb', 'discovery'],
+    example: `PORT    STATE SERVICE\n445/tcp open  microsoft-ds\n| smb-os-discovery:\n|   OS: Windows 10 Pro 19041\n|   Computer name: HOST\n|_  Workgroup: WORKGROUP`,
+    phase: 'hostrule',
+  },
+  {
+    name: 'ftp-anon',
+    description: 'Checks for anonymous FTP access.',
+    tags: ['ftp', 'auth'],
+    example: `PORT   STATE SERVICE\n21/tcp open  ftp\n| ftp-anon: Anonymous FTP login allowed (FTP code 230)\n|_-rw-r--r--    1 ftp  ftp           73 Feb 02 00:15 welcome.msg`,
+    phase: 'portrule',
+  },
+  {
+    name: 'http-enum',
+    description: 'Enumerates directories on web servers.',
+    tags: ['http', 'vuln'],
+    example: `PORT   STATE SERVICE\n80/tcp open  http\n| http-enum:\n|   /admin/: Potential admin interface\n|_  /images/: Potentially interesting directory w/ listing`,
+    phase: 'portrule',
+  },
+  {
+    name: 'dns-brute',
+    description: 'Performs DNS subdomain brute force enumeration.',
+    tags: ['dns', 'brute'],
+    example: `Host scripts results:\n| dns-brute:\n|   mail.example.com - 192.0.2.10\n|   dev.example.com - 192.0.2.20\n|_  shop.example.com - 192.0.2.30`,
+    phase: 'hostrule',
+  },
+];
+
+export const scanResult: NmapScanResult = {
+  hosts: [
+    {
+      ip: '192.0.2.10',
+      ports: [
+        {
+          port: 80,
+          service: 'http',
+          cvss: 5.0,
+          scripts: [
+            { name: 'http-title', output: 'Example Domain' },
+            {
+              name: 'http-enum',
+              output:
+                '/admin/: Potential admin interface\n/images/: Potentially interesting directory w/ listing',
+            },
+          ],
+        },
+        {
+          port: 443,
+          service: 'https',
+          cvss: 3.1,
+          scripts: [
+            {
+              name: 'ssl-cert',
+              output:
+                'Subject: commonName=example.com\nNot valid before: 2020-06-01\nNot valid after: 2022-06-01',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      ip: '192.0.2.20',
+      ports: [
+        {
+          port: 21,
+          service: 'ftp',
+          cvss: 7.5,
+          scripts: [
+            {
+              name: 'ftp-anon',
+              output: 'Anonymous FTP login allowed\nwelcome.msg',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      ip: '192.0.2.30',
+      ports: [
+        {
+          port: 445,
+          service: 'microsoft-ds',
+          cvss: 4.0,
+          scripts: [
+            {
+              name: 'smb-os-discovery',
+              output: 'OS: Windows 10 Pro\nComputer name: HOST\nWorkgroup: WORKGROUP',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export const nmapPhaseDescriptions: Record<
+  NmapScript['phase'],
+  { description: string; example: string }
+> = {
+  prerule: {
+    description:
+      'Runs before any hosts are scanned. Often used for broadcast discovery.',
+    example: 'broadcast-dhcp-discover',
+  },
+  hostrule: {
+    description: 'Runs once for each target host.',
+    example: 'smb-os-discovery',
+  },
+  portrule: {
+    description: 'Runs once for each target port.',
+    example: 'http-title',
+  },
+};
+
+export const nmapPortPresets = [
+  { label: 'Default', flag: '' },
+  { label: 'Common', flag: '-F' },
+  { label: 'Full', flag: '-p-' },
+];
+
+export const nmapStoryboard: NmapStoryboardStep[] = [
+  {
+    title: 'Scope confirmation',
+    command: 'nmap -sn 192.0.2.0/24',
+    description:
+      'Start with a ping sweep in a lab range to confirm which demo hosts should respond before touching service scans.',
+    takeaway:
+      'Keep scans inside approved IP space and record the intent before you continue.',
+  },
+  {
+    title: 'Service discovery',
+    command: 'nmap -sV -p80,443 example.com --script http-title,http-enum',
+    description:
+      'Focus on web ports and pair them with safe discovery scripts. The canned output shows a typical corporate portal with an exposed admin path.',
+    takeaway:
+      'Match scripts to the services you expect and explain why each script was selected.',
+  },
+  {
+    title: 'Deeper validation',
+    command: 'nmap -sV -p21,445 example.net --script ftp-anon,smb-os-discovery',
+    description:
+      'Pivot to internal services to illustrate how credential hygiene issues surface. Sample responses highlight anonymous FTP access and SMB metadata.',
+    takeaway:
+      'Document follow-up actions instead of exploiting the findings in the simulation.',
+  },
+];
+
+export const loadNmapScripts = async (): Promise<NmapScript[]> => {
+  return scriptCatalog;
+};
+
+export const loadNmapScanResult = async (): Promise<NmapScanResult> => {
+  return scanResult;
+};
+
+export const loadNmapStoryboard = async (): Promise<NmapStoryboardStep[]> => {
+  return nmapStoryboard;
+};
+
+export default {
+  loadNmapScripts,
+  loadNmapScanResult,
+  loadNmapStoryboard,
+  scriptCatalog,
+  scanResult,
+  nmapPhaseDescriptions,
+  nmapPortPresets,
+  nmapStoryboard,
+};


### PR DESCRIPTION
## Summary
- add simulation adapters for nmap, hydra, metasploit, and john with canned demo outputs
- update the nmap, hydra, metasploit, and john UIs to consume the adapters and surface storyboard guidance

## Testing
- yarn lint *(fails: repository already has numerous accessibility lint violations; see log for details)*

------
https://chatgpt.com/codex/tasks/task_e_68d668281a188328b79b518b2ca02583