### PR TITLE
[desktop] Support window shading toggle

### DIFF
--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -39,6 +39,15 @@
   border-radius: 0;
 }
 
+.windowFrameShaded {
+  min-height: 0 !important;
+  height: auto !important;
+}
+
+.windowFrameShaded .windowMainScreen {
+  display: none;
+}
+
 .windowTitlebar {
   height: 28px;
   border-top-left-radius: calc(var(--radius-6) - 1px);


### PR DESCRIPTION
## Summary
- add a per-window shaded state toggled with Alt+double-click on the title bar
- collapse window content to the title bar height and restore prior dimensions when unshaded
- prevent conflicts with snap and maximize logic and hide content styling when shaded

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label and no-top-level-window violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d812aa8470832881948d7865b4d4a5