### PR TITLE
[desktop] close workspace callback to fix compile error

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -834,16 +834,16 @@ export class Desktop extends Component {
                 favourite_apps[objId] = true; // adds opened app to sideBar
                 closed_windows[objId] = false; // openes app's window
                 this.setWorkspaceState({ closed_windows, favourite_apps, allAppsView: false }, () => {
-
-                const nextState = { closed_windows, favourite_apps, allAppsView: false };
-                if (context) {
-                    nextState.window_context = contextState;
-                }
-                this.setState(nextState, () => {
-                    this.focus(objId);
-                    this.saveSession();
+                    const nextState = { closed_windows, favourite_apps, allAppsView: false };
+                    if (context) {
+                        nextState.window_context = contextState;
+                    }
+                    this.setState(nextState, () => {
+                        this.focus(objId);
+                        this.saveSession();
+                    });
+                    this.getActiveStack().push(objId);
                 });
-                this.getActiveStack().push(objId);
             }, 200);
         }
     }


### PR DESCRIPTION
## Summary
- close the `setWorkspaceState` callback when opening apps so the Desktop component compiles again

## Testing
- yarn lint *(fails: repository currently reports numerous existing accessibility violations and `no-top-level-window` errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d703087f1c8328a57f32381809acd1