### PR TITLE
[desktop] add window titlebar context menu

### DIFF
--- a/__tests__/windowStateStore.test.ts
+++ b/__tests__/windowStateStore.test.ts
@@ -1,0 +1,72 @@
+import { DEFAULT_WINDOW_PREFERENCES } from '../utils/windowStateStore';
+
+describe('windowStateStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.resetModules();
+  });
+
+  it('persists preferences to localStorage', async () => {
+    const {
+      getWindowPreferences,
+      setWindowPreferences,
+    } = await import('../utils/windowStateStore');
+
+    expect(getWindowPreferences('terminal')).toEqual(DEFAULT_WINDOW_PREFERENCES);
+
+    setWindowPreferences('terminal', { alwaysOnTop: true, workspaceId: 2 });
+
+    expect(getWindowPreferences('terminal')).toEqual({
+      alwaysOnTop: true,
+      workspaceId: 2,
+    });
+
+    const stored = localStorage.getItem('window-preferences');
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!)).toEqual({
+      terminal: { alwaysOnTop: true, workspaceId: 2 },
+    });
+  });
+
+  it('rehydrates state from storage on new import', async () => {
+    localStorage.setItem(
+      'window-preferences',
+      JSON.stringify({
+        browser: { alwaysOnTop: true, workspaceId: 1 },
+      }),
+    );
+
+    const { getWindowPreferences } = await import('../utils/windowStateStore');
+
+    expect(getWindowPreferences('browser')).toEqual({
+      alwaysOnTop: true,
+      workspaceId: 1,
+    });
+  });
+
+  it('notifies subscribers when state changes', async () => {
+    const {
+      subscribeToWindowPreferences,
+      setWindowPreferences,
+    } = await import('../utils/windowStateStore');
+
+    const listener = jest.fn();
+    const unsubscribe = subscribeToWindowPreferences(listener);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    listener.mockClear();
+
+    setWindowPreferences('files', { alwaysOnTop: true });
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        files: { alwaysOnTop: true, workspaceId: null },
+      }),
+    );
+
+    unsubscribe();
+    listener.mockClear();
+
+    setWindowPreferences('files', { alwaysOnTop: false });
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/utils/windowStateStore.ts
+++ b/utils/windowStateStore.ts
@@ -1,0 +1,128 @@
+import { safeLocalStorage } from './safeStorage';
+
+export interface WindowPreferences {
+  alwaysOnTop: boolean;
+  workspaceId: number | null;
+}
+
+export type WindowPreferencesMap = Record<string, WindowPreferences>;
+
+export const DEFAULT_WINDOW_PREFERENCES: WindowPreferences = Object.freeze({
+  alwaysOnTop: false,
+  workspaceId: null,
+});
+
+const STORAGE_KEY = 'window-preferences';
+
+let loaded = false;
+let state: WindowPreferencesMap = {};
+const listeners = new Set<(prefs: WindowPreferencesMap) => void>();
+
+function cloneState(map: WindowPreferencesMap) {
+  return Object.keys(map).reduce<WindowPreferencesMap>((acc, key) => {
+    const value = map[key];
+    acc[key] = { ...value };
+    return acc;
+  }, {});
+}
+
+function sanitizePreferences(value: any): WindowPreferences {
+  if (!value || typeof value !== 'object') {
+    return { ...DEFAULT_WINDOW_PREFERENCES };
+  }
+  const alwaysOnTop = Boolean(value.alwaysOnTop);
+  const workspaceId =
+    typeof value.workspaceId === 'number' && Number.isFinite(value.workspaceId)
+      ? value.workspaceId
+      : null;
+  return { alwaysOnTop, workspaceId };
+}
+
+function loadState() {
+  if (loaded) return;
+  loaded = true;
+  if (!safeLocalStorage) return;
+  try {
+    const raw = safeLocalStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return;
+    const next: WindowPreferencesMap = {};
+    Object.keys(parsed).forEach((key) => {
+      next[key] = sanitizePreferences(parsed[key]);
+    });
+    state = next;
+  } catch {
+    state = {};
+  }
+}
+
+function persistState() {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // ignore write errors
+  }
+}
+
+function notifyListeners() {
+  const snapshot = cloneState(state);
+  listeners.forEach((listener) => listener(snapshot));
+}
+
+export function getAllWindowPreferences(): WindowPreferencesMap {
+  loadState();
+  return cloneState(state);
+}
+
+export function getWindowPreferences(windowId: string): WindowPreferences {
+  loadState();
+  const existing = state[windowId];
+  return existing ? { ...existing } : { ...DEFAULT_WINDOW_PREFERENCES };
+}
+
+export function setWindowPreferences(
+  windowId: string,
+  update: Partial<WindowPreferences>,
+): WindowPreferences {
+  loadState();
+  const current = getWindowPreferences(windowId);
+  const next: WindowPreferences = {
+    ...current,
+    ...update,
+  };
+  state = {
+    ...state,
+    [windowId]: next,
+  };
+  persistState();
+  notifyListeners();
+  return { ...next };
+}
+
+export function subscribeToWindowPreferences(
+  listener: (prefs: WindowPreferencesMap) => void,
+): () => void {
+  loadState();
+  listeners.add(listener);
+  listener(cloneState(state));
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function clearWindowPreferences(windowId: string) {
+  loadState();
+  if (!state[windowId]) return;
+  const { [windowId]: _removed, ...rest } = state;
+  state = rest;
+  persistState();
+  notifyListeners();
+}
+
+export function resetWindowPreferences() {
+  state = {};
+  persistState();
+  notifyListeners();
+}


### PR DESCRIPTION
## Summary
- add a titlebar context menu that lets windows toggle always-on-top and jump to workspaces with accessible controls
- persist per-window preferences in a dedicated store and apply them when desktop windows mount
- enhance the shared context menu component for keyboard activation, separators, and checked states, and cover the store with unit tests

## Testing
- yarn lint *(fails: repo has existing jsx-a11y/no-top-level-window violations in unrelated apps)*
- yarn test *(fails: existing suites such as nmapNse, taskbar, and desktopNameBar do not pass on main)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d5254d1c83288296d682ecfbedb7