### PR TITLE
[desktop] add onboarding tour and settings toggle

### DIFF
--- a/__tests__/tour.test.tsx
+++ b/__tests__/tour.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import Tour from '../components/onboarding/Tour';
+import { SettingsContext } from '../hooks/useSettings';
+import {
+  defaults,
+  getTourCompleted,
+  setTourCompleted,
+} from '../utils/settingsStore';
+
+const createSettingsValue = (
+  overrides: Partial<React.ContextType<typeof SettingsContext>> = {},
+): React.ContextType<typeof SettingsContext> => ({
+  accent: defaults.accent,
+  wallpaper: defaults.wallpaper,
+  bgImageName: defaults.wallpaper,
+  useKaliWallpaper: defaults.useKaliWallpaper,
+  density: defaults.density as 'regular' | 'compact',
+  reducedMotion: defaults.reducedMotion,
+  fontScale: defaults.fontScale,
+  highContrast: defaults.highContrast,
+  largeHitAreas: defaults.largeHitAreas,
+  pongSpin: defaults.pongSpin,
+  allowNetwork: defaults.allowNetwork,
+  haptics: defaults.haptics,
+  theme: 'default',
+  tourCompleted: false,
+  setAccent: jest.fn(),
+  setWallpaper: jest.fn(),
+  setUseKaliWallpaper: jest.fn(),
+  setDensity: jest.fn(),
+  setReducedMotion: jest.fn(),
+  setFontScale: jest.fn(),
+  setHighContrast: jest.fn(),
+  setLargeHitAreas: jest.fn(),
+  setPongSpin: jest.fn(),
+  setAllowNetwork: jest.fn(),
+  setHaptics: jest.fn(),
+  setTheme: jest.fn(),
+  setTourCompleted: jest.fn(),
+  ...overrides,
+} as React.ContextType<typeof SettingsContext>);
+
+describe('desktop tour persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('stores and retrieves completion state', async () => {
+    expect(await getTourCompleted()).toBe(false);
+    await setTourCompleted(true);
+    expect(await getTourCompleted()).toBe(true);
+    await setTourCompleted(false);
+    expect(await getTourCompleted()).toBe(false);
+  });
+});
+
+describe('desktop tour navigation', () => {
+  it('advances through steps and finishes', () => {
+    const setTourCompletedMock = jest.fn();
+    const contextValue = createSettingsValue({ setTourCompleted: setTourCompletedMock });
+
+    render(
+      <SettingsContext.Provider value={contextValue}>
+        <div>
+          <div data-tour-target="launcher" style={{ width: 120, height: 120 }} />
+          <nav data-tour-target="dock" style={{ width: 56, height: 300 }} />
+          <div data-tour-target="window-controls" style={{ width: 160, height: 40 }} />
+        </div>
+        <Tour />
+      </SettingsContext.Provider>,
+    );
+
+    expect(screen.getByRole('heading', { name: /launcher/i })).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'ArrowRight' });
+    expect(screen.getByRole('heading', { name: /dock/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByRole('heading', { name: /window controls/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /finish/i }));
+    expect(setTourCompletedMock).toHaveBeenCalledWith(true);
+  });
+});

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { getUnlockedThemes } from '../utils/theme';
 import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
+import ToggleSwitch from './ToggleSwitch';
 
 interface Props {
   highScore?: number;
@@ -9,7 +10,7 @@ interface Props {
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
-  const { accent, setAccent, theme, setTheme } = useSettings();
+  const { accent, setAccent, theme, setTheme, tourCompleted, setTourCompleted } = useSettings();
 
   return (
     <div>
@@ -52,6 +53,19 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
               ))}
             </div>
           </label>
+          <div className="mt-4">
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-sm font-medium text-white">Replay tour</span>
+              <ToggleSwitch
+                ariaLabel="Replay desktop tour"
+                checked={!tourCompleted}
+                onChange={(checked) => setTourCompleted(!checked)}
+              />
+            </div>
+            <p className="mt-1 text-xs text-ubt-grey" aria-live="polite">
+              Toggle on to restart the onboarding tour and highlight key desktop controls.
+            </p>
+          </div>
         </div>
       )}
     </div>

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -763,7 +763,10 @@ export function WindowEditButtons(props) {
     const { togglePin } = useDocPiP(props.pip || (() => null));
     const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
     return (
-        <div className={`${styles.windowControls} absolute select-none right-0 top-0 mr-1 flex justify-center items-center min-w-[8.25rem]`}>
+        <div
+            className={`${styles.windowControls} absolute select-none right-0 top-0 mr-1 flex justify-center items-center min-w-[8.25rem]`}
+            data-tour-target="window-controls"
+        >
             {pipSupported && props.pip && (
                 <button
                     type="button"

--- a/components/onboarding/Tour.tsx
+++ b/components/onboarding/Tour.tsx
@@ -1,0 +1,338 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import { useSettings } from '../../hooks/useSettings';
+
+type Placement = 'top' | 'right' | 'bottom' | 'left';
+
+interface TourStep {
+  id: string;
+  title: string;
+  description: string;
+  target: string;
+  placement: Placement;
+}
+
+interface HighlightRect {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+
+const STEPS: TourStep[] = [
+  {
+    id: 'launcher',
+    title: 'Launcher',
+    description:
+      'Open the launcher to browse every app in the Kali desktop. Use the grid button at the bottom of the dock or press the Super key.',
+    target: '[data-tour-target="launcher"]',
+    placement: 'right',
+  },
+  {
+    id: 'dock',
+    title: 'Dock',
+    description:
+      'Pinned tools live in the dock for quick access. Click an icon to open it or right-click for more actions.',
+    target: '[data-tour-target="dock"]',
+    placement: 'right',
+  },
+  {
+    id: 'window-controls',
+    title: 'Window controls',
+    description:
+      'Every window has minimize, maximize, and close controls. Use them with the mouse or keyboard shortcuts to manage your workspace.',
+    target: '[data-tour-target="window-controls"]',
+    placement: 'bottom',
+  },
+];
+
+const HIGHLIGHT_PADDING = 12;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+function expandRect(rect: DOMRect, padding: number): HighlightRect {
+  return {
+    top: rect.top - padding,
+    left: rect.left - padding,
+    right: rect.right + padding,
+    bottom: rect.bottom + padding,
+    width: rect.width + padding * 2,
+    height: rect.height + padding * 2,
+  };
+}
+
+function computeCardPosition(rect: HighlightRect | null, placement: Placement) {
+  if (typeof window === 'undefined' || !rect) {
+    return {
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+    } as const;
+  }
+
+  const margin = 20;
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  let top = rect.top;
+  let left = rect.left;
+  let translateX = 0;
+  let translateY = 0;
+
+  switch (placement) {
+    case 'top':
+      top = rect.top - margin;
+      left = rect.left + rect.width / 2;
+      translateX = -50;
+      translateY = -100;
+      break;
+    case 'right':
+      top = rect.top + rect.height / 2;
+      left = rect.right + margin;
+      translateX = 0;
+      translateY = -50;
+      break;
+    case 'left':
+      top = rect.top + rect.height / 2;
+      left = rect.left - margin;
+      translateX = -100;
+      translateY = -50;
+      break;
+    case 'bottom':
+    default:
+      top = rect.bottom + margin;
+      left = rect.left + rect.width / 2;
+      translateX = -50;
+      translateY = 0;
+      break;
+  }
+
+  top = clamp(top, margin, viewportHeight - margin);
+  left = clamp(left, margin, viewportWidth - margin);
+
+  return {
+    top,
+    left,
+    transform: `translate(${translateX}%, ${translateY}%)`,
+  } as const;
+}
+
+interface TourProps {
+  ready?: boolean;
+}
+
+const Tour = ({ ready = true }: TourProps) => {
+  const { tourCompleted, setTourCompleted, reducedMotion } = useSettings();
+  const [isOpen, setIsOpen] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
+  const [highlightRect, setHighlightRect] = useState<HighlightRect | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const nextButtonRef = useRef<HTMLButtonElement>(null);
+
+  useFocusTrap(panelRef, isOpen);
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      setPortalRoot(document.body);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!tourCompleted && ready) {
+      setIsOpen(true);
+      setStepIndex(0);
+    } else {
+      setIsOpen(false);
+    }
+  }, [tourCompleted, ready]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const button = nextButtonRef.current;
+    button?.focus();
+  }, [isOpen, stepIndex]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
+  const currentStep = useMemo(() => STEPS[stepIndex] ?? null, [stepIndex]);
+
+  useEffect(() => {
+    if (!isOpen || !currentStep || !ready) {
+      setHighlightRect(null);
+      return;
+    }
+
+    const node = document.querySelector(currentStep.target) as HTMLElement | null;
+    if (!node) {
+      setHighlightRect(null);
+      return;
+    }
+
+    const updateRect = () => {
+      const rect = node.getBoundingClientRect();
+      setHighlightRect(expandRect(rect, HIGHLIGHT_PADDING));
+    };
+
+    updateRect();
+
+    const resizeObserver =
+      typeof window !== 'undefined' && 'ResizeObserver' in window
+        ? new ResizeObserver(() => updateRect())
+        : null;
+
+    resizeObserver?.observe(node);
+    window.addEventListener('resize', updateRect);
+    window.addEventListener('scroll', updateRect, true);
+
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', updateRect);
+      window.removeEventListener('scroll', updateRect, true);
+    };
+  }, [isOpen, currentStep, ready]);
+
+  const finishTour = useCallback(() => {
+    setTourCompleted(true);
+    setIsOpen(false);
+  }, [setTourCompleted]);
+
+  const goNext = useCallback(() => {
+    setStepIndex((index) => {
+      if (index >= STEPS.length - 1) {
+        finishTour();
+        return index;
+      }
+      return index + 1;
+    });
+  }, [finishTour]);
+
+  const goPrevious = useCallback(() => {
+    setStepIndex((index) => Math.max(0, index - 1));
+  }, []);
+
+  const skipTour = useCallback(() => {
+    finishTour();
+  }, [finishTour]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!isOpen) return;
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        goNext();
+      } else if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        goPrevious();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        skipTour();
+      }
+    },
+    [goNext, goPrevious, isOpen, skipTour],
+  );
+
+  if (!portalRoot || !isOpen || !currentStep || !ready) {
+    return null;
+  }
+
+  const titleId = 'desktop-tour-title';
+  const descriptionId = 'desktop-tour-description';
+  const stepPosition = computeCardPosition(highlightRect, currentStep.placement);
+  const highlightStyle = highlightRect
+    ? {
+        top: Math.max(0, highlightRect.top),
+        left: Math.max(0, highlightRect.left),
+        width: highlightRect.width,
+        height: highlightRect.height,
+      }
+    : undefined;
+
+  const transitionClass = reducedMotion ? '' : 'transition-all duration-300 ease-out';
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[1000]"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="absolute inset-0 bg-black/60" aria-hidden="true" />
+      {highlightRect && (
+        <div
+          aria-hidden="true"
+          className={`pointer-events-none absolute rounded-xl border-2 border-ub-orange shadow-[0_0_0_9999px_rgba(0,0,0,0.6)] ${transitionClass}`}
+          style={highlightStyle}
+        />
+      )}
+      <div
+        className="absolute w-full max-w-md px-4"
+        style={{ top: stepPosition.top, left: stepPosition.left, transform: stepPosition.transform }}
+      >
+        <div
+          ref={panelRef}
+          tabIndex={-1}
+          className="rounded-lg border border-ubt-grey/60 bg-ub-dark p-4 text-white shadow-xl focus:outline-none"
+        >
+          <p className="text-xs uppercase tracking-wide text-ubt-grey" aria-live="polite">
+            Step {stepIndex + 1} of {STEPS.length}
+          </p>
+          <h2 id={titleId} className="mt-1 text-lg font-semibold">
+            {currentStep.title}
+          </h2>
+          <p id={descriptionId} className="mt-2 text-sm text-ubt-grey" aria-live="polite">
+            {currentStep.description}
+          </p>
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
+            <button
+              type="button"
+              onClick={goPrevious}
+              disabled={stepIndex === 0}
+              className={`rounded bg-ubt-cool-grey px-3 py-2 text-sm font-medium text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
+                stepIndex === 0
+                  ? 'cursor-not-allowed opacity-60'
+                  : 'hover:bg-ub-orange/90'
+              }`}
+            >
+              Back
+            </button>
+            <div className="ml-auto flex gap-2">
+              <button
+                type="button"
+                onClick={skipTour}
+                className="rounded border border-ubt-grey px-3 py-2 text-sm font-medium text-white hover:bg-ubt-grey/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              >
+                Skip tour
+              </button>
+              <button
+                ref={nextButtonRef}
+                type="button"
+                onClick={stepIndex === STEPS.length - 1 ? finishTour : goNext}
+                className="rounded bg-ub-orange px-3 py-2 text-sm font-semibold text-white hover:bg-ub-orange/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              >
+                {stepIndex === STEPS.length - 1 ? 'Finish' : 'Next'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    portalRoot,
+  );
+};
+
+export default Tour;

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -29,6 +29,7 @@ export default function SideBar(props) {
         <>
             <nav
                 aria-label="Dock"
+                data-tour-target="dock"
                 className={(props.hide ? " -translate-x-full " : "") +
                     " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
             >
@@ -52,6 +53,7 @@ export function AllApps(props) {
 
     return (
         <div
+            data-tour-target="launcher"
             className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
             style={{ marginTop: 'auto' }}
             onMouseEnter={() => {

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -7,6 +7,7 @@ import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
+import Tour from './onboarding/Tour';
 
 export default class Ubuntu extends Component {
 	constructor() {
@@ -126,9 +127,16 @@ export default class Ubuntu extends Component {
 					isShutDown={this.state.shutDownScreen}
 					turnOn={this.turnOn}
 				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+                                <Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
+                                <Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
+                                <Tour
+                                        ready={
+                                                !this.state.booting_screen &&
+                                                !this.state.screen_locked &&
+                                                !this.state.shutDownScreen
+                                        }
+                                />
+                        </div>
+                );
+        }
 }

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -22,6 +22,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getTourCompleted as loadTourCompleted,
+  setTourCompleted as saveTourCompleted,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -67,6 +69,7 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  tourCompleted: boolean;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setUseKaliWallpaper: (value: boolean) => void;
@@ -79,6 +82,7 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setTourCompleted: (value: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -95,6 +99,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  tourCompleted: defaults.tourCompleted,
   setAccent: () => {},
   setWallpaper: () => {},
   setUseKaliWallpaper: () => {},
@@ -107,6 +112,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setTourCompleted: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -122,6 +128,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [tourCompleted, setTourCompletedState] = useState<boolean>(defaults.tourCompleted);
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -138,6 +145,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
       setTheme(loadTheme());
+      setTourCompletedState(await loadTourCompleted());
     })();
   }, []);
 
@@ -250,6 +258,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveTourCompleted(tourCompleted);
+  }, [tourCompleted]);
+
+  const updateTourCompleted = (value: boolean) => {
+    setTourCompletedState(value);
+  };
+
   const bgImageName = useKaliWallpaper ? 'kali-gradient' : wallpaper;
 
   return (
@@ -268,6 +284,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        tourCompleted,
         setAccent,
         setWallpaper,
         setUseKaliWallpaper,
@@ -280,6 +297,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setTourCompleted: updateTourCompleted,
       }}
     >
       {children}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -15,7 +15,10 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  tourCompleted: false,
 };
+
+const TOUR_COMPLETED_KEY = 'desktop-tour-completed';
 
 export async function getAccent() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
@@ -135,6 +138,22 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getTourCompleted() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.tourCompleted;
+  const stored = window.localStorage.getItem(TOUR_COMPLETED_KEY);
+  return stored === null ? DEFAULT_SETTINGS.tourCompleted : stored === 'true';
+}
+
+export async function setTourCompleted(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(TOUR_COMPLETED_KEY, value ? 'true' : 'false');
+}
+
+export async function resetTourCompleted() {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(TOUR_COMPLETED_KEY);
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -150,6 +169,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
   window.localStorage.removeItem('use-kali-wallpaper');
+  window.localStorage.removeItem(TOUR_COMPLETED_KEY);
 }
 
 export async function exportSettings() {


### PR DESCRIPTION
## Summary
- add an accessible desktop onboarding tour that highlights the launcher, dock, and window controls
- persist the tour completion flag in the shared settings store and surface a "Replay tour" toggle in the settings drawer
- cover the persistence helper and tour navigation with focused tests

## Testing
- yarn lint *(fails: existing repo lint issues unrelated to this change)*
- yarn test __tests__/tour.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d6d5233b808328aca5837a1abec8cb