### PR TITLE
[desktop] add power menu and soft reboot

### DIFF
--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -1,9 +1,17 @@
 import React, { act } from 'react';
 import { render, screen } from '@testing-library/react';
-import Ubuntu from '../components/ubuntu';
+import Ubuntu, { Ubuntu as UbuntuBase } from '../components/ubuntu';
 
-jest.mock('../components/screen/desktop', () => function DesktopMock() {
-  return <div data-testid="desktop" />;
+jest.mock('../components/screen/desktop', () => {
+  const React = require('react');
+  return React.forwardRef((_props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      handleLogOut: jest.fn(),
+      handleRestart: jest.fn(),
+      handleSoftReboot: jest.fn(),
+    }));
+    return <div data-testid="desktop" />;
+  });
 });
 jest.mock('../components/screen/navbar', () => function NavbarMock() {
   return <div data-testid="navbar" />;
@@ -38,7 +46,7 @@ describe('Ubuntu component', () => {
   });
 
   it('handles lockScreen when status bar is missing', () => {
-    let instance: Ubuntu | null = null;
+    let instance: UbuntuBase | null = null;
     render(<Ubuntu ref={(c) => (instance = c)} />);
     expect(instance).not.toBeNull();
     act(() => {
@@ -49,7 +57,7 @@ describe('Ubuntu component', () => {
   });
 
   it('handles shutDown when status bar is missing', () => {
-    let instance: Ubuntu | null = null;
+    let instance: UbuntuBase | null = null;
     render(<Ubuntu ref={(c) => (instance = c)} />);
     expect(instance).not.toBeNull();
     act(() => {

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,4 +1,12 @@
-import React, { Component } from 'react';
+import React, {
+        Component,
+        useCallback,
+        useEffect,
+        useId,
+        useImperativeHandle,
+        useRef,
+        useState
+} from 'react';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
@@ -6,48 +14,278 @@ import NotificationBell from '../ui/NotificationBell';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import PerformanceGraph from '../ui/PerformanceGraph';
 
+const PowerMenuButton = React.forwardRef(
+        (
+                { onLock, onLogout, onRestart, onSoftReboot, onOpenChange },
+                forwardedRef
+        ) => {
+                const actions = [
+                        { id: 'lock', label: 'Lock', icon: '🔒', handler: onLock },
+                        { id: 'logout', label: 'Log out', icon: '🚪', handler: onLogout },
+                        { id: 'soft-reboot', label: 'Soft reboot', icon: '♻️', handler: onSoftReboot },
+                        { id: 'restart', label: 'Restart', icon: '🔁', handler: onRestart }
+                ].filter((action) => typeof action.handler === 'function');
+
+                const [open, setOpen] = useState(false);
+                const [activeIndex, setActiveIndex] = useState(0);
+                const buttonRef = useRef(null);
+                const menuRef = useRef(null);
+                const itemRefs = useRef([]);
+                const menuId = useId();
+
+                const closeMenu = useCallback(
+                        (focusButton = false) => {
+                                setOpen(false);
+                                if (focusButton) {
+                                        const focusTarget = () => {
+                                                buttonRef.current?.focus();
+                                        };
+                                        if (typeof window !== 'undefined' && window.requestAnimationFrame) {
+                                                window.requestAnimationFrame(focusTarget);
+                                        } else {
+                                                focusTarget();
+                                        }
+                                }
+                        },
+                        []
+                );
+
+                useImperativeHandle(
+                        forwardedRef,
+                        () => ({
+                                close: (focusButton = false) => closeMenu(focusButton)
+                        }),
+                        [closeMenu]
+                );
+
+                useEffect(() => {
+                        if (typeof onOpenChange === 'function') {
+                                onOpenChange(open);
+                        }
+                }, [open, onOpenChange]);
+
+                useEffect(() => {
+                        if (!open) return () => {};
+                        const handleClick = (event) => {
+                                if (
+                                        menuRef.current?.contains(event.target) ||
+                                        buttonRef.current?.contains(event.target)
+                                ) {
+                                        return;
+                                }
+                                closeMenu(false);
+                        };
+                        document.addEventListener('mousedown', handleClick);
+                        return () => {
+                                document.removeEventListener('mousedown', handleClick);
+                        };
+                }, [open, closeMenu]);
+
+                useEffect(() => {
+                        if (!open) return;
+                        const current = itemRefs.current[activeIndex];
+                        current?.focus();
+                }, [open, activeIndex, actions.length]);
+
+                useEffect(() => {
+                        if (activeIndex >= actions.length && actions.length) {
+                                setActiveIndex(actions.length - 1);
+                        }
+                }, [actions.length, activeIndex]);
+
+                const openMenu = useCallback(
+                        (index = 0) => {
+                                if (!actions.length) return;
+                                setActiveIndex(Math.max(0, Math.min(index, actions.length - 1)));
+                                setOpen(true);
+                        },
+                        [actions.length]
+                );
+
+                const handleButtonClick = useCallback(() => {
+                        if (open) {
+                                closeMenu(true);
+                                return;
+                        }
+                        openMenu(0);
+                }, [closeMenu, open, openMenu]);
+
+                const handleButtonKeyDown = useCallback(
+                        (event) => {
+                                if (!actions.length) return;
+                                if (event.key === 'ArrowDown') {
+                                        event.preventDefault();
+                                        openMenu(0);
+                                } else if (event.key === 'ArrowUp') {
+                                        event.preventDefault();
+                                        openMenu(actions.length - 1);
+                                } else if (event.key === 'Enter' || event.key === ' ') {
+                                        event.preventDefault();
+                                        if (open) {
+                                                closeMenu(true);
+                                        } else {
+                                                openMenu(0);
+                                        }
+                                } else if (event.key === 'Escape' && open) {
+                                        event.preventDefault();
+                                        closeMenu(true);
+                                }
+                        },
+                        [actions.length, closeMenu, open, openMenu]
+                );
+
+                const handleMenuKeyDown = useCallback(
+                        (event) => {
+                                if (!actions.length) return;
+                                if (event.key === 'Escape') {
+                                        event.preventDefault();
+                                        closeMenu(true);
+                                } else if (event.key === 'ArrowDown') {
+                                        event.preventDefault();
+                                        setActiveIndex((prev) => (prev + 1) % actions.length);
+                                } else if (event.key === 'ArrowUp') {
+                                        event.preventDefault();
+                                        setActiveIndex((prev) => (prev - 1 + actions.length) % actions.length);
+                                } else if (event.key === 'Home') {
+                                        event.preventDefault();
+                                        setActiveIndex(0);
+                                } else if (event.key === 'End') {
+                                        event.preventDefault();
+                                        setActiveIndex(actions.length - 1);
+                                } else if (event.key === 'Tab') {
+                                        closeMenu(false);
+                                }
+                        },
+                        [actions.length, closeMenu]
+                );
+
+                const handleSelect = useCallback(
+                        (handler) => {
+                                closeMenu(true);
+                                if (typeof handler === 'function') {
+                                        handler();
+                                }
+                        },
+                        [closeMenu]
+                );
+
+                if (!actions.length) {
+                        return null;
+                }
+
+                itemRefs.current = [];
+
+                return (
+                        <div className="relative">
+                                <button
+                                        type="button"
+                                        ref={buttonRef}
+                                        aria-haspopup="true"
+                                        aria-expanded={open}
+                                        aria-controls={`power-menu-${menuId}`}
+                                        onClick={handleButtonClick}
+                                        onKeyDown={handleButtonKeyDown}
+                                        className="pr-3 pl-3 py-1 border-b-2 border-transparent focus:border-ubb-orange outline-none transition duration-100 ease-in-out text-ubt-grey hover:text-white"
+                                >
+                                        <span className="sr-only">Power menu</span>
+                                        <span aria-hidden="true" className="text-lg leading-none">
+                                                ⏻
+                                        </span>
+                                </button>
+                                <div
+                                        id={`power-menu-${menuId}`}
+                                        role="menu"
+                                        ref={menuRef}
+                                        tabIndex={-1}
+                                        onKeyDown={handleMenuKeyDown}
+                                        className={`${open ? 'block' : 'hidden'} absolute right-0 mt-2 w-44 bg-ub-cool-grey text-white rounded-md border border-black border-opacity-20 shadow-lg z-50 focus:outline-none`}
+                                >
+                                        <ul role="none">
+                                                {actions.map((action, index) => (
+                                                        <li role="none" key={action.id}>
+                                                                <button
+                                                                        type="button"
+                                                                        role="menuitem"
+                                                                        ref={(node) => {
+                                                                                itemRefs.current[index] = node;
+                                                                        }}
+                                                                        onClick={() => handleSelect(action.handler)}
+                                                                        className="flex w-full items-center px-4 py-2 text-left text-sm hover:bg-ub-warm-grey hover:bg-opacity-20 focus:bg-ub-warm-grey focus:bg-opacity-20 focus:outline-none"
+                                                                >
+                                                                        <span aria-hidden="true" className="mr-2">
+                                                                                {action.icon}
+                                                                        </span>
+                                                                        <span>{action.label}</span>
+                                                                </button>
+                                                        </li>
+                                                ))}
+                                        </ul>
+                                </div>
+                        </div>
+                );
+        }
+);
+PowerMenuButton.displayName = 'PowerMenuButton';
+
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
+        constructor() {
+                super();
                 this.state = {
                         status_card: false,
                         applicationsMenuOpen: false,
                         placesMenuOpen: false
                 };
+                this.powerMenuRef = React.createRef();
         }
 
-		render() {
-			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
-						<WhiskerMenu />
-						<PerformanceGraph />
-					</div>
-					<div
-						className={
-							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-						}
-					>
-						<Clock />
-					</div>
-					<button
-						type="button"
-						id="status-bar"
-						aria-label="System status"
-						onClick={() => {
-							this.setState({ status_card: !this.state.status_card });
-						}}
-						className={
-							'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-						}
-					>
-						<Status />
-						<QuickSettings open={this.state.status_card} />
-					</button>
-				</div>
-			);
-		}
+                render() {
+                        const { lockScreen, logOut, restart, softReboot } = this.props;
+                        return (
+                                <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                        <div className="flex items-center">
+                                                <WhiskerMenu />
+                                                <PerformanceGraph />
+                                        </div>
+                                        <div
+                                                className={
+                                                        'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                }
+                                        >
+                                                <Clock />
+                                        </div>
+                                        <div className="flex items-center">
+                                                <PowerMenuButton
+                                                        ref={this.powerMenuRef}
+                                                        onLock={lockScreen}
+                                                        onLogout={logOut}
+                                                        onRestart={restart}
+                                                        onSoftReboot={softReboot}
+                                                        onOpenChange={(open) => {
+                                                                if (open && this.state.status_card) {
+                                                                        this.setState({ status_card: false });
+                                                                }
+                                                        }}
+                                                />
+                                                <button
+                                                        type="button"
+                                                        id="status-bar"
+                                                        aria-label="System status"
+                                                        onClick={() => {
+                                                                this.powerMenuRef.current?.close();
+                                                                this.setState({ status_card: !this.state.status_card });
+                                                        }}
+                                                        className={
+                                                                'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                                        }
+                                                >
+                                                        <Status />
+                                                        <QuickSettings open={this.state.status_card} />
+                                                </button>
+                                        </div>
+                                </div>
+                        );
+                }
 
 
 }

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -7,21 +7,30 @@ import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
+import useSession from '../hooks/useSession';
 
-export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
-			screen_locked: false,
-			bg_image_name: 'wall-2',
-			booting_screen: true,
-			shutDownScreen: false
-		};
-	}
+export class Ubuntu extends Component {
+        constructor(props) {
+                super(props);
+                this.state = {
+                        screen_locked: false,
+                        bg_image_name: 'wall-2',
+                        booting_screen: true,
+                        shutDownScreen: false
+                };
+                this.desktopRef = React.createRef();
+                this.restartTimeout = null;
+        }
 
-	componentDidMount() {
-		this.getLocalData();
-	}
+        componentDidMount() {
+                this.getLocalData();
+        }
+
+        componentWillUnmount() {
+                if (this.restartTimeout) {
+                        clearTimeout(this.restartTimeout);
+                }
+        }
 
 	setTimeOutBootScreen = () => {
 		setTimeout(() => {
@@ -58,11 +67,11 @@ export default class Ubuntu extends Component {
 		}
 	};
 
-	lockScreen = () => {
-		// google analytics
-		ReactGA.send({ hitType: "pageview", page: "/lock-screen", title: "Lock Screen" });
-		ReactGA.event({
-			category: `Screen Change`,
+        lockScreen = () => {
+                // google analytics
+                ReactGA.send({ hitType: "pageview", page: "/lock-screen", title: "Lock Screen" });
+                ReactGA.event({
+                        category: `Screen Change`,
 			action: `Set Screen to Locked`
 		});
 
@@ -73,10 +82,10 @@ export default class Ubuntu extends Component {
 			this.setState({ screen_locked: true });
 		}, 100); // waiting for all windows to close (transition-duration)
                 safeLocalStorage?.setItem('screen-locked', true);
-	};
+        };
 
-	unLockScreen = () => {
-		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        unLockScreen = () => {
+                ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
 		window.removeEventListener('click', this.unLockScreen);
 		window.removeEventListener('keypress', this.unLockScreen);
@@ -90,11 +99,11 @@ export default class Ubuntu extends Component {
                 safeLocalStorage?.setItem('bg-image', img_name);
 	};
 
-	shutDown = () => {
-		ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
+        shutDown = () => {
+                ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
 
-		ReactGA.event({
-			category: `Screen Change`,
+                ReactGA.event({
+                        category: `Screen Change`,
 			action: `Switched off the Ubuntu`
 		});
 
@@ -103,32 +112,93 @@ export default class Ubuntu extends Component {
                 statusBar?.blur();
 		this.setState({ shutDownScreen: true });
                 safeLocalStorage?.setItem('shut-down', true);
-	};
+        };
 
-	turnOn = () => {
-		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+        turnOn = () => {
+                ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
 
-		this.setState({ shutDownScreen: false, booting_screen: true });
-		this.setTimeOutBootScreen();
+                this.setState({ shutDownScreen: false, booting_screen: true });
+                this.setTimeOutBootScreen();
                 safeLocalStorage?.setItem('shut-down', false);
-	};
+        };
 
-	render() {
-		return (
-			<div className="w-screen h-screen overflow-hidden" id="monitor-screen">
-				<LockScreen
-					isLocked={this.state.screen_locked}
-					bgImgName={this.state.bg_image_name}
-					unLockScreen={this.unLockScreen}
-				/>
-				<BootingScreen
-					visible={this.state.booting_screen}
-					isShutDown={this.state.shutDownScreen}
-					turnOn={this.turnOn}
-				/>
-				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-			</div>
-		);
-	}
+        logOut = () => {
+                const desktop = this.desktopRef.current;
+                if (desktop?.handleLogOut) {
+                        desktop.handleLogOut();
+                }
+                this.lockScreen();
+        };
+
+        restart = () => {
+                const desktop = this.desktopRef.current;
+                if (desktop?.handleRestart) {
+                        desktop.handleRestart();
+                }
+                this.shutDown();
+                if (this.restartTimeout) {
+                        clearTimeout(this.restartTimeout);
+                }
+                this.restartTimeout = setTimeout(() => {
+                        this.turnOn();
+                        this.restartTimeout = null;
+                }, 1200);
+        };
+
+        softReboot = () => {
+                const desktop = this.desktopRef.current;
+                if (desktop?.handleSoftReboot) {
+                        desktop.handleSoftReboot();
+                }
+        };
+
+        render() {
+                const { session, setSession, clearSession } = this.props;
+                return (
+                        <div className="w-screen h-screen overflow-hidden" id="monitor-screen">
+                                <LockScreen
+                                        isLocked={this.state.screen_locked}
+                                        bgImgName={this.state.bg_image_name}
+                                        unLockScreen={this.unLockScreen}
+                                />
+                                <BootingScreen
+                                        visible={this.state.booting_screen}
+                                        isShutDown={this.state.shutDownScreen}
+                                        turnOn={this.turnOn}
+                                />
+                                <Navbar
+                                        lockScreen={this.lockScreen}
+                                        shutDown={this.shutDown}
+                                        logOut={this.logOut}
+                                        restart={this.restart}
+                                        softReboot={this.softReboot}
+                                />
+                                <Desktop
+                                        ref={this.desktopRef}
+                                        bg_image_name={this.state.bg_image_name}
+                                        changeBackgroundImage={this.changeBackgroundImage}
+                                        session={session}
+                                        setSession={setSession}
+                                        clearSession={clearSession}
+                                />
+                        </div>
+                );
+        }
 }
+
+const UbuntuWithSession = React.forwardRef((props, ref) => {
+        const { session, setSession, resetSession } = useSession();
+        return (
+                <Ubuntu
+                        {...props}
+                        ref={ref}
+                        session={session}
+                        setSession={setSession}
+                        clearSession={resetSession}
+                />
+        );
+});
+
+UbuntuWithSession.displayName = 'UbuntuWithSession';
+
+export default UbuntuWithSession;


### PR DESCRIPTION
## Summary
- add a keyboard-accessible power menu button with lock, log out, soft reboot, and restart actions
- expose desktop power handlers via refs and wrap Ubuntu with the session hook so soft reboot clears state without a reload
- update the Ubuntu test doubles to support the forwarded refs used by the new power menu

## Testing
- yarn test ubuntu

------
https://chatgpt.com/codex/tasks/task_e_68d75068ba408328a465bf10542260c6