### PR TITLE
[screen] Improve taskbar focus handling

### DIFF
--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -17,6 +17,7 @@ describe('Taskbar', () => {
         minimized_windows={{ app1: false }}
         focused_windows={{ app1: true }}
         openApp={openApp}
+        focusWindow={jest.fn()}
         minimize={minimize}
       />
     );
@@ -26,12 +27,15 @@ describe('Taskbar', () => {
     expect(button).toHaveAttribute('data-context', 'taskbar');
     expect(button).toHaveAttribute('aria-pressed', 'true');
     expect(button).toHaveAttribute('data-active', 'true');
-    expect(button.querySelector('[data-testid="running-indicator"]')).toBeTruthy();
+    const indicator = button.querySelector('[data-testid="running-indicator"]');
+    expect(indicator).toBeTruthy();
+    expect(indicator).toHaveClass('rounded-full');
   });
 
   it('restores minimized window on click', () => {
     const openApp = jest.fn();
     const minimize = jest.fn();
+    const focusWindow = jest.fn();
     render(
       <Taskbar
         apps={apps}
@@ -39,14 +43,79 @@ describe('Taskbar', () => {
         minimized_windows={{ app1: true }}
         focused_windows={{ app1: false }}
         openApp={openApp}
+        focusWindow={focusWindow}
         minimize={minimize}
       />
     );
     const button = screen.getByRole('button', { name: /app one/i });
     fireEvent.click(button);
     expect(openApp).toHaveBeenCalledWith('app1');
+    expect(openApp).toHaveBeenCalledTimes(1);
+    expect(focusWindow).not.toHaveBeenCalled();
     expect(button).toHaveAttribute('aria-pressed', 'false');
     expect(button).toHaveAttribute('data-active', 'false');
     expect(button.querySelector('[data-testid="running-indicator"]')).toBeFalsy();
+  });
+
+  it('focuses existing window when clicked while running', () => {
+    const openApp = jest.fn();
+    const minimize = jest.fn();
+    const focusWindow = jest.fn();
+    render(
+      <Taskbar
+        apps={apps}
+        closed_windows={{ app1: false }}
+        minimized_windows={{ app1: false }}
+        focused_windows={{ app1: false }}
+        openApp={openApp}
+        focusWindow={focusWindow}
+        minimize={minimize}
+      />
+    );
+    const button = screen.getByRole('button', { name: /app one/i });
+    fireEvent.click(button);
+    expect(focusWindow).toHaveBeenCalledWith('app1');
+    expect(openApp).not.toHaveBeenCalled();
+    expect(minimize).not.toHaveBeenCalled();
+  });
+
+  it('restores minimized apps without duplicating windows', () => {
+    const openApp = jest.fn();
+    const minimize = jest.fn();
+    const focusWindow = jest.fn();
+    const { rerender } = render(
+      <Taskbar
+        apps={apps}
+        closed_windows={{ app1: false }}
+        minimized_windows={{ app1: true }}
+        focused_windows={{ app1: false }}
+        openApp={openApp}
+        focusWindow={focusWindow}
+        minimize={minimize}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: /app one/i });
+    fireEvent.click(button);
+
+    expect(openApp).toHaveBeenCalledTimes(1);
+    expect(focusWindow).not.toHaveBeenCalled();
+
+    rerender(
+      <Taskbar
+        apps={apps}
+        closed_windows={{ app1: false }}
+        minimized_windows={{ app1: false }}
+        focused_windows={{ app1: false }}
+        openApp={openApp}
+        focusWindow={focusWindow}
+        minimize={minimize}
+      />
+    );
+
+    fireEvent.click(button);
+
+    expect(openApp).toHaveBeenCalledTimes(1);
+    expect(focusWindow).toHaveBeenCalledWith('app1');
   });
 });

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1102,6 +1102,7 @@ export class Desktop extends Component {
                     minimized_windows={this.state.minimized_windows}
                     focused_windows={this.state.focused_windows}
                     openApp={this.openApp}
+                    focusWindow={this.focus}
                     minimize={this.hasMinimised}
                     workspaces={workspaceSummaries}
                     activeWorkspace={this.state.activeWorkspace}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -8,13 +8,26 @@ export default function Taskbar(props) {
 
     const handleClick = (app) => {
         const id = app.id;
-        if (props.minimized_windows[id]) {
+        const isMinimized = Boolean(props.minimized_windows[id]);
+        const isFocused = Boolean(props.focused_windows[id]);
+        const isOpen = props.closed_windows[id] === false;
+
+        if (isMinimized) {
             props.openApp(id);
-        } else if (props.focused_windows[id]) {
-            props.minimize(id);
-        } else {
-            props.openApp(id);
+            return;
         }
+
+        if (isFocused) {
+            props.minimize(id);
+            return;
+        }
+
+        if (isOpen && typeof props.focusWindow === 'function') {
+            props.focusWindow(id);
+            return;
+        }
+
+        props.openApp(id);
     };
 
     return (
@@ -55,7 +68,7 @@ export default function Taskbar(props) {
                                 <span
                                     aria-hidden="true"
                                     data-testid="running-indicator"
-                                    className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded"
+                                    className="absolute -bottom-1 left-1/2 -translate-x-1/2 h-1.5 w-6 rounded-full bg-[var(--kali-blue)] shadow-[0_0_6px_rgba(23,147,209,0.6)]"
                                 />
                             )}
                         </button>


### PR DESCRIPTION
## Summary
- restyle the taskbar running indicator into a Kali-blue pill accent
- focus existing taskbar windows before launching new instances
- expand taskbar interaction tests to cover restore and focus flows

## Testing
- yarn test taskbar
- yarn lint *(fails: existing repo accessibility violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d8129fdbec8328a866562417e35c5b