### PR TITLE
[games] Improve help overlay accessibility

### DIFF
--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -271,6 +271,8 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           type="button"
           aria-label="Help"
           aria-expanded={showHelp}
+          aria-haspopup="dialog"
+          title="Open help overlay"
           onClick={toggle}
           className="bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
         >

--- a/components/apps/Games/common/input-remap/InputRemap.tsx
+++ b/components/apps/Games/common/input-remap/InputRemap.tsx
@@ -1,44 +1,97 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 interface Props {
   mapping: Record<string, string>;
-  setKey: (action: string, key: string) => string | null;
+  setKey: (action: string, key: string) => string[] | null;
   actions: Record<string, string>;
+  conflictActions?: string[];
 }
 
-const InputRemap: React.FC<Props> = ({ mapping, setKey, actions }) => {
+const InputRemap: React.FC<Props> = ({
+  mapping,
+  setKey,
+  actions,
+  conflictActions = [],
+}) => {
   const [waiting, setWaiting] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
 
   const capture = (action: string) => {
     setWaiting(action);
-    setMessage(null);
-    const handler = (e: KeyboardEvent) => {
-      e.preventDefault();
-      const conflict = setKey(action, e.key);
-      if (conflict) setMessage(`Replaced ${conflict}`);
-      else setMessage(null);
-      setWaiting(null);
-      window.removeEventListener('keydown', handler);
-    };
-    window.addEventListener('keydown', handler);
+    setMessage(`Listening for new key for ${action}`);
   };
 
+  useEffect(() => {
+    if (!waiting) return undefined;
+    const handler = (e: KeyboardEvent) => {
+      e.preventDefault();
+      const conflicts = setKey(waiting, e.key) || [];
+      if (conflicts.length > 0) {
+        setMessage(`Conflict with ${conflicts.join(', ')}`);
+      } else {
+        setMessage(`Set ${waiting} to ${e.key}`);
+      }
+      setWaiting(null);
+    };
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+    };
+  }, [waiting, setKey]);
+
+  const conflictSet = useMemo(
+    () => new Set(conflictActions),
+    [conflictActions],
+  );
+
   return (
-    <div className="space-y-2">
-      {Object.keys(actions).map((action) => (
-        <div key={action} className="flex items-center justify-between">
-          <span className="mr-2 capitalize">{action}</span>
-          <button
-            type="button"
-            onClick={() => capture(action)}
-            className="px-2 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
-          >
-            {waiting === action ? 'Press key...' : mapping[action]}
-          </button>
+    <div className="space-y-3">
+      <dl className="space-y-3">
+        {Object.keys(actions).map((action) => {
+          const hasConflict = conflictSet.has(action);
+          const conflictId = hasConflict ? `${action}-conflict` : undefined;
+          return (
+            <div
+              key={action}
+              className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <dt className="capitalize text-sm font-medium">
+                {action}
+                <span className="block text-xs font-normal text-gray-300">
+                  Default: {actions[action]}
+                </span>
+              </dt>
+              <dd>
+                <button
+                  type="button"
+                  onClick={() => capture(action)}
+                  className={`px-2 py-1 rounded focus:outline-none focus:ring font-mono min-w-[6rem] text-sm ${
+                    hasConflict
+                      ? 'bg-amber-700/80 ring-2 ring-amber-400'
+                      : 'bg-gray-700'
+                  }`}
+                  aria-describedby={conflictId}
+                >
+                  {waiting === action ? 'Press key…' : mapping[action] || actions[action]}
+                </button>
+                {hasConflict && (
+                  <p
+                    id={conflictId}
+                    className="mt-1 text-xs text-amber-300"
+                  >
+                    Shares a key with another action.
+                  </p>
+                )}
+              </dd>
+            </div>
+          );
+        })}
+      </dl>
+      {message && (
+        <div className="text-sm text-amber-200" role="status" aria-live="polite">
+          {message}
         </div>
-      ))}
-      {message && <div className="text-sm text-yellow-300">{message}</div>}
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add dialog metadata to the in-game help toggle button so the "?" control is screen-reader friendly
- extend the help overlay with import/export actions, conflict warnings, and live shortcut summaries
- update the input remapping hook/component to track conflicts and support sharing mappings

## Testing
- yarn lint *(fails: repository has existing accessibility and no-top-level-window lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d812d2288c8328ab1b6ee3c0f57826