### PR TITLE
[desktop] Expand snap regions and shortcuts

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -302,12 +302,19 @@ export class Desktop extends Component {
             const direction = e.key === 'ArrowLeft' || e.key === 'ArrowUp' ? -1 : 1;
             this.shiftWorkspace(direction);
         }
-        else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
-            e.preventDefault();
-            const id = this.getFocusedWindowId();
-            if (id) {
-                const event = new CustomEvent('super-arrow', { detail: e.key });
-                document.getElementById(id)?.dispatchEvent(event);
+        else if (e.metaKey) {
+            const superKeys = new Set([
+                'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',
+                'Numpad0', 'Numpad1', 'Numpad2', 'Numpad3', 'Numpad4',
+                'Numpad5', 'Numpad6', 'Numpad7', 'Numpad8', 'Numpad9'
+            ]);
+            if (superKeys.has(e.key)) {
+                e.preventDefault();
+                const id = this.getFocusedWindowId();
+                if (id) {
+                    const event = new CustomEvent('super-arrow', { detail: e.key });
+                    document.getElementById(id)?.dispatchEvent(event);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- extend snap region calculations to support bottom-half and corner placements with updated previews and cancellation
- add Super+Numpad handling alongside existing shortcuts to reach the new snap targets
- wire Escape handling for snap previews while keeping reduced-motion safeguards intact for window animations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d812a838a88328a05badfe8bf3b56e