### PR TITLE
[accessibility] Add global skip link for main content

### DIFF
--- a/__tests__/appSkipLink.test.tsx
+++ b/__tests__/appSkipLink.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@vercel/analytics/next', () => ({
+  Analytics: () => null,
+}));
+
+jest.mock('@vercel/speed-insights/next', () => ({
+  SpeedInsights: () => null,
+}));
+
+jest.mock('next/script', () => function MockScript() {
+  return null;
+});
+
+jest.mock('next/font/google', () => ({
+  Ubuntu: () => ({ className: 'mock-ubuntu-font' }),
+}));
+
+import MyApp from '../pages/_app';
+
+describe('MyApp skip link accessibility', () => {
+  const LauncherPage = () => <button type="button">Launcher focusable control</button>;
+  const AppsPage = () => <a href="#apps">Apps link</a>;
+
+  it('places the skip link first in the tab order', async () => {
+    const user = userEvent.setup();
+    render(<MyApp Component={LauncherPage} pageProps={{}} />);
+
+    await user.tab();
+
+    const skipLink = screen.getByRole('link', { name: /skip to main content/i });
+    expect(document.activeElement).toBe(skipLink);
+  });
+
+  it('moves focus to the main content container when activated across pages', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<MyApp Component={LauncherPage} pageProps={{}} />);
+
+    let skipLink = screen.getByRole('link', { name: /skip to main content/i });
+    await user.click(skipLink);
+
+    let mainContent = document.getElementById('app-main-content');
+    expect(mainContent).not.toBeNull();
+    expect(document.activeElement).toBe(mainContent);
+
+    rerender(<MyApp Component={AppsPage} pageProps={{}} />);
+
+    skipLink = screen.getByRole('link', { name: /skip to main content/i });
+    await user.click(skipLink);
+
+    mainContent = document.getElementById('app-main-content');
+    expect(mainContent).not.toBeNull();
+    expect(document.activeElement).toBe(mainContent);
+  });
+});

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import '../styles/tailwind.css';
@@ -28,6 +28,13 @@ const ubuntu = Ubuntu({
 
 function MyApp(props) {
   const { Component, pageProps } = props;
+  const mainContentRef = useRef(null);
+
+  const focusMainContent = () => {
+    if (mainContentRef.current) {
+      mainContentRef.current.focus();
+    }
+  };
 
 
   useEffect(() => {
@@ -152,16 +159,24 @@ function MyApp(props) {
       <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
         <a
-          href="#app-grid"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+          href="#app-main-content"
+          onClick={focusMainContent}
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:p-3 focus:bg-white focus:text-black focus:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
         >
-          Skip to app grid
+          Skip to main content
         </a>
         <SettingsProvider>
           <NotificationCenter>
             <PipPortalProvider>
               <div aria-live="polite" id="live-region" />
-              <Component {...pageProps} />
+              <div
+                id="app-main-content"
+                ref={mainContentRef}
+                tabIndex={-1}
+                className="focus:outline-none"
+              >
+                <Component {...pageProps} />
+              </div>
               <ShortcutOverlay />
               <Analytics
                 beforeSend={(e) => {


### PR DESCRIPTION
## Summary
- add a global skip link in the application shell that directs to the main content container
- wrap rendered pages in a focusable main-content wrapper so the skip target can receive focus
- add Jest coverage to verify the skip link’s tab order and cross-page focus behaviour

## Testing
- yarn lint *(fails: repository contains numerous pre-existing accessibility lint violations unrelated to this change)*
- yarn test *(fails: repository contains pre-existing failures such as nmapNse, modal shortcuts, taskbar, and desktop name bar suites)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d53a07b483289e0d3a4a4f7cbdb4