### PR TITLE
[ui] Enhance quick settings panel

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,56 +1,174 @@
 "use client";
 
-import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+import { useSettings } from '../../hooks/useSettings';
+import { isDarkTheme } from '../../utils/theme';
 
 interface Props {
   open: boolean;
 }
 
 const QuickSettings = ({ open }: Props) => {
-  const [theme, setTheme] = usePersistentState('qs-theme', 'light');
-  const [sound, setSound] = usePersistentState('qs-sound', true);
-  const [online, setOnline] = usePersistentState('qs-online', true);
-  const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const {
+    theme,
+    setTheme,
+    allowNetwork,
+    setAllowNetwork,
+    reducedMotion,
+    setReducedMotion,
+  } = useSettings();
+
+  const [bluetoothEnabled, setBluetoothEnabled] = usePersistentState('qs-bluetooth', true);
+  const [nightTintEnabled, setNightTintEnabled] = usePersistentState('qs-night-tint', false);
+  const [volume, setVolume] = usePersistentState('qs-volume', 70);
+  const [brightness, setBrightness] = usePersistentState('qs-brightness', 80);
 
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-  }, [theme]);
+    const normalizedBrightness = 0.5 + (brightness / 100) * 0.7;
+    document.documentElement.style.setProperty(
+      '--qs-brightness',
+      normalizedBrightness.toFixed(2)
+    );
+  }, [brightness]);
 
   useEffect(() => {
-    document.documentElement.classList.toggle('reduce-motion', reduceMotion);
-  }, [reduceMotion]);
+    document.documentElement.style.setProperty(
+      '--qs-night-tint-opacity',
+      nightTintEnabled ? '0.35' : '0'
+    );
+  }, [nightTintEnabled]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      '--qs-volume-level',
+      (volume / 100).toFixed(2)
+    );
+  }, [volume]);
+
+  const darkModeEnabled = isDarkTheme(theme);
+
+  const toggleClasses = (active: boolean) =>
+    `flex items-center justify-between w-full rounded px-3 py-2 text-left text-sm transition-colors focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
+      active ? 'bg-black/50 text-white shadow-inner' : 'bg-black/20 text-ubt-grey hover:bg-black/30'
+    }`;
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
-        open ? '' : 'hidden'
+      className={`absolute top-9 right-3 z-50 w-64 rounded-md border border-black border-opacity-20 bg-ub-cool-grey py-3 shadow ${
+        open ? 'animateShow' : 'hidden'
       }`}
+      role="menu"
+      aria-label="Quick settings"
+      aria-hidden={!open}
+      onClick={(event) => event.stopPropagation()}
     >
-      <div className="px-4 pb-2">
+      <div className="space-y-1 px-3 pb-3">
         <button
-          className="w-full flex justify-between"
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          type="button"
+          role="menuitemcheckbox"
+          aria-checked={allowNetwork}
+          className={toggleClasses(allowNetwork)}
+          onClick={() => setAllowNetwork(!allowNetwork)}
         >
-          <span>Theme</span>
-          <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
+          <span className="font-medium">Wi-Fi</span>
+          <span className="text-xs uppercase tracking-wide opacity-80">
+            {allowNetwork ? 'Connected' : 'Off'}
+          </span>
+        </button>
+        <button
+          type="button"
+          role="menuitemcheckbox"
+          aria-checked={bluetoothEnabled}
+          className={toggleClasses(bluetoothEnabled)}
+          onClick={() => setBluetoothEnabled(!bluetoothEnabled)}
+        >
+          <span className="font-medium">Bluetooth</span>
+          <span className="text-xs uppercase tracking-wide opacity-80">
+            {bluetoothEnabled ? 'Discoverable' : 'Off'}
+          </span>
+        </button>
+        <button
+          type="button"
+          role="menuitemcheckbox"
+          aria-checked={darkModeEnabled}
+          className={toggleClasses(darkModeEnabled)}
+          onClick={() => setTheme(darkModeEnabled ? 'default' : 'dark')}
+        >
+          <span className="font-medium">Dark mode</span>
+          <span className="text-xs uppercase tracking-wide opacity-80">
+            {darkModeEnabled ? 'On' : 'Off'}
+          </span>
+        </button>
+        <button
+          type="button"
+          role="menuitemcheckbox"
+          aria-checked={nightTintEnabled}
+          className={toggleClasses(nightTintEnabled)}
+          onClick={() => setNightTintEnabled(!nightTintEnabled)}
+        >
+          <span className="font-medium">Night tint</span>
+          <span className="text-xs uppercase tracking-wide opacity-80">
+            {nightTintEnabled ? 'Warm' : 'Neutral'}
+          </span>
+        </button>
+        <button
+          type="button"
+          role="menuitemcheckbox"
+          aria-checked={reducedMotion}
+          className={toggleClasses(reducedMotion)}
+          onClick={() => setReducedMotion(!reducedMotion)}
+        >
+          <span className="font-medium">Reduced motion</span>
+          <span className="text-xs uppercase tracking-wide opacity-80">
+            {reducedMotion ? 'On' : 'Off'}
+          </span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
-        <input
-          type="checkbox"
-          checked={reduceMotion}
-          onChange={() => setReduceMotion(!reduceMotion)}
-        />
+
+      <div className="space-y-3 border-t border-white/10 px-3 pt-3" role="none">
+        <div role="group" aria-labelledby="quick-settings-volume-label">
+          <div className="flex items-center justify-between">
+            <span id="quick-settings-volume-label" className="text-sm font-medium text-white">
+              Volume
+            </span>
+            <span className="text-xs text-ubt-grey">{volume}%</span>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={volume}
+            onChange={(event) => setVolume(Number(event.target.value))}
+            className="ubuntu-slider mt-2 w-full"
+            aria-valuenow={volume}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-labelledby="quick-settings-volume-label"
+            style={{ backgroundSize: `${Math.max(volume, 5)}% 3px` }}
+          />
+        </div>
+        <div role="group" aria-labelledby="quick-settings-brightness-label">
+          <div className="flex items-center justify-between">
+            <span id="quick-settings-brightness-label" className="text-sm font-medium text-white">
+              Brightness
+            </span>
+            <span className="text-xs text-ubt-grey">{brightness}%</span>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={brightness}
+            onChange={(event) => setBrightness(Number(event.target.value))}
+            className="ubuntu-slider mt-2 w-full"
+            aria-valuenow={brightness}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-labelledby="quick-settings-brightness-label"
+            style={{ backgroundSize: `${Math.max(brightness, 5)}% 3px` }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,5 +1,11 @@
 @import './globals.css';
 
+:root {
+    --qs-brightness: 1;
+    --qs-night-tint-opacity: 0;
+    --qs-night-tint-color: 255, 153, 0;
+}
+
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
 }
@@ -9,6 +15,20 @@ body{
     font-display: swap;
     background-color: var(--color-bg);
     color: var(--color-text);
+    position: relative;
+    filter: brightness(var(--qs-brightness));
+    transition: filter 150ms ease;
+}
+
+body::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background: rgba(var(--qs-night-tint-color), var(--qs-night-tint-opacity));
+    mix-blend-mode: soft-light;
+    transition: background 150ms ease;
+    z-index: 2147483646;
 }
 
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {


### PR DESCRIPTION
## Summary
- expand the quick settings popover with Wi-Fi, Bluetooth, dark mode, and night tint toggles tied into the global settings store
- add mock volume and brightness sliders that immediately tint or dim the UI for feedback
- apply menu semantics and global CSS hooks so toggle changes surface visually across the desktop shell

## Testing
- npx eslint components/ui/QuickSettings.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d75066d4c88328a44b933a46e9bb69