### PR TITLE
[desktop] Add show desktop taskbar button

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -712,6 +712,36 @@ export class Desktop extends Component {
         this.giveFocusToLastApp();
     }
 
+    minimizeAllWindows = () => {
+        const minimized_windows = { ...this.state.minimized_windows };
+        const focused_windows = { ...this.state.focused_windows };
+        let hasChanges = false;
+
+        Object.keys(this.state.closed_windows).forEach((id) => {
+            if (this.state.closed_windows[id] === false) {
+                if (!minimized_windows[id]) {
+                    minimized_windows[id] = true;
+                    hasChanges = true;
+                }
+                if (focused_windows[id]) {
+                    focused_windows[id] = false;
+                    hasChanges = true;
+                }
+            }
+        });
+
+        if (!hasChanges) {
+            this.hideSideBar(null, false);
+            this.giveFocusToLastApp();
+            return;
+        }
+
+        this.setWorkspaceState({ minimized_windows, focused_windows }, () => {
+            this.hideSideBar(null, false);
+            this.giveFocusToLastApp();
+        });
+    }
+
     giveFocusToLastApp = () => {
         // if there is atleast one app opened, give it focus
         if (!this.checkAllMinimised()) {
@@ -1103,6 +1133,7 @@ export class Desktop extends Component {
                     focused_windows={this.state.focused_windows}
                     openApp={this.openApp}
                     minimize={this.hasMinimised}
+                    minimizeAll={this.minimizeAllWindows}
                     workspaces={workspaceSummaries}
                     activeWorkspace={this.state.activeWorkspace}
                     onSelectWorkspace={this.switchWorkspace}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -24,7 +24,8 @@ export default function Taskbar(props) {
                 activeWorkspace={props.activeWorkspace}
                 onSelect={props.onSelectWorkspace}
             />
-            <div className="flex items-center overflow-x-auto">
+            <div className="flex items-center gap-2">
+                <div className="flex items-center overflow-x-auto">
                 {runningApps.map(app => {
                     const isMinimized = Boolean(props.minimized_windows[app.id]);
                     const isFocused = Boolean(props.focused_windows[app.id]);
@@ -61,6 +62,16 @@ export default function Taskbar(props) {
                         </button>
                     );
                 })}
+                </div>
+                <button
+                    type="button"
+                    aria-label="Show desktop"
+                    title="Show desktop"
+                    onClick={() => props.minimizeAll && props.minimizeAll()}
+                    className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-sm border border-ub-border-orange text-ub-border-orange transition focus:outline-none focus:ring-2 focus:ring-ub-border-orange focus:ring-offset-2 focus:ring-offset-black hover:bg-ub-cool-grey hover:bg-opacity-40"
+                >
+                    <span aria-hidden="true" className="block h-3 w-3 border border-ub-border-orange"></span>
+                </button>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- add a show-desktop control to the taskbar with accent styling and tooltip
- add a Desktop helper that minimizes all open windows and wire it to the new control

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7535f09e08328834e551b45bd1c45