### PR TITLE
[window] refresh kali window controls

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -763,37 +763,37 @@ export function WindowEditButtons(props) {
     const { togglePin } = useDocPiP(props.pip || (() => null));
     const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
     return (
-        <div className={`${styles.windowControls} absolute select-none right-0 top-0 mr-1 flex justify-center items-center min-w-[8.25rem]`}>
+        <div className={`${styles.windowControls} absolute select-none right-0 top-0 mr-2 flex items-center justify-center`}>
             {pipSupported && props.pip && (
                 <button
                     type="button"
                     aria-label="Window pin"
-                    className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                    className={styles.windowControlButton}
                     onClick={togglePin}
                 >
                     <NextImage
                         src="/themes/Yaru/window/window-pin-symbolic.svg"
                         alt="Kali window pin"
-                        className="h-4 w-4 inline"
-                        width={16}
-                        height={16}
-                        sizes="16px"
+                        className="h-5 w-5 inline"
+                        width={20}
+                        height={20}
+                        sizes="20px"
                     />
                 </button>
             )}
             <button
                 type="button"
                 aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                className={styles.windowControlButton}
                 onClick={props.minimize}
             >
                 <NextImage
-                    src="/themes/Yaru/window/window-minimize-symbolic.svg"
+                    src="/themes/Kali/window/window-minimize.svg"
                     alt="Kali window minimize"
-                    className="h-4 w-4 inline"
-                    width={16}
-                    height={16}
-                    sizes="16px"
+                    className="h-5 w-5 inline"
+                    width={20}
+                    height={20}
+                    sizes="20px"
                 />
             </button>
             {props.allowMaximize && (
@@ -802,32 +802,32 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className={styles.windowControlButton}
                             onClick={props.maximize}
                         >
                             <NextImage
-                                src="/themes/Yaru/window/window-restore-symbolic.svg"
+                                src="/themes/Kali/window/window-restore.svg"
                                 alt="Kali window restore"
-                                className="h-4 w-4 inline"
-                                width={16}
-                                height={16}
-                                sizes="16px"
+                                className="h-5 w-5 inline"
+                                width={20}
+                                height={20}
+                                sizes="20px"
                             />
                         </button>
                     ) : (
                         <button
                             type="button"
                             aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className={styles.windowControlButton}
                             onClick={props.maximize}
                         >
                             <NextImage
-                                src="/themes/Yaru/window/window-maximize-symbolic.svg"
+                                src="/themes/Kali/window/window-maximize.svg"
                                 alt="Kali window maximize"
-                                className="h-4 w-4 inline"
-                                width={16}
-                                height={16}
-                                sizes="16px"
+                                className="h-5 w-5 inline"
+                                width={20}
+                                height={20}
+                                sizes="20px"
                             />
                         </button>
                     )
@@ -836,16 +836,16 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                className={`${styles.windowControlButton} ${styles.windowControlButtonDanger}`}
                 onClick={props.close}
             >
                 <NextImage
-                    src="/themes/Yaru/window/window-close-symbolic.svg"
+                    src="/themes/Kali/window/window-close.svg"
                     alt="Kali window close"
-                    className="h-4 w-4 inline"
-                    width={16}
-                    height={16}
-                    sizes="16px"
+                    className="h-5 w-5 inline"
+                    width={20}
+                    height={20}
+                    sizes="20px"
                 />
             </button>
         </div>

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -48,7 +48,39 @@
 }
 
 .windowControls {
-  height: 28px;
+  height: max(40px, var(--hit-area));
+  padding-inline: var(--space-2);
+  gap: var(--space-2);
+}
+
+.windowControlButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: max(40px, var(--hit-area));
+  min-height: max(40px, var(--hit-area));
+  border-radius: var(--radius-round);
+  border: 1px solid transparent;
+  background-color: color-mix(in srgb, transparent 70%, var(--kali-panel-highlight));
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+}
+
+.windowControlButton:hover,
+.windowControlButton:focus-visible {
+  background-color: color-mix(in srgb, var(--kali-blue) 18%, transparent 82%);
+  border-color: color-mix(in srgb, var(--kali-blue) 40%, transparent 60%);
+}
+
+.windowControlButton:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--focus-outline-color) 35%, transparent 65%);
+}
+
+.windowControlButtonDanger:hover,
+.windowControlButtonDanger:focus-visible {
+  background-color: color-mix(in srgb, var(--game-color-danger) 20%, transparent 80%);
+  border-color: color-mix(in srgb, var(--game-color-danger) 35%, transparent 65%);
 }
 
 .windowYBorder {

--- a/public/themes/Kali/window/window-close.svg
+++ b/public/themes/Kali/window/window-close.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#ff6b6b" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M8 8l8 8" />
+  <path d="M16 8l-8 8" />
+  <rect x="5" y="5" width="14" height="14" rx="3" stroke="#1f2630" stroke-width="1.2" fill="none" opacity="0.3" />
+</svg>

--- a/public/themes/Kali/window/window-maximize.svg
+++ b/public/themes/Kali/window/window-maximize.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="6" y="6" width="12" height="12" rx="2.5" />
+  <rect x="4.5" y="4.5" width="15" height="15" rx="3.5" stroke="#1f2630" stroke-width="1.2" fill="none" opacity="0.3" />
+</svg>

--- a/public/themes/Kali/window/window-minimize.svg
+++ b/public/themes/Kali/window/window-minimize.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 12h12" />
+  <rect x="5" y="5" width="14" height="14" rx="3" stroke="#1f2630" stroke-width="1.2" fill="none" opacity="0.3" />
+</svg>

--- a/public/themes/Kali/window/window-restore.svg
+++ b/public/themes/Kali/window/window-restore.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#1793d1" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 9h9v9H9z" />
+  <path d="M6 6h9v3" />
+  <path d="M6 6v9h3" />
+  <rect x="4.5" y="4.5" width="15" height="15" rx="3.5" stroke="#1f2630" stroke-width="1.2" fill="none" opacity="0.3" />
+</svg>


### PR DESCRIPTION
## Summary
- replace window control icons with Kali-themed assets and enlarge target areas to 40px minimum
- restyle window control hover and focus states to use shared Kali theme tokens
- ensure restore state also uses the refreshed glyph set for consistent chrome

## Testing
- yarn lint *(fails: existing accessibility lint violations across apps and legacy public game scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68d812ca996483288249cbc810e83eb2