### PR TITLE
[pwa] Make offline assets aware of base paths

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Offline</title>
-  <link rel="stylesheet" href="/offline.css">
+  <link rel="stylesheet" href="./offline.css">
 </head>
 <body>
   <main>
@@ -16,6 +16,6 @@
       <ul id="apps"></ul>
     </section>
   </main>
-  <script src="/offline.js" defer></script>
+  <script src="./offline.js" defer></script>
 </body>
 </html>

--- a/public/offline.js
+++ b/public/offline.js
@@ -1,36 +1,77 @@
 /* eslint-disable no-top-level-window/no-top-level-window-or-document */
+const offlinePageName = 'offline.html';
+
+function getBasePath() {
+  const { pathname } = window.location;
+  if (!pathname) return '';
+
+  if (pathname.endsWith(`/${offlinePageName}`)) {
+    const withoutPage = pathname.slice(0, -offlinePageName.length - 1);
+    return withoutPage === '/' ? '' : withoutPage;
+  }
+
+  if (pathname.endsWith(offlinePageName)) {
+    const withoutPage = pathname.slice(0, -offlinePageName.length);
+    if (withoutPage === '/' || withoutPage === '') {
+      return '';
+    }
+    return withoutPage.endsWith('/') ? withoutPage.slice(0, -1) : withoutPage;
+  }
+
+  const directory = pathname.replace(/\/?[^/]*$/, '');
+  if (directory === '/' || directory === '') {
+    return '';
+  }
+  return directory.endsWith('/') ? directory.slice(0, -1) : directory;
+}
+
+const basePath = getBasePath();
+const basePathPrefix = basePath || '';
+
+function formatAppLabel(path) {
+  return path.replace(/^\/apps\//, '').replace(/\/$/, '') || 'home';
+}
+
 document.getElementById('retry').addEventListener('click', () => {
   window.location.reload();
 });
 
 (async () => {
   const list = document.getElementById('apps');
+  list.innerHTML = '';
   try {
     const names = await caches.keys();
     const urls = new Set();
+    const appsPrefix = `${basePathPrefix}/apps/`;
+
     for (const name of names) {
       const cache = await caches.open(name);
       const keys = await cache.keys();
       for (const request of keys) {
         const url = new URL(request.url);
-        if (url.pathname.startsWith('/apps/') && !url.pathname.endsWith('.js')) {
-          urls.add(url.pathname);
+        const { pathname } = url;
+        if (pathname.startsWith(appsPrefix) && !pathname.endsWith('.js')) {
+          const appPath = pathname.slice(basePathPrefix.length);
+          urls.add(appPath);
         }
       }
     }
+
     if (urls.size === 0) {
       list.innerHTML = '<li>No apps available offline.</li>';
-    } else {
-      urls.forEach((path) => {
-        const li = document.createElement('li');
-        const a = document.createElement('a');
-        a.href = path;
-        a.textContent = path.replace('/apps/', '');
-        li.appendChild(a);
-        list.appendChild(li);
-      });
+      return;
     }
+
+    urls.forEach((relativePath) => {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = `${basePathPrefix}${relativePath}`;
+      a.textContent = formatAppLabel(relativePath);
+      li.appendChild(a);
+      list.appendChild(li);
+    });
   } catch (err) {
+    console.warn('Unable to enumerate cached apps', err);
     list.innerHTML = '<li>Unable to access cached apps.</li>';
   }
 })();


### PR DESCRIPTION
## Summary
- make the offline HTML and script load relative assets so they work under a base path
- add base-path aware helpers in the PWA config so cached routes and the navigate fallback resolve correctly
- ensure cached app links on the offline screen strip the base path before rendering labels

## Testing
- yarn lint *(fails: repository currently has existing accessibility and window usage lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d7459c3c488328a991348983ff7c53