### PR TITLE
[search] Add idle search refresh manager

### DIFF
--- a/__tests__/idleTaskManager.test.ts
+++ b/__tests__/idleTaskManager.test.ts
@@ -1,0 +1,69 @@
+import { createIdleTaskManager } from '../utils/idleTaskManager';
+
+const flushPromises = () => Promise.resolve();
+
+describe('idle task manager', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('runs the task after the idle timeout elapses', async () => {
+    const task = jest.fn().mockResolvedValue(undefined);
+    const manager = createIdleTaskManager(task, {
+      idleTimeout: 1000,
+      refreshInterval: 10_000,
+    });
+
+    jest.advanceTimersByTime(999);
+    expect(task).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+    expect(task).toHaveBeenCalledTimes(1);
+
+    manager.stop();
+  });
+
+  it('pauses on activity and resumes when the user is idle again', async () => {
+    const task = jest.fn().mockResolvedValue(undefined);
+    const manager = createIdleTaskManager(task, {
+      idleTimeout: 1000,
+      refreshInterval: 5_000,
+    });
+
+    window.dispatchEvent(new Event('mousemove'));
+    jest.advanceTimersByTime(500);
+    window.dispatchEvent(new Event('keydown'));
+    jest.advanceTimersByTime(500);
+    expect(task).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(500);
+    expect(task).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(500);
+    await flushPromises();
+    expect(task).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(4_999);
+    expect(task).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+    expect(task).toHaveBeenCalledTimes(2);
+
+    window.dispatchEvent(new Event('scroll'));
+    jest.advanceTimersByTime(4_999);
+    expect(task).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(1_001);
+    await flushPromises();
+    expect(task).toHaveBeenCalledTimes(3);
+
+    manager.stop();
+  });
+});

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -1,0 +1,106 @@
+import { buildAppMetadata, loadAppRegistry } from '../appRegistry';
+
+export interface SearchIndexEntry {
+  id: string;
+  title: string;
+  description: string;
+  path: string;
+  icon?: string;
+  keywords: string;
+}
+
+const STORAGE_KEY = 'app-search-index';
+
+let cache: SearchIndexEntry[] | null = null;
+const listeners = new Set<(entries: SearchIndexEntry[]) => void>();
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const readFromStorage = (): SearchIndexEntry[] => {
+  if (!isBrowser()) return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      cache = parsed as SearchIndexEntry[];
+      return cache;
+    }
+  } catch {
+    // ignore malformed storage entries
+  }
+  return [];
+};
+
+const writeToStorage = (entries: SearchIndexEntry[]) => {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // ignore quota errors
+  }
+};
+
+export const getSearchIndex = (): SearchIndexEntry[] => {
+  if (cache) return cache;
+  return readFromStorage();
+};
+
+export const subscribeToSearchIndex = (
+  listener: (entries: SearchIndexEntry[]) => void,
+): (() => void) => {
+  listeners.add(listener);
+  if (cache) {
+    listener(cache);
+  }
+  return () => listeners.delete(listener);
+};
+
+export const refreshSearchIndex = async (): Promise<SearchIndexEntry[]> => {
+  try {
+    const { apps, metadata } = await loadAppRegistry();
+    const entries: SearchIndexEntry[] = apps
+      .filter((app: any) => !app?.disabled)
+      .map((app: any) => {
+        const meta = metadata[app.id] ?? buildAppMetadata(app);
+        const keyboardHints = Array.isArray(meta.keyboard)
+          ? meta.keyboard.join(' ')
+          : '';
+        const entry: SearchIndexEntry = {
+          id: app.id,
+          title: meta.title,
+          description: meta.description,
+          path: meta.path,
+          icon: meta.icon,
+          keywords: [
+            app.id,
+            meta.title,
+            meta.description,
+            keyboardHints,
+          ]
+            .filter(Boolean)
+            .join(' ')
+            .toLowerCase(),
+        };
+        return entry;
+      });
+
+    cache = entries;
+    writeToStorage(entries);
+    listeners.forEach((listener) => listener(entries));
+    return entries;
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('Failed to refresh search index', error);
+    }
+    return cache ?? getSearchIndex();
+  }
+};
+
+export const SEARCH_INDEX_STORAGE_KEY = STORAGE_KEY;
+
+export default {
+  getSearchIndex,
+  refreshSearchIndex,
+  subscribeToSearchIndex,
+};

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -17,6 +17,8 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { refreshSearchIndex } from '../lib/search';
+import { createIdleTaskManager, idleTaskDefaults } from '../utils/idleTaskManager';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -79,6 +81,19 @@ function MyApp(props) {
         console.error('Service worker setup failed', err);
       });
     }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return () => {};
+
+    const manager = createIdleTaskManager(() => refreshSearchIndex(), {
+      idleTimeout: idleTaskDefaults.idleTimeout,
+      refreshInterval: idleTaskDefaults.refreshInterval,
+    });
+
+    return () => {
+      manager.stop();
+    };
   }, []);
 
   useEffect(() => {

--- a/utils/idleTaskManager.ts
+++ b/utils/idleTaskManager.ts
@@ -1,0 +1,156 @@
+export type IdleTask = () => void | Promise<void>;
+
+export interface IdleTaskManagerOptions {
+  /**
+   * Time in milliseconds of inactivity before the task runs.
+   * Defaults to 45 seconds.
+   */
+  idleTimeout?: number;
+  /**
+   * Minimum time in milliseconds between task executions while idle.
+   * Defaults to 15 minutes.
+   */
+  refreshInterval?: number;
+  /**
+   * Whether to start listening immediately. Defaults to true.
+   */
+  autoStart?: boolean;
+}
+
+export interface IdleTaskController {
+  start(): void;
+  stop(): void;
+}
+
+const DEFAULT_IDLE_TIMEOUT = 45_000;
+const DEFAULT_REFRESH_INTERVAL = 15 * 60 * 1000;
+
+const ACTIVITY_EVENTS: Array<keyof WindowEventMap> = [
+  'mousemove',
+  'mousedown',
+  'keydown',
+  'touchstart',
+  'pointerdown',
+  'scroll',
+  'focus',
+  'visibilitychange',
+];
+
+class BrowserIdleTaskManager implements IdleTaskController {
+  private readonly task: IdleTask;
+  private readonly idleTimeout: number;
+  private readonly refreshInterval: number;
+  private idleTimer: number | null = null;
+  private refreshTimer: number | null = null;
+  private running = false;
+  private started = false;
+
+  constructor(task: IdleTask, options: IdleTaskManagerOptions = {}) {
+    this.task = task;
+    this.idleTimeout = options.idleTimeout ?? DEFAULT_IDLE_TIMEOUT;
+    this.refreshInterval = options.refreshInterval ?? DEFAULT_REFRESH_INTERVAL;
+    if (options.autoStart !== false) {
+      this.start();
+    }
+  }
+
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.attachListeners();
+    this.resetIdleTimer();
+  }
+
+  stop(): void {
+    if (!this.started) return;
+    this.started = false;
+    this.clearTimers();
+    this.detachListeners();
+  }
+
+  private attachListeners(): void {
+    ACTIVITY_EVENTS.forEach((event) => {
+      window.addEventListener(event, this.handleActivity, { passive: true });
+    });
+  }
+
+  private detachListeners(): void {
+    ACTIVITY_EVENTS.forEach((event) => {
+      window.removeEventListener(event, this.handleActivity);
+    });
+  }
+
+  private readonly handleActivity = (): void => {
+    if (!this.started) return;
+    this.clearTimers();
+    this.resetIdleTimer();
+  };
+
+  private clearTimers(): void {
+    if (this.idleTimer !== null) {
+      window.clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+    if (this.refreshTimer !== null) {
+      window.clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  private resetIdleTimer(): void {
+    if (this.idleTimeout <= 0 || !this.started) return;
+    this.idleTimer = window.setTimeout(() => {
+      void this.onIdle();
+    }, this.idleTimeout);
+  }
+
+  private scheduleRefresh(): void {
+    if (this.refreshInterval <= 0 || !this.started) {
+      this.resetIdleTimer();
+      return;
+    }
+    this.refreshTimer = window.setTimeout(() => {
+      void this.onIdle();
+    }, this.refreshInterval);
+  }
+
+  private async onIdle(): Promise<void> {
+    if (this.running || !this.started) return;
+    this.clearTimers();
+    this.running = true;
+    try {
+      await this.task();
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('Idle task manager failed to run task', error);
+      }
+    } finally {
+      this.running = false;
+      if (this.started) {
+        this.scheduleRefresh();
+      }
+    }
+  }
+}
+
+class NoopIdleTaskManager implements IdleTaskController {
+  start(): void {}
+  stop(): void {}
+}
+
+export function createIdleTaskManager(
+  task: IdleTask,
+  options?: IdleTaskManagerOptions,
+): IdleTaskController {
+  if (typeof window === 'undefined') {
+    return new NoopIdleTaskManager();
+  }
+  return new BrowserIdleTaskManager(task, options);
+}
+
+export const idleTaskDefaults = {
+  idleTimeout: DEFAULT_IDLE_TIMEOUT,
+  refreshInterval: DEFAULT_REFRESH_INTERVAL,
+};
+
+export default createIdleTaskManager;


### PR DESCRIPTION
## Summary
- add a browser idle task manager utility to orchestrate background refresh work
- create a shared search index module that reuses the existing app registry metadata
- hook the manager into the app shell so search indexes refresh while idle and cover the behavior with tests

## Testing
- yarn lint *(fails: repository already has numerous accessibility violations)*
- yarn test *(fails: existing suites and environment issues; run interrupted after multiple failures)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d544ef748328868c118c51d2dbff