### PR TITLE
[settings] add random wallpaper rotation

### DIFF
--- a/public/wallpapers/manifest.json
+++ b/public/wallpapers/manifest.json
@@ -1,0 +1,14 @@
+{
+  "collection": "kali-dragon",
+  "version": 1,
+  "items": [
+    { "id": "wall-1", "file": "wall-1.webp", "name": "Kali Dragon Aurora" },
+    { "id": "wall-2", "file": "wall-2.webp", "name": "Kali Dragon Storm" },
+    { "id": "wall-3", "file": "wall-3.webp", "name": "Kali Dragon Horizon" },
+    { "id": "wall-4", "file": "wall-4.webp", "name": "Kali Dragon Pulse" },
+    { "id": "wall-5", "file": "wall-5.webp", "name": "Kali Dragon Prism" },
+    { "id": "wall-6", "file": "wall-6.webp", "name": "Kali Dragon Midnight" },
+    { "id": "wall-7", "file": "wall-7.webp", "name": "Kali Dragon Ember" },
+    { "id": "wall-8", "file": "wall-8.webp", "name": "Kali Dragon Flux" }
+  ]
+}


### PR DESCRIPTION
## Summary
- load the Kali Dragon wallpaper manifest and surface its metadata in the settings picker
- add a random daily wallpaper toggle that persists the latest selection and refreshes at local midnight
- persist new wallpaper preferences in the settings store while honoring future Undercover overrides

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d750731cac8328bc37bc25b7d67795