### PR TITLE
[theme] Centralize tokens and apply across UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ See Vercel's [Speed Insights Quickstart](https://vercel.com/docs/speed-insights/
 - Client-side only **simulations** of security tools (no real exploitation)
 - A large set of games rendered in-browser (Canvas/DOM), with a shared `GameLayout`
 
+## Styling & Theme Tokens
+
+- Base CSS variables live in [`styles/tokens.css`](./styles/tokens.css). They define the Kali palette, panel transparencies, hover/highlight fills, shadows, and accessibility variants.
+- Components import [`styles/themes/kali.ts`](./styles/themes/kali.ts) to consume those tokens. The exported `kaliTheme` object exposes both the CSS variable references (e.g. `kaliTheme.colors.panel`) and raw hex values for environments that can’t read `var()` tokens (canvas renderers, etc.).
+- To tweak the desktop chrome, update the `rawColors` map in `kaliTheme` (for code-driven consumers) and mirror the change in `tokens.css` so the CSS variables stay in sync. Focus rings, hover fills, panel shadows, and overlay scrims are all grouped there.
+- App code and new UI should use `kaliTheme` or `var(--token)` rather than hard-coded Tailwind colors. Accent changes triggered from the Settings drawer automatically update the relevant CSS variables.
+
 ### Gamepad Input & Remapping
 
 Games can listen for normalized gamepad events via `utils/gamepad.ts`. The manager polls

--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import { ModuleMetadata } from '../modules/metadata';
+import { kaliTheme } from '../styles/themes/kali';
 
 interface ModuleCardProps {
   module: ModuleMetadata;
@@ -33,9 +34,12 @@ export default function ModuleCard({
   return (
     <button
       onClick={() => onSelect(module)}
-      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
-        selected ? 'bg-gray-100' : ''
-      }`}
+      className="w-full text-left border rounded p-3 flex items-start justify-between transition-colors hover:bg-[var(--kali-hover-surface)] focus:outline-none"
+      style={{
+        backgroundColor: selected ? kaliTheme.colors.panelHighlight : 'transparent',
+        borderColor: selected ? kaliTheme.colors.accent : kaliTheme.colors.border,
+        color: kaliTheme.colors.text,
+      }}
     >
       <div className="flex-1 pr-2 font-mono">
         <h3 className="font-bold">{highlight(module.name, query)}</h3>

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -99,7 +99,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
       aria-hidden={!open}
       style={{ left: pos.x, top: pos.y }}
       className={(open ? 'block ' : 'hidden ') +
-        'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+        'context-menu cursor-default w-52 rounded py-4 absolute z-50 text-sm text-left'}
     >
       {items.map((item, i) => (
         <button
@@ -110,7 +110,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
             item.onSelect();
             setOpen(false);
           }}
-          className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+          className="context-menu__item w-full text-left cursor-default py-0.5 mb-1.5"
         >
           {item.label}
         </button>

--- a/components/common/ShortcutOverlay.tsx
+++ b/components/common/ShortcutOverlay.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState, useCallback } from 'react';
 import useKeymap from '../../apps/settings/keymapRegistry';
+import { kaliTheme } from '../../styles/themes/kali';
 
 const formatEvent = (e: KeyboardEvent) => {
   const parts = [
@@ -68,11 +69,19 @@ const ShortcutOverlay: React.FC = () => {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/80 text-white p-4 overflow-auto"
+      className="fixed inset-0 z-50 flex items-start justify-center p-4 overflow-auto"
       role="dialog"
       aria-modal="true"
+      style={{ backgroundColor: kaliTheme.colors.overlayScrim, color: kaliTheme.colors.text }}
     >
-      <div className="max-w-lg w-full space-y-4">
+      <div
+        className="max-w-lg w-full space-y-4 rounded-md border p-4"
+        style={{
+          backgroundColor: kaliTheme.colors.panel,
+          borderColor: kaliTheme.colors.panelBorder,
+          boxShadow: kaliTheme.shadows.panel,
+        }}
+      >
         <div className="flex justify-between items-center">
           <h2 className="text-xl font-bold">Keyboard Shortcuts</h2>
           <button
@@ -86,7 +95,11 @@ const ShortcutOverlay: React.FC = () => {
         <button
           type="button"
           onClick={handleExport}
-          className="px-2 py-1 bg-gray-700 rounded text-sm"
+          className="px-2 py-1 rounded text-sm transition-colors hover:bg-[var(--kali-hover-surface)]"
+          style={{
+            backgroundColor: kaliTheme.colors.surface,
+            color: kaliTheme.colors.text,
+          }}
         >
           Export JSON
         </button>
@@ -95,10 +108,16 @@ const ShortcutOverlay: React.FC = () => {
             <li
               key={i}
               data-conflict={conflicts.has(s.keys) ? 'true' : 'false'}
-              className={
+              className="flex justify-between px-2 py-1 rounded"
+              style={
                 conflicts.has(s.keys)
-                  ? 'flex justify-between bg-red-600/70 px-2 py-1 rounded'
-                  : 'flex justify-between px-2 py-1'
+                  ? {
+                      backgroundColor: kaliTheme.colors.danger,
+                      color: kaliTheme.colors.text,
+                    }
+                  : {
+                      backgroundColor: 'transparent',
+                    }
               }
             >
               <span className="font-mono mr-4">{s.keys}</span>

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -28,14 +28,14 @@ function AppMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+            className={(props.active ? ' block ' : ' hidden ') + ' context-menu cursor-default w-52 rounded py-4 absolute z-50 text-sm text-left'}
         >
             <button
                 type="button"
                 onClick={handlePin}
                 role="menuitem"
                 aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu__item w-full text-left cursor-default py-0.5 mb-1.5"
             >
                 <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
             </button>

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -20,7 +20,7 @@ function DefaultMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            className={(props.active ? " block " : " hidden ") + " context-menu cursor-default w-52 rounded py-4 absolute z-50 text-sm text-left"}
         >
 
             <Devider />
@@ -30,7 +30,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Linkedin"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu__item w-full block cursor-default py-0.5 mb-1.5"
             >
                 <span className="ml-5">🙋‍♂️</span> <span className="ml-2">Follow on <strong>Linkedin</strong></span>
             </a>
@@ -40,7 +40,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Github"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu__item w-full block cursor-default py-0.5 mb-1.5"
             >
                 <span className="ml-5">🤝</span> <span className="ml-2">Follow on <strong>Github</strong></span>
             </a>
@@ -50,7 +50,7 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Contact Me"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu__item w-full block cursor-default py-0.5 mb-1.5"
             >
                 <span className="ml-5">📥</span> <span className="ml-2">Contact Me</span>
             </a>
@@ -60,7 +60,7 @@ function DefaultMenu(props) {
                 onClick={() => { localStorage.clear(); window.location.reload() }}
                 role="menuitem"
                 aria-label="Reset Kali Linux"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu__item w-full text-left cursor-default py-0.5 mb-1.5"
             >
                 <span className="ml-5">🧹</span> <span className="ml-2">Reset Kali Linux</span>
             </button>
@@ -71,7 +71,7 @@ function DefaultMenu(props) {
 function Devider() {
     return (
         <div className="flex justify-center w-full">
-            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
+            <div className="context-menu__divider py-1 w-2/5"></div>
         </div>
     );
 }

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -48,14 +48,14 @@ function DesktopMenu(props) {
             id="desktop-menu"
             role="menu"
             aria-label="Desktop context menu"
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            className={(props.active ? " block " : " hidden ") + " context-menu cursor-default w-52 rounded py-4 absolute z-50 text-sm text-left font-light"}
         >
             <button
                 onClick={props.addNewFolder}
                 type="button"
                 role="menuitem"
                 aria-label="New Folder"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu__item w-full text-left py-0.5 mb-1.5"
             >
                 <span className="ml-5">New Folder</span>
             </button>
@@ -64,16 +64,16 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Create Shortcut"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu__item w-full text-left py-0.5 mb-1.5"
             >
                 <span className="ml-5">Create Shortcut...</span>
             </button>
             <Devider />
-            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="context-menu__item w-full py-0.5 mb-1.5 cursor-not-allowed" style={{ color: 'var(--kali-text-muted)' }}>
                 <span className="ml-5">Paste</span>
             </div>
             <Devider />
-            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="context-menu__item w-full py-0.5 mb-1.5 cursor-not-allowed" style={{ color: 'var(--kali-text-muted)' }}>
                 <span className="ml-5">Show Desktop in Files</span>
             </div>
             <button
@@ -81,7 +81,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Open in Terminal"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu__item w-full text-left py-0.5 mb-1.5"
             >
                 <span className="ml-5">Open in Terminal</span>
             </button>
@@ -91,12 +91,12 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Change Background"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu__item w-full text-left py-0.5 mb-1.5"
             >
                 <span className="ml-5">Change Background...</span>
             </button>
             <Devider />
-            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
+            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="context-menu__item w-full py-0.5 mb-1.5 cursor-not-allowed" style={{ color: 'var(--kali-text-muted)' }}>
                 <span className="ml-5">Display Settings</span>
             </div>
             <button
@@ -104,7 +104,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Settings"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu__item w-full text-left py-0.5 mb-1.5"
             >
                 <span className="ml-5">Settings</span>
             </button>
@@ -114,7 +114,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu__item w-full text-left py-0.5 mb-1.5"
             >
                 <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
             </button>
@@ -124,7 +124,7 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Clear Session"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="context-menu__item w-full text-left py-0.5 mb-1.5"
             >
                 <span className="ml-5">Clear Session</span>
             </button>
@@ -135,7 +135,7 @@ function DesktopMenu(props) {
 function Devider() {
     return (
         <div className="flex justify-center w-full">
-            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
+            <div className="context-menu__divider py-1 w-2/5"></div>
         </div>
     );
 }

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -30,14 +30,14 @@ function TaskbarMenu(props) {
             aria-hidden={!props.active}
             ref={menuRef}
             onKeyDown={handleKeyDown}
-            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
+            className={(props.active ? ' block ' : ' hidden ') + ' context-menu cursor-default w-40 rounded py-2 absolute z-50 text-sm text-left'}
         >
             <button
                 type="button"
                 onClick={handleMinimize}
                 role="menuitem"
                 aria-label={props.minimized ? 'Restore Window' : 'Minimize Window'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu__item w-full text-left cursor-default py-0.5 mb-1.5"
             >
                 <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
             </button>
@@ -46,7 +46,7 @@ function TaskbarMenu(props) {
                 onClick={handleClose}
                 role="menuitem"
                 aria-label="Close Window"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="context-menu__item w-full text-left cursor-default py-0.5 mb-1.5"
             >
                 <span className="ml-5">Close</span>
             </button>

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1041,7 +1041,7 @@ export class Desktop extends Component {
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <input className="outline-none mt-5 px-1 w-10/12 context-menu__input border-2 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
                 </div>
                 <div className="flex">
                     <button

--- a/pages/nessus-report.tsx
+++ b/pages/nessus-report.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo, useState } from 'react';
 import data from '../components/apps/nessus/sample-report.json';
+import { kaliTheme } from '../styles/themes/kali';
 
 const severityColors: Record<string, string> = {
   Critical: '#991b1b',
@@ -134,24 +135,34 @@ const NessusReport: React.FC = () => {
   }, [counts, findings.length]);
 
   return (
-    <div className="p-4 bg-gray-900 text-white min-h-screen">
+    <div
+      className="p-4 min-h-screen"
+      style={{
+        backgroundColor: kaliTheme.colors.background,
+        color: kaliTheme.colors.text,
+      }}
+    >
       <h1 className="text-2xl mb-4">Sample Nessus Report</h1>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
         {['Critical', 'High', 'Medium', 'Low'].map((sev) => (
           <div
             key={sev}
-            className="bg-gray-800 p-2 rounded flex items-center justify-between"
+            className="p-2 rounded flex items-center justify-between border"
+            style={{
+              backgroundColor: kaliTheme.colors.surface,
+              borderColor: kaliTheme.colors.panelBorder,
+              boxShadow: kaliTheme.shadows.panel,
+            }}
           >
             <span
-              className="px-2 py-0.5 rounded-full text-xs text-white"
-              style={{ backgroundColor: severityColors[sev] }}
+              className="px-2 py-0.5 rounded-full text-xs"
+              style={{ backgroundColor: severityColors[sev], color: kaliTheme.colors.text }}
             >
               {sev}
             </span>
             <span className="font-mono">{counts[sev] || 0}</span>
           </div>
         ))}
-
       </div>
       <div className="flex items-center space-x-2 mb-4 flex-wrap">
         <label htmlFor="report-file" className="text-sm">
@@ -161,7 +172,12 @@ const NessusReport: React.FC = () => {
           id="report-file"
           type="file"
           accept=".json"
-          className="text-black p-1 rounded"
+          className="p-1 rounded border transition-colors"
+          style={{
+            backgroundColor: kaliTheme.colors.surface,
+            borderColor: kaliTheme.colors.panelBorder,
+            color: kaliTheme.colors.text,
+          }}
           onChange={handleFile}
         />
         <label htmlFor="severity-filter" className="text-sm">
@@ -169,7 +185,12 @@ const NessusReport: React.FC = () => {
         </label>
         <select
           id="severity-filter"
-          className="text-black p-1 rounded"
+          className="p-1 rounded border transition-colors"
+          style={{
+            backgroundColor: kaliTheme.colors.surface,
+            borderColor: kaliTheme.colors.panelBorder,
+            color: kaliTheme.colors.text,
+          }}
           value={severity}
           onChange={(e) => setSeverity(e.target.value)}
         >
@@ -184,7 +205,12 @@ const NessusReport: React.FC = () => {
         </label>
         <select
           id="host-filter"
-          className="text-black p-1 rounded"
+          className="p-1 rounded border transition-colors"
+          style={{
+            backgroundColor: kaliTheme.colors.surface,
+            borderColor: kaliTheme.colors.panelBorder,
+            color: kaliTheme.colors.text,
+          }}
           value={host}
           onChange={(e) => setHost(e.target.value)}
         >
@@ -199,7 +225,12 @@ const NessusReport: React.FC = () => {
         </label>
         <select
           id="family-filter"
-          className="text-black p-1 rounded"
+          className="p-1 rounded border transition-colors"
+          style={{
+            backgroundColor: kaliTheme.colors.surface,
+            borderColor: kaliTheme.colors.panelBorder,
+            color: kaliTheme.colors.text,
+          }}
           value={family}
           onChange={(e) => setFamily(e.target.value)}
         >
@@ -212,8 +243,13 @@ const NessusReport: React.FC = () => {
         <button
           type="button"
           onClick={exportCSV}
-          className="p-2 bg-blue-600 rounded"
+          className="p-2 rounded border transition-colors hover:bg-[var(--kali-hover-surface)]"
           aria-label="Export CSV"
+          style={{
+            backgroundColor: kaliTheme.colors.surface,
+            borderColor: kaliTheme.colors.panelBorder,
+            color: kaliTheme.colors.text,
+          }}
         >
           <svg
             viewBox="0 0 24 24"
@@ -230,7 +266,7 @@ const NessusReport: React.FC = () => {
           </svg>
         </button>
       </div>
-      <p className="text-xs text-gray-400 mb-2">
+      <p className="text-xs mb-2" style={{ color: kaliTheme.colors.textMuted }}>
         Only the bundled sample-report.json is supported. Files are processed locally and never uploaded.
       </p>
       <svg
@@ -241,9 +277,15 @@ const NessusReport: React.FC = () => {
       >
         {segments}
       </svg>
-      <table className="w-full mb-4 text-sm">
+      <table
+        className="w-full mb-4 text-sm border-separate"
+        style={{ borderSpacing: 0, color: kaliTheme.colors.text }}
+      >
         <thead>
-          <tr className="text-left border-b border-gray-700 h-9">
+          <tr
+            className="text-left h-9"
+            style={{ borderBottom: `1px solid ${kaliTheme.colors.panelBorder}` }}
+          >
             <th className="px-2" scope="col">ID</th>
             <th className="px-2" scope="col">Finding</th>
             <th className="px-2" scope="col">CVSS</th>
@@ -256,9 +298,12 @@ const NessusReport: React.FC = () => {
           {filtered.map((f) => (
             <tr
               key={f.id}
-              className="border-b border-gray-800 cursor-pointer hover:bg-gray-800 border-l-4"
-              style={{ borderLeftColor: severityColors[f.severity] }}
-
+              className="cursor-pointer border-b border-l-4 transition-colors hover:bg-[var(--kali-hover-surface)]"
+              style={{
+                borderLeftColor: severityColors[f.severity],
+                borderBottomColor: kaliTheme.colors.panelBorder,
+                backgroundColor: kaliTheme.colors.panel,
+              }}
               onClick={() => setSelected(f)}
             >
               <td className="px-2">{f.id}</td>
@@ -266,8 +311,8 @@ const NessusReport: React.FC = () => {
               <td className="px-2">{f.cvss}</td>
               <td className="px-2">
                 <span
-                  className="px-2 py-0.5 rounded-full text-xs text-white"
-                  style={{ backgroundColor: severityColors[f.severity] }}
+                  className="px-2 py-0.5 rounded-full text-xs"
+                  style={{ backgroundColor: severityColors[f.severity], color: kaliTheme.colors.text }}
                 >
                   {f.severity}
                 </span>
@@ -281,12 +326,21 @@ const NessusReport: React.FC = () => {
       {selected && (
         <div
           role="dialog"
-          className="fixed top-0 right-0 h-full w-80 bg-gray-800 p-4 overflow-auto shadow-lg"
+          className="fixed top-0 right-0 h-full w-80 p-4 overflow-auto border-l"
+          style={{
+            backgroundColor: kaliTheme.colors.panel,
+            borderColor: kaliTheme.colors.panelBorder,
+            boxShadow: kaliTheme.shadows.panel,
+          }}
         >
           <button
             type="button"
             onClick={() => setSelected(null)}
-            className="mb-2 text-sm bg-red-600 px-2 py-1 rounded"
+            className="mb-2 text-sm px-2 py-1 rounded"
+            style={{
+              backgroundColor: kaliTheme.colors.danger,
+              color: kaliTheme.colors.text,
+            }}
           >
             Close
           </button>
@@ -297,7 +351,7 @@ const NessusReport: React.FC = () => {
           <p className="mb-4 text-sm whitespace-pre-wrap">
             {selected.description}
           </p>
-          <p className="text-xs text-gray-400">
+          <p className="text-xs" style={{ color: kaliTheme.colors.textMuted }}>
             Disclaimer: This sample report is for demonstration purposes only.
           </p>
         </div>

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -5,6 +5,7 @@ import Meta from '../components/SEO/Meta';
 import modules, { ModuleMetadata } from '../modules/metadata';
 import ModuleCard from '../components/ModuleCard';
 import VirtualList from 'rc-virtual-list';
+import { kaliTheme } from '../styles/themes/kali';
 
 export default function PostExploitation() {
   const [query, setQuery] = useState('');
@@ -35,7 +36,10 @@ export default function PostExploitation() {
   return (
     <>
       <Meta />
-      <main className="mx-auto grid gap-4 p-4 md:grid-cols-2">
+      <main
+        className="mx-auto grid gap-4 p-4 md:grid-cols-2"
+        style={{ color: kaliTheme.colors.text }}
+      >
         <section className="prose">
           <h1>Metasploit Post-Exploitation Modules</h1>
           <p>
@@ -55,7 +59,12 @@ export default function PostExploitation() {
             placeholder="Search modules..."
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="mb-4 w-full rounded border p-2"
+            className="mb-4 w-full rounded border p-2 transition-colors"
+            style={{
+              backgroundColor: kaliTheme.colors.panel,
+              borderColor: kaliTheme.colors.panelBorder,
+              color: kaliTheme.colors.text,
+            }}
           />
           <div className="mb-4 flex flex-wrap gap-2">
             {allTags.map((tag) => (
@@ -114,12 +123,24 @@ export default function PostExploitation() {
           )}
           <h3>Example Transcript</h3>
           <div className="flex items-start gap-2">
-            <pre className="flex-1 overflow-x-auto rounded bg-black p-3 text-green-400 font-mono">
+            <pre
+              className="flex-1 overflow-x-auto rounded p-3 font-mono"
+              style={{
+                backgroundColor: kaliTheme.colors.background,
+                color: kaliTheme.colors.terminal,
+                border: `1px solid ${kaliTheme.colors.panelBorder}`,
+              }}
+            >
               {transcript}
             </pre>
             <button
               onClick={copyTranscript}
-              className="px-2 py-1 text-sm rounded bg-gray-700"
+              className="px-2 py-1 text-sm rounded transition-colors hover:bg-[var(--kali-hover-surface)]"
+              style={{
+                backgroundColor: kaliTheme.colors.surface,
+                color: kaliTheme.colors.text,
+                border: `1px solid ${kaliTheme.colors.panelBorder}`,
+              }}
             >
               Copy
             </button>

--- a/pages/recon/graph.tsx
+++ b/pages/recon/graph.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import dynamic from 'next/dynamic';
+import { kaliTheme } from '../../styles/themes/kali';
 
 interface CytoscapeNode {
   data: { id: string; label: string };
@@ -37,6 +38,19 @@ const ForceGraph2D = dynamic(
 
 const ReconGraph: React.FC = () => {
   const [data, setData] = useState<ReconChainData | null>(null);
+  const [accentColor, setAccentColor] = useState<string>(kaliTheme.rawColors.accent);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const root = document.documentElement;
+    const updateAccent = () => {
+      const value = getComputedStyle(root).getPropertyValue('--color-primary').trim();
+      if (value) {
+        setAccentColor(value);
+      }
+    };
+    updateAccent();
+  }, []);
 
   useEffect(() => {
     fetch('/reconng-chain.json')
@@ -77,22 +91,36 @@ const ReconGraph: React.FC = () => {
   }, [data]);
 
   return (
-    <div className="p-4 bg-gray-900 text-white min-h-screen">
+    <div
+      className="p-4 min-h-screen"
+      style={{
+        backgroundColor: kaliTheme.colors.background,
+        color: kaliTheme.colors.text,
+      }}
+    >
       <h1 className="text-2xl mb-4">Recon Graph</h1>
       <p className="mb-2 text-sm">
         Nodes: {graphData.nodes.length} | Edges: {graphData.links.length}
       </p>
-      <div className="h-96 bg-black rounded">
+      <div
+        className="h-96 rounded border"
+        style={{
+          backgroundColor: kaliTheme.colors.surface,
+          borderColor: kaliTheme.colors.panelBorder,
+          boxShadow: kaliTheme.shadows.panel,
+        }}
+      >
         <ForceGraph2D
           graphData={graphData}
           nodeId="id"
           nodeCanvasObject={(node: any, ctx) => {
-            ctx.fillStyle = 'lightblue';
+            ctx.fillStyle = accentColor;
             ctx.beginPath();
             ctx.arc(node.x, node.y, 4, 0, 2 * Math.PI, false);
             ctx.fill();
             ctx.font = '8px sans-serif';
             const label = node.label || node.id;
+            ctx.fillStyle = kaliTheme.rawColors.text;
             ctx.fillText(label, node.x + 6, node.y + 2);
           }}
           linkDirectionalArrowLength={4}

--- a/styles/index.css
+++ b/styles/index.css
@@ -365,18 +365,59 @@ dialog {
 }
 
 /* Context Menu & Panels */
-.context-menu-bg,
+.context-menu,
+.context-menu-bg {
+    background-color: var(--kali-panel);
+    color: var(--color-text);
+    border: 1px solid var(--kali-panel-border);
+    box-shadow: var(--shadow-panel);
+}
+
 .windowMainScreen {
-    background-color: color-mix(in srgb, var(--color-bg), transparent 15%); /* Fallback for unsupported browsers */
+    background-color: color-mix(in srgb, var(--color-bg), transparent 15%);
 }
 
 @supports ((-webkit-backdrop-filter: blur(0)) or (backdrop-filter: blur(0))) {
+    .context-menu,
     .context-menu-bg,
     .windowMainScreen {
         -webkit-backdrop-filter: blur(10px);
         backdrop-filter: blur(10px);
         background-color: color-mix(in srgb, var(--color-bg), transparent 60%);
     }
+}
+
+.context-menu__item {
+    background: transparent;
+    color: inherit;
+    display: block;
+    width: 100%;
+    border-radius: var(--radius-sm);
+    transition: background-color var(--motion-fast) ease;
+}
+
+.context-menu__item:hover,
+.context-menu__item:focus-visible {
+    background-color: var(--kali-hover-surface);
+}
+
+.context-menu__item:focus-visible {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: 0;
+}
+
+.context-menu__divider {
+    border-top: 1px solid var(--kali-panel-border);
+}
+
+.context-menu__input {
+    background-color: transparent;
+    border-color: var(--color-accent);
+    color: var(--color-text);
+}
+
+.context-menu__input::placeholder {
+    color: var(--kali-text-muted);
 }
 
 .emoji-list>li {

--- a/styles/themes/kali.ts
+++ b/styles/themes/kali.ts
@@ -1,8 +1,72 @@
+const rawColors = {
+  background: '#0f1317',
+  text: '#f5f5f5',
+  accent: '#1793d1',
+  secondary: '#1a1f26',
+  surface: '#1a1f26',
+  muted: '#2a2e36',
+  border: '#2a2e36',
+  panel: 'rgba(26, 31, 38, 0.9)',
+  panelBorder: 'rgba(255, 255, 255, 0.08)',
+  panelHighlight: 'rgba(255, 255, 255, 0.05)',
+  hoverSurface: 'rgba(255, 255, 255, 0.08)',
+  focusRing: '#1793d1',
+  textMuted: 'rgba(245, 245, 245, 0.7)',
+  terminal: '#00ff00',
+  inverse: '#000000',
+  backdrop: 'rgba(15, 19, 23, 0.85)',
+  overlayScrim: 'rgba(8, 11, 15, 0.82)',
+  danger: '#dc2626',
+};
+
+const cssVar = (token: string) => `var(${token})`;
+
 export const kaliTheme = {
-  background: 'var(--color-bg)',
-  text: 'var(--color-text)',
-  accent: 'var(--color-primary)',
-  sidebar: 'var(--color-secondary)',
+  background: cssVar('--color-bg'),
+  text: cssVar('--color-text'),
+  accent: cssVar('--color-primary'),
+  sidebar: cssVar('--color-secondary'),
+  rawColors,
+  colors: {
+    background: cssVar('--color-bg'),
+    text: cssVar('--color-text'),
+    accent: cssVar('--color-primary'),
+    secondary: cssVar('--color-secondary'),
+    surface: cssVar('--color-surface'),
+    muted: cssVar('--color-muted'),
+    border: cssVar('--color-border'),
+    panel: cssVar('--kali-panel'),
+    panelBorder: cssVar('--kali-panel-border'),
+    panelHighlight: cssVar('--kali-panel-highlight'),
+    hoverSurface: cssVar('--kali-hover-surface'),
+    focusRing: cssVar('--color-focus-ring'),
+    textMuted: cssVar('--kali-text-muted'),
+    terminal: cssVar('--color-terminal'),
+    inverse: cssVar('--color-inverse'),
+    backdrop: cssVar('--kali-bg'),
+    overlayScrim: cssVar('--kali-overlay-scrim'),
+    danger: cssVar('--color-danger'),
+  },
+  focus: {
+    outlineColor: cssVar('--focus-outline-color'),
+    outlineWidth: cssVar('--focus-outline-width'),
+  },
+  shadows: {
+    panel: cssVar('--shadow-panel'),
+    focusRing: `0 0 0 ${cssVar('--focus-outline-width')} ${cssVar('--focus-outline-color')}`,
+  },
+  radii: {
+    sm: cssVar('--radius-sm'),
+    md: cssVar('--radius-md'),
+    lg: cssVar('--radius-lg'),
+    xl: cssVar('--radius-6'),
+    pill: cssVar('--radius-round'),
+  },
+  motion: {
+    fast: cssVar('--motion-fast'),
+    medium: cssVar('--motion-medium'),
+    slow: cssVar('--motion-slow'),
+  },
 };
 
 export type KaliTheme = typeof kaliTheme;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -36,6 +36,11 @@
   --kali-panel: rgba(26, 31, 38, 0.9);
   --kali-panel-border: rgba(255, 255, 255, 0.08);
   --kali-panel-highlight: rgba(255, 255, 255, 0.05);
+  --kali-hover-surface: rgba(255, 255, 255, 0.08);
+  --kali-text-muted: rgba(245, 245, 245, 0.7);
+  --kali-overlay-scrim: rgba(8, 11, 15, 0.82);
+  --shadow-panel: 0 6px 20px rgba(0, 0, 0, 0.35);
+  --color-danger: #dc2626;
   --kali-terminal-green: #00ff00;
   --kali-terminal-text: #f5f5f5;
 
@@ -97,6 +102,11 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --kali-hover-surface: rgba(255, 255, 255, 0.35);
+  --kali-text-muted: #ffffff;
+  --kali-overlay-scrim: rgba(0, 0, 0, 0.85);
+  --shadow-panel: 0 0 0 2px #ffff00;
+  --color-danger: #ff0000;
 }
 
 /* Dyslexia-friendly fonts */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -55,7 +55,7 @@ module.exports = {
         },
       },
       boxShadow: {
-        'kali-panel': '0 6px 20px rgba(0,0,0,.35)',
+        'kali-panel': 'var(--shadow-panel)',
       },
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],


### PR DESCRIPTION
## Summary
- expand the Kali theme export with panel, hover, focus, and shadow tokens plus raw color fallbacks
- refactor context menus, module cards, overlays, and themed pages to consume CSS variables instead of hard-coded colors
- document how to adjust the shared palette in styles/themes/kali.ts and tokens.css

## Testing
- yarn lint *(fails: repository already contains widespread jsx-a11y control labeling violations and no-top-level-window warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d7507d5f788328b2e59ef7e8dbae39