### PR TITLE
[desktop] Add titlebar double-click maximize toggle

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -169,6 +169,41 @@ describe('Window snapping preview', () => {
   });
 });
 
+describe('Window titlebar interactions', () => {
+  it('toggles maximize state on double click', () => {
+    const hideSideBar = jest.fn();
+    const ref = React.createRef<Window>();
+
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={hideSideBar}
+        openApp={() => {}}
+        ref={ref}
+      />
+    );
+
+    const titleBar = screen.getByRole('button', { name: 'Test' });
+
+    fireEvent.doubleClick(titleBar);
+
+    expect(ref.current!.state.maximized).toBe(true);
+    expect(ref.current!.state.cursorType).toBe('cursor-default');
+    expect(hideSideBar).toHaveBeenLastCalledWith('test-window', true);
+
+    fireEvent.doubleClick(titleBar);
+
+    expect(ref.current!.state.maximized).toBe(false);
+    expect(ref.current!.state.cursorType).toBe('cursor-default');
+    expect(hideSideBar).toHaveBeenLastCalledWith('test-window', false);
+  });
+});
+
 describe('Window snapping finalize and release', () => {
   it('snaps window on drag stop near left edge', () => {
     setViewport(1024, 768);


### PR DESCRIPTION
## Summary
- add double-click handling on the desktop window titlebar so maximized windows toggle in place without accidental drag starts
- ensure maximize and restore flows reset cursors and notify the sidebar/window manager so state stays accurate after toggles
- extend the window unit suite with a double-click regression test that covers the new toggle behavior

## Testing
- yarn lint *(fails: repository has existing jsx-a11y and no-top-level-window violations)*
- yarn test *(fails: repository has existing Jest suites that error in unrelated areas)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d52428a08328b70f0a34b2d8abd1