### PR TITLE
[desktop] refine escape handling

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -567,3 +567,62 @@ describe('Window overlay inert behaviour', () => {
     document.body.removeChild(opener);
   });
 });
+
+describe('Escape key handling', () => {
+  it('ignores Escape for persistent windows', () => {
+    jest.useFakeTimers();
+    const closed = jest.fn();
+
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={closed}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Test' });
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(closed).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it('closes transient windows when Escape is pressed', () => {
+    jest.useFakeTimers();
+    const closed = jest.fn();
+
+    render(
+      <Window
+        id="test-window"
+        title="Test"
+        screen={() => <div>content</div>}
+        focus={() => {}}
+        hasMinimised={() => {}}
+        closed={closed}
+        hideSideBar={() => {}}
+        openApp={() => {}}
+        closeOnEscape
+      />
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Test' });
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(closed).toHaveBeenCalledWith('test-window');
+    jest.useRealTimers();
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -625,6 +625,7 @@ const apps = [
     screen: displayCalculator,
     resizable: false,
     allowMaximize: false,
+    closeOnEscape: true,
     defaultWidth: 28,
     defaultHeight: 50,
   },

--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -87,10 +87,14 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
     }, []);
 
     useEffect(() => {
-        inertRootRef.current = getOverlayRoot();
+        const overlayEl = getOverlayRoot();
+        inertRootRef.current = overlayEl;
+
         if (isOpen) {
-            triggerRef.current = document.activeElement as HTMLElement;
-            inertRootRef.current?.setAttribute('inert', '');
+            if (!triggerRef.current) {
+                triggerRef.current = document.activeElement as HTMLElement;
+            }
+            overlayEl?.setAttribute('inert', '');
             const elements = modalRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
             if (elements && elements.length > 0) {
                 elements[0].focus();
@@ -98,12 +102,18 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
                 modalRef.current?.focus();
             }
         } else {
-            inertRootRef.current?.removeAttribute('inert');
-            triggerRef.current?.focus();
-            triggerRef.current = null;
+            overlayEl?.removeAttribute('inert');
         }
+
         return () => {
-            inertRootRef.current?.removeAttribute('inert');
+            overlayEl?.removeAttribute('inert');
+            if (triggerRef.current && typeof triggerRef.current.focus === 'function') {
+                const target = triggerRef.current;
+                triggerRef.current = null;
+                if (document.contains(target)) {
+                    target.focus();
+                }
+            }
         };
     }, [isOpen, getOverlayRoot]);
 

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -549,9 +549,50 @@ export class Window extends Component {
         }
     }
 
+    isTransientWindow = () => {
+        if (typeof this.props.closeOnEscape === 'boolean') {
+            return this.props.closeOnEscape;
+        }
+
+        const disableMaximize = this.props.allowMaximize === false;
+        const disableResize = this.props.resizable === false;
+
+        if (!(disableMaximize && disableResize)) {
+            return false;
+        }
+
+        const width = typeof this.props.defaultWidth === 'number' ? this.props.defaultWidth : this.state.width;
+        const height = typeof this.props.defaultHeight === 'number' ? this.props.defaultHeight : this.state.height;
+
+        const compactWidth = typeof width === 'number' && width <= 40;
+        const compactHeight = typeof height === 'number' && height <= 50;
+
+        return compactWidth || compactHeight;
+    }
+
     handleKeyDown = (e) => {
         if (e.key === 'Escape') {
-            this.closeWindow();
+            const isTransient = this.isTransientWindow();
+
+            if (this.state.grabbed) {
+                e.preventDefault();
+                e.stopPropagation();
+                this.releaseGrab();
+                this.focusWindow();
+                if (!isTransient) {
+                    return;
+                }
+            }
+
+            if (isTransient) {
+                e.preventDefault();
+                e.stopPropagation();
+                this.closeWindow();
+            } else {
+                e.preventDefault();
+                e.stopPropagation();
+                this.focusWindow();
+            }
         } else if (e.key === 'Tab') {
             this.focusWindow();
         } else if (e.altKey) {

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -633,6 +633,7 @@ export class Desktop extends Component {
                     allowMaximize: app.allowMaximize,
                     defaultWidth: app.defaultWidth,
                     defaultHeight: app.defaultHeight,
+                    closeOnEscape: app.closeOnEscape,
                     initialX: pos ? pos.x : undefined,
                     initialY: pos ? pos.y : undefined,
                     onPositionChange: (x, y) => this.updateWindowPosition(app.id, x, y),


### PR DESCRIPTION
## Summary
- gate Escape-based closing behind a transient window flag and release drags for persistent windows
- ensure modals restore focus to their triggering control when they unmount
- cover the new Escape behavior with targeted window tests

## Testing
- [x] CI=1 yarn test --runTestsByPath __tests__/window.test.tsx __tests__/Modal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d812b1b86083288cbb5ce80108ff52