### PR TITLE
[build] Remove explicit Tailwind JIT mode

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,12 +2,13 @@ const plugin = require('tailwindcss/plugin');
 
 module.exports = {
   darkMode: 'class',
-  mode: 'jit',
   content: [
+    './app/**/*.{js,ts,jsx,tsx}',
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
     './apps/**/*.{js,ts,jsx,tsx}',
     './hooks/**/*.{js,ts,jsx,tsx}',
+    './games/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- drop the deprecated `mode: 'jit'` setting so Tailwind uses the default JIT compiler
- expand the Tailwind content globs to include the app shell and game components to keep purge coverage intact

## Testing
- npx tailwindcss -i ./styles/tailwind.css -o ./styles/.tailwind-build.css --minify

------
https://chatgpt.com/codex/tasks/task_e_68d812d5f4948328802b463cb4062d1b