### PR TITLE
[desktop] mark shell components as client modules

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Component } from "react";
 import Image from 'next/image';
 import { toCanvas } from 'html-to-image';

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Component } from 'react'
 import Image from 'next/image'
 

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useRef, useEffect } from 'react';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';

--- a/components/common/NotificationCenter.tsx
+++ b/components/common/NotificationCenter.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { createContext, useCallback, useEffect, useState } from 'react';
 
 export interface AppNotification {

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useRef } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useRef } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useEffect } from 'react'
 import logger from '../../utils/logger'
 

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useRef } from 'react';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import UbuntuApp from '../base/ubuntu_app';
 

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react'
 import Image from 'next/image'
 

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Component } from 'react';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import UbuntuApp from '../base/ubuntu_app';
 

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState } from 'react'
 import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import Image from 'next/image';
 

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState, useRef } from 'react';
 
 export default function WindowSwitcher({ windows = [], onSelect, onClose }) {


### PR DESCRIPTION
## Summary
- add the `"use client"` directive to desktop shell screens, taskbar, and context menu components so browser APIs stay on the client bundle
- mark the shared Ubuntu app wrappers and notification/context providers as client modules to prevent server-side `window` usage

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d668287cd083288385adc47e60741b