### PR TITLE
[settings] Dynamic wallpaper picker and random daily option

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,18 +1,35 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 import KaliWallpaper from '../util-components/kali-wallpaper';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme, wallpapers: wallpaperAssets, randomDailyWallpaperId, randomDailyWallpaperFile, bgImageFile } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
 
-    const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
+    const wallpaperMap = useMemo(() => new Map(wallpaperAssets.map((asset) => [asset.id, asset.file])), [wallpaperAssets]);
+    const wallpaperOptions = useMemo(() => {
+        const ids = wallpaperAssets.map((asset) => asset.id);
+        const combined = [...ids, 'random-daily'];
+        return combined.filter((value, index) => combined.indexOf(value) === index);
+    }, [wallpaperAssets]);
+
+    const formatWallpaperLabel = useCallback((id) => {
+        if (id === 'random-daily') return 'Random daily';
+        if (id.startsWith('wall-')) return id.replace('wall-', 'wallpaper ');
+        return id.replace(/[-_]/g, ' ');
+    }, []);
+
+    const randomDailyLabel = useMemo(
+        () => (randomDailyWallpaperId ? formatWallpaperLabel(randomDailyWallpaperId) : null),
+        [randomDailyWallpaperId, formatWallpaperLabel]
+    );
 
     const changeBackgroundImage = (e) => {
         const name = e.currentTarget.dataset.path;
+        if (!name) return;
         setWallpaper(name);
     };
 
@@ -64,7 +81,7 @@ export function Settings() {
                 ) : (
                     <div
                         className="absolute inset-0 bg-cover bg-center"
-                        style={{ backgroundImage: `url(/wallpapers/${wallpaper}.webp)` }}
+                        style={bgImageFile ? { backgroundImage: `url(/wallpapers/${bgImageFile})` } : undefined}
                         aria-hidden="true"
                     />
                 )}
@@ -223,26 +240,52 @@ export function Settings() {
             </div>
             <div className="flex flex-wrap justify-center items-center border-t border-gray-900">
                 {
-                    wallpapers.map((name, index) => (
-                        <div
-                            key={name}
-                            role="button"
-                            aria-label={`Select ${name.replace('wall-', 'wallpaper ')}`}
-                            aria-pressed={name === wallpaper}
-                            tabIndex="0"
-                            onClick={changeBackgroundImage}
-                            onFocus={changeBackgroundImage}
-                            onKeyDown={(e) => {
-                                if (e.key === 'Enter' || e.key === ' ') {
-                                    e.preventDefault();
-                                    changeBackgroundImage(e);
-                                }
-                            }}
-                            data-path={name}
-                            className={((name === wallpaper) ? " border-yellow-700 " : " border-transparent ") + " md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80"}
-                            style={{ backgroundImage: `url(/wallpapers/${name}.webp)`, backgroundSize: "cover", backgroundRepeat: "no-repeat", backgroundPosition: "center center" }}
-                        ></div>
-                    ))
+                    wallpaperOptions.map((name) => {
+                        const isRandom = name === 'random-daily';
+                        const file = isRandom ? randomDailyWallpaperFile : wallpaperMap.get(name);
+                        const label = formatWallpaperLabel(name);
+                        const isActive = name === wallpaper;
+                        const style = {
+                            backgroundImage: file ? `url(/wallpapers/${file})` : undefined,
+                            backgroundSize: 'cover',
+                            backgroundRepeat: 'no-repeat',
+                            backgroundPosition: 'center center',
+                        };
+
+                        return (
+                            <div
+                                key={name}
+                                role="button"
+                                aria-label={`Select ${label}`}
+                                aria-pressed={isActive}
+                                tabIndex="0"
+                                onClick={changeBackgroundImage}
+                                onFocus={changeBackgroundImage}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        changeBackgroundImage(e);
+                                    }
+                                }}
+                                data-path={name}
+                                className={((isActive) ? ' border-yellow-700 ' : ' border-transparent ') + ' md:px-28 md:py-20 md:m-4 m-2 px-14 py-10 outline-none border-4 border-opacity-80 flex flex-col justify-end'}
+                                style={style}
+                                title={label}
+                            >
+                                <span className="sr-only">{label}</span>
+                                {isRandom && (
+                                    <div className="mt-2 text-xs font-medium text-white bg-black/60 px-2 py-1 rounded self-center">
+                                        Random daily
+                                        {randomDailyLabel && (
+                                            <span className="block text-[10px] font-normal text-white/80">
+                                                Today: {randomDailyLabel}
+                                            </span>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                        );
+                    })
                 }
             </div>
             <div className="flex justify-center my-4 border-t border-gray-900 pt-4 space-x-4">

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -5,7 +5,7 @@ import KaliWallpaper from '../util-components/kali-wallpaper';
 
 export default function LockScreen(props) {
 
-    const { bgImageName, useKaliWallpaper } = useSettings();
+    const { bgImageName, bgImageFile, useKaliWallpaper } = useSettings();
     const useKaliTheme = useKaliWallpaper || bgImageName === 'kali-gradient';
 
     if (props.isLocked) {
@@ -23,11 +23,13 @@ export default function LockScreen(props) {
                     className={`absolute top-0 left-0 h-full w-full transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
                 />
             ) : (
-                <img
-                    src={`/wallpapers/${bgImageName}.webp`}
-                    alt=""
-                    className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
-                />
+                bgImageFile && (
+                    <img
+                        src={`/wallpapers/${bgImageFile}`}
+                        alt=""
+                        className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                    />
+                )
             )}
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
                 <div className=" text-7xl">

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -5,16 +5,16 @@ import { useSettings } from '../../hooks/useSettings';
 import KaliWallpaper from './kali-wallpaper';
 
 export default function BackgroundImage() {
-    const { bgImageName, useKaliWallpaper } = useSettings();
+    const { bgImageName, bgImageFile, useKaliWallpaper } = useSettings();
     const [needsOverlay, setNeedsOverlay] = useState(false);
 
     useEffect(() => {
-        if (useKaliWallpaper || bgImageName === 'kali-gradient') {
+        if (useKaliWallpaper || bgImageName === 'kali-gradient' || !bgImageFile) {
             setNeedsOverlay(false);
             return;
         }
         const img = new Image();
-        img.src = `/wallpapers/${bgImageName}.webp`;
+        img.src = `/wallpapers/${bgImageFile}`;
         img.onload = () => {
             const canvas = document.createElement('canvas');
             canvas.width = img.width;
@@ -39,23 +39,25 @@ export default function BackgroundImage() {
             const contrast = (1.05) / (lum + 0.05); // white text luminance is 1
             setNeedsOverlay(contrast < 4.5);
         };
-    }, [bgImageName, useKaliWallpaper]);
+    }, [bgImageFile, bgImageName, useKaliWallpaper]);
 
     return (
         <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
             {useKaliWallpaper || bgImageName === 'kali-gradient' ? (
                 <KaliWallpaper />
             ) : (
-                <>
-                    <img
-                        src={`/wallpapers/${bgImageName}.webp`}
-                        alt=""
-                        className="w-full h-full object-cover"
-                    />
-                    {needsOverlay && (
-                        <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>
-                    )}
-                </>
+                bgImageFile && (
+                    <>
+                        <img
+                            src={`/wallpapers/${bgImageFile}`}
+                            alt=""
+                            className="w-full h-full object-cover"
+                        />
+                        {needsOverlay && (
+                            <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>
+                        )}
+                    </>
+                )
             )}
         </div>
     )

--- a/pages/api/wallpapers.js
+++ b/pages/api/wallpapers.js
@@ -2,12 +2,20 @@ import fs from 'fs';
 import path from 'path';
 
 export default function handler(req, res) {
-  const dir = path.join(process.cwd(), 'public', 'images', 'wallpapers');
+  const dir = path.join(process.cwd(), 'public', 'wallpapers');
   try {
     const files = fs
       .readdirSync(dir)
-      .filter((file) => /\.(?:png|jpe?g|webp|gif)$/i.test(file));
-    res.status(200).json(files);
+      .filter((file) => /\.(?:png|jpe?g|webp|gif|avif)$/i.test(file))
+      .map((file) => ({
+        id: path.parse(file).name,
+        file,
+      }));
+
+    const unique = Array.from(new Map(files.map((item) => [item.id, item])).values());
+    unique.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true, sensitivity: 'base' }));
+
+    res.status(200).json(unique);
   } catch {
     res.status(200).json([]);
   }


### PR DESCRIPTION
## Summary
- auto-discover wallpapers from `public/wallpapers` and expose wallpaper metadata through `useSettings`
- add a random daily wallpaper mode with override support and live preview updates
- update settings screens, slideshow picker, and background renderers to use dynamic wallpaper files

## Testing
- yarn lint *(fails: existing accessibility and lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d812b541ac8328867bab6e0d39128f