### PR TITLE
[settings] unify desktop controls

### DIFF
--- a/__tests__/settingsStore.test.ts
+++ b/__tests__/settingsStore.test.ts
@@ -1,0 +1,61 @@
+jest.mock('idb-keyval', () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+}));
+
+jest.mock('../utils/theme', () => ({
+  getTheme: jest.fn(() => 'default'),
+  setTheme: jest.fn(),
+}));
+
+import { importSettings, resetSettings } from '../utils/settingsStore';
+import { setTheme } from '../utils/theme';
+import { set as idbSet, del as idbDel } from 'idb-keyval';
+
+describe('settingsStore persistence', () => {
+  beforeEach(() => {
+    (idbSet as jest.Mock).mockResolvedValue(undefined);
+    (idbDel as jest.Mock).mockResolvedValue(undefined);
+    window.localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('imports settings and writes all toggles', async () => {
+    await importSettings({
+      accent: '#ffffff',
+      wallpaper: 'wall-4',
+      useKaliWallpaper: true,
+      density: 'compact',
+      reducedMotion: true,
+      fontScale: 1.25,
+      highContrast: true,
+      largeHitAreas: true,
+      pongSpin: false,
+      allowNetwork: true,
+      haptics: false,
+      theme: 'dark',
+    });
+
+    expect(idbSet).toHaveBeenCalledWith('accent', '#ffffff');
+    expect(idbSet).toHaveBeenCalledWith('bg-image', 'wall-4');
+    expect(window.localStorage.getItem('use-kali-wallpaper')).toBe('true');
+    expect(window.localStorage.getItem('large-hit-areas')).toBe('true');
+    expect(window.localStorage.getItem('pong-spin')).toBe('false');
+    expect(window.localStorage.getItem('allow-network')).toBe('true');
+    expect(window.localStorage.getItem('haptics')).toBe('false');
+    expect(setTheme).toHaveBeenCalledWith('dark');
+  });
+
+  it('resets stored values', async () => {
+    window.localStorage.setItem('large-hit-areas', 'true');
+    window.localStorage.setItem('allow-network', 'true');
+    window.localStorage.setItem('pong-spin', 'false');
+    await resetSettings();
+    expect(idbDel).toHaveBeenCalledWith('accent');
+    expect(idbDel).toHaveBeenCalledWith('bg-image');
+    expect(window.localStorage.getItem('large-hit-areas')).toBeNull();
+    expect(window.localStorage.getItem('allow-network')).toBeNull();
+    expect(window.localStorage.getItem('pong-spin')).toBeNull();
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
@@ -13,6 +13,33 @@ import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
 import KaliWallpaper from "../../components/util-components/kali-wallpaper";
+
+const hexToRgb = (hex: string) => {
+  const normalized = hex.replace("#", "");
+  const bigint = parseInt(normalized, 16);
+  return {
+    r: (bigint >> 16) & 255,
+    g: (bigint >> 8) & 255,
+    b: bigint & 255,
+  };
+};
+
+const luminance = ({ r, g, b }: { r: number; g: number; b: number }) => {
+  const channel = (value: number) => {
+    const scaled = value / 255;
+    return scaled <= 0.03928
+      ? scaled / 12.92
+      : Math.pow((scaled + 0.055) / 1.055, 2.4);
+  };
+  const [lr, lg, lb] = [channel(r), channel(g), channel(b)];
+  return lr * 0.2126 + lg * 0.7152 + lb * 0.0722;
+};
+
+const contrastRatio = (foreground: string, background: string) => {
+  const l1 = luminance(hexToRgb(foreground)) + 0.05;
+  const l2 = luminance(hexToRgb(background)) + 0.05;
+  return l1 > l2 ? l1 / l2 : l2 / l1;
+};
 
 export default function Settings() {
   const {
@@ -30,20 +57,27 @@ export default function Settings() {
     setFontScale,
     highContrast,
     setHighContrast,
+    largeHitAreas,
+    setLargeHitAreas,
+    pongSpin,
+    setPongSpin,
+    allowNetwork,
+    setAllowNetwork,
     haptics,
     setHaptics,
     theme,
     setTheme,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const liveRegionRef = useRef<HTMLSpanElement>(null);
 
   const tabs = [
-    { id: "appearance", label: "Appearance" },
+    { id: "desktop", label: "Desktop" },
     { id: "accessibility", label: "Accessibility" },
-    { id: "privacy", label: "Privacy" },
+    { id: "system", label: "System" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
-  const [activeTab, setActiveTab] = useState<TabId>("appearance");
+  const [activeTab, setActiveTab] = useState<TabId>("desktop");
 
   const wallpapers = [
     "wall-1",
@@ -58,6 +92,24 @@ export default function Settings() {
 
   const changeBackground = (name: string) => setWallpaper(name);
   const wallpaperIndex = Math.max(0, wallpapers.indexOf(wallpaper));
+
+  const accentTextColor = useMemo(() => {
+    return contrastRatio(accent, "#000000") > contrastRatio(accent, "#ffffff")
+      ? "#000000"
+      : "#ffffff";
+  }, [accent]);
+
+  const contrast = useMemo(() => contrastRatio(accent, accentTextColor), [
+    accent,
+    accentTextColor,
+  ]);
+
+  useEffect(() => {
+    if (!liveRegionRef.current) return;
+    liveRegionRef.current.textContent = `Contrast ratio ${contrast.toFixed(
+      2
+    )}:1 ${contrast >= 4.5 ? "passes" : "fails"}`;
+  }, [contrast]);
 
   const handleExport = async () => {
     const data = await exportSettingsData();
@@ -83,6 +135,14 @@ export default function Settings() {
       if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
+      if (parsed.largeHitAreas !== undefined)
+        setLargeHitAreas(parsed.largeHitAreas);
+      if (parsed.pongSpin !== undefined) setPongSpin(parsed.pongSpin);
+      if (parsed.allowNetwork !== undefined)
+        setAllowNetwork(parsed.allowNetwork);
+      if (parsed.useKaliWallpaper !== undefined)
+        setUseKaliWallpaper(parsed.useKaliWallpaper);
+      if (parsed.haptics !== undefined) setHaptics(parsed.haptics);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
     } catch (err) {
       console.error("Invalid settings", err);
@@ -97,13 +157,17 @@ export default function Settings() {
     )
       return;
     await resetSettings();
-    window.localStorage.clear();
     setAccent(defaults.accent);
     setWallpaper(defaults.wallpaper);
+    setUseKaliWallpaper(defaults.useKaliWallpaper);
     setDensity(defaults.density as any);
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
+    setLargeHitAreas(defaults.largeHitAreas);
+    setPongSpin(defaults.pongSpin);
+    setAllowNetwork(defaults.allowNetwork);
+    setHaptics(defaults.haptics);
     setTheme("default");
   };
 
@@ -114,214 +178,317 @@ export default function Settings() {
       <div className="flex justify-center border-b border-gray-900">
         <Tabs tabs={tabs} active={activeTab} onChange={setActiveTab} />
       </div>
-      {activeTab === "appearance" && (
-        <>
-          <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4 relative overflow-hidden rounded-lg shadow-inner">
-            {useKaliWallpaper ? (
-              <KaliWallpaper />
-            ) : (
-              <div
-                className="absolute inset-0 bg-cover bg-center"
-                style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)` }}
-                aria-hidden="true"
-              />
-            )}
-          </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Theme:</label>
-            <select
-              value={theme}
-              onChange={(e) => setTheme(e.target.value)}
-              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-            >
-              <option value="default">Default</option>
-              <option value="dark">Dark</option>
-              <option value="neon">Neon</option>
-              <option value="matrix">Matrix</option>
-            </select>
-          </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Accent:</label>
-            <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
-              {ACCENT_OPTIONS.map((c) => (
-                <button
-                  key={c}
-                  aria-label={`select-accent-${c}`}
-                  role="radio"
-                  aria-checked={accent === c}
-                  onClick={() => setAccent(c)}
-                  className={`w-8 h-8 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
-                  style={{ backgroundColor: c }}
+      {activeTab === "desktop" && (
+        <div className="px-6 py-6 space-y-6 text-ubt-grey">
+          <section aria-labelledby="desktop-theme" className="space-y-4">
+            <div className="md:w-2/5 w-full md:min-w-[300px] h-48 m-auto relative overflow-hidden rounded-lg shadow-inner">
+              {useKaliWallpaper ? (
+                <KaliWallpaper />
+              ) : (
+                <div
+                  className="absolute inset-0 bg-cover bg-center"
+                  style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)` }}
+                  aria-hidden="true"
                 />
-              ))}
+              )}
             </div>
-          </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey flex items-center">
-              <input
-                type="checkbox"
-                checked={useKaliWallpaper}
-                onChange={(e) => setUseKaliWallpaper(e.target.checked)}
-                className="mr-2"
-              />
-              Kali Gradient Wallpaper
-            </label>
-          </div>
-          {useKaliWallpaper && (
-            <p className="text-center text-xs text-ubt-grey/70 px-6 -mt-2 mb-4">
-              Your previous wallpaper selection is preserved for when you turn this off.
-            </p>
-          )}
-          <div className="flex justify-center my-4">
-            <label htmlFor="wallpaper-slider" className="mr-2 text-ubt-grey">Wallpaper:</label>
-            <input
-              id="wallpaper-slider"
-              type="range"
-              min="0"
-              max={wallpapers.length - 1}
-              step="1"
-              value={wallpaperIndex}
-              onChange={(e) =>
-                changeBackground(wallpapers[parseInt(e.target.value, 10)])
-              }
-              className="ubuntu-slider"
-              aria-label="Wallpaper"
-            />
-          </div>
-          <div className="flex justify-center my-4">
-            <BackgroundSlideshow />
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 justify-items-center border-t border-gray-900">
-            {wallpapers.map((name) => (
-              <div
-                key={name}
-                role="button"
-                aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
-                aria-pressed={name === wallpaper}
-                tabIndex={0}
-                onClick={() => changeBackground(name)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    changeBackground(name);
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div className="space-y-2" aria-labelledby="desktop-theme">
+                <h2 id="desktop-theme" className="text-lg font-semibold text-white">
+                  Theme & Accent
+                </h2>
+                <div className="flex flex-wrap gap-4 items-center">
+                  <label className="flex flex-col text-sm">
+                    <span className="mb-1">Theme</span>
+                    <select
+                      value={theme}
+                      onChange={(e) => setTheme(e.target.value)}
+                      className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                    >
+                      <option value="default">Default</option>
+                      <option value="dark">Dark</option>
+                      <option value="neon">Neon</option>
+                      <option value="matrix">Matrix</option>
+                    </select>
+                  </label>
+                  <div>
+                    <span className="block text-sm mb-1">Accent</span>
+                    <div
+                      aria-label="Accent color picker"
+                      role="radiogroup"
+                      className="flex flex-wrap gap-2"
+                    >
+                      {ACCENT_OPTIONS.map((c) => (
+                        <button
+                          key={c}
+                          aria-label={`select-accent-${c}`}
+                          role="radio"
+                          aria-checked={accent === c}
+                          onClick={() => setAccent(c)}
+                          className={`w-8 h-8 rounded-full border-2 ${
+                            accent === c ? "border-white" : "border-transparent"
+                          }`}
+                          style={{ backgroundColor: c }}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="p-4 rounded border border-ubt-cool-grey bg-ub-cool-grey/70 text-sm text-white">
+                <p className="mb-2 text-center font-semibold">Accent Preview</p>
+                <button
+                  className="px-3 py-1 rounded"
+                  style={{ backgroundColor: accent, color: accentTextColor }}
+                  type="button"
+                >
+                  Accent
+                </button>
+                <p
+                  className={`mt-3 text-center ${
+                    contrast >= 4.5 ? "text-green-400" : "text-red-400"
+                  }`}
+                >
+                  Contrast {contrast.toFixed(2)}:1 {contrast >= 4.5 ? "Pass" : "Fail"}
+                </p>
+                <span ref={liveRegionRef} role="status" aria-live="polite" className="sr-only" />
+              </div>
+            </div>
+          </section>
+
+          <section aria-labelledby="desktop-wallpaper" className="space-y-4">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div>
+                <h2 id="desktop-wallpaper" className="text-lg font-semibold text-white">
+                  Wallpaper
+                </h2>
+                <p className="text-sm text-ubt-grey">
+                  Choose a static wallpaper or let the slideshow rotate through your favorites.
+                </p>
+              </div>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={useKaliWallpaper}
+                  onChange={(e) => setUseKaliWallpaper(e.target.checked)}
+                  aria-label="Use Kali gradient wallpaper"
+                />
+                Use Kali gradient wallpaper
+              </label>
+            </div>
+            {useKaliWallpaper && (
+              <p className="text-xs text-ubt-grey/70">
+                Your previous wallpaper selection is preserved for when you turn this off.
+              </p>
+            )}
+            <div className="flex flex-col gap-4">
+              <label htmlFor="wallpaper-slider" className="flex items-center gap-3">
+                <span className="text-sm">Browse wallpapers</span>
+                <input
+                  id="wallpaper-slider"
+                  type="range"
+                  min="0"
+                  max={wallpapers.length - 1}
+                  step="1"
+                  value={wallpaperIndex}
+                  onChange={(e) =>
+                    changeBackground(wallpapers[parseInt(e.target.value, 10)])
                   }
-                }}
-                className={
-                  (name === wallpaper
-                    ? " border-yellow-700 "
-                    : " border-transparent ") +
-                  " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"
-                }
-                style={{
-                  backgroundImage: `url(/wallpapers/${name}.webp)`,
-                  backgroundSize: "cover",
-                  backgroundRepeat: "no-repeat",
-                  backgroundPosition: "center center",
-                }}
-              ></div>
-            ))}
-          </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
-            <button
-              onClick={handleReset}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Reset Desktop
-            </button>
-          </div>
-        </>
+                  className="ubuntu-slider flex-1"
+                  aria-label="Wallpaper"
+                />
+              </label>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                {wallpapers.map((name) => (
+                  <button
+                    key={name}
+                    type="button"
+                    aria-label={`Select ${name.replace("wall-", "wallpaper ")}`}
+                    aria-pressed={name === wallpaper}
+                    onClick={() => changeBackground(name)}
+                    className={`h-24 md:h-32 rounded border-4 border-opacity-80 bg-cover bg-center outline-none focus-visible:ring-2 focus-visible:ring-ub-orange ${
+                      name === wallpaper ? "border-yellow-700" : "border-transparent"
+                    }`}
+                    style={{ backgroundImage: `url(/wallpapers/${name}.webp)` }}
+                  />
+                ))}
+              </div>
+            </div>
+            <div className="border border-gray-900/60 rounded">
+              <BackgroundSlideshow />
+            </div>
+          </section>
+
+          <section aria-labelledby="desktop-motion" className="space-y-4">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div>
+                <h2 id="desktop-motion" className="text-lg font-semibold text-white">
+                  Motion & Input
+                </h2>
+                <p className="text-sm text-ubt-grey">
+                  Control animations, haptics, and shortcuts across the desktop.
+                </p>
+              </div>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <div className="flex items-center gap-2">
+                  <span>Reduced Motion</span>
+                  <ToggleSwitch
+                    checked={reducedMotion}
+                    onChange={setReducedMotion}
+                    ariaLabel="Reduced Motion"
+                  />
+                </div>
+                <div className="flex items-center gap-2">
+                  <span>Haptics</span>
+                  <ToggleSwitch
+                    checked={haptics}
+                    onChange={setHaptics}
+                    ariaLabel="Haptics"
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-4">
+              <button
+                onClick={() => setShowKeymap(true)}
+                className="px-4 py-2 rounded bg-ub-orange text-white"
+                type="button"
+                aria-label="Open shortcut grab overlay"
+              >
+                Grab keyboard shortcuts
+              </button>
+              <button
+                onClick={handleReset}
+                className="px-4 py-2 rounded border border-ub-orange text-ub-orange hover:bg-ub-orange/20"
+                type="button"
+              >
+                Reset desktop
+              </button>
+            </div>
+          </section>
+        </div>
       )}
       {activeTab === "accessibility" && (
-        <>
-          <div className="flex justify-center my-4">
-            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
-            <input
-              id="font-scale"
-              type="range"
-              min="0.75"
-              max="1.5"
-              step="0.05"
-              value={fontScale}
-              onChange={(e) => setFontScale(parseFloat(e.target.value))}
-              className="ubuntu-slider"
-              aria-label="Icon size"
-            />
-          </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey">Density:</label>
-            <select
-              value={density}
-              onChange={(e) => setDensity(e.target.value as any)}
-              className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
-            >
-              <option value="regular">Regular</option>
-              <option value="compact">Compact</option>
-            </select>
-          </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">Reduced Motion:</span>
-            <ToggleSwitch
-              checked={reducedMotion}
-              onChange={setReducedMotion}
-              ariaLabel="Reduced Motion"
-            />
-          </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">High Contrast:</span>
-            <ToggleSwitch
-              checked={highContrast}
-              onChange={setHighContrast}
-              ariaLabel="High Contrast"
-            />
-          </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">Haptics:</span>
-            <ToggleSwitch
-              checked={haptics}
-              onChange={setHaptics}
-              ariaLabel="Haptics"
-            />
-          </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
-            <button
-              onClick={() => setShowKeymap(true)}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Edit Shortcuts
-            </button>
-          </div>
-        </>
+        <div className="px-6 py-6 space-y-6 text-ubt-grey">
+          <section aria-labelledby="access-visual" className="space-y-4">
+            <h2 id="access-visual" className="text-lg font-semibold text-white">
+              Layout & Legibility
+            </h2>
+            <div className="flex flex-col gap-4">
+              <label htmlFor="font-scale" className="flex flex-col gap-2 text-sm">
+                <span>Icon size</span>
+                <input
+                  id="font-scale"
+                  type="range"
+                  min="0.75"
+                  max="1.5"
+                  step="0.05"
+                  value={fontScale}
+                  onChange={(e) => setFontScale(parseFloat(e.target.value))}
+                  className="ubuntu-slider"
+                  aria-label="Icon size"
+                />
+              </label>
+              <label className="flex flex-col gap-2 text-sm max-w-xs">
+                <span>Density</span>
+                <select
+                  value={density}
+                  onChange={(e) => setDensity(e.target.value as typeof density)}
+                  className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                >
+                  <option value="regular">Regular</option>
+                  <option value="compact">Compact</option>
+                </select>
+              </label>
+            </div>
+          </section>
+
+          <section aria-labelledby="access-contrast" className="space-y-4">
+            <h2 id="access-contrast" className="text-lg font-semibold text-white">
+              Contrast & Targets
+            </h2>
+            <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+              <div className="flex items-center gap-2">
+                <span>High contrast</span>
+                <ToggleSwitch
+                  checked={highContrast}
+                  onChange={setHighContrast}
+                  ariaLabel="High contrast"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <span>Large hit areas</span>
+                <ToggleSwitch
+                  checked={largeHitAreas}
+                  onChange={setLargeHitAreas}
+                  ariaLabel="Large hit areas"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <span>Pong spin</span>
+                <ToggleSwitch
+                  checked={pongSpin}
+                  onChange={setPongSpin}
+                  ariaLabel="Pong spin"
+                />
+              </div>
+            </div>
+          </section>
+        </div>
       )}
-      {activeTab === "privacy" && (
-        <>
-          <div className="flex justify-center my-4 space-x-4">
-            <button
-              onClick={handleExport}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Export Settings
-            </button>
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Import Settings
-            </button>
-          </div>
-        </>
+      {activeTab === "system" && (
+        <div className="px-6 py-6 space-y-6 text-ubt-grey">
+          <section aria-labelledby="system-privacy" className="space-y-4">
+            <h2 id="system-privacy" className="text-lg font-semibold text-white">
+              System Preferences
+            </h2>
+            <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+              <div className="flex items-center gap-2">
+                <span>Allow network requests</span>
+                <ToggleSwitch
+                  checked={allowNetwork}
+                  onChange={setAllowNetwork}
+                  ariaLabel="Allow network requests"
+                />
+              </div>
+            </div>
+          </section>
+
+          <section aria-labelledby="system-backup" className="space-y-4">
+            <h2 id="system-backup" className="text-lg font-semibold text-white">
+              Backup & Restore
+            </h2>
+            <div className="flex flex-wrap gap-4">
+              <button
+                onClick={handleExport}
+                className="px-4 py-2 rounded bg-ub-orange text-white"
+                type="button"
+              >
+                Export settings
+              </button>
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                className="px-4 py-2 rounded border border-ub-orange text-ub-orange hover:bg-ub-orange/20"
+                type="button"
+              >
+                Import settings
+              </button>
+            </div>
+          </section>
+        </div>
       )}
-        <input
-          type="file"
-          accept="application/json"
-          ref={fileInputRef}
-          aria-label="Import settings file"
-          onChange={(e) => {
-            const file = e.target.files && e.target.files[0];
-            if (file) handleImport(file);
-            e.target.value = "";
-          }}
-          className="hidden"
-        />
+      <input
+        type="file"
+        accept="application/json"
+        ref={fileInputRef}
+        aria-label="Import settings file"
+        onChange={(e) => {
+          const file = e.target.files && e.target.files[0];
+          if (file) handleImport(file);
+          e.target.value = "";
+        }}
+        className="hidden"
+      />
       <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
     </div>
   );


### PR DESCRIPTION
## Summary
- combine desktop personalization controls into a single tab with accessible labeling, contrast preview, and Kali wallpaper toggle
- add accessibility and system tabs covering large hit areas, pong spin, and network permissions migrated from Tweaks
- extend settings import/reset handling and add persistence tests for new toggles

## Testing
- npx eslint apps/settings/index.tsx
- npx eslint __tests__/settingsStore.test.ts
- yarn test __tests__/settingsStore.test.ts
- yarn test *(fails: existing suites such as __tests__/nmapNse.test.tsx, desktopNameBar.test.tsx)*
- yarn lint *(fails: repository-wide accessibility rules in unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d52392788328b33ee4db65bceb61