### PR TITLE
[desktop] add panel autohide setting

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -26,6 +26,8 @@ export default function Settings() {
     setDensity,
     reducedMotion,
     setReducedMotion,
+    panelAutohide,
+    setPanelAutohide,
     fontScale,
     setFontScale,
     highContrast,
@@ -80,6 +82,8 @@ export default function Settings() {
       if (parsed.density !== undefined) setDensity(parsed.density);
       if (parsed.reducedMotion !== undefined)
         setReducedMotion(parsed.reducedMotion);
+      if (parsed.panelAutohide !== undefined)
+        setPanelAutohide(parsed.panelAutohide);
       if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
       if (parsed.highContrast !== undefined)
         setHighContrast(parsed.highContrast);
@@ -102,6 +106,7 @@ export default function Settings() {
     setWallpaper(defaults.wallpaper);
     setDensity(defaults.density as any);
     setReducedMotion(defaults.reducedMotion);
+    setPanelAutohide(defaults.panelAutohide);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
     setTheme("default");
@@ -156,14 +161,16 @@ export default function Settings() {
               ))}
             </div>
           </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey flex items-center">
-              <input
-                type="checkbox"
-                checked={useKaliWallpaper}
-                onChange={(e) => setUseKaliWallpaper(e.target.checked)}
-                className="mr-2"
-              />
+          <div className="flex justify-center my-4 items-center">
+            <input
+              id="use-kali-wallpaper"
+              type="checkbox"
+              checked={useKaliWallpaper}
+              onChange={(e) => setUseKaliWallpaper(e.target.checked)}
+              className="mr-2"
+              aria-label="Toggle Kali gradient wallpaper"
+            />
+            <label htmlFor="use-kali-wallpaper" className="text-ubt-grey flex items-center">
               Kali Gradient Wallpaper
             </label>
           </div>
@@ -264,6 +271,14 @@ export default function Settings() {
               checked={reducedMotion}
               onChange={setReducedMotion}
               ariaLabel="Reduced Motion"
+            />
+          </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">Panel Autohide:</span>
+            <ToggleSwitch
+              checked={panelAutohide}
+              onChange={setPanelAutohide}
+              ariaLabel="Panel Autohide"
             />
           </div>
           <div className="flex justify-center my-4 items-center">

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -4,7 +4,7 @@ import { resetSettings, defaults, exportSettings as exportSettingsData, importSe
 import KaliWallpaper from '../util-components/kali-wallpaper';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, panelAutohide, setPanelAutohide, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -83,12 +83,14 @@ export function Settings() {
                 </select>
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+                <label htmlFor="settings-use-kali-wallpaper" className="mr-2 text-ubt-grey flex items-center">
                     <input
+                        id="settings-use-kali-wallpaper"
                         type="checkbox"
                         checked={useKaliWallpaper}
                         onChange={(e) => setUseKaliWallpaper(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle Kali gradient wallpaper"
                     />
                     Kali Gradient Wallpaper
                 </label>
@@ -126,8 +128,9 @@ export function Settings() {
                 </select>
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Font Size:</label>
+                <label className="mr-2 text-ubt-grey" htmlFor="settings-font-scale">Font Size:</label>
                 <input
+                    id="settings-font-scale"
                     type="range"
                     min="0.75"
                     max="1.5"
@@ -135,70 +138,96 @@ export function Settings() {
                     value={fontScale}
                     onChange={(e) => setFontScale(parseFloat(e.target.value))}
                     className="ubuntu-slider"
+                    aria-label="Adjust font scale"
                 />
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+                <label htmlFor="settings-reduced-motion" className="mr-2 text-ubt-grey flex items-center">
                     <input
+                        id="settings-reduced-motion"
                         type="checkbox"
                         checked={reducedMotion}
                         onChange={(e) => setReducedMotion(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle reduced motion"
                     />
                     Reduced Motion
                 </label>
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+                <label htmlFor="settings-panel-autohide" className="mr-2 text-ubt-grey flex items-center">
                     <input
+                        id="settings-panel-autohide"
+                        type="checkbox"
+                        checked={panelAutohide}
+                        onChange={(e) => setPanelAutohide(e.target.checked)}
+                        className="mr-2"
+                        aria-label="Toggle panel autohide"
+                    />
+                    Panel Autohide
+                </label>
+            </div>
+            <div className="flex justify-center my-4">
+                <label htmlFor="settings-large-hit-areas" className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        id="settings-large-hit-areas"
                         type="checkbox"
                         checked={largeHitAreas}
                         onChange={(e) => setLargeHitAreas(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle large hit areas"
                     />
                     Large Hit Areas
                 </label>
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+                <label htmlFor="settings-high-contrast" className="mr-2 text-ubt-grey flex items-center">
                     <input
+                        id="settings-high-contrast"
                         type="checkbox"
                         checked={highContrast}
                         onChange={(e) => setHighContrast(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle high contrast"
                     />
                     High Contrast
                 </label>
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+                <label htmlFor="settings-allow-network" className="mr-2 text-ubt-grey flex items-center">
                     <input
+                        id="settings-allow-network"
                         type="checkbox"
                         checked={allowNetwork}
                         onChange={(e) => setAllowNetwork(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle network requests"
                     />
                     Allow Network Requests
                 </label>
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+                <label htmlFor="settings-haptics" className="mr-2 text-ubt-grey flex items-center">
                     <input
+                        id="settings-haptics"
                         type="checkbox"
                         checked={haptics}
                         onChange={(e) => setHaptics(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle haptics"
                     />
                     Haptics
                 </label>
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
+                <label htmlFor="settings-pong-spin" className="mr-2 text-ubt-grey flex items-center">
                     <input
+                        id="settings-pong-spin"
                         type="checkbox"
                         checked={pongSpin}
                         onChange={(e) => setPongSpin(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle pong spin"
                     />
                     Pong Spin
                 </label>
@@ -274,6 +303,7 @@ export function Settings() {
                         setWallpaper(defaults.wallpaper);
                         setDensity(defaults.density);
                         setReducedMotion(defaults.reducedMotion);
+                        setPanelAutohide(defaults.panelAutohide);
                         setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
@@ -288,6 +318,7 @@ export function Settings() {
                 type="file"
                 accept="application/json"
                 ref={fileInput}
+                aria-label="Import settings file"
                 onChange={async (e) => {
                     const file = e.target.files && e.target.files[0];
                     if (!file) return;
@@ -299,6 +330,7 @@ export function Settings() {
                         if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
                         if (parsed.density !== undefined) setDensity(parsed.density);
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
+                        if (parsed.panelAutohide !== undefined) setPanelAutohide(parsed.panelAutohide);
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
                         if (parsed.theme !== undefined) { setTheme(parsed.theme); }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,10 +1,101 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
 import WorkspaceSwitcher from '../panel/WorkspaceSwitcher';
+import { useSettings } from '../../hooks/useSettings';
+
+const HIDE_DELAY_MS = 180;
 
 export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const { panelAutohide, reducedMotion } = useSettings();
+    const runningApps = useMemo(
+        () => props.apps.filter((app) => props.closed_windows[app.id] === false),
+        [props.apps, props.closed_windows]
+    );
     const workspaces = props.workspaces || [];
+    const panelRef = useRef(null);
+    const hideTimeoutRef = useRef(null);
+    const [fullscreenWindows, setFullscreenWindows] = useState(() => new Set());
+    const [bottomCollisions, setBottomCollisions] = useState(() => new Set());
+    const [documentFullscreen, setDocumentFullscreen] = useState(false);
+    const [isInteracting, setIsInteracting] = useState(false);
+
+    const clearHideTimeout = useCallback(() => {
+        if (hideTimeoutRef.current) {
+            clearTimeout(hideTimeoutRef.current);
+            hideTimeoutRef.current = null;
+        }
+    }, []);
+
+    const scheduleHide = useCallback(() => {
+        if (!panelAutohide) return;
+        clearHideTimeout();
+        hideTimeoutRef.current = setTimeout(() => {
+            setIsInteracting(false);
+            hideTimeoutRef.current = null;
+        }, HIDE_DELAY_MS);
+    }, [clearHideTimeout, panelAutohide]);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return undefined;
+        const handleFullscreen = (event) => {
+            const detail = event?.detail || {};
+            if (!detail.id) return;
+            setFullscreenWindows((prev) => {
+                const next = new Set(prev);
+                if (detail.fullscreen) {
+                    next.add(detail.id);
+                } else {
+                    next.delete(detail.id);
+                }
+                return next;
+            });
+        };
+        const handleEdgeCollision = (event) => {
+            const detail = event?.detail || {};
+            if (!detail.id || detail.edge !== 'bottom') return;
+            setBottomCollisions((prev) => {
+                const next = new Set(prev);
+                if (detail.collided) {
+                    next.add(detail.id);
+                } else {
+                    next.delete(detail.id);
+                }
+                return next;
+            });
+        };
+        window.addEventListener('desktop:window-fullscreen', handleFullscreen);
+        window.addEventListener('desktop:edge-collision', handleEdgeCollision);
+        return () => {
+            window.removeEventListener('desktop:window-fullscreen', handleFullscreen);
+            window.removeEventListener('desktop:edge-collision', handleEdgeCollision);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (typeof document === 'undefined') return undefined;
+        const updateState = () => {
+            setDocumentFullscreen(Boolean(document.fullscreenElement));
+        };
+        updateState();
+        document.addEventListener('fullscreenchange', updateState);
+        return () => {
+            document.removeEventListener('fullscreenchange', updateState);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!panelAutohide) {
+            clearHideTimeout();
+            setIsInteracting(false);
+        }
+    }, [panelAutohide, clearHideTimeout]);
+
+    useEffect(() => {
+        return () => clearHideTimeout();
+    }, [clearHideTimeout]);
+
+    const shouldAutoHide = panelAutohide && (documentFullscreen || fullscreenWindows.size > 0 || bottomCollisions.size > 0);
+    const hidden = shouldAutoHide && !isInteracting;
 
     const handleClick = (app) => {
         const id = app.id;
@@ -17,51 +108,101 @@ export default function Taskbar(props) {
         }
     };
 
-    return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center justify-between px-2 z-40" role="toolbar">
-            <WorkspaceSwitcher
-                workspaces={workspaces}
-                activeWorkspace={props.activeWorkspace}
-                onSelect={props.onSelectWorkspace}
-            />
-            <div className="flex items-center overflow-x-auto">
-                {runningApps.map(app => {
-                    const isMinimized = Boolean(props.minimized_windows[app.id]);
-                    const isFocused = Boolean(props.focused_windows[app.id]);
-                    const isActive = !isMinimized;
+    const handleFocusCapture = () => {
+        if (!shouldAutoHide) return;
+        clearHideTimeout();
+        setIsInteracting(true);
+    };
 
-                    return (
-                        <button
-                            key={app.id}
-                            type="button"
-                            aria-label={app.title}
-                            data-context="taskbar"
-                            data-app-id={app.id}
-                            data-active={isActive ? 'true' : 'false'}
-                            aria-pressed={isActive}
-                            onClick={() => handleClick(app)}
-                            className={`${isFocused && isActive ? 'bg-white bg-opacity-20 ' : ''}relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10`}
-                        >
-                            <Image
-                                width={24}
-                                height={24}
-                                className="w-5 h-5"
-                                src={app.icon.replace('./', '/')}
-                                alt=""
-                                sizes="24px"
-                            />
-                            <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
-                            {isActive && (
-                                <span
-                                    aria-hidden="true"
-                                    data-testid="running-indicator"
-                                    className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded"
+    const handleBlurCapture = (event) => {
+        if (!shouldAutoHide) return;
+        const nextTarget = event?.relatedTarget;
+        if (panelRef.current && nextTarget && panelRef.current.contains(nextTarget)) {
+            return;
+        }
+        scheduleHide();
+    };
+
+    const handleMouseEnter = () => {
+        if (!shouldAutoHide) return;
+        clearHideTimeout();
+        setIsInteracting(true);
+    };
+
+    const handleMouseLeave = () => {
+        if (!shouldAutoHide) return;
+        scheduleHide();
+    };
+
+    const handleRevealEnter = () => {
+        if (!shouldAutoHide) return;
+        clearHideTimeout();
+        setIsInteracting(true);
+    };
+
+    return (
+        <>
+            {panelAutohide && (
+                <div
+                    aria-hidden="true"
+                    className="absolute bottom-0 left-0 w-full h-2 z-30"
+                    onMouseEnter={handleRevealEnter}
+                />
+            )}
+            <div
+                ref={panelRef}
+                className={`absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center justify-between px-2 z-40 ${hidden ? 'translate-y-full pointer-events-none' : 'translate-y-0'} ${reducedMotion ? '' : 'transition-transform duration-200'}`}
+                role="toolbar"
+                data-autohide={panelAutohide ? 'true' : 'false'}
+                onFocusCapture={handleFocusCapture}
+                onBlurCapture={handleBlurCapture}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+            >
+                <WorkspaceSwitcher
+                    workspaces={workspaces}
+                    activeWorkspace={props.activeWorkspace}
+                    onSelect={props.onSelectWorkspace}
+                />
+                <div className="flex items-center overflow-x-auto">
+                    {runningApps.map(app => {
+                        const isMinimized = Boolean(props.minimized_windows[app.id]);
+                        const isFocused = Boolean(props.focused_windows[app.id]);
+                        const isActive = !isMinimized;
+
+                        return (
+                            <button
+                                key={app.id}
+                                type="button"
+                                aria-label={app.title}
+                                data-context="taskbar"
+                                data-app-id={app.id}
+                                data-active={isActive ? 'true' : 'false'}
+                                aria-pressed={isActive}
+                                onClick={() => handleClick(app)}
+                                className={`${isFocused && isActive ? 'bg-white bg-opacity-20 ' : ''}relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10`}
+                            >
+                                <Image
+                                    width={24}
+                                    height={24}
+                                    className="w-5 h-5"
+                                    src={app.icon.replace('./', '/')}
+                                    alt=""
+                                    sizes="24px"
                                 />
-                            )}
-                        </button>
-                    );
-                })}
+                                <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                                {isActive && (
+                                    <span
+                                        aria-hidden="true"
+                                        data-testid="running-indicator"
+                                        className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded"
+                                    />
+                                )}
+                            </button>
+                        );
+                    })}
+                </div>
             </div>
-        </div>
+        </>
     );
 }

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -10,6 +10,8 @@ import {
   setDensity as saveDensity,
   getReducedMotion as loadReducedMotion,
   setReducedMotion as saveReducedMotion,
+  getPanelAutohide as loadPanelAutohide,
+  setPanelAutohide as savePanelAutohide,
   getFontScale as loadFontScale,
   setFontScale as saveFontScale,
   getHighContrast as loadHighContrast,
@@ -60,6 +62,7 @@ interface SettingsContextValue {
   useKaliWallpaper: boolean;
   density: Density;
   reducedMotion: boolean;
+  panelAutohide: boolean;
   fontScale: number;
   highContrast: boolean;
   largeHitAreas: boolean;
@@ -72,6 +75,7 @@ interface SettingsContextValue {
   setUseKaliWallpaper: (value: boolean) => void;
   setDensity: (density: Density) => void;
   setReducedMotion: (value: boolean) => void;
+  setPanelAutohide: (value: boolean) => void;
   setFontScale: (value: number) => void;
   setHighContrast: (value: boolean) => void;
   setLargeHitAreas: (value: boolean) => void;
@@ -88,6 +92,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   useKaliWallpaper: defaults.useKaliWallpaper,
   density: defaults.density as Density,
   reducedMotion: defaults.reducedMotion,
+  panelAutohide: defaults.panelAutohide,
   fontScale: defaults.fontScale,
   highContrast: defaults.highContrast,
   largeHitAreas: defaults.largeHitAreas,
@@ -100,6 +105,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setUseKaliWallpaper: () => {},
   setDensity: () => {},
   setReducedMotion: () => {},
+  setPanelAutohide: () => {},
   setFontScale: () => {},
   setHighContrast: () => {},
   setLargeHitAreas: () => {},
@@ -115,6 +121,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [useKaliWallpaper, setUseKaliWallpaper] = useState<boolean>(defaults.useKaliWallpaper);
   const [density, setDensity] = useState<Density>(defaults.density as Density);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
+  const [panelAutohide, setPanelAutohide] = useState<boolean>(defaults.panelAutohide);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
   const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
   const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
@@ -131,6 +138,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setUseKaliWallpaper(await loadUseKaliWallpaper());
       setDensity((await loadDensity()) as Density);
       setReducedMotion(await loadReducedMotion());
+      setPanelAutohide(await loadPanelAutohide());
       setFontScale(await loadFontScale());
       setHighContrast(await loadHighContrast());
       setLargeHitAreas(await loadLargeHitAreas());
@@ -202,6 +210,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [reducedMotion]);
 
   useEffect(() => {
+    savePanelAutohide(panelAutohide);
+  }, [panelAutohide]);
+
+  useEffect(() => {
     document.documentElement.style.setProperty('--font-multiplier', fontScale.toString());
     saveFontScale(fontScale);
   }, [fontScale]);
@@ -261,6 +273,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         useKaliWallpaper,
         density,
         reducedMotion,
+        panelAutohide,
         fontScale,
         highContrast,
         largeHitAreas,
@@ -273,6 +286,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setUseKaliWallpaper,
         setDensity,
         setReducedMotion,
+        setPanelAutohide,
         setFontScale,
         setHighContrast,
         setLargeHitAreas,

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -9,6 +9,7 @@ const DEFAULT_SETTINGS = {
   useKaliWallpaper: false,
   density: 'regular',
   reducedMotion: false,
+  panelAutohide: false,
   fontScale: 1,
   highContrast: false,
   largeHitAreas: false,
@@ -70,6 +71,17 @@ export async function getReducedMotion() {
 export async function setReducedMotion(value) {
   if (typeof window === 'undefined') return;
   window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+}
+
+export async function getPanelAutohide() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.panelAutohide;
+  const stored = window.localStorage.getItem('panel-autohide');
+  return stored === null ? DEFAULT_SETTINGS.panelAutohide : stored === 'true';
+}
+
+export async function setPanelAutohide(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('panel-autohide', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
@@ -143,6 +155,7 @@ export async function resetSettings() {
   ]);
   window.localStorage.removeItem('density');
   window.localStorage.removeItem('reduced-motion');
+  window.localStorage.removeItem('panel-autohide');
   window.localStorage.removeItem('font-scale');
   window.localStorage.removeItem('high-contrast');
   window.localStorage.removeItem('large-hit-areas');
@@ -159,6 +172,7 @@ export async function exportSettings() {
     useKaliWallpaper,
     density,
     reducedMotion,
+    panelAutohide,
     fontScale,
     highContrast,
     largeHitAreas,
@@ -171,6 +185,7 @@ export async function exportSettings() {
     getUseKaliWallpaper(),
     getDensity(),
     getReducedMotion(),
+    getPanelAutohide(),
     getFontScale(),
     getHighContrast(),
     getLargeHitAreas(),
@@ -184,6 +199,7 @@ export async function exportSettings() {
     wallpaper,
     density,
     reducedMotion,
+    panelAutohide,
     fontScale,
     highContrast,
     largeHitAreas,
@@ -210,6 +226,7 @@ export async function importSettings(json) {
     useKaliWallpaper,
     density,
     reducedMotion,
+    panelAutohide,
     fontScale,
     highContrast,
     largeHitAreas,
@@ -223,6 +240,7 @@ export async function importSettings(json) {
   if (useKaliWallpaper !== undefined) await setUseKaliWallpaper(useKaliWallpaper);
   if (density !== undefined) await setDensity(density);
   if (reducedMotion !== undefined) await setReducedMotion(reducedMotion);
+  if (panelAutohide !== undefined) await setPanelAutohide(panelAutohide);
   if (fontScale !== undefined) await setFontScale(fontScale);
   if (highContrast !== undefined) await setHighContrast(highContrast);
   if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);


### PR DESCRIPTION
## Summary
- add a panel autohide preference to the settings store and expose it through the desktop settings context
- wire panel autohide toggles into both settings experiences with improved checkbox labelling
- emit window fullscreen/edge collision events and teach the taskbar to hide responsively while honoring reduced motion

## Testing
- npx eslint apps/settings/index.tsx components/apps/settings.js components/base/window.js components/screen/taskbar.js hooks/useSettings.tsx utils/settingsStore.js

------
https://chatgpt.com/codex/tasks/task_e_68d812a2ad1883288285ea8d556e4f0a