### PR TITLE
[desktop] improve tiling shortcuts

### DIFF
--- a/__tests__/ShortcutOverlay.test.tsx
+++ b/__tests__/ShortcutOverlay.test.tsx
@@ -21,8 +21,12 @@ describe('ShortcutOverlay', () => {
       screen.getByText('Show keyboard shortcuts')
     ).toBeInTheDocument();
     expect(screen.getByText('Open settings')).toBeInTheDocument();
-    const items = screen.getAllByRole('listitem');
-    expect(items[0]).toHaveAttribute('data-conflict', 'true');
-    expect(items[1]).toHaveAttribute('data-conflict', 'true');
+    const conflictRows = screen
+      .getAllByRole('row')
+      .filter((row) => row.getAttribute('data-conflict') === 'true');
+    expect(conflictRows).toHaveLength(2);
+    conflictRows.forEach((row) => {
+      expect(row).toHaveAttribute('data-conflict', 'true');
+    });
   });
 });

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,14 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Cycle windows', keys: 'Alt+Tab' },
+  { description: 'Cycle windows within app', keys: 'Alt+`' },
+  { description: 'Snap window left', keys: 'Alt+ArrowLeft' },
+  { description: 'Snap window right', keys: 'Alt+ArrowRight' },
+  { description: 'Maximize window', keys: 'Alt+ArrowUp' },
+  { description: 'Restore window', keys: 'Alt+ArrowDown' },
+  { description: 'Previous workspace', keys: 'Ctrl+Alt+ArrowLeft' },
+  { description: 'Next workspace', keys: 'Ctrl+Alt+ArrowRight' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -280,6 +280,14 @@ export class Desktop extends Component {
     }
 
     handleGlobalShortcut = (e) => {
+        const target = e.target;
+        const isEditable = target && target instanceof HTMLElement && (
+            target.tagName === 'INPUT' ||
+            target.tagName === 'TEXTAREA' ||
+            target.tagName === 'SELECT' ||
+            target.isContentEditable
+        );
+
         if (e.altKey && e.key === 'Tab') {
             e.preventDefault();
             if (!this.state.showWindowSwitcher) {
@@ -302,7 +310,11 @@ export class Desktop extends Component {
             const direction = e.key === 'ArrowLeft' || e.key === 'ArrowUp' ? -1 : 1;
             this.shiftWorkspace(direction);
         }
-        else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+        else if (
+            e.altKey &&
+            ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key) &&
+            !isEditable
+        ) {
             e.preventDefault();
             const id = this.getFocusedWindowId();
             if (id) {


### PR DESCRIPTION
## Summary
- update the window manager to capture Alt+arrow tiling shortcuts, store workspace-aware metrics, and support maximization restore flows
- document the tiling shortcuts in the settings keymap and refresh the shortcut overlay with accessible markup
- extend unit coverage for shortcut conflicts and tiling transitions across snapping, maximizing, and restoring

## Testing
- yarn lint *(fails: legacy apps without labelled controls and legacy public game bundles)*
- yarn test __tests__/window.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d6d525a4948328b52d7fcee681aa3a