### PR TITLE
[desktop] improve workspace snapshot handling

### DIFF
--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -7,6 +7,10 @@ function TaskbarMenu(props) {
     useFocusTrap(menuRef, props.active);
     useRovingTabIndex(menuRef, props.active, 'vertical');
 
+    const availableWorkspaces = (props.workspaces || []).filter(
+        (workspace) => typeof workspace.id === 'number' && workspace.id !== props.activeWorkspace
+    );
+
     const handleKeyDown = (e) => {
         if (e.key === 'Escape') {
             props.onCloseMenu && props.onCloseMenu();
@@ -20,6 +24,13 @@ function TaskbarMenu(props) {
 
     const handleClose = () => {
         props.onClose && props.onClose();
+        props.onCloseMenu && props.onCloseMenu();
+    };
+
+    const handleMove = (workspaceId) => {
+        if (props.onMoveToWorkspace) {
+            props.onMoveToWorkspace(workspaceId);
+        }
         props.onCloseMenu && props.onCloseMenu();
     };
 
@@ -50,6 +61,25 @@ function TaskbarMenu(props) {
             >
                 <span className="ml-5">Close</span>
             </button>
+            {availableWorkspaces.length > 0 && (
+                <div className="mt-1 border-t border-gray-800 pt-1">
+                    <p className="px-5 pb-1 text-[11px] uppercase tracking-wide text-gray-300/70">
+                        Move to workspace
+                    </p>
+                    {availableWorkspaces.map((workspace) => (
+                        <button
+                            key={workspace.id}
+                            type="button"
+                            onClick={() => handleMove(workspace.id)}
+                            role="menuitem"
+                            aria-label={`Move window to ${workspace.label}`}
+                            className="w-full text-left cursor-default py-0.5 hover:bg-gray-700"
+                        >
+                            <span className="ml-5">{workspace.label}</span>
+                        </button>
+                    ))}
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- store per-workspace snapshots for focus, minimization, positions, and sizing without cross-merging
- add APIs and context menu affordance to move windows between workspaces while updating stacks and snapshots
- restore saved layout when switching workspaces, including window positions and stored dimensions

## Testing
- yarn eslint components/screen/desktop.js components/context-menus/taskbar-menu.js components/base/window.js

------
https://chatgpt.com/codex/tasks/task_e_68d7506c047883289cf9e555758caeac