### PR TITLE
[tests] de-duplicate jest alias mapping

### DIFF
--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -82,7 +82,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,9 +4,11 @@ const createJestConfig = nextJest({ dir: './' });
 
 const customJestConfig = {
   testEnvironment: 'jest-environment-jsdom',
+  testEnvironmentOptions: {
+    url: 'http://localhost',
+  },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/$1',
     '^@xterm/xterm/css/xterm.css$': '<rootDir>/__mocks__/styleMock.js',
     '^@/(.*)$': '<rootDir>/$1',
   },


### PR DESCRIPTION
## Summary
- remove the duplicate `@/(.*)` moduleNameMapper entry in `jest.config.js`
- set a jsdom URL so clipboard-dependent tests have a stable origin
- update the Nmap NSE test to match the toast's `role="status"`

## Testing
- yarn jest --runInBand __tests__/nmapNse.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d812d7f5c48328a110e4f97ebd8f7c