### PR TITLE
[apps] Add open-in-terminal option to Files

### DIFF
--- a/apps/terminal/commands/types.ts
+++ b/apps/terminal/commands/types.ts
@@ -5,6 +5,8 @@ export interface CommandContext {
   aliases: Record<string, string>;
   setAlias: (name: string, value: string) => void;
   runWorker: (command: string) => Promise<void>;
+  cwd: string;
+  setCwd: (path: string) => void;
 }
 
 export type CommandHandler = (args: string, ctx: CommandContext) => void | Promise<void>;

--- a/apps/terminal/tabs/index.tsx
+++ b/apps/terminal/tabs/index.tsx
@@ -1,26 +1,31 @@
 'use client';
 
-import React, { useRef } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../../components/ui/TabbedWindow';
 import Terminal, { TerminalProps } from '..';
 
-const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
+const TerminalTabs: React.FC<TerminalProps> = ({ openApp, initialPath }) => {
   const countRef = useRef(1);
 
-  const createTab = (): TabDefinition => {
-    const id = Date.now().toString();
-    return {
-      id,
-      title: `Session ${countRef.current++}`,
-      content: <Terminal openApp={openApp} />,
-    };
-  };
+  const createTab = useCallback(
+    (path?: string): TabDefinition => {
+      const id = Date.now().toString();
+      return {
+        id,
+        title: `Session ${countRef.current++}`,
+        content: <Terminal openApp={openApp} initialPath={path} />,
+      };
+    },
+    [openApp]
+  );
+
+  const [initialTabs] = useState(() => [createTab(initialPath)]);
 
   return (
     <TabbedWindow
       className="h-full w-full"
-      initialTabs={[createTab()]}
-      onNewTab={createTab}
+      initialTabs={initialTabs}
+      onNewTab={() => createTab()}
     />
   );
 };

--- a/components/apps/terminal.tsx
+++ b/components/apps/terminal.tsx
@@ -1,6 +1,17 @@
 import dynamic from 'next/dynamic';
 import HelpPanel from '../HelpPanel';
 
+interface TerminalWrapperContext {
+  path?: string;
+  initialPath?: string;
+  [key: string]: unknown;
+}
+
+interface TerminalWrapperProps {
+  openApp?: (id: string) => void;
+  context?: TerminalWrapperContext;
+}
+
 // Lazily load the heavy terminal app with session tabs on the client only.
 const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
   ssr: false,
@@ -16,11 +27,12 @@ const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
  * overflows. The actual indicator/scroll handling lives inside the terminal
  * app, this wrapper just provides the necessary container styles.
  */
-export default function Terminal() {
+export default function Terminal({ openApp, context }: TerminalWrapperProps) {
+  const initialPath = context?.initialPath ?? context?.path;
   return (
     <div className="h-full w-full overflow-y-auto">
       <HelpPanel appId="terminal" />
-      <TerminalApp />
+      <TerminalApp openApp={openApp} initialPath={initialPath} />
     </div>
   );
 }

--- a/public/docs/apps/file-explorer.md
+++ b/public/docs/apps/file-explorer.md
@@ -1,0 +1,9 @@
+# Files Help
+
+The Files app lets you browse folders stored in the browser sandbox (OPFS) or in a directory you pick with the native picker.
+
+- Use the breadcrumb trail to jump back up the folder hierarchy.
+- Press **Enter** or **Space** on a focused item to open it.
+- Open the context menu with a right click or by pressing **Shift+F10** when an item is focused.
+- Choose **Open in Terminal** to launch the Terminal app with the working directory set to the selected folder. For files, the terminal opens in their containing directory.
+- Use the search box at the bottom of the window to find text inside files in the current folder.


### PR DESCRIPTION
## Summary
- add an accessible context menu to Files items that includes an "Open in Terminal" action and dispatches the selected path
- surface Files documentation via the in-app help panel explaining keyboard access to the new action
- plumb initial path context through the terminal wrapper and tabs so the prompt reflects folders launched from Files

## Testing
- `yarn lint` *(fails: existing jsx-a11y and no-top-level-window rules across unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d750747fbc8328a2f39cd6c564d736