### PR TITLE
[desktop] Improve window focus visuals

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -657,7 +657,7 @@ export class Window extends Component {
                             this.props.isFocused ? 'z-30' : 'z-20',
                             'opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute flex flex-col window-shadow',
                             styles.windowFrame,
-                            this.props.isFocused ? styles.windowFrameActive : styles.windowFrameInactive,
+                            this.props.isFocused ? styles.windowFrameFocused : styles.windowFrameDimmed,
                             this.state.maximized ? styles.windowFrameMaximized : '',
                         ].filter(Boolean).join(' ')}
                         id={this.id}

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -4,6 +4,7 @@
   border-radius: var(--radius-6);
   box-shadow: var(--shadow-2);
   overflow: hidden;
+  outline: none;
   transition: filter var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
 }
 
@@ -23,12 +24,19 @@
   z-index: 2;
 }
 
-.windowFrameActive::before {
+.windowFrameFocused {
+  box-shadow:
+    0 18px 48px rgba(3, 7, 15, 0.5),
+    0 0 0 calc(var(--focus-outline-width) + 1px) color-mix(in srgb, var(--focus-outline-color) 85%, transparent),
+    0 0 0 calc(var(--focus-outline-width) * 3) color-mix(in srgb, var(--focus-outline-color) 30%, transparent);
+}
+
+.windowFrameFocused::before {
   opacity: 1;
 }
 
-.windowFrameInactive {
-  filter: brightness(0.85);
+.windowFrameDimmed {
+  filter: brightness(0.88);
 }
 
 .windowFrameMaximized {


### PR DESCRIPTION
## Summary
- add an elevated focus outline and accent glow to desktop windows
- slightly dim unfocused windows to reinforce hierarchy

## Testing
- npx eslint components/base/window.js

------
https://chatgpt.com/codex/tasks/task_e_68d812b272948328a36778ad9997b61c