### PR TITLE
[components] Rename UbuntuApp component to KaliApp

### DIFF
--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useRef, useCallback, useEffect } from 'react';
-import UbuntuApp from '../base/ubuntu_app';
+import KaliApp from '../base/KaliApp';
 import apps from '../../apps.config';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { Grid } from 'react-window';
@@ -98,7 +98,7 @@ export default function AppGrid({ openApp }) {
             onFocus={onFocus}
             onBlur={onBlur}
           >
-            <UbuntuApp
+            <KaliApp
               id={app.id}
               icon={app.icon}
               name={app.title}

--- a/components/base/KaliApp.js
+++ b/components/base/KaliApp.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import Image from 'next/image'
 
-export class UbuntuApp extends Component {
+export class KaliApp extends Component {
     constructor() {
         super();
         this.state = { launching: false, dragging: false, prefetched: false };
@@ -65,4 +65,4 @@ export class UbuntuApp extends Component {
     }
 }
 
-export default UbuntuApp
+export default KaliApp

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import Image from 'next/image';
-import UbuntuApp from '../base/ubuntu_app';
+import KaliApp from '../base/KaliApp';
 import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { KALI_CATEGORIES as BASE_KALI_CATEGORIES } from './ApplicationsMenu';
@@ -475,7 +475,7 @@ const WhiskerMenu: React.FC = () => {
                     idx === highlight ? 'ring-2 ring-ubb-orange ring-offset-gray-900' : 'ring-0'
                   }`}
                 >
-                  <UbuntuApp
+                  <KaliApp
                     id={app.id}
                     icon={app.icon}
                     name={app.title}

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import UbuntuApp from '../base/ubuntu_app';
+import KaliApp from '../base/KaliApp';
 import { safeLocalStorage } from '../../utils/safeStorage';
 
 const FAVORITES_KEY = 'launcherFavorites';
@@ -140,7 +140,7 @@ class AllApplications extends React.Component {
                 >
                     ★
                 </button>
-                <UbuntuApp
+                <KaliApp
                     name={app.title}
                     id={app.id}
                     icon={app.icon}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -10,7 +10,7 @@ const BackgroundImage = dynamic(
 import SideBar from './side_bar';
 import apps, { games } from '../../apps.config';
 import Window from '../base/window';
-import UbuntuApp from '../base/ubuntu_app';
+import KaliApp from '../base/KaliApp';
 import AllApplications from '../screen/all-applications'
 import ShortcutSelector from '../screen/shortcut-selector'
 import WindowSwitcher from '../screen/window-switcher'
@@ -604,7 +604,7 @@ export class Desktop extends Component {
                 }
 
                 appsJsx.push(
-                    <UbuntuApp key={app.id} {...props} />
+                    <KaliApp key={app.id} {...props} />
                 );
             }
         });

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import UbuntuApp from '../base/ubuntu_app';
+import KaliApp from '../base/KaliApp';
 
 class ShortcutSelector extends React.Component {
     constructor() {
@@ -41,7 +41,7 @@ class ShortcutSelector extends React.Component {
     renderApps = () => {
         const apps = this.state.apps || [];
         return apps.map((app) => (
-            <UbuntuApp
+            <KaliApp
                 key={app.id}
                 name={app.title}
                 id={app.id}


### PR DESCRIPTION
## Summary
- rename the base UbuntuApp component file and export to KaliApp
- update all app grid, menu, and screen imports and JSX usage to the new KaliApp name

## Testing
- yarn build
- yarn test *(fails: existing suite errors around jsdom localStorage and act warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d7536f0d5c8328b5e710836ec6d7fa