### PR TITLE
[desktop] Refresh context menu styling

### DIFF
--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -14,11 +14,17 @@ function DesktopMenu(props) {
 
 
     const openTerminal = () => {
-        props.openApp("terminal");
+        props.openApp && props.openApp("terminal")
     }
 
     const openSettings = () => {
-        props.openApp("settings");
+        props.openApp && props.openApp("settings")
+    }
+
+    const handleRefreshDesktop = () => {
+        if (typeof props.refreshDesktop === 'function') {
+            props.refreshDesktop()
+        }
     }
 
     const checkFullScreen = () => {
@@ -43,99 +49,129 @@ function DesktopMenu(props) {
         }
     }
 
+    const baseItemClasses = "flex w-full items-center rounded-md px-4 py-1.5 text-left text-sm font-medium text-white/90 transition-colors duration-150 hover:bg-[var(--color-accent)]/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-0 focus-visible:ring-offset-transparent disabled:cursor-not-allowed disabled:text-white/35 disabled:hover:bg-transparent disabled:focus-visible:ring-0"
+    const dangerItemClasses = "flex w-full items-center rounded-md px-4 py-1.5 text-left text-sm font-medium text-red-300 transition-colors duration-150 hover:bg-red-500/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-0 focus-visible:ring-offset-transparent"
+
     return (
         <div
             id="desktop-menu"
             role="menu"
             aria-label="Desktop context menu"
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            className={`${props.active ? 'block' : 'hidden'} glass absolute z-50 w-60 cursor-default rounded-xl py-3 text-left text-sm shadow-2xl`}
         >
-            <button
-                onClick={props.addNewFolder}
-                type="button"
-                role="menuitem"
-                aria-label="New Folder"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">New Folder</span>
-            </button>
-            <button
-                onClick={props.openShortcutSelector}
-                type="button"
-                role="menuitem"
-                aria-label="Create Shortcut"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Create Shortcut...</span>
-            </button>
-            <Devider />
-            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Paste</span>
+            <div className="flex flex-col gap-1">
+                <button
+                    onClick={props.addNewFolder}
+                    type="button"
+                    role="menuitem"
+                    aria-label="Create Folder"
+                    className={baseItemClasses}
+                >
+                    Create Folder
+                </button>
+                <button
+                    onClick={props.openShortcutSelector}
+                    type="button"
+                    role="menuitem"
+                    aria-label="Add Launcher"
+                    className={baseItemClasses}
+                >
+                    Add Launcher…
+                </button>
+                <button
+                    onClick={handleRefreshDesktop}
+                    type="button"
+                    role="menuitem"
+                    aria-label="Refresh Desktop"
+                    className={baseItemClasses}
+                >
+                    Refresh Desktop
+                </button>
+                <Devider />
+                <button
+                    type="button"
+                    role="menuitem"
+                    aria-label="Paste Items"
+                    disabled
+                    className={baseItemClasses}
+                >
+                    Paste Items
+                </button>
+                <button
+                    type="button"
+                    role="menuitem"
+                    aria-label="Open Desktop in File Manager"
+                    disabled
+                    className={baseItemClasses}
+                >
+                    Open Desktop in File Manager
+                </button>
+                <button
+                    onClick={openTerminal}
+                    type="button"
+                    role="menuitem"
+                    aria-label="Open Terminal Here"
+                    className={baseItemClasses}
+                >
+                    Open Terminal Here
+                </button>
+                <Devider />
+                <button
+                    onClick={openSettings}
+                    type="button"
+                    role="menuitem"
+                    aria-label="Change Wallpaper"
+                    className={baseItemClasses}
+                >
+                    Change Wallpaper…
+                </button>
+                <button
+                    type="button"
+                    role="menuitem"
+                    aria-label="Display Settings"
+                    disabled
+                    className={baseItemClasses}
+                >
+                    Display Settings
+                </button>
+                <button
+                    onClick={openSettings}
+                    type="button"
+                    role="menuitem"
+                    aria-label="System Settings"
+                    className={baseItemClasses}
+                >
+                    System Settings
+                </button>
+                <Devider />
+                <button
+                    onClick={goFullScreen}
+                    type="button"
+                    role="menuitem"
+                    aria-label={isFullScreen ? "Exit Fullscreen Mode" : "Enter Fullscreen Mode"}
+                    className={baseItemClasses}
+                >
+                    {isFullScreen ? 'Exit Fullscreen Mode' : 'Enter Fullscreen Mode'}
+                </button>
+                <Devider />
+                <button
+                    onClick={props.clearSession}
+                    type="button"
+                    role="menuitem"
+                    aria-label="Reset Session"
+                    className={dangerItemClasses}
+                >
+                    Reset Session
+                </button>
             </div>
-            <Devider />
-            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Show Desktop in Files</span>
-            </div>
-            <button
-                onClick={openTerminal}
-                type="button"
-                role="menuitem"
-                aria-label="Open in Terminal"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Open in Terminal</span>
-            </button>
-            <Devider />
-            <button
-                onClick={openSettings}
-                type="button"
-                role="menuitem"
-                aria-label="Change Background"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Change Background...</span>
-            </button>
-            <Devider />
-            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Display Settings</span>
-            </div>
-            <button
-                onClick={openSettings}
-                type="button"
-                role="menuitem"
-                aria-label="Settings"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Settings</span>
-            </button>
-            <Devider />
-            <button
-                onClick={goFullScreen}
-                type="button"
-                role="menuitem"
-                aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
-            </button>
-            <Devider />
-            <button
-                onClick={props.clearSession}
-                type="button"
-                role="menuitem"
-                aria-label="Clear Session"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Clear Session</span>
-            </button>
         </div>
     )
 }
 
 function Devider() {
     return (
-        <div className="flex justify-center w-full">
-            <div className=" border-t border-gray-900 py-1 w-2/5"></div>
+        <div className="px-3 py-1">
+            <div className="h-px w-full bg-white/10"></div>
         </div>
     );
 }

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -588,6 +588,11 @@ export class Desktop extends Component {
         this.initFavourite = { ...favourite_apps };
     }
 
+    refreshDesktop = () => {
+        this.updateAppsData();
+        this.hideAllContextMenu();
+    }
+
     renderDesktopApps = () => {
         if (Object.keys(this.state.closed_windows).length === 0) return;
         let appsJsx = [];
@@ -1117,6 +1122,7 @@ export class Desktop extends Component {
                     openApp={this.openApp}
                     addNewFolder={this.addNewFolder}
                     openShortcutSelector={this.openShortcutSelector}
+                    refreshDesktop={this.refreshDesktop}
                     clearSession={() => { this.props.clearSession(); window.location.reload(); }}
                 />
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -9,6 +9,13 @@
   .transition-active {
     @apply transition ease-out duration-100;
   }
+  .glass {
+    background: var(--kali-panel);
+    border: 1px solid var(--kali-panel-border);
+    box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(18px) saturate(140%);
+    -webkit-backdrop-filter: blur(18px) saturate(140%);
+  }
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- restyle the desktop context menu with Kali-themed copy and frosted glass treatment
- introduce a refresh action and accent-driven button states while keeping disabled entries subdued
- expose a desktop refresh helper on the desktop shell for the new menu command

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7536594348328b7a15f2d6f42e624