### PR TITLE
[menu] Improve launcher keyboard accessibility

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -749,10 +749,16 @@ export class Desktop extends Component {
     }
 
     openApp = (objId, params) => {
-        const context = params && typeof params === 'object'
+        const paramsObject = params && typeof params === 'object' ? { ...params } : undefined;
+        const spawnNew = paramsObject?.spawnNew;
+        if (paramsObject) {
+            delete paramsObject.spawnNew;
+        }
+        const hasContext = paramsObject && Object.keys(paramsObject).length > 0;
+        const context = hasContext
             ? {
-                ...params,
-                ...(params.path && !params.initialPath ? { initialPath: params.path } : {}),
+                ...paramsObject,
+                ...(paramsObject.path && !paramsObject.initialPath ? { initialPath: paramsObject.path } : {}),
             }
             : undefined;
         const contextState = context
@@ -770,7 +776,7 @@ export class Desktop extends Component {
         if (this.state.disabled_apps[objId]) return;
 
         // if app is already open, focus it instead of spawning a new window
-        if (this.state.closed_windows[objId] === false) {
+        if (!spawnNew && this.state.closed_windows[objId] === false) {
             // if it's minimised, restore its last position
             if (this.state.minimized_windows[objId]) {
                 this.focus(objId);

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -8,22 +8,48 @@ import PerformanceGraph from '../ui/PerformanceGraph';
 
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
+        constructor() {
+                super();
                 this.state = {
                         status_card: false,
                         applicationsMenuOpen: false,
                         placesMenuOpen: false
                 };
+                this.menuButton = null;
         }
 
-		render() {
-			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
-						<WhiskerMenu />
-						<PerformanceGraph />
-					</div>
+        componentDidMount() {
+                window.addEventListener('keydown', this.handleMetaFocus);
+        }
+
+        componentWillUnmount() {
+                window.removeEventListener('keydown', this.handleMetaFocus);
+        }
+
+        setMenuButton = (button) => {
+                this.menuButton = button;
+        };
+
+        handleMetaFocus = (event) => {
+                if (
+                        event.key === 'Meta' &&
+                        !event.altKey &&
+                        !event.ctrlKey &&
+                        !event.shiftKey
+                ) {
+                        if (this.menuButton && document.activeElement !== this.menuButton) {
+                                this.menuButton.focus();
+                        }
+                }
+        };
+
+                render() {
+                        return (
+                                <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                        <div className="flex items-center">
+                                                <WhiskerMenu onButtonRef={this.setMenuButton} />
+                                                <PerformanceGraph />
+                                        </div>
 					<div
 						className={
 							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'


### PR DESCRIPTION
## Summary
- add Shift+Enter handling, new-window callback, and category/grid arrow navigation in the Whisker menu
- surface the highlighted app to assistive tech via aria-activedescendant and live region updates
- focus the Whisker button on Super key presses and plumb a spawnNew flag through desktop app opening

## Testing
- yarn lint *(fails: repo contains pre-existing jsx-a11y/control-has-associated-label violations in multiple apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d7505c3e7c83289cc72f1ffec6d945