### PR TITLE
[desktop] add grid layout and rename tools

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -31,21 +31,38 @@ export class UbuntuApp extends Component {
     }
 
     render() {
+        const isRenaming = !!this.props.isRenaming;
+        const displayName = this.props.displayName || this.props.name;
+        const handleDoubleClick = isRenaming ? () => { } : this.openApp;
+        const draggable = !isRenaming;
+
         return (
             <div
                 role="button"
-                aria-label={this.props.name}
+                aria-label={displayName}
                 aria-disabled={this.props.disabled}
                 data-context="app"
                 data-app-id={this.props.id}
-                draggable
-                onDragStart={this.handleDragStart}
-                onDragEnd={this.handleDragEnd}
+                draggable={draggable}
+                onDragStart={draggable ? this.handleDragStart : undefined}
+                onDragEnd={draggable ? this.handleDragEnd : undefined}
                 className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-24 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}
-                onDoubleClick={this.openApp}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
+                onDoubleClick={handleDoubleClick}
+                onKeyDown={(e) => {
+                    if (isRenaming) {
+                        if (e.key === 'Escape') {
+                            e.preventDefault();
+                            this.props.onRenameCancel && this.props.onRenameCancel();
+                        }
+                        return;
+                    }
+                    if ((e.key === 'Enter' || e.key === ' ') && !this.props.disabled) {
+                        e.preventDefault();
+                        this.openApp();
+                    }
+                }}
                 tabIndex={this.props.disabled ? -1 : 0}
                 onMouseEnter={this.handlePrefetch}
                 onFocus={this.handlePrefetch}
@@ -55,10 +72,38 @@ export class UbuntuApp extends Component {
                     height={40}
                     className="mb-1 w-10"
                     src={this.props.icon.replace('./', '/')}
-                    alt={"Kali " + this.props.name}
+                    alt={"Kali " + displayName}
                     sizes="40px"
                 />
-                {this.props.displayName || this.props.name}
+                {isRenaming ? (
+                    <form
+                        className="w-full"
+                        onSubmit={(e) => {
+                            e.preventDefault();
+                            this.props.onRenameSubmit && this.props.onRenameSubmit();
+                        }}
+                    >
+                        <input
+                            autoFocus
+                            aria-label={`Rename ${displayName}`}
+                            value={this.props.renameValue}
+                            onChange={(e) => this.props.onRenameChange && this.props.onRenameChange(e.target.value)}
+                            onBlur={() => this.props.onRenameSubmit && this.props.onRenameSubmit()}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Escape') {
+                                    e.preventDefault();
+                                    this.props.onRenameCancel && this.props.onRenameCancel();
+                                }
+                            }}
+                            spellCheck={false}
+                            className="w-full rounded bg-white bg-opacity-80 px-1 py-0.5 text-xs font-medium text-ub-cool-grey focus:outline-none focus:ring-2 focus:ring-ub-cream"
+                        />
+                    </form>
+                ) : (
+                    <span className="w-full px-1 text-xs font-normal text-white">
+                        <span className="block truncate" title={displayName}>{displayName}</span>
+                    </span>
+                )}
 
             </div>
         )

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -21,6 +21,14 @@ function AppMenu(props) {
         }
     }
 
+    const handleRename = () => {
+        props.onRename && props.onRename();
+    };
+
+    const handleUndoRename = () => {
+        props.onUndoRename && props.onUndoRename();
+    };
+
     return (
         <div
             id="app-menu"
@@ -38,6 +46,25 @@ function AppMenu(props) {
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
+            </button>
+            <button
+                type="button"
+                onClick={handleRename}
+                role="menuitem"
+                aria-label="Rename"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">Rename</span>
+            </button>
+            <button
+                type="button"
+                disabled={!props.canUndoRename}
+                onClick={handleUndoRename}
+                role="menuitem"
+                aria-label="Undo Rename"
+                className={`w-full text-left cursor-default py-0.5 mb-1.5 ${props.canUndoRename ? 'hover:bg-gray-700' : 'text-gray-500 cursor-not-allowed'}`}
+            >
+                <span className="ml-5">Undo Rename</span>
             </button>
         </div>
     )

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -43,6 +43,31 @@ function DesktopMenu(props) {
         }
     }
 
+    const arrangeOptions = [
+        { mode: 'name', label: 'Arrange by Name' },
+        { mode: 'type', label: 'Arrange by Type' },
+        { mode: 'date', label: 'Arrange by Date Added' },
+    ];
+
+    const renderArrangeButton = (option) => {
+        const isActive = props.currentArrange === option.mode;
+        return (
+            <button
+                key={option.mode}
+                onClick={() => props.arrangeDesktopApps && props.arrangeDesktopApps(option.mode)}
+                type="button"
+                role="menuitem"
+                aria-label={option.label}
+                className={`w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 ${isActive ? 'font-semibold' : ''}`}
+            >
+                <span className="ml-5 flex justify-between pr-4">
+                    <span>{option.label}</span>
+                    {isActive && <span aria-hidden="true">✓</span>}
+                </span>
+            </button>
+        );
+    };
+
     return (
         <div
             id="desktop-menu"
@@ -72,6 +97,8 @@ function DesktopMenu(props) {
             <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Paste</span>
             </div>
+            <Devider />
+            {arrangeOptions.map(renderArrangeButton)}
             <Devider />
             <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
                 <span className="ml-5">Show Desktop in Files</span>


### PR DESCRIPTION
## Summary
- introduce a desktop icon grid manager with persistent positions and a configurable layout
- add context menu actions to arrange icons by name, type, or date added while retaining custom metadata
- support inline icon renaming with undo controls wired into the existing context menus

## Testing
- npx eslint components/base/ubuntu_app.js components/context-menus/app-menu.js components/context-menus/desktop-menu.js components/screen/desktop.js

------
https://chatgpt.com/codex/tasks/task_e_68d75072a6e88328a0afde9f26f9302c