### PR TITLE
[shell] Add dock persistence and accessibility improvements

### DIFF
--- a/__tests__/Dock.test.tsx
+++ b/__tests__/Dock.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Dock from '../components/shell/Dock';
+
+const apps = [
+  { id: 'terminal', title: 'Terminal', icon: '/icons/terminal.svg' },
+  { id: 'files', title: 'Files', icon: '/icons/files.svg' },
+  { id: 'browser', title: 'Browser', icon: '/icons/browser.svg' },
+];
+
+describe('Dock component', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('reorders pinned apps via keyboard fallback commands', async () => {
+    const user = userEvent.setup();
+    render(
+      <Dock
+        apps={apps}
+        initialPinned={['terminal', 'files']}
+        storageKey="dock-component-reorder"
+      />,
+    );
+
+    const terminalButton = screen.getByRole('menuitem', { name: /terminal/i });
+    expect(terminalButton).toBeInTheDocument();
+    terminalButton.focus();
+
+    await user.keyboard('{Shift>}{F10}{/Shift}');
+
+    const menu = await screen.findByRole('menu', { name: /dock item options/i });
+    const moveRight = within(menu).getByRole('menuitem', { name: /move right/i });
+    await user.click(moveRight);
+
+    const buttons = screen.getAllByRole('menuitem');
+    expect(buttons[0]).toHaveAccessibleName('Files');
+    expect(buttons[1]).toHaveAccessibleName('Terminal');
+  });
+
+  it('pins a running app from the context menu', async () => {
+    const user = userEvent.setup();
+    render(
+      <Dock
+        apps={apps}
+        initialPinned={['terminal']}
+        runningAppIds={['browser']}
+        storageKey="dock-component-pin"
+      />,
+    );
+
+    const browserButton = screen.getByRole('menuitem', { name: /browser/i });
+    expect(browserButton).toHaveAttribute('data-pinned', 'false');
+
+    await user.pointer([{ target: browserButton, keys: '[MouseRight]' }]);
+
+    const menu = await screen.findByRole('menu', { name: /dock item options/i });
+    const pinOption = within(menu).getByRole('menuitem', { name: /pin to dock/i });
+    await user.click(pinOption);
+
+    const updatedBrowser = screen.getByRole('menuitem', { name: /browser/i });
+    expect(updatedBrowser).toHaveAttribute('data-pinned', 'true');
+  });
+});

--- a/__tests__/useDockStore.test.ts
+++ b/__tests__/useDockStore.test.ts
@@ -1,0 +1,46 @@
+import { act, renderHook } from '@testing-library/react';
+import useDockStore from '../hooks/useDockStore';
+
+describe('useDockStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('persists pinned order across hook lifecycles', () => {
+    const storageKey = 'dock-test-storage';
+    const { result, unmount } = renderHook(() =>
+      useDockStore({ initialPinned: ['terminal', 'files', 'browser'], storageKey }),
+    );
+
+    expect(result.current.pinned).toEqual(['terminal', 'files', 'browser']);
+
+    act(() => result.current.reorderPinned(0, 2));
+    expect(result.current.pinned).toEqual(['files', 'browser', 'terminal']);
+
+    unmount();
+
+    const { result: rerendered } = renderHook(() =>
+      useDockStore({ initialPinned: ['terminal', 'files', 'browser'], storageKey }),
+    );
+
+    expect(rerendered.current.pinned).toEqual(['files', 'browser', 'terminal']);
+  });
+
+  it('keeps running apps separate from pinned ones', () => {
+    const storageKey = 'dock-test-running';
+    const { result } = renderHook(() =>
+      useDockStore({ initialPinned: ['terminal'], storageKey }),
+    );
+
+    act(() => result.current.setRunningApps(['terminal', 'notes', 'notes', 'music']));
+
+    expect(result.current.pinned).toEqual(['terminal']);
+    expect(result.current.running).toEqual(['notes', 'music']);
+
+    act(() => result.current.unpinApp('terminal'));
+    expect(result.current.pinned).toEqual([]);
+
+    act(() => result.current.setRunningApps(['terminal', 'music']));
+    expect(result.current.running).toEqual(['terminal', 'music']);
+  });
+});

--- a/components/shell/Dock.tsx
+++ b/components/shell/Dock.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import Image from 'next/image';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type {
+  DragEvent as ReactDragEvent,
+  KeyboardEvent as ReactKeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+} from 'react';
+import useDockStore from '../../hooks/useDockStore';
+
+export interface DockApp {
+  id: string;
+  title: string;
+  icon: string;
+}
+
+export interface DockProps {
+  apps: DockApp[];
+  runningAppIds?: string[];
+  onLaunch?: (id: string) => void;
+  onFocus?: (id: string) => void;
+  /**
+   * Default pinned order used when no stored state exists yet.
+   */
+  initialPinned?: string[];
+  /**
+   * Optional storage key override. Useful for isolated tests.
+   */
+  storageKey?: string;
+}
+
+interface ContextMenuState {
+  open: boolean;
+  x: number;
+  y: number;
+  appId: string | null;
+}
+
+const baseButtonClasses =
+  'group relative flex h-12 w-12 items-center justify-center rounded-lg transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500';
+
+const iconClasses =
+  'h-9 w-9 drop-shadow-[0_0_4px_rgba(0,0,0,0.35)] transition group-hover:scale-105 group-active:scale-95';
+
+const runningIndicatorClasses =
+  'absolute -bottom-1 left-1/2 h-1 w-4 -translate-x-1/2 rounded-full bg-sky-400 group-data-[active="true"]:bg-sky-200';
+
+const menuButtonClasses =
+  'flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm text-white hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400';
+
+const normalizeIds = (ids: string[] = []) => Array.from(new Set(ids));
+
+const Dock = ({
+  apps,
+  runningAppIds = [],
+  onLaunch,
+  onFocus,
+  initialPinned,
+  storageKey,
+}: DockProps) => {
+  const {
+    pinned,
+    running,
+    togglePin,
+    pinApp,
+    unpinApp,
+    reorderPinned,
+    movePinnedByOffset,
+    setRunningApps,
+    isPinned,
+  } = useDockStore({ initialPinned, storageKey });
+
+  const appMap = useMemo(() => new Map(apps.map((app) => [app.id, app])), [apps]);
+  const normalizedRunning = useMemo(() => normalizeIds(runningAppIds), [runningAppIds]);
+
+  useEffect(() => {
+    setRunningApps(normalizedRunning);
+  }, [normalizedRunning, setRunningApps]);
+
+  const pinnedItems = useMemo(
+    () => pinned.map((id) => appMap.get(id)).filter(Boolean) as DockApp[],
+    [appMap, pinned],
+  );
+  const runningItems = useMemo(
+    () => running.map((id) => appMap.get(id)).filter(Boolean) as DockApp[],
+    [appMap, running],
+  );
+
+  const items = [...pinnedItems, ...runningItems];
+
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const dragIdRef = useRef<string | null>(null);
+
+  const [menuState, setMenuState] = useState<ContextMenuState>({
+    open: false,
+    x: 0,
+    y: 0,
+    appId: null,
+  });
+
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const closeMenu = (event: globalThis.MouseEvent) => {
+      if (!menuState.open) return;
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMenuState({ open: false, x: 0, y: 0, appId: null });
+      }
+    };
+    const handleEscape = (event: globalThis.KeyboardEvent) => {
+      if (menuState.open && event.key === 'Escape') {
+        setMenuState({ open: false, x: 0, y: 0, appId: null });
+      }
+    };
+    document.addEventListener('mousedown', closeMenu as EventListener);
+    document.addEventListener('keydown', handleEscape as EventListener);
+    return () => {
+      document.removeEventListener('mousedown', closeMenu as EventListener);
+      document.removeEventListener('keydown', handleEscape as EventListener);
+    };
+  }, [menuState.open]);
+
+  useEffect(() => {
+    if (!menuState.open || !menuRef.current) return;
+    const focusable = menuRef.current.querySelector<HTMLButtonElement>('button');
+    focusable?.focus();
+  }, [menuState.open]);
+
+  const openContextMenu = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement> | ReactKeyboardEvent<HTMLButtonElement>, appId: string) => {
+      event.preventDefault();
+      const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+      setMenuState({
+        open: true,
+        x: 'clientX' in event ? event.clientX : rect.left,
+        y: 'clientY' in event ? event.clientY : rect.bottom,
+        appId,
+      });
+    },
+    [],
+  );
+
+  const handleMenuAction = useCallback(
+    (action: 'pin' | 'unpin' | 'left' | 'right') => {
+      const targetId = menuState.appId;
+      if (!targetId) return;
+      if (action === 'pin') {
+        pinApp(targetId);
+      } else if (action === 'unpin') {
+        unpinApp(targetId);
+      } else if (action === 'left') {
+        movePinnedByOffset(targetId, -1);
+      } else if (action === 'right') {
+        movePinnedByOffset(targetId, 1);
+      }
+      setMenuState({ open: false, x: 0, y: 0, appId: null });
+    },
+    [menuState.appId, movePinnedByOffset, pinApp, unpinApp],
+  );
+
+  const handleLaunch = useCallback(
+    (id: string) => {
+      if (onLaunch) onLaunch(id);
+      else if (onFocus) onFocus(id);
+    },
+    [onFocus, onLaunch],
+  );
+
+  const handleDragStart = useCallback(
+    (event: ReactDragEvent<HTMLButtonElement>, id: string) => {
+      if (!isPinned(id)) return;
+      setDraggingId(id);
+      dragIdRef.current = id;
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('text/plain', id);
+    },
+    [isPinned],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDraggingId(null);
+    dragIdRef.current = null;
+  }, []);
+
+  const handleDrop = useCallback(
+    (event: ReactDragEvent<HTMLElement>, targetId: string | null) => {
+      event.preventDefault();
+      const sourceId = event.dataTransfer.getData('text/plain') || dragIdRef.current;
+      if (!sourceId || !isPinned(sourceId)) return;
+      const fromIndex = pinned.indexOf(sourceId);
+      if (fromIndex === -1) return;
+      const toIndex = targetId ? pinned.indexOf(targetId) : pinned.length - 1;
+      if (toIndex === -1) return;
+      reorderPinned(fromIndex, toIndex);
+      setDraggingId(null);
+      dragIdRef.current = null;
+    },
+    [isPinned, pinned, reorderPinned],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>, id: string) => {
+      if ((event.shiftKey && event.key === 'F10') || event.key === 'ContextMenu') {
+        openContextMenu(event, id);
+        return;
+      }
+      if ((event.ctrlKey || event.metaKey) && (event.key === 'p' || event.key === 'P')) {
+        event.preventDefault();
+        togglePin(id);
+        return;
+      }
+      if (event.altKey && event.key === 'ArrowLeft') {
+        event.preventDefault();
+        movePinnedByOffset(id, -1);
+        return;
+      }
+      if (event.altKey && event.key === 'ArrowRight') {
+        event.preventDefault();
+        movePinnedByOffset(id, 1);
+        return;
+      }
+    },
+    [movePinnedByOffset, openContextMenu, togglePin],
+  );
+
+  return (
+    <nav
+      aria-label="Dock"
+      className="pointer-events-auto flex h-full w-16 select-none flex-col items-center gap-2 bg-black/50 py-4 text-white backdrop-blur"
+    >
+      <ul className="flex h-full flex-col items-center gap-3" role="menubar">
+        {items.map((item) => {
+          const pinnedStatus = isPinned(item.id);
+          const isActive = normalizedRunning.includes(item.id);
+          return (
+            <li key={item.id} role="none">
+              <button
+                type="button"
+                role="menuitem"
+                className={[
+                  baseButtonClasses,
+                  pinnedStatus ? 'cursor-grab' : 'cursor-default',
+                  draggingId === item.id ? 'opacity-50' : 'opacity-100',
+                ].join(' ')}
+                onClick={() => handleLaunch(item.id)}
+                onContextMenu={(event) => openContextMenu(event, item.id)}
+                onKeyDown={(event) => handleKeyDown(event, item.id)}
+                draggable={pinnedStatus}
+                onDragStart={(event) => handleDragStart(event, item.id)}
+                onDragEnd={handleDragEnd}
+                onDragOver={(event) => event.preventDefault()}
+                onDrop={(event) => handleDrop(event, item.id)}
+                data-active={String(isActive)}
+                data-pinned={String(pinnedStatus)}
+                aria-pressed={isActive}
+                aria-haspopup="menu"
+              >
+                <Image
+                  src={item.icon}
+                  alt={item.title}
+                  width={36}
+                  height={36}
+                  className={iconClasses}
+                />
+                {isActive && <span data-testid="running-indicator" className={runningIndicatorClasses} />}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      <div
+        className="mt-auto h-12 w-12"
+        onDragOver={(event) => event.preventDefault()}
+        onDrop={(event) => handleDrop(event, null)}
+      />
+      {menuState.open && (
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label="Dock item options"
+          className="fixed z-50 min-w-[12rem] rounded-lg border border-white/10 bg-black/80 p-2 shadow-lg backdrop-blur"
+          style={{ left: menuState.x, top: menuState.y }}
+        >
+          {menuState.appId && !isPinned(menuState.appId) && (
+            <button
+              type="button"
+              role="menuitem"
+              className={menuButtonClasses}
+              onClick={() => handleMenuAction('pin')}
+            >
+              Pin to Dock
+            </button>
+          )}
+          {menuState.appId && isPinned(menuState.appId) && (
+            <>
+              <button
+                type="button"
+                role="menuitem"
+                className={menuButtonClasses}
+                onClick={() => handleMenuAction('unpin')}
+              >
+                Unpin from Dock
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className={menuButtonClasses}
+                onClick={() => handleMenuAction('left')}
+              >
+                Move Left
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className={menuButtonClasses}
+                onClick={() => handleMenuAction('right')}
+              >
+                Move Right
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </nav>
+  );
+};
+
+export default Dock;

--- a/hooks/useDockStore.ts
+++ b/hooks/useDockStore.ts
@@ -1,0 +1,182 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import usePersistentState from './usePersistentState';
+
+export interface DockPersistedState {
+  pinned: string[];
+}
+
+export interface UseDockStoreOptions {
+  /**
+   * Storage key used for persisting the dock state.
+   * Allowing overrides keeps tests isolated and avoids collisions with other docks.
+   */
+  storageKey?: string;
+  /**
+   * Default pinned app order. Any ids not yet present in storage will be appended
+   * the first time the hook runs.
+   */
+  initialPinned?: string[];
+}
+
+const isPersistedState = (value: unknown): value is DockPersistedState =>
+  Boolean(
+    value &&
+    typeof value === 'object' &&
+    Array.isArray((value as DockPersistedState).pinned) &&
+    (value as DockPersistedState).pinned.every((id) => typeof id === 'string'),
+  );
+
+const unique = (values: string[]) => {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    if (seen.has(value)) return false;
+    seen.add(value);
+    return true;
+  });
+};
+
+const move = (list: string[], from: number, to: number) => {
+  if (from === to) return list;
+  const next = [...list];
+  const [item] = next.splice(from, 1);
+  next.splice(to, 0, item);
+  return next;
+};
+
+export default function useDockStore(options: UseDockStoreOptions = {}) {
+  const { storageKey = 'dock-state', initialPinned = [] } = options;
+  const [persisted, setPersisted] = usePersistentState<DockPersistedState>(
+    storageKey,
+    () => ({ pinned: [...initialPinned] }),
+    isPersistedState,
+  );
+  const [running, setRunning] = useState<string[]>([]);
+  const didInit = useRef(false);
+  const cachedInitial = useRef<string[]>(initialPinned);
+
+  useEffect(() => {
+    // Only react to changes if the caller truly changed the defaults.
+    if (cachedInitial.current.join('\u0000') === initialPinned.join('\u0000')) {
+      return;
+    }
+    cachedInitial.current = [...initialPinned];
+  }, [initialPinned]);
+
+  useEffect(() => {
+    if (didInit.current) return;
+    didInit.current = true;
+    setPersisted((prev) => {
+      const merged = unique([...prev.pinned, ...cachedInitial.current]);
+      if (merged.length === prev.pinned.length) {
+        return prev;
+      }
+      return { pinned: merged };
+    });
+  }, [setPersisted]);
+
+  const pinApp = useCallback(
+    (id: string, position?: number) => {
+      if (!id) return;
+      setPersisted((prev) => {
+        if (prev.pinned.includes(id)) return prev;
+        const next = [...prev.pinned];
+        if (typeof position === 'number' && position >= 0 && position <= next.length) {
+          next.splice(position, 0, id);
+        } else {
+          next.push(id);
+        }
+        return { pinned: next };
+      });
+    },
+    [setPersisted],
+  );
+
+  const unpinApp = useCallback(
+    (id: string) => {
+      if (!id) return;
+      setPersisted((prev) => {
+        if (!prev.pinned.includes(id)) return prev;
+        return { pinned: prev.pinned.filter((item) => item !== id) };
+      });
+    },
+    [setPersisted],
+  );
+
+  const togglePin = useCallback(
+    (id: string) => {
+      setPersisted((prev) =>
+        prev.pinned.includes(id)
+          ? { pinned: prev.pinned.filter((item) => item !== id) }
+          : { pinned: [...prev.pinned, id] },
+      );
+    },
+    [setPersisted],
+  );
+
+  const reorderPinned = useCallback(
+    (fromIndex: number, toIndex: number) => {
+      if (fromIndex === toIndex) return;
+      setPersisted((prev) => {
+        if (
+          fromIndex < 0 ||
+          toIndex < 0 ||
+          fromIndex >= prev.pinned.length ||
+          toIndex >= prev.pinned.length
+        ) {
+          return prev;
+        }
+        return { pinned: move(prev.pinned, fromIndex, toIndex) };
+      });
+    },
+    [setPersisted],
+  );
+
+  const movePinnedByOffset = useCallback(
+    (id: string, offset: number) => {
+      if (!offset) return;
+      setPersisted((prev) => {
+        const index = prev.pinned.indexOf(id);
+        if (index === -1) return prev;
+        let nextIndex = index + offset;
+        if (nextIndex < 0) nextIndex = 0;
+        if (nextIndex >= prev.pinned.length) nextIndex = prev.pinned.length - 1;
+        return { pinned: move(prev.pinned, index, nextIndex) };
+      });
+    },
+    [setPersisted],
+  );
+
+  const setRunningApps = useCallback((ids: string[]) => {
+    setRunning((prev) => {
+      const next = unique(ids);
+      if (prev.length === next.length && prev.every((value, index) => value === next[index])) {
+        return prev;
+      }
+      return next;
+    });
+  }, []);
+
+  const isPinned = useCallback(
+    (id: string) => persisted.pinned.includes(id),
+    [persisted.pinned],
+  );
+
+  const visibleRunning = useMemo(
+    () => running.filter((id) => !persisted.pinned.includes(id)),
+    [running, persisted.pinned],
+  );
+
+  return {
+    pinned: persisted.pinned,
+    running: visibleRunning,
+    pinApp,
+    unpinApp,
+    togglePin,
+    reorderPinned,
+    movePinnedByOffset,
+    setRunningApps,
+    isPinned,
+  };
+}


### PR DESCRIPTION
## Summary
- implement a new shell dock component with drag-and-drop reordering, context menu pin/unpin, and keyboard access
- add a dedicated dock store that persists pinned items separately from running instances
- cover dock persistence and ordering behaviours with focused unit tests

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in unrelated apps)*
- CI=1 yarn test --runTestsByPath __tests__/Dock.test.tsx
- CI=1 yarn test --runTestsByPath __tests__/useDockStore.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d6d519cce883289f7e1a228177c87b