### PR TITLE
[terminal] align theme tokens with kali palette

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -40,6 +40,24 @@ import TerminalTabs from '../apps/terminal/tabs';
 describe('Terminal component', () => {
   const openApp = jest.fn();
 
+  beforeEach(() => {
+    document.documentElement.style.setProperty('--terminal-background', '#0f1317');
+    document.documentElement.style.setProperty('--terminal-foreground', '#f5f5f5');
+    document.documentElement.style.setProperty('--terminal-cursor', '#1793d1');
+    document.documentElement.style.setProperty(
+      '--terminal-selection',
+      'rgba(23, 147, 209, 0.35)',
+    );
+    document.documentElement.style.setProperty(
+      '--terminal-font-family',
+      "'Hack', 'Fira Code', monospace",
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders container and exposes runCommand', async () => {
     const ref = createRef<any>();
     render(<Terminal ref={ref} openApp={openApp} />);
@@ -59,6 +77,31 @@ describe('Terminal component', () => {
       ref.current.runCommand('open calculator');
     });
     expect(openApp).toHaveBeenCalledWith('calculator');
+  });
+
+  it('applies terminal tokens to container styles and new sessions', async () => {
+    const ref = createRef<any>();
+    const { getByTestId } = render(<Terminal ref={ref} openApp={openApp} />);
+    await act(async () => {});
+    const container = getByTestId('xterm-container');
+    expect(container).toHaveStyle('background: var(--terminal-background)');
+    expect(container).toHaveStyle('color: var(--terminal-foreground)');
+    expect(container).toHaveStyle('font-family: var(--terminal-font-family)');
+
+    const { Terminal: TerminalCtor } = require('@xterm/xterm') as {
+      Terminal: jest.Mock;
+    };
+
+    expect(TerminalCtor).toHaveBeenCalled();
+    const options = TerminalCtor.mock.calls[0][0];
+    expect(options).toMatchObject({ cursorBlink: true });
+    expect(options.fontFamily).toContain('Fira Code');
+    expect(options.theme).toMatchObject({
+      background: '#0f1317',
+      cursor: '#1793d1',
+      foreground: '#f5f5f5',
+      selection: 'rgba(23, 147, 209, 0.35)',
+    });
   });
 
   it('supports tab management shortcuts', async () => {

--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -11,10 +11,11 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
       data-testid="xterm-container"
       className={`text-white ${className}`}
       style={{
-        background: 'var(--kali-bg)',
+        background: 'var(--terminal-background)',
         backdropFilter: 'blur(4px)',
-        border: '1px solid var(--color-border)',
-        fontFamily: 'monospace',
+        border: '1px solid var(--terminal-border, var(--color-border))',
+        color: 'var(--terminal-foreground)',
+        fontFamily: 'var(--terminal-font-family)',
         fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
         lineHeight: 1.4,
         ...style,

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -303,16 +303,26 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
       ]);
       await import('@xterm/xterm/css/xterm.css');
       if (disposed) return;
+      const styles = getComputedStyle(document.documentElement);
+      const getToken = (name: string, fallback: string) =>
+        (styles.getPropertyValue(name) || '').trim() || fallback;
+
+      const fontFamily = getToken(
+        '--terminal-font-family',
+        '"Hack", "Fira Code", monospace',
+      );
+
       const term = new XTerm({
         cursorBlink: true,
         scrollback: 1000,
         cols: 80,
         rows: 24,
-        fontFamily: '"Fira Code", monospace',
+        fontFamily,
         theme: {
-          background: '#0f1317',
-          foreground: '#f5f5f5',
-          cursor: '#1793d1',
+          background: getToken('--terminal-background', '#0f1317'),
+          foreground: getToken('--terminal-foreground', '#f5f5f5'),
+          cursor: getToken('--terminal-cursor', '#1793d1'),
+          selection: getToken('--terminal-selection', 'rgba(23, 147, 209, 0.35)'),
         },
       });
       const fit = new FitAddon();

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -39,6 +39,14 @@
   --kali-terminal-green: #00ff00;
   --kali-terminal-text: #f5f5f5;
 
+  /* Terminal theme tokens */
+  --terminal-background: #0f1317;
+  --terminal-border: color-mix(in srgb, var(--kali-blue) 25%, transparent);
+  --terminal-foreground: var(--kali-terminal-text);
+  --terminal-cursor: var(--kali-blue);
+  --terminal-selection: color-mix(in srgb, var(--kali-blue) 35%, transparent);
+  --terminal-font-family: 'Hack', 'Fira Code', monospace;
+
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
   --game-color-success: #15803d;


### PR DESCRIPTION
## Summary
- add Kali terminal theme tokens to the shared design tokens file
- consume the new tokens in the terminal container and xterm session options with the Hack/Fira Code stack
- extend terminal unit tests to cover the themed defaults for new sessions

## Testing
- yarn test --watch=false __tests__/terminal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7507829b48328a58158a0d05738f5