### PR TITLE
[desktop] Add dock context menu actions

### DIFF
--- a/components/base/side_bar_app.js
+++ b/components/base/side_bar_app.js
@@ -1,15 +1,21 @@
 import React, { Component } from "react";
 import Image from 'next/image';
 import { toCanvas } from 'html-to-image';
+import SidebarAppMenu from '../context-menus/sidebar-app-menu';
 
 export class SideBarApp extends Component {
     constructor() {
         super();
         this.id = null;
+        this.buttonRef = React.createRef();
+        this.containerRef = React.createRef();
+        this.menuRef = React.createRef();
         this.state = {
             showTitle: false,
             scaleImage: false,
             thumbnail: null,
+            contextMenuVisible: false,
+            contextMenuPosition: { x: 0, y: 0 },
         };
     }
 
@@ -22,6 +28,10 @@ export class SideBarApp extends Component {
         if (prevProps.notifications !== this.props.notifications || prevProps.tasks !== this.props.tasks) {
             this.updateBadge();
         }
+    }
+
+    componentWillUnmount() {
+        this.removeContextMenuListeners();
     }
 
     updateBadge = () => {
@@ -56,8 +66,102 @@ export class SideBarApp extends Component {
         if (!this.props.isMinimized[this.id] && this.props.isClose[this.id]) {
             this.scaleImage();
         }
+        this.closeContextMenu();
         this.props.openApp(this.id);
         this.setState({ showTitle: false, thumbnail: null });
+    };
+
+    addContextMenuListeners = () => {
+        document.addEventListener('mousedown', this.handleDocumentInteraction);
+        document.addEventListener('contextmenu', this.handleDocumentInteraction);
+        document.addEventListener('keydown', this.handleMenuKeyDown, true);
+    };
+
+    removeContextMenuListeners = () => {
+        document.removeEventListener('mousedown', this.handleDocumentInteraction);
+        document.removeEventListener('contextmenu', this.handleDocumentInteraction);
+        document.removeEventListener('keydown', this.handleMenuKeyDown, true);
+    };
+
+    handleDocumentInteraction = (event) => {
+        const button = this.buttonRef.current;
+        const menu = this.menuRef.current;
+        if (button && button.contains(event.target)) return;
+        if (menu && menu.contains(event.target)) return;
+        this.closeContextMenu();
+    };
+
+    handleMenuKeyDown = (event) => {
+        if (event.key === 'Escape') {
+            this.closeContextMenu();
+        }
+    };
+
+    openContextMenu = (event) => {
+        if (event && event.preventDefault) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+        if (event && event.nativeEvent && event.nativeEvent.stopImmediatePropagation) {
+            event.nativeEvent.stopImmediatePropagation();
+        }
+
+        const container = this.containerRef.current;
+        const rect = container ? container.getBoundingClientRect() : null;
+        let clientX = event && typeof event.clientX === 'number' ? event.clientX : null;
+        let clientY = event && typeof event.clientY === 'number' ? event.clientY : null;
+
+        if (rect && (clientX === null || clientY === null)) {
+            clientX = rect.left + rect.width / 2;
+            clientY = rect.top + rect.height;
+        }
+
+        const baseX = rect ? rect.width + 8 : 0;
+        const relativeX = rect && clientX !== null ? clientX - rect.left : baseX;
+        const relativeY = rect && clientY !== null ? clientY - rect.top : (rect ? rect.height / 2 : 0);
+
+        const position = {
+            x: Math.max(relativeX, baseX),
+            y: Math.max(relativeY, 0),
+        };
+
+        this.setState({
+            contextMenuVisible: true,
+            contextMenuPosition: position,
+        }, this.addContextMenuListeners);
+    };
+
+    closeContextMenu = () => {
+        if (this.state.contextMenuVisible) {
+            this.setState({ contextMenuVisible: false });
+        }
+        this.removeContextMenuListeners();
+    };
+
+    handleToggleFavourite = () => {
+        const { isFavourite, pinApp, unpinApp } = this.props;
+        if (isFavourite) {
+            unpinApp && unpinApp(this.id);
+        } else {
+            pinApp && pinApp(this.id);
+        }
+        this.closeContextMenu();
+    };
+
+    handleOpenInWorkspace = () => {
+        if (this.props.openInNewWorkspace) {
+            this.props.openInNewWorkspace(this.id);
+        }
+        this.closeContextMenu();
+    };
+
+    handleKeyDown = (event) => {
+        if (event.shiftKey && event.key === 'F10') {
+            this.openContextMenu(event);
+        }
+        if (event.key === 'ContextMenu') {
+            this.openContextMenu(event);
+        }
     };
 
     captureThumbnail = async () => {
@@ -87,73 +191,87 @@ export class SideBarApp extends Component {
 
     render() {
         return (
-            <button
-                type="button"
-                aria-label={this.props.title}
-                data-context="app"
-                data-app-id={this.props.id}
-                onClick={this.openApp}
-                onMouseEnter={() => {
-                    this.captureThumbnail();
-                    this.setState({ showTitle: true });
-                }}
-                onMouseLeave={() => {
-                    this.setState({ showTitle: false, thumbnail: null });
-                }}
-                className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
-                    " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
-                id={"sidebar-" + this.props.id}
-            >
-                <Image
-                    width={28}
-                    height={28}
-                    className="w-7"
-                    src={this.props.icon.replace('./', '/')}
-                    alt="Ubuntu App Icon"
-                    sizes="28px"
-                />
-                <Image
-                    width={28}
-                    height={28}
-                    className={(this.state.scaleImage ? " scale " : "") + " scalable-app-icon w-7 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"}
-                    src={this.props.icon.replace('./', '/')}
-                    alt=""
-                    sizes="28px"
-                />
-                {
-                    (
-                        this.props.isClose[this.id] === false
-                            ? <div className=" w-2 h-1 absolute bottom-0 left-1/2 transform -translate-x-1/2 bg-white rounded-md"></div>
-                            : null
-                    )
-                }
-                {this.state.thumbnail && (
+            <div ref={this.containerRef} className="relative inline-block">
+                <button
+                    type="button"
+                    aria-label={this.props.title}
+                    data-context="app"
+                    data-app-id={this.props.id}
+                    onClick={this.openApp}
+                    onContextMenu={this.openContextMenu}
+                    onKeyDown={this.handleKeyDown}
+                    onMouseEnter={() => {
+                        this.captureThumbnail();
+                        this.setState({ showTitle: true });
+                    }}
+                    onMouseLeave={() => {
+                        this.setState({ showTitle: false, thumbnail: null });
+                    }}
+                    className={(this.props.isClose[this.id] === false && this.props.isFocus[this.id] ? "bg-white bg-opacity-10 " : "") +
+                        " w-auto p-2 outline-none relative hover:bg-white hover:bg-opacity-10 rounded m-1 transition-hover transition-active"}
+                    id={"sidebar-" + this.props.id}
+                    ref={this.buttonRef}
+                >
+                    <Image
+                        width={28}
+                        height={28}
+                        className="w-7"
+                        src={this.props.icon.replace('./', '/')}
+                        alt="Ubuntu App Icon"
+                        sizes="28px"
+                    />
+                    <Image
+                        width={28}
+                        height={28}
+                        className={(this.state.scaleImage ? " scale " : "") + " scalable-app-icon w-7 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"}
+                        src={this.props.icon.replace('./', '/')}
+                        alt=""
+                        sizes="28px"
+                    />
+                    {
+                        (
+                            this.props.isClose[this.id] === false
+                                ? <div className=" w-2 h-1 absolute bottom-0 left-1/2 transform -translate-x-1/2 bg-white rounded-md"></div>
+                                : null
+                        )
+                    }
+                    {this.state.thumbnail && (
+                        <div
+                            className={
+                                (this.state.showTitle ? " visible " : " invisible ") +
+                                " pointer-events-none absolute bottom-full mb-2 left-1/2 transform -translate-x-1/2" +
+                                " rounded border border-gray-400 border-opacity-40 shadow-lg overflow-hidden bg-black bg-opacity-50"
+                            }
+                        >
+                            <Image
+                                width={128}
+                                height={80}
+                                src={this.state.thumbnail}
+                                alt={`Preview of ${this.props.title}`}
+                                className="w-32 h-20 object-cover"
+                                sizes="128px"
+                            />
+                        </div>
+                    )}
                     <div
                         className={
                             (this.state.showTitle ? " visible " : " invisible ") +
-                            " pointer-events-none absolute bottom-full mb-2 left-1/2 transform -translate-x-1/2" +
-                            " rounded border border-gray-400 border-opacity-40 shadow-lg overflow-hidden bg-black bg-opacity-50"
+                            " w-max py-0.5 px-1.5 absolute top-1.5 left-full ml-3 m-1 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
                         }
                     >
-                        <Image
-                            width={128}
-                            height={80}
-                            src={this.state.thumbnail}
-                            alt={`Preview of ${this.props.title}`}
-                            className="w-32 h-20 object-cover"
-                            sizes="128px"
-                        />
+                        {this.props.title}
                     </div>
-                )}
-                <div
-                    className={
-                        (this.state.showTitle ? " visible " : " invisible ") +
-                        " w-max py-0.5 px-1.5 absolute top-1.5 left-full ml-3 m-1 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
-                    }
-                >
-                    {this.props.title}
-                </div>
-            </button>
+                </button>
+                <SidebarAppMenu
+                    ref={this.menuRef}
+                    active={this.state.contextMenuVisible}
+                    position={this.state.contextMenuPosition}
+                    pinned={this.props.isFavourite !== false}
+                    onClose={this.closeContextMenu}
+                    onToggleFavourite={this.handleToggleFavourite}
+                    onOpenInNewWorkspace={this.handleOpenInWorkspace}
+                />
+            </div>
         );
     }
 }

--- a/components/context-menus/sidebar-app-menu.js
+++ b/components/context-menus/sidebar-app-menu.js
@@ -1,0 +1,67 @@
+import React, { forwardRef, useEffect, useRef } from 'react'
+import useFocusTrap from '../../hooks/useFocusTrap'
+import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+
+const SidebarAppMenu = forwardRef(function SidebarAppMenu(props, forwardedRef) {
+    const { active, position, pinned, onClose, onToggleFavourite, onOpenInNewWorkspace } = props
+    const menuRef = useRef(null)
+
+    useFocusTrap(menuRef, active)
+    useRovingTabIndex(menuRef, active, 'vertical')
+
+    useEffect(() => {
+        if (!forwardedRef) return
+        if (typeof forwardedRef === 'function') {
+            forwardedRef(menuRef.current)
+        } else {
+            forwardedRef.current = menuRef.current
+        }
+    }, [forwardedRef, active])
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            onClose && onClose()
+        }
+    }
+
+    const style = {
+        top: `${position?.y ?? 0}px`,
+        left: `${position?.x ?? 0}px`,
+    }
+
+    const favouriteLabel = pinned ? 'Unpin from Favorites' : 'Pin to Favorites'
+
+    return (
+        <div
+            id="sidebar-app-menu"
+            role="menu"
+            aria-hidden={!active}
+            ref={menuRef}
+            tabIndex={-1}
+            onKeyDown={handleKeyDown}
+            className={(active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-3 absolute z-50 text-sm'}
+            style={style}
+        >
+            <button
+                type="button"
+                onClick={onToggleFavourite}
+                role="menuitem"
+                aria-label={favouriteLabel}
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5 px-4"
+            >
+                {favouriteLabel}
+            </button>
+            <button
+                type="button"
+                onClick={onOpenInNewWorkspace}
+                role="menuitem"
+                aria-label="Open in New Workspace"
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5 px-4"
+            >
+                Open in New Workspace
+            </button>
+        </div>
+    )
+})
+
+export default SidebarAppMenu

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -7,7 +7,21 @@ let renderApps = (props) => {
     props.apps.forEach((app, index) => {
         if (props.favourite_apps[app.id] === false) return;
         sideBarAppsJsx.push(
-            <SideBarApp key={app.id} id={app.id} title={app.title} icon={app.icon} isClose={props.closed_windows} isFocus={props.focused_windows} openApp={props.openAppByAppId} isMinimized={props.isMinimized} openFromMinimised={props.openFromMinimised} />
+            <SideBarApp
+                key={app.id}
+                id={app.id}
+                title={app.title}
+                icon={app.icon}
+                isClose={props.closed_windows}
+                isFocus={props.focused_windows}
+                openApp={props.openAppByAppId}
+                isMinimized={props.isMinimized}
+                openFromMinimised={props.openFromMinimised}
+                isFavourite={props.favourite_apps[app.id]}
+                pinApp={props.pinApp}
+                unpinApp={props.unpinApp}
+                openInNewWorkspace={props.openInNewWorkspace}
+            />
         );
     });
     return sideBarAppsJsx;


### PR DESCRIPTION
## Summary
- add a sidebar app context menu component with favourite toggle and workspace launch actions
- update the dock app button to open the context menu on right-click and wire up the new actions
- teach the desktop manager how to open apps in another workspace and feed the dock callbacks

## Testing
- yarn lint *(fails: repository has hundreds of pre-existing accessibility and window usage lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d75364787c832883a5e48fbde2b8df