### PR TITLE
[ui] refresh kali app card interactions

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -31,22 +31,35 @@ export class UbuntuApp extends Component {
     }
 
     render() {
+        const { launching, dragging } = this.state
+        const { disabled } = this.props
+
+        const cardClasses = [
+            launching ? 'app-icon-launch' : '',
+            dragging ? 'opacity-70' : '',
+            'p-1 m-px z-10 bg-white/0 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active',
+            'hover:bg-[var(--kali-accent)]/15 focus:bg-[var(--kali-accent)]/20 focus:ring-2 focus:ring-[var(--kali-focus-ring)] focus:ring-offset-2 focus:ring-offset-transparent'
+        ]
+
+        if (disabled) {
+            cardClasses.push('opacity-40 cursor-not-allowed hover:bg-transparent focus:bg-transparent focus:ring-0 focus:ring-offset-0')
+        }
+
         return (
             <div
                 role="button"
                 aria-label={this.props.name}
-                aria-disabled={this.props.disabled}
+                aria-disabled={disabled}
                 data-context="app"
                 data-app-id={this.props.id}
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
-                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                className={cardClasses.filter(Boolean).join(' ')}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
-                tabIndex={this.props.disabled ? -1 : 0}
+                tabIndex={disabled ? -1 : 0}
                 onMouseEnter={this.handlePrefetch}
                 onFocus={this.handlePrefetch}
             >


### PR DESCRIPTION
## Summary
- update Kali app card styling to use Kali accent hover background and focus ring
- keep disabled cards muted while adopting the accent-focused states

## Testing
- yarn lint *(fails: existing jsx-a11y warnings and legacy public game scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68d75370639c832887fe4807824cc775