### PR TITLE
[desktop] Improve mobile windowing experience

### DIFF
--- a/__tests__/mobileAppSwitcher.test.tsx
+++ b/__tests__/mobileAppSwitcher.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MobileAppSwitcher from '../components/screen/mobile-app-switcher';
+
+jest.mock('next/image', () => ({ __esModule: true, default: (props: any) => <img {...props} /> }));
+
+describe('MobileAppSwitcher', () => {
+  it('cycles between windows and calls onSelect', () => {
+    const onSelect = jest.fn();
+    const onOpenApps = jest.fn();
+    const onOpenSwitcher = jest.fn();
+    render(
+      <MobileAppSwitcher
+        windows={[
+          { id: 'terminal', title: 'Terminal', icon: '/terminal.png' },
+          { id: 'browser', title: 'Browser', icon: '/browser.png' },
+          { id: 'editor', title: 'Editor', icon: '/editor.png' },
+        ]}
+        activeId="browser"
+        onSelect={onSelect}
+        onOpenApplications={onOpenApps}
+        onOpenSwitcher={onOpenSwitcher}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /switch window \(browser\)/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /next app/i }));
+    expect(onSelect).toHaveBeenCalledWith('editor');
+
+    fireEvent.click(screen.getByRole('button', { name: /previous app/i }));
+    expect(onSelect).toHaveBeenCalledWith('terminal');
+
+    fireEvent.click(screen.getByRole('button', { name: /show applications/i }));
+    expect(onOpenApps).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /switch window/i }));
+    expect(onOpenSwitcher).toHaveBeenCalled();
+  });
+
+  it('disables controls when no windows are open', () => {
+    const onSelect = jest.fn();
+    const onOpenApps = jest.fn();
+    const onOpenSwitcher = jest.fn();
+    render(
+      <MobileAppSwitcher
+        windows={[]}
+        activeId={null}
+        onSelect={onSelect}
+        onOpenApplications={onOpenApps}
+        onOpenSwitcher={onOpenSwitcher}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /previous app/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /next app/i })).toBeDisabled();
+
+    const switcherButton = screen.getByRole('button', { name: /no apps open/i });
+    expect(switcherButton).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /show applications/i }));
+    expect(onOpenApps).toHaveBeenCalled();
+    expect(onOpenSwitcher).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -51,6 +51,51 @@ describe('Window lifecycle', () => {
   });
 });
 
+describe('Window mobile layout', () => {
+  it('expands to full screen on mobile', () => {
+    const { container } = render(
+      <Window
+        id="mobile-window"
+        title="Mobile"
+        screen={() => <div>mobile</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        isMobile
+        isMobileActive
+      />
+    );
+
+    const element = container.querySelector('#mobile-window') as HTMLElement;
+    expect(element).toHaveStyle({ width: '100%', height: '100%' });
+    expect(element.className).toMatch(/fixed/);
+  });
+
+  it('hides inactive windows on mobile', () => {
+    const { container } = render(
+      <Window
+        id="mobile-window-hidden"
+        title="Hidden"
+        screen={() => <div>hidden</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={() => {}}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        isMobile
+        isMobileActive={false}
+      />
+    );
+
+    const element = container.querySelector('#mobile-window-hidden') as HTMLElement;
+    expect(element).toHaveAttribute('aria-hidden', 'true');
+    expect(element).toHaveStyle({ display: 'none' });
+    expect(element.tabIndex).toBe(-1);
+  });
+});
+
 describe('Window snapping preview', () => {
   it('shows preview when dragged near left edge', () => {
     setViewport(1920, 1080);

--- a/components/screen/mobile-app-switcher.tsx
+++ b/components/screen/mobile-app-switcher.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import Image from 'next/image';
+
+type WindowMeta = {
+  id: string;
+  title: string;
+  icon?: string;
+};
+
+interface MobileAppSwitcherProps {
+  windows: WindowMeta[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onOpenApplications: () => void;
+  onOpenSwitcher: () => void;
+}
+
+function normaliseIconPath(icon?: string) {
+  if (!icon) return undefined;
+  return icon.startsWith('./') ? icon.replace('./', '/') : icon;
+}
+
+const MobileAppSwitcher: React.FC<MobileAppSwitcherProps> = ({
+  windows,
+  activeId,
+  onSelect,
+  onOpenApplications,
+  onOpenSwitcher,
+}) => {
+  const activeIndex = activeId ? windows.findIndex((window) => window.id === activeId) : -1;
+  const hasActive = activeIndex >= 0;
+  const activeWindow = hasActive ? windows[activeIndex] : null;
+  const cycleAvailable = hasActive && windows.length > 1;
+
+  const getRelativeId = (offset: number) => {
+    if (!hasActive) return null;
+    const index = (activeIndex + offset + windows.length) % windows.length;
+    return windows[index]?.id ?? null;
+  };
+
+  const previousId = cycleAvailable ? getRelativeId(-1) : null;
+  const nextId = cycleAvailable ? getRelativeId(1) : null;
+
+  const handleSelect = (id: string | null) => {
+    if (!id) return;
+    onSelect(id);
+  };
+
+  const activeIcon = normaliseIconPath(activeWindow?.icon);
+
+  return (
+    <header
+      data-testid="mobile-app-switcher"
+      className="md:hidden fixed top-0 left-0 right-0 z-50 flex items-center gap-3 px-4 py-2 bg-black bg-opacity-70 backdrop-blur text-white"
+    >
+      <button
+        type="button"
+        aria-label="Show applications"
+        onClick={onOpenApplications}
+        className="flex items-center gap-2 rounded-full bg-white bg-opacity-10 px-3 py-1 text-sm font-medium"
+      >
+        <Image
+          src="/themes/Yaru/system/view-app-grid-symbolic.svg"
+          alt="Open applications"
+          width={20}
+          height={20}
+          className="h-5 w-5"
+          sizes="20px"
+        />
+      </button>
+      <div className="flex flex-1 items-center justify-center gap-2">
+        <button
+          type="button"
+          aria-label="Previous app"
+          onClick={() => handleSelect(previousId)}
+          disabled={!previousId}
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-white bg-opacity-10 text-lg disabled:opacity-40"
+        >
+          ‹
+        </button>
+        <button
+          type="button"
+          aria-label={activeWindow ? `Switch window (${activeWindow.title})` : 'No apps open'}
+          onClick={windows.length ? onOpenSwitcher : undefined}
+          disabled={!windows.length}
+          className="flex min-w-[8rem] flex-1 items-center justify-center gap-2 rounded-full bg-white bg-opacity-10 px-3 py-1 text-sm font-semibold disabled:opacity-40"
+        >
+          {activeIcon && (
+            <Image src={activeIcon} alt="" width={20} height={20} className="h-5 w-5" sizes="20px" />
+          )}
+          <span className="truncate text-sm font-medium">
+            {activeWindow ? activeWindow.title : 'No apps open'}
+          </span>
+        </button>
+        <button
+          type="button"
+          aria-label="Next app"
+          onClick={() => handleSelect(nextId)}
+          disabled={!nextId}
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-white bg-opacity-10 text-lg disabled:opacity-40"
+        >
+          ›
+        </button>
+      </div>
+    </header>
+  );
+};
+
+export default MobileAppSwitcher;

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -25,57 +25,44 @@ export default function Taskbar(props) {
                 onSelect={props.onSelectWorkspace}
             />
             <div className="flex items-center overflow-x-auto">
-                {runningApps.map(app => (
+                {runningApps.map(app => {
+                    const isMinimized = Boolean(props.minimized_windows[app.id]);
+                    const isFocused = Boolean(props.focused_windows[app.id]);
+                    const isActive = !isMinimized;
 
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => {
-                const isMinimized = Boolean(props.minimized_windows[app.id]);
-                const isFocused = Boolean(props.focused_windows[app.id]);
-                const isActive = !isMinimized;
-
-                return (
-                    <button
-                        key={app.id}
-                        type="button"
-                        aria-label={app.title}
-                        data-context="taskbar"
-                        data-app-id={app.id}
-                        onClick={() => handleClick(app)}
-                        className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        aria-pressed={isActive}
-                        data-context="taskbar"
-                        data-app-id={app.id}
-                        data-active={isActive ? 'true' : 'false'}
-                        onClick={() => handleClick(app)}
-                        className={(isFocused && isActive ? ' bg-white bg-opacity-20 ' : ' ') +
-                            'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                    >
-                        <Image
-                            width={24}
-                            height={24}
-                            className="w-5 h-5"
-                            src={app.icon.replace('./', '/')}
-                            alt=""
-                            sizes="24px"
-                        />
-                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                        {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                        )}
-                    </button>
-                ))}
-            </div>
-
-                        {isActive && (
-                            <span
-                                aria-hidden="true"
-                                data-testid="running-indicator"
-                                className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded"
+                    return (
+                        <button
+                            key={app.id}
+                            type="button"
+                            aria-label={app.title}
+                            aria-pressed={isActive}
+                            data-context="taskbar"
+                            data-app-id={app.id}
+                            data-active={isActive ? 'true' : 'false'}
+                            onClick={() => handleClick(app)}
+                            className={(isFocused && isActive ? ' bg-white bg-opacity-20 ' : ' ') +
+                                'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
+                        >
+                            <Image
+                                width={24}
+                                height={24}
+                                className="w-5 h-5"
+                                src={app.icon.replace('./', '/')}
+                                alt=""
+                                sizes="24px"
                             />
-                        )}
-                    </button>
-                );
-            })}
+                            <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                            {isActive && (
+                                <span
+                                    aria-hidden="true"
+                                    data-testid="running-indicator"
+                                    className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded"
+                                />
+                            )}
+                        </button>
+                    );
+                })}
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- adjust the desktop shell to detect mobile viewports, hide the dock/taskbar, and show a header-based MobileAppSwitcher with swipe gestures
- update the shared Window component to expand to a fullscreen, non-draggable frame on mobile while hiding inactive windows
- add focused tests covering the mobile window behaviour and the new switcher component

## Testing
- yarn lint *(fails: repository already contains hundreds of existing jsx-a11y/no-top-level-window violations)*
- yarn test *(fails: existing suites such as nmapNse, taskbar, desktopNameBar, etc. break before the new tests can complete)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d5481ca483289d15bea876e73e46