### PR TITLE
[desktop] expose window snap toggle

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -4,7 +4,7 @@ import { resetSettings, defaults, exportSettings as exportSettingsData, importSe
 import KaliWallpaper from '../util-components/kali-wallpaper';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme, snapEnabled, setSnapEnabled } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -171,6 +171,22 @@ export function Settings() {
                 </label>
             </div>
             <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-start">
+                    <input
+                        type="checkbox"
+                        checked={snapEnabled}
+                        onChange={(e) => setSnapEnabled(e.target.checked)}
+                        className="mr-2 mt-1"
+                    />
+                    <span>
+                        Window Snap Grid
+                        <span className="block text-xs text-ubt-grey/70">
+                            Keep windows aligned to an 8px grid when enabled. Turn this off for free-form dragging.
+                        </span>
+                    </span>
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
                         type="checkbox"
@@ -277,6 +293,7 @@ export function Settings() {
                         setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
+                        setSnapEnabled(defaults.snapEnabled);
                         setTheme('default');
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
@@ -301,6 +318,7 @@ export function Settings() {
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
+                        if (parsed.snapEnabled !== undefined) setSnapEnabled(parsed.snapEnabled);
                         if (parsed.theme !== undefined) { setTheme(parsed.theme); }
                     } catch (err) {
                         console.error('Invalid settings', err);

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1179,6 +1179,8 @@ export class Desktop extends Component {
 }
 
 export default function DesktopWithSnap(props) {
-    const [snapEnabled] = useSnapSetting();
-    return <Desktop {...props} snapEnabled={snapEnabled} />;
+    const { snapEnabled: snapEnabledProp, ...rest } = props;
+    const [snapEnabledState] = useSnapSetting();
+    const snapEnabled = snapEnabledProp ?? snapEnabledState;
+    return <Desktop {...rest} snapEnabled={snapEnabled} />;
 }

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -7,6 +7,7 @@ import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
+import { SettingsContext } from '../hooks/useSettings';
 
 export default class Ubuntu extends Component {
 	constructor() {
@@ -18,6 +19,8 @@ export default class Ubuntu extends Component {
 			shutDownScreen: false
 		};
 	}
+
+	static contextType = SettingsContext;
 
 	componentDidMount() {
 		this.getLocalData();
@@ -114,20 +117,25 @@ export default class Ubuntu extends Component {
 	};
 
 	render() {
+		const { snapEnabled = true } = this.context || {};
 		return (
 			<div className="w-screen h-screen overflow-hidden" id="monitor-screen">
 				<LockScreen
 					isLocked={this.state.screen_locked}
 					bgImgName={this.state.bg_image_name}
 					unLockScreen={this.unLockScreen}
-				/>
+					/>
 				<BootingScreen
 					visible={this.state.booting_screen}
 					isShutDown={this.state.shutDownScreen}
 					turnOn={this.turnOn}
 				/>
 				<Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-				<Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
+				<Desktop
+				bg_image_name={this.state.bg_image_name}
+				changeBackgroundImage={this.changeBackgroundImage}
+				snapEnabled={snapEnabled}
+				/>
 			</div>
 		);
 	}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -22,6 +22,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getSnapEnabled as loadSnapEnabled,
+  setSnapEnabled as saveSnapEnabled,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -66,6 +68,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  snapEnabled: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -78,6 +81,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setSnapEnabled: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -94,6 +98,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  snapEnabled: defaults.snapEnabled,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -106,6 +111,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setSnapEnabled: () => {},
   setTheme: () => {},
 });
 
@@ -121,6 +127,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [snapEnabled, setSnapEnabled] = useState<boolean>(defaults.snapEnabled);
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -137,6 +144,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setSnapEnabled(await loadSnapEnabled());
       setTheme(loadTheme());
     })();
   }, []);
@@ -250,6 +258,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveSnapEnabled(snapEnabled);
+  }, [snapEnabled]);
+
   const bgImageName = useKaliWallpaper ? 'kali-gradient' : wallpaper;
 
   return (
@@ -267,6 +279,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        snapEnabled,
         theme,
         setAccent,
         setWallpaper,
@@ -279,6 +292,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setSnapEnabled,
         setTheme,
       }}
     >

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -15,6 +15,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  snapEnabled: true,
 };
 
 export async function getAccent() {
@@ -135,6 +136,23 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getSnapEnabled() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.snapEnabled;
+  const stored = window.localStorage.getItem('snap-enabled');
+  if (stored === null) return DEFAULT_SETTINGS.snapEnabled;
+  try {
+    return JSON.parse(stored);
+  } catch (e) {
+    console.error('Invalid snap setting', e);
+    return DEFAULT_SETTINGS.snapEnabled;
+  }
+}
+
+export async function setSnapEnabled(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('snap-enabled', JSON.stringify(!!value));
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -150,6 +168,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
   window.localStorage.removeItem('use-kali-wallpaper');
+  window.localStorage.removeItem('snap-enabled');
 }
 
 export async function exportSettings() {
@@ -165,6 +184,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    snapEnabled,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -177,6 +197,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getSnapEnabled(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -191,6 +212,7 @@ export async function exportSettings() {
     allowNetwork,
     haptics,
     useKaliWallpaper,
+    snapEnabled,
     theme,
   });
 }
@@ -216,6 +238,7 @@ export async function importSettings(json) {
     pongSpin,
     allowNetwork,
     haptics,
+    snapEnabled,
     theme,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
@@ -229,6 +252,7 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (snapEnabled !== undefined) await setSnapEnabled(snapEnabled);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add a window snap grid toggle to the Settings app so users can enable or disable snapping
- persist the snap-enabled preference alongside other desktop settings and pass it into the desktop shell
- allow DesktopWithSnap to accept an injected snap state for consumers that already have the setting

## Testing
- yarn test window

------
https://chatgpt.com/codex/tasks/task_e_68d812afebfc832886b98d85643365b4