### PR TITLE
[desktop] fix addToDesktop syntax

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1021,7 +1021,7 @@ export class Desktop extends Component {
         safeLocalStorage?.setItem('new_folders', JSON.stringify(new_folders));
 
         this.setState({ showNameBar: false }, this.updateAppsData);
-    }
+    };
 
     showAllApps = () => { this.setState({ allAppsView: !this.state.allAppsView }); };
 


### PR DESCRIPTION
## Summary
- add the missing semicolon for the Desktop addToDesktop handler so the class parses correctly

## Testing
- [ ] yarn lint
- [ ] yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d7411737d483288fc26562270d7c1d