### PR TITLE
[shell] Add dock running indicators

### DIFF
--- a/__tests__/Dock.test.tsx
+++ b/__tests__/Dock.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { act, render, screen, fireEvent, within } from "@testing-library/react";
+import Dock, { DockApp } from "../components/shell/Dock";
+import { windowManagerStore } from "../modules/window-manager/store";
+
+const apps: DockApp[] = [
+  {
+    id: "terminal",
+    title: "Terminal",
+    icon: "/icons/terminal.svg",
+  },
+];
+
+describe("Dock indicators", () => {
+  beforeEach(() => {
+    windowManagerStore.reset();
+  });
+
+  it("shows and hides running indicator based on window state", () => {
+    render(<Dock apps={apps} onLaunch={() => {}} />);
+
+    expect(screen.queryByTestId("dock-indicator-terminal")).toBeNull();
+
+    act(() => {
+      windowManagerStore.openWindow({
+        id: "terminal-1",
+        appId: "terminal",
+        title: "Terminal 1",
+      });
+    });
+
+    expect(screen.getByTestId("dock-indicator-terminal")).toBeInTheDocument();
+
+    act(() => {
+      windowManagerStore.closeWindow("terminal-1");
+    });
+
+    expect(screen.queryByTestId("dock-indicator-terminal")).toBeNull();
+  });
+
+  it("lists open windows in a hover popover", () => {
+    render(<Dock apps={apps} onLaunch={() => {}} />);
+
+    act(() => {
+      windowManagerStore.openWindow({
+        id: "terminal-1",
+        appId: "terminal",
+        title: "Shell",
+      });
+      windowManagerStore.openWindow({
+        id: "terminal-2",
+        appId: "terminal",
+        title: "Logs",
+      });
+      windowManagerStore.focusWindow("terminal-2");
+    });
+
+    const dockButton = screen.getByRole("button", { name: "Terminal" });
+
+    fireEvent.mouseEnter(dockButton);
+
+    const listbox = screen.getByRole("listbox", { name: /open windows for terminal/i });
+    expect(within(listbox).getByRole("option", { name: "Shell" })).toBeInTheDocument();
+    expect(within(listbox).getByRole("option", { name: "Logs" })).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.mouseLeave(dockButton.parentElement!);
+    expect(screen.queryByRole("listbox", { name: /open windows for terminal/i })).toBeNull();
+  });
+});

--- a/__tests__/windowManagerStore.test.ts
+++ b/__tests__/windowManagerStore.test.ts
@@ -1,0 +1,45 @@
+import { windowManagerStore } from "../modules/window-manager/store";
+
+describe("window manager store", () => {
+  beforeEach(() => {
+    windowManagerStore.reset();
+  });
+
+  it("opens and closes windows", () => {
+    windowManagerStore.openWindow({
+      id: "one",
+      appId: "terminal",
+      title: "Terminal",
+    });
+
+    expect(Object.keys(windowManagerStore.getState().windows)).toEqual(["one"]);
+
+    windowManagerStore.closeWindow("one");
+    expect(windowManagerStore.getState().windows).toEqual({});
+  });
+
+  it("tracks focus and minimization", () => {
+    windowManagerStore.openWindow({
+      id: "one",
+      appId: "terminal",
+      title: "Terminal",
+    });
+    windowManagerStore.openWindow({
+      id: "two",
+      appId: "terminal",
+      title: "Terminal 2",
+    });
+
+    windowManagerStore.focusWindow("one");
+    expect(windowManagerStore.getState().windows["one"].isFocused).toBe(true);
+    expect(windowManagerStore.getState().windows["two"].isFocused).toBe(false);
+
+    windowManagerStore.setMinimized("one", true);
+    const stateAfterMinimize = windowManagerStore.getState();
+    expect(stateAfterMinimize.windows["one"].isMinimized).toBe(true);
+    expect(stateAfterMinimize.windows["one"].isFocused).toBe(false);
+
+    windowManagerStore.focusWindow("two");
+    expect(windowManagerStore.getState().windows["two"].isFocused).toBe(true);
+  });
+});

--- a/components/shell/Dock.tsx
+++ b/components/shell/Dock.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import Image from "next/image";
+import React, { useMemo, useState } from "react";
+import {
+  selectWindowsByApp,
+  useWindowManagerState,
+  WindowRecord,
+} from "../../modules/window-manager/store";
+
+export interface DockApp {
+  id: string;
+  title: string;
+  icon: string;
+}
+
+export interface DockProps {
+  apps: DockApp[];
+  onLaunch: (appId: string) => void;
+  orientation?: "vertical" | "horizontal";
+}
+
+function getFocusedState(records: WindowRecord[]) {
+  return records.some((record) => record.isFocused && !record.isMinimized);
+}
+
+export default function Dock({
+  apps,
+  onLaunch,
+  orientation = "vertical",
+}: DockProps) {
+  const { windows } = useWindowManagerState();
+  const [popoverApp, setPopoverApp] = useState<string | null>(null);
+
+  const windowsByApp = useMemo(() => selectWindowsByApp({ windows }), [windows]);
+
+  const directionClasses =
+    orientation === "horizontal"
+      ? "flex-row px-3 py-2"
+      : "flex-col px-2 py-3";
+
+  return (
+    <nav
+      aria-label="Dock"
+      className={`pointer-events-auto flex rounded-2xl bg-black/60 backdrop-blur-md`}
+    >
+      <ul className={`flex ${directionClasses} gap-2`}>
+        {apps.map((app) => {
+          const windowList = windowsByApp.get(app.id) ?? [];
+          const isRunning = windowList.length > 0;
+          const hasFocus = isRunning && getFocusedState(windowList);
+          const showPopover = popoverApp === app.id && isRunning;
+
+          const show = () => {
+            if (windowList.length > 0) {
+              setPopoverApp(app.id);
+            }
+          };
+
+          const hide = () => {
+            setPopoverApp((current) => (current === app.id ? null : current));
+          };
+
+          return (
+            <li
+              key={app.id}
+              className="relative"
+              onMouseEnter={show}
+              onMouseLeave={hide}
+            >
+              <button
+                type="button"
+                aria-label={app.title}
+                aria-pressed={hasFocus}
+                data-app-id={app.id}
+                onClick={() => onLaunch(app.id)}
+                onFocus={show}
+                onBlur={hide}
+                className={`relative flex h-12 w-12 items-center justify-center rounded-xl transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 ${
+                  hasFocus ? "bg-white/20" : "hover:bg-white/10"
+                }`}
+              >
+                <Image
+                  src={app.icon}
+                  alt=""
+                  width={32}
+                  height={32}
+                  className="h-8 w-8"
+                />
+                {isRunning && (
+                  <span
+                    aria-hidden="true"
+                    data-testid={`dock-indicator-${app.id}`}
+                    className={`absolute bottom-1 h-1 w-2 rounded-full bg-white transition-opacity ${
+                      hasFocus ? "opacity-100" : "opacity-70"
+                    }`}
+                  />
+                )}
+              </button>
+              {showPopover && (
+                <div
+                  role="listbox"
+                  aria-label={`Open windows for ${app.title}`}
+                  className="absolute left-1/2 top-full z-20 mt-2 w-max -translate-x-1/2 rounded-lg bg-black/80 px-3 py-2 text-xs text-white shadow-lg"
+                >
+                  {windowList.map((record) => (
+                    <div
+                      key={record.id}
+                      role="option"
+                      aria-selected={record.isFocused && !record.isMinimized}
+                      className="whitespace-nowrap"
+                    >
+                      {record.title}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/modules/window-manager/store.ts
+++ b/modules/window-manager/store.ts
@@ -1,0 +1,173 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+type Listener = () => void;
+
+export type WindowId = string;
+
+export interface WindowRecord {
+  id: WindowId;
+  appId: string;
+  title: string;
+  /**
+   * True when the window has been minimized. Minimized windows should
+   * still be considered running but are not marked as focused.
+   */
+  isMinimized: boolean;
+  /**
+   * True when the window currently has input focus.
+   */
+  isFocused: boolean;
+}
+
+export interface WindowManagerState {
+  windows: Record<WindowId, WindowRecord>;
+}
+
+const defaultState: WindowManagerState = { windows: {} };
+
+let state: WindowManagerState = { windows: {} };
+const listeners = new Set<Listener>();
+
+function notify() {
+  listeners.forEach((listener) => listener());
+}
+
+function setState(updater: (prev: WindowManagerState) => WindowManagerState) {
+  const next = updater(state);
+  if (next === state) return;
+  state = next;
+  notify();
+}
+
+function cloneWindows() {
+  return { ...state.windows };
+}
+
+function compareRecords(a: WindowRecord, b: WindowRecord) {
+  return (
+    a.id === b.id &&
+    a.appId === b.appId &&
+    a.title === b.title &&
+    a.isMinimized === b.isMinimized &&
+    a.isFocused === b.isFocused
+  );
+}
+
+export const windowManagerStore = {
+  getState: () => state,
+  getServerSnapshot: () => defaultState,
+  subscribe(listener: Listener) {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+  openWindow(descriptor: Omit<WindowRecord, "isMinimized" | "isFocused"> & {
+    isMinimized?: boolean;
+    isFocused?: boolean;
+  }) {
+    setState((prev) => {
+      const existing = prev.windows[descriptor.id];
+      const nextRecord: WindowRecord = {
+        id: descriptor.id,
+        appId: descriptor.appId,
+        title: descriptor.title,
+        isMinimized: descriptor.isMinimized ?? false,
+        isFocused: descriptor.isFocused ?? false,
+      };
+
+      if (existing && compareRecords(existing, nextRecord)) {
+        return prev;
+      }
+
+      const windows = { ...prev.windows, [descriptor.id]: nextRecord };
+      return { windows };
+    });
+  },
+  closeWindow(id: WindowId) {
+    setState((prev) => {
+      if (!prev.windows[id]) return prev;
+      const windows = cloneWindows();
+      delete windows[id];
+      return { windows };
+    });
+  },
+  focusWindow(id: WindowId) {
+    setState((prev) => {
+      if (!prev.windows[id]) return prev;
+      let changed = false;
+      const windows: Record<WindowId, WindowRecord> = {};
+      for (const [winId, record] of Object.entries(prev.windows)) {
+        if (winId === id) {
+          const nextRecord: WindowRecord = record.isFocused && !record.isMinimized
+            ? record
+            : { ...record, isFocused: true, isMinimized: false };
+          if (nextRecord !== record) changed = true;
+          windows[winId] = nextRecord;
+        } else if (record.isFocused) {
+          windows[winId] = { ...record, isFocused: false };
+          changed = true;
+        } else {
+          windows[winId] = record;
+        }
+      }
+      return changed ? { windows } : prev;
+    });
+  },
+  blurWindow(id: WindowId) {
+    setState((prev) => {
+      const record = prev.windows[id];
+      if (!record || !record.isFocused) return prev;
+      const windows = { ...prev.windows, [id]: { ...record, isFocused: false } };
+      return { windows };
+    });
+  },
+  setMinimized(id: WindowId, minimized: boolean) {
+    setState((prev) => {
+      const record = prev.windows[id];
+      if (!record || record.isMinimized === minimized) return prev;
+      const nextRecord: WindowRecord = {
+        ...record,
+        isMinimized: minimized,
+        isFocused: minimized ? false : record.isFocused,
+      };
+      const windows = { ...prev.windows, [id]: nextRecord };
+      return { windows };
+    });
+  },
+  updateTitle(id: WindowId, title: string) {
+    setState((prev) => {
+      const record = prev.windows[id];
+      if (!record || record.title === title) return prev;
+      const windows = { ...prev.windows, [id]: { ...record, title } };
+      return { windows };
+    });
+  },
+  reset() {
+    state = { windows: {} };
+    notify();
+  },
+};
+
+export function useWindowManagerState(): WindowManagerState {
+  return useSyncExternalStore(
+    windowManagerStore.subscribe,
+    windowManagerStore.getState,
+    windowManagerStore.getServerSnapshot,
+  );
+}
+
+export function selectWindowsByApp(state: WindowManagerState): Map<string, WindowRecord[]> {
+  const result = new Map<string, WindowRecord[]>();
+  for (const record of Object.values(state.windows)) {
+    const collection = result.get(record.appId);
+    if (collection) {
+      collection.push(record);
+    } else {
+      result.set(record.appId, [record]);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- add a Dock component that shows running indicators and window list popovers
- create a window manager store that tracks window lifecycle events for the dock
- add unit tests covering dock indicator visibility and store focus/minimize state

## Testing
- yarn lint *(fails: pre-existing unlabeled control errors across apps)*
- yarn test Dock.test.tsx windowManagerStore.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d6d51a1d808328af53832e8c8550b5