### PR TITLE
[settings] Add menu configuration import/export

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -6,6 +6,7 @@ import UbuntuApp from '../base/ubuntu_app';
 import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { KALI_CATEGORIES as BASE_KALI_CATEGORIES } from './ApplicationsMenu';
+import { MENU_CONFIG_EVENT } from '../../utils/menuConfig';
 
 type AppMeta = {
   id: string;
@@ -159,12 +160,21 @@ const WhiskerMenu: React.FC = () => {
   const menuRef = useRef<HTMLDivElement>(null);
   const categoryListRef = useRef<HTMLDivElement>(null);
   const categoryButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const [menuVersion, setMenuVersion] = useState(0);
 
 
   const allApps: AppMeta[] = apps as any;
-  const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
+  const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps, menuVersion]);
   useEffect(() => {
     setRecentIds(readRecentAppIds());
+  }, []);
+
+  useEffect(() => {
+    const handleUpdate = () => {
+      setMenuVersion((version) => version + 1);
+    };
+    window.addEventListener(MENU_CONFIG_EVENT, handleUpdate);
+    return () => window.removeEventListener(MENU_CONFIG_EVENT, handleUpdate);
   }, []);
 
   useEffect(() => {

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -4,7 +4,25 @@ import SideBarApp from '../base/side_bar_app';
 
 let renderApps = (props) => {
     let sideBarAppsJsx = [];
-    props.apps.forEach((app, index) => {
+    let orderedApps = props.apps;
+    if (Array.isArray(props.pinnedOrder) && props.pinnedOrder.length) {
+        const map = new Map(props.apps.map((app) => [app.id, app]));
+        const seen = new Set();
+        orderedApps = [];
+        props.pinnedOrder.forEach((id) => {
+            const app = map.get(id);
+            if (app) {
+                orderedApps.push(app);
+                seen.add(id);
+            }
+        });
+        props.apps.forEach((app) => {
+            if (!seen.has(app.id)) {
+                orderedApps.push(app);
+            }
+        });
+    }
+    orderedApps.forEach((app) => {
         if (props.favourite_apps[app.id] === false) return;
         sideBarAppsJsx.push(
             <SideBarApp key={app.id} id={app.id} title={app.title} icon={app.icon} isClose={props.closed_windows} isFocus={props.focused_windows} openApp={props.openAppByAppId} isMinimized={props.isMinimized} openFromMinimised={props.openFromMinimised} />

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -25,6 +25,12 @@ import {
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import {
+  exportMenuConfig as exportMenuConfigData,
+  importMenuConfig as importMenuConfigData,
+  MenuConfigImportResult,
+  MenuConfigInput,
+} from '../utils/menuConfig';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -79,6 +85,8 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  exportMenuConfig: () => Promise<string>;
+  importMenuConfig: (input: string | MenuConfigInput) => Promise<MenuConfigImportResult>;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -107,6 +115,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  exportMenuConfig: async () => JSON.stringify({}),
+  importMenuConfig: async () => ({ favorites: [], pins: [], ordering: [], ignoredFavorites: [], ignoredPins: [], ignoredOrdering: [] }),
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -252,6 +262,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   const bgImageName = useKaliWallpaper ? 'kali-gradient' : wallpaper;
 
+  const exportMenuConfig = async () => exportMenuConfigData();
+
+  const importMenuConfig = async (input: string | MenuConfigInput) => importMenuConfigData(input);
+
   return (
     <SettingsContext.Provider
       value={{
@@ -280,6 +294,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        exportMenuConfig,
+        importMenuConfig,
       }}
     >
       {children}

--- a/utils/menuConfig.ts
+++ b/utils/menuConfig.ts
@@ -1,0 +1,275 @@
+"use client";
+
+import apps from '../apps.config';
+import { safeLocalStorage } from './safeStorage';
+import { defaults } from './settingsStore.js';
+
+export const MENU_CONFIG_EVENT = 'menu-config-updated';
+export const MENU_CONFIG_VERSION = 1;
+
+const FAVORITES_KEY = 'launcherFavorites';
+const PINNED_KEY = 'pinnedApps';
+const DESKTOP_SESSION_KEY = 'desktop-session';
+
+interface DesktopSessionRecord {
+  windows?: unknown;
+  wallpaper?: unknown;
+  dock?: unknown;
+  [key: string]: unknown;
+}
+
+export interface MenuConfigSnapshot {
+  favorites: string[];
+  pins: string[];
+  ordering: string[];
+}
+
+export interface MenuConfigImportResult extends MenuConfigSnapshot {
+  ignoredFavorites: string[];
+  ignoredPins: string[];
+  ignoredOrdering: string[];
+}
+
+export type MenuConfigInput = Partial<{
+  favorites: unknown;
+  pins: unknown;
+  ordering: unknown;
+  version: unknown;
+}>;
+
+type SanitizeResult = {
+  ids: string[];
+  ignored: string[];
+};
+
+type AppLike = {
+  id?: unknown;
+  favourite?: unknown;
+};
+
+const availableAppIds = new Set(
+  ((apps as AppLike[]) ?? [])
+    .map((app) => (app && typeof app.id === 'string' ? app.id : null))
+    .filter((id): id is string => Boolean(id)),
+);
+
+const sanitizeIds = (value: unknown): SanitizeResult => {
+  if (!Array.isArray(value)) {
+    return { ids: [], ignored: [] };
+  }
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  const ignored: string[] = [];
+  value.forEach((entry) => {
+    if (typeof entry !== 'string') {
+      return;
+    }
+    if (!availableAppIds.has(entry)) {
+      ignored.push(entry);
+      return;
+    }
+    if (seen.has(entry)) {
+      return;
+    }
+    seen.add(entry);
+    ids.push(entry);
+  });
+  return { ids, ignored };
+};
+
+const readJsonArray = (key: string): unknown => {
+  if (!safeLocalStorage) return [];
+  try {
+    const raw = safeLocalStorage.getItem(key);
+    if (!raw) return [];
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
+};
+
+const writeJsonArray = (key: string, value: unknown[]): void => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore storage failures
+  }
+};
+
+const readFavoritesFromStorage = (): string[] => sanitizeIds(readJsonArray(FAVORITES_KEY)).ids;
+
+const writeFavoritesToStorage = (favorites: string[]): void => {
+  writeJsonArray(FAVORITES_KEY, favorites);
+};
+
+const readPinnedFromStorage = (): string[] => sanitizeIds(readJsonArray(PINNED_KEY)).ids;
+
+const writePinnedToStorage = (pins: string[]): void => {
+  writeJsonArray(PINNED_KEY, pins);
+};
+
+const readSession = (): DesktopSessionRecord | null => {
+  if (!safeLocalStorage) return null;
+  try {
+    const raw = safeLocalStorage.getItem(DESKTOP_SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as DesktopSessionRecord;
+    }
+  } catch {
+    // ignore parsing errors
+  }
+  return null;
+};
+
+const writeSession = (session: DesktopSessionRecord): void => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(DESKTOP_SESSION_KEY, JSON.stringify(session));
+  } catch {
+    // ignore write errors
+  }
+};
+
+const readOrderingFromStorage = (): string[] => {
+  const session = readSession();
+  if (!session) return [];
+  return sanitizeIds(session.dock).ids;
+};
+
+const writeOrderingToStorage = (ordering: string[]): void => {
+  const session = readSession() ?? {};
+  const next: DesktopSessionRecord = { ...session };
+  next.dock = ordering;
+  if (!Array.isArray(next.windows)) {
+    next.windows = [];
+  }
+  if (typeof next.wallpaper !== 'string') {
+    next.wallpaper = defaults.wallpaper;
+  }
+  writeSession(next);
+};
+
+const applyPinsToAppConfig = (pins: string[]): void => {
+  const pinnedSet = new Set(pins);
+  (apps as AppLike[]).forEach((app) => {
+    if (!app || typeof app !== 'object') return;
+    if (typeof app.id !== 'string') return;
+    (app as AppLike).favourite = pinnedSet.has(app.id) ? true : false;
+  });
+};
+
+const mergeOrdering = (pins: string[], ordering: string[]): string[] => {
+  const order = ordering.filter((id) => pins.includes(id));
+  const seen = new Set(order);
+  pins.forEach((id) => {
+    if (!seen.has(id)) {
+      seen.add(id);
+      order.push(id);
+    }
+  });
+  return order;
+};
+
+const getSnapshotFromStorage = (): MenuConfigSnapshot => {
+  const favorites = readFavoritesFromStorage();
+  const pins = readPinnedFromStorage();
+  const ordering = mergeOrdering(pins, readOrderingFromStorage());
+  return { favorites, pins, ordering };
+};
+
+const setSnapshotToStorage = (snapshot: MenuConfigSnapshot): void => {
+  writeFavoritesToStorage(snapshot.favorites);
+  writePinnedToStorage(snapshot.pins);
+  writeOrderingToStorage(snapshot.ordering);
+  applyPinsToAppConfig(snapshot.pins);
+};
+
+export const readMenuConfig = (): MenuConfigSnapshot => getSnapshotFromStorage();
+
+export const emitMenuConfigUpdate = (detail?: MenuConfigSnapshot): void => {
+  if (typeof window === 'undefined') return;
+  const payload = detail ?? getSnapshotFromStorage();
+  window.dispatchEvent(new CustomEvent<MenuConfigSnapshot>(MENU_CONFIG_EVENT, { detail: payload }));
+};
+
+export const exportMenuConfig = (): string => {
+  const snapshot = getSnapshotFromStorage();
+  return JSON.stringify({ version: MENU_CONFIG_VERSION, ...snapshot }, null, 2);
+};
+
+const coerceArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
+
+export const importMenuConfig = (
+  input: string | MenuConfigInput,
+): MenuConfigImportResult => {
+  let payload: MenuConfigInput;
+  if (typeof input === 'string') {
+    try {
+      payload = JSON.parse(input);
+    } catch (error) {
+      throw new Error('Invalid menu configuration: unable to parse JSON');
+    }
+  } else {
+    payload = input;
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Menu configuration must be an object');
+  }
+
+  const { ids: favoriteIds, ignored: ignoredFavorites } = sanitizeIds(
+    coerceArray(payload.favorites),
+  );
+  const { ids: pinIdsRaw, ignored: ignoredPins } = sanitizeIds(
+    coerceArray(payload.pins),
+  );
+  const { ids: orderingIdsRaw, ignored: ignoredOrdering } = sanitizeIds(
+    coerceArray(payload.ordering),
+  );
+
+  const pins = pinIdsRaw;
+  const ordering = mergeOrdering(pins, orderingIdsRaw);
+  const snapshot: MenuConfigSnapshot = {
+    favorites: favoriteIds,
+    pins,
+    ordering,
+  };
+
+  setSnapshotToStorage(snapshot);
+  emitMenuConfigUpdate(snapshot);
+
+  return {
+    ...snapshot,
+    ignoredFavorites,
+    ignoredPins,
+    ignoredOrdering,
+  };
+};
+
+export const setPinnedApps = (pins: string[], emit = true): void => {
+  const ordering = mergeOrdering(pins, readOrderingFromStorage());
+  const snapshot: MenuConfigSnapshot = {
+    favorites: readFavoritesFromStorage(),
+    pins,
+    ordering,
+  };
+  setSnapshotToStorage(snapshot);
+  if (emit) emitMenuConfigUpdate(snapshot);
+};
+
+export const setFavoritesList = (favorites: string[], emit = true): void => {
+  const pins = readPinnedFromStorage();
+  const ordering = mergeOrdering(pins, readOrderingFromStorage());
+  const snapshot: MenuConfigSnapshot = {
+    favorites,
+    pins,
+    ordering,
+  };
+  setSnapshotToStorage(snapshot);
+  if (emit) emitMenuConfigUpdate(snapshot);
+};
+
+export const getPinnedOrder = (): string[] => readOrderingFromStorage();


### PR DESCRIPTION
## Summary
- add a client-side menu configuration store for favorites, pins, and ordering with import/export helpers and events
- surface export/import actions in the settings context and privacy tab with validation feedback
- synchronize desktop, launcher, and whisker menu components when menu configuration changes so favorites update immediately

## Testing
- yarn lint *(fails: repository has existing accessibility and browser-global lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d750613ba08328a01a9b3ce7f7607c