### PR TITLE
[ui] track launcher recents

### DIFF
--- a/__tests__/recentStorage.test.ts
+++ b/__tests__/recentStorage.test.ts
@@ -1,0 +1,125 @@
+import type { RecentEntry } from '../utils/recentStorage';
+
+const createMemoryStorage = (backing: Record<string, string>) => {
+  return {
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(backing, key) ? backing[key] : null;
+    },
+    setItem(key: string, value: string) {
+      backing[key] = String(value);
+    },
+    removeItem(key: string) {
+      delete backing[key];
+    },
+    clear() {
+      Object.keys(backing).forEach((key) => delete backing[key]);
+    },
+    key(index: number) {
+      const keys = Object.keys(backing);
+      return keys[index] ?? null;
+    },
+    get length() {
+      return Object.keys(backing).length;
+    },
+  } as Storage;
+};
+
+describe('recentStorage', () => {
+  let store: Record<string, string>;
+  let addRecentApp: (id: string) => RecentEntry[];
+  let addRecentFile: (options: { path: string; title?: string }) => RecentEntry[];
+  let readRecentEntries: () => RecentEntry[];
+  let clearRecentEntries: () => void;
+  let RECENT_STORAGE_KEY: string;
+
+  const setLocalStorage = () => {
+    const storage = createMemoryStorage(store);
+    Object.defineProperty(global, 'localStorage', {
+      value: storage,
+      configurable: true,
+      writable: true,
+    });
+  };
+
+  const importRecentStorage = async () => {
+    const mod = await import('../utils/recentStorage');
+    addRecentApp = mod.addRecentApp;
+    addRecentFile = mod.addRecentFile;
+    readRecentEntries = mod.readRecentEntries;
+    clearRecentEntries = mod.clearRecentEntries;
+    RECENT_STORAGE_KEY = mod.RECENT_STORAGE_KEY;
+  };
+
+  beforeEach(async () => {
+    jest.resetModules();
+    store = {};
+    setLocalStorage();
+    await importRecentStorage();
+  });
+
+  afterEach(() => {
+    delete (global as any).localStorage;
+    jest.restoreAllMocks();
+  });
+
+  it('records apps with newest first ordering and deduplication', () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    nowSpy.mockReturnValueOnce(1_000);
+    addRecentApp('terminal');
+    nowSpy.mockReturnValueOnce(2_000);
+    addRecentApp('files');
+    nowSpy.mockReturnValueOnce(3_000);
+    addRecentApp('terminal');
+
+    const apps = readRecentEntries().filter((entry) => entry.type === 'app');
+    expect(apps.map((entry) => [entry.id, entry.openedAt])).toEqual([
+      ['terminal', 3_000],
+      ['files', 2_000],
+    ]);
+
+    const stored = store[RECENT_STORAGE_KEY];
+    expect(stored).toBeDefined();
+    expect(JSON.parse(stored as string)).toHaveLength(2);
+  });
+
+  it('migrates legacy arrays from previous storage keys', () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(10_000);
+    localStorage.setItem('recentApps', JSON.stringify(['browser', 'terminal']));
+
+    const entries = readRecentEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0].id).toBe('browser');
+    expect(entries[1].id).toBe('terminal');
+    expect(localStorage.getItem('recentApps')).toBeNull();
+    nowSpy.mockRestore();
+  });
+
+  it('persists recent entries across module reloads', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    nowSpy.mockReturnValueOnce(5_000);
+    addRecentApp('terminal');
+    nowSpy.mockReturnValueOnce(6_000);
+    addRecentFile({ path: '/notes.txt', title: 'notes.txt' });
+    nowSpy.mockRestore();
+
+    jest.resetModules();
+    setLocalStorage();
+    await importRecentStorage();
+
+    const entries = readRecentEntries();
+    expect(entries).toHaveLength(2);
+    const appEntry = entries.find((entry) => entry.type === 'app');
+    const fileEntry = entries.find((entry) => entry.type === 'file');
+    expect(appEntry?.id).toBe('terminal');
+    expect(fileEntry?.meta?.path).toBe('/notes.txt');
+  });
+
+  it('clears persisted entries', () => {
+    addRecentApp('terminal');
+    expect(readRecentEntries()).toHaveLength(1);
+    clearRecentEntries();
+    expect(readRecentEntries()).toHaveLength(0);
+    expect(localStorage.getItem(RECENT_STORAGE_KEY)).toBe('[]');
+  });
+});
+

--- a/utils/recentStorage.ts
+++ b/utils/recentStorage.ts
@@ -1,78 +1,186 @@
 import { safeLocalStorage } from './safeStorage';
 
-export const RECENT_STORAGE_KEY = 'kali-recent';
-const LEGACY_RECENT_STORAGE_KEY = 'recentApps';
+export const RECENT_STORAGE_KEY = 'kali-recent:v2';
+const LEGACY_RECENT_KEYS = ['kali-recent', 'recentApps'] as const;
 const MAX_RECENT_ENTRIES = 20;
 
-type RecentId = string;
+export type RecentEntryType = 'app' | 'file';
 
-const parseIds = (raw: string | null): RecentId[] => {
-  if (!raw) return [];
+export type RecentMeta = {
+  title?: string;
+  subtitle?: string;
+  path?: string;
+  icon?: string;
+};
+
+export type RecentEntry = {
+  id: string;
+  type: RecentEntryType;
+  openedAt: number;
+  meta?: RecentMeta;
+};
+
+type RecentEntryInput = {
+  id: string;
+  type: RecentEntryType;
+  openedAt?: number;
+  meta?: RecentMeta;
+};
+
+const clampMeta = (meta?: RecentMeta): RecentMeta | undefined => {
+  if (!meta || typeof meta !== 'object') return undefined;
+  const next: RecentMeta = {};
+  if (typeof meta.title === 'string') next.title = meta.title;
+  if (typeof meta.subtitle === 'string') next.subtitle = meta.subtitle;
+  if (typeof meta.path === 'string') next.path = meta.path;
+  if (typeof meta.icon === 'string') next.icon = meta.icon;
+  return Object.keys(next).length > 0 ? next : undefined;
+};
+
+const normalizeRecentEntry = (value: unknown, fallbackOpenedAt: number): RecentEntry | null => {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Partial<RecentEntry>;
+  if (typeof candidate.id !== 'string') return null;
+  const type = candidate.type === 'file' || candidate.type === 'app' ? candidate.type : null;
+  if (!type) return null;
+  const openedAtValue = typeof candidate.openedAt === 'number' && Number.isFinite(candidate.openedAt)
+    ? candidate.openedAt
+    : fallbackOpenedAt;
+
+  const meta = clampMeta(candidate.meta);
+
+  return {
+    id: candidate.id,
+    type,
+    openedAt: openedAtValue,
+    ...(meta ? { meta } : {}),
+  };
+};
+
+const sanitizeEntries = (raw: unknown): RecentEntry[] => {
+  if (!Array.isArray(raw)) return [];
+  if (raw.every((value) => typeof value === 'string')) {
+    const now = Date.now();
+    return (raw as string[])
+      .filter((value) => typeof value === 'string')
+      .slice(0, MAX_RECENT_ENTRIES)
+      .map((id, index) => ({
+        id,
+        type: 'app' as const,
+        openedAt: now - index,
+      }));
+  }
+
+  const now = Date.now();
+  const normalized = (raw as unknown[])
+    .map((value, index) => normalizeRecentEntry(value, now - index))
+    .filter((entry): entry is RecentEntry => Boolean(entry));
+
+  const deduped = new Map<string, RecentEntry>();
+  for (const entry of normalized) {
+    const key = `${entry.type}:${entry.id}`;
+    const existing = deduped.get(key);
+    if (!existing || existing.openedAt < entry.openedAt) {
+      deduped.set(key, entry);
+    }
+  }
+
+  return Array.from(deduped.values())
+    .sort((a, b) => b.openedAt - a.openedAt)
+    .slice(0, MAX_RECENT_ENTRIES);
+};
+
+const parseStoredValue = (raw: string): RecentEntry[] => {
   try {
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter((value): value is RecentId => typeof value === 'string');
+    return sanitizeEntries(parsed);
   } catch {
     return [];
   }
 };
 
-export const seedRecentAppsFromLegacy = (): RecentId[] => {
+export const readRecentEntries = (): RecentEntry[] => {
   if (!safeLocalStorage) return [];
+
   const currentRaw = safeLocalStorage.getItem(RECENT_STORAGE_KEY);
   if (currentRaw !== null) {
-    return parseIds(currentRaw);
+    const entries = parseStoredValue(currentRaw);
+    writeRecentEntries(entries);
+    return entries;
   }
 
-  const legacyRaw = safeLocalStorage.getItem(LEGACY_RECENT_STORAGE_KEY);
-  if (legacyRaw === null) {
-    return [];
+  for (const key of LEGACY_RECENT_KEYS) {
+    const legacyRaw = safeLocalStorage.getItem(key);
+    if (legacyRaw === null) continue;
+    const entries = parseStoredValue(legacyRaw);
+    writeRecentEntries(entries);
+    try {
+      safeLocalStorage.removeItem(key);
+    } catch {
+      // ignore storage failures while cleaning up legacy keys
+    }
+    return entries;
   }
 
-  const legacyIds = parseIds(legacyRaw).slice(0, MAX_RECENT_ENTRIES);
-
-  try {
-    safeLocalStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(legacyIds));
-    safeLocalStorage.removeItem(LEGACY_RECENT_STORAGE_KEY);
-  } catch {
-    // ignore storage failures (e.g., quota exceeded)
-  }
-
-  return legacyIds;
-};
-
-export const readRecentAppIds = (): RecentId[] => {
-  if (!safeLocalStorage) return [];
-  const seeded = seedRecentAppsFromLegacy();
-  if (seeded.length > 0 || safeLocalStorage.getItem(RECENT_STORAGE_KEY) !== null) {
-    return seeded;
-  }
   return [];
 };
 
-export const writeRecentAppIds = (ids: RecentId[]): void => {
+export const writeRecentEntries = (entries: RecentEntry[]): void => {
   if (!safeLocalStorage) return;
   try {
-    safeLocalStorage.setItem(
-      RECENT_STORAGE_KEY,
-      JSON.stringify(ids.filter((id): id is RecentId => typeof id === 'string').slice(0, MAX_RECENT_ENTRIES))
-    );
+    const sanitized = sanitizeEntries(entries);
+    safeLocalStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(sanitized));
   } catch {
     // ignore storage failures
   }
 };
 
-export const addRecentApp = (id: RecentId): RecentId[] => {
-  if (!safeLocalStorage || !id) return [];
-
-  const current = seedRecentAppsFromLegacy();
-  const updated = [id, ...current.filter(existingId => existingId !== id)].slice(0, MAX_RECENT_ENTRIES);
-
+export const clearRecentEntries = (): void => {
+  if (!safeLocalStorage) return;
   try {
-    safeLocalStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(updated));
+    safeLocalStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify([]));
   } catch {
     // ignore storage failures
   }
+};
 
+export const addRecentEntry = (entry: RecentEntryInput): RecentEntry[] => {
+  if (!entry || typeof entry.id !== 'string' || !entry.id) return readRecentEntries();
+  if (entry.type !== 'app' && entry.type !== 'file') return readRecentEntries();
+
+  const openedAt = typeof entry.openedAt === 'number' && Number.isFinite(entry.openedAt)
+    ? entry.openedAt
+    : Date.now();
+
+  const meta = clampMeta(entry.meta);
+  const next: RecentEntry = {
+    id: entry.id,
+    type: entry.type,
+    openedAt,
+    ...(meta ? { meta } : {}),
+  };
+
+  const current = readRecentEntries();
+  const updated = sanitizeEntries([next, ...current]);
+  writeRecentEntries(updated);
   return updated;
+};
+
+export const addRecentApp = (id: string): RecentEntry[] =>
+  addRecentEntry({ id, type: 'app' });
+
+export const addRecentFile = (options: { path: string; title?: string; icon?: string; subtitle?: string }): RecentEntry[] => {
+  const { path, title, icon, subtitle } = options;
+  if (typeof path !== 'string' || !path) {
+    return readRecentEntries();
+  }
+
+  const meta: RecentMeta = {
+    title: typeof title === 'string' ? title : undefined,
+    icon: typeof icon === 'string' ? icon : undefined,
+    subtitle: typeof subtitle === 'string' ? subtitle : path,
+    path,
+  };
+
+  return addRecentEntry({ id: path, type: 'file', meta });
 };


### PR DESCRIPTION
## Summary
- persist recent activity with timestamps and migrate legacy app-only storage to the new schema
- surface the recent list in the launcher and whisker menu with accessible timestamps and clear controls
- record file explorer usage in the shared recent store and cover ordering/persistence with unit tests

## Testing
- yarn lint *(fails: repository has numerous existing accessibility and window usage violations)*
- yarn test *(fails: existing suites such as nmap Nse, taskbar, and desktopNameBar break due to legacy code issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d534e2308328b8587a952ae1ad82