### PR TITLE
[ui] add Undercover desktop skin

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -13,6 +13,7 @@ import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
 import KaliWallpaper from "../../components/util-components/kali-wallpaper";
+import UndercoverWallpaper from "../../components/util-components/undercover-wallpaper";
 
 export default function Settings() {
   const {
@@ -34,6 +35,8 @@ export default function Settings() {
     setHaptics,
     theme,
     setTheme,
+    undercoverMode,
+    setUndercoverMode,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -83,6 +86,8 @@ export default function Settings() {
       if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
+      if (parsed.undercoverMode !== undefined)
+        setUndercoverMode(parsed.undercoverMode);
       if (parsed.theme !== undefined) setTheme(parsed.theme);
     } catch (err) {
       console.error("Invalid settings", err);
@@ -104,6 +109,7 @@ export default function Settings() {
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
+    setUndercoverMode(defaults.undercoverMode);
     setTheme("default");
   };
 
@@ -117,7 +123,9 @@ export default function Settings() {
       {activeTab === "appearance" && (
         <>
           <div className="md:w-2/5 w-2/3 h-1/3 m-auto my-4 relative overflow-hidden rounded-lg shadow-inner">
-            {useKaliWallpaper ? (
+            {undercoverMode ? (
+              <UndercoverWallpaper />
+            ) : useKaliWallpaper ? (
               <KaliWallpaper />
             ) : (
               <div
@@ -274,6 +282,20 @@ export default function Settings() {
               ariaLabel="High Contrast"
             />
           </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Undercover Mode:</span>
+            <ToggleSwitch
+              checked={undercoverMode}
+              onChange={setUndercoverMode}
+              ariaLabel="Undercover Mode"
+            />
+          </div>
+          {undercoverMode && (
+            <p className="text-center text-xs text-ubt-grey/70 px-6 -mt-2 mb-4">
+              A Windows-inspired skin is applied instantly. Your wallpaper and accent
+              selections are saved for when you turn this off.
+            </p>
+          )}
           <div className="flex justify-center my-4 items-center">
             <span className="mr-2 text-ubt-grey">Haptics:</span>
             <ToggleSwitch

--- a/components/common/WindowsLogo.tsx
+++ b/components/common/WindowsLogo.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+
+export type WindowsLogoProps = {
+  className?: string;
+  title?: string;
+  ariaHidden?: boolean;
+};
+
+const DEFAULT_TITLE = 'Windows logo';
+
+const WindowsLogo: React.FC<WindowsLogoProps> = ({
+  className = '',
+  title = DEFAULT_TITLE,
+  ariaHidden = false,
+}) => {
+  const labelledProps = ariaHidden
+    ? { 'aria-hidden': true }
+    : { role: 'img', 'aria-label': title };
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      focusable="false"
+      className={className}
+      {...labelledProps}
+    >
+      <path
+        fill="currentColor"
+        d="M2.5 4.5 12 3v8.5H2.5zm9.5-1.7L21.5 2v9.5H12zm-9.5 10H12V21L2.5 19.5zm9.5 0H21.5V22l-9.5-1.4z"
+      />
+    </svg>
+  );
+};
+
+export default WindowsLogo;

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -6,6 +6,8 @@ import UbuntuApp from '../base/ubuntu_app';
 import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { KALI_CATEGORIES as BASE_KALI_CATEGORIES } from './ApplicationsMenu';
+import { useSettings } from '../../hooks/useSettings';
+import WindowsLogo from '../common/WindowsLogo';
 
 type AppMeta = {
   id: string;
@@ -158,6 +160,8 @@ const WhiskerMenu: React.FC = () => {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const categoryListRef = useRef<HTMLDivElement>(null);
+  const { undercoverMode } = useSettings();
+  const menuLabel = undercoverMode ? 'Start' : 'Applications';
   const categoryButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
 
@@ -379,16 +383,22 @@ const WhiskerMenu: React.FC = () => {
         ref={buttonRef}
         type="button"
         onClick={toggleMenu}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className={`pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 ${
+          undercoverMode ? 'rounded-full bg-white/10 hover:bg-white/20 text-slate-100 shadow-sm border border-white/10' : ''
+        }`}
       >
-        <Image
-          src="/themes/Yaru/status/decompiler-symbolic.svg"
-          alt="Menu"
-          width={16}
-          height={16}
-          className="inline mr-1"
-        />
-        Applications
+        {undercoverMode ? (
+          <WindowsLogo className="inline mr-2 h-4 w-4 text-sky-200" ariaHidden />
+        ) : (
+          <Image
+            src="/themes/Yaru/status/decompiler-symbolic.svg"
+            alt="Menu"
+            width={16}
+            height={16}
+            className="inline mr-1"
+          />
+        )}
+        {menuLabel}
       </button>
       {isVisible && (
         <div

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -2,11 +2,13 @@ import React from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
 import KaliWallpaper from '../util-components/kali-wallpaper';
+import UndercoverWallpaper from '../util-components/undercover-wallpaper';
 
 export default function LockScreen(props) {
 
-    const { bgImageName, useKaliWallpaper } = useSettings();
-    const useKaliTheme = useKaliWallpaper || bgImageName === 'kali-gradient';
+    const { bgImageName, useKaliWallpaper, undercoverMode } = useSettings();
+    const useUndercoverTheme = undercoverMode || bgImageName === 'undercover-windows';
+    const useKaliTheme = !useUndercoverTheme && (useKaliWallpaper || bgImageName === 'kali-gradient');
 
     if (props.isLocked) {
         window.addEventListener('click', props.unLockScreen);
@@ -18,7 +20,11 @@ export default function LockScreen(props) {
             id="ubuntu-lock-screen"
             style={{ zIndex: "100", contentVisibility: 'auto' }}
             className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
-            {useKaliTheme ? (
+            {useUndercoverTheme ? (
+                <UndercoverWallpaper
+                    className={`absolute top-0 left-0 h-full w-full transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                />
+            ) : useKaliTheme ? (
                 <KaliWallpaper
                     className={`absolute top-0 left-0 h-full w-full transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
                 />

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -5,11 +5,14 @@ import QuickSettings from '../ui/QuickSettings';
 import NotificationBell from '../ui/NotificationBell';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import PerformanceGraph from '../ui/PerformanceGraph';
+import { SettingsContext } from '../../hooks/useSettings';
+import WindowsLogo from '../common/WindowsLogo';
 
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
+        static contextType = SettingsContext;
+        constructor() {
+                super();
                 this.state = {
                         status_card: false,
                         applicationsMenuOpen: false,
@@ -18,16 +21,23 @@ export default class Navbar extends Component {
         }
 
 		render() {
-			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
-						<WhiskerMenu />
-						<PerformanceGraph />
-					</div>
-					<div
-						className={
-							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-						}
+                        const { undercoverMode } = this.context || {};
+                        return (
+                                <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                        <div className="flex items-center">
+                                                <WhiskerMenu />
+                                                <PerformanceGraph />
+                                                {undercoverMode ? (
+                                                        <div className="ml-3 hidden sm:flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.25em] text-sky-100">
+                                                                <WindowsLogo className="h-4 w-4 text-sky-200" ariaHidden />
+                                                                <span>Undercover active</span>
+                                                        </div>
+                                                ) : null}
+                                        </div>
+                                        <div
+                                                className={
+                                                        'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                }
 					>
 						<Clock />
 					</div>

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -1,6 +1,8 @@
 import React, { useState } from 'react'
 import Image from 'next/image'
 import SideBarApp from '../base/side_bar_app';
+import { useSettings } from '../../hooks/useSettings';
+import WindowsLogo from '../common/WindowsLogo';
 
 let renderApps = (props) => {
     let sideBarAppsJsx = [];
@@ -49,6 +51,8 @@ export default function SideBar(props) {
 export function AllApps(props) {
 
     const [title, setTitle] = useState(false);
+    const { undercoverMode } = useSettings();
+    const label = undercoverMode ? 'Open Start menu' : 'Show Applications';
 
     return (
         <div
@@ -61,23 +65,29 @@ export function AllApps(props) {
                 setTitle(false);
             }}
             onClick={props.showApps}
+            role="button"
+            aria-label={label}
         >
             <div className="relative">
-                <Image
-                    width={28}
-                    height={28}
-                    className="w-7"
-                    src="/themes/Yaru/system/view-app-grid-symbolic.svg"
-                    alt="Ubuntu view app"
-                    sizes="28px"
-                />
+                {undercoverMode ? (
+                    <WindowsLogo className="w-7 h-7 text-sky-200" ariaHidden />
+                ) : (
+                    <Image
+                        width={28}
+                        height={28}
+                        className="w-7"
+                        src="/themes/Yaru/system/view-app-grid-symbolic.svg"
+                        alt="Ubuntu view app"
+                        sizes="28px"
+                    />
+                )}
                 <div
                     className={
                         (title ? " visible " : " invisible ") +
                         " w-max py-0.5 px-1.5 absolute top-1 left-full ml-5 text-ubt-grey text-opacity-90 text-sm bg-ub-grey bg-opacity-70 border-gray-400 border border-opacity-40 rounded-md"
                     }
                 >
-                    Show Applications
+                    {label}
                 </div>
             </div>
         </div>

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -3,12 +3,17 @@
 import React, { useEffect, useState } from 'react'
 import { useSettings } from '../../hooks/useSettings';
 import KaliWallpaper from './kali-wallpaper';
+import UndercoverWallpaper from './undercover-wallpaper';
 
 export default function BackgroundImage() {
-    const { bgImageName, useKaliWallpaper } = useSettings();
+    const { bgImageName, useKaliWallpaper, undercoverMode } = useSettings();
     const [needsOverlay, setNeedsOverlay] = useState(false);
 
     useEffect(() => {
+        if (undercoverMode || bgImageName === 'undercover-windows') {
+            setNeedsOverlay(false);
+            return;
+        }
         if (useKaliWallpaper || bgImageName === 'kali-gradient') {
             setNeedsOverlay(false);
             return;
@@ -39,11 +44,13 @@ export default function BackgroundImage() {
             const contrast = (1.05) / (lum + 0.05); // white text luminance is 1
             setNeedsOverlay(contrast < 4.5);
         };
-    }, [bgImageName, useKaliWallpaper]);
+    }, [bgImageName, useKaliWallpaper, undercoverMode]);
 
     return (
         <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
-            {useKaliWallpaper || bgImageName === 'kali-gradient' ? (
+            {undercoverMode || bgImageName === 'undercover-windows' ? (
+                <UndercoverWallpaper />
+            ) : useKaliWallpaper || bgImageName === 'kali-gradient' ? (
                 <KaliWallpaper />
             ) : (
                 <>

--- a/components/util-components/undercover-wallpaper.js
+++ b/components/util-components/undercover-wallpaper.js
@@ -1,0 +1,46 @@
+"use client";
+
+import React from 'react';
+
+const BASE_LAYER = {
+  background: 'radial-gradient(circle at 20% 20%, rgba(62, 126, 214, 0.9) 0%, rgba(14, 37, 79, 0.92) 45%, rgba(4, 11, 24, 0.98) 100%)',
+};
+
+const LIGHT_CURVE = {
+  background:
+    'radial-gradient(circle at 80% 10%, rgba(96, 165, 250, 0.6) 0%, rgba(14, 37, 79, 0) 55%)',
+  mixBlendMode: 'screen',
+};
+
+const DARK_CURVE = {
+  background:
+    'radial-gradient(circle at 0% 80%, rgba(30, 64, 175, 0.65) 0%, rgba(15, 23, 42, 0.05) 55%, rgba(2, 6, 17, 0.1) 100%)',
+};
+
+const PANEL_OVERLAY = {
+  background: 'linear-gradient(145deg, rgba(12, 26, 48, 0.25) 0%, rgba(12, 26, 48, 0.75) 45%, rgba(8, 19, 38, 0.85) 100%)',
+};
+
+const GLOW_GRID = {
+  backgroundImage:
+    'radial-gradient(circle at center, rgba(148, 197, 255, 0.18) 0%, rgba(148, 197, 255, 0) 60%)',
+  mixBlendMode: 'screen',
+};
+
+export default function UndercoverWallpaper({ className = '' }) {
+  return (
+    <div className={`relative h-full w-full overflow-hidden ${className}`} aria-hidden="true">
+      <div className="absolute inset-0" style={BASE_LAYER} />
+      <div
+        className="absolute -left-1/4 top-[-5%] h-[140%] w-[70%] rotate-6 opacity-70 blur-3xl"
+        style={LIGHT_CURVE}
+      />
+      <div
+        className="absolute -right-1/3 bottom-[-15%] h-[150%] w-[85%] -rotate-3 opacity-60 blur-[140px]"
+        style={DARK_CURVE}
+      />
+      <div className="absolute inset-0 opacity-80" style={GLOW_GRID} />
+      <div className="absolute inset-0" style={PANEL_OVERLAY} />
+    </div>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -24,9 +24,49 @@
   accent-color: var(--color-control-accent);
 }
 
+:root.undercover {
+  --color-primary: #0f6ad6;
+  --color-secondary: rgba(15, 31, 58, 0.85);
+  --color-accent: #0f6ad6;
+  --color-muted: rgba(15, 25, 45, 0.72);
+  --color-surface: rgba(16, 32, 64, 0.86);
+  --color-inverse: #050810;
+  --color-border: rgba(148, 197, 255, 0.22);
+  --color-terminal: #7dd3fc;
+  --color-dark: rgba(7, 18, 36, 0.94);
+  --color-focus-ring: #3b82f6;
+  --color-selection: rgba(59, 130, 246, 0.32);
+  --color-control-accent: #0f6ad6;
+  accent-color: var(--color-control-accent);
+}
+
 body {
   background: var(--kali-bg);
   color: var(--kali-text);
+}
+
+:root.undercover body {
+  background: rgba(10, 22, 44, 0.82);
+  color: #f8fafc;
+}
+
+:root.undercover .main-navbar-vp {
+  backdrop-filter: blur(18px);
+  background-color: rgba(11, 25, 47, 0.75);
+  border-bottom: 1px solid rgba(148, 197, 255, 0.15);
+}
+
+:root.undercover .main-navbar-vp button {
+  color: #e2e8f0;
+}
+
+:root.undercover .main-navbar-vp button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-bottom-color: transparent;
+}
+
+:root.undercover .windowMainScreen {
+  background-color: rgba(12, 28, 54, 0.85);
 }
 
 /* Dark theme */

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -82,6 +82,46 @@
   --focus-outline-width: 2px;
 }
 
+:root.undercover {
+  --color-ub-grey: #0b1729;
+  --color-ub-warm-grey: #8ca6c9;
+  --color-ub-cool-grey: rgba(15, 23, 42, 0.92);
+  --color-ub-orange: #0f6ad6;
+  --color-ub-lite-abrgn: rgba(17, 36, 68, 0.88);
+  --color-ub-med-abrgn: rgba(12, 28, 54, 0.92);
+  --color-ub-drk-abrgn: rgba(8, 19, 38, 0.94);
+  --color-ub-window-title: rgba(10, 25, 45, 0.95);
+  --color-ubt-grey: #f4f7fb;
+  --color-ubt-warm-grey: #dbe4f4;
+  --color-ubt-cool-grey: #1e293b;
+  --color-ubt-blue: #60a5fa;
+  --color-ubt-green: #38d0a4;
+  --color-ubt-gedit-orange: #f59e0b;
+  --color-ubt-gedit-blue: #38bdf8;
+  --color-ubt-gedit-dark: #1d4ed8;
+  --color-ub-border-orange: #0b4aa2;
+  --color-ub-dark-grey: #1b2f4d;
+  --color-bg: #0a1528;
+  --color-text: #f1f5ff;
+  --kali-bg: rgba(10, 25, 50, 0.85);
+  --kali-blue: #0f6ad6;
+  --kali-blue-dark: #0b4aa2;
+  --kali-blue-glow: rgba(96, 165, 250, 0.35);
+  --kali-bg-solid: #0a1528;
+  --kali-panel: rgba(14, 30, 58, 0.88);
+  --kali-panel-border: rgba(255, 255, 255, 0.12);
+  --kali-panel-highlight: rgba(255, 255, 255, 0.06);
+  --game-color-secondary: #2563eb;
+  --game-color-success: #22c55e;
+  --game-color-warning: #f59e0b;
+  --game-color-danger: #ef4444;
+  --color-window-border: rgba(148, 197, 255, 0.25);
+  --color-window-accent: #0f6ad6;
+  --font-family-base: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  --focus-outline-color: #3b82f6;
+  --shadow-2: 0 16px 40px rgba(15, 76, 129, 0.35);
+}
+
 /* High contrast theme */
 .high-contrast {
   --color-bg: #000000;

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -15,6 +15,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  undercoverMode: false,
 };
 
 export async function getAccent() {
@@ -114,6 +115,17 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getUndercoverMode() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.undercoverMode;
+  const stored = window.localStorage.getItem('undercover-mode');
+  return stored === null ? DEFAULT_SETTINGS.undercoverMode : stored === 'true';
+}
+
+export async function setUndercoverMode(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('undercover-mode', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -150,6 +162,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
   window.localStorage.removeItem('use-kali-wallpaper');
+  window.localStorage.removeItem('undercover-mode');
 }
 
 export async function exportSettings() {
@@ -191,6 +204,7 @@ export async function exportSettings() {
     allowNetwork,
     haptics,
     useKaliWallpaper,
+    undercoverMode,
     theme,
   });
 }
@@ -216,6 +230,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    undercoverMode,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -229,6 +244,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (undercoverMode !== undefined) await setUndercoverMode(undercoverMode);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add an Undercover mode flag to the global settings store and persist it across sessions
- apply a Windows-inspired wallpaper, badge, and palette when the undercover skin is toggled on
- refresh the Settings UI, sidebar launcher, and start menu to expose the Undercover toggle and iconography

## Testing
- yarn lint *(fails: repository contains pre-existing accessibility rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d812c8e3e883288ebd300a488e7576