### PR TITLE
[desktop] Fix missing brace in Desktop openApp

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -780,6 +780,8 @@ export class Desktop extends Component {
                 minimized_windows[objId] = false;
                 this.setWorkspaceState({ minimized_windows }, this.saveSession);
 
+            }
+
             const reopen = () => {
                 // if it's minimised, restore its last position
                 if (this.state.minimized_windows[objId]) {


### PR DESCRIPTION
## Summary
- add missing closing brace in `Desktop.openApp` so the render method parses correctly

## Testing
- yarn lint *(fails: repository currently has existing jsx-a11y and no-top-level-window violations outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d742760b7c83289a8545437080b6c8