### PR TITLE
[desktop] Update window controls to Kali theme

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -762,18 +762,22 @@ export class WindowXBorder extends Component {
 export function WindowEditButtons(props) {
     const { togglePin } = useDocPiP(props.pip || (() => null));
     const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
+    const glowButtonClass =
+        "mx-1 rounded-full flex justify-center items-center h-6 w-6 bg-transparent text-white transition focus-visible:outline-none " +
+        "hover:shadow-[0_0_8px_rgba(23,147,209,0.65)] focus-visible:shadow-[0_0_8px_rgba(23,147,209,0.85)] " +
+        "focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:ring-[#1793d1]";
     return (
         <div className={`${styles.windowControls} absolute select-none right-0 top-0 mr-1 flex justify-center items-center min-w-[8.25rem]`}>
             {pipSupported && props.pip && (
                 <button
                     type="button"
                     aria-label="Window pin"
-                    className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                    className={glowButtonClass}
                     onClick={togglePin}
                 >
                     <NextImage
-                        src="/themes/Yaru/window/window-pin-symbolic.svg"
-                        alt="Kali window pin"
+                        src="/themes/Kali/window/window-pin-symbolic.svg"
+                        alt="Pin window"
                         className="h-4 w-4 inline"
                         width={16}
                         height={16}
@@ -784,12 +788,12 @@ export function WindowEditButtons(props) {
             <button
                 type="button"
                 aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                className={glowButtonClass}
                 onClick={props.minimize}
             >
                 <NextImage
-                    src="/themes/Yaru/window/window-minimize-symbolic.svg"
-                    alt="Kali window minimize"
+                    src="/themes/Kali/window/window-minimize-symbolic.svg"
+                    alt="Minimize window"
                     className="h-4 w-4 inline"
                     width={16}
                     height={16}
@@ -802,12 +806,12 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className={glowButtonClass}
                             onClick={props.maximize}
                         >
                             <NextImage
-                                src="/themes/Yaru/window/window-restore-symbolic.svg"
-                                alt="Kali window restore"
+                                src="/themes/Kali/window/window-restore-symbolic.svg"
+                                alt="Restore window"
                                 className="h-4 w-4 inline"
                                 width={16}
                                 height={16}
@@ -818,12 +822,12 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className={glowButtonClass}
                             onClick={props.maximize}
                         >
                             <NextImage
-                                src="/themes/Yaru/window/window-maximize-symbolic.svg"
-                                alt="Kali window maximize"
+                                src="/themes/Kali/window/window-maximize-symbolic.svg"
+                                alt="Maximize window"
                                 className="h-4 w-4 inline"
                                 width={16}
                                 height={16}
@@ -836,12 +840,12 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                className={`${glowButtonClass} cursor-default`}
                 onClick={props.close}
             >
                 <NextImage
-                    src="/themes/Yaru/window/window-close-symbolic.svg"
-                    alt="Kali window close"
+                    src="/themes/Kali/window/window-close-symbolic.svg"
+                    alt="Close window"
                     className="h-4 w-4 inline"
                     width={16}
                     height={16}

--- a/public/themes/Kali/window/window-close-symbolic.svg
+++ b/public/themes/Kali/window/window-close-symbolic.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M5 5l6 6M11 5l-6 6" stroke="#1793D1" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/public/themes/Kali/window/window-maximize-symbolic.svg
+++ b/public/themes/Kali/window/window-maximize-symbolic.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="3" width="10" height="10" rx="1.5" fill="none" stroke="#1793D1" stroke-width="1.6"/>
+</svg>

--- a/public/themes/Kali/window/window-minimize-symbolic.svg
+++ b/public/themes/Kali/window/window-minimize-symbolic.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="11" width="10" height="2" rx="1" fill="#1793D1"/>
+</svg>

--- a/public/themes/Kali/window/window-pin-symbolic.svg
+++ b/public/themes/Kali/window/window-pin-symbolic.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="1" width="8" height="3.5" rx="1.2" fill="#1793D1"/>
+  <rect x="7" y="4.5" width="2" height="4" rx="1" fill="#1793D1"/>
+  <polygon points="8,8.5 11,12 9.4,12 9.4,15 6.6,15 6.6,12 5,12" fill="#1793D1"/>
+</svg>

--- a/public/themes/Kali/window/window-restore-symbolic.svg
+++ b/public/themes/Kali/window/window-restore-symbolic.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4.5" y="5.5" width="7.5" height="7.5" rx="1.2" stroke="#1793D1" stroke-width="1.5"/>
+  <path d="M6.5 3.25h5.25a1.25 1.25 0 0 1 1.25 1.25v5.25" stroke="#1793D1" stroke-width="1.5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- replace the window control icons with Kali-themed assets and clean up the associated alt text
- add accent glow hover and focus styles for the window controls to match the Kali palette
- add Kali window control SVGs for pin, minimize, restore, maximize, and close

## Testing
- yarn lint *(fails: repository contains pre-existing accessibility lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d7536873748328acb2c468b8bce0da