### PR TITLE
[settings] add system theme selection

### DIFF
--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -2,12 +2,65 @@ import { renderHook, act } from '@testing-library/react';
 import { SettingsProvider, useSettings } from '../hooks/useSettings';
 import { getTheme, getUnlockedThemes, setTheme } from '../utils/theme';
 
+type MediaQueryListener = (event: MediaQueryListEvent | { matches: boolean }) => void;
+
+const createMatchMediaMock = (initialMatch = false) => {
+  let match = initialMatch;
+  const listeners: MediaQueryListener[] = [];
+
+  const matchMedia = jest.fn().mockImplementation(() => {
+    const mediaQueryList = {
+      media: '(prefers-color-scheme: dark)',
+      get matches() {
+        return match;
+      },
+      addEventListener: jest.fn((event: string, handler: MediaQueryListener) => {
+        if (event === 'change') {
+          listeners.push(handler);
+        }
+      }),
+      removeEventListener: jest.fn((event: string, handler: MediaQueryListener) => {
+        if (event === 'change') {
+          const index = listeners.indexOf(handler);
+          if (index !== -1) listeners.splice(index, 1);
+        }
+      }),
+      addListener: jest.fn((handler: MediaQueryListener) => {
+        listeners.push(handler);
+      }),
+      removeListener: jest.fn((handler: MediaQueryListener) => {
+        const index = listeners.indexOf(handler);
+        if (index !== -1) listeners.splice(index, 1);
+      }),
+      dispatchEvent: jest.fn(),
+    } as unknown as MediaQueryList;
+
+    return mediaQueryList;
+  });
+
+  return {
+    matchMedia,
+    update(value: boolean) {
+      match = value;
+      listeners.forEach((listener) => listener({ matches: value }));
+    },
+  };
+};
 
 describe('theme persistence and unlocking', () => {
+  let originalMatchMedia: typeof window.matchMedia;
+
   beforeEach(() => {
     window.localStorage.clear();
     document.documentElement.dataset.theme = '';
+    delete document.documentElement.dataset.themePreference;
     document.documentElement.className = '';
+    document.documentElement.style.removeProperty('color-scheme');
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
   });
 
   test('theme persists across sessions', () => {
@@ -18,12 +71,13 @@ describe('theme persistence and unlocking', () => {
     expect(result.current.theme).toBe('dark');
     expect(getTheme()).toBe('dark');
     expect(window.localStorage.getItem('app:theme')).toBe('dark');
-
   });
 
   test('themes unlock at score milestones', () => {
     const unlocked = getUnlockedThemes(600);
-    expect(unlocked).toEqual(expect.arrayContaining(['default', 'neon', 'dark']));
+    expect(unlocked).toEqual(
+      expect.arrayContaining(['system', 'default', 'light', 'neon', 'dark'])
+    );
     expect(unlocked).not.toContain('matrix');
   });
 
@@ -37,13 +91,13 @@ describe('theme persistence and unlocking', () => {
   test('updates CSS variables without reload', () => {
     const style = document.createElement('style');
     style.innerHTML = `
-      :root { --color-bg: white; }
+      :root { --color-bg: grey; }
+      html[data-theme='light'] { --color-bg: white; }
       html[data-theme='dark'] { --color-bg: black; }
-      html[data-theme='neon'] { --color-bg: red; }
     `;
     document.head.appendChild(style);
 
-    setTheme('default');
+    setTheme('light');
     expect(
       getComputedStyle(document.documentElement).getPropertyValue('--color-bg')
     ).toBe('white');
@@ -52,21 +106,23 @@ describe('theme persistence and unlocking', () => {
     expect(
       getComputedStyle(document.documentElement).getPropertyValue('--color-bg')
     ).toBe('black');
-
-    setTheme('neon');
-    expect(
-      getComputedStyle(document.documentElement).getPropertyValue('--color-bg')
-    ).toBe('red');
   });
 
-  test('defaults to system preference when no stored theme', () => {
-    // simulate dark mode preference
-    // @ts-ignore
-    window.matchMedia = jest.fn().mockReturnValue({ matches: true });
-    expect(getTheme()).toBe('dark');
-    // simulate light mode preference
-    // @ts-ignore
-    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
-    expect(getTheme()).toBe('default');
+  test('system theme persists preference and follows OS changes', () => {
+    const { matchMedia, update } = createMatchMediaMock(false);
+    window.matchMedia = matchMedia as unknown as typeof window.matchMedia;
+
+    setTheme('system');
+    expect(getTheme()).toBe('system');
+    expect(window.localStorage.getItem('app:theme')).toBe('system');
+    expect(document.documentElement.dataset.themePreference).toBe('system');
+    expect(document.documentElement.dataset.theme).toBe('light');
+
+    update(true);
+    expect(document.documentElement.dataset.theme).toBe('dark');
+
+    update(false);
+    expect(document.documentElement.dataset.theme).toBe('light');
   });
 });
+

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -104,7 +104,7 @@ export default function Settings() {
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
-    setTheme("default");
+    setTheme("system");
   };
 
   const [showKeymap, setShowKeymap] = useState(false);
@@ -134,7 +134,9 @@ export default function Settings() {
               onChange={(e) => setTheme(e.target.value)}
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
             >
-              <option value="default">Default</option>
+              <option value="system">System (Auto)</option>
+              <option value="light">Light</option>
+              <option value="default">Kali</option>
               <option value="dark">Dark</option>
               <option value="neon">Neon</option>
               <option value="matrix">Matrix</option>

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -2,6 +2,15 @@ import { useState } from 'react';
 import { getUnlockedThemes } from '../utils/theme';
 import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
 
+const THEME_LABELS: Record<string, string> = {
+  system: 'System (Auto)',
+  default: 'Kali',
+  light: 'Light',
+  dark: 'Dark',
+  neon: 'Neon',
+  matrix: 'Matrix',
+};
+
 interface Props {
   highScore?: number;
 }
@@ -27,7 +36,7 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
             >
               {unlocked.map((t) => (
                 <option key={t} value={t}>
-                  {t}
+                  {THEME_LABELS[t] ?? t}
                 </option>
               ))}
             </select>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -76,7 +76,9 @@ export function Settings() {
                     onChange={(e) => setTheme(e.target.value)}
                     className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
                 >
-                    <option value="default">Default</option>
+                    <option value="system">System (Auto)</option>
+                    <option value="light">Light</option>
+                    <option value="default">Kali</option>
                     <option value="dark">Dark</option>
                     <option value="neon">Neon</option>
                     <option value="matrix">Matrix</option>
@@ -277,7 +279,7 @@ export function Settings() {
                         setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
-                        setTheme('default');
+                        setTheme('system');
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
                 >

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -24,7 +24,7 @@ import {
   setHaptics as saveHaptics,
   defaults,
 } from '../utils/settingsStore';
-import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import { getTheme as loadTheme, applyTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -94,7 +94,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
-  theme: 'default',
+  theme: 'system',
   setAccent: () => {},
   setWallpaper: () => {},
   setUseKaliWallpaper: () => {},

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { THEME_KEY, getTheme, setTheme as applyTheme } from '../utils/theme';
+import { THEME_KEY, getTheme, applyTheme } from '../utils/theme';
 
 export const useTheme = () => {
   const [theme, setThemeState] = useState<string>(() => getTheme());

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,23 +1,55 @@
 (function () {
   var THEME_KEY = 'app:theme';
+  var SYSTEM_THEME = 'system';
+  var DARK_THEMES = ['dark', 'neon', 'matrix'];
+  var PREFERS_DARK_QUERY = '(prefers-color-scheme: dark)';
+
+  function isDarkTheme(theme) {
+    return DARK_THEMES.indexOf(theme) !== -1;
+  }
+
+  function resolveSystemTheme() {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return 'light';
+    }
+    return window.matchMedia(PREFERS_DARK_QUERY).matches ? 'dark' : 'light';
+  }
+
+  function applyTheme(theme) {
+    if (typeof document === 'undefined') return;
+    var effective = theme === SYSTEM_THEME ? resolveSystemTheme() : theme;
+    document.documentElement.dataset.themePreference = theme;
+    document.documentElement.dataset.theme = effective;
+    var darkClassActive = isDarkTheme(effective);
+    var prefersDarkColors = effective !== 'light';
+    document.documentElement.classList.toggle('dark', darkClassActive);
+    document.documentElement.style.setProperty(
+      'color-scheme',
+      prefersDarkColors ? 'dark' : 'light'
+    );
+  }
+
   try {
     var stored = null;
     if (typeof window !== 'undefined' && typeof window.localStorage !== 'undefined') {
       stored = window.localStorage.getItem(THEME_KEY);
     }
+    var theme = stored || SYSTEM_THEME;
+    applyTheme(theme);
 
-    var prefersDark = false;
-    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
-      prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (theme === SYSTEM_THEME && typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      var media = window.matchMedia(PREFERS_DARK_QUERY);
+      var handler = function () {
+        applyTheme(SYSTEM_THEME);
+      };
+      if (typeof media.addEventListener === 'function') {
+        media.addEventListener('change', handler);
+      } else if (typeof media.addListener === 'function') {
+        media.addListener(handler);
+      }
     }
-
-    var theme = stored || (prefersDark ? 'dark' : 'default');
-    document.documentElement.dataset.theme = theme;
-    var darkThemes = ['dark', 'neon', 'matrix'];
-    document.documentElement.classList.toggle('dark', darkThemes.includes(theme));
   } catch (e) {
     console.error('Failed to apply theme', e);
-    document.documentElement.dataset.theme = 'default';
-    document.documentElement.classList.remove('dark');
+    applyTheme('default');
   }
 })();

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,6 +2,7 @@
 
 /* Accessible theme color palette meeting WCAG AA contrast ratios */
 :root {
+  color-scheme: dark;
   /* Base colors */
   --color-bg: #0f1317; /* kali background */
   --color-text: #f5f5f5; /* text on dark backgrounds */
@@ -25,12 +26,33 @@
 }
 
 body {
-  background: var(--kali-bg);
+  background: var(--kali-bg, var(--color-bg));
   color: var(--kali-text);
+}
+
+html[data-theme='light'] {
+  color-scheme: light;
+  --color-bg: #f5f7fb;
+  --color-text: #0f172a;
+  --color-primary: #2563eb;
+  --color-secondary: #e2e8f0;
+  --color-accent: var(--color-primary);
+  --color-muted: #e2e8f0;
+  --color-surface: #ffffff;
+  --color-inverse: #101b2d;
+  --color-border: #cbd5f5;
+  --color-terminal: #047857;
+  --color-dark: #e0e7ff;
+  --color-focus-ring: var(--color-primary);
+  --color-selection: color-mix(in srgb, var(--color-primary) 35%, white);
+  --color-control-accent: var(--color-primary);
+  --kali-text: #0f172a;
+  --kali-bg: rgba(245, 249, 252, 0.88);
 }
 
 /* Dark theme */
 html[data-theme='dark'] {
+  color-scheme: dark;
   --color-bg: #000000;
   --color-text: #e5e5e5;
   --color-primary: #1e88e5;
@@ -42,10 +64,15 @@ html[data-theme='dark'] {
   --color-border: #333333;
   --color-terminal: #00ff00;
   --color-dark: #0a0a0a;
+  --color-focus-ring: #1e88e5;
+  --color-selection: color-mix(in srgb, var(--color-primary) 55%, black);
+  --kali-bg: rgba(15, 19, 23, 0.92);
+  --kali-text: #e5e5e5;
 }
 
 /* Neon theme */
 html[data-theme='neon'] {
+  color-scheme: dark;
   --color-bg: #000000;
   --color-text: #ffffff;
   --color-primary: #39ff14;
@@ -57,10 +84,15 @@ html[data-theme='neon'] {
   --color-border: #333333;
   --color-terminal: #39ff14;
   --color-dark: #000000;
+  --color-focus-ring: #39ff14;
+  --color-selection: color-mix(in srgb, #39ff14 45%, black);
+  --kali-bg: rgba(0, 0, 0, 0.9);
+  --kali-text: #ffffff;
 }
 
 /* Matrix theme */
 html[data-theme='matrix'] {
+  color-scheme: dark;
   --color-bg: #000000;
   --color-text: #00ff00;
   --color-primary: #00ff00;
@@ -72,6 +104,10 @@ html[data-theme='matrix'] {
   --color-border: #003300;
   --color-terminal: #00ff00;
   --color-dark: #000000;
+  --color-focus-ring: #00ff00;
+  --color-selection: color-mix(in srgb, #00ff00 45%, black);
+  --kali-bg: rgba(0, 0, 0, 0.92);
+  --kali-text: #00ff00;
 
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -82,6 +82,24 @@
   --focus-outline-width: 2px;
 }
 
+html[data-theme='light'] {
+  --color-ub-grey: #f3f4f6;
+  --color-ub-warm-grey: #e0e0e0;
+  --color-ub-cool-grey: #cbd5e1;
+  --color-ub-orange: #2563eb;
+  --color-ub-lite-abrgn: #e2e8f0;
+  --color-ub-med-abrgn: #cbd5f5;
+  --color-ub-drk-abrgn: #94a3b8;
+  --color-ub-window-title: #1e293b;
+  --color-ub-dark-grey: #94a3b8;
+  --kali-bg: rgba(245, 249, 252, 0.88);
+  --kali-panel: rgba(255, 255, 255, 0.82);
+  --kali-panel-border: rgba(15, 23, 42, 0.12);
+  --kali-panel-highlight: rgba(148, 163, 184, 0.16);
+  --kali-terminal-green: #047857;
+  --kali-terminal-text: #0f172a;
+}
+
 /* High contrast theme */
 .high-contrast {
   --color-bg: #000000;

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -3,45 +3,105 @@ export const THEME_KEY = 'app:theme';
 // Score required to unlock each theme
 export const THEME_UNLOCKS: Record<string, number> = {
   default: 0,
+  light: 0,
   neon: 100,
   dark: 500,
   matrix: 1000,
 };
 
 const DARK_THEMES = ['dark', 'neon', 'matrix'] as const;
+const SYSTEM_THEME = 'system';
+const DEFAULT_THEME = SYSTEM_THEME;
+
+let systemMediaQuery: MediaQueryList | null = null;
+let systemListener: ((event?: MediaQueryListEvent) => void) | null = null;
+
+const prefersDarkQuery = '(prefers-color-scheme: dark)';
+
+const cleanupSystemListener = () => {
+  if (!systemMediaQuery || !systemListener) return;
+  if (typeof systemMediaQuery.removeEventListener === 'function') {
+    systemMediaQuery.removeEventListener('change', systemListener);
+  } else if (typeof systemMediaQuery.removeListener === 'function') {
+    systemMediaQuery.removeListener(systemListener);
+  }
+  systemMediaQuery = null;
+  systemListener = null;
+};
+
+const ensureSystemListener = () => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return;
+  }
+  cleanupSystemListener();
+  systemMediaQuery = window.matchMedia(prefersDarkQuery);
+  systemListener = () => applyDocumentTheme(SYSTEM_THEME);
+  if (typeof systemMediaQuery.addEventListener === 'function') {
+    systemMediaQuery.addEventListener('change', systemListener);
+  } else if (typeof systemMediaQuery.addListener === 'function') {
+    systemMediaQuery.addListener(systemListener);
+  }
+};
+
+const resolveSystemTheme = (): 'dark' | 'light' => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'light';
+  }
+  const query = window.matchMedia(prefersDarkQuery);
+  return query.matches ? 'dark' : 'light';
+};
+
+const applyDocumentTheme = (theme: string): void => {
+  if (typeof document === 'undefined') return;
+  const effective = theme === SYSTEM_THEME ? resolveSystemTheme() : theme;
+  document.documentElement.dataset.themePreference = theme;
+  document.documentElement.dataset.theme = effective;
+  const darkClassActive = isDarkTheme(effective);
+  const prefersDarkColors = effective !== 'light';
+  document.documentElement.classList.toggle('dark', darkClassActive);
+  document.documentElement.style.setProperty(
+    'color-scheme',
+    prefersDarkColors ? 'dark' : 'light'
+  );
+};
 
 export const isDarkTheme = (theme: string): boolean =>
   DARK_THEMES.includes(theme as (typeof DARK_THEMES)[number]);
 
 export const getTheme = (): string => {
-  if (typeof window === 'undefined') return 'default';
+  if (typeof window === 'undefined') return DEFAULT_THEME;
   try {
     const stored = window.localStorage.getItem(THEME_KEY);
     if (stored) return stored;
-    const prefersDark = window.matchMedia?.(
-      '(prefers-color-scheme: dark)'
-    ).matches;
-    return prefersDark ? 'dark' : 'default';
+    return DEFAULT_THEME;
   } catch {
-    return 'default';
+    return DEFAULT_THEME;
   }
 };
 
-export const setTheme = (theme: string): void => {
+export const applyTheme = (theme: string): void => {
   if (typeof window === 'undefined') return;
   try {
     window.localStorage.setItem(THEME_KEY, theme);
-    document.documentElement.dataset.theme = theme;
-    document.documentElement.classList.toggle('dark', isDarkTheme(theme));
+    if (theme === SYSTEM_THEME) {
+      ensureSystemListener();
+    } else {
+      cleanupSystemListener();
+    }
+    applyDocumentTheme(theme);
   } catch {
     /* ignore storage errors */
   }
 };
 
-export const getUnlockedThemes = (highScore: number): string[] =>
-  Object.entries(THEME_UNLOCKS)
+export const setTheme = applyTheme;
+
+export const getUnlockedThemes = (highScore: number): string[] => {
+  const unlocked = Object.entries(THEME_UNLOCKS)
     .filter(([, score]) => highScore >= score)
     .map(([theme]) => theme);
+  return ['system', ...new Set(unlocked)];
+};
 
 export const isThemeUnlocked = (theme: string, highScore: number): boolean =>
   highScore >= (THEME_UNLOCKS[theme] ?? Infinity);


### PR DESCRIPTION
## Summary
- add a system theme preference that persists, applies matchMedia listeners, and exposes a light theme option
- refresh global CSS variables/tokens so light, dark, neon, and matrix themes update colors, Tailwind classes, and color-scheme
- surface the new theme options in the settings UI components and expand the theme persistence tests for auto detection

## Testing
- yarn lint *(fails: existing jsx-a11y/no-top-level-window errors in untouched files)*
- yarn test *(fails: existing suite errors and act() warnings in untouched tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d53cf8b88328a40720670f6ad278