### PR TITLE
[mobile] improve mobile form keyboard handling

### DIFF
--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -8,6 +8,7 @@ import { contactSchema } from "../../utils/contactSchema";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openMailto } from "../../utils/mailto";
 import { trackEvent } from "@/lib/analytics-client";
+import { useMobileInputSafeArea } from "@/hooks/useMobileInputSafeArea";
 
 const DRAFT_KEY = "contact-draft";
 const EMAIL = "alex.unnippillil@hotmail.com";
@@ -24,6 +25,7 @@ const getRecaptchaToken = (siteKey: string): Promise<string> =>
   });
 
 const ContactApp: React.FC = () => {
+  const safeAreaRef = useMobileInputSafeArea<HTMLDivElement>();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [message, setMessage] = useState("");
@@ -120,7 +122,10 @@ const ContactApp: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-900 text-white p-4">
+    <div
+      ref={safeAreaRef}
+      className="min-h-screen bg-gray-900 text-white p-4"
+    >
       <h1 className="mb-4 text-2xl">Contact</h1>
       <p className="mb-4 text-sm">
         Prefer email?{" "}

--- a/apps/http/index.tsx
+++ b/apps/http/index.tsx
@@ -2,14 +2,19 @@
 
 import React, { useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import { useMobileInputSafeArea } from '@/hooks/useMobileInputSafeArea';
 
 const HTTPBuilder: React.FC = () => {
+  const safeAreaRef = useMobileInputSafeArea<HTMLDivElement>();
   const [method, setMethod] = useState('GET');
   const [url, setUrl] = useState('');
   const command = `curl -X ${method} ${url}`.trim();
 
   return (
-    <div className="h-full bg-gray-900 p-4 text-white overflow-auto">
+    <div
+      ref={safeAreaRef}
+      className="h-full bg-gray-900 p-4 text-white overflow-auto"
+    >
       <h1 className="mb-4 text-2xl">HTTP Request Builder</h1>
       <p className="mb-4 text-sm text-yellow-300">
         Build a curl command without sending any requests. Learn more at{' '}

--- a/apps/input-lab/index.tsx
+++ b/apps/input-lab/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { z } from 'zod';
+import { useMobileInputSafeArea } from '@/hooks/useMobileInputSafeArea';
 
 const SAVE_KEY = 'input-lab:text';
 
@@ -10,6 +11,7 @@ const schema = z.object({
 });
 
 export default function InputLab() {
+  const safeAreaRef = useMobileInputSafeArea<HTMLDivElement>();
   const [text, setText] = useState('');
   const [error, setError] = useState('');
   const [status, setStatus] = useState('');
@@ -70,7 +72,10 @@ export default function InputLab() {
   }, [text]);
 
   return (
-    <div className="min-h-screen bg-gray-900 p-4 text-white">
+    <div
+      ref={safeAreaRef}
+      className="min-h-screen bg-gray-900 p-4 text-white"
+    >
       <h1 className="mb-4 text-2xl">Input Lab</h1>
       <form onSubmit={(e) => e.preventDefault()} className="space-y-4">
         <div>

--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -2,15 +2,20 @@
 
 import React, { useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import { useMobileInputSafeArea } from '@/hooks/useMobileInputSafeArea';
 
 const SSHBuilder: React.FC = () => {
+  const safeAreaRef = useMobileInputSafeArea<HTMLDivElement>();
   const [user, setUser] = useState('');
   const [host, setHost] = useState('');
   const [port, setPort] = useState('');
   const command = `ssh ${user ? `${user}@` : ''}${host}${port ? ` -p ${port}` : ''}`.trim();
 
   return (
-    <div className="h-full bg-gray-900 p-4 text-white overflow-auto">
+    <div
+      ref={safeAreaRef}
+      className="h-full bg-gray-900 p-4 text-white overflow-auto"
+    >
       <h1 className="mb-4 text-2xl">SSH Command Builder</h1>
       <p className="mb-4 text-sm text-yellow-300">
         Generate an SSH command without executing it. Learn more at{' '}

--- a/apps/subnet-calculator/index.tsx
+++ b/apps/subnet-calculator/index.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react';
 import type { HostRange } from '../../modules/networking/subnet';
 import { calculateSubnetInfo } from '../../modules/networking/subnet';
+import { useMobileInputSafeArea } from '@/hooks/useMobileInputSafeArea';
 
 const formatHostRange = (range: HostRange) => {
   if (!range.firstHost || !range.lastHost) {
@@ -27,6 +28,7 @@ const Stat = ({ label, value }: StatProps) => (
 );
 
 const SubnetCalculator = () => {
+  const safeAreaRef = useMobileInputSafeArea<HTMLDivElement>();
   const [ipAddress, setIpAddress] = useState('192.168.1.10');
   const [cidrInput, setCidrInput] = useState('24');
 
@@ -59,7 +61,10 @@ const SubnetCalculator = () => {
   }, [ipAddress, cidrInput]);
 
   return (
-    <div className="h-full w-full overflow-auto bg-ub-cool-grey text-white">
+    <div
+      ref={safeAreaRef}
+      className="h-full w-full overflow-auto bg-ub-cool-grey text-white"
+    >
       <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-6">
         <header className="space-y-2">
           <h1 className="text-3xl font-semibold">Subnet Calculator</h1>

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -9,6 +9,7 @@ import AttachmentUploader, {
   MAX_TOTAL_ATTACHMENT_SIZE,
 } from '../../../apps/contact/components/AttachmentUploader';
 import AttachmentCarousel from '../../../apps/contact/components/AttachmentCarousel';
+import { useMobileInputSafeArea } from '@/hooks/useMobileInputSafeArea';
 
 const sanitize = (str: string) =>
   str.replace(/[&<>"']/g, (c) => ({
@@ -140,6 +141,7 @@ const uploadAttachments = async (files: File[]) => {
 };
 
 const ContactApp: React.FC = () => {
+  const safeAreaRef = useMobileInputSafeArea<HTMLDivElement>();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
@@ -261,7 +263,7 @@ const ContactApp: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-900 text-white p-6">
+    <div ref={safeAreaRef} className="min-h-screen bg-gray-900 text-white p-6">
       <h1 className="mb-6 text-2xl">Contact</h1>
       {banner && (
         <div

--- a/hooks/useMobileInputSafeArea.ts
+++ b/hooks/useMobileInputSafeArea.ts
@@ -1,0 +1,136 @@
+import { useCallback, useRef } from 'react';
+
+type Cleanup = () => void;
+
+type ScrollTarget = HTMLElement & {
+  scrollIntoView: (options?: boolean | ScrollIntoViewOptions) => void;
+};
+
+const MOBILE_WIDTH = 900;
+
+const isFocusableInput = (element: Element | null): element is ScrollTarget => {
+  if (!element || !(element instanceof HTMLElement)) return false;
+  if (element.hasAttribute('data-ignore-safe-area')) return false;
+
+  const tagName = element.tagName;
+  if (tagName === 'INPUT') {
+    const type = element.getAttribute('type');
+    if (type && ['hidden', 'range', 'checkbox', 'radio', 'file'].includes(type)) {
+      return false;
+    }
+    return true;
+  }
+
+  return tagName === 'TEXTAREA' || tagName === 'SELECT' || element.isContentEditable;
+};
+
+const supportsCoarsePointer = () => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  try {
+    return window.matchMedia('(pointer:coarse)').matches;
+  } catch {
+    return false;
+  }
+};
+
+const getEnvFallback = () => {
+  if (typeof CSS !== 'undefined' && typeof CSS.supports === 'function') {
+    if (CSS.supports('padding-bottom', 'env(safe-area-inset-bottom)')) {
+      return 'env(safe-area-inset-bottom, 0px)';
+    }
+  }
+  return '0px';
+};
+
+/**
+ * Adds keyboard-safe bottom padding for mobile form containers and
+ * scrolls focused inputs into view when the on-screen keyboard appears.
+ */
+export const useMobileInputSafeArea = <T extends HTMLElement>() => {
+  const cleanupRef = useRef<Cleanup>();
+  const basePaddingRef = useRef<number>(0);
+  const envFallback = getEnvFallback();
+
+  const setRef = useCallback((node: T | null) => {
+    cleanupRef.current?.();
+    cleanupRef.current = undefined;
+
+    if (
+      !node ||
+      typeof window === 'undefined' ||
+      process.env.NODE_ENV === 'test'
+    ) {
+      return;
+    }
+
+    const viewport = window.visualViewport;
+    const pointerCoarse = supportsCoarsePointer();
+    const isMobileViewport = () => window.innerWidth <= MOBILE_WIDTH || (viewport ? viewport.width <= MOBILE_WIDTH : false);
+
+    if (!pointerCoarse && !isMobileViewport()) {
+      return;
+    }
+
+    const computedStyles = window.getComputedStyle(node);
+    basePaddingRef.current = Number.parseFloat(computedStyles.paddingBottom || '0') || 0;
+
+    const applyPadding = () => {
+      if (!node) return;
+      const keyboardOffset = viewport
+        ? Math.max(0, Math.round(window.innerHeight - viewport.height))
+        : 0;
+
+      node.style.setProperty('--mobile-safe-area-bottom', `${keyboardOffset}px`);
+      node.style.setProperty('--mobile-safe-base-padding', `${basePaddingRef.current}px`);
+      const paddingExpression = `calc(var(--mobile-safe-base-padding, 0px) + var(--mobile-safe-area-bottom, 0px) + ${envFallback})`;
+      node.style.paddingBottom = paddingExpression;
+    };
+
+    const schedulePadding = () => window.requestAnimationFrame(applyPadding);
+
+    const handleFocus = (event: FocusEvent) => {
+      const target = event.target as Element | null;
+      if (!target || !node.contains(target) || !isFocusableInput(target)) {
+        return;
+      }
+
+      schedulePadding();
+      window.requestAnimationFrame(() => {
+        const element = target as ScrollTarget;
+        if (typeof element.scrollIntoView !== 'function') return;
+        try {
+          element.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'smooth' });
+        } catch {
+          element.scrollIntoView();
+        }
+      });
+    };
+
+    applyPadding();
+
+    viewport?.addEventListener('resize', schedulePadding);
+    viewport?.addEventListener('scroll', schedulePadding);
+    window.addEventListener('resize', schedulePadding);
+    window.addEventListener('orientationchange', schedulePadding);
+    document.addEventListener('focusin', handleFocus, { passive: true });
+
+    cleanupRef.current = () => {
+      viewport?.removeEventListener('resize', schedulePadding);
+      viewport?.removeEventListener('scroll', schedulePadding);
+      window.removeEventListener('resize', schedulePadding);
+      window.removeEventListener('orientationchange', schedulePadding);
+      document.removeEventListener('focusin', handleFocus);
+      if (node) {
+        node.style.removeProperty('padding-bottom');
+        node.style.removeProperty('--mobile-safe-area-bottom');
+        node.style.removeProperty('--mobile-safe-base-padding');
+      }
+    };
+  }, [envFallback]);
+
+  return setRef;
+};
+
+export default useMobileInputSafeArea;

--- a/pages/dummy-form.tsx
+++ b/pages/dummy-form.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import FormError from '../components/ui/FormError';
+import { useMobileInputSafeArea } from '@/hooks/useMobileInputSafeArea';
 
 const STORAGE_KEY = 'dummy-form-draft';
 
@@ -11,6 +12,7 @@ const DummyForm: React.FC = () => {
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
+  const safeAreaRef = useMobileInputSafeArea<HTMLDivElement>();
   const [recovered, setRecovered] = useState(false);
 
   useEffect(() => {
@@ -86,7 +88,10 @@ const DummyForm: React.FC = () => {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
+    <div
+      ref={safeAreaRef}
+      className="flex min-h-screen items-center justify-center bg-gray-100"
+    >
       <form onSubmit={handleSubmit} className="w-full max-w-md rounded bg-white p-6 shadow-md">
         <h1 className="mb-4 text-xl font-bold">Contact Us</h1>
         {recovered && <p className="mb-4 text-sm text-blue-600">Recovered draft</p>}

--- a/pages/input-hub.tsx
+++ b/pages/input-hub.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import emailjs from '@emailjs/browser';
 import { useRouter } from 'next/router';
+import { useMobileInputSafeArea } from '@/hooks/useMobileInputSafeArea';
 
 const subjectTemplates = [
   'General Inquiry',
@@ -25,6 +26,7 @@ const getRecaptchaToken = (siteKey: string): Promise<string> =>
 const QUEUE_KEY = 'input-hub-queue';
 
 const InputHub = () => {
+  const safeAreaRef = useMobileInputSafeArea<HTMLDivElement>();
   const router = useRouter();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -169,7 +171,10 @@ const InputHub = () => {
   };
 
   return (
-    <div className="p-4 text-black max-w-md mx-auto">
+    <div
+      ref={safeAreaRef}
+      className="p-4 text-black max-w-md mx-auto"
+    >
       <div className="mb-4">
         <span
           className={`px-2 py-1 text-sm rounded ${

--- a/pages/qr/index.tsx
+++ b/pages/qr/index.tsx
@@ -7,6 +7,7 @@ import { BrowserQRCodeReader, NotFoundException } from '@zxing/library';
 import Tabs from '../../components/Tabs';
 import FormError from '../../components/ui/FormError';
 import { clearScans, loadScans, saveScans } from '../../utils/qrStorage';
+import { useMobileInputSafeArea } from '@/hooks/useMobileInputSafeArea';
 
 const tabs = [
   { id: 'text', label: 'Text' },
@@ -31,6 +32,7 @@ const QRPage: React.FC = () => {
   const [qrPng, setQrPng] = useState('');
   const [qrSvg, setQrSvg] = useState('');
   const [fileName, setFileName] = useState('qr');
+  const safeAreaRef = useMobileInputSafeArea<HTMLDivElement>();
   const [scanResult, setScanResult] = useState('');
   const [batch, setBatch] = useState<string[]>([]);
   const [error, setError] = useState('');
@@ -188,7 +190,10 @@ const QRPage: React.FC = () => {
   };
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-8 p-4">
+    <div
+      ref={safeAreaRef}
+      className="flex min-h-screen flex-col items-center justify-center gap-8 p-4"
+    >
       <div className="w-full max-w-md">
         <Tabs
           tabs={tabs}

--- a/pages/qr/vcard.tsx
+++ b/pages/qr/vcard.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
 import QRCode from 'qrcode';
+import { useMobileInputSafeArea } from '@/hooks/useMobileInputSafeArea';
 
 const VCardPage: React.FC = () => {
   const [name, setName] = useState('');
@@ -11,6 +12,7 @@ const VCardPage: React.FC = () => {
   const [email, setEmail] = useState('');
   const [vcard, setVcard] = useState('');
   const [png, setPng] = useState('');
+  const safeAreaRef = useMobileInputSafeArea<HTMLDivElement>();
   const [svg, setSvg] = useState('');
 
   useEffect(() => {
@@ -69,7 +71,10 @@ const VCardPage: React.FC = () => {
   };
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
+    <div
+      ref={safeAreaRef}
+      className="flex min-h-screen flex-col items-center justify-center gap-4 p-4"
+    >
       <form className="w-full max-w-md space-y-2">
         <label className="block text-sm">
           Full Name


### PR DESCRIPTION
## Summary
- add a reusable `useMobileInputSafeArea` hook to pad mobile forms for on-screen keyboards
- wrap contact, QR, and utility form surfaces with the safe-area ref so inputs remain visible on mobile devices

## Testing
- yarn lint *(fails: existing accessibility violations across legacy apps)*
- yarn test *(fails: upstream jest suites expecting alert roles and browser storage support)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d548bea8832883897d21f47e3524