### PR TITLE
[ui] Standardize lucide icon usage

### DIFF
--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -8,6 +8,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { Bell } from 'lucide-react';
 import { useNotifications } from '../../hooks/useNotifications';
 
 const focusableSelector =
@@ -156,16 +157,7 @@ const NotificationBell: React.FC = () => {
         onClick={togglePanel}
         className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey transition focus:border-ubb-orange focus:outline-none focus:ring-0 hover:bg-white hover:bg-opacity-10"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          className="h-5 w-5"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path d="M10 2a4 4 0 00-4 4v1.09c0 .471-.158.93-.45 1.3L4.3 10.2A1 1 0 005 11.8h10a1 1 0 00.7-1.6l-1.25-1.81a2 2 0 01-.45-1.3V6a4 4 0 00-4-4z" />
-          <path d="M7 12a3 3 0 006 0H7z" />
-        </svg>
+        <Bell aria-hidden="true" focusable="false" className="h-5 w-5" />
         {unreadCount > 0 && (
           <span className="absolute -top-1.5 -right-1.5 min-w-[1.5rem] rounded-full bg-ubb-orange px-1 text-center text-[0.65rem] font-semibold leading-5 text-white">
             {unreadCount > 99 ? '99+' : unreadCount}

--- a/components/ui/VolumeControl.tsx
+++ b/components/ui/VolumeControl.tsx
@@ -1,17 +1,18 @@
 "use client";
 
-import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { LucideIcon } from "lucide-react";
+import { Volume, Volume1, Volume2, VolumeX } from "lucide-react";
 import usePersistentState from "../../hooks/usePersistentState";
 
-const ICONS = {
-  muted: "/themes/Yaru/status/audio-volume-muted-symbolic.svg",
-  low: "/themes/Yaru/status/audio-volume-low-symbolic.svg",
-  medium: "/themes/Yaru/status/audio-volume-medium-symbolic.svg",
-  high: "/themes/Yaru/status/audio-volume-high-symbolic.svg",
-} as const;
+type VolumeLevel = "muted" | "low" | "medium" | "high";
 
-type VolumeLevel = keyof typeof ICONS;
+const ICONS: Record<VolumeLevel, LucideIcon> = {
+  muted: VolumeX,
+  low: Volume,
+  medium: Volume1,
+  high: Volume2,
+};
 
 const clamp = (value: number) => Math.min(1, Math.max(0, value));
 
@@ -40,6 +41,7 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
     if (volume <= 0.66) return "medium";
     return "high";
   }, [volume]);
+  const VolumeIcon = ICONS[level];
 
   const setClampedVolume = useCallback(
     (value: number | ((current: number) => number)) => {
@@ -116,14 +118,11 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
         onClick={handleToggle}
         onPointerDown={(event) => event.stopPropagation()}
       >
-        <Image
-          width={16}
-          height={16}
-          src={ICONS[level]}
-          alt={`${level} volume`}
+        <VolumeIcon
+          aria-hidden="true"
+          focusable="false"
           className="status-symbol h-4 w-4"
-          draggable={false}
-          sizes="16px"
+          strokeWidth={2}
         />
       </button>
       {open && (

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import Image from 'next/image';
+import { BatteryFull, Wifi, WifiOff } from "lucide-react";
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
 import VolumeControl from '../ui/VolumeControl';
@@ -37,33 +37,51 @@ export default function Status() {
     };
   }, []);
 
+  const networkStatusLabel = online
+    ? allowNetwork
+      ? "Online"
+      : "Online (requests blocked)"
+    : "Offline";
+
   return (
     <div className="flex justify-center items-center">
       <span
-        className="mx-1.5 relative"
-        title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
+        className="mx-1.5 relative inline-flex"
+        role="img"
+        aria-label={networkStatusLabel}
+        title={networkStatusLabel}
       >
-        <Image
-          width={16}
-          height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
-          alt={online ? "online" : "offline"}
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
-        />
+        {online ? (
+          <Wifi
+            aria-hidden="true"
+            focusable="false"
+            className="status-symbol h-4 w-4"
+            strokeWidth={2}
+          />
+        ) : (
+          <WifiOff
+            aria-hidden="true"
+            focusable="false"
+            className="status-symbol h-4 w-4"
+            strokeWidth={2}
+          />
+        )}
         {!allowNetwork && (
-          <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
+          <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-red-500" aria-hidden="true" />
         )}
       </span>
       <VolumeControl className="mx-1.5" />
-      <span className="mx-1.5">
-        <Image
-          width={16}
-          height={16}
-          src="/themes/Yaru/status/battery-good-symbolic.svg"
-          alt="ubuntu battry"
-          className="inline status-symbol w-4 h-4"
-          sizes="16px"
+      <span
+        className="mx-1.5 inline-flex"
+        role="img"
+        aria-label="Battery level: good"
+        title="Battery level: good"
+      >
+        <BatteryFull
+          aria-hidden="true"
+          focusable="false"
+          className="status-symbol h-4 w-4"
+          strokeWidth={2}
         />
       </span>
       <span className="mx-1">

--- a/next.config.js
+++ b/next.config.js
@@ -206,6 +206,13 @@ try {
 module.exports = withBundleAnalyzer(
   withPWA({
     ...(isStaticExport && { output: 'export' }),
+    experimental: {
+      modularizeImports: {
+        'lucide-react': {
+          transform: 'lucide-react/dist/esm/icons/{{member}}',
+        },
+      },
+    },
     webpack: configureWebpack,
 
     // Temporarily ignore ESLint during builds; use only when a separate lint step runs in CI

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "jspdf": "^3.0.2",
     "kaitai-struct": "^0.10.0",
     "leaflet": "^1.9.4",
+    "lucide-react": "^0.544.0",
     "marked": "^16.2.1",
     "mathjs": "^14.6.0",
     "matter-js": "0.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9657,6 +9657,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lucide-react@npm:^0.544.0":
+  version: 0.544.0
+  resolution: "lucide-react@npm:0.544.0"
+  peerDependencies:
+    react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/2503f8cf65e62915997073b6053423bf8091b9470cb397560b417ef2f1628ea162c49e821b787cf153afb86828482d941f051c3f2aa642a1fa58c3de227e0113
+  languageName: node
+  linkType: hard
+
 "luxon@npm:^3.7.1":
   version: 3.7.1
   resolution: "luxon@npm:3.7.1"
@@ -13922,6 +13931,7 @@ __metadata:
     jspdf: "npm:^3.0.2"
     kaitai-struct: "npm:^0.10.0"
     leaflet: "npm:^1.9.4"
+    lucide-react: "npm:^0.544.0"
     magic-string: "npm:0.30.18"
     marked: "npm:^16.2.1"
     mathjs: "npm:^14.6.0"


### PR DESCRIPTION
## Summary
- adopt lucide-react as the shared icon set for desktop controls and notifications
- update status indicators and volume control to provide accessible labels for informative icons
- enable modularized lucide imports in Next.js for better tree shaking

## Testing
- yarn lint *(fails: existing accessibility violations in multiple legacy apps)*
- yarn test *(fails: pre-existing test regressions around Nmap NSE clipboard alerts and legacy class components)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d53e36cc8328b9abe2cd9b7476d1