### PR TITLE
[desktop] add deep link state restoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ To send text or links directly into the Sticky Notes app:
 3. After installation, use the system **Share** action and select "Kali Linux Portfolio".
 4. The shared content will appear as a new note.
 
+### Deep links into desktop apps
+
+- Append query parameters to the root URL to open an app with prefilled state:
+  - `/?app=terminal&cmd=help` launches the terminal and runs `help` after the session boots.
+  - Other apps receive the same props, enabling bookmarks that prefill forms or focus a specific workspace.
+- The desktop restores saved window size, position, and dock preferences before applying the deep link, so reopening an app via URL keeps the previous layout intact.
+- All additional parameters are forwarded to the app component as props, making it easy to hydrate complex state from links or bookmarks.
+
 ### Service Worker (SW)
 
 - Generated via [`@ducanh2912/next-pwa`](https://github.com/DuCanhGH/next-pwa); output is `public/sw.js`.

--- a/__tests__/deepLink.test.ts
+++ b/__tests__/deepLink.test.ts
@@ -1,0 +1,78 @@
+import {
+  parseDeepLinkFromQuery,
+  deepLinkSignature,
+  normalizeDeepLinkContext,
+} from '../lib/deepLink';
+
+describe('parseDeepLinkFromQuery', () => {
+  it('returns null when app id is missing', () => {
+    expect(parseDeepLinkFromQuery({})).toBeNull();
+    expect(parseDeepLinkFromQuery({ app: [''] })).toBeNull();
+  });
+
+  it('extracts app id and flattens query values', () => {
+    const result = parseDeepLinkFromQuery({
+      app: 'terminal',
+      cmd: ['help', 'version'],
+      theme: 'dark',
+      empty: '',
+    });
+    expect(result).toEqual({
+      app: 'terminal',
+      context: { cmd: 'version', theme: 'dark' },
+    });
+  });
+
+  it('drops falsy context entries after coercion', () => {
+    expect(
+      parseDeepLinkFromQuery({ app: 'terminal', cmd: [''] }),
+    ).toEqual({ app: 'terminal' });
+  });
+});
+
+describe('deepLinkSignature', () => {
+  it('generates stable signatures for context maps', () => {
+    const link = {
+      app: 'terminal',
+      context: { cmd: 'help', theme: 'dark' },
+    };
+    const shuffled = {
+      app: 'terminal',
+      context: { theme: 'dark', cmd: 'help' },
+    };
+    expect(deepLinkSignature(link)).toBe('terminal|cmd:help|theme:dark');
+    expect(deepLinkSignature(shuffled)).toBe('terminal|cmd:help|theme:dark');
+  });
+});
+
+describe('normalizeDeepLinkContext', () => {
+  it('drops nullish context and returns undefined', () => {
+    expect(normalizeDeepLinkContext('terminal', null)).toBeUndefined();
+    expect(normalizeDeepLinkContext('terminal', {})).toBeUndefined();
+  });
+
+  it('preserves truthy values and coerces to strings', () => {
+    expect(
+      normalizeDeepLinkContext('files', {
+        path: 123,
+        empty: '',
+        zero: 0,
+      }),
+    ).toEqual({ path: '123', zero: '0' });
+  });
+
+  it('prefers initialCommand but falls back to command fields', () => {
+    expect(
+      normalizeDeepLinkContext('terminal', {
+        command: '  ls  ',
+        cmd: 'ignored',
+      }),
+    ).toEqual({ command: '  ls  ', cmd: 'ignored', initialCommand: '  ls  ' });
+    expect(
+      normalizeDeepLinkContext('terminal', {
+        initialCommand: '',
+        cmd: 'help',
+      }),
+    ).toEqual({ cmd: 'help', initialCommand: 'help' });
+  });
+});

--- a/__tests__/desktopDeepLink.test.tsx
+++ b/__tests__/desktopDeepLink.test.tsx
@@ -1,0 +1,46 @@
+jest.mock('../components/screen/taskbar', () => () => null);
+
+import { Desktop } from '../components/screen/desktop';
+
+describe('Desktop deep link handling', () => {
+  it('opens apps with normalized context', () => {
+    const desktop = new Desktop({ deepLink: null });
+    const openSpy = jest.spyOn(desktop, 'openApp').mockImplementation(() => {});
+    const link = { app: 'terminal', context: { cmd: 'help' } };
+
+    desktop.applyDeepLink(link as any);
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith('terminal', {
+      cmd: 'help',
+      initialCommand: 'help',
+    });
+    expect(link.context).toEqual({ cmd: 'help' });
+  });
+
+  it('ignores repeated deep links with the same signature', () => {
+    const desktop = new Desktop({ deepLink: null });
+    const openSpy = jest.spyOn(desktop, 'openApp').mockImplementation(() => {});
+    const link = { app: 'terminal', context: { cmd: 'help' } };
+
+    desktop.applyDeepLink(link as any);
+    desktop.applyDeepLink(link as any);
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows the same link after clearing the signature', () => {
+    const desktop = new Desktop({ deepLink: null });
+    const openSpy = jest.spyOn(desktop, 'openApp').mockImplementation(() => {});
+    const link = { app: 'terminal', context: { cmd: 'help' } };
+
+    desktop.applyDeepLink(link as any);
+    expect(desktop.lastDeepLinkSignature).not.toBeNull();
+
+    desktop.applyDeepLink(null as any);
+    expect(desktop.lastDeepLinkSignature).toBeNull();
+
+    desktop.applyDeepLink(link as any);
+    expect(openSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -51,6 +51,13 @@ describe('Terminal component', () => {
     expect(ref.current.getContent()).toContain('help');
   });
 
+  it('runs an initial command when provided', async () => {
+    const ref = createRef<any>();
+    render(<Terminal ref={ref} openApp={openApp} initialCommand="help" />);
+    await act(async () => {});
+    expect(ref.current.getContent()).toContain('Available commands');
+  });
+
   it('invokes openApp for open command', async () => {
     const ref = createRef<any>();
     render(<Terminal ref={ref} openApp={openApp} />);

--- a/apps/terminal/tabs/index.tsx
+++ b/apps/terminal/tabs/index.tsx
@@ -4,15 +4,28 @@ import React, { useRef } from 'react';
 import TabbedWindow, { TabDefinition } from '../../../components/ui/TabbedWindow';
 import Terminal, { TerminalProps } from '..';
 
-const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
+const TerminalTabs: React.FC<TerminalProps> = ({ openApp, initialCommand, command, cmd, ...rest }) => {
   const countRef = useRef(1);
+  const initialCommandRef = useRef<string | undefined>(
+    [initialCommand, command, cmd]
+      .map((value) => (typeof value === 'string' ? value.trim() : ''))
+      .find((value) => value.length > 0) || undefined,
+  );
 
   const createTab = (): TabDefinition => {
     const id = Date.now().toString();
+    const commandForTab = initialCommandRef.current;
+    initialCommandRef.current = undefined;
     return {
       id,
       title: `Session ${countRef.current++}`,
-      content: <Terminal openApp={openApp} />,
+      content: (
+        <Terminal
+          openApp={openApp}
+          initialCommand={commandForTab}
+          {...rest}
+        />
+      ),
     };
   };
 

--- a/components/apps/terminal.tsx
+++ b/components/apps/terminal.tsx
@@ -16,11 +16,11 @@ const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
  * overflows. The actual indicator/scroll handling lives inside the terminal
  * app, this wrapper just provides the necessary container styles.
  */
-export default function Terminal() {
+export default function Terminal(props) {
   return (
     <div className="h-full w-full overflow-y-auto">
       <HelpPanel appId="terminal" />
-      <TerminalApp />
+      <TerminalApp {...props} />
     </div>
   );
 }

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -9,9 +9,9 @@ import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
 
 export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
+        constructor(props) {
+                super(props);
+                this.state = {
 			screen_locked: false,
 			bg_image_name: 'wall-2',
 			booting_screen: true,
@@ -127,8 +127,12 @@ export default class Ubuntu extends Component {
 					turnOn={this.turnOn}
 				/>
 				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+                                <Desktop
+                                        bg_image_name={this.state.bg_image_name}
+                                        changeBackgroundImage={this.changeBackgroundImage}
+                                        deepLink={this.props.deepLink}
+                                />
+                        </div>
+                );
+        }
 }

--- a/lib/deepLink.ts
+++ b/lib/deepLink.ts
@@ -1,0 +1,86 @@
+import type { ParsedUrlQuery } from 'querystring';
+
+export interface DeepLinkContext {
+  [key: string]: string;
+}
+
+export interface DeepLink {
+  app: string;
+  context?: DeepLinkContext;
+}
+
+const RESERVED_KEYS = new Set(['app']);
+
+const coerceValue = (value: string | string[] | undefined): string | undefined => {
+  if (Array.isArray(value)) {
+    const last = value[value.length - 1];
+    return typeof last === 'string' ? last : undefined;
+  }
+  return typeof value === 'string' ? value : undefined;
+};
+
+export const parseDeepLinkFromQuery = (
+  query: ParsedUrlQuery,
+): DeepLink | null => {
+  const app = coerceValue(query.app);
+  if (!app) return null;
+
+  const contextEntries = Object.entries(query)
+    .filter(([key]) => !RESERVED_KEYS.has(key))
+    .map(([key, value]) => [key, coerceValue(value)] as const)
+    .filter(([, value]) => typeof value === 'string' && value.length > 0);
+
+  if (contextEntries.length === 0) {
+    return { app };
+  }
+
+  const context: DeepLinkContext = {};
+  for (const [key, value] of contextEntries) {
+    if (value) {
+      context[key] = value;
+    }
+  }
+
+  return { app, context };
+};
+
+export const hasDeepLink = (link: DeepLink | null | undefined): link is DeepLink => {
+  return !!(link && typeof link.app === 'string' && link.app.length > 0);
+};
+
+export const normalizeDeepLinkContext = (
+  app: string,
+  context?: DeepLinkContext | null,
+): DeepLinkContext | undefined => {
+  if (!context || typeof context !== 'object') return undefined;
+  const normalized: DeepLinkContext = {};
+  Object.entries(context).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
+    const str = typeof value === 'string' ? value : String(value);
+    if (!str.length) return;
+    normalized[key] = str;
+  });
+  if (app === 'terminal') {
+    const candidate = ['initialCommand', 'command', 'cmd']
+      .map((key) => normalized[key])
+      .find((val) => typeof val === 'string' && val.trim().length > 0);
+    if (candidate && normalized.initialCommand !== candidate) {
+      normalized.initialCommand = candidate;
+    }
+  }
+  return Object.keys(normalized).length ? normalized : undefined;
+};
+
+export const deepLinkSignature = (link: DeepLink | null | undefined): string | null => {
+  if (!link || typeof link.app !== 'string') return null;
+  const ctx = link.context;
+  if (!ctx || typeof ctx !== 'object') {
+    return link.app;
+  }
+  const keys = Object.keys(ctx).sort();
+  const encoded = keys
+    .map((key) => `${key}:${ctx[key]}`)
+    .join('|');
+  return `${link.app}|${encoded}`;
+};
+

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,9 @@
 import dynamic from 'next/dynamic';
+import { useMemo } from 'react';
+import { useRouter } from 'next/router';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
+import { parseDeepLinkFromQuery } from '../lib/deepLink';
 
 const Ubuntu = dynamic(
   () =>
@@ -28,16 +31,24 @@ const InstallButton = dynamic(
 /**
  * @returns {JSX.Element}
  */
-const App = () => (
-  <>
-    <a href="#window-area" className="sr-only focus:not-sr-only">
-      Skip to content
-    </a>
-    <Meta />
-    <Ubuntu />
-    <BetaBadge />
-    <InstallButton />
-  </>
-);
+const App = () => {
+  const router = useRouter();
+  const deepLink = useMemo(() => {
+    if (!router.isReady) return null;
+    return parseDeepLinkFromQuery(router.query);
+  }, [router.isReady, router.asPath]);
+
+  return (
+    <>
+      <a href="#window-area" className="sr-only focus:not-sr-only">
+        Skip to content
+      </a>
+      <Meta />
+      <Ubuntu deepLink={deepLink} />
+      <BetaBadge />
+      <InstallButton />
+    </>
+  );
+};
 
 export default App;


### PR DESCRIPTION
## Summary
- add reusable deep-link parsing and normalization helpers so routes can hydrate app state
- teach the desktop shell to apply deep links while preserving saved workspace state and allow terminal to execute initial commands
- document the query-string format and cover the new helpers and desktop flow with focused unit tests

## Testing
- yarn lint *(fails: existing jsx-a11y/no-top-level-window violations in legacy apps)*
- yarn test *(fails: existing SWC parser errors in legacy taskbar/desktop tests)*
- yarn test __tests__/deepLink.test.ts --runInBand
- yarn test __tests__/desktopDeepLink.test.tsx --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d6d531256c832885ec01720d4aa2d2