### PR TITLE
[desktop] Fix workspace state callback closure

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -834,16 +834,16 @@ export class Desktop extends Component {
                 favourite_apps[objId] = true; // adds opened app to sideBar
                 closed_windows[objId] = false; // openes app's window
                 this.setWorkspaceState({ closed_windows, favourite_apps, allAppsView: false }, () => {
-
-                const nextState = { closed_windows, favourite_apps, allAppsView: false };
-                if (context) {
-                    nextState.window_context = contextState;
-                }
-                this.setState(nextState, () => {
-                    this.focus(objId);
-                    this.saveSession();
+                    const nextState = { closed_windows, favourite_apps, allAppsView: false };
+                    if (context) {
+                        nextState.window_context = contextState;
+                    }
+                    this.setState(nextState, () => {
+                        this.focus(objId);
+                        this.saveSession();
+                    });
+                    this.getActiveStack().push(objId);
                 });
-                this.getActiveStack().push(objId);
             }, 200);
         }
     }


### PR DESCRIPTION
## Summary
- restore the missing callback closure when updating workspace state so the desktop build compiles again

## Testing
- [ ] yarn lint
- [ ] yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d734b987408328a5f957763df3857e