### PR TITLE
[ui] polish Kali dock styling

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -100,8 +100,10 @@ export class SideBarApp extends Component {
                 onMouseLeave={() => {
                     this.setState({ showTitle: false, thumbnail: null });
                 }}
-                className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
-                    " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
+                className={[
+                    this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? 'bg-white bg-opacity-10' : null,
+                    'w-auto p-1.5 outline-none relative hover:bg-white hover:bg-opacity-10 rounded-lg my-1.5 transition-hover transition-active',
+                ].filter(Boolean).join(' ')}
                 id={"sidebar-" + this.props.id}
             >
                 <Image

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -29,8 +29,7 @@ export default function SideBar(props) {
         <>
             <nav
                 aria-label="Dock"
-                className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                className={`${props.hide ? '-translate-x-full' : ''} glass accent-border absolute left-0 top-0 z-40 flex h-full min-h-screen w-14 transform select-none flex-col items-center justify-start gap-2 pt-5 pb-6 transition-transform duration-300 border-r`}
             >
                 {
                     (
@@ -52,7 +51,7 @@ export function AllApps(props) {
 
     return (
         <div
-            className={`w-10 h-10 rounded m-1 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
+            className={`w-9 h-9 rounded-lg my-1.5 hover:bg-white hover:bg-opacity-10 flex items-center justify-center transition-hover transition-active`}
             style={{ marginTop: 'auto' }}
             onMouseEnter={() => {
                 setTitle(true);
@@ -67,8 +66,8 @@ export function AllApps(props) {
                     width={28}
                     height={28}
                     className="w-7"
-                    src="/themes/Yaru/system/view-app-grid-symbolic.svg"
-                    alt="Ubuntu view app"
+                    src="/themes/Kali/categories/applications-all.svg"
+                    alt="Kali view app"
                     sizes="28px"
                 />
                 <div

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -9,6 +9,15 @@
   .transition-active {
     @apply transition ease-out duration-100;
   }
+  .glass {
+    background-color: color-mix(in srgb, var(--color-bg), transparent 55%);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+    -webkit-backdrop-filter: blur(18px);
+    backdrop-filter: blur(18px);
+  }
+  .accent-border {
+    border-color: color-mix(in srgb, var(--color-accent), transparent 45%);
+  }
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- add a reusable glass surface utility and accent border color token for Kali panels
- restyle the dock navigation to use the glass finish, accent edge, and tighter spacing
- swap the all-apps launcher icon to the Kali variant for visual consistency

## Testing
- npx eslint components/screen/side_bar.js components/base/side_bar_app.js


------
https://chatgpt.com/codex/tasks/task_e_68d7535f8a308328b80eeb82c7712dbb