### PR TITLE
[terminal] respect folder context when launching terminal

### DIFF
--- a/__tests__/terminal.test.tsx
+++ b/__tests__/terminal.test.tsx
@@ -40,6 +40,10 @@ import TerminalTabs from '../apps/terminal/tabs';
 describe('Terminal component', () => {
   const openApp = jest.fn();
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders container and exposes runCommand', async () => {
     const ref = createRef<any>();
     render(<Terminal ref={ref} openApp={openApp} />);
@@ -59,6 +63,15 @@ describe('Terminal component', () => {
       ref.current.runCommand('open calculator');
     });
     expect(openApp).toHaveBeenCalledWith('calculator');
+  });
+
+  it('shows contextual path in the prompt', async () => {
+    const ref = createRef<any>();
+    render(<Terminal ref={ref} openApp={openApp} context={{ path: '~/Projects' }} />);
+    await act(async () => {});
+    const { Terminal: TerminalMock } = require('@xterm/xterm');
+    const instance = TerminalMock.mock.results[TerminalMock.mock.results.length - 1].value;
+    expect(instance.writeln).toHaveBeenCalledWith(expect.stringContaining('~/Projects'));
   });
 
   it('supports tab management shortcuts', async () => {

--- a/apps/terminal/commands/types.ts
+++ b/apps/terminal/commands/types.ts
@@ -5,6 +5,7 @@ export interface CommandContext {
   aliases: Record<string, string>;
   setAlias: (name: string, value: string) => void;
   runWorker: (command: string) => Promise<void>;
+  cwd: string;
 }
 
 export type CommandHandler = (args: string, ctx: CommandContext) => void | Promise<void>;

--- a/apps/terminal/tabs/index.tsx
+++ b/apps/terminal/tabs/index.tsx
@@ -1,20 +1,32 @@
 'use client';
 
-import React, { useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import TabbedWindow, { TabDefinition } from '../../../components/ui/TabbedWindow';
 import Terminal, { TerminalProps } from '..';
 
-const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
+const TerminalTabs: React.FC<TerminalProps> = ({
+  openApp,
+  context,
+  path,
+  initialPath,
+}) => {
   const countRef = useRef(1);
 
-  const createTab = (): TabDefinition => {
+  const createTab = useCallback((): TabDefinition => {
     const id = Date.now().toString();
     return {
       id,
       title: `Session ${countRef.current++}`,
-      content: <Terminal openApp={openApp} />,
+      content: (
+        <Terminal
+          openApp={openApp}
+          context={context}
+          path={path}
+          initialPath={initialPath}
+        />
+      ),
     };
-  };
+  }, [context, initialPath, openApp, path]);
 
   return (
     <TabbedWindow

--- a/components/apps/terminal.tsx
+++ b/components/apps/terminal.tsx
@@ -1,26 +1,30 @@
 import dynamic from 'next/dynamic';
 import HelpPanel from '../HelpPanel';
+import type { TerminalProps } from '../../apps/terminal';
 
 // Lazily load the heavy terminal app with session tabs on the client only.
-const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
-  ssr: false,
-  loading: () => (
-    <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-      Loading Terminal...
-    </div>
-  ),
-});
+const TerminalApp = dynamic<TerminalProps>(
+  () => import('../../apps/terminal/tabs'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
+        Loading Terminal...
+      </div>
+    ),
+  },
+);
 
 /**
  * Wrapper component that ensures the terminal area can scroll when content
  * overflows. The actual indicator/scroll handling lives inside the terminal
  * app, this wrapper just provides the necessary container styles.
  */
-export default function Terminal() {
+export default function Terminal(props: TerminalProps) {
   return (
     <div className="h-full w-full overflow-y-auto">
       <HelpPanel appId="terminal" />
-      <TerminalApp />
+      <TerminalApp {...props} />
     </div>
   );
 }

--- a/utils/path-utils.ts
+++ b/utils/path-utils.ts
@@ -1,0 +1,103 @@
+export type DisplayPathBase = '~' | '/';
+
+export interface DisplayPathInfo {
+  base: DisplayPathBase;
+  segments: string[];
+}
+
+function normalizeInput(input?: string | null): string {
+  if (!input) return '';
+  return String(input).trim().replace(/\\/g, '/');
+}
+
+export function normalizeDisplayPath(input?: string | null): string {
+  const value = normalizeInput(input);
+  if (!value || value === '~') {
+    return '~';
+  }
+  if (value === '/') {
+    return '/';
+  }
+  if (value.startsWith('~/')) {
+    const rest = value.slice(2).replace(/^\/+/, '');
+    return rest ? `~/${rest}` : '~';
+  }
+  const stripped = value.replace(/^\/+/, '');
+  if (!stripped) {
+    return '/';
+  }
+  const parts = stripped.split('/').filter(Boolean);
+  if (parts.length >= 2 && parts[0] === 'home' && parts[1] === 'kali') {
+    const rest = parts.slice(2);
+    return rest.length ? `~/${rest.join('/')}` : '~';
+  }
+  return `/${parts.join('/')}`;
+}
+
+export function parseDisplayPath(input?: string | null): DisplayPathInfo {
+  const normalized = normalizeDisplayPath(input);
+  if (normalized === '~') {
+    return { base: '~', segments: [] };
+  }
+  if (normalized === '/') {
+    return { base: '/', segments: [] };
+  }
+  if (normalized.startsWith('~/')) {
+    return {
+      base: '~',
+      segments: normalized
+        .slice(2)
+        .split('/')
+        .filter(Boolean),
+    };
+  }
+  if (normalized.startsWith('/')) {
+    return {
+      base: '/',
+      segments: normalized
+        .slice(1)
+        .split('/')
+        .filter(Boolean),
+    };
+  }
+  return { base: '~', segments: [] };
+}
+
+export function formatDisplayPath(info: DisplayPathInfo): string {
+  if (info.segments.length === 0) {
+    return info.base;
+  }
+  if (info.base === '~') {
+    return `~/${info.segments.join('/')}`;
+  }
+  return `/${info.segments.join('/')}`;
+}
+
+export function toDisplayPath(input?: string | null): string {
+  return formatDisplayPath(parseDisplayPath(input));
+}
+
+export function appendPathSegment(
+  info: DisplayPathInfo,
+  segment: string,
+): DisplayPathInfo {
+  const clean = normalizeInput(segment).replace(/[\\/]/g, '');
+  if (!clean) {
+    return info;
+  }
+  return {
+    base: info.base,
+    segments: [...info.segments, clean],
+  };
+}
+
+export function sliceDisplayPath(
+  info: DisplayPathInfo,
+  depth: number,
+): DisplayPathInfo {
+  const safeDepth = Math.max(0, Math.min(depth, info.segments.length));
+  return {
+    base: info.base,
+    segments: info.segments.slice(0, safeDepth),
+  };
+}


### PR DESCRIPTION
## Summary
- add shared path helpers to normalize and extend display paths used across the desktop
- allow the terminal app to consume launch context, update prompts, and expose the resolved cwd to commands
- surface "Open Terminal Here" actions in the file explorer (including static fallback) and wire per-directory context menu buttons
- extend terminal tests to cover contextual prompt rendering

## Testing
- `yarn test --runTestsByPath __tests__/terminal.test.tsx` *(fails: yarn unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d812b7ba288328b1df5ad820db6555