### PR TITLE
[terminal] Support reopening closed tabs

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -40,6 +40,10 @@ import TerminalTabs from '../apps/terminal/tabs';
 describe('Terminal component', () => {
   const openApp = jest.fn();
 
+  beforeEach(() => {
+    openApp.mockClear();
+  });
+
   it('renders container and exposes runCommand', async () => {
     const ref = createRef<any>();
     render(<Terminal ref={ref} openApp={openApp} />);
@@ -67,13 +71,25 @@ describe('Terminal component', () => {
     const root = container.firstChild as HTMLElement;
     root.focus();
     fireEvent.keyDown(root, { ctrlKey: true, key: 't' });
-    expect(container.querySelectorAll('.flex.items-center.cursor-pointer').length).toBe(2);
+    let headers = container.querySelectorAll('.flex.items-center.cursor-pointer');
+    expect(headers.length).toBe(2);
 
     fireEvent.keyDown(root, { ctrlKey: true, key: 'Tab' });
-    const headers = container.querySelectorAll('.flex.items-center.cursor-pointer');
+    headers = container.querySelectorAll('.flex.items-center.cursor-pointer');
     expect((headers[0] as HTMLElement).className).toContain('bg-gray-700');
 
     fireEvent.keyDown(root, { ctrlKey: true, key: 'w' });
-    expect(container.querySelectorAll('.flex.items-center.cursor-pointer').length).toBe(1);
+    headers = container.querySelectorAll('.flex.items-center.cursor-pointer');
+    expect(headers.length).toBe(1);
+
+    fireEvent.keyDown(root, { ctrlKey: true, shiftKey: true, key: 'T' });
+    headers = container.querySelectorAll('.flex.items-center.cursor-pointer');
+    expect(headers.length).toBe(2);
+    expect(
+      Array.from(headers).some((el) => el.textContent?.includes('Session 2'))
+    ).toBe(true);
+
+    fireEvent.keyDown(root, { ctrlKey: true, shiftKey: true, key: 'N' });
+    expect(openApp).toHaveBeenCalledWith('terminal');
   });
 });

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,10 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'New terminal tab', keys: 'Ctrl+T' },
+  { description: 'Reopen last terminal tab', keys: 'Ctrl+Shift+T' },
+  { description: 'Close terminal tab', keys: 'Ctrl+W' },
+  { description: 'Open new terminal window', keys: 'Ctrl+Shift+N' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/apps/terminal/tabs/index.tsx
+++ b/apps/terminal/tabs/index.tsx
@@ -21,6 +21,7 @@ const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
       className="h-full w-full"
       initialTabs={[createTab()]}
       onNewTab={createTab}
+      onNewWindow={() => openApp?.('terminal')}
     />
   );
 };

--- a/public/docs/apps/terminal.md
+++ b/public/docs/apps/terminal.md
@@ -2,6 +2,16 @@
 
 This terminal emulates basic shell commands. Type commands and press Enter to execute.
 
+## Tips
+
 - Use arrow keys to navigate history.
 - Press `Ctrl+C` to cancel a running command.
 - The `help` command lists available commands.
+
+## Tab & window shortcuts
+
+- `Ctrl+T` — Open a new terminal tab.
+- `Ctrl+Shift+T` — Reopen the most recently closed tab with its content.
+- `Ctrl+W` — Close the active tab.
+- `Ctrl+Tab` — Cycle between tabs.
+- `Ctrl+Shift+N` — Open another terminal window from the desktop launcher.


### PR DESCRIPTION
## Summary
- capture Ctrl+Shift+T and Ctrl+Shift+N in the tabbed window to restore closed tabs and request a new terminal instance
- expose the terminal window shortcut in the keyboard overlay and update the in-app help documentation
- extend terminal keyboard shortcut tests to cover reopening tabs and the new-window signal

## Testing
- yarn test __tests__/terminal.test.tsx __tests__/ShortcutOverlay.test.tsx --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d75079172c8328adac48f1d08146c1