### PR TITLE
[a11y] Honor global high contrast and reduced motion

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -422,7 +422,9 @@ export class Window extends Component {
 
         const node = document.querySelector("#" + this.id);
         const endTransform = `translate(${posx}px,${sidebBarApp.y.toFixed(1) - 240}px) scale(0.2)`;
-        const prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const prefersReducedMotion =
+            (typeof document !== 'undefined' && document.documentElement.classList.contains('reduced-motion')) ||
+            (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
 
         if (prefersReducedMotion) {
             node.style.transform = endTransform;
@@ -450,7 +452,9 @@ export class Window extends Component {
         let posy = node.style.getPropertyValue("--window-transform-y");
         const startTransform = node.style.transform;
         const endTransform = `translate(${posx},${posy})`;
-        const prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const prefersReducedMotion =
+            (typeof document !== 'undefined' && document.documentElement.classList.contains('reduced-motion')) ||
+            (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
 
         if (prefersReducedMotion) {
             node.style.transform = endTransform;

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -154,7 +154,7 @@ const NotificationBell: React.FC = () => {
         aria-expanded={isOpen}
         aria-controls={panelId}
         onClick={togglePanel}
-        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey transition focus:border-ubb-orange focus:outline-none focus:ring-0 hover:bg-white hover:bg-opacity-10"
+        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-kali-text transition-colors duration-[var(--motion-fast)] focus:border-kali-focus focus:outline-none focus:ring-0 hover:bg-[color:color-mix(in_srgb,var(--color-text)_12%,transparent)]"
       >
         <svg
           aria-hidden="true"
@@ -167,7 +167,7 @@ const NotificationBell: React.FC = () => {
           <path d="M7 12a3 3 0 006 0H7z" />
         </svg>
         {unreadCount > 0 && (
-          <span className="absolute -top-1.5 -right-1.5 min-w-[1.5rem] rounded-full bg-ubb-orange px-1 text-center text-[0.65rem] font-semibold leading-5 text-white">
+          <span className="absolute -top-1.5 -right-1.5 min-w-[1.5rem] rounded-full px-1 text-center text-[0.65rem] font-semibold leading-5 bg-kali-primary text-[color:var(--color-bg)]">
             {unreadCount > 99 ? '99+' : unreadCount}
           </span>
         )}
@@ -180,37 +180,42 @@ const NotificationBell: React.FC = () => {
           aria-modal="false"
           aria-labelledby={headingId}
           tabIndex={-1}
-          className="absolute right-0 z-50 mt-2 w-72 max-h-96 overflow-hidden rounded-md border border-white/10 bg-ub-grey/95 text-ubt-grey shadow-xl backdrop-blur"
+          className="absolute right-0 z-50 mt-2 w-72 max-h-96 overflow-hidden rounded-md shadow-xl backdrop-blur surface-popover"
         >
-          <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
-            <h2 id={headingId} className="text-sm font-semibold text-white">
+          <div className="flex items-center justify-between border-b px-4 py-2"
+            style={{ borderColor: 'color-mix(in srgb, var(--color-text) 24%, transparent)' }}
+          >
+            <h2 id={headingId} className="text-sm font-semibold text-kali-text">
               Notifications
             </h2>
             <button
               type="button"
               onClick={handleDismissAll}
               disabled={notifications.length === 0}
-              className="text-xs font-medium text-ubb-orange transition disabled:cursor-not-allowed disabled:text-ubt-grey disabled:text-opacity-50"
+              className="text-xs font-medium text-kali-primary transition-colors duration-[var(--motion-fast)] disabled:cursor-not-allowed disabled:text-kali-text/50"
             >
               Dismiss all
             </button>
           </div>
           <div className="max-h-80 overflow-y-auto">
             {notifications.length === 0 ? (
-              <p className="px-4 py-6 text-center text-sm text-ubt-grey text-opacity-80">
+              <p className="px-4 py-6 text-center text-sm text-kali-text/80">
                 You&apos;re all caught up.
               </p>
             ) : (
-              <ul role="list" className="divide-y divide-white/10">
+              <ul
+                role="list"
+                className="divide-y surface-divider"
+              >
                 {formattedNotifications.map(notification => (
-                  <li key={notification.id} className="px-4 py-3 text-sm text-white">
+                  <li key={notification.id} className="px-4 py-3 text-sm text-kali-text">
                     <p className="font-medium">{notification.title}</p>
                     {notification.body && (
-                      <p className="mt-1 text-xs text-ubt-grey text-opacity-80">
+                      <p className="mt-1 text-xs text-kali-text/80">
                         {notification.body}
                       </p>
                     )}
-                    <div className="mt-2 flex items-center justify-between text-[0.65rem] uppercase tracking-wide text-ubt-grey text-opacity-70">
+                    <div className="mt-2 flex items-center justify-between text-[0.65rem] uppercase tracking-wide text-kali-text/70">
                       <span>{notification.appId}</span>
                       <time dateTime={notification.formattedTime}>{notification.readableTime}</time>
                     </div>

--- a/components/ui/PerformanceGraph.tsx
+++ b/components/ui/PerformanceGraph.tsx
@@ -14,23 +14,38 @@ function usePrefersReducedMotion() {
     }
 
     const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const root = document.documentElement;
 
     const updatePreference = () => {
-      setPrefersReducedMotion(mediaQuery.matches);
+      const classPreference = root.classList.contains('reduced-motion');
+      setPrefersReducedMotion(classPreference || mediaQuery.matches);
     };
 
     updatePreference();
 
     if (typeof mediaQuery.addEventListener === 'function') {
       mediaQuery.addEventListener('change', updatePreference);
-      return () => {
-        mediaQuery.removeEventListener('change', updatePreference);
-      };
+    } else {
+      mediaQuery.addListener(updatePreference);
     }
 
-    mediaQuery.addListener(updatePreference);
+    let observer: MutationObserver | undefined;
+    if (typeof MutationObserver !== 'undefined') {
+      observer = new MutationObserver(mutations => {
+        if (mutations.some(mutation => mutation.attributeName === 'class')) {
+          updatePreference();
+        }
+      });
+      observer.observe(root, { attributes: true, attributeFilter: ['class'] });
+    }
+
     return () => {
-      mediaQuery.removeListener(updatePreference);
+      if (typeof mediaQuery.removeEventListener === 'function') {
+        mediaQuery.removeEventListener('change', updatePreference);
+      } else {
+        mediaQuery.removeListener(updatePreference);
+      }
+      observer?.disconnect();
     };
   }, []);
 
@@ -128,7 +143,7 @@ const PerformanceGraph: React.FC<PerformanceGraphProps> = ({ className }) => {
   return (
     <div
       className={
-        'hidden items-center pr-2 text-ubt-grey/70 sm:flex md:pr-3 lg:pr-4' + (className ? ` ${className}` : '')
+        'hidden items-center pr-2 text-kali-text/70 sm:flex md:pr-3 lg:pr-4' + (className ? ` ${className}` : '')
       }
       aria-hidden="true"
       data-reduced-motion={prefersReducedMotion ? 'true' : 'false'}
@@ -143,8 +158,8 @@ const PerformanceGraph: React.FC<PerformanceGraphProps> = ({ className }) => {
       >
         <defs>
           <linearGradient id="kaliSpark" x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stopColor="#61a3ff" stopOpacity="0.9" />
-            <stop offset="100%" stopColor="#1f4aa8" stopOpacity="0.25" />
+            <stop offset="0%" stopColor="var(--color-primary)" stopOpacity="0.9" />
+            <stop offset="100%" stopColor="var(--color-primary)" stopOpacity="0.25" />
           </linearGradient>
         </defs>
         <path

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -18,18 +18,21 @@ const QuickSettings = ({ open }: Props) => {
   }, [theme]);
 
   useEffect(() => {
-    document.documentElement.classList.toggle('reduce-motion', reduceMotion);
+    document.documentElement.classList.toggle('reduced-motion', reduceMotion);
   }, [reduceMotion]);
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute right-3 top-9 z-50 w-56 rounded-md py-4 shadow-lg surface-popover ${
         open ? '' : 'hidden'
       }`}
+      role="dialog"
+      aria-label="Quick settings"
     >
       <div className="px-4 pb-2">
         <button
-          className="w-full flex justify-between"
+          className="flex w-full items-center justify-between rounded px-2 py-1 text-sm transition-colors duration-[var(--motion-fast)] hover:bg-[color:color-mix(in_srgb,var(--color-text)_12%,transparent)] focus-visible:bg-[color:color-mix(in_srgb,var(--color-text)_18%,transparent)]"
+          aria-pressed={theme === 'dark'}
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
         >
           <span>Theme</span>

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,25 @@ body{
     color: var(--color-text);
 }
 
+.surface-popover {
+    background-color: color-mix(in srgb, var(--color-surface) 94%, transparent);
+    border: 1px solid color-mix(in srgb, var(--color-text) 32%, transparent);
+    color: var(--color-text);
+}
+
+.surface-divider > :not([hidden]) ~ :not([hidden]) {
+    border-color: color-mix(in srgb, var(--color-text) 22%, transparent);
+}
+
+.high-contrast .surface-popover {
+    background-color: var(--color-bg);
+    border-color: var(--color-text);
+}
+
+.high-contrast .surface-divider > :not([hidden]) ~ :not([hidden]) {
+    border-color: var(--color-text);
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -86,6 +86,20 @@
 .high-contrast {
   --color-bg: #000000;
   --color-text: #ffffff;
+  --color-primary: #ffff00;
+  --color-secondary: #000000;
+  --color-accent: #ffff00;
+  --color-muted: #000000;
+  --color-surface: #000000;
+  --color-inverse: #000000;
+  --color-border: #ffffff;
+  --color-focus-ring: #ffff00;
+  --color-selection: #ffff00;
+  --color-control-accent: #ffff00;
+  --kali-bg: #000000;
+  --kali-panel: #000000;
+  --kali-panel-border: #ffffff;
+  --kali-panel-highlight: #ffffff;
   --color-ub-grey: #000000;
   --color-ub-cool-grey: #000000;
   --color-ubt-grey: #ffffff;


### PR DESCRIPTION
## Summary
- expand the high-contrast token set and add shared surface styles so popovers keep 4.5:1 contrast targets
- update QuickSettings, NotificationBell, PerformanceGraph, and window chrome to read the `.reduced-motion` class alongside system preferences

## Testing
- yarn lint *(fails: repository already contains hundreds of jsx-a11y label violations)*
- yarn a11y *(fails: puppeteer could not launch because libatk-1.0 is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d812ce86248328b61d6b2337b72a6a