### PR TITLE
[a11y] Improve modal focus handling

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -6,6 +6,7 @@ import UbuntuApp from '../base/ubuntu_app';
 import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { KALI_CATEGORIES as BASE_KALI_CATEGORIES } from './ApplicationsMenu';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 type AppMeta = {
   id: string;
@@ -159,6 +160,7 @@ const WhiskerMenu: React.FC = () => {
   const menuRef = useRef<HTMLDivElement>(null);
   const categoryListRef = useRef<HTMLDivElement>(null);
   const categoryButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
 
   const allApps: AppMeta[] = apps as any;
@@ -279,6 +281,9 @@ const WhiskerMenu: React.FC = () => {
 
   const hideMenu = useCallback(() => {
     setIsOpen(false);
+    if (buttonRef.current) {
+      buttonRef.current.focus();
+    }
   }, []);
 
   const toggleMenu = useCallback(() => {
@@ -338,6 +343,14 @@ const WhiskerMenu: React.FC = () => {
     }
   }, []);
 
+  useEffect(() => {
+    if (isOpen && isVisible) {
+      searchInputRef.current?.focus();
+    }
+  }, [isOpen, isVisible]);
+
+  useFocusTrap(menuRef, isVisible);
+
   const focusCategoryButton = (index: number) => {
     const btn = categoryButtonRefs.current[index];
     if (btn) {
@@ -393,6 +406,10 @@ const WhiskerMenu: React.FC = () => {
       {isVisible && (
         <div
           ref={menuRef}
+          data-testid="whisker-menu"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Applications launcher"
           className={`absolute left-0 mt-1 z-50 flex w-[520px] bg-ub-grey text-white shadow-lg rounded-md overflow-hidden transition-all duration-200 ease-out ${
             isOpen ? 'opacity-100 translate-y-0 scale-100' : 'pointer-events-none opacity-0 -translate-y-2 scale-95'
           }`}
@@ -458,6 +475,7 @@ const WhiskerMenu: React.FC = () => {
           </div>
           <div className="flex flex-col p-3">
             <input
+              ref={searchInputRef}
               className="mb-3 w-64 rounded bg-black bg-opacity-20 px-2 py-1 focus:outline-none"
 
               placeholder="Search"

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -41,6 +41,7 @@ export class Desktop extends Component {
         ]);
         this.initFavourite = {};
         this.allWindowClosed = false;
+        this.windowSwitcherTrigger = null;
         this.state = {
             focused_windows: {},
             closed_windows: {},
@@ -356,15 +357,23 @@ export class Desktop extends Component {
             .map(id => apps.find(a => a.id === id))
             .filter(Boolean);
         if (windows.length) {
+            const activeElement = document.activeElement;
+            this.windowSwitcherTrigger = activeElement instanceof HTMLElement ? activeElement : null;
             this.setState({ showWindowSwitcher: true, switcherWindows: windows });
         }
     }
 
     closeWindowSwitcher = () => {
-        this.setState({ showWindowSwitcher: false, switcherWindows: [] });
+        this.setState({ showWindowSwitcher: false, switcherWindows: [] }, () => {
+            if (this.windowSwitcherTrigger && typeof this.windowSwitcherTrigger.focus === 'function') {
+                this.windowSwitcherTrigger.focus();
+            }
+            this.windowSwitcherTrigger = null;
+        });
     }
 
     selectWindow = (id) => {
+        this.windowSwitcherTrigger = null;
         this.setState({ showWindowSwitcher: false, switcherWindows: [] }, () => {
             this.openApp(id);
         });
@@ -1040,8 +1049,8 @@ export class Desktop extends Component {
         return (
             <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
-                    <span>New folder name</span>
-                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} />
+                    <label htmlFor="folder-name-input" className="w-full text-left">New folder name</label>
+                    <input className="outline-none mt-5 px-1 w-10/12  context-menu-bg border-2 border-blue-700 rounded py-0.5" id="folder-name-input" type="text" autoComplete="off" spellCheck="false" autoFocus={true} aria-label="New folder name" />
                 </div>
                 <div className="flex">
                     <button

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -8,46 +8,70 @@ import PerformanceGraph from '../ui/PerformanceGraph';
 
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
+        constructor() {
+                super();
                 this.state = {
                         status_card: false,
                         applicationsMenuOpen: false,
                         placesMenuOpen: false
                 };
+                this.statusButtonRef = React.createRef();
         }
 
-		render() {
-			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
-						<WhiskerMenu />
-						<PerformanceGraph />
-					</div>
-					<div
-						className={
-							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-						}
-					>
-						<Clock />
-					</div>
-					<button
-						type="button"
-						id="status-bar"
-						aria-label="System status"
-						onClick={() => {
-							this.setState({ status_card: !this.state.status_card });
-						}}
-						className={
-							'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-						}
-					>
-						<Status />
-						<QuickSettings open={this.state.status_card} />
-					</button>
-				</div>
-			);
-		}
+        toggleQuickSettings = () => {
+                this.setState(
+                        (state) => ({ status_card: !state.status_card }),
+                        () => {
+                                if (!this.state.status_card && this.statusButtonRef?.current) {
+                                        this.statusButtonRef.current.focus();
+                                }
+                        }
+                );
+        };
+
+        closeQuickSettings = () => {
+                if (!this.state.status_card) return;
+                this.setState({ status_card: false }, () => {
+                        if (this.statusButtonRef?.current) {
+                                this.statusButtonRef.current.focus();
+                        }
+                });
+        };
+
+                render() {
+                        return (
+                                <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                        <div className="flex items-center">
+                                                <WhiskerMenu />
+                                                <PerformanceGraph />
+                                        </div>
+                                        <div
+                                                className={
+                                                        'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                }
+                                        >
+                                                <Clock />
+                                        </div>
+                                        <div className="relative">
+                                                <button
+                                                        ref={this.statusButtonRef}
+                                                        type="button"
+                                                        id="status-bar"
+                                                        aria-label="System status"
+                                                        aria-haspopup="dialog"
+                                                        aria-expanded={this.state.status_card}
+                                                        onClick={this.toggleQuickSettings}
+                                                        className={
+                                                                'pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                                        }
+                                                >
+                                                        <Status />
+                                                </button>
+                                                <QuickSettings open={this.state.status_card} onClose={this.closeQuickSettings} />
+                                        </div>
+                                </div>
+                        );
+                }
 
 
 }

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -1,9 +1,13 @@
 import React, { useEffect, useState, useRef } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(0);
   const inputRef = useRef(null);
+  const containerRef = useRef(null);
+
+  useFocusTrap(containerRef, true);
 
   const filtered = windows.filter((w) =>
     w.title.toLowerCase().includes(query.toLowerCase())
@@ -57,7 +61,14 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white">
+    <div
+      ref={containerRef}
+      data-testid="window-switcher"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Window switcher"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white"
+    >
       <div className="bg-ub-grey p-4 rounded w-3/4 md:w-1/3">
         <input
           ref={inputRef}
@@ -66,6 +77,7 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
           onKeyDown={handleKeyDown}
           className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
           placeholder="Search windows"
+          aria-label="Search windows"
         />
         <ul>
           {filtered.map((w, i) => (

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,17 +1,25 @@
 "use client";
 
+import { useEffect, useRef } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 interface Props {
   open: boolean;
+  onClose: () => void;
 }
 
-const QuickSettings = ({ open }: Props) => {
+const focusableSelector =
+  'button:not([disabled]), input:not([disabled])';
+
+const QuickSettings = ({ open, onClose }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(containerRef, open);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -21,10 +29,37 @@ const QuickSettings = ({ open }: Props) => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
 
+  useEffect(() => {
+    if (!open) return;
+    const firstFocusable = containerRef.current?.querySelector<HTMLElement>(focusableSelector);
+    firstFocusable?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onClose]);
+
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
-        open ? '' : 'hidden'
+      ref={containerRef}
+      data-testid="quick-settings"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Quick settings"
+      aria-hidden={!open}
+      className={`absolute right-0 top-full mt-2 bg-ub-cool-grey rounded-md py-4 shadow border-black border border-opacity-20 focus:outline-none ${
+        open ? 'block' : 'hidden'
       }`}
     >
       <div className="px-4 pb-2">
@@ -36,22 +71,33 @@ const QuickSettings = ({ open }: Props) => {
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
+      <label className="px-4 pb-2 flex justify-between items-center text-left">
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
+        <input
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+          aria-label="Sound"
+        />
+      </label>
+      <label className="px-4 pb-2 flex justify-between items-center text-left">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
+        <input
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+          aria-label="Network"
+        />
+      </label>
+      <label className="px-4 flex justify-between items-center text-left">
         <span>Reduced motion</span>
         <input
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
+          aria-label="Reduced motion"
         />
-      </div>
+      </label>
     </div>
   );
 };

--- a/tests/accessibility.dialog-focus.spec.ts
+++ b/tests/accessibility.dialog-focus.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const isFocusInside = async (page: Page, selector: string) =>
+  page.evaluate((dialogSelector) => {
+    const active = document.activeElement;
+    if (!active) return false;
+    return Boolean(active.closest(dialogSelector));
+  }, selector);
+
+test.describe('dialog focus management', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('quick settings traps focus and restores the trigger', async ({ page }) => {
+    const statusButton = page.locator('#status-bar');
+    await statusButton.focus();
+    await statusButton.click();
+
+    const quickSettings = page.locator('[data-testid="quick-settings"]');
+    await expect(quickSettings).toBeVisible();
+
+    const themeToggle = quickSettings.locator('button').first();
+    await expect(themeToggle).toBeFocused();
+
+    await page.keyboard.press('Shift+Tab');
+    const toggles = quickSettings.locator('input[type="checkbox"]');
+    const toggleCount = await toggles.count();
+    await expect(toggles.nth(Math.max(0, toggleCount - 1))).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(themeToggle).toBeFocused();
+
+    await page.keyboard.press('Escape');
+    await expect(quickSettings).toBeHidden();
+    await expect(statusButton).toBeFocused();
+  });
+
+  test('launcher keeps focus within the menu and returns focus on close', async ({ page }) => {
+    const launcherButton = page.getByRole('button', { name: 'Applications' });
+    await launcherButton.focus();
+    await launcherButton.click();
+
+    const launcher = page.locator('[data-testid="whisker-menu"]');
+    await expect(launcher).toBeVisible();
+
+    const searchInput = launcher.locator('input[aria-label="Search applications"]');
+    await expect(searchInput).toBeFocused();
+
+    await page.keyboard.press('Shift+Tab');
+    await expect(await isFocusInside(page, '[data-testid="whisker-menu"]')).toBe(true);
+
+    await page.keyboard.press('Escape');
+    await expect(launcher).toHaveCount(0);
+    await expect(launcherButton).toBeFocused();
+  });
+
+  test('window switcher retains focus while open and restores the trigger on exit', async ({ page }) => {
+    const statusButton = page.locator('#status-bar');
+    await statusButton.focus();
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('open-app', { detail: 'terminal' }));
+      window.dispatchEvent(new CustomEvent('open-app', { detail: 'calculator' }));
+    });
+
+    await page.waitForSelector('#terminal');
+    await page.waitForSelector('#calculator');
+
+    await page.evaluate(() => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', altKey: true, bubbles: true });
+      document.dispatchEvent(event);
+    });
+
+    const switcher = page.locator('[data-testid="window-switcher"]');
+    await expect(switcher).toBeVisible();
+
+    const search = switcher.locator('input[placeholder="Search windows"]');
+    await expect(search).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(search).toBeFocused();
+
+    await page.keyboard.press('Escape');
+    await expect(switcher).toHaveCount(0);
+    await expect(statusButton).toBeFocused();
+  });
+});
+


### PR DESCRIPTION
## Summary
- trap focus in the quick settings popover, window switcher, and applications launcher dialogs and restore focus to their triggers on close
- update the navbar and desktop helpers to coordinate modal toggles and remember the invoking control for focus return
- add Playwright coverage that exercises dialog focus trapping for quick settings, launcher, and window switcher

## Testing
- `npx eslint components/ui/QuickSettings.tsx components/menu/WhiskerMenu.tsx components/screen/window-switcher.js components/screen/desktop.js components/screen/navbar.js tests/accessibility.dialog-focus.spec.ts`
- `yarn test --runTestsByPath __tests__/desktopNameBar.test.tsx`
- `npx playwright test tests/accessibility.dialog-focus.spec.ts` *(fails: Playwright browsers are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d812d0c1948328bbd7c03fc362b57e