### PR TITLE
[desktop] add grid layout sorting and rename

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -7,16 +7,40 @@ export class UbuntuApp extends Component {
         this.state = { launching: false, dragging: false, prefetched: false };
     }
 
-    handleDragStart = () => {
+    handleDragStart = (event) => {
+        if (this.props.renaming) return;
+        if (event && event.dataTransfer) {
+            event.dataTransfer.setData('text/plain', this.props.id);
+            event.dataTransfer.effectAllowed = 'move';
+        }
         this.setState({ dragging: true });
+        if (typeof this.props.onDragStart === 'function') {
+            this.props.onDragStart(this.props.id);
+        }
     }
 
     handleDragEnd = () => {
         this.setState({ dragging: false });
+        if (typeof this.props.onDragEnd === 'function') {
+            this.props.onDragEnd(this.props.id);
+        }
+    }
+
+    handleKeyDown = (e) => {
+        if (this.props.renaming) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            this.openApp();
+            return;
+        }
+        if (e.key === 'F2' && typeof this.props.onRequestRename === 'function') {
+            e.preventDefault();
+            this.props.onRequestRename(this.props.id);
+        }
     }
 
     openApp = () => {
-        if (this.props.disabled) return;
+        if (this.props.disabled || this.props.renaming) return;
         this.setState({ launching: true }, () => {
             setTimeout(() => this.setState({ launching: false }), 300);
         });
@@ -30,25 +54,86 @@ export class UbuntuApp extends Component {
         }
     }
 
+    handleRenameKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            if (typeof this.props.onRenameCancel === 'function') {
+                this.props.onRenameCancel();
+            }
+        }
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            if (typeof this.props.onRenameSubmit === 'function') {
+                this.props.onRenameSubmit();
+            }
+        }
+    }
+
+    renderName = () => {
+        if (!this.props.renaming) {
+            return (
+                <span className="text-center leading-tight line-clamp-2">
+                    {this.props.displayName || this.props.name}
+                </span>
+            );
+        }
+
+        return (
+            <form
+                className="w-full mt-1"
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    if (typeof this.props.onRenameSubmit === 'function') {
+                        this.props.onRenameSubmit();
+                    }
+                }}
+            >
+                <input
+                    type="text"
+                    autoFocus
+                    value={this.props.renameValue}
+                    onChange={(e) => this.props.onRenameChange?.(e.target.value)}
+                    onBlur={() => this.props.onRenameSubmit?.()}
+                    onKeyDown={this.handleRenameKeyDown}
+                    className="w-full rounded bg-black bg-opacity-40 text-white text-xs px-1 py-0.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                    spellCheck={false}
+                />
+            </form>
+        );
+    }
+
     render() {
+        const isDisabled = this.props.disabled;
+        const isSelected = this.props.selected;
+        const className = [
+            this.state.launching ? 'app-icon-launch' : '',
+            this.state.dragging ? 'opacity-70' : '',
+            'p-1 m-px z-10 rounded select-none w-24 h-24 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition hover:bg-opacity-20 focus:border-yellow-700 focus:border-opacity-100 border outline-none',
+            isSelected ? 'bg-white bg-opacity-20 border border-blue-400 focus:bg-white focus:bg-opacity-30' : 'bg-white bg-opacity-0 border border-transparent hover:bg-white focus:bg-white focus:bg-opacity-30'
+        ].filter(Boolean).join(' ');
+
         return (
             <div
                 role="button"
                 aria-label={this.props.name}
-                aria-disabled={this.props.disabled}
+                aria-disabled={isDisabled}
                 data-context="app"
                 data-app-id={this.props.id}
-                draggable
+                draggable={!this.props.renaming}
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
-                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                className={className}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
-                tabIndex={this.props.disabled ? -1 : 0}
+                onKeyDown={this.handleKeyDown}
+                tabIndex={isDisabled ? -1 : 0}
                 onMouseEnter={this.handlePrefetch}
-                onFocus={this.handlePrefetch}
+                onFocus={(event) => {
+                    this.handlePrefetch();
+                    this.props.onSelect?.(this.props.id, event);
+                }}
+                onClick={(event) => this.props.onSelect?.(this.props.id, event)}
+                style={this.props.style}
             >
                 <Image
                     width={40}
@@ -58,8 +143,7 @@ export class UbuntuApp extends Component {
                     alt={"Kali " + this.props.name}
                     sizes="40px"
                 />
-                {this.props.displayName || this.props.name}
-
+                {this.renderName()}
             </div>
         )
     }

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -3,6 +3,12 @@ import logger from '../../utils/logger'
 
 function DesktopMenu(props) {
 
+    const sortOptions = [
+        { id: 'name', label: 'Name' },
+        { id: 'type', label: 'Type' },
+        { id: 'date', label: 'Date' },
+    ];
+
     const [isFullScreen, setIsFullScreen] = useState(false)
 
     useEffect(() => {
@@ -67,6 +73,36 @@ function DesktopMenu(props) {
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
                 <span className="ml-5">Create Shortcut...</span>
+            </button>
+            <Devider />
+            <div className="text-[0.65rem] uppercase tracking-wide text-gray-300 px-5 pb-1">Sort by</div>
+            {sortOptions.map((option) => {
+                const active = props.sortMode === option.id;
+                return (
+                    <button
+                        key={option.id}
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={active}
+                        onClick={() => props.onChangeSort?.(option.id)}
+                        className={`w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 ${active ? 'font-medium' : ''}`}
+                    >
+                        <span className="ml-5 flex items-center gap-2">
+                            <span className="w-2 text-center">{active ? '•' : ''}</span>
+                            <span>{option.label}</span>
+                        </span>
+                    </button>
+                );
+            })}
+            <button
+                type="button"
+                role="menuitem"
+                aria-label="Undo Rename"
+                disabled={!props.canUndoRename}
+                onClick={() => props.canUndoRename && props.onUndoRename?.()}
+                className={`w-full text-left py-0.5 mb-1.5 ${props.canUndoRename ? 'hover:bg-ub-warm-grey hover:bg-opacity-20' : 'text-gray-400 cursor-default'}`}
+            >
+                <span className="ml-5">Undo Rename</span>
             </button>
             <Devider />
             <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">


### PR DESCRIPTION
## Summary
- add a persistent grid-based layout for desktop icons with drag-and-drop reordering
- support name/type/date sorting plus inline renaming with undo behaviour
- persist icon metadata in localStorage so layouts and custom labels survive reloads

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window lint violations in unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d812b4e0c88328a61d95bcc050d81d