### PR TITLE
[desktop] add drag-to-trash interactions

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -7,12 +7,27 @@ export class UbuntuApp extends Component {
         this.state = { launching: false, dragging: false, prefetched: false };
     }
 
-    handleDragStart = () => {
+    handleDragStart = (event) => {
+        if (event && event.dataTransfer) {
+            event.dataTransfer.effectAllowed = 'move';
+            try {
+                event.dataTransfer.setData('application/x-ubuntu-app', this.props.id);
+                event.dataTransfer.setData('text/plain', this.props.id);
+            } catch (e) {
+                // Ignore unsupported data transfer operations
+            }
+        }
         this.setState({ dragging: true });
+        if (typeof this.props.onDragStart === 'function') {
+            this.props.onDragStart(event);
+        }
     }
 
-    handleDragEnd = () => {
+    handleDragEnd = (event) => {
         this.setState({ dragging: false });
+        if (typeof this.props.onDragEnd === 'function') {
+            this.props.onDragEnd(event);
+        }
     }
 
     openApp = () => {
@@ -41,14 +56,22 @@ export class UbuntuApp extends Component {
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
-                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                className={[
+                    this.state.launching ? 'app-icon-launch' : '',
+                    this.state.dragging ? 'opacity-70' : '',
+                    this.props.dropActive ? 'ring-2 ring-ub-orange ring-offset-2 ring-offset-black' : '',
+                    'p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active'
+                ].filter(Boolean).join(' ')}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
                 tabIndex={this.props.disabled ? -1 : 0}
                 onMouseEnter={this.handlePrefetch}
                 onFocus={this.handlePrefetch}
+                onDragOver={this.props.onDragOver}
+                onDrop={this.props.onDrop}
+                onDragEnter={this.props.onDragEnter}
+                onDragLeave={this.props.onDragLeave}
             >
                 <Image
                     width={40}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -398,12 +398,41 @@ export class Window extends Component {
 
     handleStop = () => {
         this.changeCursorToDefault();
+        const droppedOnTrash = this.checkTrashDrop();
+        if (droppedOnTrash) {
+            this.setState({ snapPreview: null, snapPosition: null });
+            return;
+        }
         const snapPos = this.state.snapPosition;
         if (snapPos) {
             this.snapWindow(snapPos);
         } else {
             this.setState({ snapPreview: null, snapPosition: null });
         }
+    }
+
+    checkTrashDrop = () => {
+        const node = document.getElementById(this.id);
+        const trashNode = document.getElementById('app-trash');
+        if (!node || !trashNode) return false;
+        const windowRect = node.getBoundingClientRect();
+        const trashRect = trashNode.getBoundingClientRect();
+        const intersects = !(
+            windowRect.right < trashRect.left ||
+            windowRect.left > trashRect.right ||
+            windowRect.bottom < trashRect.top ||
+            windowRect.top > trashRect.bottom
+        );
+        if (intersects) {
+            window.dispatchEvent(new CustomEvent('desktop-drop-to-trash', {
+                detail: {
+                    id: this.id,
+                    type: 'window',
+                },
+            }));
+            return true;
+        }
+        return false;
     }
 
     focusWindow = () => {


### PR DESCRIPTION
## Summary
- enable dragging desktop shortcuts and windows onto the Trash icon with undo support
- highlight newly deleted items in the Trash app, surface an undo toast, and refresh dock shortcuts
- allow trash items to be restored by dragging them out of the Trash window while persisting local storage state

## Testing
- yarn lint *(fails: pre-existing accessibility and window globals lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d75075a3d48328a45deb4dcc2ec98c