### PR TITLE
[desktop] refresh context menu actions

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -3,11 +3,13 @@ import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 import KaliWallpaper from '../util-components/kali-wallpaper';
 
-export function Settings() {
+export function Settings(props = {}) {
+    const { focusWallpaperPicker } = props;
     const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
+    const wallpaperGridRef = useRef(null);
 
     const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
 
@@ -55,6 +57,12 @@ export function Settings() {
         });
         return () => cancelAnimationFrame(raf);
     }, [accent, accentText, contrastRatio]);
+
+    useEffect(() => {
+        if (focusWallpaperPicker && wallpaperGridRef.current) {
+            wallpaperGridRef.current.focus({ preventScroll: true });
+        }
+    }, [focusWallpaperPicker]);
 
     return (
         <div className={"w-full flex-col flex-grow z-20 max-h-full overflow-y-auto windowMainScreen select-none bg-ub-cool-grey"}>
@@ -221,7 +229,12 @@ export function Settings() {
                     <span ref={liveRegion} role="status" aria-live="polite" className="sr-only"></span>
                 </div>
             </div>
-            <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
+            <div
+                ref={wallpaperGridRef}
+                tabIndex={-1}
+                aria-label="Desktop wallpaper selection"
+                className="flex flex-wrap justify-center items-center border-t border-gray-900"
+            >
                 {
                     wallpapers.map((name, index) => (
                         <div

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,144 +1,254 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
+import useFocusTrap from '../../hooks/useFocusTrap'
+import useRovingTabIndex from '../../hooks/useRovingTabIndex'
 import logger from '../../utils/logger'
 
-function DesktopMenu(props) {
+const ARRANGE_OPTIONS = [
+    { value: 'name', label: 'Name' },
+    { value: 'favorites', label: 'Favorites First' },
+    { value: 'recent', label: 'Recently Used' },
+]
 
-    const [isFullScreen, setIsFullScreen] = useState(false)
+function DesktopMenu(props) {
+    const {
+        active,
+        onClose,
+        onOpenTerminal,
+        onCreateFolder,
+        onCreateShortcut,
+        onArrange,
+        arrangement,
+        onChangeBackground,
+        onToggleFullScreen,
+        isFullScreen,
+        onClearSession,
+    } = props
+
+    const [fullScreen, setFullScreen] = useState(false)
+    const [arrangeOpen, setArrangeOpen] = useState(false)
+    const menuRef = useRef(null)
+    const arrangeButtonRef = useRef(null)
+    const submenuRef = useRef(null)
 
     useEffect(() => {
-        document.addEventListener('fullscreenchange', checkFullScreen);
+        const updateFullScreen = () => {
+            setFullScreen(Boolean(document.fullscreenElement))
+        }
+        document.addEventListener('fullscreenchange', updateFullScreen)
+        updateFullScreen()
         return () => {
-            document.removeEventListener('fullscreenchange', checkFullScreen);
-        };
+            document.removeEventListener('fullscreenchange', updateFullScreen)
+        }
     }, [])
 
+    useFocusTrap(menuRef, active)
+    useRovingTabIndex(menuRef, active, 'vertical')
 
-    const openTerminal = () => {
-        props.openApp("terminal");
-    }
-
-    const openSettings = () => {
-        props.openApp("settings");
-    }
-
-    const checkFullScreen = () => {
-        if (document.fullscreenElement) {
-            setIsFullScreen(true)
-        } else {
-            setIsFullScreen(false)
+    useEffect(() => {
+        if (!active) {
+            setArrangeOpen(false)
+            return
         }
-    }
-
-    const goFullScreen = () => {
-        // make website full screen
-        try {
-            if (document.fullscreenElement) {
-                document.exitFullscreen()
-            } else {
-                document.documentElement.requestFullscreen()
+        const focusFirst = () => {
+            const first = menuRef.current?.querySelector('[data-menu-item]')
+            if (first instanceof HTMLElement) {
+                first.focus()
             }
         }
-        catch (e) {
-            logger.error(e)
+        const id = window.requestAnimationFrame(focusFirst)
+        return () => window.cancelAnimationFrame(id)
+    }, [active])
+
+    const closeMenu = () => {
+        onClose && onClose()
+    }
+
+    const handleMenuKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            e.preventDefault()
+            setArrangeOpen(false)
+            closeMenu()
+        }
+        if (e.key === 'ArrowLeft' && arrangeOpen) {
+            e.preventDefault()
+            setArrangeOpen(false)
+            arrangeButtonRef.current?.focus()
         }
     }
+
+    const handleArrangeKeyDown = (e) => {
+        if (e.key === 'ArrowRight') {
+            e.preventDefault()
+            setArrangeOpen(true)
+        } else if (e.key === 'ArrowLeft' && arrangeOpen) {
+            e.preventDefault()
+            setArrangeOpen(false)
+        }
+    }
+
+    const handleSubmenuKeyDown = (e) => {
+        const items = submenuRef.current
+            ? Array.from(submenuRef.current.querySelectorAll('button[role="menuitemradio"]'))
+            : []
+        const currentIndex = items.findIndex((item) => item === document.activeElement)
+        if (e.key === 'Escape' || e.key === 'ArrowLeft') {
+            e.preventDefault()
+            setArrangeOpen(false)
+            arrangeButtonRef.current?.focus()
+            return
+        }
+        if (e.key === 'ArrowDown') {
+            e.preventDefault()
+            if (items.length === 0) return
+            const next = items[(currentIndex + 1) % items.length]
+            next?.focus()
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault()
+            if (items.length === 0) return
+            const next = items[(currentIndex - 1 + items.length) % items.length]
+            next?.focus()
+        }
+    }
+
+    useEffect(() => {
+        if (!arrangeOpen) return
+        const first = submenuRef.current?.querySelector('button[role="menuitemradio"]')
+        if (first instanceof HTMLElement) {
+            first.focus()
+        }
+    }, [arrangeOpen])
+
+    const handleToggleFullScreen = async () => {
+        try {
+            if (typeof onToggleFullScreen === 'function') {
+                await onToggleFullScreen()
+            } else if (document.fullscreenElement) {
+                await document.exitFullscreen()
+            } else {
+                await document.documentElement.requestFullscreen()
+            }
+        } catch (error) {
+            logger.error(error)
+        }
+    }
+
+    const handleArrangeSelect = (mode) => {
+        if (typeof onArrange === 'function') {
+            onArrange(mode)
+        }
+        setArrangeOpen(false)
+        closeMenu()
+    }
+
+    const callAndClose = (fn) => () => {
+        if (typeof fn === 'function') {
+            fn()
+        }
+        closeMenu()
+    }
+
+    const showFullScreen = typeof isFullScreen === 'boolean' ? isFullScreen : fullScreen
 
     return (
         <div
             id="desktop-menu"
             role="menu"
             aria-label="Desktop context menu"
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            aria-hidden={!active}
+            ref={menuRef}
+            onKeyDown={handleMenuKeyDown}
+            className={(active ? ' block ' : ' hidden ') + ' cursor-default w-56 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm shadow-lg'}
         >
-            <button
-                onClick={props.addNewFolder}
-                type="button"
-                role="menuitem"
-                aria-label="New Folder"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">New Folder</span>
-            </button>
-            <button
-                onClick={props.openShortcutSelector}
-                type="button"
-                role="menuitem"
-                aria-label="Create Shortcut"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Create Shortcut...</span>
-            </button>
-            <Devider />
-            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Paste</span>
+            <MenuButton
+                label="Open Terminal Here"
+                onClick={callAndClose(onOpenTerminal)}
+            />
+            <MenuButton
+                label="Create Folder"
+                onClick={callAndClose(onCreateFolder)}
+            />
+            {typeof onCreateShortcut === 'function' && (
+                <MenuButton
+                    label="Create Shortcut..."
+                    onClick={callAndClose(onCreateShortcut)}
+                />
+            )}
+            <div className="relative">
+                <button
+                    type="button"
+                    role="menuitem"
+                    ref={arrangeButtonRef}
+                    aria-haspopup="true"
+                    aria-expanded={arrangeOpen}
+                    data-menu-item
+                    className="w-full text-left py-0.5 px-5 hover:bg-ub-warm-grey hover:bg-opacity-20 flex items-center justify-between"
+                    onClick={() => setArrangeOpen((open) => !open)}
+                    onKeyDown={handleArrangeKeyDown}
+                >
+                    <span>Arrange Icons by…</span>
+                    <span aria-hidden="true" className="ml-2">▸</span>
+                </button>
+                <div
+                    role="menu"
+                    aria-label="Arrange icons by"
+                    aria-hidden={!arrangeOpen}
+                    ref={submenuRef}
+                    className={(arrangeOpen ? ' block ' : ' hidden ') + ' absolute top-0 left-full ml-1 w-48 context-menu-bg border border-gray-900 rounded shadow-lg py-2'}
+                    onKeyDown={handleSubmenuKeyDown}
+                >
+                    {ARRANGE_OPTIONS.map((option) => (
+                        <button
+                            key={option.value}
+                            type="button"
+                            role="menuitemradio"
+                            aria-checked={arrangement === option.value}
+                            tabIndex={arrangeOpen ? 0 : -1}
+                            className="w-full text-left px-5 py-1 hover:bg-ub-warm-grey hover:bg-opacity-20 flex items-center justify-between"
+                            onClick={() => handleArrangeSelect(option.value)}
+                        >
+                            <span>{option.label}</span>
+                            {arrangement === option.value && <span aria-hidden="true">✓</span>}
+                        </button>
+                    ))}
+                </div>
             </div>
-            <Devider />
-            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Show Desktop in Files</span>
-            </div>
-            <button
-                onClick={openTerminal}
-                type="button"
-                role="menuitem"
-                aria-label="Open in Terminal"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Open in Terminal</span>
-            </button>
-            <Devider />
-            <button
-                onClick={openSettings}
-                type="button"
-                role="menuitem"
-                aria-label="Change Background"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Change Background...</span>
-            </button>
-            <Devider />
-            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Display Settings</span>
-            </div>
-            <button
-                onClick={openSettings}
-                type="button"
-                role="menuitem"
-                aria-label="Settings"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Settings</span>
-            </button>
-            <Devider />
-            <button
-                onClick={goFullScreen}
-                type="button"
-                role="menuitem"
-                aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
-            </button>
-            <Devider />
-            <button
-                onClick={props.clearSession}
-                type="button"
-                role="menuitem"
-                aria-label="Clear Session"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Clear Session</span>
-            </button>
+            <MenuButton
+                label="Change Desktop Background"
+                onClick={callAndClose(onChangeBackground)}
+            />
+            <Divider />
+            <MenuButton
+                label={`${showFullScreen ? 'Exit' : 'Enter'} Full Screen`}
+                onClick={callAndClose(handleToggleFullScreen)}
+            />
+            <MenuButton
+                label="Clear Session"
+                onClick={callAndClose(onClearSession)}
+            />
         </div>
     )
 }
 
-function Devider() {
+function MenuButton({ label, onClick }) {
     return (
-        <div className="flex justify-center w-full">
-            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
-        </div>
-    );
+        <button
+            type="button"
+            role="menuitem"
+            data-menu-item
+            className="w-full text-left py-0.5 px-5 hover:bg-ub-warm-grey hover:bg-opacity-20"
+            onClick={onClick}
+        >
+            {label}
+        </button>
+    )
 }
 
+function Divider() {
+    return (
+        <div className="flex justify-center w-full my-1">
+            <div className="border-t border-gray-900 w-4/5" aria-hidden="true"></div>
+        </div>
+    )
+}
 
 export default DesktopMenu

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -42,7 +42,7 @@ export default function BackgroundImage() {
     }, [bgImageName, useKaliWallpaper]);
 
     return (
-        <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
+        <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full" data-context="desktop-area">
             {useKaliWallpaper || bgImageName === 'kali-gradient' ? (
                 <KaliWallpaper />
             ) : (


### PR DESCRIPTION
## Summary
- rebuild the desktop context menu to match Kali’s options and add a keyboard accessible submenu for arranging icons
- route menu actions through Desktop state, including persisted icon arrangement modes and a background shortcut into Settings
- scope context-menu activation to desktop targets and tag the wallpaper so the menu can be invoked on empty background

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d75071f65483289a179402d90343ad