### PR TITLE
[desktop] Support corner tiling previews

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -306,7 +306,7 @@ export class Desktop extends Component {
             e.preventDefault();
             const id = this.getFocusedWindowId();
             if (id) {
-                const event = new CustomEvent('super-arrow', { detail: e.key });
+                const event = new CustomEvent('super-arrow', { detail: { key: e.key, shiftKey: e.shiftKey } });
                 document.getElementById(id)?.dispatchEvent(event);
             }
         }


### PR DESCRIPTION
## Summary
- add keyboard-driven snap preview logic with corner tiling support, preview overlays, and reduced-motion handling
- pass shortcut metadata from the desktop shell so windows can trigger corner snaps
- extend window unit tests with keyboard preview coverage and quadrant placement expectations

## Testing
- yarn lint *(fails: repository has 586 existing accessibility and no-top-level-window violations)*
- yarn test *(fails: existing suites such as Modal, nmap NSE, and desktopNameBar error under jsdom localStorage/mock dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d526c92c832884fd0f6daee1d90e