### PR TITLE
[design] centralize theme tokens

### DIFF
--- a/__tests__/design-tokens.test.ts
+++ b/__tests__/design-tokens.test.ts
@@ -1,0 +1,64 @@
+import tokens, { colors, spacing, radii, shadows, zIndex } from '../tokens';
+
+type RecordLike = Record<string, unknown>;
+
+const expectDeepFrozen = (value: unknown) => {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  expect(Object.isFrozen(value)).toBe(true);
+
+  Object.values(value as RecordLike).forEach((child) => {
+    if (child && typeof child === 'object') {
+      expectDeepFrozen(child);
+    }
+  });
+};
+
+describe('design tokens', () => {
+  it('exposes deep-frozen token maps', () => {
+    expectDeepFrozen(tokens);
+    expectDeepFrozen(colors);
+    expectDeepFrozen(spacing);
+    expectDeepFrozen(radii);
+    expectDeepFrozen(shadows);
+    expectDeepFrozen(zIndex);
+  });
+
+  it('keeps spacing tokens tied to CSS custom properties', () => {
+    expect.assertions(Object.keys(spacing).length);
+    Object.entries(spacing).forEach(([token, value]) => {
+      const expectedPrefix = token === 'hit-area' ? '^var\\(--hit-area' : '^var\\(--space-';
+      expect(String(value)).toMatch(new RegExp(expectedPrefix));
+    });
+  });
+
+  it('keeps radius tokens tied to CSS custom properties', () => {
+    expect.assertions(Object.keys(radii).length);
+    Object.values(radii).forEach((value) => {
+      expect(String(value)).toMatch(/^var\(--radius-/);
+    });
+  });
+
+  it('keeps box shadows tied to CSS custom properties', () => {
+    expect.assertions(Object.keys(shadows.box).length);
+    Object.values(shadows.box).forEach((value) => {
+      expect(String(value)).toMatch(/^var\(--shadow-/);
+    });
+  });
+
+  it('keeps drop shadows tied to CSS custom properties', () => {
+    expect.assertions(Object.keys(shadows.drop).length);
+    Object.values(shadows.drop).forEach((value) => {
+      expect(String(value)).toMatch(/^var\(--shadow-/);
+    });
+  });
+
+  it('keeps z-index tokens tied to CSS custom properties', () => {
+    expect.assertions(Object.keys(zIndex).length);
+    Object.values(zIndex).forEach((value) => {
+      expect(String(value)).toMatch(/^var\(--z-/);
+    });
+  });
+});

--- a/apps/About/index.tsx
+++ b/apps/About/index.tsx
@@ -31,28 +31,28 @@ function LinkedInIcon({ className }: { className?: string }) {
 
 export default function AboutPage() {
   return (
-    <div className="min-h-screen w-full bg-[var(--kali-bg)] text-sm">
-      <div className="max-w-screen-md mx-auto my-4 sm:my-8 p-4 sm:p-6">
-        <section className="flex items-center mb-8">
+    <div className="min-h-screen w-full bg-kali-backdrop text-sm">
+      <div className="max-w-screen-md mx-auto my-space-4 sm:my-space-6 p-space-4 sm:p-space-6">
+        <section className="flex items-center mb-space-6">
           <Image
             src="/images/logos/bitmoji.png"
             alt="Alex Unnippillil"
             width={128}
             height={128}
-            className="w-32 h-32 rounded-full"
+            className="w-32 h-32 rounded-pill"
             priority
           />
-          <div className="ml-4 flex-1 space-y-1.5">
+          <div className="ml-space-4 flex-1 space-y-space-1-5">
             <h1 className="text-xl font-bold">Alex Unnippillil</h1>
             <p className="text-gray-200">Cybersecurity Specialist</p>
           </div>
-          <div className="ml-4 flex gap-3">
+          <div className="ml-space-4 flex gap-space-3">
             <a
               href="https://github.com/unnippillil"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="GitHub"
-              className="text-white"
+              className="text-kali-text"
             >
               <GitHubIcon className="w-6 h-6" />
             </a>
@@ -61,7 +61,7 @@ export default function AboutPage() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="LinkedIn"
-              className="text-white"
+              className="text-kali-text"
             >
               <LinkedInIcon className="w-6 h-6" />
             </a>

--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -189,7 +189,7 @@ export default function Calculator() {
   }, [setHistory]);
 
     return (
-    <div className="calculator !bg-[var(--kali-bg)]">
+    <div className="calculator !bg-kali-backdrop">
       <ModeSwitcher />
             <input id="display" className="display h-12" />
       <button id="toggle-precise" className="toggle h-12" aria-pressed="false" aria-label="toggle precise mode">Precise Mode: Off</button>

--- a/apps/quote/index.tsx
+++ b/apps/quote/index.tsx
@@ -318,9 +318,9 @@ export default function QuoteApp() {
   const isFav = current ? favorites.includes(keyOf(current)) : false;
 
   return (
-    <div className="h-full w-full flex flex-col items-center justify-start bg-ub-cool-grey text-white p-4 overflow-auto">
+    <div className="h-full w-full flex flex-col items-center justify-start bg-ub-cool-grey text-white p-space-4 overflow-auto">
       {dailyQuote && (
-        <div className="mb-4 p-3 bg-gray-700 rounded" id="daily-quote">
+        <div className="mb-space-4 p-space-3 bg-gray-700 rounded-panel" id="daily-quote">
           <p className="text-sm italic">&ldquo;{dailyQuote.content}&rdquo;</p>
           <p className="text-xs text-gray-300 text-right">- {dailyQuote.author}</p>
         </div>
@@ -329,7 +329,7 @@ export default function QuoteApp() {
         <div
           ref={cardRef}
           id="quote-card"
-          className="group relative p-6 rounded text-center bg-gradient-to-br from-[var(--color-primary)]/30 to-[var(--color-secondary)]/30 text-white"
+          className="group relative p-space-6 rounded-panel text-center bg-gradient-to-br from-kali-primary/30 to-kali-secondary/30 text-white"
         >
           {current ? (
             <div key={keyOf(current)} className="animate-quote">
@@ -343,17 +343,17 @@ export default function QuoteApp() {
                 {current.content}
               </p>
               <p className="text-sm text-white/80">— {current.author}</p>
-              <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition">
+              <div className="absolute top-space-2 right-space-2 flex gap-space-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition">
                 <button
                   onClick={copyQuote}
-                  className="p-1 bg-black/30 hover:bg-black/50 rounded"
+                  className="p-space-1 bg-black/30 hover:bg-black/50 rounded-control"
                   aria-label="Copy quote"
                 >
                   <CopyIcon className="w-6 h-6" />
                 </button>
                 <button
                   onClick={tweetQuote}
-                  className="p-1 bg-black/30 hover:bg-black/50 rounded"
+                  className="p-space-1 bg-black/30 hover:bg-black/50 rounded-control"
                   aria-label="Tweet quote"
                 >
                   <TwitterIcon className="w-6 h-6" />

--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -32,12 +32,12 @@ export default function NetworkInsights() {
   }, [setHistory]);
 
   return (
-    <div className="p-2 text-xs text-white bg-[var(--kali-bg)]">
-      <h2 className="font-bold mb-1">Active Fetches</h2>
-      <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
-        {active.length === 0 && <li className="p-1 text-gray-400">None</li>}
+    <div className="p-space-2 text-xs text-white bg-kali-backdrop">
+      <h2 className="font-bold mb-space-1">Active Fetches</h2>
+      <ul className="mb-space-2 divide-y divide-gray-700 border border-gray-700 rounded-panel bg-kali-panel">
+        {active.length === 0 && <li className="p-space-1 text-gray-400">None</li>}
         {active.map((f) => (
-          <li key={f.id} className="p-1">
+          <li key={f.id} className="p-space-1">
             <div className="truncate">
               {f.method} {f.url}
             </div>
@@ -47,23 +47,23 @@ export default function NetworkInsights() {
           </li>
         ))}
       </ul>
-      <div className="flex items-center mb-1">
+      <div className="flex items-center mb-space-1">
         <h2 className="font-bold">History</h2>
         <button
           onClick={() => exportMetrics(history)}
-          className="ml-auto px-2 py-1 rounded bg-[var(--kali-panel)]"
+          className="ml-auto px-space-2 py-space-1 rounded-control bg-kali-panel"
         >
           Export
         </button>
       </div>
-      <ul className="divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
-        {history.length === 0 && <li className="p-1 text-gray-400">No requests</li>}
+      <ul className="divide-y divide-gray-700 border border-gray-700 rounded-panel bg-kali-panel">
+        {history.length === 0 && <li className="p-space-1 text-gray-400">No requests</li>}
         {history.map((f) => (
-          <li key={f.id} className="p-1">
+          <li key={f.id} className="p-space-1">
             <div className="truncate">
               {f.method} {f.url}
               {f.fromServiceWorkerCache && (
-                <span className="ml-2 text-green-400">(SW cache)</span>
+                <span className="ml-space-2 text-green-400">(SW cache)</span>
               )}
             </div>
             <div className="text-gray-400">
@@ -72,7 +72,7 @@ export default function NetworkInsights() {
           </li>
         ))}
       </ul>
-      <div className="mt-2 flex justify-center">
+      <div className="mt-space-2 flex justify-center">
         <RequestChart
           data={history.map((h) => h.duration ?? 0)}
           label="Request duration (ms)"

--- a/apps/spotify/components/MoodTuner.tsx
+++ b/apps/spotify/components/MoodTuner.tsx
@@ -81,8 +81,8 @@ const MoodTuner = () => {
   const index = moods.indexOf(mood);
 
   return (
-    <div className="h-full w-full bg-[var(--color-bg)] text-[var(--color-text)] flex flex-col">
-      <div className="p-2 flex items-center gap-2 bg-black bg-opacity-30">
+    <div className="h-full w-full bg-kali-background text-kali-text flex flex-col">
+      <div className="p-space-2 flex items-center gap-space-2 bg-black bg-opacity-30">
         <input
           type="range"
           min={0}
@@ -105,7 +105,7 @@ const MoodTuner = () => {
             allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
             loading="lazy"
           />
-          <div className="flex justify-center space-x-4 p-2 bg-black bg-opacity-30">
+          <div className="flex justify-center space-x-space-4 p-space-2 bg-black bg-opacity-30">
             <button
               onClick={previous}
               title="Prev (P)"

--- a/apps/spotify/index.tsx
+++ b/apps/spotify/index.tsx
@@ -147,13 +147,13 @@ const SpotifyApp = () => {
 
   return (
     <div
-      className={`h-full w-full bg-[var(--color-bg)] text-[var(--color-text)] flex flex-col ${
-        mini ? "p-2" : "p-4"
+      className={`h-full w-full bg-kali-background text-kali-text flex flex-col ${
+        mini ? "p-space-2" : "p-space-4"
       }`}
       tabIndex={0}
       onKeyDown={handleKey}
     >
-      <div className="flex items-center justify-between mb-2">
+      <div className="flex items-center justify-between mb-space-2">
         <div className="space-x-1.5">
           <button
             onClick={previous}
@@ -180,7 +180,7 @@ const SpotifyApp = () => {
             ⏭
           </button>
         </div>
-        <div className="space-x-4 text-sm flex items-center">
+        <div className="space-x-space-4 text-sm flex items-center">
           <label className="flex items-center space-x-1">
             <span>Crossfade</span>
             <input
@@ -201,7 +201,7 @@ const SpotifyApp = () => {
           </label>
           <button
             onClick={() => setMini(!mini)}
-            className="border px-2 py-1 rounded"
+            className="border px-space-2 py-space-1 rounded-control"
           >
             {mini ? "Full" : "Mini"}
           </button>
@@ -218,13 +218,13 @@ const SpotifyApp = () => {
             playerRef.current?.seek(t);
             setProgress(t);
           }}
-          className="w-full h-1 mb-2"
+          className="w-full h-1 mb-space-2"
           disabled={!queue.length}
         />
       )}
       {currentTrack && (
-        <div className="mt-2">
-          <div className="relative w-32 aspect-square mb-2 shadow-lg overflow-hidden">
+        <div className="mt-space-2">
+          <div className="relative w-32 aspect-square mb-space-2 shadow-elevated overflow-hidden">
             {currentTrack.cover ? (
               <img
                 src={currentTrack.cover}
@@ -232,36 +232,36 @@ const SpotifyApp = () => {
                 className="w-full h-full object-cover"
               />
             ) : (
-              <div className="w-full h-full bg-[var(--color-muted)]" />
+              <div className="w-full h-full bg-kali-muted" />
             )}
             <div className="absolute inset-0 bg-black/40" />
           </div>
-          <p className="mb-2">{currentTrack.title}</p>
+          <p className="mb-space-2">{currentTrack.title}</p>
           {analyser && <Visualizer analyser={analyser} />}
           <Lyrics title={currentTrack.title} player={playerRef.current} />
         </div>
       )}
       {!mini && (
-        <div className="flex-1 overflow-auto mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="flex-1 overflow-auto mt-space-4 grid grid-cols-1 md:grid-cols-2 gap-space-4">
           <div className="hidden md:block">
-            <h2 className="mb-2 text-lg">Playlist JSON</h2>
+            <h2 className="mb-space-2 text-lg">Playlist JSON</h2>
             <textarea
-              className="w-full h-40 text-black p-1"
+              className="w-full h-40 text-black p-space-1"
               value={playlistText}
               onChange={(e) => setPlaylistText(e.target.value)}
             />
             <button
               onClick={loadPlaylist}
-              className="mt-2 rounded bg-blue-600 px-2 py-1 text-sm"
+              className="mt-space-2 rounded-control bg-kali-primary px-space-2 py-space-1 text-sm text-kali-inverse"
             >
               Load Playlist
             </button>
-            <h2 className="mt-4 mb-2 text-lg">Queue</h2>
-            <ul className="max-h-40 overflow-auto border border-gray-700 rounded">
+            <h2 className="mt-space-4 mb-space-2 text-lg">Queue</h2>
+            <ul className="max-h-40 overflow-auto border border-gray-700 rounded-panel">
               {queue.map((t, i) => (
                 <li key={t.url} className={i === current ? "bg-gray-700" : ""}>
                   <button
-                    className="w-full text-left px-2 py-1 hover:bg-gray-600 focus:outline-none"
+                    className="w-full text-left px-space-2 py-space-1 hover:bg-gray-600 focus:outline-none"
                     onClick={() => setCurrent(i)}
                   >
                     {t.title || t.url}
@@ -271,12 +271,12 @@ const SpotifyApp = () => {
             </ul>
           </div>
           <div>
-            <h2 className="mb-2 text-lg">Recently Played</h2>
-            <ul className="max-h-72 overflow-auto border border-gray-700 rounded">
+            <h2 className="mb-space-2 text-lg">Recently Played</h2>
+            <ul className="max-h-72 overflow-auto border border-gray-700 rounded-panel">
               {recent.map((t) => (
                 <li
                   key={t.url}
-                  className="px-2 py-1 border-b border-gray-700 last:border-b-0"
+                  className="px-space-2 py-space-1 border-b border-gray-700 last:border-b-0"
                 >
                   {t.title || t.url}
                 </li>

--- a/apps/x/index.tsx
+++ b/apps/x/index.tsx
@@ -255,21 +255,21 @@ export default function XTimeline() {
     <>
       {showSetup && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center"
+          className="fixed inset-0 z-modal flex items-center justify-center"
           style={{
             backgroundColor:
               'color-mix(in srgb, var(--color-inverse) 50%, transparent)',
           }}
         >
           <div
-            className="p-4 rounded max-w-sm text-sm"
+            className="p-space-4 rounded-panel max-w-sm text-sm"
             style={{ backgroundColor: 'var(--color-surface)' }}
           >
-            <p className="mb-2">
+            <p className="mb-space-2">
               To use this app you need X API credentials: API key, API secret,
               access token and access token secret.
             </p>
-            <p className="mb-4">
+            <p className="mb-space-4">
               You can explore with a demo account{' '}
               <a
                 href="https://x.com/AUnnippillil"
@@ -284,7 +284,7 @@ export default function XTimeline() {
             <button
               type="button"
               onClick={() => setShowSetup(false)}
-              className="px-3 py-1 rounded text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+              className="px-space-3 py-space-1 rounded-control text-kali-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-accent"
               style={{ backgroundColor: accent }}
             >
               Close
@@ -302,12 +302,12 @@ export default function XTimeline() {
         onError={() => setScriptError(true)}
       />
       <div className="flex flex-col h-full">
-        <header className="flex items-center justify-between p-1.5 border-b gap-1.5">
+        <header className="flex items-center justify-between p-space-1-5 border-b gap-space-1-5">
           <button
             type="button"
             aria-label="Refresh timeline"
             onClick={() => loaded && loadTimeline()}
-            className="p-1 rounded hover:bg-[var(--color-muted)]"
+            className="p-space-1 rounded-control hover:bg-kali-muted"
           >
             <IconRefresh className="w-6 h-6" />
           </button>
@@ -318,29 +318,29 @@ export default function XTimeline() {
             type="button"
             aria-label="Open on x.com"
             onClick={() => window.open(`https://x.com/${feed}`, '_blank')}
-            className="p-1 rounded hover:bg-[var(--color-muted)]"
-          >
+            className="p-space-1 rounded-control hover:bg-kali-muted"
+        >
             <IconShare className="w-6 h-6" />
           </button>
         </header>
-        <div className="p-1.5 space-y-4 flex-1 overflow-auto">
-        <form onSubmit={handleScheduleTweet} className="space-y-2">
+        <div className="p-space-1-5 space-y-space-4 flex-1 overflow-auto">
+        <form onSubmit={handleScheduleTweet} className="space-y-space-2">
           <textarea
             value={tweetText}
             onChange={(e) => setTweetText(e.target.value)}
             placeholder="Tweet text"
-            className="w-full p-2 rounded border bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            className="w-full p-space-2 rounded-panel border bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-accent"
           />
-          <div className="flex gap-2 items-center">
+          <div className="flex gap-space-2 items-center">
             <input
               type="datetime-local"
               value={tweetTime}
               onChange={(e) => setTweetTime(e.target.value)}
-              className="flex-1 p-2 rounded border bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+              className="flex-1 p-space-2 rounded-panel border bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-accent"
             />
             <button
               type="submit"
-              className="px-3 py-1 rounded text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+              className="px-space-3 py-space-1 rounded-control text-kali-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-accent"
               style={{ backgroundColor: accent }}
             >
               Schedule
@@ -348,14 +348,14 @@ export default function XTimeline() {
           </div>
         </form>
         {scheduled.length > 0 && (
-          <ul className="space-y-2">
+          <ul className="space-y-space-2">
             {scheduled.map((t) => (
               <li key={t.id}>
                 <div
                   tabIndex={0}
                   data-scheduled-item
                   onKeyDown={(e) => handleScheduledKey(e, t.id)}
-                  className="flex justify-between items-center p-2 rounded border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+                  className="flex justify-between items-center p-space-2 rounded-panel border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-accent"
                 >
                   <span>
                     {t.text} - {new Date(t.time).toLocaleString()}
@@ -363,7 +363,7 @@ export default function XTimeline() {
                   <button
                     type="button"
                     onClick={() => removeScheduled(t.id)}
-                    className="ml-2 px-2 py-1 rounded bg-[var(--color-muted)] text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+                    className="ml-space-2 px-space-2 py-space-1 rounded-control bg-kali-muted text-kali-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-accent"
                   >
                     ×
                   </button>
@@ -372,14 +372,14 @@ export default function XTimeline() {
             ))}
           </ul>
         )}
-        <div className="flex gap-2">
+        <div className="flex gap-space-2">
           <button
             type="button"
             onClick={() => setTimelineType('profile')}
-            className={`px-2 py-1 rounded text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] ${
+            className={`px-space-2 py-space-1 rounded-control text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-accent ${
               timelineType === 'profile'
-                ? 'text-[var(--color-text)]'
-                : 'bg-[var(--color-muted)]'
+                ? 'text-kali-text'
+                : 'bg-kali-muted'
             }`}
             style={
               timelineType === 'profile' ? { backgroundColor: accent } : undefined
@@ -390,10 +390,10 @@ export default function XTimeline() {
           <button
             type="button"
             onClick={() => setTimelineType('list')}
-            className={`px-2 py-1 rounded text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] ${
+            className={`px-space-2 py-space-1 rounded-control text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-accent ${
               timelineType === 'list'
-                ? 'text-[var(--color-text)]'
-                : 'bg-[var(--color-muted)]'
+                ? 'text-kali-text'
+                : 'bg-kali-muted'
             }`}
             style={
               timelineType === 'list' ? { backgroundColor: accent } : undefined
@@ -402,7 +402,7 @@ export default function XTimeline() {
             List
           </button>
         </div>
-        <form onSubmit={handleAddPreset} className="flex gap-2">
+        <form onSubmit={handleAddPreset} className="flex gap-space-2">
           <input
             value={input}
             onChange={(e) => setInput(e.target.value)}
@@ -411,18 +411,18 @@ export default function XTimeline() {
                 ? 'Add screen name'
                 : 'Add list (owner/slug or id)'
             }
-            className="flex-1 p-2 rounded border bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            className="flex-1 p-space-2 rounded-panel border bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-accent"
           />
           <button
             type="submit"
-            className="px-3 py-1 rounded text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            className="px-space-3 py-space-1 rounded-control text-kali-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-accent"
             style={{ backgroundColor: accent }}
           >
             Save
           </button>
         </form>
         {presets.length > 0 && (
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-space-2">
             {presets.map((p) => (
               <button
                 key={p}
@@ -430,10 +430,10 @@ export default function XTimeline() {
                 onClick={() => {
                   setFeed(p);
                 }}
-                className={`px-2 py-1 rounded-full text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] ${
+                className={`px-space-2 py-space-1 rounded-pill text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-accent ${
                   feed === p
-                    ? 'text-[var(--color-text)]'
-                    : 'bg-[var(--color-muted)]'
+                    ? 'text-kali-text'
+                    : 'bg-kali-muted'
                 }`}
                 style={feed === p ? { backgroundColor: accent } : undefined}
               >
@@ -449,7 +449,7 @@ export default function XTimeline() {
               setLoaded(true);
               if (scriptLoaded) loadTimeline();
             }}
-            className="px-4 py-2 rounded text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            className="px-space-4 py-space-2 rounded-control text-kali-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-accent"
             style={{ backgroundColor: accent }}
           >
             Load timeline
@@ -457,22 +457,22 @@ export default function XTimeline() {
         ) : (
           <>
             {loading && !timelineLoaded && !scriptError && (
-              <ul className="tweet-feed space-y-1.5" aria-hidden="true">
+              <ul className="tweet-feed space-y-space-1-5" aria-hidden="true">
                 {Array.from({ length: 3 }).map((_, i) => (
                   <li
                     key={i}
-                    className="flex gap-1.5 p-1.5 rounded-md border"
+                    className="flex gap-space-1-5 p-space-1-5 rounded-panel border"
                   >
                     <div className="relative">
-                      <div className="w-12 h-12 rounded-full bg-[var(--color-muted)] animate-pulse" />
-                      <IconBadge className="w-3 h-3 absolute bottom-0 right-0 text-[var(--color-muted)]" />
+                      <div className="w-12 h-12 rounded-full bg-kali-muted animate-pulse" />
+                      <IconBadge className="w-3 h-3 absolute bottom-0 right-0 text-kali-muted" />
                     </div>
-                    <div className="flex-1 space-y-1.5">
-                      <div className="h-3 bg-[var(--color-muted)] rounded animate-pulse w-3/4" />
-                      <div className="h-3 bg-[var(--color-muted)] rounded animate-pulse w-1/2" />
-                      <div className="h-3 bg-[var(--color-muted)] rounded animate-pulse w-full" />
+                    <div className="flex-1 space-y-space-1-5">
+                      <div className="h-3 bg-kali-muted rounded-panel animate-pulse w-3/4" />
+                      <div className="h-3 bg-kali-muted rounded-panel animate-pulse w-1/2" />
+                      <div className="h-3 bg-kali-muted rounded-panel animate-pulse w-full" />
                     </div>
-                    <IconShare className="w-5 h-5 text-[var(--color-muted)]" />
+                    <IconShare className="w-5 h-5 text-kali-muted" />
                   </li>
                 ))}
               </ul>
@@ -496,7 +496,7 @@ export default function XTimeline() {
               </div>
             )}
             {!loading && !timelineLoaded && !scriptError && (
-              <div className="text-center text-[var(--color-muted)]">Nothing to see</div>
+              <div className="text-center text-kali-muted">Nothing to see</div>
             )}
           </>
         )}

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -40,7 +40,7 @@ type AnimatedCard = Card & {
 };
 
 const renderCard = (card: Card) => (
-  <div className="w-16 h-24 min-w-[24px] min-h-[24px] rounded border border-black bg-white flex items-center justify-center transition-transform duration-300 shadow-[0_1px_0_rgba(0,0,0,0.5)]">
+  <div className="w-16 h-24 min-w-[24px] min-h-[24px] rounded-card border border-black bg-white flex items-center justify-center transition-transform duration-300 shadow-card">
     <span className={card.color === 'red' ? 'text-red-600' : ''}>
       {valueToString(card.value)}{card.suit}
     </span>
@@ -48,7 +48,7 @@ const renderCard = (card: Card) => (
 );
 
 const renderFaceDown = () => (
-  <div className="w-16 h-24 min-w-[24px] min-h-[24px] rounded border border-black bg-blue-800 shadow-[0_1px_0_rgba(0,0,0,0.5)]" />
+  <div className="w-16 h-24 min-w-[24px] min-h-[24px] rounded-card border border-black bg-blue-800 shadow-card" />
 );
 
 const Solitaire = () => {

--- a/components/panel/WorkspaceSwitcher.tsx
+++ b/components/panel/WorkspaceSwitcher.tsx
@@ -35,7 +35,7 @@ export default function WorkspaceSwitcher({
   return (
     <nav
       aria-label="Workspace switcher"
-      className="flex items-center gap-1 rounded-full bg-black/50 px-1 py-0.5"
+      className="flex items-center gap-space-1 rounded-pill bg-black/50 px-space-1 py-space-0-5"
     >
       {workspaces.map((workspace, index) => {
         const isActive = workspace.id === activeWorkspace;
@@ -48,15 +48,15 @@ export default function WorkspaceSwitcher({
             aria-pressed={isActive}
             aria-label={formatAriaLabel(workspace)}
             onClick={() => onSelect(workspace.id)}
-            className={`min-w-[28px] rounded-full px-2 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-offset-black ${
+            className={`min-w-[28px] rounded-pill px-space-2 py-space-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-kali-accent focus-visible:ring-offset-1 focus-visible:ring-offset-black ${
               isActive
-                ? "bg-[var(--kali-blue)] text-black"
-                : "bg-transparent text-white/80 hover:bg-white/10"
+                ? "bg-kali-primary text-kali-inverse"
+                : "bg-transparent text-kali-text/80 hover:bg-white/10"
             }`}
           >
             <span>{index + 1}</span>
             {workspace.openWindows > 0 && !isActive && (
-              <span className="ml-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-white/10 px-1 text-[10px] text-white/80">
+              <span className="ml-space-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-pill bg-white/10 px-space-1 text-[10px] text-kali-text/80">
                 {workspace.openWindows}
               </span>
             )}

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -42,7 +42,7 @@ export default function BackgroundImage() {
     }, [bgImageName, useKaliWallpaper]);
 
     return (
-        <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
+        <div className="bg-ubuntu-img absolute z-underlay top-0 right-0 overflow-hidden h-full w-full">
             {useKaliWallpaper || bgImageName === 'kali-gradient' ? (
                 <KaliWallpaper />
             ) : (

--- a/components/util-components/kali-wallpaper.js
+++ b/components/util-components/kali-wallpaper.js
@@ -23,7 +23,7 @@ const DRAGON_PATH = "M256 62c-63 0-117 31-152 80 69-21 121 12 150 38 23 21 29 44
 function KaliDragon({ className = '' }) {
   return (
     <svg
-      className={`pointer-events-none text-cyan-300/80 drop-shadow-[0_0_25px_rgba(23,147,209,0.55)] ${className}`}
+      className={`pointer-events-none text-cyan-300/80 drop-shadow-glow ${className}`}
       viewBox="0 0 512 512"
       role="img"
       aria-label="Stylized Kali dragon"

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -1,0 +1,38 @@
+# Design token guide
+
+This project defines a unified set of design tokens that can be consumed from both CSS and JavaScript / TypeScript.
+Tokens live in [`styles/tokens.css`](../styles/tokens.css) as CSS custom properties and are exported in a typed
+structure under [`tokens/`](../tokens/index.ts). The Tailwind theme consumes the same token map so that utility classes
+remain in sync with runtime styles.
+
+## Token categories
+
+| Category | Source | Tailwind usage |
+| --- | --- | --- |
+| Colors | `tokens.colors` | `bg-kali-primary`, `text-kali-muted`, `ring-kali-accent` |
+| Spacing | `tokens.spacing` | `p-space-2`, `mt-space-4`, `gap-space-1-5` |
+| Radii | `tokens.radii` | `rounded-control`, `rounded-panel`, `rounded-pill` |
+| Shadows | `tokens.shadows.box`, `tokens.shadows.drop` | `shadow-panel`, `shadow-card`, `drop-shadow-glow` |
+| Z levels | `tokens.zIndex` | `z-underlay`, `z-modal`, `z-popover` |
+
+> The `tokens` module exports deep-frozen objects so the design system cannot be mutated accidentally at runtime.
+
+## Authoring guidelines
+
+1. Prefer the token-backed Tailwind utilities (`p-space-2`, `rounded-panel`, `shadow-card`, etc.) instead of hard-coded
+   numeric or color values.
+2. When adding a new visual primitive, define the CSS custom property in `styles/tokens.css`, add it to
+   `tokens/design-tokens.json`, and re-export it through `tokens/index.ts`. Tailwind picks it up automatically.
+3. For runtime logic or tests that need token values, import from `tokens/index.ts` instead of duplicating constants.
+4. If a component needs a value between tokens, first evaluate whether a new token should be introduced to keep spacing
+   consistent across the desktop shell.
+
+## Testing and linting
+
+A lightweight unit test (`__tests__/design-tokens.test.ts`) verifies that the exported tokens match the expected CSS
+custom property structure. Run the standard quality gates to validate changes:
+
+```bash
+yarn lint
+yarn test
+```

--- a/pages/daily-quote.tsx
+++ b/pages/daily-quote.tsx
@@ -56,10 +56,10 @@ export default function DailyQuote() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-ub-cool-grey text-white p-4">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-ub-cool-grey text-white p-space-4">
       <div
         ref={cardRef}
-        className="group relative p-6 rounded text-center bg-gradient-to-br from-[var(--color-primary)]/30 to-[var(--color-secondary)]/30 text-white"
+        className="group relative p-space-6 rounded-panel text-center bg-gradient-to-br from-kali-primary/30 to-kali-secondary/30 text-white"
       >
         {quote ? (
           <div key={quote.content} className="animate-quote">
@@ -73,17 +73,17 @@ export default function DailyQuote() {
               {quote.content}
             </p>
             <p className="text-sm text-white/80">— {quote.author}</p>
-            <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition">
+            <div className="absolute top-space-2 right-space-2 flex gap-space-2 opacity-0 group-hover:opacity-100 transition">
               <button
                 onClick={copyQuote}
-                className="p-1 bg-black/30 hover:bg-black/50 rounded"
+                className="p-space-1 bg-black/30 hover:bg-black/50 rounded-control"
                 aria-label="Copy quote"
               >
                 <CopyIcon className="w-6 h-6" />
               </button>
               <button
                 onClick={tweetQuote}
-                className="p-1 bg-black/30 hover:bg-black/50 rounded"
+                className="p-space-1 bg-black/30 hover:bg-black/50 rounded-control"
                 aria-label="Tweet quote"
               >
                 <TwitterIcon className="w-6 h-6" />
@@ -94,9 +94,9 @@ export default function DailyQuote() {
           <p>Loading...</p>
         )}
       </div>
-      <div className="flex gap-2 mt-4">
+      <div className="flex gap-space-2 mt-space-4">
         <button
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded"
+          className="px-space-4 py-space-2 bg-gray-700 hover:bg-gray-600 rounded-control"
           onClick={exportCard}
           disabled={!quote}
         >

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -46,7 +46,9 @@
   --game-color-danger: #b91c1c;
 
   /* Spacing scale */
+  --space-0-5: 0.125rem;
   --space-1: 0.25rem;
+  --space-1-5: 0.375rem;
   --space-2: 0.5rem;
   --space-3: 0.75rem;
   --space-4: 1rem;
@@ -62,6 +64,9 @@
 
   /* Elevation */
   --shadow-2: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+  --shadow-panel: 0 6px 20px rgba(0, 0, 0, 0.35);
+  --shadow-card: 0 1px 0 rgba(0, 0, 0, 0.5);
+  --shadow-glow: 0 0 25px rgba(23, 147, 209, 0.55);
 
   /* Window chrome */
   --color-window-border: #0d1a2a;
@@ -80,6 +85,13 @@
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
+  --z-underlay: -10;
+  --z-base: 0;
+  --z-overlay: 10;
+  --z-panel: 20;
+  --z-popover: 30;
+  --z-modal: 50;
+  --z-toast: 50;
 }
 
 /* High contrast theme */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,7 @@
 const plugin = require('tailwindcss/plugin');
+const tokens = require('./tokens/design-tokens.json');
+
+const { colors, spacing, radii, shadows, zIndex } = tokens;
 
 module.exports = {
   darkMode: 'class',
@@ -14,49 +17,11 @@ module.exports = {
       screens: {
         '3xl': '1920px',
       },
-      colors: {
-        'ub-grey': 'var(--color-ub-grey)',
-        'ub-warm-grey': 'var(--color-ub-warm-grey)',
-        'ub-cool-grey': 'var(--color-ub-cool-grey)',
-        'ub-orange': 'var(--color-ub-orange)',
-        'ub-lite-abrgn': 'var(--color-ub-lite-abrgn)',
-        'ub-med-abrgn': 'var(--color-ub-med-abrgn)',
-        'ub-drk-abrgn': 'var(--color-ub-drk-abrgn)',
-        'ub-window-title': 'var(--color-ub-window-title)',
-        'ub-gedit-dark': 'var(--color-ub-gedit-dark)',
-        'ub-gedit-light': 'var(--color-ub-gedit-light)',
-        'ub-gedit-darker': 'var(--color-ub-gedit-darker)',
-        'ubt-grey': 'var(--color-ubt-grey)',
-        'ubt-warm-grey': 'var(--color-ubt-warm-grey)',
-        'ubt-cool-grey': 'var(--color-ubt-cool-grey)',
-        'ubt-blue': 'var(--color-ubt-blue)',
-        'ubt-green': 'var(--color-ubt-green)',
-        'ubt-gedit-orange': 'var(--color-ubt-gedit-orange)',
-        'ubt-gedit-blue': 'var(--color-ubt-gedit-blue)',
-        'ubt-gedit-dark': 'var(--color-ubt-gedit-dark)',
-        'ub-border-orange': 'var(--color-ub-border-orange)',
-        'ub-dark-grey': 'var(--color-ub-dark-grey)',
-        kali: {
-          background: 'var(--color-bg)',
-          text: 'var(--color-text)',
-          primary: 'var(--color-primary)',
-          secondary: 'var(--color-secondary)',
-          accent: 'var(--color-accent)',
-          muted: 'var(--color-muted)',
-          surface: 'var(--color-surface)',
-          inverse: 'var(--color-inverse)',
-          border: 'var(--color-border)',
-          terminal: 'var(--color-terminal)',
-          dark: 'var(--color-dark)',
-          focus: 'var(--color-focus-ring)',
-          selection: 'var(--color-selection)',
-          control: 'var(--color-control-accent)',
-          backdrop: 'var(--kali-bg)',
-        },
-      },
-      boxShadow: {
-        'kali-panel': '0 6px 20px rgba(0,0,0,.35)',
-      },
+      colors,
+      spacing,
+      borderRadius: radii,
+      boxShadow: shadows.box,
+      dropShadow: shadows.drop,
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],
       },
@@ -74,9 +39,7 @@ module.exports = {
         '3/4': '75%',
         'full': '100%',
       },
-      zIndex: {
-        '-10': '-10',
-      },
+      zIndex,
       width: {
         'app-icon': '64px',
         'app-icon-lg': '96px',

--- a/tokens/design-tokens.json
+++ b/tokens/design-tokens.json
@@ -1,0 +1,88 @@
+{
+  "colors": {
+    "ub-grey": "var(--color-ub-grey)",
+    "ub-warm-grey": "var(--color-ub-warm-grey)",
+    "ub-cool-grey": "var(--color-ub-cool-grey)",
+    "ub-orange": "var(--color-ub-orange)",
+    "ub-lite-abrgn": "var(--color-ub-lite-abrgn)",
+    "ub-med-abrgn": "var(--color-ub-med-abrgn)",
+    "ub-drk-abrgn": "var(--color-ub-drk-abrgn)",
+    "ub-window-title": "var(--color-ub-window-title)",
+    "ub-gedit-dark": "var(--color-ub-gedit-dark)",
+    "ub-gedit-light": "var(--color-ub-gedit-light)",
+    "ub-gedit-darker": "var(--color-ub-gedit-darker)",
+    "ubt-grey": "var(--color-ubt-grey)",
+    "ubt-warm-grey": "var(--color-ubt-warm-grey)",
+    "ubt-cool-grey": "var(--color-ubt-cool-grey)",
+    "ubt-blue": "var(--color-ubt-blue)",
+    "ubt-green": "var(--color-ubt-green)",
+    "ubt-gedit-orange": "var(--color-ubt-gedit-orange)",
+    "ubt-gedit-blue": "var(--color-ubt-gedit-blue)",
+    "ubt-gedit-dark": "var(--color-ubt-gedit-dark)",
+    "ub-border-orange": "var(--color-ub-border-orange)",
+    "ub-dark-grey": "var(--color-ub-dark-grey)",
+    "kali": {
+      "background": "var(--color-bg)",
+      "text": "var(--color-text)",
+      "primary": "var(--color-primary)",
+      "secondary": "var(--color-secondary)",
+      "accent": "var(--color-accent)",
+      "muted": "var(--color-muted)",
+      "surface": "var(--color-surface)",
+      "inverse": "var(--color-inverse)",
+      "border": "var(--color-border)",
+      "terminal": "var(--color-terminal)",
+      "dark": "var(--color-dark)",
+      "focus": "var(--color-focus-ring)",
+      "selection": "var(--color-selection)",
+      "control": "var(--color-control-accent)",
+      "backdrop": "var(--kali-bg)",
+      "panel": "var(--kali-panel)",
+      "panel-border": "var(--kali-panel-border)",
+      "panel-highlight": "var(--kali-panel-highlight)"
+    },
+    "game": {
+      "secondary": "var(--game-color-secondary)",
+      "success": "var(--game-color-success)",
+      "warning": "var(--game-color-warning)",
+      "danger": "var(--game-color-danger)"
+    }
+  },
+  "spacing": {
+    "space-0-5": "var(--space-0-5)",
+    "space-1": "var(--space-1)",
+    "space-1-5": "var(--space-1-5)",
+    "space-2": "var(--space-2)",
+    "space-3": "var(--space-3)",
+    "space-4": "var(--space-4)",
+    "space-5": "var(--space-5)",
+    "space-6": "var(--space-6)",
+    "hit-area": "var(--hit-area)"
+  },
+  "radii": {
+    "control": "var(--radius-sm)",
+    "surface": "var(--radius-md)",
+    "panel": "var(--radius-lg)",
+    "card": "var(--radius-6)",
+    "pill": "var(--radius-round)"
+  },
+  "shadows": {
+    "box": {
+      "panel": "var(--shadow-panel)",
+      "elevated": "var(--shadow-2)",
+      "card": "var(--shadow-card)"
+    },
+    "drop": {
+      "glow": "var(--shadow-glow)"
+    }
+  },
+  "zIndex": {
+    "underlay": "var(--z-underlay)",
+    "base": "var(--z-base)",
+    "overlay": "var(--z-overlay)",
+    "panel": "var(--z-panel)",
+    "popover": "var(--z-popover)",
+    "modal": "var(--z-modal)",
+    "toast": "var(--z-toast)"
+  }
+}

--- a/tokens/index.ts
+++ b/tokens/index.ts
@@ -1,0 +1,40 @@
+import designTokens from './design-tokens.json';
+
+type Primitive = string | number | boolean | null | undefined;
+
+type DeepReadonly<T> = T extends Primitive
+  ? T
+  : T extends Array<infer U>
+    ? ReadonlyArray<DeepReadonly<U>>
+    : { readonly [K in keyof T]: DeepReadonly<T[K]> };
+
+const deepFreeze = <T extends Record<string, unknown>>(object: T): DeepReadonly<T> => {
+  const entries = Object.entries(object).map(([key, value]) => {
+    if (value && typeof value === 'object') {
+      return [key, deepFreeze(value as Record<string, unknown>)];
+    }
+
+    return [key, value];
+  });
+
+  return Object.freeze(Object.fromEntries(entries)) as DeepReadonly<T>;
+};
+
+const tokens = deepFreeze(designTokens);
+
+export const colors = tokens.colors;
+export const spacing = tokens.spacing;
+export const radii = tokens.radii;
+export const shadows = tokens.shadows;
+export const zIndex = tokens.zIndex;
+
+export type ColorToken = keyof typeof colors;
+export type KaliColorToken = keyof typeof colors.kali;
+export type GameColorToken = keyof typeof colors.game;
+export type SpacingToken = keyof typeof spacing;
+export type RadiusToken = keyof typeof radii;
+export type BoxShadowToken = keyof typeof shadows.box;
+export type DropShadowToken = keyof typeof shadows.drop;
+export type ZIndexToken = keyof typeof zIndex;
+
+export default tokens;


### PR DESCRIPTION
## Summary
- add shared design-token source under tokens/ and expose immutable TypeScript exports
- wire Tailwind to consume color, spacing, radius, shadow, and z-index tokens and update key components to use the new utilities
- document the token workflow and add a regression test that validates the exported maps stay linked to CSS custom properties

## Testing
- yarn lint *(fails: existing jsx-a11y/no-top-level-window violations throughout apps)*
- yarn test *(fails: pre-existing suite issues including modal, taskbar, and desktopNameBar tests)*
- yarn test __tests__/design-tokens.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6d53c11848328a113ce8903b6f4a3