### PR TITLE
[security] tighten CSP nonce handling

### DIFF
--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -5,6 +5,7 @@ import ModeSwitcher from './components/ModeSwitcher';
 import MemorySlots from './components/MemorySlots';
 import FormulaEditor from './components/FormulaEditor';
 import Tape from './components/Tape';
+import { getCspNonce } from '../../utils/csp';
 
 export default function Calculator() {
   const HISTORY_LIMIT = 10;
@@ -41,6 +42,8 @@ export default function Calculator() {
           script.src =
             'https://cdn.jsdelivr.net/npm/mathjs@13.2.3/lib/browser/math.js';
           script.onload = resolve as any;
+          const nonce = getCspNonce();
+          if (nonce) script.nonce = nonce;
           document.body.appendChild(script);
         });
       }

--- a/apps/x/index.tsx
+++ b/apps/x/index.tsx
@@ -14,6 +14,7 @@ import { useSettings } from '../../hooks/useSettings';
 import useScheduledTweets, {
   ScheduledTweet,
 } from './state/scheduled';
+import { getCspNonce } from '../../utils/csp';
 
 const IconRefresh = (
   props: SVGProps<SVGSVGElement>,
@@ -65,6 +66,7 @@ const IconBadge = (props: SVGProps<SVGSVGElement>) => (
 );
 
 export default function XTimeline() {
+  const nonce = getCspNonce();
   const { accent } = useSettings();
   const [profilePresets, setProfilePresets] = usePersistentState<string[]>(
     'x-profile-presets',
@@ -300,6 +302,7 @@ export default function XTimeline() {
           if (loaded) loadTimeline();
         }}
         onError={() => setScriptError(true)}
+        nonce={nonce}
       />
       <div className="flex flex-col h-full">
         <header className="flex items-center justify-between p-1.5 border-b gap-1.5">

--- a/apps/youtube/components/ClipMaker.tsx
+++ b/apps/youtube/components/ClipMaker.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import copyToClipboard from '../../../utils/clipboard';
+import { getCspNonce } from '../../../utils/csp';
 
 function extractVideoId(input: string): string {
   try {
@@ -29,6 +30,8 @@ export default function ClipMaker() {
     }
     const tag = document.createElement('script');
     tag.src = 'https://www.youtube.com/iframe_api';
+    const nonce = getCspNonce();
+    if (nonce) tag.nonce = nonce;
     document.body.appendChild(tag);
     window.onYouTubeIframeAPIReady = () => setReady(true);
     return () => {

--- a/apps/youtube/components/ComparePlayers.tsx
+++ b/apps/youtube/components/ComparePlayers.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { getCspNonce } from '../../../utils/csp';
 
 function parseVideoId(input: string): string {
   try {
@@ -33,6 +34,8 @@ const ComparePlayers = () => {
     }
     const tag = document.createElement('script');
     tag.src = 'https://www.youtube.com/iframe_api';
+    const nonce = getCspNonce();
+    if (nonce) tag.nonce = nonce;
     window.onYouTubeIframeAPIReady = () => setReady(true);
     document.body.appendChild(tag);
   }, []);

--- a/components/YouTubePlayer.js
+++ b/components/YouTubePlayer.js
@@ -4,6 +4,7 @@ import React, { useRef, useState, useEffect, useCallback } from 'react';
 import Head from 'next/head';
 import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';
 import useOPFS from '../hooks/useOPFS';
+import { getCspNonce } from '../utils/csp';
 
 // Basic YouTube player with keyboard shortcuts, playback rate cycling,
 // chapter drawer and Picture-in-Picture helpers. The Doc-PiP window is a
@@ -66,6 +67,8 @@ export default function YouTubePlayer({ videoId }) {
         const tag = document.createElement('script');
         tag.src = 'https://www.youtube-nocookie.com/iframe_api';
         tag.async = true;
+        const nonce = getCspNonce();
+        if (nonce) tag.nonce = nonce;
         window.onYouTubeIframeAPIReady = createPlayer;
         document.body.appendChild(tag);
       } else {

--- a/components/apps/spotify.jsx
+++ b/components/apps/spotify.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { getCspNonce } from '../../utils/csp';
 
 const SAMPLE_TRACKS = [
   { title: 'Song 1', url: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3' },
@@ -19,6 +20,8 @@ export default function SpotifyApp() {
     const script = document.createElement('script');
     script.src = 'https://sdk.scdn.co/spotify-player.js';
     script.async = true;
+    const nonce = getCspNonce();
+    if (nonce) script.nonce = nonce;
     document.body.appendChild(script);
 
     window.onSpotifyWebPlaybackSDKReady = () => {

--- a/components/apps/x.js
+++ b/components/apps/x.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { getCspNonce } from '../../utils/csp';
 
 const sanitizeHandle = (handle) =>
   handle.replace(/[^A-Za-z0-9_]/g, '').slice(0, 15);
@@ -65,7 +66,11 @@ export default function XApp() {
   useEffect(() => {
     if (!shouldLoad) return;
     const src = 'https://platform.twitter.com/widgets.js';
+    const nonce = getCspNonce();
     let script = document.querySelector(`script[src="${src}"]`);
+    if (script && nonce && !script.nonce) {
+      script.nonce = nonce;
+    }
     let timeout;
     const handleError = () => {
       clearTimeout(timeout);
@@ -93,6 +98,7 @@ export default function XApp() {
         script = document.createElement('script');
         script.src = src;
         script.async = true;
+        if (nonce) script.nonce = nonce;
         document.body.appendChild(script);
       }
       timeout = window.setTimeout(handleError, 10000);

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { getCspNonce } from '../../../utils/csp';
 import useWatchLater, {
   Video as WatchLaterVideo,
 } from '../../../apps/youtube/state/watchLater';
@@ -337,6 +338,8 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
     } else {
       const tag = document.createElement('script');
       tag.src = 'https://www.youtube.com/iframe_api';
+      const nonce = getCspNonce();
+      if (nonce) tag.nonce = nonce;
       window.onYouTubeIframeAPIReady = initPlayer;
       document.body.appendChild(tag);
     }

--- a/docs/csp.md
+++ b/docs/csp.md
@@ -1,0 +1,10 @@
+# Content Security Policy Notes
+
+- The middleware now issues a CSP without `'unsafe-inline'` in the `script-src` directive and injects a per-request nonce via the `x-csp-nonce` header.
+- `_document.jsx` propagates that nonce into the DOM so client utilities can read it from `document.documentElement.dataset.cspNonce`.
+- All `next/script` usages and dynamically created `<script>` elements read the nonce and apply it before execution, covering:
+  - `/pages/_app.jsx`
+  - `apps/x/index.tsx` (Twitter widgets)
+  - Async loaders inside apps such as YouTube helpers, Spotify, the calculator, Input Hub reCAPTCHA, and the X desktop widget.
+- Sandbox helpers that emit HTML (`PluginManager` iframe runner and the BeEF payload preview) mirror the active nonce where available and fall back to `'unsafe-inline'` only when no nonce can be generated (e.g., legacy browsers without `crypto.getRandomValues`).
+- Manual validation via `curl http://localhost:3000` under `yarn dev` shows the new CSP header omits `'unsafe-inline'` and includes a `nonce-...` token. No CSP violations were logged in the server output during smoke testing.

--- a/middleware.ts
+++ b/middleware.ts
@@ -6,14 +6,28 @@ function nonce() {
   return Buffer.from(arr).toString('base64');
 }
 
-export function middleware(req: NextRequest) {
+export function middleware(_req: NextRequest) {
   const n = nonce();
+  const scriptSrc = [
+    "'self'",
+    `'nonce-${n}'`,
+    "'strict-dynamic'",
+    'https://vercel.live',
+    'https://platform.twitter.com',
+    'https://syndication.twitter.com',
+    'https://cdn.syndication.twimg.com',
+    'https://www.youtube.com',
+    'https://www.google.com',
+    'https://www.gstatic.com',
+    'https://cdn.jsdelivr.net',
+    'https://cdnjs.cloudflare.com',
+  ];
   const csp = [
     "default-src 'self'",
     "img-src 'self' https: data:",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
-    `script-src 'self' 'unsafe-inline' 'nonce-${n}' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com`,
+    `script-src ${scriptSrc.join(' ')}`,
     "connect-src 'self' https://cdn.syndication.twimg.com https://*.twitter.com https://stackblitz.com",
     "frame-src 'self' https://vercel.live https://stackblitz.com https://ghbtns.com https://platform.twitter.com https://open.spotify.com https://todoist.com https://www.youtube.com https://www.youtube-nocookie.com",
     "frame-ancestors 'self'",

--- a/next.config.js
+++ b/next.config.js
@@ -18,10 +18,10 @@ const ContentSecurityPolicy = [
   "style-src 'self' 'unsafe-inline'",
   // Explicitly allow inline style tags
   "style-src-elem 'self' 'unsafe-inline'",
-  // Restrict fonts to same origin
-  "font-src 'self'",
+  // Restrict fonts to same origin and Google Fonts CDN
+  "font-src 'self' https://fonts.gstatic.com",
   // External scripts required for embedded timelines
-  "script-src 'self' 'unsafe-inline' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+  "script-src 'self' 'strict-dynamic' https://vercel.live https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://www.youtube.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
   // Allow outbound connections for embeds and the in-browser Chrome app
   "connect-src 'self' https://example.com https://developer.mozilla.org https://en.wikipedia.org https://www.google.com https://platform.twitter.com https://syndication.twitter.com https://cdn.syndication.twimg.com https://*.twitter.com https://*.x.com https://*.google.com https://stackblitz.com",
   // Allow iframes from specific providers so the Chrome and StackBlitz apps can load allowed content

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -17,6 +17,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { getCspNonce } from '../utils/csp';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -28,6 +29,7 @@ const ubuntu = Ubuntu({
 
 function MyApp(props) {
   const { Component, pageProps } = props;
+  const nonce = getCspNonce();
 
 
   useEffect(() => {
@@ -149,7 +151,7 @@ function MyApp(props) {
 
   return (
     <ErrorBoundary>
-      <Script src="/a2hs.js" strategy="beforeInteractive" />
+      <Script src="/a2hs.js" strategy="beforeInteractive" nonce={nonce} />
       <div className={ubuntu.className}>
         <a
           href="#app-grid"

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -6,7 +6,12 @@ class MyDocument extends Document {
    */
   static async getInitialProps(ctx) {
     const initial = await Document.getInitialProps(ctx);
-    const nonce = ctx?.res?.getHeader?.('x-csp-nonce');
+    const rawNonce = ctx?.res?.getHeader?.('x-csp-nonce');
+    const nonce = Array.isArray(rawNonce)
+      ? rawNonce[0]
+      : rawNonce != null
+        ? String(rawNonce)
+        : undefined;
     return { ...initial, nonce };
   }
 

--- a/pages/input-hub.tsx
+++ b/pages/input-hub.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import emailjs from '@emailjs/browser';
 import { useRouter } from 'next/router';
+import { getCspNonce } from '../utils/csp';
 
 const subjectTemplates = [
   'General Inquiry',
@@ -78,6 +79,8 @@ const InputHub = () => {
       const script = document.createElement('script');
       script.src = `https://www.google.com/recaptcha/api.js?render=${siteKey}`;
       script.async = true;
+      const nonce = getCspNonce();
+      if (nonce) script.nonce = nonce;
       document.head.appendChild(script);
     }
   }, []);


### PR DESCRIPTION
## Summary
- remove `'unsafe-inline'` from the script CSP, generate a per-request nonce in middleware, and propagate it through `_document`
- attach the CSP nonce to all `<Script>` usages and dynamically created scripts, and align the static header fallbacks
- update sandboxed HTML helpers to reuse the nonce or fall back safely and document the new CSP flow

## Testing
- yarn lint *(fails: repository contains existing accessibility and top-level window lint errors)*
- curl -I http://localhost:3000

------
https://chatgpt.com/codex/tasks/task_e_68d812dc55ec83289a263d5962578480