### PR TITLE
[desktop] add configurable window snapping

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,10 +1,12 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
+import { useSnapSetting } from '../../hooks/usePersistentState';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 import KaliWallpaper from '../util-components/kali-wallpaper';
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const [snapEnabled, setSnapEnabled, snapGridSize, setSnapGridSize] = useSnapSetting();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -159,6 +161,32 @@ export function Settings() {
                     Large Hit Areas
                 </label>
             </div>
+            <div className="flex flex-col items-center my-4 space-y-2">
+                <label className="text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
+                        checked={snapEnabled}
+                        onChange={(e) => setSnapEnabled(e.target.checked)}
+                        className="mr-2"
+                    />
+                    Snap windows to grid
+                </label>
+                <div className="flex items-center space-x-2 text-ubt-grey">
+                    <label htmlFor="snap-grid-size">Grid size:</label>
+                    <input
+                        id="snap-grid-size"
+                        type="range"
+                        min="4"
+                        max="64"
+                        step="4"
+                        value={snapGridSize}
+                        onChange={(e) => setSnapGridSize(Number(e.target.value))}
+                        className="ubuntu-slider"
+                        disabled={!snapEnabled}
+                    />
+                    <span className="w-12 text-right tabular-nums">{snapGridSize}px</span>
+                </div>
+            </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
@@ -277,6 +305,8 @@ export function Settings() {
                         setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
+                        setSnapEnabled(defaults.snapEnabled ?? true);
+                        setSnapGridSize(defaults.snapGridSize ?? 8);
                         setTheme('default');
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
@@ -301,6 +331,8 @@ export function Settings() {
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
+                        if (parsed.snapEnabled !== undefined) setSnapEnabled(parsed.snapEnabled);
+                        if (parsed.snapGridSize !== undefined) setSnapGridSize(parsed.snapGridSize);
                         if (parsed.theme !== undefined) { setTheme(parsed.theme); }
                     } catch (err) {
                         console.error('Invalid settings', err);

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -225,9 +225,18 @@ export class Window extends Component {
         this.setState({ cursorType: "cursor-default", grabbed: false })
     }
 
+    getSnapGridSize = () => {
+        const value = Number(this.props.snapGridSize);
+        if (!Number.isFinite(value) || value <= 0) {
+            return 8;
+        }
+        return value;
+    }
+
     snapToGrid = (value) => {
         if (!this.props.snapEnabled) return value;
-        return Math.round(value / 8) * 8;
+        const gridSize = this.getSnapGridSize();
+        return Math.round(value / gridSize) * gridSize;
     }
 
     handleVerticleResize = () => {
@@ -636,7 +645,7 @@ export class Window extends Component {
                 <Draggable
                     axis="both"
                     handle=".bg-ub-window-title"
-                    grid={this.props.snapEnabled ? [8, 8] : [1, 1]}
+                    grid={this.props.snapEnabled ? [this.getSnapGridSize(), this.getSnapGridSize()] : [1, 1]}
                     scale={1}
                     onStart={this.changeCursorToMove}
                     onStop={this.handleStop}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -72,6 +72,14 @@ export class Desktop extends Component {
         }
     }
 
+    getSnapGridSize = () => {
+        const value = Number(this.props.snapGridSize);
+        if (!Number.isFinite(value) || value <= 0) {
+            return 8;
+        }
+        return value;
+    }
+
     createEmptyWorkspaceState = () => ({
         focused_windows: {},
         closed_windows: {},
@@ -613,6 +621,7 @@ export class Desktop extends Component {
 
     renderWindows = () => {
         let windowsJsx = [];
+        const snapGridSize = this.getSnapGridSize();
         apps.forEach((app, index) => {
             if (this.state.closed_windows[app.id] === false) {
 
@@ -637,6 +646,7 @@ export class Desktop extends Component {
                     initialY: pos ? pos.y : undefined,
                     onPositionChange: (x, y) => this.updateWindowPosition(app.id, x, y),
                     snapEnabled: this.props.snapEnabled,
+                    snapGridSize,
                     context: this.state.window_context[app.id],
                 }
 
@@ -649,8 +659,9 @@ export class Desktop extends Component {
     }
 
     updateWindowPosition = (id, x, y) => {
+        const gridSize = this.getSnapGridSize();
         const snap = this.props.snapEnabled
-            ? (v) => Math.round(v / 8) * 8
+            ? (v) => Math.round(v / gridSize) * gridSize
             : (v) => v;
         this.setWorkspaceState(prev => ({
             window_positions: { ...prev.window_positions, [id]: { x: snap(x), y: snap(y) } }
@@ -1179,6 +1190,6 @@ export class Desktop extends Component {
 }
 
 export default function DesktopWithSnap(props) {
-    const [snapEnabled] = useSnapSetting();
-    return <Desktop {...props} snapEnabled={snapEnabled} />;
+    const [snapEnabled, , snapGridSize] = useSnapSetting();
+    return <Desktop {...props} snapEnabled={snapEnabled} snapGridSize={snapGridSize} />;
 }

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -15,6 +15,8 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  snapEnabled: true,
+  snapGridSize: 8,
 };
 
 export async function getAccent() {
@@ -135,6 +137,44 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getSnapEnabled() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.snapEnabled;
+  const stored = window.localStorage.getItem('snap-enabled');
+  if (stored === null) return DEFAULT_SETTINGS.snapEnabled;
+  try {
+    return JSON.parse(stored);
+  } catch {
+    return stored === 'true';
+  }
+}
+
+export async function setSnapEnabled(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('snap-enabled', JSON.stringify(Boolean(value)));
+}
+
+export async function getSnapGridSize() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.snapGridSize;
+  const stored = window.localStorage.getItem('snap-grid-size');
+  if (stored === null) return DEFAULT_SETTINGS.snapGridSize;
+  try {
+    const parsed = JSON.parse(stored);
+    return Number.isFinite(parsed) ? parsed : DEFAULT_SETTINGS.snapGridSize;
+  } catch {
+    const numeric = Number(stored);
+    return Number.isFinite(numeric) ? numeric : DEFAULT_SETTINGS.snapGridSize;
+  }
+}
+
+export async function setSnapGridSize(value) {
+  if (typeof window === 'undefined') return;
+  const numeric = Number(value);
+  const clamped = Number.isFinite(numeric)
+    ? Math.min(64, Math.max(4, Math.round(numeric)))
+    : DEFAULT_SETTINGS.snapGridSize;
+  window.localStorage.setItem('snap-grid-size', JSON.stringify(clamped));
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -150,6 +190,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
   window.localStorage.removeItem('use-kali-wallpaper');
+  window.localStorage.removeItem('snap-enabled');
+  window.localStorage.removeItem('snap-grid-size');
 }
 
 export async function exportSettings() {
@@ -165,6 +207,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    snapEnabled,
+    snapGridSize,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -177,6 +221,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getSnapEnabled(),
+    getSnapGridSize(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -192,6 +238,8 @@ export async function exportSettings() {
     haptics,
     useKaliWallpaper,
     theme,
+    snapEnabled,
+    snapGridSize,
   });
 }
 
@@ -217,6 +265,8 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    snapEnabled,
+    snapGridSize,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -230,6 +280,8 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (snapEnabled !== undefined) await setSnapEnabled(snapEnabled);
+  if (snapGridSize !== undefined) await setSnapGridSize(snapGridSize);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- surface snap-to-grid controls in the Settings app backed by the shared snap state hook
- persist the snap grid size and pass it through the desktop/window stack so drag updates use the configured threshold
- extend the settings store to reset, export, and import the snap preferences

## Testing
- yarn lint *(fails: existing accessibility violations and banned globals reported across legacy app pages)*

------
https://chatgpt.com/codex/tasks/task_e_68d7506fa9788328acf601159ce57939