### PR TITLE
[desktop] Improve Alt+Tab window switcher UX

### DIFF
--- a/__tests__/desktopAltTab.test.ts
+++ b/__tests__/desktopAltTab.test.ts
@@ -1,0 +1,52 @@
+import { Desktop } from '../components/screen/desktop';
+import { WINDOW_SWITCHER_CYCLE_EVENT } from '../components/screen/window-switcher';
+
+describe('Desktop Alt+Tab shortcuts', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('opens the window switcher in reverse order with Shift+Alt+Tab', () => {
+    const desktop = new Desktop();
+    const preventDefault = jest.fn();
+    const openSpy = jest
+      .spyOn(desktop, 'openWindowSwitcher')
+      .mockImplementation(() => {});
+
+    desktop.state.showWindowSwitcher = false;
+
+    desktop.handleGlobalShortcut({
+      key: 'Tab',
+      altKey: true,
+      shiftKey: true,
+      preventDefault,
+    } as KeyboardEvent);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(openSpy).toHaveBeenCalledWith(-1);
+  });
+
+  it('cycles backwards when Shift+Alt+Tab is pressed while open', () => {
+    const desktop = new Desktop();
+    const preventDefault = jest.fn();
+    desktop.state.showWindowSwitcher = true;
+    desktop.state.switcherWindows = [
+      { id: 'one', title: 'One', icon: '', minimized: false, isFocused: false },
+    ] as any;
+
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+
+    desktop.handleGlobalShortcut({
+      key: 'Tab',
+      altKey: true,
+      shiftKey: true,
+      preventDefault,
+    } as KeyboardEvent);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(dispatchSpy).toHaveBeenCalled();
+    const eventArg = dispatchSpy.mock.calls[0][0] as CustomEvent;
+    expect(eventArg.type).toBe(WINDOW_SWITCHER_CYCLE_EVENT);
+    expect(eventArg.detail).toEqual({ direction: -1 });
+  });
+});

--- a/__tests__/windowSwitcherAltSelect.test.tsx
+++ b/__tests__/windowSwitcherAltSelect.test.tsx
@@ -1,0 +1,39 @@
+import { act, render, cleanup } from '@testing-library/react';
+import WindowSwitcher, { WINDOW_SWITCHER_CYCLE_EVENT } from '../components/screen/window-switcher';
+
+describe('WindowSwitcher keyboard interactions', () => {
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  it('selects the highlighted window when Alt is released', () => {
+    const onSelect = jest.fn();
+    const windows = [
+      { id: 'one', title: 'First App', icon: '/icon-1.png' },
+      { id: 'two', title: 'Second App', icon: '/icon-2.png' },
+      { id: 'three', title: 'Third App', icon: '/icon-3.png' },
+    ];
+
+    render(
+      <WindowSwitcher
+        windows={windows}
+        onSelect={onSelect}
+        onClose={jest.fn()}
+        initialWindowId="one"
+      />
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(WINDOW_SWITCHER_CYCLE_EVENT, { detail: { direction: 1 } })
+      );
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Alt' }));
+    });
+
+    expect(onSelect).toHaveBeenCalledWith('two');
+  });
+});

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -1,13 +1,54 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
+export const WINDOW_SWITCHER_CYCLE_EVENT = 'desktop-window-switcher-cycle';
+
+export default function WindowSwitcher({
+  windows = [],
+  onSelect,
+  onClose,
+  initialWindowId,
+  cycleEventName = WINDOW_SWITCHER_CYCLE_EVENT,
+}) {
   const [query, setQuery] = useState('');
-  const [selected, setSelected] = useState(0);
+  const [selectedId, setSelectedId] = useState(null);
   const inputRef = useRef(null);
 
-  const filtered = windows.filter((w) =>
-    w.title.toLowerCase().includes(query.toLowerCase())
-  );
+  const normalizedQuery = query.trim().toLowerCase();
+  const filtered = useMemo(() => {
+    if (!normalizedQuery) {
+      return windows;
+    }
+    return windows.filter((w) =>
+      (w.title || '').toLowerCase().includes(normalizedQuery)
+    );
+  }, [windows, normalizedQuery]);
+
+  useEffect(() => {
+    if (!filtered.length) {
+      if (selectedId !== null) {
+        setSelectedId(null);
+      }
+      return;
+    }
+
+    if (selectedId && filtered.some((w) => w.id === selectedId)) {
+      return;
+    }
+
+    if (initialWindowId && filtered.some((w) => w.id === initialWindowId)) {
+      setSelectedId(initialWindowId);
+      return;
+    }
+
+    setSelectedId(filtered[0].id);
+  }, [filtered, initialWindowId, selectedId]);
+
+  const selectedIndex = useMemo(() => {
+    if (!filtered.length || !selectedId) {
+      return -1;
+    }
+    return filtered.findIndex((w) => w.id === selectedId);
+  }, [filtered, selectedId]);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -16,9 +57,11 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
   useEffect(() => {
     const handleKeyUp = (e) => {
       if (e.key === 'Alt') {
-        const win = filtered[selected];
-        if (win && typeof onSelect === 'function') {
-          onSelect(win.id);
+        if (filtered.length && selectedIndex >= 0) {
+          const win = filtered[selectedIndex];
+          if (win && typeof onSelect === 'function') {
+            onSelect(win.id);
+          }
         } else if (typeof onClose === 'function') {
           onClose();
         }
@@ -26,25 +69,49 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
     };
     window.addEventListener('keyup', handleKeyUp);
     return () => window.removeEventListener('keyup', handleKeyUp);
-  }, [filtered, selected, onSelect, onClose]);
+  }, [filtered, selectedIndex, onSelect, onClose]);
+
+  const moveSelection = useCallback(
+    (direction) => {
+      if (!filtered.length) return;
+      const len = filtered.length;
+      const current = selectedIndex >= 0 ? selectedIndex : 0;
+      const nextIndex = (current + direction + len) % len;
+      const nextWindow = filtered[nextIndex];
+      if (nextWindow) {
+        setSelectedId(nextWindow.id);
+      }
+    },
+    [filtered, selectedIndex]
+  );
+
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event || typeof event.detail !== 'object') return;
+      const { direction } = event.detail;
+      const step = direction < 0 ? -1 : 1;
+      moveSelection(step);
+    };
+    window.addEventListener(cycleEventName, handler);
+    return () => window.removeEventListener(cycleEventName, handler);
+  }, [cycleEventName, moveSelection]);
 
   const handleKeyDown = (e) => {
     if (e.key === 'Tab') {
       e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      const dir = e.shiftKey ? -1 : 1;
-      setSelected((selected + dir + len) % len);
-    } else if (e.key === 'ArrowDown') {
+      moveSelection(e.shiftKey ? -1 : 1);
+    } else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
       e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      setSelected((selected + 1) % len);
-    } else if (e.key === 'ArrowUp') {
+      moveSelection(1);
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
       e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      setSelected((selected - 1 + len) % len);
+      moveSelection(-1);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const win = filtered[selectedIndex];
+      if (win && typeof onSelect === 'function') {
+        onSelect(win.id);
+      }
     } else if (e.key === 'Escape') {
       e.preventDefault();
       if (typeof onClose === 'function') onClose();
@@ -53,30 +120,111 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
 
   const handleChange = (e) => {
     setQuery(e.target.value);
-    setSelected(0);
+  };
+
+  const handleItemClick = (id) => {
+    if (typeof onSelect === 'function') {
+      onSelect(id);
+    }
+  };
+
+  const handleItemHover = (index) => {
+    const target = filtered[index];
+    if (target) {
+      setSelectedId(target.id);
+    }
+  };
+
+  const renderPlaceholderIcon = (title = '') => {
+    const letter = title.trim().charAt(0).toUpperCase() || '?';
+    return (
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-black/40 text-lg font-semibold">
+        {letter}
+      </div>
+    );
   };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white">
-      <div className="bg-ub-grey p-4 rounded w-3/4 md:w-1/3">
+      <div className="w-full max-w-5xl rounded-xl bg-ub-grey/95 p-6 shadow-2xl">
         <input
           ref={inputRef}
           value={query}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+          aria-label="Search open windows"
+          className="w-full rounded border border-white/10 bg-black/40 px-3 py-2 text-base focus:border-ub-orange focus:outline-none"
           placeholder="Search windows"
         />
-        <ul>
-          {filtered.map((w, i) => (
-            <li
-              key={w.id}
-              className={`px-2 py-1 rounded ${i === selected ? 'bg-ub-orange text-black' : ''}`}
-            >
-              {w.title}
-            </li>
-          ))}
-        </ul>
+
+        {filtered.length ? (
+          <div className="mt-6 flex gap-4 overflow-x-auto pb-2">
+            {filtered.map((w, index) => {
+              const selected = index === selectedIndex;
+              const displayTitle = (w.title || w.id || '').trim() || w.id;
+              return (
+                <button
+                  key={w.id}
+                  type="button"
+                  onClick={() => handleItemClick(w.id)}
+                  onMouseEnter={() => handleItemHover(index)}
+                  onFocus={() => handleItemHover(index)}
+                  className={`group flex w-48 flex-shrink-0 flex-col rounded-lg border transition focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange ${
+                    selected
+                      ? 'border-ub-orange bg-black/50'
+                      : 'border-transparent bg-black/30 hover:border-white/20 hover:bg-black/40'
+                  } ${w.minimized ? 'opacity-60' : ''}`}
+                  aria-selected={selected}
+                  aria-label={`Switch to ${displayTitle}`}
+                  title={displayTitle}
+                >
+                  <div className="flex h-28 w-full items-center justify-center overflow-hidden rounded-t-lg bg-black/40">
+                    {w.thumbnail ? (
+                      <img
+                        src={w.thumbnail}
+                        alt=""
+                        className="h-full w-full object-cover"
+                      />
+                    ) : w.icon ? (
+                      <img
+                        src={w.icon}
+                        alt=""
+                        className="h-16 w-16 object-contain"
+                      />
+                    ) : (
+                      renderPlaceholderIcon(displayTitle)
+                    )}
+                  </div>
+                  <div className="flex w-full items-center gap-3 truncate px-3 py-3 text-left">
+                    {w.icon ? (
+                      <img
+                        src={w.icon}
+                        alt=""
+                        className="h-6 w-6 flex-shrink-0 object-contain"
+                      />
+                    ) : (
+                      <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded bg-white/10 text-xs font-semibold">
+                        {displayTitle.charAt(0).toUpperCase() || '?'}
+                      </div>
+                    )}
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">
+                        {displayTitle}
+                      </p>
+                      {w.minimized ? (
+                        <p className="truncate text-xs text-gray-300">Minimized</p>
+                      ) : null}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="mt-6 rounded-lg bg-black/30 px-4 py-8 text-center text-sm text-gray-200">
+            No windows match your search.
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- fix the Desktop Alt+Tab shortcut to keep the switcher open while cycling forward or backward
- redesign the window switcher with horizontal thumbnails, icons, and incremental search tied to the highlighted window
- ensure releasing Alt activates the highlighted entry and cover the interaction with targeted unit tests

## Testing
- yarn test --runTestsByPath __tests__/desktopAltTab.test.ts __tests__/windowSwitcherAltSelect.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7506a35b483288e9c5d4abbf54338