### PR TITLE
[ui] Refresh Kali desktop glass styling

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -86,6 +86,20 @@ export class SideBarApp extends Component {
     };
 
     render() {
+        const isOpen = this.props.isClose[this.id] === false;
+        const isFocused = this.props.isFocus[this.id];
+        const buttonClasses = [
+            'dock-button',
+            'm-1',
+            'outline-none',
+            'relative',
+            'focus-visible:ring-2',
+            'focus-visible:ring-ubb-orange/70',
+            'focus-visible:ring-offset-2',
+            'focus-visible:ring-offset-transparent',
+            isOpen ? 'dock-button-active' : '',
+            isFocused ? 'ring-1 ring-ubb-orange/60' : '',
+        ].filter(Boolean).join(' ');
         return (
             <button
                 type="button"
@@ -100,16 +114,15 @@ export class SideBarApp extends Component {
                 onMouseLeave={() => {
                     this.setState({ showTitle: false, thumbnail: null });
                 }}
-                className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
-                    " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
+                className={buttonClasses}
                 id={"sidebar-" + this.props.id}
             >
                 <Image
                     width={28}
                     height={28}
-                    className="w-7"
+                    className="w-7 drop-shadow-[0_0_12px_rgba(23,147,209,0.45)]"
                     src={this.props.icon.replace('./', '/')}
-                    alt="Ubuntu App Icon"
+                    alt={`${this.props.title} icon`}
                     sizes="28px"
                 />
                 <Image
@@ -120,36 +133,22 @@ export class SideBarApp extends Component {
                     alt=""
                     sizes="28px"
                 />
-                {
-                    (
-                        this.props.isClose[this.id] === false
-                            ? <div className=" w-2 h-1 absolute bottom-0 left-1/2 transform -translate-x-1/2 bg-white rounded-md"></div>
-                            : null
-                    )
-                }
                 {this.state.thumbnail && (
                     <div
-                        className={
-                            (this.state.showTitle ? " visible " : " invisible ") +
-                            " pointer-events-none absolute bottom-full mb-2 left-1/2 transform -translate-x-1/2" +
-                            " rounded border border-gray-400 border-opacity-40 shadow-lg overflow-hidden bg-black bg-opacity-50"
-                        }
+                        className={`${this.state.showTitle ? 'visible' : 'invisible'} pointer-events-none absolute bottom-full mb-3 left-1/2 w-32 -translate-x-1/2 overflow-hidden rounded-lg border border-white/10 bg-ub-grey/90 shadow-xl backdrop-blur`}
                     >
                         <Image
                             width={128}
                             height={80}
                             src={this.state.thumbnail}
                             alt={`Preview of ${this.props.title}`}
-                            className="w-32 h-20 object-cover"
+                            className="h-20 w-full object-cover"
                             sizes="128px"
                         />
                     </div>
                 )}
                 <div
-                    className={
-                        (this.state.showTitle ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1.5 left-full ml-3 m-1 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
-                    }
+                    className={`${this.state.showTitle ? 'visible' : 'invisible'} pointer-events-none absolute top-1.5 left-full ml-3 whitespace-nowrap rounded-lg border border-white/10 bg-ub-grey/90 px-2 py-1 text-xs text-ubt-grey shadow-lg backdrop-blur`}
                 >
                     {this.props.title}
                 </div>

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -1,9 +1,16 @@
 .windowFrame {
   position: relative;
-  border: 1px solid var(--color-window-border);
+  border: 1px solid color-mix(in srgb, var(--kali-panel-border) 85%, transparent);
   border-radius: var(--radius-6);
   box-shadow: var(--shadow-2);
   overflow: hidden;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--kali-panel) 96%, transparent) 0%,
+    color-mix(in srgb, var(--kali-panel) 78%, transparent) 100%
+  );
+  backdrop-filter: blur(14px) saturate(125%);
+  -webkit-backdrop-filter: blur(14px) saturate(125%);
   transition: filter var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
 }
 
@@ -25,10 +32,11 @@
 
 .windowFrameActive::before {
   opacity: 1;
+  box-shadow: 0 0 16px rgba(23, 147, 209, 0.45);
 }
 
 .windowFrameInactive {
-  filter: brightness(0.85);
+  filter: brightness(0.8);
 }
 
 .windowFrameMaximized {
@@ -45,6 +53,15 @@
   border-top-right-radius: calc(var(--radius-6) - 1px);
   position: relative;
   z-index: 1;
+  border-bottom: 1px solid color-mix(in srgb, var(--kali-panel-border) 70%, transparent);
+}
+
+.windowTitlebar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(23, 147, 209, 0.32) 0%, rgba(23, 147, 209, 0.08) 45%, transparent 100%);
+  pointer-events: none;
 }
 
 .windowControls {

--- a/components/panel/WorkspaceSwitcher.tsx
+++ b/components/panel/WorkspaceSwitcher.tsx
@@ -35,7 +35,7 @@ export default function WorkspaceSwitcher({
   return (
     <nav
       aria-label="Workspace switcher"
-      className="flex items-center gap-1 rounded-full bg-black/50 px-1 py-0.5"
+      className="flex items-center gap-1 rounded-full border border-white/10 bg-ub-grey/80 px-1 py-0.5 shadow-[0_4px_18px_rgba(0,0,0,0.4)] backdrop-blur"
     >
       {workspaces.map((workspace, index) => {
         const isActive = workspace.id === activeWorkspace;
@@ -48,10 +48,10 @@ export default function WorkspaceSwitcher({
             aria-pressed={isActive}
             aria-label={formatAriaLabel(workspace)}
             onClick={() => onSelect(workspace.id)}
-            className={`min-w-[28px] rounded-full px-2 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-offset-black ${
+            className={`min-w-[28px] rounded-full px-2 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ubb-orange/70 focus-visible:ring-offset-1 focus-visible:ring-offset-transparent ${
               isActive
-                ? "bg-[var(--kali-blue)] text-black"
-                : "bg-transparent text-white/80 hover:bg-white/10"
+                ? "bg-[var(--kali-blue)] text-black shadow-[0_0_12px_rgba(23,147,209,0.6)]"
+                : "bg-white/5 text-white/80 hover:bg-white/10"
             }`}
           >
             <span>{index + 1}</span>

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -18,33 +18,37 @@ export default class Navbar extends Component {
         }
 
 		render() {
+			const { status_card } = this.state;
 			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
+				<div className="main-navbar-vp absolute left-0 right-0 top-0 z-50 grid grid-cols-[auto_1fr_auto] items-center px-3 py-1 text-ubt-grey text-xs md:text-sm select-none">
+					<div className="flex items-center gap-2 md:gap-3">
 						<WhiskerMenu />
+						<div className="hidden sm:flex items-center gap-1 text-[0.65rem] uppercase tracking-[0.4em] text-ubt-grey/65">
+							<span className="font-semibold text-ubt-grey text-opacity-90">Kali</span>
+							<span className="font-light">Linux</span>
+						</div>
 						<PerformanceGraph />
 					</div>
-					<div
-						className={
-							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-						}
-					>
-						<Clock />
+					<div className="flex items-center justify-center">
+						<div className="rounded-full border border-white/10 bg-white/5 px-4 py-1 text-[0.7rem] font-medium uppercase tracking-[0.35em] text-ubt-grey/80 shadow-[0_6px_18px_rgba(0,0,0,0.35)]">
+							<Clock />
+						</div>
 					</div>
-					<button
-						type="button"
-						id="status-bar"
-						aria-label="System status"
-						onClick={() => {
-							this.setState({ status_card: !this.state.status_card });
-						}}
-						className={
-							'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-						}
-					>
-						<Status />
-						<QuickSettings open={this.state.status_card} />
-					</button>
+					<div className="flex items-center justify-end gap-1.5 md:gap-2 pr-1">
+						<NotificationBell />
+						<button
+							 type="button"
+							 id="status-bar"
+							 aria-label="System status"
+							 onClick={() => {
+								 this.setState({ status_card: !status_card });
+							 }}
+							 className="relative flex items-center gap-2 rounded-lg border border-transparent px-3 py-1 transition focus:border-ubb-orange focus:outline-none hover:bg-white/10"
+						>
+							<Status />
+							<QuickSettings open={status_card} />
+						</button>
+					</div>
 				</div>
 			);
 		}

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -29,8 +29,7 @@ export default function SideBar(props) {
         <>
             <nav
                 aria-label="Dock"
-                className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                className={`${props.hide ? '-translate-x-full' : ''} desktop-dock absolute left-0 top-0 z-40 flex h-full min-h-screen w-16 transform flex-col items-center justify-start overflow-visible rounded-r-3xl pt-6 transition duration-300`}
             >
                 {
                     (
@@ -41,7 +40,7 @@ export default function SideBar(props) {
                 }
                 <AllApps showApps={props.showAllApps} />
             </nav>
-            <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className={"w-1 h-full absolute top-0 left-0 bg-transparent z-50"}></div>
+            <div onMouseEnter={showSideBar} onMouseLeave={hideSideBar} className="absolute left-0 top-0 z-50 h-full w-1 bg-transparent"></div>
         </>
     )
 }
@@ -51,8 +50,9 @@ export function AllApps(props) {
     const [title, setTitle] = useState(false);
 
     return (
-        <div
-            className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
+        <button
+            type="button"
+            className={`dock-button m-1 text-ubt-grey/85 ${title ? 'ring-1 ring-ubb-orange/60' : ''}`}
             style={{ marginTop: 'auto' }}
             onMouseEnter={() => {
                 setTitle(true);
@@ -66,20 +66,17 @@ export function AllApps(props) {
                 <Image
                     width={28}
                     height={28}
-                    className="w-7"
+                    className="w-7 drop-shadow-[0_0_12px_rgba(23,147,209,0.45)]"
                     src="/themes/Yaru/system/view-app-grid-symbolic.svg"
-                    alt="Ubuntu view app"
+                    alt="Show applications"
                     sizes="28px"
                 />
                 <div
-                    className={
-                        (title ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1 left-full ml-5 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
-                    }
+                    className={`${title ? 'visible' : 'invisible'} pointer-events-none absolute top-1 left-full ml-4 whitespace-nowrap rounded-lg border border-white/10 bg-ub-grey/90 px-2 py-1 text-xs text-ubt-grey shadow-lg backdrop-blur`}
                 >
                     Show Applications
                 </div>
             </div>
-        </div>
+        </button>
     );
 }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -3,79 +3,89 @@ import Image from 'next/image';
 import WorkspaceSwitcher from '../panel/WorkspaceSwitcher';
 
 export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
-    const workspaces = props.workspaces || [];
+    const {
+        apps,
+        closed_windows,
+        minimized_windows,
+        focused_windows,
+        openApp,
+        minimize,
+        workspaces = [],
+        activeWorkspace,
+        onSelectWorkspace,
+    } = props;
+
+    const runningApps = Array.isArray(apps)
+        ? apps.filter((app) => closed_windows[app.id] === false)
+        : [];
 
     const handleClick = (app) => {
         const id = app.id;
-        if (props.minimized_windows[id]) {
-            props.openApp(id);
-        } else if (props.focused_windows[id]) {
-            props.minimize(id);
+        if (minimized_windows[id]) {
+            openApp(id);
+        } else if (focused_windows[id]) {
+            minimize(id);
         } else {
-            props.openApp(id);
+            openApp(id);
         }
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center justify-between px-2 z-40" role="toolbar">
+        <div
+            className="taskbar-panel absolute bottom-0 left-0 right-0 z-40 flex h-12 items-center justify-between px-3"
+            role="toolbar"
+            aria-label="Running applications"
+        >
             <WorkspaceSwitcher
                 workspaces={workspaces}
-                activeWorkspace={props.activeWorkspace}
-                onSelect={props.onSelectWorkspace}
+                activeWorkspace={activeWorkspace}
+                onSelect={onSelectWorkspace}
             />
-            <div className="flex items-center overflow-x-auto">
-                {runningApps.map(app => (
+            <div className="flex items-center gap-1 overflow-x-auto pl-3">
+                {runningApps.length === 0 ? (
+                    <span className="px-3 text-xs text-ubt-grey/70">No apps running</span>
+                ) : (
+                    runningApps.map((app) => {
+                        const isMinimized = Boolean(minimized_windows[app.id]);
+                        const isFocused = Boolean(focused_windows[app.id]);
+                        const isActive = !isMinimized;
+                        const buttonClasses = [
+                            'taskbar-launcher',
+                            isFocused && isActive ? 'ring-1 ring-ubb-orange/60' : '',
+                        ]
+                            .filter(Boolean)
+                            .join(' ');
 
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => {
-                const isMinimized = Boolean(props.minimized_windows[app.id]);
-                const isFocused = Boolean(props.focused_windows[app.id]);
-                const isActive = !isMinimized;
-
-                return (
-                    <button
-                        key={app.id}
-                        type="button"
-                        aria-label={app.title}
-                        data-context="taskbar"
-                        data-app-id={app.id}
-                        onClick={() => handleClick(app)}
-                        className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        aria-pressed={isActive}
-                        data-context="taskbar"
-                        data-app-id={app.id}
-                        data-active={isActive ? 'true' : 'false'}
-                        onClick={() => handleClick(app)}
-                        className={(isFocused && isActive ? ' bg-white bg-opacity-20 ' : ' ') +
-                            'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                    >
-                        <Image
-                            width={24}
-                            height={24}
-                            className="w-5 h-5"
-                            src={app.icon.replace('./', '/')}
-                            alt=""
-                            sizes="24px"
-                        />
-                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                        {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                        )}
-                    </button>
-                ))}
+                        return (
+                            <button
+                                key={app.id}
+                                type="button"
+                                aria-label={app.title}
+                                aria-pressed={isActive}
+                                data-context="taskbar"
+                                data-app-id={app.id}
+                                data-active={isActive ? 'true' : 'false'}
+                                data-minimized={isMinimized ? 'true' : 'false'}
+                                onClick={() => handleClick(app)}
+                                className={buttonClasses}
+                                title={isMinimized ? `${app.title} (click to restore)` : app.title}
+                            >
+                                <Image
+                                    width={24}
+                                    height={24}
+                                    className="h-5 w-5 drop-shadow-[0_0_10px_rgba(23,147,209,0.4)]"
+                                    src={app.icon.replace('./', '/')}
+                                    alt=""
+                                    sizes="24px"
+                                />
+                                <span className="hidden whitespace-nowrap text-sm font-medium text-white/90 sm:inline">
+                                    {app.title}
+                                </span>
+                            </button>
+                        );
+                    })
+                )}
             </div>
-
-                        {isActive && (
-                            <span
-                                aria-hidden="true"
-                                data-testid="running-indicator"
-                                className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded"
-                            />
-                        )}
-                    </button>
-                );
-            })}
         </div>
     );
 }

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -13,7 +13,7 @@ export default class Ubuntu extends Component {
 		super();
 		this.state = {
 			screen_locked: false,
-			bg_image_name: 'wall-2',
+                        bg_image_name: 'kali-gradient',
 			booting_screen: true,
 			shutDownScreen: false
 		};

--- a/styles/index.css
+++ b/styles/index.css
@@ -40,10 +40,143 @@ button:focus-visible {
 
 /* Top NavBar styling */
 
+.main-navbar-vp {
+    background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--kali-panel) 92%, transparent) 0%,
+        color-mix(in srgb, var(--kali-panel) 86%, transparent) 100%
+    );
+    border-bottom: 1px solid color-mix(in srgb, var(--kali-panel-border) 70%, transparent);
+    backdrop-filter: blur(16px) saturate(140%);
+    -webkit-backdrop-filter: blur(16px) saturate(140%);
+    box-shadow: 0 6px 20px rgba(3, 8, 15, 0.55);
+}
+
+.main-navbar-vp::after {
+    content: '';
+    position: absolute;
+    inset-inline: 0;
+    inset-block-end: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent 0%, rgba(23, 147, 209, 0.6) 50%, transparent 100%);
+    pointer-events: none;
+}
+
 .top-arrow-up {
     border-inline-start: 5px solid transparent;
     border-inline-end: 5px solid transparent;
     border-block-end: 5px solid var(--color-muted);
+}
+
+.desktop-dock {
+    background: linear-gradient(
+        90deg,
+        color-mix(in srgb, var(--kali-panel) 95%, transparent) 0%,
+        color-mix(in srgb, var(--kali-panel) 72%, transparent) 100%
+    );
+    border-right: 1px solid color-mix(in srgb, var(--kali-panel-border) 80%, transparent);
+    box-shadow: 12px 0 32px rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(22px) saturate(140%);
+    -webkit-backdrop-filter: blur(22px) saturate(140%);
+}
+
+.desktop-dock::before {
+    content: '';
+    position: absolute;
+    inset-inline-start: 0;
+    inset-block: 12px;
+    width: 2px;
+    border-radius: 9999px;
+    background: linear-gradient(180deg, rgba(23, 147, 209, 0) 0%, rgba(23, 147, 209, 0.6) 45%, rgba(23, 147, 209, 0) 100%);
+    opacity: 0.45;
+    pointer-events: none;
+}
+
+.dock-button {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 3rem;
+    border-radius: 0.9rem;
+    transition: background var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+}
+
+.dock-button::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 1px solid transparent;
+    transition: inherit;
+}
+
+.dock-button:hover,
+.dock-button:focus-visible {
+    background: color-mix(in srgb, var(--kali-panel-highlight) 85%, transparent);
+}
+
+.dock-button:focus-visible::before {
+    border-color: color-mix(in srgb, var(--color-focus-ring) 80%, transparent);
+}
+
+.dock-button-active {
+    background: color-mix(in srgb, var(--kali-panel-highlight) 95%, transparent);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+.dock-button-active::after {
+    content: '';
+    position: absolute;
+    bottom: 6px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 8px;
+    height: 8px;
+    border-radius: 9999px;
+    background: var(--kali-blue);
+    box-shadow: 0 0 10px rgba(23, 147, 209, 0.75);
+}
+
+.taskbar-panel {
+    background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--kali-panel) 85%, transparent) 0%,
+        color-mix(in srgb, var(--kali-panel) 70%, transparent) 100%
+    );
+    border-top: 1px solid color-mix(in srgb, var(--kali-panel-border) 70%, transparent);
+    backdrop-filter: blur(18px) saturate(150%);
+    -webkit-backdrop-filter: blur(18px) saturate(150%);
+    box-shadow: 0 -6px 24px rgba(0, 0, 0, 0.45);
+}
+
+.taskbar-launcher {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.8rem;
+    border-radius: 0.75rem;
+    transition: background var(--motion-fast) ease, color var(--motion-fast) ease;
+    color: color-mix(in srgb, var(--color-text) 85%, transparent);
+}
+
+.taskbar-launcher[data-active="true"] {
+    background: color-mix(in srgb, var(--kali-panel-highlight) 92%, transparent);
+    color: var(--color-text);
+    box-shadow: 0 12px 20px rgba(0, 0, 0, 0.35);
+}
+
+.taskbar-launcher[data-active="true"]::after {
+    content: '';
+    position: absolute;
+    inset-inline: 25%;
+    bottom: 4px;
+    height: 3px;
+    border-radius: 9999px;
+    background: var(--kali-blue);
+    box-shadow: 0 0 6px rgba(23, 147, 209, 0.65);
 }
 
 

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -6,7 +6,7 @@ import { getTheme, setTheme } from './theme';
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
   wallpaper: 'wall-2',
-  useKaliWallpaper: false,
+  useKaliWallpaper: true,
   density: 'regular',
   reducedMotion: false,
   fontScale: 1,


### PR DESCRIPTION
## Summary
- Apply a glassy Kali-inspired treatment to the top panel, dock, and taskbar so the desktop shell matches the reference aesthetic.
- Refine dock app buttons, quick launcher tooltips, and the workspace switcher to sit comfortably in the refreshed chrome while maintaining focus affordances.
- Update window chrome and default wallpaper preferences to surface the Kali gradient background out of the box.

## Testing
- `yarn lint` *(fails: repository already contains hundreds of accessibility and no-top-level-window lint errors outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d7349517d88328ae6ea0e7815fb1e9