### PR TITLE
[menu] Add launcher context menu with persistent favorites

### DIFF
--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -38,6 +38,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
 
     const handleContextMenu = (e: MouseEvent) => {
       e.preventDefault();
+      e.stopPropagation();
       setPos({ x: e.pageX, y: e.pageY });
       setOpen(true);
     };
@@ -45,6 +46,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.shiftKey && e.key === 'F10') {
         e.preventDefault();
+        e.stopPropagation();
         const rect = node.getBoundingClientRect();
         setPos({ x: rect.left, y: rect.bottom });
         setOpen(true);


### PR DESCRIPTION
## Summary
- add a per-tile context menu to the Whisker launcher with favorite, pin, and new window actions
- persist launcher favorites and panel pins through the shared settings store and sync changes to the desktop shell
- enable drag-and-drop reordering for favorite apps while guarding against conflicting global context menus

## Testing
- yarn lint *(fails: existing accessibility and window globals lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d81293f4948328bfdf7846e612bfef