### PR TITLE
[a11y] Enforce media captioning controls

### DIFF
--- a/__tests__/mediaAccessibility.test.tsx
+++ b/__tests__/mediaAccessibility.test.tsx
@@ -1,0 +1,104 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import CameraApp from '../components/apps/camera';
+import QRScanner from '../components/apps/qr';
+import ScreenRecorder from '../components/apps/screen-recorder';
+import SpotifyApp from '../components/apps/spotify';
+
+class MockBarcodeDetector {
+  detect() {
+    return Promise.resolve([] as { rawValue: string }[]);
+  }
+}
+
+declare global {
+  interface Window {
+    BarcodeDetector?: typeof MockBarcodeDetector;
+    onSpotifyWebPlaybackSDKReady?: () => void;
+    Spotify: any;
+  }
+}
+
+describe('media components accessibility', () => {
+  beforeAll(() => {
+    Object.defineProperty(global.HTMLMediaElement.prototype, 'play', {
+      configurable: true,
+      value: jest.fn().mockResolvedValue(undefined),
+    });
+    Object.defineProperty(global.HTMLMediaElement.prototype, 'pause', {
+      configurable: true,
+      value: jest.fn(),
+    });
+    Object.defineProperty(global.HTMLMediaElement.prototype, 'load', {
+      configurable: true,
+      value: jest.fn(),
+    });
+    Object.defineProperty(global.HTMLMediaElement.prototype, 'srcObject', {
+      configurable: true,
+      get() {
+        return (this as any).__srcObject || null;
+      },
+      set(value) {
+        (this as any).__srcObject = value;
+      },
+    });
+  });
+
+  beforeEach(() => {
+    const mockStream = {
+      getTracks: () => [],
+      getVideoTracks: () => [],
+    } as unknown as MediaStream;
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia: jest.fn().mockResolvedValue(mockStream),
+        getDisplayMedia: jest.fn().mockResolvedValue(mockStream),
+      },
+    });
+
+    window.BarcodeDetector = MockBarcodeDetector as unknown as typeof MockBarcodeDetector;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    delete window.BarcodeDetector;
+  });
+
+  it('CameraApp video is muted, described, and captioned', async () => {
+    render(<CameraApp />);
+    const video = (await screen.findByTestId('camera-video')) as HTMLVideoElement;
+    expect(video.muted).toBe(true);
+    expect(video).toHaveAttribute('aria-describedby', 'camera-video-description');
+    expect(video.querySelector('track[kind="captions"]')).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /hide captions/i })).toBeInTheDocument();
+  });
+
+  it('QRScanner video is muted, described, and captioned', async () => {
+    render(<QRScanner />);
+    const video = (await screen.findByTestId('qr-video')) as HTMLVideoElement;
+    expect(video.muted).toBe(true);
+    expect(video).toHaveAttribute('aria-describedby', 'qr-video-description');
+    expect(video.querySelector('track[kind="captions"]')).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /hide captions/i })).toBeInTheDocument();
+  });
+
+  it('ScreenRecorder playback video exposes captions and descriptions', async () => {
+    render(<ScreenRecorder initialVideoUrl="blob:example" />);
+    const video = (await screen.findByTestId('screen-recorder-video')) as HTMLVideoElement;
+    expect(video.muted).toBe(true);
+    expect(video).toHaveAttribute('aria-describedby', 'screen-recorder-video-description');
+    expect(video.querySelector('track[kind="captions"]')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /hide captions/i })).toBeInTheDocument();
+  });
+
+  it('Spotify sample audio starts muted with captions and descriptions', () => {
+    render(<SpotifyApp />);
+    const audio = screen.getByTestId('spotify-audio') as HTMLAudioElement;
+    expect(audio.muted).toBe(true);
+    expect(audio).toHaveAttribute('aria-describedby', 'spotify-audio-description');
+    expect(audio.querySelector('track[kind="captions"]')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /hide captions/i })).toBeInTheDocument();
+  });
+});

--- a/components/apps/spotify.jsx
+++ b/components/apps/spotify.jsx
@@ -11,6 +11,9 @@ export default function SpotifyApp() {
   const [player, setPlayer] = useState(null);
   const [index, setIndex] = useState(0);
   const audioRef = useRef(null);
+  const captionTrackRef = useRef(null);
+  const [captionsEnabled, setCaptionsEnabled] = useState(true);
+  const [isMuted, setIsMuted] = useState(true);
 
   useEffect(() => {
     const token = typeof window !== 'undefined' ? localStorage.getItem('spotify-token') : null;
@@ -50,12 +53,29 @@ export default function SpotifyApp() {
     }
   }, [index]);
 
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (audio) {
+      audio.muted = isMuted;
+    }
+  }, [isMuted]);
+
+  useEffect(() => {
+    const track = captionTrackRef.current;
+    if (track) {
+      track.mode = captionsEnabled ? 'showing' : 'disabled';
+    }
+  }, [captionsEnabled]);
+
   const toggleSample = () => {
     const audio = audioRef.current;
     if (!audio) return;
     if (audio.paused) audio.play();
     else audio.pause();
   };
+
+  const toggleMute = () => setIsMuted(muted => !muted);
+  const toggleCaptions = () => setCaptionsEnabled(enabled => !enabled);
 
   return connected && player ? (
     <div className="h-full w-full flex flex-col items-center justify-center gap-4 bg-black bg-opacity-30 text-white">
@@ -69,11 +89,48 @@ export default function SpotifyApp() {
   ) : (
     <div className="h-full w-full flex flex-col items-center justify-center gap-4 bg-black bg-opacity-30 text-white">
       <p>Sample tracks (CC‑licensed)</p>
-      <audio ref={audioRef} src={SAMPLE_TRACKS[index].url} onEnded={nextSample} />
+      <p id="spotify-audio-description" className="sr-only">
+        Sample audio player. Tracks start muted, and captions describe playback controls.
+      </p>
+      <audio
+        ref={audioRef}
+        src={SAMPLE_TRACKS[index].url}
+        onEnded={nextSample}
+        muted={isMuted}
+        aria-describedby="spotify-audio-description"
+        data-testid="spotify-audio"
+      >
+        <track
+          ref={captionTrackRef}
+          kind="captions"
+          srcLang="en"
+          src="/captions/spotify-sample.vtt"
+          label="Sample track information"
+          default
+        />
+      </audio>
       <div className="flex gap-4">
-        <button onClick={prevSample}>⏮</button>
-        <button onClick={toggleSample}>⏯</button>
-        <button onClick={nextSample}>⏭</button>
+        <button type="button" onClick={prevSample}>⏮</button>
+        <button type="button" onClick={toggleSample}>⏯</button>
+        <button type="button" onClick={nextSample}>⏭</button>
+      </div>
+      <div className="flex gap-4">
+        <button
+          type="button"
+          onClick={toggleMute}
+          aria-pressed={!isMuted}
+          className="px-3 py-1 rounded bg-ub-dracula"
+        >
+          {isMuted ? 'Unmute' : 'Mute'}
+        </button>
+        <button
+          type="button"
+          onClick={toggleCaptions}
+          aria-pressed={captionsEnabled}
+          className="px-3 py-1 rounded bg-purple-700"
+        >
+          {captionsEnabled ? 'Hide Captions' : 'Show Captions'}
+        </button>
       </div>
       <p className="text-xs">{SAMPLE_TRACKS[index].title}</p>
     </div>

--- a/public/captions/camera-live.vtt
+++ b/public/captions/camera-live.vtt
@@ -1,0 +1,7 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:05.000
+Live camera preview is muted to protect your privacy.
+
+00:00:05.000 --> 00:00:10.000
+Use the drawing overlay to highlight areas of interest on the feed.

--- a/public/captions/qr-scanner.vtt
+++ b/public/captions/qr-scanner.vtt
@@ -1,0 +1,7 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:04.000
+Camera preview for QR scanning. The feed is muted.
+
+00:00:04.000 --> 00:00:09.000
+Center a QR code in the frame. Captions describe scanner status.

--- a/public/captions/screen-recorder.vtt
+++ b/public/captions/screen-recorder.vtt
@@ -1,0 +1,7 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:05.000
+Screen recording playback. Audio starts muted to avoid feedback.
+
+00:00:05.000 --> 00:00:10.000
+Use the caption toggle to review recording tips while you watch.

--- a/public/captions/spotify-sample.vtt
+++ b/public/captions/spotify-sample.vtt
@@ -1,0 +1,7 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:05.000
+Sample track playback is muted until you choose to listen.
+
+00:00:05.000 --> 00:00:10.000
+Use the transport controls and captions toggle to explore the demo audio.


### PR DESCRIPTION
## Summary
- ensure the camera, QR scanner, screen recorder, and Spotify sample apps load media muted, expose caption toggles, and include screen reader descriptions
- add reusable caption tracks for each media experience to document default behavior
- cover the new accessibility guarantees with focused tests for video and audio components

## Testing
- yarn lint *(fails: pre-existing jsx-a11y/control-has-associated-label violations across unrelated app files)*
- yarn test mediaAccessibility

------
https://chatgpt.com/codex/tasks/task_e_68d6d53b740883289372ab4aabbf0674