### PR TITLE
[ui] Standardize elevation shadows

### DIFF
--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -90,7 +90,7 @@ const BadgeList = ({ badges, className = '' }) => {
         >
           <div
             ref={modalRef}
-            className="bg-white text-black p-4 rounded shadow max-w-sm"
+            className="bg-white text-black p-4 rounded shadow-elevation-4 max-w-sm"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="font-bold mb-2">{selected.label}</div>

--- a/components/apps/bluetooth/index.tsx
+++ b/components/apps/bluetooth/index.tsx
@@ -152,7 +152,7 @@ const BluetoothApp: React.FC = () => {
       </div>
       {showPermissionModal && (
         <div className="absolute inset-0 flex items-center justify-center bg-black/70">
-          <div className="w-64 rounded bg-gray-800 p-4 text-center">
+          <div className="w-64 rounded bg-gray-800 p-4 text-center shadow-elevation-4">
             <p className="mb-4">Allow access to Bluetooth devices?</p>
             <div className="flex justify-end gap-2">
               <button
@@ -180,7 +180,7 @@ const BluetoothApp: React.FC = () => {
       )}
       {pairingDevice && (
         <div className="absolute inset-0 flex items-center justify-center bg-black/70">
-          <div className="w-64 rounded bg-gray-800 p-4 text-center">
+          <div className="w-64 rounded bg-gray-800 p-4 text-center shadow-elevation-4">
             <p className="mb-4">
               Pair with {pairingDevice.name || pairingDevice.address}?
             </p>

--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -116,6 +116,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
             ref={modalRef}
             onKeyDown={handleKeyDown}
             tabIndex={-1}
+            className="shadow-elevation-4"
         >
             {children}
         </div>,

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -655,7 +655,7 @@ export class Window extends Component {
                             this.state.grabbed ? 'opacity-70' : '',
                             this.state.snapPreview ? 'ring-2 ring-blue-400' : '',
                             this.props.isFocused ? 'z-30' : 'z-20',
-                            'opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute flex flex-col window-shadow',
+                            'opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute flex flex-col',
                             styles.windowFrame,
                             this.props.isFocused ? styles.windowFrameActive : styles.windowFrameInactive,
                             this.state.maximized ? styles.windowFrameMaximized : '',

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -27,6 +27,10 @@
   opacity: 1;
 }
 
+.windowFrameActive {
+  box-shadow: var(--shadow-3);
+}
+
 .windowFrameInactive {
   filter: brightness(0.85);
 }

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -376,7 +376,7 @@ n
       {isVisible && (
         <div
           ref={menuRef}
-          className={`absolute left-0 mt-1 z-50 flex w-[520px] bg-ub-grey text-white shadow-lg rounded-md overflow-hidden transition-all duration-200 ease-out ${
+          className={`absolute left-0 mt-1 z-50 flex w-[520px] bg-ub-grey text-white shadow-elevation-2 rounded-md overflow-hidden transition-all duration-200 ease-out ${
             isOpen ? 'opacity-100 translate-y-0 scale-100' : 'pointer-events-none opacity-0 -translate-y-2 scale-95'
           }`}
           style={{ transitionDuration: `${TRANSITION_DURATION}ms` }}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -18,7 +18,7 @@ export default class Navbar extends Component {
 
         render() {
                 return (
-                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                        <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-elevation-1 flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
                                 <button
                                         type="button"
                                         aria-haspopup="true"

--- a/components/ui/DelayedTooltip.tsx
+++ b/components/ui/DelayedTooltip.tsx
@@ -136,7 +136,7 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
                 left: position.left,
                 zIndex: 1000,
               }}
-              className="pointer-events-none max-w-xs rounded-md border border-gray-500/60 bg-ub-grey/95 px-3 py-2 text-xs text-white shadow-xl backdrop-blur"
+              className="pointer-events-none max-w-xs rounded-md border border-gray-500/60 bg-ub-grey/95 px-3 py-2 text-xs text-white shadow-elevation-2 backdrop-blur"
             >
               {content}
             </div>,

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -180,7 +180,7 @@ const NotificationBell: React.FC = () => {
           aria-modal="false"
           aria-labelledby={headingId}
           tabIndex={-1}
-          className="absolute right-0 z-50 mt-2 w-72 max-h-96 overflow-hidden rounded-md border border-white/10 bg-ub-grey/95 text-ubt-grey shadow-xl backdrop-blur"
+          className="absolute right-0 z-50 mt-2 w-72 max-h-96 overflow-hidden rounded-md border border-white/10 bg-ub-grey/95 text-ubt-grey shadow-elevation-2 backdrop-blur"
         >
           <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
             <h2 id={headingId} className="text-sm font-semibold text-white">

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -23,7 +23,7 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow-elevation-2 border-black border border-opacity-20 ${
         open ? '' : 'hidden'
       }`}
     >

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -32,7 +32,7 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-elevation-2 flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
       <span>{message}</span>
       {onAction && actionLabel && (

--- a/components/ui/VolumeControl.tsx
+++ b/components/ui/VolumeControl.tsx
@@ -128,7 +128,7 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
       </button>
       {open && (
         <div
-          className="absolute bottom-full right-0 z-50 mb-2 min-w-[9rem] rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-2 text-xs text-white shadow-lg"
+          className="absolute bottom-full right-0 z-50 mb-2 min-w-[9rem] rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-2 text-xs text-white shadow-elevation-2"
           onClick={(event) => event.stopPropagation()}
           onPointerDown={(event) => event.stopPropagation()}
           onWheel={handleWheel}

--- a/docs/TASKS_UI_POLISH.md
+++ b/docs/TASKS_UI_POLISH.md
@@ -106,6 +106,16 @@ This document tracks UI polish tasks for the Kali/Ubuntu inspired desktop experi
     - **Accept:** 4 levels: dock, window inactive, active, modal; consistent blurs and offsets.
     - **Where:** CSS tokens.
 
+    | Token            | Utility class         | Intended surface          | Shadow value                                                                 |
+    | ---------------- | --------------------- | ------------------------- | ----------------------------------------------------------------------------- |
+    | `--shadow-0`     | `.shadow-elevation-0` | Flat surfaces / dock rail | `none`                                                                        |
+    | `--shadow-1`     | `.shadow-elevation-1` | Dock + pinned trays       | `0 1px 2px -1px color-mix(in srgb, var(--color-inverse), transparent 92%), 0 1px 4px 0 color-mix(in srgb, var(--color-inverse), transparent 94%)`             |
+    | `--shadow-2`     | `.shadow-elevation-2` | Menus, dropdown panels    | `0 6px 18px -4px color-mix(in srgb, var(--color-inverse), transparent 88%), 0 3px 8px -2px color-mix(in srgb, var(--color-inverse), transparent 90%)`         |
+    | `--shadow-3`     | `.shadow-elevation-3` | Active window chrome      | `0 12px 32px -6px color-mix(in srgb, var(--color-inverse), transparent 84%), 0 6px 16px -3px color-mix(in srgb, var(--color-inverse), transparent 88%)`       |
+    | `--shadow-4`     | `.shadow-elevation-4` | Modals & system dialogs   | `0 18px 48px -8px color-mix(in srgb, var(--color-inverse), transparent 80%), 0 12px 28px -6px color-mix(in srgb, var(--color-inverse), transparent 84%)`      |
+
+    > All values reuse `var(--color-inverse)` so they adapt automatically across light, dark, and neon themes. High contrast mode reduces elevation to focus outlines.
+
 25. **Accent color setting**
     - **Accept:** Choose from 6 accents; applies to focus, selection, controls; stored persistently.
     - **Where:** Settings app + CSS variables.

--- a/styles/index.css
+++ b/styles/index.css
@@ -104,10 +104,34 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
     --window-transform-y: 0px;
 }
 
-.window-shadow {
+.shadow-elevation-0 {
+    box-shadow: var(--shadow-0);
+    -webkit-box-shadow: var(--shadow-0);
+    -moz-box-shadow: var(--shadow-0);
+}
+
+.shadow-elevation-1 {
+    box-shadow: var(--shadow-1);
+    -webkit-box-shadow: var(--shadow-1);
+    -moz-box-shadow: var(--shadow-1);
+}
+
+.shadow-elevation-2 {
     box-shadow: var(--shadow-2);
     -webkit-box-shadow: var(--shadow-2);
     -moz-box-shadow: var(--shadow-2);
+}
+
+.shadow-elevation-3 {
+    box-shadow: var(--shadow-3);
+    -webkit-box-shadow: var(--shadow-3);
+    -moz-box-shadow: var(--shadow-3);
+}
+
+.shadow-elevation-4 {
+    box-shadow: var(--shadow-4);
+    -webkit-box-shadow: var(--shadow-4);
+    -moz-box-shadow: var(--shadow-4);
 }
 
 .closed-window {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -61,7 +61,15 @@
   --radius-round: 9999px;
 
   /* Elevation */
-  --shadow-2: 1px 4px 12px 4px color-mix(in srgb, var(--color-inverse), transparent 80%);
+  --shadow-0: none;
+  --shadow-1: 0 1px 2px -1px color-mix(in srgb, var(--color-inverse), transparent 92%),
+    0 1px 4px 0 color-mix(in srgb, var(--color-inverse), transparent 94%);
+  --shadow-2: 0 6px 18px -4px color-mix(in srgb, var(--color-inverse), transparent 88%),
+    0 3px 8px -2px color-mix(in srgb, var(--color-inverse), transparent 90%);
+  --shadow-3: 0 12px 32px -6px color-mix(in srgb, var(--color-inverse), transparent 84%),
+    0 6px 16px -3px color-mix(in srgb, var(--color-inverse), transparent 88%);
+  --shadow-4: 0 18px 48px -8px color-mix(in srgb, var(--color-inverse), transparent 80%),
+    0 12px 28px -6px color-mix(in srgb, var(--color-inverse), transparent 84%);
 
   /* Window chrome */
   --color-window-border: #0d1a2a;
@@ -97,6 +105,11 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --shadow-0: none;
+  --shadow-1: 0 0 0 1px var(--color-text);
+  --shadow-2: 0 0 0 1px var(--color-text);
+  --shadow-3: 0 0 0 2px var(--color-text);
+  --shadow-4: 0 0 0 3px var(--color-text);
 }
 
 /* Dyslexia-friendly fonts */


### PR DESCRIPTION
## Summary
- add a five-step elevation token scale and shared utility classes so shadows adapt to theme changes and high-contrast mode
- document the elevation mapping for designers and engineers in the UI polish guide
- update windows, desktop menus, and representative modals/toasts to consume the standardized shadow utilities

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations across legacy app stubs)*
- yarn test *(fails: pre-existing issues in nmapNse, Modal, taskbar, and desktopNameBar suites)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d5418028832892e2cf4b336c1342