### PR TITLE
[desktop] Improve workspace switcher controls

### DIFF
--- a/components/panel/WorkspaceSwitcher.tsx
+++ b/components/panel/WorkspaceSwitcher.tsx
@@ -12,6 +12,7 @@ interface WorkspaceSwitcherProps {
   workspaces: WorkspaceSummary[];
   activeWorkspace: number;
   onSelect: (workspaceId: number) => void;
+  onShift: (direction: number) => void;
 }
 
 function formatAriaLabel(workspace: WorkspaceSummary) {
@@ -29,17 +30,51 @@ export default function WorkspaceSwitcher({
   workspaces,
   activeWorkspace,
   onSelect,
+  onShift,
 }: WorkspaceSwitcherProps) {
   if (workspaces.length === 0) return null;
+
+  const activeId = `workspace-dot-${activeWorkspace}`;
+
+  const handleWheel = React.useCallback(
+    (event: React.WheelEvent<HTMLElement>) => {
+      const { deltaX, deltaY } = event;
+      const magnitude = Math.abs(deltaY) > Math.abs(deltaX) ? deltaY : deltaX;
+      if (!magnitude) return;
+      event.preventDefault();
+      onShift(magnitude > 0 ? 1 : -1);
+    },
+    [onShift],
+  );
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (!event.ctrlKey || !event.altKey) return;
+      if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+        event.preventDefault();
+        onShift(-1);
+      } else if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+        event.preventDefault();
+        onShift(1);
+      }
+    },
+    [onShift],
+  );
 
   return (
     <nav
       aria-label="Workspace switcher"
-      className="flex items-center gap-1 rounded-full bg-black/50 px-1 py-0.5"
+      aria-activedescendant={activeId}
+      role="tablist"
+      aria-orientation="horizontal"
+      onWheel={handleWheel}
+      onKeyDown={handleKeyDown}
+      className="flex items-center gap-1.5 rounded-full bg-black/50 px-1.5 py-1"
     >
       {workspaces.map((workspace, index) => {
         const isActive = workspace.id === activeWorkspace;
         const tabIndex = workspace.id === activeWorkspace ? 0 : -1;
+        const controlId = `workspace-dot-${workspace.id}`;
         return (
           <button
             key={workspace.id}
@@ -47,16 +82,27 @@ export default function WorkspaceSwitcher({
             tabIndex={tabIndex}
             aria-pressed={isActive}
             aria-label={formatAriaLabel(workspace)}
+            aria-selected={isActive}
+            aria-current={isActive ? "page" : undefined}
+            role="tab"
+            id={controlId}
+            title={`${index + 1}`}
             onClick={() => onSelect(workspace.id)}
-            className={`min-w-[28px] rounded-full px-2 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-offset-black ${
+            className={`relative flex h-6 w-6 items-center justify-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-offset-black ${
               isActive
-                ? "bg-[var(--kali-blue)] text-black"
-                : "bg-transparent text-white/80 hover:bg-white/10"
+                ? "bg-white/90 text-black shadow-inner"
+                : "bg-white/10 text-white/80 hover:bg-white/20"
             }`}
           >
-            <span>{index + 1}</span>
+            <span className="sr-only">{`Workspace ${index + 1}`}</span>
+            <span
+              aria-hidden="true"
+              className={`h-2.5 w-2.5 rounded-full transition-transform ${
+                isActive ? "scale-110 bg-[var(--kali-blue)]" : "bg-white/70"
+              }`}
+            />
             {workspace.openWindows > 0 && !isActive && (
-              <span className="ml-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-white/10 px-1 text-[10px] text-white/80">
+              <span className="absolute -right-1.5 -top-1 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-white/10 px-1 text-[10px] text-white/80">
                 {workspace.openWindows}
               </span>
             )}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -23,6 +23,7 @@ export default function Taskbar(props) {
                 workspaces={workspaces}
                 activeWorkspace={props.activeWorkspace}
                 onSelect={props.onSelectWorkspace}
+                onShift={(direction) => props.onShiftWorkspace && props.onShiftWorkspace(direction)}
             />
             <div className="flex items-center overflow-x-auto">
                 {runningApps.map(app => {

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -22,6 +22,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getWorkspaceCount as loadWorkspaceCount,
+  setWorkspaceCount as saveWorkspaceCount,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -67,6 +69,7 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  workspaceCount: number;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setUseKaliWallpaper: (value: boolean) => void;
@@ -79,6 +82,7 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setWorkspaceCount: (value: number) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -95,6 +99,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  workspaceCount: defaults.workspaceCount,
   setAccent: () => {},
   setWallpaper: () => {},
   setUseKaliWallpaper: () => {},
@@ -107,6 +112,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setWorkspaceCount: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -122,6 +128,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [workspaceCount, setWorkspaceCountState] = useState<number>(defaults.workspaceCount);
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -138,6 +145,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
       setTheme(loadTheme());
+      setWorkspaceCountState(await loadWorkspaceCount());
     })();
   }, []);
 
@@ -250,6 +258,15 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveWorkspaceCount(workspaceCount);
+  }, [workspaceCount]);
+
+  const normalizeWorkspaceCount = (value: number) => {
+    const next = Number.isFinite(value) ? Math.round(value) : defaults.workspaceCount;
+    return Math.max(1, next);
+  };
+
   const bgImageName = useKaliWallpaper ? 'kali-gradient' : wallpaper;
 
   return (
@@ -268,6 +285,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        workspaceCount,
         setAccent,
         setWallpaper,
         setUseKaliWallpaper,
@@ -280,6 +298,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setWorkspaceCount: (value: number) => setWorkspaceCountState(normalizeWorkspaceCount(value)),
       }}
     >
       {children}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -15,6 +15,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  workspaceCount: 4,
 };
 
 export async function getAccent() {
@@ -135,6 +136,20 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getWorkspaceCount() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.workspaceCount;
+  const stored = window.localStorage.getItem('workspace-count');
+  if (!stored) return DEFAULT_SETTINGS.workspaceCount;
+  const parsed = Number.parseInt(stored, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_SETTINGS.workspaceCount;
+}
+
+export async function setWorkspaceCount(count) {
+  if (typeof window === 'undefined') return;
+  const next = Number.isFinite(count) && count > 0 ? Math.round(count) : DEFAULT_SETTINGS.workspaceCount;
+  window.localStorage.setItem('workspace-count', String(next));
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -150,6 +165,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
   window.localStorage.removeItem('use-kali-wallpaper');
+  window.localStorage.removeItem('workspace-count');
 }
 
 export async function exportSettings() {
@@ -192,6 +208,7 @@ export async function exportSettings() {
     haptics,
     useKaliWallpaper,
     theme,
+    workspaceCount,
   });
 }
 
@@ -217,6 +234,7 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    workspaceCount,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -230,6 +248,7 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (workspaceCount !== undefined) await setWorkspaceCount(workspaceCount);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- replace the workspace switcher buttons with dot indicators that expose numeric tooltips and richer aria metadata
- wire scroll wheel and Ctrl+Alt arrow shortcuts through the switcher via Desktop props
- persist workspace count in the shared settings store and surface it through the provider for reuse

## Testing
- yarn lint *(fails: repository has numerous pre-existing accessibility violations in app bundles and public game scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68d75063d0308328b7effd5a6a796441