### PR TITLE
[ui] Rebrand Ubuntu shell to Kali

### DIFF
--- a/__tests__/kali.test.tsx
+++ b/__tests__/kali.test.tsx
@@ -1,6 +1,6 @@
 import React, { act } from 'react';
 import { render, screen } from '@testing-library/react';
-import Ubuntu from '../components/ubuntu';
+import Kali from '../components/kali';
 
 jest.mock('../components/screen/desktop', () => function DesktopMock() {
   return <div data-testid="desktop" />;
@@ -13,7 +13,7 @@ jest.mock('../components/screen/lock_screen', () => function LockScreenMock() {
 });
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 
-describe('Ubuntu component', () => {
+describe('Kali component', () => {
   beforeEach(() => {
     jest.useFakeTimers();
   });
@@ -24,8 +24,8 @@ describe('Ubuntu component', () => {
   });
 
   it('renders boot screen then desktop', () => {
-    render(<Ubuntu />);
-    const bootLogo = screen.getByAltText('Ubuntu Logo');
+    render(<Kali />);
+    const bootLogo = screen.getByAltText('Kali Logo');
     const bootScreen = bootLogo.parentElement as HTMLElement;
     expect(bootScreen).toHaveClass('visible');
 
@@ -38,8 +38,8 @@ describe('Ubuntu component', () => {
   });
 
   it('handles lockScreen when status bar is missing', () => {
-    let instance: Ubuntu | null = null;
-    render(<Ubuntu ref={(c) => (instance = c)} />);
+    let instance: Kali | null = null;
+    render(<Kali ref={(c) => (instance = c)} />);
     expect(instance).not.toBeNull();
     act(() => {
       instance!.lockScreen();
@@ -49,8 +49,8 @@ describe('Ubuntu component', () => {
   });
 
   it('handles shutDown when status bar is missing', () => {
-    let instance: Ubuntu | null = null;
-    render(<Ubuntu ref={(c) => (instance = c)} />);
+    let instance: Kali | null = null;
+    render(<Kali ref={(c) => (instance = c)} />);
     expect(instance).not.toBeNull();
     act(() => {
       instance!.shutDown();

--- a/components/apps/alex/data.json
+++ b/components/apps/alex/data.json
@@ -39,7 +39,7 @@
       { "src": "https://img.shields.io/badge/Unity-%23000000.svg?logo=unity&logoColor=white", "alt": "Unity", "description": "Game Engine" },
       { "src": "https://img.shields.io/badge/Xcode-007ACC?logo=Xcode&logoColor=white", "alt": "Xcode", "description": "Apple IDE" },
       { "src": "https://img.shields.io/badge/Android%20Studio-3DDC84?logo=android-studio&logoColor=white", "alt": "Android Studio", "description": "Android IDE" },
-      { "src": "https://img.shields.io/badge/Ubuntu-E95420?logo=ubuntu&logoColor=white", "alt": "Ubuntu", "description": "Ubuntu Linux" },
+      { "src": "https://img.shields.io/badge/Kali%20Linux%20Themed-557C94?logo=kalilinux&logoColor=fff", "alt": "Kali Linux Themed", "description": "Kali Linux (Themed)" },
       { "src": "https://img.shields.io/badge/Debian-D70A53?logo=debian&logoColor=white", "alt": "Debian", "description": "Debian Linux" },
       { "src": "https://img.shields.io/badge/Visual%20Studio-5C2D91?logo=visual-studio&logoColor=white", "alt": "Visual Studio", "description": "Microsoft IDE" },
       { "src": "https://img.shields.io/badge/VS%20Code-007ACC?logo=visual-studio-code&logoColor=white", "alt": "VS Code", "description": "Code Editor" },

--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useRef, useCallback, useEffect } from 'react';
-import UbuntuApp from '../base/ubuntu_app';
+import KaliApp from '../base/kali_app';
 import apps from '../../apps.config';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { Grid } from 'react-window';
@@ -98,7 +98,7 @@ export default function AppGrid({ openApp }) {
             onFocus={onFocus}
             onBlur={onBlur}
           >
-            <UbuntuApp
+            <KaliApp
               id={app.id}
               icon={app.icon}
               name={app.title}

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -195,7 +195,7 @@ export class Gedit extends Component {
                                 <Image
                                     className="w-8 motion-safe:animate-spin"
                                     src="/themes/Yaru/status/process-working-symbolic.svg"
-                                    alt="Ubuntu Process Symbol"
+                                    alt="Kali Process Symbol"
                                     width={32}
                                     height={32}
                                     sizes="32px"

--- a/components/base/kali_app.js
+++ b/components/base/kali_app.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import Image from 'next/image'
 
-export class UbuntuApp extends Component {
+export class KaliApp extends Component {
     constructor() {
         super();
         this.state = { launching: false, dragging: false, prefetched: false };
@@ -65,4 +65,4 @@ export class UbuntuApp extends Component {
     }
 }
 
-export default UbuntuApp
+export default KaliApp

--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -109,7 +109,7 @@ export class SideBarApp extends Component {
                     height={28}
                     className="w-7"
                     src={this.props.icon.replace('./', '/')}
-                    alt="Ubuntu App Icon"
+                    alt="Kali App Icon"
                     sizes="28px"
                 />
                 <Image

--- a/components/kali.js
+++ b/components/kali.js
@@ -8,7 +8,7 @@ import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
 
-export default class Ubuntu extends Component {
+export default class Kali extends Component {
 	constructor() {
 		super();
 		this.state = {
@@ -93,10 +93,10 @@ export default class Ubuntu extends Component {
 	shutDown = () => {
 		ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
 
-		ReactGA.event({
-			category: `Screen Change`,
-			action: `Switched off the Ubuntu`
-		});
+                ReactGA.event({
+                        category: `Screen Change`,
+                        action: `Switched off the Kali`
+                });
 
                 const statusBar = document.getElementById('status-bar');
                 // Consider using a React ref if the status bar element lives within this component tree

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import Image from 'next/image';
-import UbuntuApp from '../base/ubuntu_app';
+import KaliApp from '../base/kali_app';
 import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { KALI_CATEGORIES as BASE_KALI_CATEGORIES } from './ApplicationsMenu';
@@ -475,7 +475,7 @@ const WhiskerMenu: React.FC = () => {
                     idx === highlight ? 'ring-2 ring-ubb-orange ring-offset-gray-900' : 'ring-0'
                   }`}
                 >
-                  <UbuntuApp
+                  <KaliApp
                     id={app.id}
                     icon={app.icon}
                     name={app.title}

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import UbuntuApp from '../base/ubuntu_app';
+import KaliApp from '../base/kali_app';
 import { safeLocalStorage } from '../../utils/safeStorage';
 
 const FAVORITES_KEY = 'launcherFavorites';
@@ -140,7 +140,7 @@ class AllApplications extends React.Component {
                 >
                     ★
                 </button>
-                <UbuntuApp
+                <KaliApp
                     name={app.title}
                     id={app.id}
                     icon={app.icon}

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -15,14 +15,14 @@ function BootingScreen(props) {
                 height={400}
                 className="md:w-1/4 w-1/2"
                 src="/themes/Yaru/status/cof_orange_hex.svg"
-                alt="Ubuntu Logo"
+                alt="Kali Logo"
                 sizes="(max-width: 768px) 50vw, 25vw"
                 priority
             />
             <div className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer" onClick={props.turnOn} >
                 {(props.isShutDown
                     ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><Image width={32} height={32} className="w-8" src="/themes/Yaru/status/power-button.svg" alt="Power Button" sizes="32px" priority/></div>
-                    : <Image width={40} height={40} className={" w-10 " + (props.visible ? " animate-spin " : "")} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" sizes="40px" priority/>)}
+                    : <Image width={40} height={40} className={" w-10 " + (props.visible ? " animate-spin " : "")} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Kali Process Symbol" sizes="40px" priority/>)}
             </div>
             <Image
                 width={200}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -10,7 +10,7 @@ const BackgroundImage = dynamic(
 import SideBar from './side_bar';
 import apps, { games } from '../../apps.config';
 import Window from '../base/window';
-import UbuntuApp from '../base/ubuntu_app';
+import KaliApp from '../base/kali_app';
 import AllApplications from '../screen/all-applications'
 import ShortcutSelector from '../screen/shortcut-selector'
 import WindowSwitcher from '../screen/window-switcher'
@@ -604,7 +604,7 @@ export class Desktop extends Component {
                 }
 
                 appsJsx.push(
-                    <UbuntuApp key={app.id} {...props} />
+                    <KaliApp key={app.id} {...props} />
                 );
             }
         });
@@ -1083,7 +1083,7 @@ export class Desktop extends Component {
                 {/* Background Image */}
                 <BackgroundImage />
 
-                {/* Ubuntu Side Menu Bar */}
+                {/* Kali Side Menu Bar */}
                 <SideBar apps={apps}
                     hide={this.state.hideSideBar}
                     hideSideBar={this.hideSideBar}

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import UbuntuApp from '../base/ubuntu_app';
+import KaliApp from '../base/kali_app';
 
 class ShortcutSelector extends React.Component {
     constructor() {
@@ -41,7 +41,7 @@ class ShortcutSelector extends React.Component {
     renderApps = () => {
         const apps = this.state.apps || [];
         return apps.map((app) => (
-            <UbuntuApp
+            <KaliApp
                 key={app.id}
                 name={app.title}
                 id={app.id}

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -68,7 +68,7 @@ export function AllApps(props) {
                     height={28}
                     className="w-7"
                     src="/themes/Yaru/system/view-app-grid-symbolic.svg"
-                    alt="Ubuntu view app"
+                    alt="Kali view app"
                     sizes="28px"
                 />
                 <div

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -2,15 +2,15 @@ import dynamic from 'next/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
 
-const Ubuntu = dynamic(
+const Kali = dynamic(
   () =>
-    import('../components/ubuntu').catch((err) => {
-      console.error('Failed to load Ubuntu component', err);
+    import('../components/kali').catch((err) => {
+      console.error('Failed to load Kali component', err);
       throw err;
     }),
   {
     ssr: false,
-    loading: () => <p>Loading Ubuntu...</p>,
+    loading: () => <p>Loading Kali...</p>,
   }
 );
 const InstallButton = dynamic(
@@ -34,7 +34,7 @@ const App = () => (
       Skip to content
     </a>
     <Meta />
-    <Ubuntu />
+    <Kali />
     <BetaBadge />
     <InstallButton />
   </>


### PR DESCRIPTION
## Summary
- rename the Ubuntu shell component and base app wrapper to Kali and update all imports
- retitle UI strings and badges from Ubuntu to Kali for consistency across the desktop
- update the desktop unit test to cover the Kali component name and assets

## Testing
- yarn test __tests__/kali.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7507ccaf883288cf6e904b05202e5