### PR TITLE
[window] Use theme tokens for main screen surface

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -854,22 +854,21 @@ export function WindowEditButtons(props) {
 
 // Window's Main Screen
 export class WindowMainScreen extends Component {
-    constructor() {
-        super();
-        this.state = {
-            setDarkBg: false,
-        }
-    }
-    componentDidMount() {
-        setTimeout(() => {
-            this.setState({ setDarkBg: true });
-        }, 3000);
-    }
     render() {
+        const backgroundTone = this.props.backgroundTone === 'surface' ? 'surface' : 'dark'
+        const backgroundClass = backgroundTone === 'dark' ? 'bg-[var(--color-dark)]' : 'bg-[var(--color-surface)]'
+
         return (
-            <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey")}>
+            <div
+                className={`w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen transition-colors duration-300 ${backgroundClass}`}
+                data-tone={backgroundTone}
+            >
                 {this.props.screen(this.props.addFolder, this.props.openApp, this.props.context)}
             </div>
         )
     }
+}
+
+WindowMainScreen.defaultProps = {
+    backgroundTone: 'dark',
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -130,6 +130,7 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 .windowMainScreen {
     container-type: inline-size;
+    scrollbar-color: var(--color-border) transparent;
 }
 
 .windowMainScreen::-webkit-scrollbar-track {


### PR DESCRIPTION
## Summary
- replace hard-coded Ubuntu background classes in `WindowMainScreen` with CSS variable driven themes
- remove the delayed dark background timer in favor of tone-aware classes and color transitions
- add explicit scrollbar colors so they remain visible on the updated surfaces

## Testing
- yarn eslint components/base/window.js styles/index.css (warns: CSS file ignored because no matching configuration was supplied)


------
https://chatgpt.com/codex/tasks/task_e_68d7536be83483288180165341531234