### PR TITLE
[desktop] Improve window switcher UX

### DIFF
--- a/__tests__/windowSwitcherEvents.test.tsx
+++ b/__tests__/windowSwitcherEvents.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { createEvent, fireEvent, render } from '@testing-library/react';
+import WindowSwitcher from '../components/screen/window-switcher';
+import { Desktop } from '../components/screen/desktop';
+
+describe('Window switcher keyboard safety', () => {
+  const baseWindows = [
+    { id: 'terminal', title: 'Terminal', icon: '/icon-a.png' },
+    { id: 'browser', title: 'Browser', icon: '/icon-b.png' },
+  ];
+
+  it('prevents key events from reaching underlying apps while navigating', () => {
+    const onSelect = jest.fn();
+    const onClose = jest.fn();
+    const { getByPlaceholderText } = render(
+      <WindowSwitcher windows={baseWindows} onSelect={onSelect} onClose={onClose} />
+    );
+
+    const input = getByPlaceholderText(/search windows/i);
+    const event = createEvent.keyDown(input, { key: 'ArrowRight' });
+    const preventDefault = jest.fn();
+    const stopPropagation = jest.fn();
+    event.preventDefault = preventDefault;
+    event.stopPropagation = stopPropagation;
+    fireEvent(input, event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('prevents Alt release from leaking to focused apps', () => {
+    const desktop = new Desktop();
+    desktop.state.showWindowSwitcher = true;
+    desktop.windowSwitcherRef.current = {
+      confirmSelection: jest.fn(() => ({ id: 'terminal' })),
+    } as any;
+
+    const preventDefault = jest.fn();
+    const stopPropagation = jest.fn();
+    desktop.handleGlobalShortcut({
+      type: 'keyup',
+      key: 'Alt',
+      preventDefault,
+      stopPropagation,
+    } as any);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(desktop.windowSwitcherRef.current?.confirmSelection).toHaveBeenCalled();
+  });
+
+  it('opens the switcher without propagating Alt+Tab', () => {
+    const desktop = new Desktop();
+    const openSpy = jest
+      .spyOn(desktop, 'openWindowSwitcher')
+      .mockImplementation(() => true);
+
+    const preventDefault = jest.fn();
+    const stopPropagation = jest.fn();
+    desktop.handleGlobalShortcut({
+      type: 'keydown',
+      key: 'Tab',
+      altKey: true,
+      shiftKey: false,
+      preventDefault,
+      stopPropagation,
+    } as any);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(openSpy).toHaveBeenCalled();
+  });
+});

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -1,52 +1,108 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
-export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
+const WindowSwitcher = ({ windows = [], onSelect, onClose }, ref) => {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(0);
   const inputRef = useRef(null);
 
-  const filtered = windows.filter((w) =>
-    w.title.toLowerCase().includes(query.toLowerCase())
+  const filtered = useMemo(
+    () =>
+      windows.filter((w) =>
+        w.title.toLowerCase().includes(query.toLowerCase())
+      ),
+    [windows, query]
   );
+  const filteredLength = filtered.length;
 
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
 
   useEffect(() => {
-    const handleKeyUp = (e) => {
-      if (e.key === 'Alt') {
-        const win = filtered[selected];
-        if (win && typeof onSelect === 'function') {
-          onSelect(win.id);
-        } else if (typeof onClose === 'function') {
-          onClose();
-        }
+    if (!filteredLength && selected !== 0) {
+      setSelected(0);
+      return;
+    }
+
+    if (filteredLength && selected >= filteredLength) {
+      setSelected(filteredLength - 1);
+    }
+  }, [filteredLength, selected]);
+
+  const cycleSelection = useCallback(
+    (delta) => {
+      if (!filteredLength) return;
+      setSelected((prev) => {
+        const next = (prev + delta + filteredLength) % filteredLength;
+        return next;
+      });
+    },
+    [filteredLength]
+  );
+
+  const confirmSelection = useCallback(() => {
+    if (filteredLength && typeof onSelect === 'function') {
+      const index = Math.min(selected, filteredLength - 1);
+      const win = filtered[index];
+      if (win) {
+        onSelect(win.id);
+        return win;
       }
-    };
-    window.addEventListener('keyup', handleKeyUp);
-    return () => window.removeEventListener('keyup', handleKeyUp);
-  }, [filtered, selected, onSelect, onClose]);
+    }
+    if (typeof onClose === 'function') {
+      onClose();
+    }
+    return null;
+  }, [filtered, filteredLength, selected, onSelect, onClose]);
+
+  const resetSelection = useCallback(() => {
+    setSelected(0);
+  }, []);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      confirmSelection,
+      resetSelection,
+      stepSelection: cycleSelection,
+    }),
+    [confirmSelection, cycleSelection, resetSelection]
+  );
 
   const handleKeyDown = (e) => {
+    const stopEvent = () => {
+      if (typeof e.preventDefault === 'function') e.preventDefault();
+      if (typeof e.stopPropagation === 'function') e.stopPropagation();
+    };
+
     if (e.key === 'Tab') {
-      e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      const dir = e.shiftKey ? -1 : 1;
-      setSelected((selected + dir + len) % len);
+      stopEvent();
+      cycleSelection(e.shiftKey ? -1 : 1);
+    } else if (e.key === 'ArrowRight') {
+      stopEvent();
+      cycleSelection(1);
+    } else if (e.key === 'ArrowLeft') {
+      stopEvent();
+      cycleSelection(-1);
     } else if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      setSelected((selected + 1) % len);
+      stopEvent();
+      cycleSelection(1);
     } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      setSelected((selected - 1 + len) % len);
+      stopEvent();
+      cycleSelection(-1);
+    } else if (e.key === 'Enter') {
+      stopEvent();
+      confirmSelection();
     } else if (e.key === 'Escape') {
-      e.preventDefault();
+      stopEvent();
       if (typeof onClose === 'function') onClose();
     }
   };
@@ -56,29 +112,73 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
     setSelected(0);
   };
 
+  const handlePointer = (index) => {
+    if (index === selected) return;
+    setSelected(index);
+  };
+
+  const handleClick = (win) => {
+    if (typeof onSelect === 'function') {
+      onSelect(win.id);
+    }
+  };
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white">
-      <div className="bg-ub-grey p-4 rounded w-3/4 md:w-1/3">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 text-white">
+      <div className="w-11/12 max-w-4xl rounded-xl bg-ub-grey bg-opacity-95 p-6 shadow-2xl backdrop-blur">
         <input
           ref={inputRef}
           value={query}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+          className="w-full mb-4 px-3 py-2 rounded-md bg-black/30 focus:outline-none focus:ring-2 focus:ring-ub-orange"
           placeholder="Search windows"
         />
-        <ul>
-          {filtered.map((w, i) => (
-            <li
-              key={w.id}
-              className={`px-2 py-1 rounded ${i === selected ? 'bg-ub-orange text-black' : ''}`}
-            >
-              {w.title}
-            </li>
-          ))}
-        </ul>
+        <div className="flex items-stretch space-x-4 overflow-x-auto pb-1">
+          {filteredLength ? (
+            filtered.map((w, i) => (
+              <button
+                key={w.id}
+                type="button"
+                onMouseEnter={() => handlePointer(i)}
+                onFocus={() => handlePointer(i)}
+                onClick={() => handleClick(w)}
+                className={`flex min-w-[8rem] max-w-[10rem] flex-col items-center gap-2 rounded-lg border border-transparent px-4 py-3 transition-all duration-150 focus:outline-none ${
+                  i === selected
+                    ? 'bg-ub-orange text-black shadow-lg'
+                    : 'bg-black/40 text-white hover:bg-black/50'
+                }`}
+                aria-selected={i === selected}
+              >
+                <div className={`flex h-20 w-full items-center justify-center overflow-hidden rounded-md bg-black/30 ${
+                  i === selected ? 'bg-black/20' : ''
+                }`}>
+                  {w.icon ? (
+                    <img
+                      src={w.icon}
+                      alt=""
+                      className="h-12 w-12 object-contain"
+                      draggable={false}
+                    />
+                  ) : (
+                    <span className="text-sm text-ub-grey-light">{w.title[0]}</span>
+                  )}
+                </div>
+                <span className="text-sm font-semibold text-center leading-tight">
+                  {w.title}
+                </span>
+              </button>
+            ))
+          ) : (
+            <div className="flex h-24 w-full items-center justify-center rounded-lg bg-black/30 text-sm text-ub-grey-light">
+              No matching windows
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );
-}
+};
+
+export default forwardRef(WindowSwitcher);
 


### PR DESCRIPTION
## Summary
- redesign the window switcher with horizontal thumbnails, live search, and imperative controls so the overlay stays visible while Alt is held
- update desktop global shortcut handling to manage Alt keydown/keyup transitions and close the switcher on selection
- add regression tests verifying shortcut events are intercepted during window switching

## Testing
- yarn test windowSwitcherEvents

------
https://chatgpt.com/codex/tasks/task_e_68d812aa447c8328849baa11ca502f74