### PR TITLE
[panel] Align Kali panel sections

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1041,7 +1041,15 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input
+                        className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5"
+                        id="folder-name-input"
+                        type="text"
+                        autoComplete="off"
+                        spellCheck="false"
+                        autoFocus={true}
+                        aria-label="Folder name"
+                    />
                 </div>
                 <div className="flex">
                     <button
@@ -1068,7 +1076,7 @@ export class Desktop extends Component {
     render() {
         const workspaceSummaries = this.getWorkspaceSummaries();
         return (
-            <main id="desktop" role="main" className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-8 bg-transparent relative overflow-hidden overscroll-none window-parent"}>
+            <main id="desktop" role="main" className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse pt-[calc(var(--kali-panel-height)+0.5rem)] bg-transparent relative overflow-hidden overscroll-none window-parent"}>
 
                 {/* Window Area */}
                 <div

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
@@ -6,10 +7,27 @@ import NotificationBell from '../ui/NotificationBell';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import PerformanceGraph from '../ui/PerformanceGraph';
 
+const QUICK_LAUNCHERS = [
+        {
+                id: 'terminal',
+                icon: '/themes/Kali/panel/decompiler-symbolic.svg',
+                label: 'Open Terminal',
+        },
+        {
+                id: 'files',
+                icon: '/themes/Kali/Places/folder-download.svg',
+                label: 'Open Files',
+        },
+        {
+                id: 'browser',
+                icon: '/themes/Kali/panel/network-wireless-signal-good-symbolic.svg',
+                label: 'Open Browser',
+        },
+];
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
+        constructor() {
+                super();
                 this.state = {
                         status_card: false,
                         applicationsMenuOpen: false,
@@ -17,37 +35,117 @@ export default class Navbar extends Component {
                 };
         }
 
-		render() {
-			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
-						<WhiskerMenu />
-						<PerformanceGraph />
-					</div>
-					<div
-						className={
-							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-						}
-					>
-						<Clock />
-					</div>
-					<button
-						type="button"
-						id="status-bar"
-						aria-label="System status"
-						onClick={() => {
-							this.setState({ status_card: !this.state.status_card });
-						}}
-						className={
-							'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-						}
-					>
-						<Status />
-						<QuickSettings open={this.state.status_card} />
-					</button>
-				</div>
-			);
-		}
+        handleQuickLaunch = (appId) => {
+                if (typeof this.props.onQuickLaunch === 'function') {
+                        this.props.onQuickLaunch(appId);
+                        return;
+                }
+                if (typeof window !== 'undefined') {
+                        window.dispatchEvent(
+                                new CustomEvent('panel:quick-launch', {
+                                        detail: { appId },
+                                })
+                        );
+                }
+        };
 
+        handleLock = () => {
+                if (typeof this.props.lockScreen === 'function') {
+                        this.props.lockScreen();
+                }
+        };
 
+        handlePower = () => {
+                if (typeof this.props.shutDown === 'function') {
+                        this.props.shutDown();
+                }
+        };
+
+        toggleStatus = () => {
+                this.setState((prevState) => ({ status_card: !prevState.status_card }));
+        };
+
+        renderQuickLaunchers() {
+                return (
+                        <div className="flex items-center gap-2" aria-label="Quick launchers">
+                                {QUICK_LAUNCHERS.map((launcher) => (
+                                        <button
+                                                key={launcher.id}
+                                                type="button"
+                                                onClick={() => this.handleQuickLaunch(launcher.id)}
+                                                className="group flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-white/0 transition-colors duration-150 ease-out hover:border-kali-panel-border hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-panel-border/60"
+                                        >
+                                                <span className="sr-only">{launcher.label}</span>
+                                                <Image
+                                                        src={launcher.icon}
+                                                        alt=""
+                                                        width={20}
+                                                        height={20}
+                                                        className="opacity-80 transition-opacity duration-150 group-hover:opacity-100"
+                                                />
+                                        </button>
+                                ))}
+                        </div>
+                );
+        }
+
+        render() {
+                return (
+                        <div className="main-navbar-vp fixed top-0 left-0 z-40 flex h-[var(--kali-panel-height)] w-full flex-nowrap items-center justify-between gap-4 border-b border-kali-panel-border bg-kali-panel/95 px-3 text-ubt-grey shadow-kali-panel backdrop-blur-md ring-1 ring-inset ring-kali-panel-highlight">
+                                <div className="flex h-full items-center gap-4 divide-x divide-kali-panel-divider/70">
+                                        <div className="flex h-full items-center px-3">
+                                                <WhiskerMenu />
+                                        </div>
+                                        <div className="hidden h-full items-center px-3 sm:flex">
+                                                {this.renderQuickLaunchers()}
+                                        </div>
+                                        <div className="hidden h-full items-center gap-3 px-3 lg:flex">
+                                                <span className="text-[0.65rem] uppercase tracking-widest text-white/60">Workspace</span>
+                                                <PerformanceGraph />
+                                        </div>
+                                </div>
+                                <div className="flex h-full items-center gap-4">
+                                        <div className="hidden items-center lg:flex">
+                                                <NotificationBell />
+                                        </div>
+                                        <div className="relative flex h-full items-center">
+                                                <button
+                                                        type="button"
+                                                        id="status-bar"
+                                                        aria-label="System status"
+                                                        aria-haspopup="dialog"
+                                                        aria-expanded={this.state.status_card}
+                                                        onClick={this.toggleStatus}
+                                                        className="flex h-full items-center gap-3 px-3 text-xs uppercase tracking-wide text-white/70 transition-colors duration-150 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-panel-border/60"
+                                                >
+                                                        <Status />
+                                                        <span className="hidden text-[0.6rem] font-semibold lg:inline">Status</span>
+                                                </button>
+                                                <QuickSettings open={this.state.status_card} />
+                                        </div>
+                                        <div className="hidden h-full items-center px-3 md:flex">
+                                                <Clock />
+                                        </div>
+                                        <div className="flex h-full items-center gap-2 px-3">
+                                                <button
+                                                        type="button"
+                                                        onClick={this.handleLock}
+                                                        className="flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-white/0 text-xs font-semibold uppercase tracking-wide text-white/70 transition-colors duration-150 hover:border-kali-panel-border hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-panel-border/60"
+                                                >
+                                                        <span className="sr-only">Lock screen</span>
+                                                        <Image src="/themes/Kali/panel/emblem-system-symbolic.svg" alt="" width={18} height={18} />
+                                                </button>
+                                                <button
+                                                        type="button"
+                                                        onClick={this.handlePower}
+                                                        className="flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-kali-panel-highlight/10 text-xs font-semibold uppercase tracking-wide text-white transition-colors duration-150 hover:border-kali-panel-border hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-panel-border/60"
+                                                >
+                                                        <span className="sr-only">Power options</span>
+                                                        <Image src="/themes/Kali/panel/power-button.svg" alt="" width={18} height={18} />
+                                                </button>
+                                        </div>
+                                </div>
+                        </div>
+                );
+        }
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -33,9 +33,11 @@
   --kali-blue-dark: #0f6fa1;
   --kali-blue-glow: rgba(23, 147, 209, 0.35);
   --kali-bg-solid: #0f1317;
-  --kali-panel: rgba(26, 31, 38, 0.9);
-  --kali-panel-border: rgba(255, 255, 255, 0.08);
-  --kali-panel-highlight: rgba(255, 255, 255, 0.05);
+  --kali-panel: rgba(11, 16, 24, 0.78);
+  --kali-panel-border: rgba(88, 181, 232, 0.35);
+  --kali-panel-highlight: rgba(255, 255, 255, 0.12);
+  --kali-panel-divider: rgba(255, 255, 255, 0.08);
+  --kali-panel-height: 3rem;
   --kali-terminal-green: #00ff00;
   --kali-terminal-text: #f5f5f5;
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -53,6 +53,10 @@ module.exports = {
           control: 'var(--color-control-accent)',
           backdrop: 'var(--kali-bg)',
         },
+        'kali-panel': 'var(--kali-panel)',
+        'kali-panel-border': 'var(--kali-panel-border)',
+        'kali-panel-highlight': 'var(--kali-panel-highlight)',
+        'kali-panel-divider': 'var(--kali-panel-divider)',
       },
       boxShadow: {
         'kali-panel': '0 6px 20px rgba(0,0,0,.35)',


### PR DESCRIPTION
## Summary
- redesign the top bar to follow Kali panel sections with translucent styling and quick launcher buttons
- add Kali panel design tokens to Tailwind and update desktop spacing so windows clear the panel
- improve accessibility by labelling the folder name input

## Testing
- npx eslint components/screen/navbar.js components/screen/desktop.js


------
https://chatgpt.com/codex/tasks/task_e_68d75062dd048328b50d39aeff268400