### PR TITLE
[desktop] Polish snap preview indicator

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -621,15 +621,16 @@ export class Window extends Component {
                 {this.state.snapPreview && (
                     <div
                         data-testid="snap-preview"
-                        className="fixed border-2 border-dashed border-white bg-white bg-opacity-10 pointer-events-none z-40 transition-opacity"
+                        className={[
+                            'fixed pointer-events-none z-40 transition-opacity',
+                            styles.snapPreview,
+                            styles.snapPreviewGlow,
+                        ].join(' ')}
                         style={{
                             left: `${this.state.snapPreview.left}px`,
                             top: `${this.state.snapPreview.top}px`,
                             width: `${this.state.snapPreview.width}px`,
                             height: `${this.state.snapPreview.height}px`,
-                            backdropFilter: 'brightness(1.2)',
-                            WebkitBackdropFilter: 'brightness(1.2)'
-
                         }}
                     />
                 )}

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -60,3 +60,36 @@
   height: calc(100% + 10px);
   width: calc(100% - 10px);
 }
+
+.snapPreview {
+  border: 2px dashed var(--kali-accent, var(--color-accent));
+  border-radius: var(--radius-6);
+  background-color: color-mix(in srgb, var(--kali-accent, var(--color-accent)) 18%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--kali-accent, var(--color-accent)) 40%, transparent),
+    0 0 32px 0 color-mix(in srgb, var(--kali-accent, var(--color-accent)) 35%, transparent);
+  backdrop-filter: brightness(1.2) saturate(1.05);
+  -webkit-backdrop-filter: brightness(1.2) saturate(1.05);
+  transition: opacity var(--motion-medium) ease;
+}
+
+.snapPreviewGlow {
+  animation: snapPreviewGlow 1.6s ease-in-out infinite alternate;
+}
+
+@keyframes snapPreviewGlow {
+  from {
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--kali-accent, var(--color-accent)) 40%, transparent),
+      0 0 24px 0 color-mix(in srgb, var(--kali-accent, var(--color-accent)) 28%, transparent);
+  }
+
+  to {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--kali-accent, var(--color-accent)) 55%, transparent),
+      0 0 40px 8px color-mix(in srgb, var(--kali-accent, var(--color-accent)) 45%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .snapPreviewGlow {
+    animation: none;
+  }
+}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -27,6 +27,7 @@
   --color-text: #F5F5F5;
   --kali-bg: rgba(15, 19, 23, 0.85);
   --kali-blue: #1793d1;
+  --kali-accent: var(--color-accent);
 
   /* Kali theme tokens */
   --kali-blue: #1793d1;


### PR DESCRIPTION
## Summary
- restyle the window snap preview with kali accent borders, translucent fill, and shadowed focus
- add animated glow styles that honor reduced-motion preferences
- expose a reusable `--kali-accent` token for accent-driven effects

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7536cb1bc8328963ed38c06d877ed