### PR TITLE
[desktop] Fix addToDesktop syntax

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1021,7 +1021,7 @@ export class Desktop extends Component {
         safeLocalStorage?.setItem('new_folders', JSON.stringify(new_folders));
 
         this.setState({ showNameBar: false }, this.updateAppsData);
-    }
+    };
 
     showAllApps = () => { this.setState({ allAppsView: !this.state.allAppsView }); };
 


### PR DESCRIPTION
## Summary
- add the missing semicolon to `Desktop.addToDesktop` so the class renders without syntax errors

## Testing
- yarn lint *(fails: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68d73d544a1c8328999a49df4dd60fa2