### PR TITLE
[desktop] Add accessible tooltips to window controls

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -567,3 +567,52 @@ describe('Window overlay inert behaviour', () => {
     document.body.removeChild(opener);
   });
 });
+
+describe('Window accessibility affordances', () => {
+  it('provides labeled controls with focus tooltips', () => {
+    jest.useFakeTimers();
+
+    try {
+      render(
+        <Window
+          id="test-window"
+          title="Test"
+          screen={() => <div>content</div>}
+          focus={() => {}}
+          hasMinimised={() => {}}
+          closed={() => {}}
+          hideSideBar={() => {}}
+          openApp={() => {}}
+        />
+      );
+
+      const minimizeButton = screen.getByRole('button', { name: /window minimize/i });
+      const maximizeButton = screen.getByRole('button', { name: /window maximize/i });
+      const closeButton = screen.getByRole('button', { name: /window close/i });
+
+      expect(minimizeButton).toHaveAttribute('aria-label', 'Window minimize');
+      expect(maximizeButton).toHaveAttribute('aria-label', 'Window maximize');
+      expect(closeButton).toHaveAttribute('aria-label', 'Window close');
+
+      fireEvent.focus(minimizeButton);
+      act(() => {
+        jest.advanceTimersByTime(400);
+      });
+
+      const tooltip = screen.getByRole('tooltip');
+      expect(tooltip).toHaveTextContent(/minimize window/i);
+      const describedBy = minimizeButton.getAttribute('aria-describedby');
+      expect(describedBy).toBe(tooltip.id);
+
+      fireEvent.blur(minimizeButton);
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(minimizeButton).not.toHaveAttribute('aria-describedby');
+      expect(screen.queryByRole('tooltip')).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -6,6 +6,7 @@ import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
+import DelayedTooltip from '../ui/DelayedTooltip';
 import styles from './window.module.css';
 
 const EDGE_THRESHOLD_MIN = 48;
@@ -759,21 +760,48 @@ export class WindowXBorder extends Component {
     }
 
 // Window's Edit Buttons
-export function WindowEditButtons(props) {
-    const { togglePin } = useDocPiP(props.pip || (() => null));
-    const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
+const CONTROL_BUTTON_CLASS =
+    "mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6";
+
+const CLOSE_BUTTON_CLASS =
+    "mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6";
+
+function renderControlButton({
+    key,
+    label,
+    tooltip,
+    onClick,
+    icon,
+    iconAlt,
+    className,
+    id,
+}) {
     return (
-        <div className={`${styles.windowControls} absolute select-none right-0 top-0 mr-1 flex justify-center items-center min-w-[8.25rem]`}>
-            {pipSupported && props.pip && (
+        <DelayedTooltip key={key} content={tooltip} delay={150}>
+            {({
+                ref,
+                onMouseEnter,
+                onMouseLeave,
+                onFocus,
+                onBlur,
+                'aria-describedby': ariaDescribedBy,
+            }) => (
                 <button
                     type="button"
-                    aria-label="Window pin"
-                    className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                    onClick={togglePin}
+                    ref={ref}
+                    id={id}
+                    aria-label={label}
+                    aria-describedby={ariaDescribedBy}
+                    className={className}
+                    onClick={onClick}
+                    onMouseEnter={onMouseEnter}
+                    onMouseLeave={onMouseLeave}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
                 >
                     <NextImage
-                        src="/themes/Yaru/window/window-pin-symbolic.svg"
-                        alt="Kali window pin"
+                        src={icon}
+                        alt={iconAlt}
                         className="h-4 w-4 inline"
                         width={16}
                         height={16}
@@ -781,73 +809,69 @@ export function WindowEditButtons(props) {
                     />
                 </button>
             )}
-            <button
-                type="button"
-                aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                onClick={props.minimize}
-            >
-                <NextImage
-                    src="/themes/Yaru/window/window-minimize-symbolic.svg"
-                    alt="Kali window minimize"
-                    className="h-4 w-4 inline"
-                    width={16}
-                    height={16}
-                    sizes="16px"
-                />
-            </button>
+        </DelayedTooltip>
+    );
+}
+
+export function WindowEditButtons(props) {
+    const { togglePin } = useDocPiP(props.pip || (() => null));
+    const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
+    return (
+        <div className={`${styles.windowControls} absolute select-none right-0 top-0 mr-1 flex justify-center items-center min-w-[8.25rem]`}>
+            {pipSupported && props.pip && (
+                renderControlButton({
+                    key: 'pin',
+                    label: 'Window pin',
+                    tooltip: 'Pin window',
+                    onClick: togglePin,
+                    icon: '/themes/Yaru/window/window-pin-symbolic.svg',
+                    iconAlt: 'Kali window pin',
+                    className: CONTROL_BUTTON_CLASS,
+                })
+            )}
+            {renderControlButton({
+                key: 'minimize',
+                label: 'Window minimize',
+                tooltip: 'Minimize window',
+                onClick: props.minimize,
+                icon: '/themes/Yaru/window/window-minimize-symbolic.svg',
+                iconAlt: 'Kali window minimize',
+                className: CONTROL_BUTTON_CLASS,
+            })}
             {props.allowMaximize && (
                 props.isMaximised
                     ? (
-                        <button
-                            type="button"
-                            aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                            onClick={props.maximize}
-                        >
-                            <NextImage
-                                src="/themes/Yaru/window/window-restore-symbolic.svg"
-                                alt="Kali window restore"
-                                className="h-4 w-4 inline"
-                                width={16}
-                                height={16}
-                                sizes="16px"
-                            />
-                        </button>
+                        renderControlButton({
+                            key: 'restore',
+                            label: 'Window restore',
+                            tooltip: 'Restore window',
+                            onClick: props.maximize,
+                            icon: '/themes/Yaru/window/window-restore-symbolic.svg',
+                            iconAlt: 'Kali window restore',
+                            className: CONTROL_BUTTON_CLASS,
+                        })
                     ) : (
-                        <button
-                            type="button"
-                            aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                            onClick={props.maximize}
-                        >
-                            <NextImage
-                                src="/themes/Yaru/window/window-maximize-symbolic.svg"
-                                alt="Kali window maximize"
-                                className="h-4 w-4 inline"
-                                width={16}
-                                height={16}
-                                sizes="16px"
-                            />
-                        </button>
+                        renderControlButton({
+                            key: 'maximize',
+                            label: 'Window maximize',
+                            tooltip: 'Maximize window',
+                            onClick: props.maximize,
+                            icon: '/themes/Yaru/window/window-maximize-symbolic.svg',
+                            iconAlt: 'Kali window maximize',
+                            className: CONTROL_BUTTON_CLASS,
+                        })
                     )
             )}
-            <button
-                type="button"
-                id={`close-${props.id}`}
-                aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
-                onClick={props.close}
-            >
-                <NextImage
-                    src="/themes/Yaru/window/window-close-symbolic.svg"
-                    alt="Kali window close"
-                    className="h-4 w-4 inline"
-                    width={16}
-                    height={16}
-                    sizes="16px"
-                />
-            </button>
+            {renderControlButton({
+                key: 'close',
+                label: 'Window close',
+                tooltip: 'Close window',
+                onClick: props.close,
+                icon: '/themes/Yaru/window/window-close-symbolic.svg',
+                iconAlt: 'Kali window close',
+                className: CLOSE_BUTTON_CLASS,
+                id: `close-${props.id}`,
+            })}
         </div>
     )
 }

--- a/components/ui/DelayedTooltip.tsx
+++ b/components/ui/DelayedTooltip.tsx
@@ -2,6 +2,7 @@ import React, {
   ReactNode,
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useRef,
   useState,
@@ -14,6 +15,7 @@ type TriggerProps = {
   onMouseLeave: (event: React.MouseEvent<HTMLElement>) => void;
   onFocus: (event: React.FocusEvent<HTMLElement>) => void;
   onBlur: (event: React.FocusEvent<HTMLElement>) => void;
+  'aria-describedby'?: string;
 };
 
 type DelayedTooltipProps = {
@@ -38,6 +40,7 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
   const [position, setPosition] = useState({ top: 0, left: 0 });
   const timerRef = useRef<number | null>(null);
   const [portalEl, setPortalEl] = useState<HTMLElement | null>(null);
+  const tooltipId = useId();
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
@@ -105,6 +108,8 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
     setPosition({ top, left });
   }, [visible, content]);
 
+  const describedBy = visible ? tooltipId : undefined;
+
   const triggerProps: TriggerProps = {
     ref: (node) => {
       triggerRef.current = node;
@@ -121,6 +126,7 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
     onBlur: () => {
       hide();
     },
+    'aria-describedby': describedBy,
   };
 
   return (
@@ -130,6 +136,8 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
         ? createPortal(
             <div
               ref={tooltipRef}
+              id={tooltipId}
+              role="tooltip"
               style={{
                 position: 'fixed',
                 top: position.top,


### PR DESCRIPTION
## Summary
- wrap window control buttons in a shared tooltip helper with consistent aria labels and focus/hover support
- extend the DelayedTooltip utility to provide role/id hookups so screen readers can announce tooltips once
- cover the updated controls with an accessibility-focused window test verifying labels and tooltip behavior

## Testing
- yarn lint *(fails: repository has pre-existing accessibility and global lint violations outside the touched files)*
- yarn test *(fails: repository test suite contains pre-existing failures such as nmap and taskbar suites)*
- yarn test window.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d6d53887a48328a58858abdfd5a73a