### PR TITLE
[desktop] Restore Desktop class field terminators

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1023,7 +1023,7 @@ export class Desktop extends Component {
         this.setState({ showNameBar: false }, this.updateAppsData);
     }
 
-    showAllApps = () => { this.setState({ allAppsView: !this.state.allAppsView }) }
+    showAllApps = () => { this.setState({ allAppsView: !this.state.allAppsView }); };
 
     renderNameBar = () => {
         let addFolder = () => {
@@ -1061,7 +1061,7 @@ export class Desktop extends Component {
                 </div>
             </div>
         );
-    }
+    };
 
     render() {
         const workspaceSummaries = this.getWorkspaceSummaries();


### PR DESCRIPTION
## Summary
- add missing semicolons to Desktop class fields so the Next.js compiler no longer parses render() as an expression

## Testing
- [ ] yarn lint *(hangs locally after several minutes; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d7392820b88328a82622fbffbf56d0