### PR TITLE
[ui] Improve contrast and font scaling

### DIFF
--- a/__tests__/youtube.test.tsx
+++ b/__tests__/youtube.test.tsx
@@ -76,6 +76,18 @@ describe('YouTube search app', () => {
     });
   });
 
+  it('applies high-contrast text tokens', () => {
+    const { container } = render(<YouTubeApp initialResults={mockVideos} />);
+    const root = container.querySelector('[data-testid="youtube-app-root"]');
+    expect(root).not.toBeNull();
+    expect(root as HTMLElement).toHaveClass('text-kali-muted-text');
+    const searchInput = screen.getByPlaceholderText('Search YouTube');
+    expect(searchInput).toHaveClass('text-kali-muted-text');
+    expect(
+      container.querySelectorAll('[class*="text-ubt-cool-grey"]').length,
+    ).toBe(0);
+  });
+
   it('saves named clips with timestamps', async () => {
     const user = userEvent.setup();
     let curTime = 0;

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -238,7 +238,7 @@ export default function Settings() {
             <input
               id="font-scale"
               type="range"
-              min="0.75"
+              min="1"
               max="1.5"
               step="0.05"
               value={fontScale}

--- a/apps/youtube/index.tsx
+++ b/apps/youtube/index.tsx
@@ -4,7 +4,7 @@ import YouTubeApp from '../../components/apps/youtube';
 
 export default function YouTubePage() {
   return (
-    <div className="h-full w-full bg-ub-dark-grey font-sans text-ubt-cool-grey">
+    <div className="h-full w-full bg-ub-dark-grey font-sans text-kali-muted-text">
       <YouTubeApp />
     </div>
   );

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -129,7 +129,7 @@ export function Settings() {
                 <label className="mr-2 text-ubt-grey">Font Size:</label>
                 <input
                     type="range"
-                    min="0.75"
+                    min="1"
                     max="1.5"
                     step="0.05"
                     value={fontScale}

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -671,7 +671,7 @@ export default function Todoist() {
           {WIP_LIMITS[name] ? ` (${groups[name].length}/${WIP_LIMITS[name]})` : ''}
         </h2>
         {filtered.length === 0 ? (
-          <div className="flex flex-col items-center text-gray-500 mt-3">
+          <div className="flex flex-col items-center text-gray-600 mt-3">
             <img src="/empty-tasks.svg" alt="" className="w-16 h-16 mb-1.5" />
             <span className="text-sm">No tasks</span>
           </div>

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -79,9 +79,9 @@ function ChannelHovercard({ id, name }: { id: string; name: string }) {
     <span className="relative" onMouseEnter={handleEnter} onMouseLeave={handleLeave}>
       {name}
       {show && info && (
-        <div className="absolute z-10 mt-1 w-48 rounded bg-ub-cool-grey p-2 text-xs text-ubt-cool-grey shadow">
-          <div className="font-bold">{info.name}</div>
-          {info.subscriberCount && <div>{info.subscriberCount} subs</div>}
+        <div className="absolute z-10 mt-1 w-48 rounded bg-ub-cool-grey p-2 text-xs text-kali-muted-text shadow">
+          <div className="font-semibold text-white">{info.name}</div>
+          {info.subscriberCount && <div className="text-[11px]">{info.subscriberCount} subs</div>}
         </div>
       )}
     </span>
@@ -116,8 +116,8 @@ function Sidebar({
   };
 
   return (
-    <aside className="w-64 overflow-y-auto border-l border-ub-cool-grey bg-ub-cool-grey p-2 text-sm" role="complementary">
-      <h2 className="mb-[6px] text-lg font-semibold">Queue</h2>
+    <aside className="w-64 overflow-y-auto border-l border-ub-cool-grey bg-ub-cool-grey p-2 text-sm text-kali-muted-text" role="complementary">
+      <h2 className="mb-[6px] text-lg font-semibold text-white">Queue</h2>
       <div data-testid="queue-list">
         {queue.map((v) => (
           <div
@@ -126,12 +126,12 @@ function Sidebar({
             onClick={() => onPlay(v)}
           >
             <img src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
-            <div>{v.title}</div>
+            <div className="mt-1 text-sm font-semibold text-white">{v.title}</div>
           </div>
         ))}
         {!queue.length && <div className="text-ubt-grey">Empty</div>}
       </div>
-      <h2 className="mb-[6px] mt-[24px] text-lg font-semibold">Watch Later</h2>
+      <h2 className="mb-[6px] mt-[24px] text-lg font-semibold text-white">Watch Later</h2>
       <div data-testid="watch-later-list">
         {watchLater.map((v, i) => (
           <div
@@ -146,7 +146,7 @@ function Sidebar({
             onKeyDown={(e) => handleKey(i, e)}
           >
             <img src={v.thumbnail} alt="" className="h-24 w-full rounded object-cover" />
-            <div>{v.name || v.title}</div>
+            <div className="mt-1 text-sm font-semibold text-white">{v.name || v.title}</div>
           </div>
         ))}
         {!watchLater.length && <div className="text-ubt-grey">Empty</div>}
@@ -235,11 +235,11 @@ function VirtualGrid({
                     <span className="bg-black/70 px-1 text-white">HD</span>
                   </div>
                 </div>
-                <div className="mt-[6px] text-sm line-clamp-2">
+                <div className="mt-[6px] text-sm font-semibold text-white line-clamp-2">
                   {truncateTitle(v.title)}
                 </div>
               </div>
-              <div className="mt-[6px] flex justify-between text-xs">
+              <div className="mt-[6px] flex justify-between text-xs text-kali-muted-text">
                 <ChannelHovercard id={v.channelId} name={v.channelName} />
                 <div className="space-x-[6px]">
                   <button onClick={() => onQueue(v)}>Queue</button>
@@ -537,7 +537,7 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
   ]);
 
   return (
-    <div className="flex h-full flex-1 bg-ub-dark-grey font-sans text-ubt-cool-grey">
+    <div className="flex h-full flex-1 bg-ub-dark-grey font-sans text-kali-muted-text" data-testid="youtube-app-root">
       <div className="flex flex-1 flex-col">
         <form onSubmit={handleSearch} className="p-4">
           <input
@@ -545,7 +545,7 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search YouTube"
-            className="w-full rounded bg-ub-cool-grey p-2 text-ubt-cool-grey"
+            className="w-full rounded bg-ub-cool-grey p-2 text-kali-muted-text placeholder:text-kali-muted-text placeholder:opacity-70"
           />
         </form>
         {current && (
@@ -569,7 +569,7 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
               <button
                 onClick={togglePlay}
                 aria-label={isPlaying ? 'Pause' : 'Play'}
-                className="text-ubt-cool-grey hover:text-ubt-green"
+                className="text-kali-muted-text hover:text-ubt-green"
               >
                 {isPlaying ? (
                   <svg viewBox="0 0 24 24" fill="currentColor" className="h-6 w-6">
@@ -593,7 +593,7 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
                 onClick={markStart}
                 title="Set loop start (A)"
                 aria-label="Set loop start"
-                className="text-ubt-cool-grey hover:text-ubt-green"
+                className="text-kali-muted-text hover:text-ubt-green"
               >
                 <span className="flex h-6 w-6 items-center justify-center">A</span>
               </button>
@@ -601,7 +601,7 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
                 onClick={markEnd}
                 title="Set loop end (B)"
                 aria-label="Set loop end"
-                className="text-ubt-cool-grey hover:text-ubt-green"
+                className="text-kali-muted-text hover:text-ubt-green"
               >
                 <span className="flex h-6 w-6 items-center justify-center">B</span>
               </button>
@@ -609,7 +609,7 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
                 onClick={toggleLoop}
                 disabled={loopStart === null || loopEnd === null}
                 aria-label="Toggle loop"
-                className="text-ubt-cool-grey hover:text-ubt-green disabled:opacity-50"
+                className="text-kali-muted-text hover:text-ubt-green disabled:opacity-50"
               >
                 <svg
                   viewBox="0 0 24 24"
@@ -627,7 +627,7 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
                 onClick={shareClip}
                 disabled={loopStart === null || loopEnd === null}
                 aria-label="Copy share link"
-                className="text-ubt-cool-grey hover:text-ubt-green disabled:opacity-50"
+                className="text-kali-muted-text hover:text-ubt-green disabled:opacity-50"
               >
                 <span className="flex h-6 w-6 items-center justify-center">Link</span>
               </button>
@@ -635,14 +635,14 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
                 onClick={saveClip}
                 disabled={loopStart === null || loopEnd === null}
                 aria-label="Save clip"
-                className="text-ubt-cool-grey hover:text-ubt-green disabled:opacity-50"
+                className="text-kali-muted-text hover:text-ubt-green disabled:opacity-50"
               >
                 <span className="flex h-6 w-6 items-center justify-center">Save</span>
               </button>
               <button
                 onClick={downloadCurrent}
                 aria-label="Download video"
-                className="ml-auto text-ubt-cool-grey hover:text-ubt-green"
+                className="ml-auto text-kali-muted-text hover:text-ubt-green"
               >
                 <svg viewBox="0 0 24 24" fill="currentColor" className="h-6 w-6">
                   <path

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,7 +1,7 @@
 @import './globals.css';
 
 html {
-    font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
+    font-size: clamp(16px, calc(16px * var(--font-multiplier)), 24px);
 }
 
 body{

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -25,6 +25,7 @@
   --color-ub-dark-grey: #2a2e36;
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
+  --color-muted-text: #a1adc4;
   --kali-bg: rgba(15, 19, 23, 0.85);
   --kali-blue: #1793d1;
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,6 +43,7 @@ module.exports = {
           secondary: 'var(--color-secondary)',
           accent: 'var(--color-accent)',
           muted: 'var(--color-muted)',
+          'muted-text': 'var(--color-muted-text)',
           surface: 'var(--color-surface)',
           inverse: 'var(--color-inverse)',
           border: 'var(--color-border)',

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -75,12 +75,17 @@ export async function setReducedMotion(value) {
 export async function getFontScale() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
   const stored = window.localStorage.getItem('font-scale');
-  return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
+  const parsed = stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
+  if (!Number.isFinite(parsed)) return DEFAULT_SETTINGS.fontScale;
+  return Math.min(1.5, Math.max(1, parsed));
 }
 
 export async function setFontScale(scale) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  const normalized = Number.isFinite(scale)
+    ? Math.min(1.5, Math.max(1, scale))
+    : DEFAULT_SETTINGS.fontScale;
+  window.localStorage.setItem('font-scale', String(normalized));
 }
 
 export async function getHighContrast() {


### PR DESCRIPTION
## Summary
- standardize the root font scaling controls on 16px and clamp saved preferences to the updated range
- introduce a reusable muted text token and refactor the YouTube simulation UI to use higher-contrast colors
- adjust the Todoist empty state styling and add regression coverage to ensure the YouTube UI keeps accessible classes

## Testing
- yarn lint *(fails: repository contains pre-existing jsx-a11y and no-top-level-window lint violations outside this change)*
- yarn test --watch=false *(fails: suite has longstanding jsdom/localStorage limitations and legacy syntax errors unrelated to this patch)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d53869e88328b42d095dfaccbec6