### PR TITLE
[desktop] Persist favorites and panel pins

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -1,18 +1,28 @@
 import React, { Component } from 'react'
 import Image from 'next/image'
 
+const LONG_PRESS_DURATION = 600
+
 export class UbuntuApp extends Component {
+    longPressTimer = null
+
+    longPressPoint = null
+
+    longPressTarget = null
+
     constructor() {
         super();
         this.state = { launching: false, dragging: false, prefetched: false };
     }
 
     handleDragStart = () => {
+        this.clearLongPressTimer();
         this.setState({ dragging: true });
     }
 
     handleDragEnd = () => {
         this.setState({ dragging: false });
+        this.clearLongPressTimer();
     }
 
     openApp = () => {
@@ -21,6 +31,102 @@ export class UbuntuApp extends Component {
             setTimeout(() => this.setState({ launching: false }), 300);
         });
         this.props.openApp(this.props.id);
+    }
+
+    componentWillUnmount() {
+        this.clearLongPressTimer();
+    }
+
+    clearLongPressTimer = () => {
+        if (this.longPressTimer) {
+            clearTimeout(this.longPressTimer);
+            this.longPressTimer = null;
+        }
+        this.longPressPoint = null;
+        this.longPressTarget = null;
+    }
+
+    emitContextMenu = (trigger, coords, target) => {
+        if (this.props.disabled || typeof window === 'undefined') return;
+        this.clearLongPressTimer();
+        const element = target || document.getElementById(`app-${this.props.id}`);
+        const rect = element ? element.getBoundingClientRect() : null;
+        const x = coords && typeof coords.x === 'number'
+            ? coords.x
+            : rect
+                ? rect.left + rect.width / 2
+                : 0;
+        const y = coords && typeof coords.y === 'number'
+            ? coords.y
+            : rect
+                ? rect.top + rect.height / 2
+                : 0;
+
+        const favoriteLabel = this.props.isFavorite ? 'Remove Favorite' : 'Add Favorite';
+        const pinLabel = this.props.isPinned ? 'Unpin from Panel' : 'Pin to Panel';
+
+        const detail = {
+            id: this.props.id,
+            name: this.props.name,
+            displayName: this.props.displayName || this.props.name,
+            icon: this.props.icon,
+            trigger,
+            position: { x, y },
+            rect,
+            isFavorite: !!this.props.isFavorite,
+            isPinned: !!this.props.isPinned,
+            actions: [
+                {
+                    id: this.props.isFavorite ? 'remove-favorite' : 'add-favorite',
+                    label: favoriteLabel,
+                    perform: () => {
+                        if (this.props.onToggleFavorite) {
+                            this.props.onToggleFavorite(this.props.id, !this.props.isFavorite);
+                        }
+                    },
+                },
+                {
+                    id: this.props.isPinned ? 'unpin-panel' : 'pin-panel',
+                    label: pinLabel,
+                    perform: () => {
+                        if (this.props.onTogglePin) {
+                            this.props.onTogglePin(this.props.id, !this.props.isPinned);
+                        }
+                    },
+                },
+                {
+                    id: 'open-new-window',
+                    label: 'Open New Window',
+                    perform: () => {
+                        if (this.props.onOpenNewWindow) {
+                            this.props.onOpenNewWindow(this.props.id);
+                        }
+                    },
+                },
+            ],
+        };
+
+        window.dispatchEvent(new CustomEvent('ubuntu-app-context', { detail }));
+    }
+
+    handleContextMenu = (event) => {
+        if (this.props.disabled) return;
+        this.emitContextMenu('contextmenu', { x: event.pageX, y: event.pageY }, event.currentTarget);
+    }
+
+    handlePointerDown = (event) => {
+        if (this.props.disabled) return;
+        if (event.pointerType === 'mouse' && event.button !== 0) return;
+        this.clearLongPressTimer();
+        this.longPressTarget = event.currentTarget;
+        this.longPressPoint = { x: event.pageX, y: event.pageY };
+        this.longPressTimer = setTimeout(() => {
+            this.emitContextMenu('long-press', this.longPressPoint, this.longPressTarget);
+        }, LONG_PRESS_DURATION);
+    }
+
+    handlePointerEnd = () => {
+        this.clearLongPressTimer();
     }
 
     handlePrefetch = () => {
@@ -41,6 +147,11 @@ export class UbuntuApp extends Component {
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
+                onContextMenu={this.handleContextMenu}
+                onPointerDown={this.handlePointerDown}
+                onPointerUp={this.handlePointerEnd}
+                onPointerLeave={this.handlePointerEnd}
+                onPointerCancel={this.handlePointerEnd}
                 className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
                     " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import UbuntuApp from '../base/ubuntu_app';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { useSettings } from '../../hooks/useSettings';
 
-const FAVORITES_KEY = 'launcherFavorites';
 const RECENTS_KEY = 'recentApps';
 const GROUP_SIZE = 9;
 
@@ -50,81 +50,254 @@ const chunkApps = (apps, size) => {
     return chunks;
 };
 
-class AllApplications extends React.Component {
-    constructor() {
-        super();
-        this.state = {
-            query: '',
-            apps: [],
-            unfilteredApps: [],
-            favorites: [],
-            recents: [],
-        };
-    }
+const arraysEqual = (a, b) => a.length === b.length && a.every((value, index) => value === b[index]);
 
-    componentDidMount() {
-        const { apps = [], games = [] } = this.props;
+const AllApplications = ({ apps = [], games = [], openApp }) => {
+    const { favoriteIds, pinnedIds, setFavoriteIds, setPinnedIds } = useSettings();
+    const [query, setQuery] = useState('');
+    const [draggingId, setDraggingId] = useState(null);
+
+    const allApps = useMemo(() => {
         const combined = [...apps];
         games.forEach((game) => {
             if (!combined.some((app) => app.id === game.id)) combined.push(game);
         });
-        const availableIds = new Set(combined.map((app) => app.id));
-        const favorites = sanitizeIds(readStoredIds(FAVORITES_KEY), availableIds);
-        const recents = sanitizeIds(readStoredIds(RECENTS_KEY), availableIds, 10);
+        return combined;
+    }, [apps, games]);
 
-        persistIds(FAVORITES_KEY, favorites);
-        persistIds(RECENTS_KEY, recents);
+    const availableIds = useMemo(() => new Set(allApps.map((app) => app.id)), [allApps]);
 
-        this.setState({
-            apps: combined,
-            unfilteredApps: combined,
-            favorites,
-            recents,
-        });
-    }
+    const [recentIds, setRecentIds] = useState(() =>
+        sanitizeIds(readStoredIds(RECENTS_KEY), availableIds, 10)
+    );
 
-    handleChange = (e) => {
-        const value = e.target.value;
-        const { unfilteredApps } = this.state;
-        const apps =
-            value === '' || value === null
-                ? unfilteredApps
-                : unfilteredApps.filter((app) =>
-                      app.title.toLowerCase().includes(value.toLowerCase())
-                  );
-        this.setState({ query: value, apps });
+    const sanitizedFavorites = useMemo(
+        () => favoriteIds.filter((id) => availableIds.has(id)),
+        [favoriteIds, availableIds]
+    );
+
+    const sanitizedPinned = useMemo(
+        () => pinnedIds.filter((id) => availableIds.has(id)),
+        [pinnedIds, availableIds]
+    );
+
+    useEffect(() => {
+        if (favoriteIds.some((id) => !availableIds.has(id))) {
+            setFavoriteIds(sanitizeIds(favoriteIds, availableIds));
+        }
+    }, [favoriteIds, availableIds, setFavoriteIds]);
+
+    useEffect(() => {
+        if (pinnedIds.some((id) => !availableIds.has(id))) {
+            setPinnedIds(sanitizeIds(pinnedIds, availableIds));
+        }
+    }, [pinnedIds, availableIds, setPinnedIds]);
+
+    useEffect(() => {
+        const stored = sanitizeIds(readStoredIds(RECENTS_KEY), availableIds, 10);
+        setRecentIds((prev) => (arraysEqual(prev, stored) ? prev : stored));
+        persistIds(RECENTS_KEY, stored);
+    }, [availableIds]);
+
+    const filteredApps = useMemo(() => {
+        if (!query) return allApps;
+        const lower = query.toLowerCase();
+        return allApps.filter((app) => app.title.toLowerCase().includes(lower));
+    }, [allApps, query]);
+
+    const filteredMap = useMemo(
+        () => new Map(filteredApps.map((app) => [app.id, app])),
+        [filteredApps]
+    );
+
+    const favoriteApps = useMemo(
+        () => sanitizedFavorites.map((id) => filteredMap.get(id)).filter(Boolean),
+        [sanitizedFavorites, filteredMap]
+    );
+
+    const recentApps = useMemo(
+        () => recentIds.map((id) => filteredMap.get(id)).filter(Boolean),
+        [recentIds, filteredMap]
+    );
+
+    const seenIds = useMemo(() => {
+        const set = new Set();
+        favoriteApps.forEach((app) => set.add(app.id));
+        recentApps.forEach((app) => set.add(app.id));
+        return set;
+    }, [favoriteApps, recentApps]);
+
+    const remainingApps = useMemo(
+        () => filteredApps.filter((app) => !seenIds.has(app.id)),
+        [filteredApps, seenIds]
+    );
+
+    const groupedApps = useMemo(
+        () => chunkApps(remainingApps, GROUP_SIZE),
+        [remainingApps]
+    );
+
+    const favoriteSet = useMemo(() => new Set(sanitizedFavorites), [sanitizedFavorites]);
+    const pinnedSet = useMemo(() => new Set(sanitizedPinned), [sanitizedPinned]);
+
+    const handleChange = (e) => {
+        setQuery(e.target.value);
     };
 
-    openApp = (id) => {
-        this.setState((state) => {
-            const filtered = state.recents.filter((recentId) => recentId !== id);
-            const next = [id, ...filtered].slice(0, 10);
-            persistIds(RECENTS_KEY, next);
-            return { recents: next };
-        }, () => {
-            if (typeof this.props.openApp === 'function') {
-                this.props.openApp(id);
+    const handleOpenApp = useCallback(
+        (id) => {
+            setRecentIds((state) => {
+                const filtered = state.filter((recentId) => recentId !== id);
+                const next = [id, ...filtered].slice(0, 10);
+                persistIds(RECENTS_KEY, next);
+                return next;
+            });
+            if (typeof openApp === 'function') {
+                openApp(id);
             }
-        });
-    };
+        },
+        [openApp]
+    );
 
-    handleToggleFavorite = (event, id) => {
-        event.preventDefault();
-        event.stopPropagation();
-        this.setState((state) => {
-            const isFavorite = state.favorites.includes(id);
-            const favorites = isFavorite
-                ? state.favorites.filter((favId) => favId !== id)
-                : [...state.favorites, id];
-            persistIds(FAVORITES_KEY, favorites);
-            return { favorites };
-        });
-    };
+    const handleFavoriteChange = useCallback(
+        (id, nextState) => {
+            setFavoriteIds((state) => {
+                const has = state.includes(id);
+                if (nextState && !has) {
+                    return [...state, id];
+                }
+                if (!nextState && has) {
+                    return state.filter((value) => value !== id);
+                }
+                return state;
+            });
+        },
+        [setFavoriteIds]
+    );
 
-    renderAppTile = (app) => {
-        const isFavorite = this.state.favorites.includes(app.id);
+    const handlePinChange = useCallback(
+        (id, nextState) => {
+            setPinnedIds((state) => {
+                const has = state.includes(id);
+                if (nextState && !has) {
+                    return [...state, id];
+                }
+                if (!nextState && has) {
+                    return state.filter((value) => value !== id);
+                }
+                return state;
+            });
+        },
+        [setPinnedIds]
+    );
+
+    const handleToggleFavorite = useCallback(
+        (event, id, isFavorite) => {
+            event.preventDefault();
+            event.stopPropagation();
+            handleFavoriteChange(id, !isFavorite);
+        },
+        [handleFavoriteChange]
+    );
+
+    const handleFavoriteDragStart = useCallback(
+        (id) => (event) => {
+            setDraggingId(id);
+            if (event.dataTransfer) {
+                event.dataTransfer.effectAllowed = 'move';
+                try {
+                    event.dataTransfer.setData('text/plain', id);
+                } catch (e) {
+                    // ignore data transfer failures
+                }
+            }
+        },
+        []
+    );
+
+    const handleFavoriteDragOver = useCallback(
+        (id) => (event) => {
+            if (!draggingId || draggingId === id) return;
+            event.preventDefault();
+            if (event.dataTransfer) {
+                event.dataTransfer.dropEffect = 'move';
+            }
+        },
+        [draggingId]
+    );
+
+    const handleFavoriteDrop = useCallback(
+        (id) => (event) => {
+            event.preventDefault();
+            const sourceId = draggingId || (event.dataTransfer && event.dataTransfer.getData('text/plain'));
+            if (!sourceId || sourceId === id) {
+                setDraggingId(null);
+                return;
+            }
+            setFavoriteIds((state) => {
+                const sourceIndex = state.indexOf(sourceId);
+                const targetIndex = state.indexOf(id);
+                if (sourceIndex === -1 || targetIndex === -1) return state;
+                const next = [...state];
+                next.splice(sourceIndex, 1);
+                next.splice(targetIndex, 0, sourceId);
+                return next;
+            });
+            setDraggingId(null);
+        },
+        [draggingId, setFavoriteIds]
+    );
+
+    const handleFavoriteDragEnd = useCallback(() => {
+        setDraggingId(null);
+    }, []);
+
+    const handleFavoritesContainerDragOver = useCallback(
+        (event) => {
+            if (!draggingId) return;
+            event.preventDefault();
+            if (event.dataTransfer) {
+                event.dataTransfer.dropEffect = 'move';
+            }
+        },
+        [draggingId]
+    );
+
+    const handleFavoritesContainerDrop = useCallback(
+        (event) => {
+            if (!draggingId) return;
+            event.preventDefault();
+            const sourceId = draggingId;
+            setFavoriteIds((state) => {
+                if (!state.includes(sourceId)) return state;
+                const next = state.filter((value) => value !== sourceId);
+                next.push(sourceId);
+                return next;
+            });
+            setDraggingId(null);
+        },
+        [draggingId, setFavoriteIds]
+    );
+
+    const renderAppTile = (app, { enableDrag = false } = {}) => {
+        const isFavorite = favoriteSet.has(app.id);
+        const isPinned = pinnedSet.has(app.id);
+        const dragHandlers = enableDrag
+            ? {
+                  onDragStart: handleFavoriteDragStart(app.id),
+                  onDragOver: handleFavoriteDragOver(app.id),
+                  onDrop: handleFavoriteDrop(app.id),
+                  onDragEnd: handleFavoriteDragEnd,
+              }
+            : {};
         return (
-            <div key={app.id} className="relative flex w-full justify-center">
+            <div
+                key={app.id}
+                className={`relative flex w-full justify-center${
+                    enableDrag && draggingId === app.id ? ' opacity-70' : ''
+                }`}
+                {...dragHandlers}
+            >
                 <button
                     type="button"
                     aria-pressed={isFavorite}
@@ -133,7 +306,7 @@ class AllApplications extends React.Component {
                             ? `Remove ${app.title} from favorites`
                             : `Add ${app.title} to favorites`
                     }
-                    onClick={(event) => this.handleToggleFavorite(event, app.id)}
+                    onClick={(event) => handleToggleFavorite(event, app.id, isFavorite)}
                     className={`absolute right-2 top-2 text-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
                         isFavorite ? 'text-yellow-300' : 'text-white/60 hover:text-white'
                     }`}
@@ -144,69 +317,66 @@ class AllApplications extends React.Component {
                     name={app.title}
                     id={app.id}
                     icon={app.icon}
-                    openApp={() => this.openApp(app.id)}
+                    openApp={() => handleOpenApp(app.id)}
                     disabled={app.disabled}
                     prefetch={app.screen?.prefetch}
+                    isFavorite={isFavorite}
+                    isPinned={isPinned}
+                    onToggleFavorite={handleFavoriteChange}
+                    onTogglePin={handlePinChange}
+                    onOpenNewWindow={() => handleOpenApp(app.id)}
                 />
             </div>
         );
     };
 
-    renderSection = (title, apps) => {
-        if (!apps.length) return null;
+    const renderSection = (title, sectionApps, options = {}) => {
+        if (!sectionApps.length) return null;
+        const enableDrag = options.enableDrag === true;
         return (
             <section key={title} aria-label={`${title} apps`} className="mb-8 w-full">
                 <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-white/70">
                     {title}
                 </h2>
-                <div className="grid grid-cols-3 gap-6 place-items-center pb-6 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8">
-                    {apps.map((app) => this.renderAppTile(app))}
+                <div
+                    className="grid grid-cols-3 gap-6 place-items-center pb-6 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8"
+                    onDragOver={enableDrag ? handleFavoritesContainerDragOver : undefined}
+                    onDrop={enableDrag ? handleFavoritesContainerDrop : undefined}
+                >
+                    {sectionApps.map((app) => renderAppTile(app, { enableDrag }))}
                 </div>
             </section>
         );
     };
 
-    render() {
-        const { apps, favorites, recents } = this.state;
-        const favoriteSet = new Set(favorites);
-        const appMap = new Map(apps.map((app) => [app.id, app]));
-        const favoriteApps = apps.filter((app) => favoriteSet.has(app.id));
-        const recentApps = recents
-            .map((id) => appMap.get(id))
-            .filter(Boolean);
-        const seenIds = new Set([...favoriteApps, ...recentApps].map((app) => app.id));
-        const remainingApps = apps.filter((app) => !seenIds.has(app.id));
-        const groupedApps = chunkApps(remainingApps, GROUP_SIZE);
-        const hasResults =
-            favoriteApps.length > 0 ||
-            recentApps.length > 0 ||
-            groupedApps.some((group) => group.length > 0);
+    const hasResults =
+        favoriteApps.length > 0 ||
+        recentApps.length > 0 ||
+        groupedApps.some((group) => group.length > 0);
 
-        return (
-            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
-                <input
-                    className="mt-10 mb-8 w-2/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none md:w-1/3"
-                    placeholder="Search"
-                    value={this.state.query}
-                    onChange={this.handleChange}
-                    aria-label="Search applications"
-                />
-                <div className="flex w-full max-w-5xl flex-col items-stretch px-6 pb-10">
-                    {this.renderSection('Favorites', favoriteApps)}
-                    {this.renderSection('Recent', recentApps)}
-                    {groupedApps.map((group, index) =>
-                        group.length ? this.renderSection(`Group ${index + 1}`, group) : null
-                    )}
-                    {!hasResults && (
-                        <p className="mt-6 text-center text-sm text-white/70">
-                            No applications match your search.
-                        </p>
-                    )}
-                </div>
+    return (
+        <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
+            <input
+                className="mt-10 mb-8 w-2/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none md:w-1/3"
+                placeholder="Search"
+                value={query}
+                onChange={handleChange}
+                aria-label="Search applications"
+            />
+            <div className="flex w-full max-w-5xl flex-col items-stretch px-6 pb-10">
+                {renderSection('Favorites', favoriteApps, { enableDrag: true })}
+                {renderSection('Recent', recentApps)}
+                {groupedApps.map((group, index) =>
+                    group.length ? renderSection(`Group ${index + 1}`, group) : null
+                )}
+                {!hasResults && (
+                    <p className="mt-6 text-center text-sm text-white/70">
+                        No applications match your search.
+                    </p>
+                )}
             </div>
-        );
-    }
-}
+        </div>
+    );
+};
 
 export default AllApplications;
-


### PR DESCRIPTION
## Summary
- persist favorite and pinned app ids in the settings store and context so they survive reloads
- emit a rich context-menu event from UbuntuApp including favorite, pin, and new window actions
- refactor the All Applications and Whisker menu views to consume the shared settings data and support drag-sorting favorites

## Testing
- yarn lint *(fails: repository contains pre-existing accessibility warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d7505b9f4c8328841abc9c2722dcaf