### PR TITLE
[terminal] Improve clipboard and selection handling

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -1,18 +1,37 @@
 jest.mock(
   '@xterm/xterm',
   () => ({
-    Terminal: jest.fn().mockImplementation(() => ({
-      open: jest.fn(),
-      focus: jest.fn(),
-      loadAddon: jest.fn(),
-      write: jest.fn(),
-      writeln: jest.fn(),
-      onData: jest.fn(),
-      onKey: jest.fn(),
-      onPaste: jest.fn(),
-      dispose: jest.fn(),
-      clear: jest.fn(),
-    })),
+    Terminal: jest.fn().mockImplementation(() => {
+      const element = document.createElement('div');
+      element.getBoundingClientRect = () => ({
+        width: 0,
+        height: 0,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      });
+      return {
+        open: jest.fn(),
+        focus: jest.fn(),
+        loadAddon: jest.fn(),
+        write: jest.fn(),
+        writeln: jest.fn(),
+        onData: jest.fn(),
+        onKey: jest.fn(),
+        onPaste: jest.fn(),
+        dispose: jest.fn(),
+        clear: jest.fn(),
+        selectLines: jest.fn(),
+        clearSelection: jest.fn(),
+        getSelection: jest.fn().mockReturnValue(''),
+        element,
+        buffer: { active: { getLine: jest.fn() } },
+      };
+    }),
   }),
   { virtual: true }
 );
@@ -39,6 +58,23 @@ import TerminalTabs from '../apps/terminal/tabs';
 
 describe('Terminal component', () => {
   const openApp = jest.fn();
+  let originalClipboard: any;
+
+  beforeEach(() => {
+    originalClipboard = (navigator as any).clipboard;
+  });
+
+  afterEach(() => {
+    if (originalClipboard !== undefined) {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: originalClipboard,
+      });
+    } else {
+      delete (navigator as any).clipboard;
+    }
+    jest.clearAllMocks();
+  });
 
   it('renders container and exposes runCommand', async () => {
     const ref = createRef<any>();
@@ -59,6 +95,47 @@ describe('Terminal component', () => {
       ref.current.runCommand('open calculator');
     });
     expect(openApp).toHaveBeenCalledWith('calculator');
+  });
+
+  it('handles keyboard copy and paste when clipboard is available', async () => {
+    const writeText = jest.fn();
+    const readText = jest.fn().mockResolvedValue('pasted text');
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText, readText },
+    });
+    const ref = createRef<any>();
+    render(<Terminal ref={ref} openApp={openApp} />);
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.keyDown(window, { ctrlKey: true, shiftKey: true, key: 'C' });
+    });
+    expect(writeText).toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.keyDown(window, { ctrlKey: true, shiftKey: true, key: 'V' });
+    });
+    expect(readText).toHaveBeenCalled();
+  });
+
+  it('disables clipboard actions when clipboard API is unavailable', async () => {
+    delete (navigator as any).clipboard;
+    const ref = createRef<any>();
+    const { getByLabelText } = render(<Terminal ref={ref} openApp={openApp} />);
+    await act(async () => {});
+
+    const copyButton = getByLabelText('Copy') as HTMLButtonElement;
+    const pasteButton = getByLabelText('Paste') as HTMLButtonElement;
+    expect(copyButton.disabled).toBe(true);
+    expect(pasteButton.disabled).toBe(true);
+
+    expect(() =>
+      fireEvent.keyDown(window, { ctrlKey: true, shiftKey: true, key: 'C' }),
+    ).not.toThrow();
+    expect(() =>
+      fireEvent.keyDown(window, { ctrlKey: true, shiftKey: true, key: 'V' }),
+    ).not.toThrow();
   });
 
   it('supports tab management shortcuts', async () => {

--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -9,7 +9,7 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
     <div
       ref={ref}
       data-testid="xterm-container"
-      className={`text-white ${className}`}
+      className={`text-white relative ${className}`}
       style={{
         background: 'var(--kali-bg)',
         backdropFilter: 'blur(4px)',


### PR DESCRIPTION
## Summary
- add guarded clipboard shortcuts and button states to the terminal toolbar and map Ctrl+Shift+C/V
- implement triple-click line selection and Alt+drag rectangular selection overlay with custom clipboard extraction
- extend terminal tests to cover clipboard availability scenarios

## Testing
- yarn test __tests__/terminal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7507a423883289b24b9d6833b85fd