### PR TITLE
[desktop] Improve window control accent states

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -762,13 +762,16 @@ export class WindowXBorder extends Component {
 export function WindowEditButtons(props) {
     const { togglePin } = useDocPiP(props.pip || (() => null));
     const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
+    const controlButtonClasses =
+        "mx-1 flex h-6 w-6 items-center justify-center rounded-full border border-[var(--kali-accent)] bg-transparent transition-colors duration-150 hover:bg-[var(--kali-accent)]/20 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--kali-focus-ring)] focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:border-[var(--color-muted)] disabled:opacity-50 disabled:hover:bg-transparent";
+    const closeButtonClasses = `${controlButtonClasses} cursor-default`;
     return (
         <div className={`${styles.windowControls} absolute select-none right-0 top-0 mr-1 flex justify-center items-center min-w-[8.25rem]`}>
             {pipSupported && props.pip && (
                 <button
                     type="button"
                     aria-label="Window pin"
-                    className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                    className={controlButtonClasses}
                     onClick={togglePin}
                 >
                     <NextImage
@@ -784,7 +787,7 @@ export function WindowEditButtons(props) {
             <button
                 type="button"
                 aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                className={controlButtonClasses}
                 onClick={props.minimize}
             >
                 <NextImage
@@ -802,7 +805,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className={controlButtonClasses}
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -818,7 +821,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className={controlButtonClasses}
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -836,7 +839,7 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                className={closeButtonClasses}
                 onClick={props.close}
             >
                 <NextImage

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -10,6 +10,7 @@
   --color-secondary: #1a1f26; /* complementary dark */
   --color-accent: #1793d1; /* accent matches primary */
   --kali-blue: var(--color-primary);
+  --kali-accent: var(--color-accent);
   /* Utility colors */
   --color-muted: #2a2e36; /* muted surfaces */
   --color-surface: #1a1f26; /* panel surfaces */
@@ -18,6 +19,7 @@
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
   --color-focus-ring: var(--color-accent);
+  --kali-focus-ring: var(--color-focus-ring);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   --kali-text: #f5f5f5;
@@ -81,7 +83,7 @@ html[data-theme='matrix'] {
 }
 
 *:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
+  outline: 2px solid var(--kali-focus-ring);
   outline-offset: 2px;
 }
 


### PR DESCRIPTION
## Summary
- update window control buttons to use accent borders, hover fills, and consistent focus-visible styling
- expose `--kali-accent` and `--kali-focus-ring` tokens so controls reuse the theme values

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d753678e708328a9c80f2ab04e8567