### PR TITLE
[ui] refresh help panel styling

### DIFF
--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -12,6 +12,7 @@ interface HelpPanelProps {
 export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
   const [open, setOpen] = useState(false);
   const [html, setHtml] = useState("<p>Loading...</p>");
+  const panelId = `help-panel-${appId}`;
 
   useEffect(() => {
     if (!open) return;
@@ -54,18 +55,34 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
         type="button"
         aria-label="Help"
         aria-expanded={open}
+        aria-controls={panelId}
         onClick={toggle}
-        className="fixed top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+        className={`fixed top-2 right-2 z-40 flex h-10 w-10 items-center justify-center rounded-full
+          bg-[var(--color-accent)] text-black shadow-lg transition hover:brightness-110
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]
+          focus-visible:ring-offset-2 focus-visible:ring-offset-black/40`}
       >
-        ?
+        <img
+          src="/themes/Kali/panel/emblem-system-symbolic.svg"
+          alt=""
+          aria-hidden="true"
+          className="h-5 w-5"
+        />
       </button>
       {open && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-start justify-end p-4"
+          className="fixed inset-0 z-50 flex items-start justify-end bg-black/50 p-4 backdrop-blur"
           onClick={toggle}
         >
           <div
-            className="bg-white text-black p-4 rounded max-w-md w-full h-full overflow-auto"
+            id={panelId}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Help content"
+            className={`h-full w-full max-w-md overflow-auto rounded-xl border
+              border-[color-mix(in_srgb,var(--color-accent)_60%,transparent)]
+              bg-[color-mix(in_srgb,var(--color-accent)_25%,transparent)] p-4 text-[var(--color-text)]
+              shadow-2xl backdrop-blur-xl`}
             onClick={(e) => e.stopPropagation()}
           >
             <div dangerouslySetInnerHTML={{ __html: html }} />


### PR DESCRIPTION
## Summary
- restyle the floating help toggle with the Kali accent color and dedicated icon
- apply glassy accent styling and dialog semantics to the help modal while keeping aria hooks intact

## Testing
- npx eslint components/HelpPanel.tsx --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68d7537239888328b9e26a9639d17207