### PR TITLE
[ui] Add elevation token scale for desktop layers

### DIFF
--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -83,7 +83,7 @@ const BadgeList = ({ badges, className = '' }) => {
       </div>
       {selected && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-overlay"
           onClick={closeModal}
           role="dialog"
           aria-modal="true"

--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -56,7 +56,7 @@ export default function ExternalFrame({ src, title, prefetch = false, onLoad: on
             href={src}
             target="_blank"
             rel="noopener noreferrer"
-            className="absolute top-2 right-2 z-10 px-2 py-1 text-xs bg-white text-black rounded opacity-0 focus-visible:opacity-100"
+            className="absolute top-2 right-2 z-surface px-2 py-1 text-xs bg-white text-black rounded opacity-0 focus-visible:opacity-100"
           >
             Open Externally
           </a>

--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -55,13 +55,13 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
         aria-label="Help"
         aria-expanded={open}
         onClick={toggle}
-        className="fixed top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+        className="fixed top-2 right-2 z-chrome bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
       >
         ?
       </button>
       {open && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-start justify-end p-4"
+          className="fixed inset-0 bg-black bg-opacity-50 z-overlay flex items-start justify-end p-4"
           onClick={toggle}
         >
           <div

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -42,7 +42,7 @@ export class UbuntuApp extends Component {
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
                 className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                    " p-1 m-px z-surface bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -621,7 +621,7 @@ export class Window extends Component {
                 {this.state.snapPreview && (
                     <div
                         data-testid="snap-preview"
-                        className="fixed border-2 border-dashed border-white bg-white bg-opacity-10 pointer-events-none z-40 transition-opacity"
+                        className="fixed border-2 border-dashed border-white bg-white bg-opacity-10 pointer-events-none z-popover transition-opacity"
                         style={{
                             left: `${this.state.snapPreview.left}px`,
                             top: `${this.state.snapPreview.top}px`,
@@ -654,7 +654,7 @@ export class Window extends Component {
                             this.props.minimized ? 'opacity-0 invisible duration-200' : '',
                             this.state.grabbed ? 'opacity-70' : '',
                             this.state.snapPreview ? 'ring-2 ring-blue-400' : '',
-                            this.props.isFocused ? 'z-30' : 'z-20',
+                            this.props.isFocused ? 'z-window-focused' : 'z-window-resting',
                             'opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute flex flex-col window-shadow',
                             styles.windowFrame,
                             this.props.isFocused ? styles.windowFrameActive : styles.windowFrameInactive,
@@ -867,7 +867,7 @@ export class WindowMainScreen extends Component {
     }
     render() {
         return (
-            <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey")}>
+            <div className={"w-full flex-grow z-surface max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey")}> 
                 {this.props.screen(this.props.addFolder, this.props.openApp, this.props.context)}
             </div>
         )

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -99,7 +99,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
       aria-hidden={!open}
       style={{ left: pos.x, top: pos.y }}
       className={(open ? 'block ' : 'hidden ') +
-        'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+        'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-popover text-sm'}
     >
       {items.map((item, i) => (
         <button

--- a/components/common/ShortcutOverlay.tsx
+++ b/components/common/ShortcutOverlay.tsx
@@ -68,7 +68,7 @@ const ShortcutOverlay: React.FC = () => {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/80 text-white p-4 overflow-auto"
+      className="fixed inset-0 z-overlay flex items-start justify-center bg-black/80 text-white p-4 overflow-auto"
       role="dialog"
       aria-modal="true"
     >

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -183,7 +183,7 @@ class AllApplications extends React.Component {
             groupedApps.some((group) => group.length > 0);
 
         return (
-            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
+            <div className="fixed inset-0 z-overlay flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
                 <input
                     className="mt-10 mb-8 w-2/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none md:w-1/3"
                     placeholder="Search"

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1036,7 +1036,7 @@ export class Desktop extends Component {
         }
 
         return (
-            <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
+            <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-overlay">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
                     <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -16,20 +16,20 @@ export default function LockScreen(props) {
     return (
         <div
             id="ubuntu-lock-screen"
-            style={{ zIndex: "100", contentVisibility: 'auto' }}
-            className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
+            style={{ contentVisibility: 'auto' }}
+            className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen z-critical"}>
             {useKaliTheme ? (
                 <KaliWallpaper
-                    className={`absolute top-0 left-0 h-full w-full transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                    className={`absolute top-0 left-0 h-full w-full transform z-base transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
                 />
             ) : (
                 <img
                     src={`/wallpapers/${bgImageName}.webp`}
                     alt=""
-                    className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                    className={`absolute top-0 left-0 w-full h-full object-cover transform z-base transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
                 />
             )}
-            <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
+            <div className="w-full h-full z-surface overflow-hidden relative flex flex-col justify-center items-center text-white">
                 <div className=" text-7xl">
                     <Clock onlyTime={true} />
                 </div>

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -18,7 +18,7 @@ export default class Navbar extends Component {
 
         render() {
                 return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-chrome">
                                 <button
                                         type="button"
                                         aria-haspopup="true"

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -55,7 +55,7 @@ class ShortcutSelector extends React.Component {
 
     render() {
         return (
-            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
+            <div className="fixed inset-0 z-overlay flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
                 <input
                     className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
                     placeholder="Search"

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -30,7 +30,7 @@ export default function SideBar(props) {
             <nav
                 aria-label="Dock"
                 className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                    " absolute transform duration-300 select-none z-chrome left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
             >
                 {
                     (
@@ -41,7 +41,7 @@ export default function SideBar(props) {
                 }
                 <AllApps showApps={props.showAllApps} />
             </nav>
-            <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-50"}></div>
+            <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-chrome"}></div>
         </>
     )
 }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -18,7 +18,7 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center justify-between px-2 z-40" role="toolbar">
+        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center justify-between px-2 z-chrome" role="toolbar">
             <WorkspaceSwitcher
                 workspaces={workspaces}
                 activeWorkspace={props.activeWorkspace}
@@ -27,7 +27,7 @@ export default function Taskbar(props) {
             <div className="flex items-center overflow-x-auto">
                 {runningApps.map(app => (
 
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
+        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-chrome" role="toolbar">
             {runningApps.map(app => {
                 const isMinimized = Boolean(props.minimized_windows[app.id]);
                 const isFocused = Boolean(props.focused_windows[app.id]);

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -57,7 +57,7 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white">
+    <div className="fixed inset-0 z-overlay flex items-center justify-center bg-black bg-opacity-75 text-white">
       <div className="bg-ub-grey p-4 rounded w-3/4 md:w-1/3">
         <input
           ref={inputRef}

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -180,7 +180,7 @@ const NotificationBell: React.FC = () => {
           aria-modal="false"
           aria-labelledby={headingId}
           tabIndex={-1}
-          className="absolute right-0 z-50 mt-2 w-72 max-h-96 overflow-hidden rounded-md border border-white/10 bg-ub-grey/95 text-ubt-grey shadow-xl backdrop-blur"
+          className="absolute right-0 z-popover mt-2 w-72 max-h-96 overflow-hidden rounded-md border border-white/10 bg-ub-grey/95 text-ubt-grey shadow-xl backdrop-blur"
         >
           <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
             <h2 id={headingId} className="text-sm font-semibold text-white">

--- a/components/ui/VolumeControl.tsx
+++ b/components/ui/VolumeControl.tsx
@@ -128,7 +128,7 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
       </button>
       {open && (
         <div
-          className="absolute bottom-full right-0 z-50 mb-2 min-w-[9rem] rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-2 text-xs text-white shadow-lg"
+          className="absolute bottom-full right-0 z-popover mb-2 min-w-[9rem] rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-2 text-xs text-white shadow-lg"
           onClick={(event) => event.stopPropagation()}
           onPointerDown={(event) => event.stopPropagation()}
           onWheel={handleWheel}

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -42,7 +42,7 @@ export default function BackgroundImage() {
     }, [bgImageName, useKaliWallpaper]);
 
     return (
-        <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
+        <div className="bg-ubuntu-img absolute z-background top-0 right-0 overflow-hidden h-full w-full">
             {useKaliWallpaper || bgImageName === 'kali-gradient' ? (
                 <KaliWallpaper />
             ) : (

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,26 @@
+# Design System Notes
+
+## Elevation scale
+
+The desktop shell now exposes a tokenized elevation scale backed by CSS custom properties in `styles/tokens.css` and mapped to Tailwind utilities. Use the semantic classes instead of numeric `z-*` utilities to keep overlapping UI predictable.
+
+| Token | CSS Variable | Tailwind Class | Layer | Typical Usage |
+| --- | --- | --- | --- | --- |
+| `--elevation-background` | `--elevation-background` | `z-background` | -10 | Wallpaper, decorative backdrops |
+| `--elevation-base` | `--elevation-base` | `z-base` | 0 | Default stacking context, lock screen wallpaper |
+| `--elevation-surface` | `--elevation-surface` | `z-surface` | 10 | Window contents, floating affordances inside a window |
+| `--elevation-window-resting` | `--elevation-window-resting` | `z-window-resting` | 20 | Unfocused windows and draggable shells |
+| `--elevation-window-focused` | `--elevation-window-focused` | `z-window-focused` | 30 | Active window frames |
+| `--elevation-chrome` | `--elevation-chrome` | `z-chrome` | 40 | Taskbar, global nav, persistent controls like the help toggle |
+| `--elevation-popover` | `--elevation-popover` | `z-popover` | 50 | Context menus, trays, dropdowns, transient HUDs |
+| `--elevation-overlay` | `--elevation-overlay` | `z-overlay` | 60 | App switcher, modal scrims, shortcut overlays |
+| `--elevation-critical` | `--elevation-critical` | `z-critical` | 70 | System lock screen, alerts that must sit on top of everything |
+
+### Implementation notes
+
+- The scale is registered in `tailwind.config.js`, so any component can opt into the semantic layers with Tailwind classes.
+- Windows transition between `z-window-resting` and `z-window-focused` when focus changes, keeping the focused frame above siblings while still below chrome and overlays.
+- Overlays (switcher, modals, lock screen) use `z-overlay` or `z-critical`, ensuring system surfaces eclipse regular windows without numerical juggling.
+- Menus, notifications, and tooltips consume `z-popover` so they sit above the desktop chrome but fall under blocking overlays.
+
+Verifying the hierarchy is as simple as opening overlapping windows, menus, and overlays—the focused window appears above other app frames, the dock and navbar remain above windows, and global overlays cover all underlying content while maintaining internal layering for background imagery and text.

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -61,6 +61,15 @@
   --radius-round: 9999px;
 
   /* Elevation */
+  --elevation-background: -10;
+  --elevation-base: 0;
+  --elevation-surface: 10;
+  --elevation-window-resting: 20;
+  --elevation-window-focused: 30;
+  --elevation-chrome: 40;
+  --elevation-popover: 50;
+  --elevation-overlay: 60;
+  --elevation-critical: 70;
   --shadow-2: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
 
   /* Window chrome */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -76,6 +76,15 @@ module.exports = {
       },
       zIndex: {
         '-10': '-10',
+        background: 'var(--elevation-background)',
+        base: 'var(--elevation-base)',
+        surface: 'var(--elevation-surface)',
+        'window-resting': 'var(--elevation-window-resting)',
+        'window-focused': 'var(--elevation-window-focused)',
+        chrome: 'var(--elevation-chrome)',
+        popover: 'var(--elevation-popover)',
+        overlay: 'var(--elevation-overlay)',
+        critical: 'var(--elevation-critical)',
       },
       width: {
         'app-icon': '64px',


### PR DESCRIPTION
## Summary
- add elevation design tokens and map them to Tailwind z-index utilities
- update desktop windowing components to use semantic elevation classes
- document the elevation scale and layering guidance for the design system

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window issues in legacy apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d5291e948328961196ea31a769b8