### PR TITLE
[theme] centralize kali token usage

### DIFF
--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import type { CSSProperties } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import {
   onFetchProxy,
@@ -9,11 +10,26 @@ import {
 } from '../../../lib/fetchProxy';
 import { exportMetrics } from '../export';
 import RequestChart from './RequestChart';
+import { kaliTheme } from '../../../styles/themes/kali';
 
 const HISTORY_KEY = 'network-insights-history';
 
 const formatBytes = (bytes?: number) =>
   typeof bytes === 'number' ? `${(bytes / 1024).toFixed(1)} kB` : '—';
+
+type PanelStyleVars = CSSProperties & {
+  '--panel-bg'?: string;
+  '--panel-hover'?: string;
+  '--panel-border'?: string;
+  '--focus-ring-color'?: string;
+};
+
+const panelVars: PanelStyleVars = {
+  '--panel-bg': kaliTheme.panel,
+  '--panel-hover': kaliTheme.hover,
+  '--panel-border': kaliTheme.panelBorder,
+  '--focus-ring-color': kaliTheme.focus,
+};
 
 export default function NetworkInsights() {
   const [active, setActive] = useState<FetchEntry[]>(getActiveFetches());
@@ -32,9 +48,15 @@ export default function NetworkInsights() {
   }, [setHistory]);
 
   return (
-    <div className="p-2 text-xs text-white bg-[var(--kali-bg)]">
+    <div
+      className="p-2 text-xs text-white"
+      style={{ backgroundColor: kaliTheme.background, boxShadow: kaliTheme.shadow }}
+    >
       <h2 className="font-bold mb-1">Active Fetches</h2>
-      <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
+      <ul
+        className="mb-2 divide-y divide-[var(--panel-border)] border rounded bg-[var(--panel-bg)]"
+        style={{ ...panelVars, borderColor: 'var(--panel-border)' }}
+      >
         {active.length === 0 && <li className="p-1 text-gray-400">None</li>}
         {active.map((f) => (
           <li key={f.id} className="p-1">
@@ -51,12 +73,16 @@ export default function NetworkInsights() {
         <h2 className="font-bold">History</h2>
         <button
           onClick={() => exportMetrics(history)}
-          className="ml-auto px-2 py-1 rounded bg-[var(--kali-panel)]"
+          className="ml-auto px-2 py-1 rounded bg-[var(--panel-bg)] hover:bg-[var(--panel-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-color)] transition-colors"
+          style={{ ...panelVars, boxShadow: kaliTheme.shadow }}
         >
           Export
         </button>
       </div>
-      <ul className="divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
+      <ul
+        className="divide-y divide-[var(--panel-border)] border rounded bg-[var(--panel-bg)]"
+        style={{ ...panelVars, borderColor: 'var(--panel-border)' }}
+      >
         {history.length === 0 && <li className="p-1 text-gray-400">No requests</li>}
         {history.map((f) => (
           <li key={f.id} className="p-1">

--- a/apps/resource-monitor/components/RequestChart.tsx
+++ b/apps/resource-monitor/components/RequestChart.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import React, { useEffect, useRef } from 'react';
+import type { CSSProperties } from 'react';
+import { kaliTheme, kaliThemeVars } from '../../../styles/themes/kali';
 
 interface RequestChartProps {
   data: number[];
@@ -21,8 +23,11 @@ export default function RequestChart({ data, label }: RequestChartProps) {
 
     ctx.clearRect(0, 0, width, height);
 
+    const rootStyles = getComputedStyle(document.documentElement);
+    const panelColor = rootStyles.getPropertyValue(kaliThemeVars.panel).trim();
+
     // draw panel background
-    ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--kali-panel');
+    ctx.fillStyle = panelColor || '#0f1317';
     ctx.fillRect(0, 0, width, height);
 
     // gridlines
@@ -56,8 +61,14 @@ export default function RequestChart({ data, label }: RequestChartProps) {
     ctx.fillText(label, 4, 12);
   }, [data, label]);
 
+  const surfaceVars: CSSProperties & { '--panel-bg'?: string } = {
+    '--panel-bg': kaliTheme.panel,
+    background: 'var(--panel-bg)',
+    boxShadow: kaliTheme.shadow,
+  };
+
   return (
-    <div className="w-full max-w-[300px] h-[150px]" style={{ background: 'var(--kali-panel)' }}>
+    <div className="w-full max-w-[300px] h-[150px]" style={surfaceVars}>
       <canvas ref={canvasRef} width={300} height={150} className="w-full h-full" />
     </div>
   );

--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { CSSProperties } from 'react';
 import Image from 'next/image';
 import ExternalFrame from '../../components/ExternalFrame';
 import { CloseIcon, MaximizeIcon, MinimizeIcon } from '../../components/ToolbarIcons';
@@ -10,7 +11,11 @@ export default function VsCode() {
   return (
     <div
       className="flex flex-col min-[1366px]:flex-row h-full w-full max-w-full"
-      style={{ backgroundColor: kaliTheme.background, color: kaliTheme.text }}
+      style={{
+        backgroundColor: kaliTheme.background,
+        color: kaliTheme.text,
+        boxShadow: kaliTheme.shadow,
+      }}
     >
       <aside
         className="flex flex-col items-center gap-2 p-1"
@@ -38,13 +43,25 @@ export default function VsCode() {
           className="flex items-center justify-end gap-2 px-2 py-1 border-b border-black/20"
           style={{ backgroundColor: kaliTheme.background }}
         >
-          <button aria-label="Minimize">
+          <button
+            aria-label="Minimize"
+            className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-color)]"
+            style={{ '--focus-ring-color': kaliTheme.focus } as CSSProperties}
+          >
             <MinimizeIcon />
           </button>
-          <button aria-label="Maximize">
+          <button
+            aria-label="Maximize"
+            className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-color)]"
+            style={{ '--focus-ring-color': kaliTheme.focus } as CSSProperties}
+          >
             <MaximizeIcon />
           </button>
-          <button aria-label="Close">
+          <button
+            aria-label="Close"
+            className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-color)]"
+            style={{ '--focus-ring-color': kaliTheme.focus } as CSSProperties}
+          >
             <CloseIcon />
           </button>
         </div>
@@ -55,7 +72,14 @@ export default function VsCode() {
             className="w-full h-full"
             onLoad={() => {}}
           />
-          <div className="absolute top-4 left-4 flex items-center gap-4 bg-black/50 p-4 rounded">
+          <div
+            className="absolute top-4 left-4 flex items-center gap-4 rounded"
+            style={{
+              backgroundColor: kaliTheme.hover,
+              boxShadow: kaliTheme.shadow,
+              padding: '1rem',
+            }}
+          >
             <Image
               src="/themes/Yaru/system/view-app-grid-symbolic.svg"
               alt="Open Folder"

--- a/docs/theme-tokens.md
+++ b/docs/theme-tokens.md
@@ -1,0 +1,43 @@
+# Kali theme tokens
+
+The Kali desktop shell centralises its palette in [`styles/themes/kali.ts`](../styles/themes/kali.ts).  
+Use the exported `kaliTheme` (CSS `var()` references) and `kaliThemeVars` (raw variable names) instead of hard-coding `--kali-*` values inside components.
+
+## Available tokens
+
+| Token | Purpose |
+| --- | --- |
+| `kaliTheme.background` | Primary desktop background. |
+| `kaliTheme.text` | Default foreground text colour. |
+| `kaliTheme.accent` | Accent/UI highlights. |
+| `kaliTheme.sidebar` | Sidebar and secondary panels. |
+| `kaliTheme.panel` | Frosted glass panel surface. |
+| `kaliTheme.panelBorder` | Subtle panel border/divider colour. |
+| `kaliTheme.hover` | Hover highlight used for overlays and interactive states. |
+| `kaliTheme.focus` | Focus ring colour for keyboard users. |
+| `kaliTheme.shadow` | Drop shadow token reused across panels. |
+
+> When you need the resolved colour (for example on a `<canvas>` context), read the raw variable name from `kaliThemeVars` and call `getComputedStyle(...).getPropertyValue(name)`.
+
+## Usage patterns
+
+```tsx
+import { kaliTheme } from '@/styles/themes/kali';
+
+const buttonStyles = {
+  '--focus-ring-color': kaliTheme.focus,
+  '--panel-hover': kaliTheme.hover,
+  backgroundColor: kaliTheme.panel,
+  boxShadow: kaliTheme.shadow,
+} as React.CSSProperties;
+
+<button
+  className="rounded bg-[var(--panel-hover)] focus-visible:ring-[var(--focus-ring-color)]"
+  style={buttonStyles}
+>
+  Action
+</button>
+```
+
+* Use component-level CSS custom properties (e.g. `--focus-ring-color`) when Tailwind utilities require an actual colour value.
+* Updating a token in `kaliTheme` propagates through all consumers, so prefer those constants over literal `var(--kali-*)` strings.

--- a/styles/themes/kali.ts
+++ b/styles/themes/kali.ts
@@ -1,8 +1,28 @@
+const cssVar = (name: string) => `var(${name})`;
+
+export const kaliThemeVars = {
+  background: '--color-bg',
+  text: '--color-text',
+  accent: '--color-primary',
+  sidebar: '--color-secondary',
+  panel: '--kali-panel',
+  panelBorder: '--kali-panel-border',
+  panelHover: '--kali-panel-highlight',
+  focus: '--color-focus-ring',
+  shadow: '--shadow-2',
+} as const;
+
 export const kaliTheme = {
-  background: 'var(--color-bg)',
-  text: 'var(--color-text)',
-  accent: 'var(--color-primary)',
-  sidebar: 'var(--color-secondary)',
-};
+  background: cssVar(kaliThemeVars.background),
+  text: cssVar(kaliThemeVars.text),
+  accent: cssVar(kaliThemeVars.accent),
+  sidebar: cssVar(kaliThemeVars.sidebar),
+  panel: cssVar(kaliThemeVars.panel),
+  panelBorder: cssVar(kaliThemeVars.panelBorder),
+  hover: cssVar(kaliThemeVars.panelHover),
+  focus: cssVar(kaliThemeVars.focus),
+  shadow: cssVar(kaliThemeVars.shadow),
+} as const;
 
 export type KaliTheme = typeof kaliTheme;
+export type KaliThemeVars = typeof kaliThemeVars;


### PR DESCRIPTION
## Summary
- expose the kali panel, hover, focus, and shadow tokens through `styles/themes/kali.ts`
- refactor the VS Code and resource monitor UIs to consume the shared kali theme tokens
- document how to use the consolidated theme tokens for future styling updates

## Testing
- [ ] yarn lint *(hangs locally; cancelled after extended wait)*

------
https://chatgpt.com/codex/tasks/task_e_68d812c7d5548328a7a10678fb008cb1