### PR TITLE
[taskbar] add status tray cluster

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
-import NotificationBell from '../ui/NotificationBell';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import PerformanceGraph from '../ui/PerformanceGraph';
 
@@ -42,7 +41,7 @@ export default class Navbar extends Component {
 							'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
 						}
 					>
-						<Status />
+                                                <Status visuallyHidden />
 						<QuickSettings open={this.state.status_card} />
 					</button>
 				</div>

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import Image from 'next/image';
 import WorkspaceSwitcher from '../panel/WorkspaceSwitcher';
+import NotificationBell from '../ui/NotificationBell';
+import Status from '../util-components/status';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
@@ -18,13 +20,13 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center justify-between px-2 z-40" role="toolbar">
+        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center justify-between gap-2 px-2 z-40" role="toolbar">
             <WorkspaceSwitcher
                 workspaces={workspaces}
                 activeWorkspace={props.activeWorkspace}
                 onSelect={props.onSelectWorkspace}
             />
-            <div className="flex items-center overflow-x-auto">
+            <div className="flex flex-1 items-center justify-center overflow-x-auto px-2">
                 {runningApps.map(app => {
                     const isMinimized = Boolean(props.minimized_windows[app.id]);
                     const isFocused = Boolean(props.focused_windows[app.id]);
@@ -61,6 +63,10 @@ export default function Taskbar(props) {
                         </button>
                     );
                 })}
+            </div>
+            <div className="glass flex shrink-0 items-center gap-1.5 rounded-full px-2 py-1 text-white">
+                <NotificationBell />
+                <Status className="hidden sm:flex" />
             </div>
         </div>
     );

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -4,7 +4,7 @@ import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
 import VolumeControl from '../ui/VolumeControl';
 
-export default function Status() {
+export default function Status({ className = '', visuallyHidden = false } = {}) {
   const { allowNetwork } = useSettings();
   const [online, setOnline] = useState(true);
 
@@ -37,8 +37,16 @@ export default function Status() {
     };
   }, []);
 
+  if (visuallyHidden) {
+    return (
+      <span className={`sr-only ${className}`.trim()}>
+        System status indicators
+      </span>
+    );
+  }
+
   return (
-    <div className="flex justify-center items-center">
+    <div className={`flex justify-center items-center ${className}`.trim()}>
       <span
         className="mx-1.5 relative"
         title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -9,6 +9,10 @@
   .transition-active {
     @apply transition ease-out duration-100;
   }
+  .glass {
+    @apply border border-white/10 shadow-kali-panel backdrop-blur;
+    background-color: var(--kali-panel);
+  }
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- add a right aligned status cluster to the taskbar featuring the existing notification bell and status indicators with the shared glass treatment
- allow the Status widget to be visually hidden or styled so it can be reused without duplicating icons in the top panel
- hide the navbar copy of the status icons while keeping quick settings accessible

## Testing
- yarn eslint components/screen/taskbar.js components/screen/navbar.js components/util-components/status.js


------
https://chatgpt.com/codex/tasks/task_e_68d7535e0dd88328bd5537fae6ef805e