### PR TITLE
[apps] Improve file explorer breadcrumbs

### DIFF
--- a/__tests__/Breadcrumbs.test.tsx
+++ b/__tests__/Breadcrumbs.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import Breadcrumbs from '../components/ui/Breadcrumbs';
+
+describe('Breadcrumbs', () => {
+  it('renders a home button that navigates to the root directory', () => {
+    const onNavigate = jest.fn();
+    render(
+      <Breadcrumbs
+        path={[
+          { name: 'root' },
+          { name: 'Documents' },
+        ]}
+        onNavigate={onNavigate}
+      />
+    );
+
+    const homeButton = screen.getByRole('button', { name: /Home/ });
+    fireEvent.click(homeButton);
+    expect(onNavigate).toHaveBeenCalledWith(0);
+  });
+
+  it('collapses middle segments into an accessible overflow menu', () => {
+    const onNavigate = jest.fn();
+    const path = [
+      { name: 'root' },
+      { name: 'Projects' },
+      { name: 'ClientA' },
+      { name: 'Reports' },
+      { name: '2024' },
+      { name: 'Q1' },
+    ];
+    render(<Breadcrumbs path={path} onNavigate={onNavigate} />);
+
+    const overflowToggle = screen.getByRole('button', { name: 'Show hidden folders' });
+    expect(overflowToggle).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /ClientA/ })).not.toBeInTheDocument();
+
+    fireEvent.click(overflowToggle);
+    const clientButton = screen.getByRole('menuitem', { name: /ClientA/ });
+    fireEvent.click(clientButton);
+
+    expect(onNavigate).toHaveBeenCalledWith(2);
+    expect(screen.queryByRole('menuitem', { name: /ClientA/ })).not.toBeInTheDocument();
+  });
+
+  it('marks the current location using aria-current', () => {
+    const path = [
+      { name: 'root' },
+      { name: 'Projects' },
+      { name: 'ClientA' },
+    ];
+    render(<Breadcrumbs path={path} onNavigate={jest.fn()} />);
+
+    const current = screen.getByRole('button', { name: /ClientA/ });
+    expect(current).toHaveAttribute('aria-current', 'page');
+  });
+});

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -263,6 +263,10 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
     setLocationError(null);
   };
 
+  const goHome = () => {
+    navigateTo(0);
+  };
+
   const goBack = async () => {
     if (path.length <= 1) return;
     const newPath = path.slice(0, -1);
@@ -353,6 +357,9 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
       <div className="flex items-center space-x-2 p-2 bg-ub-warm-grey bg-opacity-40">
         <button onClick={openFolder} className="px-2 py-1 bg-black bg-opacity-50 rounded">
           Open Folder
+        </button>
+        <button onClick={goHome} className="px-2 py-1 bg-black bg-opacity-50 rounded" aria-label="Go to home">
+          Home
         </button>
         {path.length > 1 && (
           <button onClick={goBack} className="px-2 py-1 bg-black bg-opacity-50 rounded">

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -1,29 +1,177 @@
-import React from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 interface Segment {
   name: string;
+  [key: string]: unknown;
 }
 
 interface Props {
   path: Segment[];
   onNavigate: (index: number) => void;
+  homeLabel?: string;
+  overflowLabel?: string;
 }
 
-const Breadcrumbs: React.FC<Props> = ({ path, onNavigate }) => {
+const MAX_VISIBLE_SEGMENTS = 4;
+
+const Breadcrumbs: React.FC<Props> = ({
+  path,
+  onNavigate,
+  homeLabel = 'Home',
+  overflowLabel = 'Show hidden folders',
+}) => {
+  const [overflowOpen, setOverflowOpen] = useState(false);
+  const overflowContainerRef = useRef<HTMLDivElement | null>(null);
+  const overflowButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  const showOverflow = path.length > MAX_VISIBLE_SEGMENTS;
+
+  const { overflowSegments, tailSegments } = useMemo(() => {
+    if (!showOverflow) {
+      return {
+        overflowSegments: [] as Segment[],
+        tailSegments: path.slice(1),
+      };
+    }
+    return {
+      overflowSegments: path.slice(1, -2),
+      tailSegments: path.slice(-2),
+    };
+  }, [path, showOverflow]);
+
+  useEffect(() => {
+    if (!overflowOpen) return;
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      const container = overflowContainerRef.current;
+      if (container && !container.contains(event.target as Node)) {
+        setOverflowOpen(false);
+      }
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOverflowOpen(false);
+        overflowButtonRef.current?.focus();
+      }
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [overflowOpen]);
+
+  useEffect(() => {
+    setOverflowOpen(false);
+  }, [path]);
+
+  const renderSeparator = (key: string) => (
+    <span key={key} aria-hidden="true">
+      /
+    </span>
+  );
+
+  const crumbs: React.ReactNode[] = [];
+
+  const addCrumb = (label: string, index: number) => {
+    const isCurrent = index === path.length - 1;
+    const key = `crumb-${index}`;
+    if (crumbs.length) {
+      crumbs.push(renderSeparator(`sep-${key}`));
+    }
+    crumbs.push(
+      <button
+        key={key}
+        type="button"
+        onClick={() => onNavigate(index)}
+        className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded"
+        aria-current={isCurrent ? 'page' : undefined}
+      >
+        <span className="flex items-center gap-1">
+          {index === 0 && (
+            <span aria-hidden="true">
+              🏠
+            </span>
+          )}
+          <span>{label || '/'}</span>
+        </span>
+      </button>
+    );
+  };
+
+  const addOverflow = () => {
+    if (!overflowSegments.length) return;
+    if (crumbs.length) {
+      crumbs.push(renderSeparator('sep-overflow'));
+    }
+    crumbs.push(
+      <div key="overflow" className="relative" ref={overflowContainerRef}>
+        <button
+          type="button"
+          ref={overflowButtonRef}
+          onClick={() => setOverflowOpen((open) => !open)}
+          aria-haspopup="menu"
+          aria-expanded={overflowOpen}
+          aria-label={overflowLabel}
+          className="px-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded hover:underline"
+        >
+          …
+        </button>
+        {overflowOpen && (
+          <div
+            role="menu"
+            className="absolute left-0 mt-1 bg-ub-warm-grey border border-white/20 rounded shadow-lg z-10 min-w-[8rem] py-1"
+          >
+            {overflowSegments.map((segment, offset) => {
+              const actualIndex = offset + 1;
+              const isCurrent = actualIndex === path.length - 1;
+              return (
+                <button
+                  key={`overflow-${actualIndex}`}
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setOverflowOpen(false);
+                    onNavigate(actualIndex);
+                  }}
+                  className="w-full text-left px-3 py-1 hover:bg-white/10 focus:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                  aria-current={isCurrent ? 'page' : undefined}
+                >
+                  {segment.name || '/'}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  if (path.length) {
+    const homeName = path[0]?.name || homeLabel;
+    const homeDisplay = homeLabel || homeName;
+    addCrumb(homeDisplay, 0);
+  } else {
+    addCrumb(homeLabel, 0);
+  }
+
+  if (showOverflow) {
+    addOverflow();
+    tailSegments.forEach((segment, idx) => {
+      const actualIndex = path.length - tailSegments.length + idx;
+      addCrumb(segment.name, actualIndex);
+    });
+  } else {
+    tailSegments.forEach((segment, idx) => {
+      addCrumb(segment.name, idx + 1);
+    });
+  }
+
   return (
     <nav className="flex items-center space-x-1 text-white" aria-label="Breadcrumb">
-      {path.map((seg, idx) => (
-        <React.Fragment key={idx}>
-          <button
-            type="button"
-            onClick={() => onNavigate(idx)}
-            className="hover:underline focus:outline-none"
-          >
-            {seg.name || '/'}
-          </button>
-          {idx < path.length - 1 && <span>/</span>}
-        </React.Fragment>
-      ))}
+      {crumbs}
     </nav>
   );
 };


### PR DESCRIPTION
## Summary
- add a dedicated Home control to the file explorer toolbar
- enhance the breadcrumb component with a home icon and accessible overflow menu
- cover the breadcrumb updates with unit tests for navigation and overflow handling

## Testing
- yarn lint *(fails: existing repo lint violations)*
- yarn test *(fails: existing failing suites and watch mode interrupted after failures)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d52f789c8328955fec58c37e645d