### PR TITLE
[ui] Strengthen window focus styling

### DIFF
--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -2,9 +2,11 @@
   position: relative;
   border: 1px solid var(--color-window-border);
   border-radius: var(--radius-6);
-  box-shadow: var(--shadow-2);
+  box-shadow: var(--window-shadow);
   overflow: hidden;
-  transition: filter var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+  outline: none;
+  isolation: isolate;
+  transition: box-shadow var(--motion-fast) ease;
 }
 
 .windowFrame::before {
@@ -23,12 +25,31 @@
   z-index: 2;
 }
 
+.windowFrame::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--window-inactive-overlay);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--motion-fast) ease;
+  z-index: 1;
+}
+
 .windowFrameActive::before {
   opacity: 1;
 }
 
-.windowFrameInactive {
-  filter: brightness(0.85);
+.windowFrameActive {
+  box-shadow: var(--window-shadow), var(--focus-ring-shadow);
+}
+
+.windowFrameInactive::after {
+  opacity: 1;
+}
+
+.windowFrame:focus-visible {
+  box-shadow: var(--window-shadow), var(--focus-ring-shadow);
 }
 
 .windowFrameMaximized {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -77,9 +77,15 @@
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;
-  /* Focus outline */
-  --focus-outline-color: var(--color-ubt-blue);
-  --focus-outline-width: 2px;
+  /* Focus and elevation */
+  --focus-ring-color: color-mix(in srgb, var(--kali-blue) 80%, #ffffff 20%);
+  --focus-ring-width: 3px;
+  --focus-ring-shadow: 0 0 0 var(--focus-ring-width) color-mix(in srgb, var(--focus-ring-color) 85%, transparent 15%),
+    0 0 24px calc(var(--focus-ring-width) * 2) color-mix(in srgb, var(--focus-ring-color) 45%, transparent 55%);
+  --focus-outline-color: var(--focus-ring-color);
+  --focus-outline-width: var(--focus-ring-width);
+  --window-shadow: 0 18px 36px -18px rgba(0, 0, 0, 0.75), 0 0 0 1px rgba(255, 255, 255, 0.05);
+  --window-inactive-overlay: rgba(15, 19, 23, 0.12);
 }
 
 /* High contrast theme */


### PR DESCRIPTION
## Summary
- add dedicated focus ring, window shadow, and inactive overlay design tokens
- update window frame styles to use the new tokens with a brighter active glow and consistent inactive dimming

## Testing
- [ ] yarn lint
- [ ] yarn test
- [x] Manual visual check in dev server

------
https://chatgpt.com/codex/tasks/task_e_68d7506d63288328958d0eabdd1b5b44