### PR TITLE
[ui] expand density presets and apply spacing tokens

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
+import {
+  useSettings,
+  ACCENT_OPTIONS,
+  DENSITY_PRESETS,
+  isDensityValue,
+  type Density,
+} from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
   resetSettings,
@@ -77,7 +83,7 @@ export default function Settings() {
       const parsed = JSON.parse(text);
       if (parsed.accent !== undefined) setAccent(parsed.accent);
       if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
-      if (parsed.density !== undefined) setDensity(parsed.density);
+      if (isDensityValue(parsed.density)) setDensity(parsed.density);
       if (parsed.reducedMotion !== undefined)
         setReducedMotion(parsed.reducedMotion);
       if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
@@ -100,7 +106,7 @@ export default function Settings() {
     window.localStorage.clear();
     setAccent(defaults.accent);
     setWallpaper(defaults.wallpaper);
-    setDensity(defaults.density as any);
+    setDensity(isDensityValue(defaults.density) ? (defaults.density as Density) : "regular");
     setReducedMotion(defaults.reducedMotion);
     setFontScale(defaults.fontScale);
     setHighContrast(defaults.highContrast);
@@ -251,11 +257,14 @@ export default function Settings() {
             <label className="mr-2 text-ubt-grey">Density:</label>
             <select
               value={density}
-              onChange={(e) => setDensity(e.target.value as any)}
+              onChange={(e) => setDensity(e.target.value as Density)}
               className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
             >
-              <option value="regular">Regular</option>
-              <option value="compact">Compact</option>
+              {DENSITY_PRESETS.map(({ value, label }) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
             </select>
           </div>
           <div className="flex justify-center my-4 items-center">

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
+import { useSettings, ACCENT_OPTIONS, DENSITY_PRESETS, isDensityValue } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 import KaliWallpaper from '../util-components/kali-wallpaper';
 
@@ -121,8 +121,11 @@ export function Settings() {
                     onChange={(e) => setDensity(e.target.value)}
                     className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
                 >
-                    <option value="regular">Regular</option>
-                    <option value="compact">Compact</option>
+                    {DENSITY_PRESETS.map(({ value, label }) => (
+                        <option key={value} value={value}>
+                            {label}
+                        </option>
+                    ))}
                 </select>
             </div>
             <div className="flex justify-center my-4">
@@ -272,7 +275,7 @@ export function Settings() {
                         await resetSettings();
                         setAccent(defaults.accent);
                         setWallpaper(defaults.wallpaper);
-                        setDensity(defaults.density);
+                        setDensity(isDensityValue(defaults.density) ? defaults.density : 'regular');
                         setReducedMotion(defaults.reducedMotion);
                         setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
@@ -297,7 +300,7 @@ export function Settings() {
                         const parsed = JSON.parse(text);
                         if (parsed.accent !== undefined) setAccent(parsed.accent);
                         if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
-                        if (parsed.density !== undefined) setDensity(parsed.density);
+                        if (isDensityValue(parsed.density)) setDensity(parsed.density);
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -379,24 +379,26 @@ const WhiskerMenu: React.FC = () => {
         ref={buttonRef}
         type="button"
         onClick={toggleMenu}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className="outline-none transition duration-100 ease-in-out border-b-2 border-transparent"
+        style={{ paddingInline: 'var(--space-3)', paddingBlock: 'var(--space-1)' }}
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"
           alt="Menu"
           width={16}
           height={16}
-          className="inline mr-1"
+          className="inline"
+          style={{ marginRight: 'var(--space-1)' }}
         />
         Applications
       </button>
       {isVisible && (
         <div
           ref={menuRef}
-          className={`absolute left-0 mt-1 z-50 flex w-[520px] bg-ub-grey text-white shadow-lg rounded-md overflow-hidden transition-all duration-200 ease-out ${
+          className={`absolute left-0 z-50 flex w-[520px] bg-ub-grey text-white shadow-lg rounded-md overflow-hidden transition-all duration-200 ease-out ${
             isOpen ? 'opacity-100 translate-y-0 scale-100' : 'pointer-events-none opacity-0 -translate-y-2 scale-95'
           }`}
-          style={{ transitionDuration: `${TRANSITION_DURATION}ms` }}
+          style={{ transitionDuration: `${TRANSITION_DURATION}ms`, marginTop: 'var(--space-1)' }}
           tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {
@@ -406,7 +408,8 @@ const WhiskerMenu: React.FC = () => {
         >
           <div
             ref={categoryListRef}
-            className="flex max-h-80 w-64 flex-col gap-1 overflow-y-auto bg-gray-900 p-3"
+            className="flex max-h-80 w-64 flex-col overflow-y-auto bg-gray-900"
+            style={{ gap: 'var(--space-1)', padding: 'var(--space-3)' }}
             role="listbox"
             aria-label="Application categories"
             tabIndex={0}
@@ -419,9 +422,14 @@ const WhiskerMenu: React.FC = () => {
                   categoryButtonRefs.current[index] = el;
                 }}
                 type="button"
-                className={`flex items-center gap-3 rounded px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-ubb-orange focus:ring-offset-2 focus:ring-offset-gray-900 ${
+                className={`flex items-center rounded text-left transition focus:outline-none focus:ring-2 focus:ring-ubb-orange focus:ring-offset-2 focus:ring-offset-gray-900 ${
                   category === cat.id ? 'bg-gray-700/80' : 'hover:bg-gray-700/60'
                 }`}
+                style={{
+                  gap: 'var(--space-3)',
+                  paddingInline: 'var(--space-3)',
+                  paddingBlock: 'var(--space-2)',
+                }}
                 role="option"
                 aria-selected={category === cat.id}
                 onClick={() => {
@@ -431,7 +439,7 @@ const WhiskerMenu: React.FC = () => {
 
               >
                 <span className="w-8 font-mono text-xs text-gray-300">{String(index + 1).padStart(2, '0')}</span>
-                <span className="flex items-center gap-2">
+                <span className="flex items-center" style={{ gap: 'var(--space-2)' }}>
                   <Image
                     src={cat.icon}
                     alt=""
@@ -444,21 +452,41 @@ const WhiskerMenu: React.FC = () => {
                 </span>
               </button>
             ))}
-            <div className="mt-4 border-t border-gray-700 pt-3">
-              <p className="text-xs uppercase tracking-wide text-gray-400 mb-2">Kali Linux Groups</p>
-              <ul className="space-y-1 text-sm">
+            <div
+              className="border-t border-gray-700"
+              style={{ marginTop: 'var(--space-4)', paddingTop: 'var(--space-3)' }}
+            >
+              <p
+                className="text-xs uppercase tracking-wide text-gray-400"
+                style={{ marginBottom: 'var(--space-2)' }}
+              >
+                Kali Linux Groups
+              </p>
+              <ul className="flex flex-col text-sm" style={{ rowGap: 'var(--space-1)' }}>
                 {KALI_CATEGORIES.map((cat) => (
                   <li key={cat.id} className="flex items-baseline text-gray-300">
-                    <span className="font-mono text-ubt-blue mr-2 w-8">{cat.number}</span>
+                    <span
+                      className="font-mono text-ubt-blue w-8"
+                      style={{ marginRight: 'var(--space-2)' }}
+                    >
+                      {cat.number}
+                    </span>
                     <span>{cat.label}</span>
                   </li>
                 ))}
               </ul>
             </div>
           </div>
-          <div className="flex flex-col p-3">
+          <div
+            className="flex flex-col"
+            style={{ gap: 'var(--space-3)', padding: 'var(--space-3)' }}
+          >
             <input
-              className="mb-3 w-64 rounded bg-black bg-opacity-20 px-2 py-1 focus:outline-none"
+              className="w-64 rounded bg-black bg-opacity-20 focus:outline-none"
+              style={{
+                paddingInline: 'var(--space-2)',
+                paddingBlock: 'var(--space-1)',
+              }}
 
               placeholder="Search"
               aria-label="Search applications"
@@ -466,7 +494,10 @@ const WhiskerMenu: React.FC = () => {
               onChange={e => setQuery(e.target.value)}
               autoFocus
             />
-            <div className="grid max-h-64 grid-cols-3 gap-2 overflow-y-auto">
+            <div
+              className="grid max-h-64 grid-cols-3 overflow-y-auto"
+              style={{ gap: 'var(--space-2)' }}
+            >
 
               {currentApps.map((app, idx) => (
                 <div

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -134,9 +134,10 @@ class AllApplications extends React.Component {
                             : `Add ${app.title} to favorites`
                     }
                     onClick={(event) => this.handleToggleFavorite(event, app.id)}
-                    className={`absolute right-2 top-2 text-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
+                    className={`absolute text-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
                         isFavorite ? 'text-yellow-300' : 'text-white/60 hover:text-white'
                     }`}
+                    style={{ top: 'var(--space-2)', right: 'var(--space-2)' }}
                 >
                     ★
                 </button>
@@ -155,11 +156,22 @@ class AllApplications extends React.Component {
     renderSection = (title, apps) => {
         if (!apps.length) return null;
         return (
-            <section key={title} aria-label={`${title} apps`} className="mb-8 w-full">
-                <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-white/70">
+            <section
+                key={title}
+                aria-label={`${title} apps`}
+                className="w-full"
+                style={{ marginBottom: 'var(--space-6)' }}
+            >
+                <h2
+                    className="text-sm font-semibold uppercase tracking-wider text-white/70"
+                    style={{ marginBottom: 'var(--space-3)' }}
+                >
                     {title}
                 </h2>
-                <div className="grid grid-cols-3 gap-6 place-items-center pb-6 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8">
+                <div
+                    className="grid grid-cols-3 place-items-center sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8"
+                    style={{ gap: 'var(--space-5)', paddingBottom: 'var(--space-5)' }}
+                >
                     {apps.map((app) => this.renderAppTile(app))}
                 </div>
             </section>
@@ -185,20 +197,35 @@ class AllApplications extends React.Component {
         return (
             <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
                 <input
-                    className="mt-10 mb-8 w-2/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none md:w-1/3"
+                    className="w-2/3 rounded bg-black bg-opacity-20 text-white focus:outline-none md:w-1/3"
+                    style={{
+                        marginTop: 'calc(var(--space-4) + var(--space-5))',
+                        marginBottom: 'var(--space-6)',
+                        paddingInline: 'var(--space-4)',
+                        paddingBlock: 'var(--space-2)',
+                    }}
                     placeholder="Search"
                     value={this.state.query}
                     onChange={this.handleChange}
                     aria-label="Search applications"
                 />
-                <div className="flex w-full max-w-5xl flex-col items-stretch px-6 pb-10">
+                <div
+                    className="flex w-full max-w-5xl flex-col items-stretch"
+                    style={{
+                        paddingInline: 'var(--space-5)',
+                        paddingBottom: 'calc(var(--space-5) + var(--space-4))',
+                    }}
+                >
                     {this.renderSection('Favorites', favoriteApps)}
                     {this.renderSection('Recent', recentApps)}
                     {groupedApps.map((group, index) =>
                         group.length ? this.renderSection(`Group ${index + 1}`, group) : null
                     )}
                     {!hasResults && (
-                        <p className="mt-6 text-center text-sm text-white/70">
+                        <p
+                            className="text-center text-sm text-white/70"
+                            style={{ marginTop: 'var(--space-5)' }}
+                        >
                             No applications match your search.
                         </p>
                     )}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -25,7 +25,17 @@ import {
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
-type Density = 'regular' | 'compact';
+export type Density = 'compact' | 'cozy' | 'regular' | 'comfortable';
+
+export const DENSITY_PRESETS: readonly { value: Density; label: string }[] = [
+  { value: 'comfortable', label: 'Comfortable' },
+  { value: 'regular', label: 'Regular' },
+  { value: 'cozy', label: 'Cozy' },
+  { value: 'compact', label: 'Compact' },
+] as const;
+
+export const isDensityValue = (value: unknown): value is Density =>
+  typeof value === 'string' && DENSITY_PRESETS.some((preset) => preset.value === value);
 
 // Predefined accent palette exposed to settings UI
 export const ACCENT_OPTIONS = [
@@ -81,12 +91,14 @@ interface SettingsContextValue {
   setTheme: (value: string) => void;
 }
 
+const DEFAULT_DENSITY: Density = isDensityValue(defaults.density) ? (defaults.density as Density) : 'regular';
+
 export const SettingsContext = createContext<SettingsContextValue>({
   accent: defaults.accent,
   wallpaper: defaults.wallpaper,
   bgImageName: defaults.wallpaper,
   useKaliWallpaper: defaults.useKaliWallpaper,
-  density: defaults.density as Density,
+  density: DEFAULT_DENSITY,
   reducedMotion: defaults.reducedMotion,
   fontScale: defaults.fontScale,
   highContrast: defaults.highContrast,
@@ -113,7 +125,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [accent, setAccent] = useState<string>(defaults.accent);
   const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
   const [useKaliWallpaper, setUseKaliWallpaper] = useState<boolean>(defaults.useKaliWallpaper);
-  const [density, setDensity] = useState<Density>(defaults.density as Density);
+  const [density, setDensity] = useState<Density>(DEFAULT_DENSITY);
   const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
   const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
   const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
@@ -129,7 +141,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAccent(await loadAccent());
       setWallpaper(await loadWallpaper());
       setUseKaliWallpaper(await loadUseKaliWallpaper());
-      setDensity((await loadDensity()) as Density);
+      const storedDensity = await loadDensity();
+      setDensity(isDensityValue(storedDensity) ? storedDensity : DEFAULT_DENSITY);
       setReducedMotion(await loadReducedMotion());
       setFontScale(await loadFontScale());
       setHighContrast(await loadHighContrast());
@@ -172,6 +185,22 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const spacing: Record<Density, Record<string, string>> = {
+      compact: {
+        '--space-1': '0.125rem',
+        '--space-2': '0.25rem',
+        '--space-3': '0.5rem',
+        '--space-4': '0.75rem',
+        '--space-5': '1rem',
+        '--space-6': '1.5rem',
+      },
+      cozy: {
+        '--space-1': '0.21875rem',
+        '--space-2': '0.4375rem',
+        '--space-3': '0.65625rem',
+        '--space-4': '0.875rem',
+        '--space-5': '1.3125rem',
+        '--space-6': '1.75rem',
+      },
       regular: {
         '--space-1': '0.25rem',
         '--space-2': '0.5rem',
@@ -180,13 +209,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         '--space-5': '1.5rem',
         '--space-6': '2rem',
       },
-      compact: {
-        '--space-1': '0.125rem',
-        '--space-2': '0.25rem',
-        '--space-3': '0.5rem',
-        '--space-4': '0.75rem',
-        '--space-5': '1rem',
-        '--space-6': '1.5rem',
+      comfortable: {
+        '--space-1': '0.375rem',
+        '--space-2': '0.75rem',
+        '--space-3': '1.125rem',
+        '--space-4': '1.5rem',
+        '--space-5': '2.25rem',
+        '--space-6': '3rem',
       },
     };
     const vars = spacing[density];


### PR DESCRIPTION
## Summary
- add cozy and comfortable density presets with validated persistence
- update settings surfaces to expose the new density options
- drive launcher menu and search spacing from density-controlled CSS variables

## Testing
- `yarn lint` *(fails: existing accessibility and window global lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d81296c1408328aec691c9042a1818