### PR TITLE
[desktop] Improve resize handle visibility

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -724,15 +724,25 @@ export class WindowYBorder extends Component {
         // Use the browser's Image constructor rather than the imported Next.js
         // Image component to avoid runtime errors when running in tests.
 
-        this.trpImg = new window.Image(0, 0);
-        this.trpImg.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-        this.trpImg.style.opacity = 0;
+        if (typeof window !== 'undefined' && typeof window.Image === 'function') {
+            this.trpImg = new window.Image(0, 0);
+            this.trpImg.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+            this.trpImg.style.opacity = 0;
+        } else {
+            this.trpImg = null;
+        }
     }
     render() {
             return (
                 <div
                     className={`${styles.windowYBorder} cursor-[e-resize] border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2`}
-                    onDragStart={(e) => { e.dataTransfer.setDragImage(this.trpImg, 0, 0) }}
+                    draggable
+                    aria-hidden="true"
+                    onDragStart={(e) => {
+                        if (this.trpImg && e.dataTransfer) {
+                            e.dataTransfer.setDragImage(this.trpImg, 0, 0);
+                        }
+                    }}
                     onDrag={this.props.resize}
                 ></div>
             )
@@ -743,15 +753,25 @@ export class WindowXBorder extends Component {
     componentDidMount() {
         // Use the global Image constructor instead of Next.js Image component
 
-        this.trpImg = new window.Image(0, 0);
-        this.trpImg.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-        this.trpImg.style.opacity = 0;
+        if (typeof window !== 'undefined' && typeof window.Image === 'function') {
+            this.trpImg = new window.Image(0, 0);
+            this.trpImg.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+            this.trpImg.style.opacity = 0;
+        } else {
+            this.trpImg = null;
+        }
     }
     render() {
             return (
                 <div
                     className={`${styles.windowXBorder} cursor-[n-resize] border-transparent border-1 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2`}
-                    onDragStart={(e) => { e.dataTransfer.setDragImage(this.trpImg, 0, 0) }}
+                    draggable
+                    aria-hidden="true"
+                    onDragStart={(e) => {
+                        if (this.trpImg && e.dataTransfer) {
+                            e.dataTransfer.setDragImage(this.trpImg, 0, 0);
+                        }
+                    }}
                     onDrag={this.props.resize}
                 ></div>
             )

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -52,11 +52,65 @@
 }
 
 .windowYBorder {
-  height: calc(100% - 10px);
-  width: calc(100% + 10px);
+  position: relative;
+  height: calc(100% - 4px);
+  width: calc(100% + 20px);
+  touch-action: none;
+}
+
+.windowYBorder::before,
+.windowYBorder::after {
+  content: '';
+  position: absolute;
+  top: 12px;
+  bottom: 12px;
+  width: 3px;
+  border-radius: 999px;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    var(--color-window-accent) 0 2px,
+    transparent 2px 6px
+  );
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.windowYBorder::before {
+  left: 10px;
+}
+
+.windowYBorder::after {
+  right: 10px;
 }
 
 .windowXBorder {
-  height: calc(100% + 10px);
-  width: calc(100% - 10px);
+  position: relative;
+  height: calc(100% + 20px);
+  width: calc(100% - 4px);
+  touch-action: none;
+}
+
+.windowXBorder::before,
+.windowXBorder::after {
+  content: '';
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  height: 3px;
+  border-radius: 999px;
+  background-image: repeating-linear-gradient(
+    to right,
+    var(--color-window-accent) 0 2px,
+    transparent 2px 6px
+  );
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.windowXBorder::before {
+  top: 10px;
+}
+
+.windowXBorder::after {
+  bottom: 10px;
 }


### PR DESCRIPTION
## Summary
- add accent styling and a larger hit area to window resize handles for better visibility
- guard access to window.Image before creating drag images to keep tests stable

## Testing
- yarn test window --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d7536dc1688328bd512689132d0773