### PR TITLE
[desktop] Improve window resizing ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ play/pause and track controls include keyboard hotkeys.
 
 ## Notable Components
 
-- **`components/base/window.js`** - draggable, focusable window with header controls; integrates with desktop z-index.
+- **`components/base/Window.tsx`** - draggable, focusable window with header controls; integrates with desktop z-index.
 - **`components/screen/*`** - lock screen, boot splash, navbar, app grid.
 - **`hooks/usePersistentState.ts`** - localStorage-backed state with validation + reset helper.
 - **`hooks/useSettings.tsx`** - global settings context exposing theme, accent, wallpaper and other preferences with persistence.

--- a/__tests__/resizeUtils.test.ts
+++ b/__tests__/resizeUtils.test.ts
@@ -1,0 +1,50 @@
+import { cursorForHandle, getResizeHandle, ResizeHitSlopConfig } from '../components/base/resizeUtils';
+
+const createRect = (left: number, top: number, width: number, height: number): DOMRect => ({
+  left,
+  top,
+  width,
+  height,
+  right: left + width,
+  bottom: top + height,
+  x: left,
+  y: top,
+  toJSON: () => ({ left, top, width, height }),
+} as DOMRect);
+
+const config: ResizeHitSlopConfig = { edge: 16, corner: 24 };
+
+describe('getResizeHandle', () => {
+  const rect = createRect(100, 100, 200, 200);
+
+  it('detects west edge when pointer is inside hit slop', () => {
+    const handle = getResizeHandle(rect, { x: 104, y: 180 }, config);
+    expect(handle).toBe('w');
+  });
+
+  it('detects east edge when pointer is just outside the frame', () => {
+    const handle = getResizeHandle(rect, { x: 308, y: 210 }, config);
+    expect(handle).toBe('e');
+  });
+
+  it('prefers diagonal handles when inside a corner zone', () => {
+    const handle = getResizeHandle(rect, { x: 102, y: 102 }, config);
+    expect(handle).toBe('nw');
+  });
+
+  it('supports south-east corner hit testing', () => {
+    const handle = getResizeHandle(rect, { x: 296, y: 296 }, config);
+    expect(handle).toBe('se');
+  });
+
+  it('returns null when pointer is away from edges', () => {
+    const handle = getResizeHandle(rect, { x: 200, y: 200 }, config);
+    expect(handle).toBeNull();
+  });
+
+  it('maps handles to CSS cursors', () => {
+    expect(cursorForHandle('n')).toBe('ns-resize');
+    expect(cursorForHandle('se')).toBe('nwse-resize');
+    expect(cursorForHandle(null)).toBeNull();
+  });
+});

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -1,6 +1,6 @@
 import React, { act } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import Window from '../components/base/window';
+import Window from '../components/base/Window';
 
 const setViewport = (width: number, height: number) => {
   Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: width });

--- a/components/base/resizeUtils.ts
+++ b/components/base/resizeUtils.ts
@@ -1,0 +1,109 @@
+export type ResizeHandle = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
+
+export interface ResizeHitSlopConfig {
+  /**
+   * Maximum distance (px) from any edge that should trigger resizing.
+   * The same tolerance applies inside and just outside the window frame.
+   */
+  edge: number;
+  /**
+   * Maximum distance (px) from a corner before snapping to the diagonal
+   * resize cursor. Should generally be greater than or equal to `edge`.
+   */
+  corner: number;
+}
+
+export interface PointLike {
+  x: number;
+  y: number;
+}
+
+const clamp = (value: number, min: number, max: number) => {
+  if (Number.isNaN(value)) return min;
+  return Math.max(min, Math.min(max, value));
+};
+
+const isWithinBand = (value: number, min: number, max: number, tolerance: number) => {
+  return value >= min - tolerance && value <= max + tolerance;
+};
+
+/**
+ * Returns the resize handle that should activate for a pointer located near the window frame.
+ */
+export const getResizeHandle = (
+  rect: DOMRect,
+  point: PointLike,
+  config: ResizeHitSlopConfig
+): ResizeHandle | null => {
+  const edgeTolerance = Math.max(0, config.edge);
+  const cornerTolerance = Math.max(edgeTolerance, config.corner);
+
+  const { left, right, top, bottom } = rect;
+
+  if (!isWithinBand(point.x, left, right, edgeTolerance) || !isWithinBand(point.y, top, bottom, edgeTolerance)) {
+    return null;
+  }
+
+  const distanceLeft = Math.abs(point.x - left);
+  const distanceRight = Math.abs(right - point.x);
+  const distanceTop = Math.abs(point.y - top);
+  const distanceBottom = Math.abs(bottom - point.y);
+
+  const isWest = distanceLeft <= edgeTolerance;
+  const isEast = distanceRight <= edgeTolerance;
+  const isNorth = distanceTop <= edgeTolerance;
+  const isSouth = distanceBottom <= edgeTolerance;
+
+  if (isNorth && isWest && distanceLeft <= cornerTolerance && distanceTop <= cornerTolerance) {
+    return 'nw';
+  }
+  if (isNorth && isEast && distanceRight <= cornerTolerance && distanceTop <= cornerTolerance) {
+    return 'ne';
+  }
+  if (isSouth && isWest && distanceLeft <= cornerTolerance && distanceBottom <= cornerTolerance) {
+    return 'sw';
+  }
+  if (isSouth && isEast && distanceRight <= cornerTolerance && distanceBottom <= cornerTolerance) {
+    return 'se';
+  }
+
+  if (isNorth) {
+    return 'n';
+  }
+  if (isSouth) {
+    return 's';
+  }
+  if (isWest) {
+    return 'w';
+  }
+  if (isEast) {
+    return 'e';
+  }
+
+  return null;
+};
+
+export const cursorForHandle = (handle: ResizeHandle | null): string | null => {
+  switch (handle) {
+    case 'n':
+    case 's':
+      return 'ns-resize';
+    case 'e':
+    case 'w':
+      return 'ew-resize';
+    case 'ne':
+    case 'sw':
+      return 'nesw-resize';
+    case 'nw':
+    case 'se':
+      return 'nwse-resize';
+    default:
+      return null;
+  }
+};
+
+export const clampToViewport = (
+  value: number,
+  min: number,
+  max: number
+) => clamp(value, min, max);

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -51,12 +51,10 @@
   height: 28px;
 }
 
-.windowYBorder {
-  height: calc(100% - 10px);
-  width: calc(100% + 10px);
-}
-
-.windowXBorder {
-  height: calc(100% + 10px);
-  width: calc(100% - 10px);
+.resizeHandle {
+  position: absolute;
+  touch-action: none;
+  z-index: 40;
+  pointer-events: auto;
+  background: transparent;
 }

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -9,7 +9,7 @@ const BackgroundImage = dynamic(
 );
 import SideBar from './side_bar';
 import apps, { games } from '../../apps.config';
-import Window from '../base/window';
+import Window from '../base/Window';
 import UbuntuApp from '../base/ubuntu_app';
 import AllApplications from '../screen/all-applications'
 import ShortcutSelector from '../screen/shortcut-selector'

--- a/docs/TASKS_UI_POLISH.md
+++ b/docs/TASKS_UI_POLISH.md
@@ -6,7 +6,7 @@ This document tracks UI polish tasks for the Kali/Ubuntu inspired desktop experi
 
 1. **Snap-to-grid for move and resize**
    - **Accept:** Dragging and resizing snaps to an 8 px grid. Toggle in Settings.
-   - **Where:** `components/base/window/*`, `components/screen/desktop.js`, `hooks/usePersistentState.ts`.
+   - **Where:** `components/base/Window.tsx`, `components/screen/desktop.js`, `hooks/usePersistentState.ts`.
    - **Why:** Consistent rhythm improves perceived quality.
 
 2. **Window size presets**

--- a/pages/nessus-dashboard.tsx
+++ b/pages/nessus-dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { loadFalsePositives, loadJobDefinitions } from '../components/apps/nessus/index';
-import { WindowMainScreen } from '../components/base/window';
+import { WindowMainScreen } from '../components/base/Window';
 
 const NessusDashboard: React.FC = () => {
   const [totals, setTotals] = useState({ jobs: 0, falsePositives: 0 });

--- a/pages/security-education.tsx
+++ b/pages/security-education.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import WorkflowCard from '../components/WorkflowCard';
-import { WindowMainScreen } from '../components/base/window';
+import { WindowMainScreen } from '../components/base/Window';
 
 interface FrameProps {
   title: string;


### PR DESCRIPTION
## Summary
- replace the legacy window border drag targets with pointer-aware resize overlays to give 16px edge and corner hit areas across mouse/touch
- move the hit-detection logic into a new reusable helper and add unit coverage for the edge/corner thresholds
- update desktop references and styles after renaming `window.js` to `Window.tsx`

## Testing
- yarn lint *(fails: repository has existing accessibility lint violations unrelated to this change)*
- yarn test *(fails: suite already contains failing UI tests unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d52a897483289e8beab13ac36244