### PR TITLE
[desktop] Add keyboard window controls

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -1,6 +1,6 @@
 import React, { act } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import Window from '../components/base/window';
+import Window, { KEYBOARD_MOVE_STEP, KEYBOARD_RESIZE_STEP } from '../components/base/window';
 
 const setViewport = (width: number, height: number) => {
   Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: width });
@@ -480,6 +480,79 @@ describe('Edge resistance', () => {
     });
 
     expect(winEl.style.transform).toBe('translate(0px, 0px)');
+  });
+});
+
+describe('Keyboard move and resize shortcuts', () => {
+  it('nudges window with Ctrl+Arrow keys', () => {
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 100,
+      width: 100,
+      height: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {}
+    });
+
+    fireEvent.keyDown(winEl, { key: 'ArrowRight', ctrlKey: true });
+    expect(winEl.style.transform).toBe(`translate(${KEYBOARD_MOVE_STEP}px, 0px)`);
+
+    fireEvent.keyDown(winEl, { key: 'ArrowDown', ctrlKey: true });
+    expect(winEl.style.transform).toBe(`translate(${KEYBOARD_MOVE_STEP}px, ${KEYBOARD_MOVE_STEP}px)`);
+  });
+
+  it('resizes window with Ctrl+Shift+Arrow keys', () => {
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+      />
+    );
+
+    const winEl = document.getElementById('test-window')!;
+    winEl.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 100,
+      width: 100,
+      height: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {}
+    });
+
+    const initialWidth = parseFloat(winEl.style.width);
+    const initialHeight = parseFloat(winEl.style.height);
+
+    fireEvent.keyDown(winEl, { key: 'ArrowRight', ctrlKey: true, shiftKey: true });
+    expect(parseFloat(winEl.style.width)).toBe(initialWidth + KEYBOARD_RESIZE_STEP);
+
+    fireEvent.keyDown(winEl, { key: 'ArrowDown', ctrlKey: true, shiftKey: true });
+    expect(parseFloat(winEl.style.height)).toBe(initialHeight + KEYBOARD_RESIZE_STEP);
   });
 });
 

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,14 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Move window up', keys: 'Ctrl+ArrowUp' },
+  { description: 'Move window down', keys: 'Ctrl+ArrowDown' },
+  { description: 'Move window left', keys: 'Ctrl+ArrowLeft' },
+  { description: 'Move window right', keys: 'Ctrl+ArrowRight' },
+  { description: 'Shrink window height', keys: 'Ctrl+Shift+ArrowUp' },
+  { description: 'Grow window height', keys: 'Ctrl+Shift+ArrowDown' },
+  { description: 'Shrink window width', keys: 'Ctrl+Shift+ArrowLeft' },
+  { description: 'Grow window width', keys: 'Ctrl+Shift+ArrowRight' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/components/context-menus/window-menu.js
+++ b/components/context-menus/window-menu.js
@@ -1,0 +1,79 @@
+import React, { useRef } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+
+const MOVE_ACTIONS = [
+    { action: 'move-up', label: 'Move up', shortcut: 'Ctrl+ArrowUp' },
+    { action: 'move-down', label: 'Move down', shortcut: 'Ctrl+ArrowDown' },
+    { action: 'move-left', label: 'Move left', shortcut: 'Ctrl+ArrowLeft' },
+    { action: 'move-right', label: 'Move right', shortcut: 'Ctrl+ArrowRight' },
+];
+
+const RESIZE_ACTIONS = [
+    { action: 'shrink-height', label: 'Shrink height', shortcut: 'Ctrl+Shift+ArrowUp' },
+    { action: 'grow-height', label: 'Grow height', shortcut: 'Ctrl+Shift+ArrowDown' },
+    { action: 'shrink-width', label: 'Shrink width', shortcut: 'Ctrl+Shift+ArrowLeft' },
+    { action: 'grow-width', label: 'Grow width', shortcut: 'Ctrl+Shift+ArrowRight' },
+];
+
+function SectionHeading({ children }) {
+    return (
+        <p className="px-4 py-1 text-xs uppercase tracking-widest text-gray-300">
+            {children}
+        </p>
+    );
+}
+
+function Divider() {
+    return (
+        <div className="flex justify-center w-full" role="presentation">
+            <div className="border-t border-gray-900 my-1 w-2/3" />
+        </div>
+    );
+}
+
+function WindowMenu({ active, onAction, onClose }) {
+    const menuRef = useRef(null);
+    useFocusTrap(menuRef, active);
+    useRovingTabIndex(menuRef, active, 'vertical');
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            onClose?.();
+        }
+    };
+
+    const renderButton = (item) => (
+        <button
+            key={item.action}
+            type="button"
+            role="menuitem"
+            data-action={item.action}
+            onClick={() => onAction?.(item.action)}
+            className="w-full flex justify-between items-center cursor-default py-1 hover:bg-gray-700 px-4"
+        >
+            <span>{item.label}</span>
+            <span className="text-[11px] text-gray-300">{item.shortcut}</span>
+        </button>
+    );
+
+    return (
+        <div
+            id="window-menu"
+            role="menu"
+            aria-hidden={!active}
+            ref={menuRef}
+            onKeyDown={handleKeyDown}
+            className={(active ? ' block ' : ' hidden ') +
+                'cursor-default w-64 context-menu-bg border text-left border-gray-900 rounded text-white py-3 absolute z-50 text-sm'}
+        >
+            <SectionHeading>Move window</SectionHeading>
+            {MOVE_ACTIONS.map(renderButton)}
+            <Divider />
+            <SectionHeading>Resize window</SectionHeading>
+            {RESIZE_ACTIONS.map(renderButton)}
+        </div>
+    );
+}
+
+export default WindowMenu;

--- a/docs/keyboard-only-test-plan.md
+++ b/docs/keyboard-only-test-plan.md
@@ -1,14 +1,24 @@
 # Keyboard-Only Window Management Test Plan
 
-## Resizing
+## Moving
 1. Open any window.
 2. Focus the window.
-3. Hold **Shift** and press arrow keys:
-   - **Shift + ArrowRight** increases width.
-   - **Shift + ArrowLeft** decreases width.
-   - **Shift + ArrowDown** increases height.
-   - **Shift + ArrowUp** decreases height.
-4. Verify the window resizes accordingly.
+3. Hold **Ctrl** and press arrow keys:
+   - **Ctrl + ArrowUp** nudges the window upward.
+   - **Ctrl + ArrowDown** nudges the window downward.
+   - **Ctrl + ArrowLeft** nudges the window to the left.
+   - **Ctrl + ArrowRight** nudges the window to the right.
+4. Confirm the window remains within the desktop bounds and updates its position without dragging.
+5. Open the window context menu (right click or **Shift+F10**) and activate any of the Move commands. The window should move in the corresponding direction.
+
+## Resizing
+1. With the window focused, use keyboard-only resizing:
+   - **Shift + ArrowRight** increases width slightly.
+   - **Shift + ArrowLeft** decreases width slightly.
+   - **Shift + ArrowDown** increases height slightly.
+   - **Shift + ArrowUp** decreases height slightly.
+2. For larger jumps, hold **Ctrl + Shift** with the same arrows to resize in 2% increments.
+3. Use the window context menu Resize commands to grow or shrink width/height and verify they match the shortcuts.
 
 ## Snapping
 1. With the window focused, press arrow keys with **Alt**:


### PR DESCRIPTION
## Summary
- add keyboard-driven move and resize helpers to the window frame and wire new Ctrl/Ctrl+Shift arrow shortcuts
- expose the commands through a dedicated window context menu and surface them in the configurable shortcut list
- update the keyboard-only test plan and extend unit coverage for the new movement and resize flows

## Testing
- yarn lint *(fails: repository has pre-existing accessibility violations; see logs for details)*
- yarn test *(fails: existing suites for nmapNse/taskbar/reconng currently red)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d53b81388328b9c1dacbb5b2adc5