### PR TITLE
[menu] Improve WhiskerMenu fuzzy scoring

### DIFF
--- a/__tests__/menu/WhiskerMenu.test.tsx
+++ b/__tests__/menu/WhiskerMenu.test.tsx
@@ -1,0 +1,67 @@
+import { createAppScorer, type AppMeta } from '../../components/menu/WhiskerMenu';
+
+describe('createAppScorer', () => {
+  const app = (overrides: Partial<AppMeta> = {}): AppMeta => ({
+    id: 'app',
+    title: 'Generic App',
+    icon: '',
+    ...overrides,
+  });
+
+  it('boosts favourites even without a query', () => {
+    const scorer = createAppScorer({
+      query: '',
+      favoriteIds: new Set(['fav-app']),
+      recentIds: [],
+    });
+
+    const favourite = scorer(app({ id: 'fav-app' }));
+    const regular = scorer(app({ id: 'other-app' }));
+
+    expect(favourite.score).toBeGreaterThan(regular.score);
+  });
+
+  it('boosts more recent apps higher than older recents', () => {
+    const scorer = createAppScorer({
+      query: '',
+      favoriteIds: new Set(),
+      recentIds: ['recent-one', 'recent-two'],
+    });
+
+    const newer = scorer(app({ id: 'recent-one' }));
+    const older = scorer(app({ id: 'recent-two' }));
+    const never = scorer(app({ id: 'never-opened' }));
+
+    expect(newer.score).toBeGreaterThan(older.score);
+    expect(older.score).toBeGreaterThan(never.score);
+  });
+
+  it('applies fuzzy scoring to match titles and ids', () => {
+    const titleScorer = createAppScorer({
+      query: 'met',
+      favoriteIds: new Set(),
+      recentIds: [],
+    });
+
+    const metasploit = titleScorer(app({ id: 'metasploit', title: 'Metasploit' }));
+    const terminal = titleScorer(app({ id: 'terminal', title: 'Terminal' }));
+    const gedit = titleScorer(app({ id: 'gedit', title: 'Gedit' }));
+
+    expect(metasploit.matches).toBe(true);
+    expect(metasploit.score).toBeGreaterThan(0);
+    expect(terminal.matches).toBe(false);
+    expect(gedit.matches).toBe(false);
+
+    const idScorer = createAppScorer({
+      query: 'msf',
+      favoriteIds: new Set(),
+      recentIds: [],
+    });
+
+    const msfPost = idScorer(app({ id: 'msf-post', title: 'MSF Post' }));
+    const calculator = idScorer(app({ id: 'calculator', title: 'Calculator' }));
+
+    expect(msfPost.matches).toBe(true);
+    expect(calculator.matches).toBe(false);
+  });
+});

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -7,12 +7,117 @@ import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { KALI_CATEGORIES as BASE_KALI_CATEGORIES } from './ApplicationsMenu';
 
-type AppMeta = {
+export type AppMeta = {
   id: string;
   title: string;
   icon: string;
   disabled?: boolean;
   favourite?: boolean;
+};
+
+type AppScoreResult = {
+  score: number;
+  matches: boolean;
+};
+
+const FAVORITE_WEIGHT = 300;
+const RECENT_WEIGHT_STEP = 25;
+
+const computeFuzzyMatchScore = (query: string, target: string): number => {
+  if (!query) {
+    return 0;
+  }
+
+  const normalizedTarget = target.toLowerCase();
+
+  if (normalizedTarget === query) {
+    return 140;
+  }
+
+  if (normalizedTarget.startsWith(query)) {
+    return 110;
+  }
+
+  const indexOfQuery = normalizedTarget.indexOf(query);
+  if (indexOfQuery !== -1) {
+    return 90 - indexOfQuery;
+  }
+
+  let score = 0;
+  let matched = 0;
+  let lastIndex = -1;
+
+  for (const char of query) {
+    const foundIndex = normalizedTarget.indexOf(char, lastIndex + 1);
+    if (foundIndex === -1) {
+      continue;
+    }
+    matched += 1;
+
+    if (foundIndex === lastIndex + 1) {
+      score += 14;
+    } else {
+      const gap = foundIndex - (lastIndex + 1);
+      score += Math.max(6, 14 - gap);
+    }
+
+    lastIndex = foundIndex;
+  }
+
+  if (matched === 0 || matched < query.length) {
+    return 0;
+  }
+
+  const coverage = matched / query.length;
+  return score * coverage;
+};
+
+export const createAppScorer = ({
+  query,
+  favoriteIds,
+  recentIds,
+}: {
+  query: string;
+  favoriteIds: ReadonlySet<string>;
+  recentIds: readonly string[];
+}): ((app: AppMeta) => AppScoreResult) => {
+  const normalizedQuery = query.trim().toLowerCase();
+  const recentWeights = new Map<string, number>();
+
+  recentIds.forEach((id, index) => {
+    if (!recentWeights.has(id)) {
+      const weightFromRecency = (recentIds.length - index) * RECENT_WEIGHT_STEP;
+      recentWeights.set(id, weightFromRecency);
+    }
+  });
+
+  return (app: AppMeta) => {
+    let score = 0;
+    let matches = true;
+
+    if (favoriteIds.has(app.id)) {
+      score += FAVORITE_WEIGHT;
+    }
+
+    const recentBoost = recentWeights.get(app.id);
+    if (typeof recentBoost === 'number') {
+      score += recentBoost;
+    }
+
+    if (normalizedQuery) {
+      const titleScore = computeFuzzyMatchScore(normalizedQuery, app.title);
+      const idScore = computeFuzzyMatchScore(normalizedQuery, app.id) * 0.6;
+      const combinedScore = Math.max(titleScore, titleScore + idScore * 0.4, idScore);
+
+      if (combinedScore <= 0) {
+        matches = false;
+      } else {
+        score += combinedScore;
+      }
+    }
+
+    return { score, matches };
+  };
 };
 
 type CategorySource =
@@ -163,6 +268,10 @@ const WhiskerMenu: React.FC = () => {
 
   const allApps: AppMeta[] = apps as any;
   const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
+  const favoriteAppIds = useMemo(
+    () => new Set(favoriteApps.map(app => app.id)),
+    [favoriteApps],
+  );
   useEffect(() => {
     setRecentIds(readRecentAppIds());
   }, []);
@@ -214,13 +323,32 @@ const WhiskerMenu: React.FC = () => {
   }, [category, categoryConfigs]);
 
   const currentApps = useMemo(() => {
-    let list = currentCategory?.apps ?? [];
-    if (query) {
-      const q = query.toLowerCase();
-      list = list.filter(a => a.title.toLowerCase().includes(q));
-    }
-    return list;
-  }, [currentCategory, query]);
+    const list = currentCategory?.apps ?? [];
+    const scorer = createAppScorer({
+      query,
+      favoriteIds: favoriteAppIds,
+      recentIds,
+    });
+
+    return list
+      .map((app, index) => {
+        const { score, matches } = scorer(app);
+        return {
+          app,
+          score: score + (list.length - index) * 0.001,
+          matches,
+          index,
+        };
+      })
+      .filter(item => item.matches)
+      .sort((a, b) => {
+        if (b.score !== a.score) {
+          return b.score - a.score;
+        }
+        return a.index - b.index;
+      })
+      .map(item => item.app);
+  }, [currentCategory, favoriteAppIds, query, recentIds]);
 
   useEffect(() => {
     const storedCategory = safeLocalStorage?.getItem(CATEGORY_STORAGE_KEY);
@@ -236,7 +364,7 @@ const WhiskerMenu: React.FC = () => {
   useEffect(() => {
     if (!isVisible) return;
     setHighlight(0);
-  }, [isVisible, category, query]);
+  }, [currentApps, isVisible]);
 
   useEffect(() => {
     if (!isVisible) return;


### PR DESCRIPTION
## Summary
- add a fuzzy scorer to WhiskerMenu that boosts favourites and recent items
- apply the scorer when deriving current apps and reset keyboard highlight to the top match
- export the scorer and cover its behaviour with targeted Jest tests

## Testing
- yarn test WhiskerMenu

------
https://chatgpt.com/codex/tasks/task_e_68d7505a31c4832895596e4e33bf44ed