### PR TITLE
[desktop] enable drag-to-trash undo workflow

### DIFF
--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import useTrashState from './state';
+import useTrashState, { TrashItem } from './state';
 import HistoryList from './components/HistoryList';
 
 const DEFAULT_ICON = '/themes/Yaru/system/folder.png';
 const EMPTY_ICON = '/themes/Yaru/status/user-trash-symbolic.svg';
 const FULL_ICON = '/themes/Yaru/status/user-trash-full-symbolic.svg';
 
-export default function Trash({ openApp }: { openApp: (id: string) => void }) {
+export default function Trash({ openApp: _openApp }: { openApp: (id: string) => void }) {
   const {
     items,
     setItems,
@@ -42,16 +42,19 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
   }, []);
 
   const notifyChange = () => window.dispatchEvent(new Event('trash-change'));
+  const dispatchRestore = (item: TrashItem) => {
+    window.dispatchEvent(new CustomEvent('restore-trash-item', { detail: item }));
+  };
 
   const restore = useCallback(() => {
     if (selected === null) return;
     const item = items[selected];
     if (!window.confirm(`Restore ${item.title}?`)) return;
-    openApp(item.id);
+    dispatchRestore(item);
     setItems(items => items.filter((_, i) => i !== selected));
     setSelected(null);
     notifyChange();
-  }, [items, selected, openApp, setItems]);
+  }, [items, selected, setItems, dispatchRestore]);
 
   const remove = useCallback(() => {
     if (selected === null) return;
@@ -81,7 +84,7 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
   const restoreAll = () => {
     if (items.length === 0) return;
     if (!window.confirm('Restore all windows?')) return;
-    items.forEach(item => openApp(item.id));
+    items.forEach(item => dispatchRestore(item));
     setItems([]);
     setSelected(null);
     notifyChange();

--- a/apps/trash/state.ts
+++ b/apps/trash/state.ts
@@ -7,6 +7,12 @@ export interface TrashItem {
   icon?: string;
   image?: string;
   closedAt: number;
+  source?: 'window' | 'desktop-icon' | string;
+  workspace?: number;
+  position?: { x: number; y: number };
+  desktopIndex?: number;
+  appIndex?: number;
+  payload?: unknown;
 }
 
 const ITEMS_KEY = 'window-trash';

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -7,12 +7,29 @@ export class UbuntuApp extends Component {
         this.state = { launching: false, dragging: false, prefetched: false };
     }
 
-    handleDragStart = () => {
+    handleDragStart = (event) => {
+        if (event && event.dataTransfer) {
+            try {
+                event.dataTransfer.effectAllowed = 'move';
+                event.dataTransfer.setData('application/x-ubuntu-app', JSON.stringify({
+                    type: 'desktop-app',
+                    id: this.props.id,
+                }));
+            } catch (e) {
+                // ignore data transfer errors
+            }
+        }
         this.setState({ dragging: true });
+        if (typeof this.props.onDragStart === 'function') {
+            this.props.onDragStart(event);
+        }
     }
 
-    handleDragEnd = () => {
+    handleDragEnd = (event) => {
         this.setState({ dragging: false });
+        if (typeof this.props.onDragEnd === 'function') {
+            this.props.onDragEnd(event);
+        }
     }
 
     openApp = () => {
@@ -41,7 +58,12 @@ export class UbuntuApp extends Component {
                 draggable
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
+                onDragOver={this.props.onDragOver}
+                onDragEnter={this.props.onDragEnter}
+                onDragLeave={this.props.onDragLeave}
+                onDrop={this.props.onDrop}
                 className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
+                    (this.props.isDropTarget ? " ring-2 ring-yellow-400 " : "") +
                     " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -396,13 +396,28 @@ export class Window extends Component {
         this.checkSnapPreview();
     }
 
-    handleStop = () => {
+    handleStop = (e, data) => {
         this.changeCursorToDefault();
         const snapPos = this.state.snapPosition;
         if (snapPos) {
             this.snapWindow(snapPos);
         } else {
             this.setState({ snapPreview: null, snapPosition: null });
+        }
+        if (this.props.onDropToTrash && data && data.node) {
+            const nodeRect = data.node.getBoundingClientRect();
+            const trash = document.getElementById('app-trash');
+            if (trash) {
+                const trashRect = trash.getBoundingClientRect();
+                const intersects =
+                    nodeRect.left < trashRect.right &&
+                    nodeRect.right > trashRect.left &&
+                    nodeRect.top < trashRect.bottom &&
+                    nodeRect.bottom > trashRect.top;
+                if (intersects) {
+                    this.props.onDropToTrash(this.id);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- allow desktop icons and windows to be dropped onto the Trash, persisting metadata for undo/restore flows
- add desktop toast notifications with Undo actions when windows or shortcuts move to the Trash
- update Trash experiences to dispatch restore events and recognize extended TrashItem metadata

## Testing
- `yarn lint` *(fails: repository already has numerous jsx-a11y/control-has-associated-label errors)*
- `yarn test` *(fails: existing suites such as __tests__/nmapNse.test.tsx and Modal.test.tsx currently break on main)*

------
https://chatgpt.com/codex/tasks/task_e_68d812be0a9c8328bebfe4fc01624b6f