### PR TITLE
[desktop] Support double-click maximize

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -543,6 +543,19 @@ export class Window extends Component {
         }
     }
 
+    handleTitleBarDoubleClick = (e) => {
+        if (this.state.grabbed || this.props.allowMaximize === false) {
+            return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        if (this.state.maximized) {
+            this.restoreWindow();
+        } else {
+            this.maximizeWindow();
+        }
+    }
+
     releaseGrab = () => {
         if (this.state.grabbed) {
             this.handleStop();
@@ -676,6 +689,7 @@ export class Window extends Component {
                             onBlur={this.releaseGrab}
                             grabbed={this.state.grabbed}
                             onPointerDown={this.focusWindow}
+                            onDoubleClick={this.handleTitleBarDoubleClick}
                         />
                         <WindowEditButtons
                             minimize={this.minimizeWindow}
@@ -702,7 +716,7 @@ export class Window extends Component {
 export default Window
 
 // Window's title bar
-export function WindowTopBar({ title, onKeyDown, onBlur, grabbed, onPointerDown }) {
+export function WindowTopBar({ title, onKeyDown, onBlur, grabbed, onPointerDown, onDoubleClick }) {
     return (
         <div
             className={`${styles.windowTitlebar} relative bg-ub-window-title px-3 text-white w-full select-none flex items-center`}
@@ -712,6 +726,8 @@ export function WindowTopBar({ title, onKeyDown, onBlur, grabbed, onPointerDown 
             onKeyDown={onKeyDown}
             onBlur={onBlur}
             onPointerDown={onPointerDown}
+            onDoubleClick={onDoubleClick}
+            title="Double-click to maximize or restore"
         >
             <div className="flex justify-center w-full text-sm font-bold">{title}</div>
         </div>

--- a/docs/keyboard-only-test-plan.md
+++ b/docs/keyboard-only-test-plan.md
@@ -17,6 +17,11 @@
    - **Alt + ArrowUp** snaps it to the top half.
    - **Alt + ArrowDown** restores the window to its previous size and position.
 
+## Maximize / Restore
+1. With the window focused, press **Super + ArrowUp** (Windows/Command key + ArrowUp) to maximize it.
+2. Press **Super + ArrowDown** to restore the window from a maximized state or exit a snap.
+3. Mouse equivalent: double-click the window title bar to toggle maximize and restore.
+
 ## Focus
 1. After resizing or snapping, press **Tab** to move focus inside the window.
 2. Continue pressing **Tab** to confirm focus can leave the window and is not trapped.


### PR DESCRIPTION
## Summary
- add a guarded double-click handler on window title bars to toggle maximize and restore
- avoid conflicts with active drags and expose the action via tooltip text
- document the Super+Arrow maximize shortcut alongside the mouse gesture in the keyboard test plan

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d750708de483288cd6ac5fa463ae30