### PR TITLE
[desktop] Enable touch long press context menus

### DIFF
--- a/__tests__/useContextMenuLongPress.test.tsx
+++ b/__tests__/useContextMenuLongPress.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import useContextMenuLongPress from '../hooks/useContextMenuLongPress';
+
+const TestComponent: React.FC<{ delay?: number }> = ({ delay = 50 }) => {
+  useContextMenuLongPress({ delay });
+  return <div data-testid="pressable" data-context="app">Press me</div>;
+};
+
+describe('useContextMenuLongPress', () => {
+  beforeAll(() => {
+    if (!('PointerEvent' in window)) {
+      class PointerEventPolyfill extends MouseEvent {
+        pointerId: number;
+        pointerType: string;
+
+        constructor(type: string, props: any = {}) {
+          super(type, props);
+          this.pointerId = props.pointerId ?? 0;
+          this.pointerType = props.pointerType ?? 'mouse';
+        }
+      }
+
+      (window as unknown as { PointerEvent: typeof PointerEvent }).PointerEvent =
+        PointerEventPolyfill as unknown as typeof PointerEvent;
+    }
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('dispatches contextmenu after a sustained touch press', () => {
+    const { getByTestId } = render(<TestComponent />);
+    const target = getByTestId('pressable');
+    const handler = jest.fn();
+    target.addEventListener('contextmenu', handler);
+
+    fireEvent.pointerDown(target, {
+      pointerType: 'touch',
+      pointerId: 1,
+      clientX: 42,
+      clientY: 84,
+    });
+
+    expect(target).toHaveClass('context-menu-pressing');
+
+    jest.advanceTimersByTime(60);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(target).not.toHaveClass('context-menu-pressing');
+  });
+
+  it('cancels when the touch is released before the threshold', () => {
+    const { getByTestId } = render(<TestComponent />);
+    const target = getByTestId('pressable');
+    const handler = jest.fn();
+    target.addEventListener('contextmenu', handler);
+
+    fireEvent.pointerDown(target, {
+      pointerType: 'touch',
+      pointerId: 7,
+      clientX: 10,
+      clientY: 10,
+    });
+
+    expect(target).toHaveClass('context-menu-pressing');
+
+    fireEvent.pointerUp(target, { pointerType: 'touch', pointerId: 7 });
+
+    jest.advanceTimersByTime(60);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(target).not.toHaveClass('context-menu-pressing');
+  });
+
+  it('cleans up feedback on pointer cancellation', () => {
+    const { getByTestId } = render(<TestComponent />);
+    const target = getByTestId('pressable');
+    const handler = jest.fn();
+    target.addEventListener('contextmenu', handler);
+
+    fireEvent.pointerDown(target, {
+      pointerType: 'touch',
+      pointerId: 3,
+      clientX: 12,
+      clientY: 18,
+    });
+
+    expect(target).toHaveClass('context-menu-pressing');
+
+    fireEvent.pointerCancel(target, { pointerType: 'touch', pointerId: 3 });
+
+    jest.advanceTimersByTime(60);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(target).not.toHaveClass('context-menu-pressing');
+  });
+});

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -24,6 +24,7 @@ import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { addRecentApp } from '../../utils/recentStorage';
 import { useSnapSetting } from '../../hooks/usePersistentState';
+import useContextMenuLongPress from '../../hooks/useContextMenuLongPress';
 
 export class Desktop extends Component {
     constructor() {
@@ -1178,5 +1179,6 @@ export class Desktop extends Component {
 
 export default function DesktopWithSnap(props) {
     const [snapEnabled] = useSnapSetting();
+    useContextMenuLongPress();
     return <Desktop {...props} snapEnabled={snapEnabled} />;
 }

--- a/hooks/useContextMenuLongPress.ts
+++ b/hooks/useContextMenuLongPress.ts
@@ -1,0 +1,253 @@
+import { useEffect } from 'react';
+
+interface Options {
+  /** Duration in ms before a long press triggers */
+  delay?: number;
+  /** CSS class applied while a press is held */
+  activeClassName?: string;
+  /** Maximum pointer movement (px) before cancelling */
+  movementThreshold?: number;
+}
+
+const DEFAULT_DELAY = 650;
+const DEFAULT_CLASS = 'context-menu-pressing';
+const DEFAULT_THRESHOLD = 10;
+
+const useContextMenuLongPress = (
+  {
+    delay = DEFAULT_DELAY,
+    activeClassName = DEFAULT_CLASS,
+    movementThreshold = DEFAULT_THRESHOLD,
+  }: Options = {},
+) => {
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const doc = window.document;
+    let timer: number | null = null;
+    let target: HTMLElement | null = null;
+    let pointerId: number | null = null;
+    let lastPosition: {
+      clientX: number;
+      clientY: number;
+      screenX: number;
+      screenY: number;
+    } | null = null;
+    let originX = 0;
+    let originY = 0;
+    let pressSource: 'pointer' | 'touch' | null = null;
+
+    const cancelLongPress = () => {
+      if (timer !== null) {
+        window.clearTimeout(timer);
+        timer = null;
+      }
+      if (target) {
+        target.classList.remove(activeClassName);
+      }
+      target = null;
+      pointerId = null;
+      lastPosition = null;
+      pressSource = null;
+    };
+
+    const dispatchContextMenu = () => {
+      if (!target || !lastPosition) {
+        cancelLongPress();
+        return;
+      }
+
+      const el = target;
+      const { clientX, clientY, screenX, screenY } = lastPosition;
+
+      cancelLongPress();
+
+      const contextEvent = new MouseEvent('contextmenu', {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        button: 2,
+        buttons: 2,
+        clientX,
+        clientY,
+        screenX,
+        screenY,
+      });
+
+      el.dispatchEvent(contextEvent);
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (pressSource !== 'pointer' || pointerId === null || event.pointerId !== pointerId) return;
+      lastPosition = {
+        clientX: event.clientX,
+        clientY: event.clientY,
+        screenX: event.screenX,
+        screenY: event.screenY,
+      };
+      if (
+        Math.abs(event.clientX - originX) > movementThreshold ||
+        Math.abs(event.clientY - originY) > movementThreshold
+      ) {
+        cancelLongPress();
+      }
+    };
+
+    const handlePointerUp = (event: PointerEvent) => {
+      if (pressSource !== 'pointer' || pointerId === null || event.pointerId !== pointerId) return;
+      cancelLongPress();
+    };
+
+    const beginPress = (
+      element: HTMLElement,
+      position: { clientX: number; clientY: number; screenX: number; screenY: number },
+      id: number | null,
+      source: 'pointer' | 'touch',
+    ) => {
+      cancelLongPress();
+
+      target = element;
+      pointerId = typeof id === 'number' ? id : null;
+      originX = position.clientX;
+      originY = position.clientY;
+      lastPosition = position;
+      pressSource = source;
+
+      element.classList.add(activeClassName);
+
+      timer = window.setTimeout(() => {
+        timer = null;
+        dispatchContextMenu();
+      }, delay);
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (event.pointerType !== 'touch' && event.pointerType !== 'pen') {
+        return;
+      }
+
+      if (typeof event.button === 'number' && event.button > 0) {
+        return;
+      }
+
+      const candidate = (event.target as HTMLElement | null)?.closest('[data-context]') as
+        | HTMLElement
+        | null;
+      if (!candidate) {
+        return;
+      }
+
+      beginPress(
+        candidate,
+        {
+          clientX: event.clientX,
+          clientY: event.clientY,
+          screenX: event.screenX,
+          screenY: event.screenY,
+        },
+        event.pointerId,
+        'pointer',
+      );
+    };
+
+    const findTouchById = (touches: TouchList): Touch | null => {
+      if (touches.length === 0) return null;
+      if (pointerId === null) return touches.item(0);
+      for (let i = 0; i < touches.length; i += 1) {
+        const touch = touches.item(i);
+        if (touch && touch.identifier === pointerId) {
+          return touch;
+        }
+      }
+      return null;
+    };
+
+    const handleTouchStart = (event: TouchEvent) => {
+      const candidate = (event.target as HTMLElement | null)?.closest('[data-context]') as
+        | HTMLElement
+        | null;
+      if (!candidate) {
+        return;
+      }
+
+      const touch = event.touches.item(0);
+      if (!touch) {
+        return;
+      }
+
+      beginPress(
+        candidate,
+        {
+          clientX: touch.clientX,
+          clientY: touch.clientY,
+          screenX: touch.screenX,
+          screenY: touch.screenY,
+        },
+        touch.identifier,
+        'touch',
+      );
+    };
+
+    const handleTouchMove = (event: TouchEvent) => {
+      if (pressSource !== 'touch') return;
+      const touch = findTouchById(event.touches);
+      if (!touch) {
+        cancelLongPress();
+        return;
+      }
+
+      lastPosition = {
+        clientX: touch.clientX,
+        clientY: touch.clientY,
+        screenX: touch.screenX,
+        screenY: touch.screenY,
+      };
+
+      if (
+        Math.abs(touch.clientX - originX) > movementThreshold ||
+        Math.abs(touch.clientY - originY) > movementThreshold
+      ) {
+        cancelLongPress();
+      }
+    };
+
+    const handleTouchEnd = (event: TouchEvent) => {
+      if (pressSource !== 'touch') return;
+      if (pointerId === null) {
+        cancelLongPress();
+        return;
+      }
+      for (let i = 0; i < event.changedTouches.length; i += 1) {
+        const touch = event.changedTouches.item(i);
+        if (touch && touch.identifier === pointerId) {
+          cancelLongPress();
+          break;
+        }
+      }
+    };
+
+    doc.addEventListener('pointerdown', handlePointerDown, { passive: true });
+    doc.addEventListener('pointermove', handlePointerMove, { passive: true });
+    doc.addEventListener('pointerup', handlePointerUp, { passive: true });
+    doc.addEventListener('pointercancel', handlePointerUp, { passive: true });
+    doc.addEventListener('touchstart', handleTouchStart, { passive: true });
+    doc.addEventListener('touchmove', handleTouchMove, { passive: true });
+    doc.addEventListener('touchend', handleTouchEnd, { passive: true });
+    doc.addEventListener('touchcancel', handleTouchEnd, { passive: true });
+
+    return () => {
+      doc.removeEventListener('pointerdown', handlePointerDown);
+      doc.removeEventListener('pointermove', handlePointerMove);
+      doc.removeEventListener('pointerup', handlePointerUp);
+      doc.removeEventListener('pointercancel', handlePointerUp);
+      doc.removeEventListener('touchstart', handleTouchStart);
+      doc.removeEventListener('touchmove', handleTouchMove);
+      doc.removeEventListener('touchend', handleTouchEnd);
+      doc.removeEventListener('touchcancel', handleTouchEnd);
+      cancelLongPress();
+    };
+  }, [delay, activeClassName, movementThreshold]);
+};
+
+export default useContextMenuLongPress;
+

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -99,3 +99,9 @@ html {
   background-color: var(--kali-border, var(--color-border));
   border-radius: 6px;
 }
+
+[data-context].context-menu-pressing {
+  transition: filter 0.12s ease, box-shadow 0.12s ease;
+  filter: brightness(1.08);
+  box-shadow: 0 0 0 2px var(--color-focus-ring, var(--kali-blue));
+}


### PR DESCRIPTION
## Summary
- add a reusable `useContextMenuLongPress` hook that dispatches context menus after a sustained touch or pen press
- integrate the hook into the desktop shell and add visual feedback while a press is held
- cover long-press activation, release, and cancellation flows with new unit tests

## Testing
- yarn lint *(fails: repository has hundreds of pre-existing accessibility errors across app suites)*
- yarn test *(fails: numerous legacy suites such as __tests__/nmapNse.test.tsx, __tests__/taskbar.test.tsx, and __tests__/desktopNameBar.test.tsx)*
- yarn test --runTestsByPath __tests__/useContextMenuLongPress.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d6d5477f1c8328abf9b5aef16db61b