### PR TITLE
[ui] Fix PerformanceGraph timeout ref typing

### DIFF
--- a/components/ui/PerformanceGraph.tsx
+++ b/components/ui/PerformanceGraph.tsx
@@ -52,7 +52,7 @@ const PerformanceGraph: React.FC<PerformanceGraphProps> = ({ className }) => {
   const [points, setPoints] = useState<number[]>(() =>
     Array.from({ length: MAX_POINTS }, (_, index) => 0.32 + (index % 3) * 0.04)
   );
-  const timeoutRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+  const timeoutRef = useRef<number | ReturnType<typeof setTimeout> | null>(null);
   const frameRef = useRef<number | null>(null);
   const lastSampleRef = useRef<number>(typeof performance !== 'undefined' ? performance.now() : 0);
 


### PR DESCRIPTION
## Summary
- widen the timeout ref type so PerformanceGraph can initialize safely during builds

## Testing
- yarn typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d74a5aa1c883289ed58c74d26be0cf