### PR TITLE
[components] Fix PerformanceGraph ref initialization

### DIFF
--- a/components/ui/PerformanceGraph.tsx
+++ b/components/ui/PerformanceGraph.tsx
@@ -52,8 +52,8 @@ const PerformanceGraph: React.FC<PerformanceGraphProps> = ({ className }) => {
   const [points, setPoints] = useState<number[]>(() =>
     Array.from({ length: MAX_POINTS }, (_, index) => 0.32 + (index % 3) * 0.04)
   );
-  const timeoutRef = useRef<number>();
-  const frameRef = useRef<number>();
+  const timeoutRef = useRef<number | null>(null);
+  const frameRef = useRef<number | null>(null);
   const lastSampleRef = useRef<number>(typeof performance !== 'undefined' ? performance.now() : 0);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- initialize the PerformanceGraph timer refs with explicit null defaults to satisfy TypeScript

## Testing
- [ ] yarn lint (hangs in container, aborted)
- [ ] yarn tsc --noEmit (hangs in container, aborted)


------
https://chatgpt.com/codex/tasks/task_e_68d7494e83dc8328800040d70c9d5870