### PR TITLE
[menu] Improve Whisker keyboard navigation

### DIFF
--- a/__tests__/WhiskerMenu.focus.test.tsx
+++ b/__tests__/WhiskerMenu.focus.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import WhiskerMenu from '../components/menu/WhiskerMenu';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img alt="" {...props} />,
+}));
+
+describe('WhiskerMenu focus management', () => {
+  const renderMenu = () => {
+    const onActiveItemChange = jest.fn();
+    const onOpenChange = jest.fn();
+    render(
+      <WhiskerMenu
+        onActiveItemChange={onActiveItemChange}
+        onOpenChange={onOpenChange}
+        announcementId="test-announcement"
+      />,
+    );
+    return { onActiveItemChange, onOpenChange };
+  };
+
+  it('moves focus to the category list when navigating left from the search input', () => {
+    renderMenu();
+    const toggle = screen.getByRole('button', { name: /applications/i });
+    fireEvent.click(toggle);
+    const search = screen.getByRole('textbox', { name: /search applications/i });
+    search.focus();
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+
+    const selectedOption = screen.getByRole('option', { selected: true });
+    expect(selectedOption).toHaveFocus();
+  });
+
+  it('returns focus to the search input when navigating right from the category list', () => {
+    renderMenu();
+    const toggle = screen.getByRole('button', { name: /applications/i });
+    fireEvent.click(toggle);
+    const search = screen.getByRole('textbox', { name: /search applications/i });
+    search.focus();
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    const selectedOption = screen.getByRole('option', { selected: true });
+
+    fireEvent.keyDown(selectedOption, { key: 'ArrowRight' });
+
+    expect(search).toHaveFocus();
+  });
+
+  it('closes the menu and restores focus to the toggle button when Escape is pressed', async () => {
+    renderMenu();
+    const toggle = screen.getByRole('button', { name: /applications/i });
+    fireEvent.click(toggle);
+    const search = screen.getByRole('textbox', { name: /search applications/i });
+    search.focus();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    await waitFor(() => expect(toggle).toHaveFocus());
+  });
+});

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -8,25 +8,48 @@ import PerformanceGraph from '../ui/PerformanceGraph';
 
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
+        constructor() {
+                super();
                 this.state = {
                         status_card: false,
                         applicationsMenuOpen: false,
-                        placesMenuOpen: false
+                        placesMenuOpen: false,
+                        whiskerAnnouncement: ''
                 };
+                this.announcementRegionId = 'whisker-active-item-announcement';
         }
 
-		render() {
-			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
-						<WhiskerMenu />
-						<PerformanceGraph />
-					</div>
-					<div
-						className={
-							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                handleWhiskerMenuOpen = (open) => {
+                        this.setState({ applicationsMenuOpen: open });
+                };
+
+                handleWhiskerAnnouncement = (message) => {
+                        this.setState({ whiskerAnnouncement: message });
+                };
+
+                render() {
+                        const { whiskerAnnouncement } = this.state;
+                        return (
+                                <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                        <div className="flex items-center" data-whisker-open={this.state.applicationsMenuOpen}>
+                                                <WhiskerMenu
+                                                        onOpenChange={this.handleWhiskerMenuOpen}
+                                                        onActiveItemChange={this.handleWhiskerAnnouncement}
+                                                        announcementId={this.announcementRegionId}
+                                                />
+                                                <div
+                                                        id={this.announcementRegionId}
+                                                        role="status"
+                                                        aria-live="polite"
+                                                        className="sr-only"
+                                                >
+                                                        {whiskerAnnouncement}
+                                                </div>
+                                                <PerformanceGraph />
+                                        </div>
+                                        <div
+                                                className={
+                                                        'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
 						}
 					>
 						<Clock />


### PR DESCRIPTION
## Summary
- expand Whisker menu keyboard handling to support lateral category navigation, Shift+Enter activation, and Escape focus restoration while emitting announcements
- connect the navbar toggle to Super-key menu changes and add an aria-live region for active items
- cover focus transitions between category list and app grid with new Jest tests

## Testing
- yarn test WhiskerMenu.focus

------
https://chatgpt.com/codex/tasks/task_e_68d8129325608328adb9abcf15ad5863