### PR TITLE
[styles] add responsive typography scale

### DIFF
--- a/__tests__/typography-scale.test.js
+++ b/__tests__/typography-scale.test.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const path = require('path');
+
+const { typographyScale, lineHeights, typeSpacing } = require('../lib/typography-scale');
+const tailwindConfig = require('../tailwind.config.js');
+
+const tokensPath = path.join(__dirname, '..', 'styles', 'tokens.css');
+const tokensCss = fs.readFileSync(tokensPath, 'utf8');
+
+describe('typography scale tokens', () => {
+  it('exposes clamp-based values for every scale level', () => {
+    Object.values(typographyScale).forEach((group) => {
+      Object.values(group).forEach((value) => {
+        expect(value.startsWith('clamp(')).toBe(true);
+        expect(value.endsWith(')')).toBe(true);
+      });
+    });
+  });
+
+  it('synchronises CSS variables with the JavaScript source of truth', () => {
+    Object.entries(typographyScale).forEach(([groupName, group]) => {
+      Object.entries(group).forEach(([level, value]) => {
+        const varName = `--font-size-${groupName}-${level}`;
+        expect(tokensCss).toContain(`${varName}: ${value};`);
+      });
+    });
+
+    Object.entries(lineHeights).forEach(([name, value]) => {
+      const varName = `--line-height-${name}`;
+      expect(tokensCss).toContain(`${varName}: ${value};`);
+    });
+
+    Object.entries(typeSpacing).forEach(([name, value]) => {
+      const kebabName = name.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`);
+      const varName = `--type-${kebabName}`;
+      expect(tokensCss).toContain(`${varName}: ${value};`);
+    });
+  });
+});
+
+describe('tailwind typography mapping', () => {
+  const fontSizeConfig = tailwindConfig?.theme?.extend?.fontSize ?? {};
+  const lineHeightConfig = tailwindConfig?.theme?.extend?.lineHeight ?? {};
+  const fontFamilyConfig = tailwindConfig?.theme?.extend?.fontFamily ?? {};
+
+  it('maps text utilities to the responsive clamp values', () => {
+    expect(fontSizeConfig.xs[0]).toBe(typographyScale.body.xs);
+    expect(fontSizeConfig.sm[0]).toBe(typographyScale.body.sm);
+    expect(fontSizeConfig.base[0]).toBe(typographyScale.body.md);
+    expect(fontSizeConfig.lg[0]).toBe(typographyScale.body.lg);
+    expect(fontSizeConfig.xl[0]).toBe(typographyScale.heading.xs);
+    expect(fontSizeConfig['2xl'][0]).toBe(typographyScale.heading.sm);
+    expect(fontSizeConfig['3xl'][0]).toBe(typographyScale.heading.md);
+    expect(fontSizeConfig['4xl'][0]).toBe(typographyScale.heading.lg);
+    expect(fontSizeConfig['5xl'][0]).toBe(typographyScale.display.sm);
+    expect(fontSizeConfig['6xl'][0]).toBe(typographyScale.display.md);
+    expect(fontSizeConfig['7xl'][0]).toBe(typographyScale.display.lg);
+  });
+
+  it('exposes line-height helpers bound to design tokens', () => {
+    expect(lineHeightConfig.tight).toBe(String(lineHeights.tight));
+    expect(lineHeightConfig.snug).toBe(String(lineHeights.snug));
+    expect(lineHeightConfig.normal).toBe(String(lineHeights.standard));
+    expect(lineHeightConfig.relaxed).toBe(String(lineHeights.relaxed));
+    expect(lineHeightConfig.mono).toBe(String(lineHeights.mono));
+  });
+
+  it('uses CSS variable driven font stacks', () => {
+    expect(fontFamilyConfig.sans[0]).toBe('var(--font-family-base)');
+    expect(fontFamilyConfig.mono[0]).toBe('var(--font-family-mono)');
+  });
+});

--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -1,5 +1,7 @@
 body {
-  font-family: Arial, sans-serif;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
   background: var(--color-bg);
   height: 100vh;
   display: flex;
@@ -24,7 +26,9 @@ body {
   margin-bottom: 0.5rem;
   padding: 0.5rem;
   text-align: right;
-  font-size: 1.2rem;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-heading-xs);
+  line-height: var(--line-height-mono);
   border-radius: 4px;
   overflow-x: auto;
   width: 100%;
@@ -69,7 +73,8 @@ body {
   background: var(--color-muted);
   border: none;
   border-radius: 4px;
-  font-size: 1rem;
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
   cursor: pointer;
   min-height: 48px;
   transition: transform 150ms;
@@ -93,7 +98,7 @@ body {
 }
 
 .button-grid .btn {
-  font-family: monospace;
+  font-family: var(--font-family-mono);
 }
 
 
@@ -107,7 +112,8 @@ body {
   background: var(--color-surface);
   border-left: 1px solid var(--color-border);
   padding: 0.5rem;
-  font-size: 0.9rem;
+  font-size: var(--font-size-body-sm);
+  line-height: var(--line-height-standard);
   box-shadow: -2px 0 5px color-mix(in srgb, var(--color-inverse), transparent 90%);
   display: flex;
   flex-direction: column;

--- a/apps/clipboard_manager/index.css
+++ b/apps/clipboard_manager/index.css
@@ -1,4 +1,18 @@
-body { font-family: Arial, sans-serif; margin: 2rem; }
-button { margin-bottom: 1rem; }
-li { cursor: pointer; margin: 0.25rem 0; }
+body {
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
+  margin: 2rem;
+}
+button {
+  margin-bottom: 1rem;
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
+}
+li {
+  cursor: pointer;
+  margin: 0.25rem 0;
+  font-size: var(--font-size-body-sm);
+  line-height: var(--line-height-standard);
+}
 li:hover { text-decoration: underline; }

--- a/apps/color_picker/index.css
+++ b/apps/color_picker/index.css
@@ -1,7 +1,10 @@
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
   padding: 2rem;
-  background: #f4f4f4;
+  background: var(--color-bg);
+  color: var(--color-text);
 }
 h1 {
   margin-bottom: 1rem;

--- a/apps/sticky_notes/styles.css
+++ b/apps/sticky_notes/styles.css
@@ -1,9 +1,12 @@
 body {
-  font-family: sans-serif;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
   margin: 0;
   padding: 0;
   height: 100vh;
   background: var(--color-bg);
+  color: var(--color-text);
 }
 
 #add-note {
@@ -40,6 +43,9 @@ body {
   background: transparent;
   resize: none;
   outline: none;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-body-sm);
+  line-height: var(--line-height-standard);
 }
 
 .note .controls {

--- a/apps/timer_stopwatch/index.css
+++ b/apps/timer_stopwatch/index.css
@@ -1,26 +1,32 @@
 body {
-  font-family: sans-serif;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
   margin-top: 50px;
-  background: #f0f0f0;
+  background: var(--color-bg);
+  color: var(--color-text);
 }
 .display {
-  font-size: 4rem;
-  font-family: 'Courier New', monospace;
+  font-size: var(--font-size-display-sm);
+  font-family: var(--font-family-mono);
+  line-height: var(--line-height-mono);
   margin: 20px 0;
 }
 button {
   margin: 5px;
   padding: 10px 20px;
-  font-size: 1rem;
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
 }
 input {
   width: 60px;
   text-align: center;
-  font-size: 1rem;
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
   padding: 5px;
 }
 ul {
@@ -35,7 +41,9 @@ li {
   margin: 2px 0;
   padding: 5px 10px;
   border-radius: 4px;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-mono-md);
+  line-height: var(--line-height-mono);
 }
 .hidden {
   display:none;

--- a/apps/timer_stopwatch/styles.css
+++ b/apps/timer_stopwatch/styles.css
@@ -1,21 +1,26 @@
 body {
-  font-family: sans-serif;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
   margin-top: 50px;
   background: var(--color-bg);
+  color: var(--color-text);
 }
 .display {
-  font-size: 4rem;
-  font-family: 'Courier New', monospace;
+  font-size: var(--font-size-display-sm);
+  font-family: var(--font-family-mono);
+  line-height: var(--line-height-mono);
   margin: 20px 0;
 }
 button {
   margin: 5px;
   padding: 10px 20px;
-  font-size: 1rem;
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
 }
 /* Tab styles */
 .tabs .tab[aria-selected='true'] {
@@ -37,7 +42,8 @@ button {
 input {
   width: 60px;
   text-align: center;
-  font-size: 1rem;
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
   padding: 5px;
 }
 ul {
@@ -52,12 +58,14 @@ li {
   margin: 2px 0;
   padding: 5px 10px;
   border-radius: 4px;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-mono-md);
+  line-height: var(--line-height-mono);
 }
 
 @container (max-width: 300px) {
   .display {
-    font-size: 2rem;
+    font-size: var(--font-size-heading-lg);
   }
   button {
     width: 100%;

--- a/apps/weather_widget/styles.css
+++ b/apps/weather_widget/styles.css
@@ -1,6 +1,9 @@
 body {
-  font-family: sans-serif;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
   background: var(--color-bg);
+  color: var(--color-text);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -50,7 +53,8 @@ body {
 }
 
 .temp {
-  font-size: 2rem;
+  font-size: var(--font-size-heading-lg);
+  line-height: var(--line-height-tight);
   margin-bottom: 10px;
 }
 
@@ -60,7 +64,8 @@ body {
 }
 
 .forecast {
-  font-size: 1rem;
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-standard);
   margin-top: 10px;
   text-transform: capitalize;
 }
@@ -76,12 +81,14 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  font-size: 0.8rem;
+  font-size: var(--font-size-body-xs);
+  line-height: var(--line-height-standard);
 }
 
 .sunrise,
 .sunset {
-  font-size: 0.9rem;
+  font-size: var(--font-size-body-sm);
+  line-height: var(--line-height-standard);
   margin-top: 5px;
 }
 

--- a/docs/typography.md
+++ b/docs/typography.md
@@ -1,0 +1,62 @@
+# Typography guide
+
+The desktop UI shares a responsive type scale that uses `clamp()` so text can flex between
+smaller laptop viewports and large displays without needing per-breakpoint overrides. The
+scale is defined once in CSS custom properties and reused by Tailwind so the semantic
+utility classes automatically map to the design tokens.
+
+## Type scale
+
+| Token | Clamp value | Typical usage |
+| --- | --- | --- |
+| `--font-size-body-xs` | `clamp(0.8125rem, 0.78rem + 0.2vw, 0.9375rem)` | fine print, captions |
+| `--font-size-body-sm` | `clamp(0.875rem, 0.84rem + 0.22vw, 1rem)` | standard body copy |
+| `--font-size-body-md` | `clamp(1rem, 0.96rem + 0.25vw, 1.125rem)` | lead paragraphs |
+| `--font-size-body-lg` | `clamp(1.125rem, 1.07rem + 0.32vw, 1.25rem)` | emphasized body text |
+| `--font-size-heading-xs` | `clamp(1.25rem, 1.17rem + 0.35vw, 1.5rem)` | h5, sidebar titles |
+| `--font-size-heading-sm` | `clamp(1.5rem, 1.4rem + 0.45vw, 1.8rem)` | h4, app section titles |
+| `--font-size-heading-md` | `clamp(1.875rem, 1.72rem + 0.6vw, 2.25rem)` | h3, dialog headers |
+| `--font-size-heading-lg` | `clamp(2.25rem, 2.05rem + 0.75vw, 2.75rem)` | h2, hero copy |
+| `--font-size-display-sm` | `clamp(2.75rem, 2.45rem + 1vw, 3.5rem)` | h1, app chrome |
+| `--font-size-display-md` | `clamp(3.25rem, 2.85rem + 1.2vw, 4rem)` | desktop banners |
+| `--font-size-display-lg` | `clamp(3.75rem, 3.25rem + 1.4vw, 4.5rem)` | large hero typography |
+| `--font-size-mono-sm` | `clamp(0.8125rem, 0.79rem + 0.15vw, 0.9375rem)` | inline code |
+| `--font-size-mono-md` | `clamp(0.9375rem, 0.9rem + 0.18vw, 1.0625rem)` | terminal output |
+| `--font-size-mono-lg` | `clamp(1.0625rem, 1.02rem + 0.22vw, 1.1875rem)` | large meter displays |
+
+The base sans-serif stack is exposed as `--font-family-base` while monospace UI uses
+`--font-family-mono`. Line-height tokens are:
+
+- `--line-height-tight` (`1.15`) for display copy.
+- `--line-height-snug` (`1.25`) for headings.
+- `--line-height-standard` (`1.5`) for paragraphs and lists.
+- `--line-height-relaxed` (`1.7`) for long-form reading.
+- `--line-height-mono` (`1.45`) for terminal and data views.
+
+Use the spacing helpers when stacking text blocks: `--type-stack-sm`, `--type-stack-md`,
+and `--type-stack-lg` already react to viewport width and keep vertical rhythm consistent.
+
+## Tailwind mapping
+
+`tailwind.config.js` wires these tokens into `text-*` utilities so existing class names
+pick up the responsive scale automatically. Examples:
+
+- `text-base` → `--font-size-body-md`
+- `text-xl` → `--font-size-heading-xs`
+- `text-4xl` → `--font-size-heading-lg`
+- `text-7xl` → `--font-size-display-lg`
+
+`font-sans` and `font-mono` also resolve to the CSS variables, ensuring user preference
+and accessibility settings can override the stacks in one place.
+
+## Authoring tips
+
+1. Prefer Tailwind utilities for everyday sizing. Reach for the custom properties only
+   when writing standalone CSS or when a component needs a bespoke clamp.
+2. Pair `leading-tight`, `leading-snug`, `leading-normal`, or `leading-relaxed` with the
+   appropriate text utility to stay inside the rhythm.
+3. Use `leading-mono` on terminal-style widgets or tables that use `font-mono` so digits
+   align neatly.
+4. When creating stacked layouts, apply `space-y-*` classes or set `margin-block-end`
+   to one of the `--type-stack-*` tokens to match the default flow spacing defined in
+   `styles/index.css`.

--- a/lib/typography-scale.js
+++ b/lib/typography-scale.js
@@ -1,0 +1,47 @@
+const clampValue = (min, preferred, max) => `clamp(${min}, ${preferred}, ${max})`;
+
+const typographyScale = Object.freeze({
+  body: Object.freeze({
+    xs: clampValue('0.8125rem', '0.78rem + 0.2vw', '0.9375rem'),
+    sm: clampValue('0.875rem', '0.84rem + 0.22vw', '1rem'),
+    md: clampValue('1rem', '0.96rem + 0.25vw', '1.125rem'),
+    lg: clampValue('1.125rem', '1.07rem + 0.32vw', '1.25rem'),
+  }),
+  heading: Object.freeze({
+    xs: clampValue('1.25rem', '1.17rem + 0.35vw', '1.5rem'),
+    sm: clampValue('1.5rem', '1.4rem + 0.45vw', '1.8rem'),
+    md: clampValue('1.875rem', '1.72rem + 0.6vw', '2.25rem'),
+    lg: clampValue('2.25rem', '2.05rem + 0.75vw', '2.75rem'),
+  }),
+  display: Object.freeze({
+    sm: clampValue('2.75rem', '2.45rem + 1vw', '3.5rem'),
+    md: clampValue('3.25rem', '2.85rem + 1.2vw', '4rem'),
+    lg: clampValue('3.75rem', '3.25rem + 1.4vw', '4.5rem'),
+  }),
+  mono: Object.freeze({
+    sm: clampValue('0.8125rem', '0.79rem + 0.15vw', '0.9375rem'),
+    md: clampValue('0.9375rem', '0.9rem + 0.18vw', '1.0625rem'),
+    lg: clampValue('1.0625rem', '1.02rem + 0.22vw', '1.1875rem'),
+  }),
+});
+
+const lineHeights = Object.freeze({
+  tight: 1.15,
+  snug: 1.25,
+  standard: 1.5,
+  relaxed: 1.7,
+  mono: 1.45,
+});
+
+const typeSpacing = Object.freeze({
+  stackSm: clampValue('0.5rem', '0.45rem + 0.2vw', '0.75rem'),
+  stackMd: clampValue('0.75rem', '0.6rem + 0.3vw', '1.25rem'),
+  stackLg: clampValue('1.25rem', '1rem + 0.4vw', '1.75rem'),
+});
+
+module.exports = {
+  clampValue,
+  typographyScale,
+  lineHeights,
+  typeSpacing,
+};

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,14 +1,93 @@
 @import './globals.css';
 
 html {
-    font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
+    font-size: var(--font-size-root);
 }
 
-body{
+body {
     font-family: var(--font-family-base);
     font-display: swap;
     background-color: var(--color-bg);
     color: var(--color-text);
+    font-size: var(--font-size-body-md);
+    line-height: var(--line-height-standard);
+    letter-spacing: 0.01em;
+}
+
+p,
+ul,
+ol,
+dl,
+blockquote,
+pre,
+figure {
+    margin-block: 0 var(--type-stack-md);
+}
+
+li {
+    margin-block: 0;
+}
+
+small {
+    font-size: var(--font-size-body-xs);
+    line-height: var(--line-height-standard);
+}
+
+code,
+kbd,
+samp {
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-mono-md);
+    line-height: var(--line-height-mono);
+}
+
+pre {
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-mono-lg);
+    line-height: var(--line-height-mono);
+    margin-block-end: var(--type-stack-md);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    margin-block: 0 var(--type-stack-sm);
+    font-weight: 600;
+}
+
+h1 {
+    font-size: var(--font-size-display-md);
+    line-height: var(--line-height-tight);
+    margin-block-end: var(--type-stack-lg);
+}
+
+h2 {
+    font-size: var(--font-size-display-sm);
+    line-height: var(--line-height-tight);
+    margin-block-end: var(--type-stack-md);
+}
+
+h3 {
+    font-size: var(--font-size-heading-lg);
+    line-height: var(--line-height-snug);
+}
+
+h4 {
+    font-size: var(--font-size-heading-md);
+    line-height: var(--line-height-snug);
+}
+
+h5 {
+    font-size: var(--font-size-heading-sm);
+    line-height: var(--line-height-snug);
+}
+
+h6 {
+    font-size: var(--font-size-heading-xs);
+    line-height: var(--line-height-standard);
 }
 
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -74,7 +74,31 @@
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
+  --font-family-mono: 'Ubuntu Mono', 'Fira Mono', 'SFMono-Regular', 'Menlo', 'monospace';
   --font-multiplier: 1;
+  --font-size-root: clamp(15px, calc(16px * var(--font-multiplier)), 18px);
+  --font-size-body-xs: clamp(0.8125rem, 0.78rem + 0.2vw, 0.9375rem);
+  --font-size-body-sm: clamp(0.875rem, 0.84rem + 0.22vw, 1rem);
+  --font-size-body-md: clamp(1rem, 0.96rem + 0.25vw, 1.125rem);
+  --font-size-body-lg: clamp(1.125rem, 1.07rem + 0.32vw, 1.25rem);
+  --font-size-heading-xs: clamp(1.25rem, 1.17rem + 0.35vw, 1.5rem);
+  --font-size-heading-sm: clamp(1.5rem, 1.4rem + 0.45vw, 1.8rem);
+  --font-size-heading-md: clamp(1.875rem, 1.72rem + 0.6vw, 2.25rem);
+  --font-size-heading-lg: clamp(2.25rem, 2.05rem + 0.75vw, 2.75rem);
+  --font-size-display-sm: clamp(2.75rem, 2.45rem + 1vw, 3.5rem);
+  --font-size-display-md: clamp(3.25rem, 2.85rem + 1.2vw, 4rem);
+  --font-size-display-lg: clamp(3.75rem, 3.25rem + 1.4vw, 4.5rem);
+  --font-size-mono-sm: clamp(0.8125rem, 0.79rem + 0.15vw, 0.9375rem);
+  --font-size-mono-md: clamp(0.9375rem, 0.9rem + 0.18vw, 1.0625rem);
+  --font-size-mono-lg: clamp(1.0625rem, 1.02rem + 0.22vw, 1.1875rem);
+  --line-height-tight: 1.15;
+  --line-height-snug: 1.25;
+  --line-height-standard: 1.5;
+  --line-height-relaxed: 1.7;
+  --line-height-mono: 1.45;
+  --type-stack-sm: clamp(0.5rem, 0.45rem + 0.2vw, 0.75rem);
+  --type-stack-md: clamp(0.75rem, 0.6rem + 0.3vw, 1.25rem);
+  --type-stack-lg: clamp(1.25rem, 1rem + 0.4vw, 1.75rem);
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 const plugin = require('tailwindcss/plugin');
+const { typographyScale, lineHeights } = require('./lib/typography-scale');
 
 module.exports = {
   darkMode: 'class',
@@ -58,7 +59,29 @@ module.exports = {
         'kali-panel': '0 6px 20px rgba(0,0,0,.35)',
       },
       fontFamily: {
+        sans: ['var(--font-family-base)', 'system-ui', 'sans-serif'],
+        mono: ['var(--font-family-mono)', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
         ubuntu: ['Ubuntu', 'sans-serif'],
+      },
+      fontSize: {
+        xs: [typographyScale.body.xs, { lineHeight: lineHeights.standard }],
+        sm: [typographyScale.body.sm, { lineHeight: lineHeights.standard }],
+        base: [typographyScale.body.md, { lineHeight: lineHeights.standard }],
+        lg: [typographyScale.body.lg, { lineHeight: lineHeights.standard }],
+        xl: [typographyScale.heading.xs, { lineHeight: lineHeights.snug }],
+        '2xl': [typographyScale.heading.sm, { lineHeight: lineHeights.snug }],
+        '3xl': [typographyScale.heading.md, { lineHeight: lineHeights.tight }],
+        '4xl': [typographyScale.heading.lg, { lineHeight: lineHeights.tight }],
+        '5xl': [typographyScale.display.sm, { lineHeight: lineHeights.tight }],
+        '6xl': [typographyScale.display.md, { lineHeight: lineHeights.tight }],
+        '7xl': [typographyScale.display.lg, { lineHeight: lineHeights.tight }],
+      },
+      lineHeight: {
+        tight: String(lineHeights.tight),
+        snug: String(lineHeights.snug),
+        normal: String(lineHeights.standard),
+        relaxed: String(lineHeights.relaxed),
+        mono: String(lineHeights.mono),
       },
       minWidth: {
         '0': '0',


### PR DESCRIPTION
## Summary
- add a shared typography scale module and custom properties backed by clamp-based font tokens
- wire the responsive scale into global styles, Tailwind utilities, and update app-specific CSS to use the new rhythm
- document the scale and add regression tests to keep Tailwind and token values in sync

## Testing
- yarn lint *(fails: legacy jsx-a11y/control-has-associated-label and existing game loader warnings)*
- yarn test --runInBand __tests__/typography-scale.test.js
- yarn test --runInBand *(fails: __tests__/nmapNse.test.tsx expects an alert element)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d53d98508328a2403b02274864c5