### PR TITLE
[ui] add navbar power menu

### DIFF
--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -57,4 +57,36 @@ describe('Ubuntu component', () => {
     });
     expect(instance!.state.shutDownScreen).toBe(true);
   });
+
+  it('restarts the UI and shows the boot sequence', () => {
+    let instance: Ubuntu | null = null;
+    render(<Ubuntu ref={(c) => (instance = c)} />);
+    expect(instance).not.toBeNull();
+    act(() => {
+      instance!.restart();
+    });
+    expect(instance!.state.shutDownScreen).toBe(true);
+    act(() => {
+      jest.advanceTimersByTime(800);
+    });
+    expect(instance!.state.booting_screen).toBe(true);
+  });
+
+  it('resets UI state and reloads the page', () => {
+    let instance: Ubuntu | null = null;
+    render(<Ubuntu ref={(c) => (instance = c)} />);
+    expect(instance).not.toBeNull();
+    window.localStorage.setItem('screen-locked', 'true');
+    act(() => {
+      try {
+        instance!.resetUI();
+      } catch (error) {
+        if (!(error instanceof Error) || !error.message.includes('navigation')) {
+          throw error;
+        }
+      }
+    });
+
+    expect(window.localStorage.getItem('screen-locked')).toBeNull();
+  });
 });

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,53 +1,172 @@
-import React, { Component } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
-import NotificationBell from '../ui/NotificationBell';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import PerformanceGraph from '../ui/PerformanceGraph';
+import PowerMenu from '../ui/PowerMenu';
+import ConfirmDialog from '../ui/ConfirmDialog';
 
+const ACTION_COPY = {
+  lock: {
+    title: 'Lock the screen?',
+    description: 'All open windows remain in place and the lock screen appears until you return.',
+    confirmLabel: 'Lock',
+  },
+  logout: {
+    title: 'Log out of the session?',
+    description: 'This returns to the lock screen and clears transient desktop state.',
+    confirmLabel: 'Log out',
+  },
+  restart: {
+    title: 'Restart the desktop?',
+    description: 'Open windows will close and the boot splash will replay before returning to the desktop.',
+    confirmLabel: 'Restart',
+  },
+  reset: {
+    title: 'Reset the interface?',
+    description: 'Clears personalised UI settings and reloads the page to restore defaults.',
+    confirmLabel: 'Reset UI',
+  },
+};
 
-export default class Navbar extends Component {
-	constructor() {
-		super();
-                this.state = {
-                        status_card: false,
-                        applicationsMenuOpen: false,
-                        placesMenuOpen: false
-                };
-        }
+const isStaticExport = process.env.NEXT_PUBLIC_STATIC_EXPORT === 'true';
 
-		render() {
-			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
-						<WhiskerMenu />
-						<PerformanceGraph />
-					</div>
-					<div
-						className={
-							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-						}
-					>
-						<Clock />
-					</div>
-					<button
-						type="button"
-						id="status-bar"
-						aria-label="System status"
-						onClick={() => {
-							this.setState({ status_card: !this.state.status_card });
-						}}
-						className={
-							'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-						}
-					>
-						<Status />
-						<QuickSettings open={this.state.status_card} />
-					</button>
-				</div>
-			);
-		}
+export default function Navbar({
+  lockScreen,
+  restart,
+  resetUI,
+}) {
+  /** @type {[import('../ui/PowerMenu').PowerAction | null, React.Dispatch<React.SetStateAction<import('../ui/PowerMenu').PowerAction | null>>]} */
+  const [pendingAction, setPendingAction] = useState(null);
+  const [statusCard, setStatusCard] = useState(false);
+  const [powerMenuOpen, setPowerMenuOpen] = useState(false);
 
+  /** @type {React.MutableRefObject<HTMLButtonElement | null>} */
+  const powerButtonRef = useRef(null);
 
+  const focusPowerButton = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      requestAnimationFrame(() => {
+        powerButtonRef.current?.focus();
+      });
+    } else {
+      powerButtonRef.current?.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (powerMenuOpen) {
+      setStatusCard(false);
+    }
+  }, [powerMenuOpen]);
+
+  const disabledActions = useMemo(() => {
+    if (!isStaticExport) return {};
+    return {
+      restart: 'Restart is disabled in static export builds.',
+    };
+  }, [isStaticExport]);
+
+  const closePowerMenu = useCallback(() => {
+    setPowerMenuOpen(false);
+    focusPowerButton();
+  }, [focusPowerButton]);
+
+  const toggleStatusCard = useCallback(() => {
+    setPowerMenuOpen(false);
+    setStatusCard(open => !open);
+  }, []);
+
+  const togglePowerMenu = useCallback(() => {
+    setStatusCard(false);
+    setPowerMenuOpen(open => !open);
+  }, []);
+
+  const handleSelectAction = useCallback(
+    /** @param {import('../ui/PowerMenu').PowerAction} action */ (action) => {
+      setPowerMenuOpen(false);
+      setPendingAction(action);
+    },
+    []
+  );
+
+  const handleCancel = useCallback(() => {
+    setPendingAction(null);
+    focusPowerButton();
+  }, [focusPowerButton]);
+
+  const handleConfirm = useCallback(() => {
+    if (!pendingAction) return;
+    switch (pendingAction) {
+      case 'lock':
+      case 'logout':
+        lockScreen?.();
+        break;
+      case 'restart':
+        restart?.();
+        break;
+      case 'reset':
+        resetUI?.();
+        break;
+      default:
+        break;
+    }
+    setPendingAction(null);
+    focusPowerButton();
+  }, [focusPowerButton, lockScreen, pendingAction, restart, resetUI]);
+
+  const confirmCopy = pendingAction ? ACTION_COPY[pendingAction] : null;
+
+  return (
+    <div className="main-navbar-vp absolute top-0 right-0 z-50 flex w-screen flex-nowrap select-none items-center justify-between bg-ub-grey text-sm text-ubt-grey shadow-md">
+      <div className="flex items-center">
+        <WhiskerMenu />
+        <PerformanceGraph />
+      </div>
+      <div className="py-1 pl-2 pr-2 text-xs outline-none transition duration-100 ease-in-out md:text-sm">
+        <Clock />
+      </div>
+      <div className="flex items-center">
+        <button
+          type="button"
+          id="status-bar"
+          aria-label="System status"
+          onClick={toggleStatusCard}
+          className="relative border-b-2 border-transparent py-1 pl-3 pr-3 outline-none transition duration-100 ease-in-out focus:border-ubb-orange"
+        >
+          <Status />
+          <QuickSettings open={statusCard} />
+        </button>
+        <button
+          type="button"
+          ref={powerButtonRef}
+          aria-haspopup="menu"
+          aria-expanded={powerMenuOpen}
+          aria-controls="power-menu"
+          onClick={togglePowerMenu}
+          className="relative ml-1 flex items-center rounded-md py-1 pl-3 pr-3 text-sm text-white transition duration-100 ease-in-out hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:ring-ub-orange"
+        >
+          <Image src="/themes/Yaru/status/system-shutdown-symbolic.svg" alt="Power options" width={16} height={16} className="mr-2" />
+          Power
+        </button>
+        <PowerMenu
+          open={powerMenuOpen}
+          onClose={closePowerMenu}
+          onSelect={handleSelectAction}
+          triggerRef={powerButtonRef}
+          disabledActions={disabledActions}
+        />
+      </div>
+      <ConfirmDialog
+        open={Boolean(pendingAction)}
+        title={confirmCopy?.title ?? ''}
+        description={confirmCopy?.description ?? ''}
+        confirmLabel={confirmCopy?.confirmLabel ?? ''}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+    </div>
+  );
 }

--- a/components/ui/ConfirmDialog.tsx
+++ b/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import React from 'react';
+import Modal from '../base/Modal';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  open,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = 'Cancel',
+  onConfirm,
+  onCancel,
+}) => {
+  const titleId = React.useId();
+  const descriptionId = React.useId();
+
+  return (
+    <Modal isOpen={open} onClose={onCancel}>
+      <div className="fixed inset-0 z-[1000] flex items-center justify-center">
+        <div className="absolute inset-0 bg-black bg-opacity-70" aria-hidden="true" />
+        <div
+          role="document"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
+          className="relative z-10 w-80 max-w-full rounded-md border border-black border-opacity-20 bg-ub-cool-grey p-5 text-white shadow-lg"
+        >
+          <h2 id={titleId} className="text-lg font-semibold">
+            {title}
+          </h2>
+          <p id={descriptionId} className="mt-2 text-sm text-ubt-grey">
+            {description}
+          </p>
+          <div className="mt-5 flex justify-end space-x-3">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-md border border-transparent bg-gray-700 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:ring-gray-300"
+            >
+              {cancelLabel}
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              className="rounded-md border border-transparent bg-ub-orange px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-orange-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:ring-ub-orange"
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ConfirmDialog;

--- a/components/ui/PowerMenu.tsx
+++ b/components/ui/PowerMenu.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+import { useClickOutside } from '../../hooks/useClickOutside';
+
+export type PowerAction = 'lock' | 'logout' | 'restart' | 'reset';
+
+interface PowerMenuProps {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (action: PowerAction) => void;
+  triggerRef: React.RefObject<HTMLElement>;
+  disabledActions?: Partial<Record<PowerAction, string>>;
+}
+
+const MENU_ITEMS: Array<{ key: PowerAction; label: string; description: string }> = [
+  { key: 'lock', label: 'Lock', description: 'Hide windows and require a click to resume.' },
+  { key: 'logout', label: 'Log out', description: 'Return to the lock screen and clear workspace.' },
+  { key: 'restart', label: 'Restart', description: 'Simulate a reboot of the desktop environment.' },
+  { key: 'reset', label: 'Reset UI', description: 'Soft reboot that restores default layout.' },
+];
+
+const PowerMenu: React.FC<PowerMenuProps> = ({
+  open,
+  onClose,
+  onSelect,
+  triggerRef,
+  disabledActions = {},
+}) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(menuRef, open);
+  useRovingTabIndex(menuRef, open, 'vertical');
+
+  useClickOutside([menuRef, triggerRef], () => {
+    if (open) {
+      onClose();
+    }
+  }, { enabled: open });
+
+  useEffect(() => {
+    if (!open) return;
+    const frame = requestAnimationFrame(() => {
+      const firstAvailable = menuRef.current?.querySelector<HTMLElement>(
+        '[data-power-menu-item]:not([disabled])'
+      );
+      if (firstAvailable) {
+        firstAvailable.focus();
+      }
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [open]);
+
+  const items = useMemo(() => MENU_ITEMS, []);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      ref={menuRef}
+      id="power-menu"
+      role="menu"
+      aria-hidden={!open}
+      className={`absolute right-3 top-9 w-60 rounded-md border border-black border-opacity-20 bg-ub-cool-grey py-2 text-white shadow-lg ${
+        open ? '' : 'hidden'
+      }`}
+      onKeyDown={handleKeyDown}
+    >
+      {items.map(item => {
+        const disabledReason = disabledActions[item.key];
+        return (
+          <button
+            key={item.key}
+            type="button"
+            role="menuitem"
+            tabIndex={open ? 0 : -1}
+            data-power-menu-item
+            className={`flex w-full flex-col items-start px-4 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:ring-ub-orange ${
+              disabledReason ? 'cursor-not-allowed opacity-60' : 'hover:bg-gray-700'
+            }`}
+            onClick={() => {
+              if (disabledReason) return;
+              onSelect(item.key);
+            }}
+            disabled={Boolean(disabledReason)}
+            aria-disabled={Boolean(disabledReason)}
+            title={disabledReason ?? undefined}
+          >
+            <span className="text-sm font-semibold">{item.label}</span>
+            <span className="mt-1 text-xs text-ubt-grey">{item.description}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default PowerMenu;


### PR DESCRIPTION
## Summary
- add a dedicated power menu in the navbar with confirmation flows for lock, log out, restart, and UI reset actions
- reuse existing lock-screen logic for lock/log out, disable restart in static export, and trigger analytics-safe reset handling
- introduce reusable dialog and menu components plus unit coverage for restart/reset behaviours

## Testing
- yarn lint *(fails: pre-existing accessibility violations across legacy apps)*
- yarn test __tests__/ubuntu.test.tsx --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d812a8d85083289914ad6c81a52f4b