### PR TITLE
[docs] Add Kali terminal help reference

### DIFF
--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -15,18 +15,32 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
 
   useEffect(() => {
     if (!open) return;
-    const path = docPath || `/docs/apps/${appId}.md`;
-    fetch(path)
-      .then((res) => (res.ok ? res.text() : ""))
-      .then((md) => {
-        if (!md) {
-          setHtml("<p>No help available.</p>");
+
+    const defaultPath = `/docs/apps/${appId}.md`;
+    const candidates = [
+      docPath,
+      appId === "terminal" ? "/docs/apps/terminal-kali.md" : undefined,
+      defaultPath,
+    ].filter(Boolean) as string[];
+
+    const loadDoc = async () => {
+      for (const path of candidates) {
+        try {
+          const res = await fetch(path);
+          if (!res.ok) continue;
+          const md = await res.text();
+          if (!md) continue;
+          const rendered = DOMPurify.sanitize(marked.parse(md) as string);
+          setHtml(rendered);
           return;
+        } catch (error) {
+          // Try the next candidate.
         }
-        const rendered = DOMPurify.sanitize(marked.parse(md) as string);
-        setHtml(rendered);
-      })
-      .catch(() => setHtml("<p>No help available.</p>"));
+      }
+      setHtml("<p>No help available.</p>");
+    };
+
+    loadDoc();
   }, [open, appId, docPath]);
 
   useEffect(() => {

--- a/public/docs/apps/terminal-kali.md
+++ b/public/docs/apps/terminal-kali.md
@@ -1,0 +1,30 @@
+# Kali Terminal Quick Reference
+
+This cheat sheet highlights shortcuts and workflow tips unique to the Kali-themed desktop experience bundled with this portfolio. Use it alongside the in-app `?` hotkey to quickly review commands.
+
+## Essential Desktop Shortcuts
+
+- **Super** (Windows/Command) — Open the application overview and launcher.
+- **Super + A** — Jump directly to the full application catalog.
+- **Super + Tab** — Cycle through the open workspaces in order.
+- **Super + `** — Toggle between windows of the focused application.
+- **Super + W** — Show all windows for the current workspace.
+- **Super + Arrow Keys** — Snap the active window to screen halves or corners.
+- **Super + H / L** — Switch to the previous/next workspace.
+- **Super + Page Up / Page Down** — Move the focused window to a different workspace.
+
+## Terminal Session Tips
+
+- **Ctrl + Alt + T** — Launch a new terminal window from anywhere on the desktop.
+- **Ctrl + Shift + T** — Open a new tab inside the terminal app.
+- **Ctrl + Shift + W** — Close the current terminal tab.
+- **Shift + Page Up / Page Down** — Scroll through terminal output a page at a time.
+- **Ctrl + Shift + C / V** — Copy and paste within the terminal.
+
+## Navigation & Search
+
+- **Super + S** — Search for files, settings, and installed utilities.
+- **Super + F** — Focus the search field inside the terminal to filter command history.
+- **Ctrl + Alt + Arrow Keys** — Switch workspaces without leaving the keyboard.
+
+Keep these at hand to stay productive while exploring the Kali-inspired environment. If a shortcut differs from your platform defaults, the generic terminal help remains available as a fallback.


### PR DESCRIPTION
## Summary
- add a Kali-specific terminal help document with desktop and session shortcuts
- update the HelpPanel loader to prefer the Kali doc while falling back to the generic help file

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d753733a008328af564df13dcb50b2