### PR TITLE
[desktop] Fix taskbar button markup regression

### DIFF
--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -25,57 +25,43 @@ export default function Taskbar(props) {
                 onSelect={props.onSelectWorkspace}
             />
             <div className="flex items-center overflow-x-auto">
-                {runningApps.map(app => (
+                {runningApps.map(app => {
+                    const isMinimized = Boolean(props.minimized_windows[app.id]);
+                    const isFocused = Boolean(props.focused_windows[app.id]);
+                    const isActive = !isMinimized;
 
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center z-40" role="toolbar">
-            {runningApps.map(app => {
-                const isMinimized = Boolean(props.minimized_windows[app.id]);
-                const isFocused = Boolean(props.focused_windows[app.id]);
-                const isActive = !isMinimized;
-
-                return (
-                    <button
-                        key={app.id}
-                        type="button"
-                        aria-label={app.title}
-                        data-context="taskbar"
-                        data-app-id={app.id}
-                        onClick={() => handleClick(app)}
-                        className={(props.focused_windows[app.id] && !props.minimized_windows[app.id] ? ' bg-white bg-opacity-20 ' : ' ') +
-                        aria-pressed={isActive}
-                        data-context="taskbar"
-                        data-app-id={app.id}
-                        data-active={isActive ? 'true' : 'false'}
-                        onClick={() => handleClick(app)}
-                        className={(isFocused && isActive ? ' bg-white bg-opacity-20 ' : ' ') +
-                            'relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10'}
-                    >
-                        <Image
-                            width={24}
-                            height={24}
-                            className="w-5 h-5"
-                            src={app.icon.replace('./', '/')}
-                            alt=""
-                            sizes="24px"
-                        />
-                        <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                        {!props.focused_windows[app.id] && !props.minimized_windows[app.id] && (
-                            <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded" />
-                        )}
-                    </button>
-                ))}
-            </div>
-
-                        {isActive && (
-                            <span
-                                aria-hidden="true"
-                                data-testid="running-indicator"
-                                className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded"
+                    return (
+                        <button
+                            key={app.id}
+                            type="button"
+                            aria-label={app.title}
+                            data-context="taskbar"
+                            data-app-id={app.id}
+                            data-active={isActive ? 'true' : 'false'}
+                            aria-pressed={isActive}
+                            onClick={() => handleClick(app)}
+                            className={`${isFocused && isActive ? 'bg-white bg-opacity-20 ' : ''}relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10`}
+                        >
+                            <Image
+                                width={24}
+                                height={24}
+                                className="w-5 h-5"
+                                src={app.icon.replace('./', '/')}
+                                alt=""
+                                sizes="24px"
                             />
-                        )}
-                    </button>
-                );
-            })}
+                            <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                            {isActive && (
+                                <span
+                                    aria-hidden="true"
+                                    data-testid="running-indicator"
+                                    className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded"
+                                />
+                            )}
+                        </button>
+                    );
+                })}
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- restore the taskbar button markup to a single toolbar map instead of the broken duplicated block
- ensure the taskbar buttons expose consistent active attributes and running indicator markup

## Testing
- yarn lint *(fails: existing repository accessibility lint violations outside the change)*

------
https://chatgpt.com/codex/tasks/task_e_68d7443bc93c8328b17a153dc35e7fc5