### PR TITLE
[desktop] Improve terminal shortcuts

### DIFF
--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,8 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'New terminal window', keys: 'Ctrl+Shift+N' },
+  { description: 'Reopen last closed terminal tab', keys: 'Ctrl+Shift+T' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -222,6 +222,7 @@ export class Desktop extends Component {
         window.addEventListener('trash-change', this.updateTrashIcon);
         document.addEventListener('keydown', this.handleGlobalShortcut);
         window.addEventListener('open-app', this.handleOpenAppEvent);
+        window.addEventListener('terminal-new-window', this.handleTerminalNewWindow);
     }
 
     componentWillUnmount() {
@@ -229,6 +230,7 @@ export class Desktop extends Component {
         document.removeEventListener('keydown', this.handleGlobalShortcut);
         window.removeEventListener('trash-change', this.updateTrashIcon);
         window.removeEventListener('open-app', this.handleOpenAppEvent);
+        window.removeEventListener('terminal-new-window', this.handleTerminalNewWindow);
     }
 
     checkForNewFolders = () => {
@@ -746,6 +748,10 @@ export class Desktop extends Component {
             const { id, ...context } = detail;
             this.openApp(id, context);
         }
+    }
+
+    handleTerminalNewWindow = () => {
+        this.openApp('terminal');
     }
 
     openApp = (objId, params) => {


### PR DESCRIPTION
## Summary
- add tab history tracking so Ctrl+Shift+T restores the most recently closed tab
- dispatch a terminal window event from tabbed views and wire the desktop listener to open the terminal
- surface the new shortcuts in the keyboard overlay defaults

## Testing
- yarn lint *(fails: existing repo accessibility and lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d812c23d5c8328a1b4ed0413bfd0b6