### PR TITLE
[desktop] show app icons in window title bar

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -33,6 +33,8 @@ const computeSnapRegions = (viewportWidth, viewportHeight) => {
     };
 };
 
+const DEFAULT_WINDOW_ICON = '/themes/Yaru/system/view-app-grid-symbolic.svg';
+
 export class Window extends Component {
     constructor(props) {
         super(props);
@@ -672,10 +674,12 @@ export class Window extends Component {
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}
                         <WindowTopBar
                             title={this.props.title}
+                            icon={this.props.context?.icon ?? this.props.icon}
                             onKeyDown={this.handleTitleBarKeyDown}
                             onBlur={this.releaseGrab}
                             grabbed={this.state.grabbed}
                             onPointerDown={this.focusWindow}
+                            isActive={this.props.isFocused}
                         />
                         <WindowEditButtons
                             minimize={this.minimizeWindow}
@@ -702,10 +706,12 @@ export class Window extends Component {
 export default Window
 
 // Window's title bar
-export function WindowTopBar({ title, onKeyDown, onBlur, grabbed, onPointerDown }) {
+export function WindowTopBar({ title, icon, onKeyDown, onBlur, grabbed, onPointerDown, isActive }) {
+    const iconSrc = icon || DEFAULT_WINDOW_ICON;
+
     return (
         <div
-            className={`${styles.windowTitlebar} relative bg-ub-window-title px-3 text-white w-full select-none flex items-center`}
+            className={`${styles.windowTitlebar} relative bg-ub-window-title px-2 w-full select-none flex items-center justify-center`}
             tabIndex={0}
             role="button"
             aria-grabbed={grabbed}
@@ -713,7 +719,22 @@ export function WindowTopBar({ title, onKeyDown, onBlur, grabbed, onPointerDown 
             onBlur={onBlur}
             onPointerDown={onPointerDown}
         >
-            <div className="flex justify-center w-full text-sm font-bold">{title}</div>
+            <div className={styles.windowTitlebarContent}>
+                <NextImage
+                    src={iconSrc}
+                    alt=""
+                    width={16}
+                    height={16}
+                    className={styles.windowTitlebarIcon}
+                    aria-hidden={true}
+                />
+                <span
+                    className={[styles.windowTitleText, isActive ? styles.windowTitleTextActive : null].filter(Boolean).join(' ')}
+                    title={typeof title === 'string' ? title : undefined}
+                >
+                    {title}
+                </span>
+            </div>
         </div>
     )
 }

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -47,6 +47,40 @@
   z-index: 1;
 }
 
+.windowTitlebarContent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  min-height: 100%;
+  text-align: center;
+}
+
+.windowTitlebarIcon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.35));
+}
+
+.windowTitleText {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: 0.01em;
+  max-width: calc(100% - 24px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: color var(--motion-fast) ease;
+}
+
+.windowTitleTextActive {
+  color: var(--color-window-accent);
+}
+
 .windowControls {
   height: 28px;
 }

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -622,6 +622,7 @@ export class Desktop extends Component {
                     id: app.id,
                     screen: app.screen,
                     addFolder: this.addToDesktop,
+                    icon: app.icon,
                     closed: this.closeApp,
                     openApp: this.openApp,
                     focus: this.focus,


### PR DESCRIPTION
## Summary
- pass each window's icon into the title bar and fall back to the app grid symbol when missing
- refresh the title bar layout to align the icon beside the title and highlight focused windows with the accent color

## Testing
- yarn lint *(fails: existing jsx-a11y control labeling and no-top-level-window lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7536976ac832897d2c4058a2a58f8