### PR TITLE
[ui] improve keyboard shortcut overlay

### DIFF
--- a/__tests__/ShortcutOverlay.test.tsx
+++ b/__tests__/ShortcutOverlay.test.tsx
@@ -1,28 +1,103 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+
+let root: HTMLDivElement;
+const originalRaf = window.requestAnimationFrame;
+const originalCancelRaf = window.cancelAnimationFrame;
+
+beforeAll(() => {
+  Object.defineProperty(window, 'requestAnimationFrame', {
+    writable: true,
+    value: (callback: FrameRequestCallback) =>
+      window.setTimeout(() => callback(Date.now()), 0),
+  });
+  Object.defineProperty(window, 'cancelAnimationFrame', {
+    writable: true,
+    value: (id: number) => window.clearTimeout(id),
+  });
+});
+
+afterAll(() => {
+  Object.defineProperty(window, 'requestAnimationFrame', {
+    writable: true,
+    value: originalRaf,
+  });
+  Object.defineProperty(window, 'cancelAnimationFrame', {
+    writable: true,
+    value: originalCancelRaf,
+  });
+});
 
 describe('ShortcutOverlay', () => {
   beforeEach(() => {
     window.localStorage.removeItem('keymap');
+    root = document.createElement('div');
+    root.setAttribute('id', '__next');
+    document.body.appendChild(root);
   });
 
-  it('lists shortcuts and highlights conflicts', () => {
+  afterEach(() => {
+    document.body.removeChild(root);
+  });
+
+  it('opens via shortcut, filters, and highlights conflicts', async () => {
     window.localStorage.setItem(
       'keymap',
       JSON.stringify({
-        'Show keyboard shortcuts': 'A',
-        'Open settings': 'A',
+        'Show keyboard shortcuts': 'a',
+        'Open settings': 'a',
       })
     );
-    render(<ShortcutOverlay />);
+
+    render(<ShortcutOverlay />, { container: root });
     fireEvent.keyDown(window, { key: 'a' });
-    expect(
-      screen.getByText('Show keyboard shortcuts')
-    ).toBeInTheDocument();
-    expect(screen.getByText('Open settings')).toBeInTheDocument();
-    const items = screen.getAllByRole('listitem');
-    expect(items[0]).toHaveAttribute('data-conflict', 'true');
-    expect(items[1]).toHaveAttribute('data-conflict', 'true');
+
+    await screen.findByRole('dialog', { name: /keyboard shortcuts/i });
+
+    const conflictLabels = await screen.findAllByText(
+      /In conflict with another shortcut/i
+    );
+    expect(conflictLabels.length).toBeGreaterThanOrEqual(2);
+
+    const search = screen.getByLabelText(/filter shortcuts/i);
+    fireEvent.change(search, { target: { value: 'workspace' } });
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent('4 shortcuts shown')
+    );
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(4);
+    options.forEach((option) => {
+      expect(option.textContent).toContain('workspace');
+    });
+  });
+
+  it('supports keyboard navigation', async () => {
+    render(<ShortcutOverlay />, { container: root });
+
+    fireEvent.keyDown(window, { key: '?', shiftKey: true });
+
+    const search = await screen.findByLabelText(/filter shortcuts/i);
+    await waitFor(() => expect(search).toHaveFocus());
+
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    const options = screen.getAllByRole('option');
+    await waitFor(() => expect(document.activeElement).toBe(options[0]));
+
+    fireEvent.keyDown(document.activeElement as Element, { key: 'ArrowDown' });
+    await waitFor(() => expect(document.activeElement).toBe(options[1]));
+
+    fireEvent.keyDown(document.activeElement as Element, { key: 'End' });
+    await waitFor(() =>
+      expect(document.activeElement).toBe(options[options.length - 1])
+    );
+
+    fireEvent.keyDown(document.activeElement as Element, { key: 'Escape' });
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: /keyboard shortcuts/i }))
+        .not.toBeInTheDocument()
+    );
   });
 });

--- a/apps/settings/components/KeymapOverlay.tsx
+++ b/apps/settings/components/KeymapOverlay.tsx
@@ -1,23 +1,13 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { formatKeyboardEvent } from '../../../utils/keyboard';
 import useKeymap from '../keymapRegistry';
 
 interface KeymapOverlayProps {
   open: boolean;
   onClose: () => void;
 }
-
-const formatEvent = (e: KeyboardEvent) => {
-  const parts = [
-    e.ctrlKey ? 'Ctrl' : '',
-    e.altKey ? 'Alt' : '',
-    e.shiftKey ? 'Shift' : '',
-    e.metaKey ? 'Meta' : '',
-    e.key.length === 1 ? e.key.toUpperCase() : e.key,
-  ];
-  return parts.filter(Boolean).join('+');
-};
 
 export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
   const { shortcuts, updateShortcut } = useKeymap();
@@ -27,7 +17,7 @@ export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
     if (!rebinding) return;
     const handler = (e: KeyboardEvent) => {
       e.preventDefault();
-      const combo = formatEvent(e);
+      const combo = formatKeyboardEvent(e);
       updateShortcut(rebinding, combo);
       setRebinding(null);
     };

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -1,14 +1,11 @@
 import usePersistentState from '../../hooks/usePersistentState';
+import {
+  DEFAULT_SHORTCUTS,
+  ShortcutDefinition,
+} from '../../data/shortcuts';
+import { normalizeShortcut } from '../../utils/keyboard';
 
-export interface Shortcut {
-  description: string;
-  keys: string;
-}
-
-const DEFAULT_SHORTCUTS: Shortcut[] = [
-  { description: 'Show keyboard shortcuts', keys: '?' },
-  { description: 'Open settings', keys: 'Ctrl+,' },
-];
+export type Shortcut = ShortcutDefinition;
 
 const validator = (value: unknown): value is Record<string, string> => {
   return (
@@ -24,7 +21,7 @@ const validator = (value: unknown): value is Record<string, string> => {
 export function useKeymap() {
   const initial = DEFAULT_SHORTCUTS.reduce<Record<string, string>>(
     (acc, s) => {
-      acc[s.description] = s.keys;
+      acc[s.description] = normalizeShortcut(s.keys);
       return acc;
     },
     {}
@@ -36,13 +33,13 @@ export function useKeymap() {
     validator
   );
 
-  const shortcuts = DEFAULT_SHORTCUTS.map(({ description, keys }) => ({
-    description,
-    keys: map[description] || keys,
+  const shortcuts: Shortcut[] = DEFAULT_SHORTCUTS.map((shortcut) => ({
+    ...shortcut,
+    keys: normalizeShortcut(map[shortcut.description] || shortcut.keys),
   }));
 
   const updateShortcut = (description: string, keys: string) =>
-    setMap({ ...map, [description]: keys });
+    setMap({ ...map, [description]: normalizeShortcut(keys) });
 
   return { shortcuts, updateShortcut };
 }

--- a/components/common/ShortcutOverlay.tsx
+++ b/components/common/ShortcutOverlay.tsx
@@ -1,113 +1,444 @@
 'use client';
 
-import React, { useEffect, useState, useCallback } from 'react';
-import useKeymap from '../../apps/settings/keymapRegistry';
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import useKeymap, { type Shortcut } from '../../apps/settings/keymapRegistry';
+import {
+  SHORTCUT_CATEGORIES,
+} from '../../data/shortcuts';
+import Modal from '../base/Modal';
+import { shortcutMatchesEvent } from '../../utils/keyboard';
 
-const formatEvent = (e: KeyboardEvent) => {
-  const parts = [
-    e.ctrlKey ? 'Ctrl' : '',
-    e.altKey ? 'Alt' : '',
-    e.shiftKey ? 'Shift' : '',
-    e.metaKey ? 'Meta' : '',
-    e.key.length === 1 ? e.key.toUpperCase() : e.key,
-  ];
-  return parts.filter(Boolean).join('+');
+type FocusTarget = 'search' | 'list';
+
+const isEditableElement = (target: EventTarget | null) => {
+  if (!target || !(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return (
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    target.isContentEditable ||
+    target.getAttribute('role') === 'textbox'
+  );
 };
 
 const ShortcutOverlay: React.FC = () => {
-  const [open, setOpen] = useState(false);
   const { shortcuts } = useKeymap();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
 
-  const toggle = useCallback(() => setOpen((o) => !o), []);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const focusIntentRef = useRef<FocusTarget>();
+
+  const titleId = useId();
+  const descriptionId = useId();
+  const instructionsId = useId();
+  const statusId = useId();
+  const listboxId = useId();
+  const searchId = useId();
+
+  const showShortcut = useMemo(
+    () =>
+      shortcuts.find(
+        (shortcut) => shortcut.description === 'Show keyboard shortcuts'
+      )?.keys || '?',
+    [shortcuts]
+  );
+
+  const openOverlay = useCallback(() => {
+    setQuery('');
+    setActiveIndex(0);
+    focusIntentRef.current = 'search';
+    setOpen(true);
+  }, []);
+
+  const closeOverlay = useCallback(() => {
+    focusIntentRef.current = undefined;
+    setOpen(false);
+  }, []);
 
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement;
-      const isInput =
-        target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        (target as HTMLElement).isContentEditable;
-      if (isInput) return;
-      const show =
-        shortcuts.find((s) => s.description === 'Show keyboard shortcuts')?.keys ||
-        '?';
-      if (formatEvent(e) === show) {
-        e.preventDefault();
-        toggle();
-      } else if (e.key === 'Escape' && open) {
-        e.preventDefault();
-        setOpen(false);
+    const handler = (event: KeyboardEvent) => {
+      const target = event.target;
+      if (isEditableElement(target)) return;
+
+      if (shortcutMatchesEvent(showShortcut, event)) {
+        event.preventDefault();
+        if (open) {
+          closeOverlay();
+        } else {
+          openOverlay();
+        }
+        return;
+      }
+
+      if (event.key === 'Escape' && open) {
+        event.preventDefault();
+        closeOverlay();
       }
     };
+
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [open, toggle, shortcuts]);
+  }, [closeOverlay, open, openOverlay, showShortcut]);
 
-  const handleExport = () => {
+  useEffect(() => {
+    if (!open) return;
+    const frame = requestAnimationFrame(() => {
+      if (focusIntentRef.current === 'search') {
+        const input = searchInputRef.current;
+        input?.focus();
+        input?.select();
+        focusIntentRef.current = undefined;
+      }
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (focusIntentRef.current !== 'list') return;
+    const node = itemRefs.current[activeIndex];
+    if (node) {
+      node.focus();
+      focusIntentRef.current = undefined;
+    }
+  }, [activeIndex, open]);
+
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const filteredShortcuts = useMemo(() => {
+    if (!normalizedQuery) return shortcuts;
+    return shortcuts.filter((shortcut) => {
+      const haystack = [
+        shortcut.description,
+        shortcut.keys,
+        shortcut.category,
+        ...(shortcut.tags ?? []),
+      ]
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(normalizedQuery);
+    });
+  }, [normalizedQuery, shortcuts]);
+
+  const annotatedShortcuts = useMemo(
+    () => filteredShortcuts.map((shortcut, index) => ({ shortcut, index })),
+    [filteredShortcuts]
+  );
+
+  const groupedShortcuts = useMemo(() => {
+    const map = new Map<string, { shortcut: Shortcut; index: number }[]>();
+    annotatedShortcuts.forEach((entry) => {
+      const category = entry.shortcut.category || 'Other';
+      const existing = map.get(category);
+      if (existing) {
+        existing.push(entry);
+      } else {
+        map.set(category, [entry]);
+      }
+    });
+
+    const ordered: { category: string; items: { shortcut: Shortcut; index: number }[] }[] = [];
+    SHORTCUT_CATEGORIES.forEach((category) => {
+      const items = map.get(category);
+      if (items && items.length) {
+        ordered.push({ category, items });
+        map.delete(category);
+      }
+    });
+
+    Array.from(map.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .forEach(([category, items]) => {
+        ordered.push({ category, items });
+      });
+
+    return ordered;
+  }, [annotatedShortcuts]);
+
+  const conflicts = useMemo(() => {
+    const counts = shortcuts.reduce<Map<string, number>>((acc, shortcut) => {
+      acc.set(shortcut.keys, (acc.get(shortcut.keys) ?? 0) + 1);
+      return acc;
+    }, new Map());
+
+    return new Set(
+      Array.from(counts.entries())
+        .filter(([, count]) => count > 1)
+        .map(([key]) => key)
+    );
+  }, [shortcuts]);
+
+  const resultsLabel = useMemo(() => {
+    const count = filteredShortcuts.length;
+    if (count === 0) return 'No shortcuts found';
+    return `${count} shortcut${count === 1 ? '' : 's'} shown`;
+  }, [filteredShortcuts.length]);
+
+  useEffect(() => {
+    if (!filteredShortcuts.length) {
+      setActiveIndex(0);
+      return;
+    }
+    if (activeIndex >= filteredShortcuts.length) {
+      setActiveIndex(filteredShortcuts.length - 1);
+    }
+  }, [activeIndex, filteredShortcuts.length]);
+
+  itemRefs.current.length = filteredShortcuts.length;
+
+  const handleExport = useCallback(() => {
     const data = JSON.stringify(shortcuts, null, 2);
     const blob = new Blob([data], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'shortcuts.json';
-    a.click();
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'shortcuts.json';
+    anchor.click();
     URL.revokeObjectURL(url);
-  };
+  }, [shortcuts]);
 
-  if (!open) return null;
+  const handlePrint = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      window.print();
+    }
+  }, []);
 
-  const keyCounts = shortcuts.reduce<Map<string, number>>((map, s) => {
-    map.set(s.keys, (map.get(s.keys) || 0) + 1);
-    return map;
-  }, new Map());
-  const conflicts = new Set(
-    Array.from(keyCounts.entries())
-      .filter(([, count]) => count > 1)
-      .map(([key]) => key)
+  const handleQueryChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setQuery(event.target.value);
+      setActiveIndex(0);
+    },
+    []
   );
 
+  const focusListItem = useCallback(
+    (index: number) => {
+      if (!filteredShortcuts.length) return;
+      focusIntentRef.current = 'list';
+      setActiveIndex((prev) => {
+        if (prev === index) {
+          const node = itemRefs.current[index];
+          if (node) {
+            requestAnimationFrame(() => {
+              node.focus();
+              focusIntentRef.current = undefined;
+            });
+          }
+          return prev;
+        }
+        return index;
+      });
+    },
+    [filteredShortcuts.length]
+  );
+
+  const handleQueryKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (!filteredShortcuts.length) return;
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        focusListItem(0);
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        focusListItem(filteredShortcuts.length - 1);
+      }
+    },
+    [filteredShortcuts.length, focusListItem]
+  );
+
+  const handleListKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>, index: number) => {
+      if (!filteredShortcuts.length) return;
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        focusListItem((index + 1) % filteredShortcuts.length);
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        focusListItem((index - 1 + filteredShortcuts.length) % filteredShortcuts.length);
+      } else if (event.key === 'Home') {
+        event.preventDefault();
+        focusListItem(0);
+      } else if (event.key === 'End') {
+        event.preventDefault();
+        focusListItem(filteredShortcuts.length - 1);
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        closeOverlay();
+      }
+    },
+    [closeOverlay, filteredShortcuts.length, focusListItem]
+  );
+
+  const handleListClick = useCallback(
+    (index: number) => {
+      focusListItem(index);
+    },
+    [focusListItem]
+  );
+
+  
+
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/80 text-white p-4 overflow-auto"
-      role="dialog"
-      aria-modal="true"
+    <Modal
+      isOpen={open}
+      onClose={closeOverlay}
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-auto bg-black/80 p-4 text-white print:relative print:bg-white print:p-8 print:text-black"
+      aria-labelledby={titleId}
+      aria-describedby={`${descriptionId} ${instructionsId} ${statusId}`.trim()}
     >
-      <div className="max-w-lg w-full space-y-4">
-        <div className="flex justify-between items-center">
-          <h2 className="text-xl font-bold">Keyboard Shortcuts</h2>
-          <button
-            type="button"
-            onClick={() => setOpen(false)}
-            className="text-sm underline"
-          >
-            Close
-          </button>
-        </div>
-        <button
-          type="button"
-          onClick={handleExport}
-          className="px-2 py-1 bg-gray-700 rounded text-sm"
-        >
-          Export JSON
-        </button>
-        <ul className="space-y-1">
-          {shortcuts.map((s, i) => (
-            <li
-              key={i}
-              data-conflict={conflicts.has(s.keys) ? 'true' : 'false'}
-              className={
-                conflicts.has(s.keys)
-                  ? 'flex justify-between bg-red-600/70 px-2 py-1 rounded'
-                  : 'flex justify-between px-2 py-1'
-              }
+      <div className="w-full max-w-4xl rounded-2xl border border-white/15 bg-slate-900/90 text-white shadow-2xl backdrop-blur print:border-black/10 print:bg-white print:text-black print:shadow-none">
+        <header className="flex flex-col gap-3 border-b border-white/10 p-6 sm:flex-row sm:items-center sm:justify-between print:border-black/10">
+          <div className="space-y-2">
+            <h2 id={titleId} className="text-2xl font-semibold tracking-wide print:text-black">
+              Keyboard shortcuts
+            </h2>
+            <p
+              id={descriptionId}
+              className="text-sm text-slate-200 print:text-slate-700"
             >
-              <span className="font-mono mr-4">{s.keys}</span>
-              <span className="flex-1">{s.description}</span>
-            </li>
-          ))}
-        </ul>
+              Type to filter the list. Use the arrow keys to explore shortcuts and
+              press Escape to close this window.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={handlePrint}
+              className="rounded-md border border-white/20 px-3 py-1.5 text-sm font-medium hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white print:border-black/30 print:text-black"
+            >
+              Print
+            </button>
+            <button
+              type="button"
+              onClick={handleExport}
+              className="rounded-md border border-white/20 px-3 py-1.5 text-sm font-medium hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white print:border-black/30 print:text-black"
+            >
+              Export JSON
+            </button>
+            <button
+              type="button"
+              onClick={closeOverlay}
+              className="rounded-md border border-white/20 px-3 py-1.5 text-sm font-medium hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white print:border-black/30 print:text-black"
+            >
+              Close
+            </button>
+          </div>
+        </header>
+        <div className="space-y-6 p-6">
+          <div className="space-y-2">
+            <label
+              htmlFor={searchId}
+              className="text-sm font-medium text-slate-100 print:text-black"
+            >
+              Filter shortcuts
+            </label>
+            <input
+              id={searchId}
+              ref={searchInputRef}
+              type="search"
+              value={query}
+              onChange={handleQueryChange}
+              onKeyDown={handleQueryKeyDown}
+              aria-controls={listboxId}
+              className="w-full rounded-lg border border-white/20 bg-black/30 px-3 py-2 text-base text-white placeholder:text-slate-400 focus:border-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 print:border-black/20 print:bg-white print:text-black"
+              placeholder="Search by action, key, or workspace"
+              enterKeyHint="search"
+            />
+            <p
+              id={instructionsId}
+              className="text-xs text-slate-300 print:text-slate-600"
+            >
+              Use the up and down arrows to move through the results.
+            </p>
+          </div>
+          <p
+            id={statusId}
+            role="status"
+            aria-live="polite"
+            className="text-sm text-slate-200 print:text-slate-700"
+          >
+            {resultsLabel}
+          </p>
+          <div className="space-y-6 print:space-y-4">
+            {groupedShortcuts.length === 0 ? (
+              <p className="rounded-lg border border-dashed border-white/20 bg-black/20 p-6 text-center text-sm text-slate-200 print:border-black/20 print:bg-transparent print:text-black">
+                No shortcuts match “{query}”. Try a different search term.
+              </p>
+            ) : (
+              <ul
+                id={listboxId}
+                role="listbox"
+                className="grid gap-3 sm:grid-cols-2"
+              >
+                {groupedShortcuts.map(({ category, items }) => (
+                  <React.Fragment key={category}>
+                    <li className="list-none sm:col-span-2" role="presentation">
+                      <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-300 print:text-black">
+                        {category}
+                      </h3>
+                    </li>
+                    {items.map(({ shortcut, index }) => (
+                      <li
+                        key={`${shortcut.description}-${shortcut.keys}-${index}`}
+                        className="list-none"
+                      >
+                        <div
+                          id={`shortcut-${index}`}
+                          ref={(node) => {
+                            itemRefs.current[index] = node;
+                          }}
+                          role="option"
+                          tabIndex={-1}
+                          aria-selected={index === activeIndex}
+                          aria-setsize={filteredShortcuts.length}
+                          aria-posinset={index + 1}
+                          onClick={() => handleListClick(index)}
+                          onKeyDown={(event) => handleListKeyDown(event, index)}
+                          className={`flex h-full flex-col justify-between gap-2 rounded-lg border px-3 py-3 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+                            index === activeIndex
+                              ? 'border-ubt-grey bg-white/15 focus-visible:outline-white'
+                              : 'border-white/10 bg-white/5 hover:bg-white/10 focus-visible:outline-white'
+                          } ${
+                            conflicts.has(shortcut.keys)
+                              ? 'ring-2 ring-red-500/70'
+                              : ''
+                          } print:border-black/20 print:bg-white print:text-black`}
+                        >
+                          <span className="text-xs font-semibold uppercase tracking-wide text-slate-300 print:text-slate-700">
+                            {shortcut.category}
+                          </span>
+                          <span className="font-mono text-lg font-semibold tracking-wider text-white print:text-black">
+                            {shortcut.keys}
+                          </span>
+                          <span className="text-sm text-slate-100 print:text-slate-700">
+                            {shortcut.description}
+                          </span>
+                          {conflicts.has(shortcut.keys) && (
+                            <span className="text-xs font-semibold text-red-300 print:text-red-600">
+                              In conflict with another shortcut
+                            </span>
+                          )}
+                        </div>
+                      </li>
+                    ))}
+                  </React.Fragment>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/data/shortcuts.ts
+++ b/data/shortcuts.ts
@@ -1,0 +1,112 @@
+export interface ShortcutDefinition {
+  description: string;
+  keys: string;
+  category: string;
+  tags?: string[];
+}
+
+export const DEFAULT_SHORTCUTS: readonly ShortcutDefinition[] = [
+  {
+    description: 'Show keyboard shortcuts',
+    keys: '?',
+    category: 'General',
+    tags: ['help', 'reference', 'overlay'],
+  },
+  {
+    description: 'Open settings',
+    keys: 'Ctrl+,',
+    category: 'General',
+    tags: ['preferences', 'configuration'],
+  },
+  {
+    description: 'Toggle app launcher',
+    keys: 'Meta',
+    category: 'General',
+    tags: ['launcher', 'start menu', 'whisker'],
+  },
+  {
+    description: 'Open clipboard manager',
+    keys: 'Ctrl+Shift+V',
+    category: 'Utilities',
+    tags: ['clipboard', 'paste history'],
+  },
+  {
+    description: 'Open context menu',
+    keys: 'Shift+F10',
+    category: 'Utilities',
+    tags: ['menu', 'accessibility'],
+  },
+  {
+    description: 'Switch between windows',
+    keys: 'Alt+Tab',
+    category: 'Window management',
+    tags: ['task switcher', 'next window'],
+  },
+  {
+    description: 'Switch to previous window',
+    keys: 'Alt+Shift+Tab',
+    category: 'Window management',
+    tags: ['task switcher', 'previous window'],
+  },
+  {
+    description: 'Cycle windows of focused app',
+    keys: "Alt+`",
+    category: 'Window management',
+    tags: ['tilde', 'same app windows'],
+  },
+  {
+    description: 'Snap window left',
+    keys: 'Meta+ArrowLeft',
+    category: 'Window management',
+    tags: ['snap', 'tile'],
+  },
+  {
+    description: 'Snap window right',
+    keys: 'Meta+ArrowRight',
+    category: 'Window management',
+    tags: ['snap', 'tile'],
+  },
+  {
+    description: 'Snap window up',
+    keys: 'Meta+ArrowUp',
+    category: 'Window management',
+    tags: ['snap', 'tile'],
+  },
+  {
+    description: 'Snap window down',
+    keys: 'Meta+ArrowDown',
+    category: 'Window management',
+    tags: ['snap', 'tile'],
+  },
+  {
+    description: 'Move to workspace on the left',
+    keys: 'Ctrl+Alt+ArrowLeft',
+    category: 'Workspaces',
+    tags: ['workspace', 'multi-desktop', 'left'],
+  },
+  {
+    description: 'Move to workspace on the right',
+    keys: 'Ctrl+Alt+ArrowRight',
+    category: 'Workspaces',
+    tags: ['workspace', 'multi-desktop', 'right'],
+  },
+  {
+    description: 'Move to workspace above',
+    keys: 'Ctrl+Alt+ArrowUp',
+    category: 'Workspaces',
+    tags: ['workspace', 'multi-desktop', 'up'],
+  },
+  {
+    description: 'Move to workspace below',
+    keys: 'Ctrl+Alt+ArrowDown',
+    category: 'Workspaces',
+    tags: ['workspace', 'multi-desktop', 'down'],
+  },
+] as const;
+
+export const SHORTCUT_DEFINITION_MAP: ReadonlyMap<string, ShortcutDefinition> =
+  new Map(DEFAULT_SHORTCUTS.map((shortcut) => [shortcut.description, shortcut]));
+
+export const SHORTCUT_CATEGORIES: readonly string[] = Array.from(
+  new Set(DEFAULT_SHORTCUTS.map((shortcut) => shortcut.category))
+);

--- a/pages/keyboard-reference.tsx
+++ b/pages/keyboard-reference.tsx
@@ -1,39 +1,77 @@
 import React from 'react';
+import {
+  DEFAULT_SHORTCUTS,
+  SHORTCUT_CATEGORIES,
+} from '../data/shortcuts';
+
+const groupedShortcuts = (() => {
+  const ordered = SHORTCUT_CATEGORIES.map((category) => ({
+    category,
+    shortcuts: DEFAULT_SHORTCUTS.filter(
+      (shortcut) => shortcut.category === category
+    ),
+  }));
+
+  const remainingCategories = Array.from(
+    new Set(DEFAULT_SHORTCUTS.map((shortcut) => shortcut.category))
+  ).filter((category) => !SHORTCUT_CATEGORIES.includes(category));
+
+  const extras = remainingCategories.map((category) => ({
+    category,
+    shortcuts: DEFAULT_SHORTCUTS.filter(
+      (shortcut) => shortcut.category === category
+    ),
+  }));
+
+  return [...ordered, ...extras];
+})();
 
 const KeyboardReference = () => (
-  <main className="min-h-screen bg-ub-cool-grey text-white p-4 space-y-4">
-    <h1 className="text-2xl font-bold">Keyboard Mapping Reference</h1>
-    <p className="mb-4">Common shortcuts for navigating and interacting with the desktop.</p>
-    <table className="w-full border-collapse">
-      <thead>
-        <tr>
-          <th className="p-2 text-left border border-ubt-grey">Key</th>
-          <th className="p-2 text-left border border-ubt-grey">Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Ctrl + C</td>
-          <td className="p-2 border border-ubt-grey">Copy selected text</td>
-        </tr>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Ctrl + V</td>
-          <td className="p-2 border border-ubt-grey">Paste from clipboard</td>
-        </tr>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Ctrl + X</td>
-          <td className="p-2 border border-ubt-grey">Cut selected text</td>
-        </tr>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Alt + Tab</td>
-          <td className="p-2 border border-ubt-grey">Switch between apps</td>
-        </tr>
-        <tr>
-          <td className="p-2 border border-ubt-grey">Alt + F4</td>
-          <td className="p-2 border border-ubt-grey">Close current window</td>
-        </tr>
-      </tbody>
-    </table>
+  <main className="min-h-screen bg-ub-cool-grey p-6 text-white space-y-6">
+    <header className="space-y-2">
+      <h1 className="text-3xl font-bold tracking-wide">Keyboard Mapping Reference</h1>
+      <p className="text-sm text-slate-200">
+        The table below lists every desktop shortcut supported by the Kali Linux
+        portfolio shell. Use it as a printable quick reference or pair it with
+        the in-app overlay (<span className="font-mono">?</span>) for live filtering.
+      </p>
+    </header>
+    <div className="space-y-8">
+      {groupedShortcuts.map(({ category, shortcuts }) => (
+        <section key={category} className="space-y-3">
+          <h2 className="text-xl font-semibold tracking-wide text-ubt-grey-light">
+            {category}
+          </h2>
+          <table className="w-full border-collapse overflow-hidden rounded-lg shadow-md">
+            <thead className="bg-black/30">
+              <tr>
+                <th className="p-3 text-left text-sm font-semibold uppercase tracking-wider text-slate-200">
+                  Shortcut
+                </th>
+                <th className="p-3 text-left text-sm font-semibold uppercase tracking-wider text-slate-200">
+                  Action
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {shortcuts.map((shortcut) => (
+                <tr
+                  key={`${shortcut.description}-${shortcut.keys}`}
+                  className="odd:bg-black/20"
+                >
+                  <td className="p-3 font-mono text-base text-white">
+                    {shortcut.keys}
+                  </td>
+                  <td className="p-3 text-sm text-slate-200">
+                    {shortcut.description}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      ))}
+    </div>
   </main>
 );
 

--- a/utils/keyboard.ts
+++ b/utils/keyboard.ts
@@ -1,0 +1,119 @@
+export const MODIFIER_ORDER = ['Ctrl', 'Alt', 'Shift', 'Meta'] as const;
+
+type Modifier = (typeof MODIFIER_ORDER)[number];
+
+const modifierLookup: Record<string, Modifier> = {
+  ctrl: 'Ctrl',
+  control: 'Ctrl',
+  alt: 'Alt',
+  option: 'Alt',
+  shift: 'Shift',
+  meta: 'Meta',
+  cmd: 'Meta',
+  command: 'Meta',
+  super: 'Meta',
+  win: 'Meta',
+  windows: 'Meta',
+};
+
+const isLetterOrNumber = (key: string) => /[A-Z0-9]/i.test(key);
+
+const normalizeKey = (key: string) => {
+  if (!key) return '';
+  if (key === ' ') return 'Space';
+  if (key.length === 1) {
+    return key.toUpperCase();
+  }
+  return key.charAt(0).toUpperCase() + key.slice(1);
+};
+
+export const normalizeShortcut = (input: string): string => {
+  if (!input) return '';
+  const parts = input
+    .split('+')
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  const modifiers: Modifier[] = [];
+  let keyPart: string | null = null;
+
+  parts.forEach((part) => {
+    const mapped = modifierLookup[part.toLowerCase()];
+    if (mapped) {
+      if (!modifiers.includes(mapped)) {
+        modifiers.push(mapped);
+      }
+      return;
+    }
+
+    const normalized = normalizeKey(part);
+    if (!normalized) return;
+    keyPart = normalized;
+  });
+
+  if (keyPart === 'Meta') {
+    const index = modifiers.indexOf('Meta');
+    if (index !== -1) modifiers.splice(index, 1);
+  }
+
+  if (
+    keyPart &&
+    keyPart.length === 1 &&
+    !isLetterOrNumber(keyPart) &&
+    modifiers.includes('Shift')
+  ) {
+    modifiers.splice(modifiers.indexOf('Shift'), 1);
+  }
+
+  const ordered = modifiers.sort(
+    (a, b) => MODIFIER_ORDER.indexOf(a) - MODIFIER_ORDER.indexOf(b)
+  );
+
+  return keyPart ? [...ordered, keyPart].join('+') : ordered.join('+');
+};
+
+export const formatKeyboardEvent = (event: KeyboardEvent): string => {
+  const modifiers: Modifier[] = [];
+  if (event.ctrlKey) modifiers.push('Ctrl');
+  if (event.altKey) modifiers.push('Alt');
+  if (event.shiftKey) modifiers.push('Shift');
+  if (event.metaKey) modifiers.push('Meta');
+
+  let key = event.key;
+  if (key === 'Unidentified') key = '';
+  if (key === ' ') key = 'Space';
+  if (key.length === 1) key = key.toUpperCase();
+
+  if (key === 'Meta') {
+    const index = modifiers.indexOf('Meta');
+    if (index !== -1) modifiers.splice(index, 1);
+  }
+
+  if (
+    key.length === 1 &&
+    !isLetterOrNumber(key) &&
+    modifiers.includes('Shift')
+  ) {
+    modifiers.splice(modifiers.indexOf('Shift'), 1);
+  }
+
+  const ordered = modifiers.sort(
+    (a, b) => MODIFIER_ORDER.indexOf(a) - MODIFIER_ORDER.indexOf(b)
+  );
+
+  if (!key || key === 'Control' || key === 'Shift' || key === 'Alt') {
+    if (key === 'Control') return 'Ctrl';
+    if (key === 'Alt') return 'Alt';
+    return key || ordered.join('+');
+  }
+
+  return key ? [...ordered, key].join('+') : ordered.join('+');
+};
+
+export const shortcutMatchesEvent = (
+  shortcut: string,
+  event: KeyboardEvent
+): boolean => {
+  if (!shortcut) return false;
+  return normalizeShortcut(shortcut) === formatKeyboardEvent(event);
+};


### PR DESCRIPTION
## Summary
- centralize keyboard shortcut metadata and formatting utilities for reuse across the keymap and documentation
- rebuild the global shortcut overlay with filtering, keyboard navigation, focus trapping, and print/export actions for better accessibility
- update the keymap settings overlay, keyboard reference page, and tests to use the shared shortcut data with new coverage for navigation

## Testing
- yarn lint *(fails: repository has numerous existing accessibility lint violations)*
- yarn test *(fails: pre-existing suites such as the nmap NSE workflow and taskbar tests)*
- yarn test __tests__/ShortcutOverlay.test.tsx --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68d6d531c2bc8328bb810d52d4c2b02a