### PR TITLE
[terminal] add profile presets and opacity control

### DIFF
--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -9,9 +9,10 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
     <div
       ref={ref}
       data-testid="xterm-container"
-      className={`text-white ${className}`}
+      className={className}
       style={{
-        background: 'var(--kali-bg)',
+        backgroundColor: 'var(--kali-bg)',
+        color: 'inherit',
         backdropFilter: 'blur(4px)',
         border: '1px solid var(--color-border)',
         fontFamily: 'monospace',

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -22,10 +22,15 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getTerminalProfile as loadTerminalProfile,
+  setTerminalProfile as saveTerminalProfile,
+  getTerminalOpacity as loadTerminalOpacity,
+  setTerminalOpacity as saveTerminalOpacity,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
 type Density = 'regular' | 'compact';
+export type TerminalProfile = 'default' | 'lowContrast' | 'solarized';
 
 // Predefined accent palette exposed to settings UI
 export const ACCENT_OPTIONS = [
@@ -67,6 +72,8 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  terminalProfile: TerminalProfile;
+  terminalOpacity: number;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setUseKaliWallpaper: (value: boolean) => void;
@@ -79,6 +86,8 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setTerminalProfile: (value: TerminalProfile) => void;
+  setTerminalOpacity: (value: number) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -95,6 +104,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  terminalProfile: defaults.terminalProfile as TerminalProfile,
+  terminalOpacity: defaults.terminalOpacity,
   setAccent: () => {},
   setWallpaper: () => {},
   setUseKaliWallpaper: () => {},
@@ -107,6 +118,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setTerminalProfile: () => {},
+  setTerminalOpacity: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -122,6 +135,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [terminalProfile, setTerminalProfile] = useState<TerminalProfile>(
+    (defaults.terminalProfile as TerminalProfile) ?? 'default',
+  );
+  const [terminalOpacity, setTerminalOpacity] = useState<number>(
+    defaults.terminalOpacity ?? 0.85,
+  );
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -138,6 +157,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
       setTheme(loadTheme());
+      setTerminalProfile((await loadTerminalProfile()) as TerminalProfile);
+      setTerminalOpacity(await loadTerminalOpacity());
     })();
   }, []);
 
@@ -250,6 +271,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveTerminalProfile(terminalProfile);
+  }, [terminalProfile]);
+
+  useEffect(() => {
+    saveTerminalOpacity(terminalOpacity);
+  }, [terminalOpacity]);
+
   const bgImageName = useKaliWallpaper ? 'kali-gradient' : wallpaper;
 
   return (
@@ -268,6 +297,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        terminalProfile,
+        terminalOpacity,
         setAccent,
         setWallpaper,
         setUseKaliWallpaper,
@@ -280,6 +311,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setTerminalProfile,
+        setTerminalOpacity,
       }}
     >
       {children}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -15,6 +15,8 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  terminalProfile: 'default',
+  terminalOpacity: 0.85,
 };
 
 export async function getAccent() {
@@ -135,6 +137,28 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getTerminalProfile() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.terminalProfile;
+  return window.localStorage.getItem('terminal-profile') || DEFAULT_SETTINGS.terminalProfile;
+}
+
+export async function setTerminalProfile(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('terminal-profile', value);
+}
+
+export async function getTerminalOpacity() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.terminalOpacity;
+  const stored = window.localStorage.getItem('terminal-opacity');
+  const parsed = stored ? parseFloat(stored) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : DEFAULT_SETTINGS.terminalOpacity;
+}
+
+export async function setTerminalOpacity(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('terminal-opacity', String(value));
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -150,6 +174,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
   window.localStorage.removeItem('use-kali-wallpaper');
+  window.localStorage.removeItem('terminal-profile');
+  window.localStorage.removeItem('terminal-opacity');
 }
 
 export async function exportSettings() {
@@ -177,6 +203,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getTerminalProfile(),
+    getTerminalOpacity(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -192,6 +220,8 @@ export async function exportSettings() {
     haptics,
     useKaliWallpaper,
     theme,
+    terminalProfile,
+    terminalOpacity,
   });
 }
 
@@ -217,6 +247,8 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    terminalProfile,
+    terminalOpacity,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -230,6 +262,8 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (terminalProfile !== undefined) await setTerminalProfile(terminalProfile);
+  if (terminalOpacity !== undefined) await setTerminalOpacity(terminalOpacity);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add terminal profile presets with palette/font metadata and expose a toolbar selector for switching
- add a live terminal background opacity slider that updates the container and xterm theme
- persist the selected profile and opacity through the shared settings context and storage helpers

## Testing
- yarn lint *(fails: repository-wide accessibility and no-top-level-window violations present before changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d812c3de408328a31d58bf0b588287