### PR TITLE
[terminal] add theme profiles and opacity controls

### DIFF
--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -11,7 +11,8 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
       data-testid="xterm-container"
       className={`text-white ${className}`}
       style={{
-        background: 'var(--kali-bg)',
+        background: 'var(--terminal-bg, var(--kali-bg))',
+        color: 'var(--terminal-foreground, #f5f5f5)',
         backdropFilter: 'blur(4px)',
         border: '1px solid var(--color-border)',
         fontFamily: 'monospace',


### PR DESCRIPTION
## Summary
- define Default, Low Contrast, and Solarized terminal theme profiles with associated token previews
- refresh the terminal settings overlay with a profiles picker and per-profile opacity slider that updates CSS variables
- persist profile selections in localStorage and apply the chosen theme to xterm immediately when switching

## Testing
- yarn lint *(fails: repository currently reports numerous pre-existing accessibility and top-level window lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d7507c4a28832895675a24af094ef1