### PR TITLE
[menu] Add quick run fallback

### DIFF
--- a/apps/terminal/context.ts
+++ b/apps/terminal/context.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+export type TerminalCommandPayload = {
+  command?: string;
+  requestId?: number;
+};
+
+export const TerminalCommandContext = createContext<TerminalCommandPayload | null>(null);

--- a/components/apps/terminal.tsx
+++ b/components/apps/terminal.tsx
@@ -1,5 +1,10 @@
+import { useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import HelpPanel from '../HelpPanel';
+import {
+  TerminalCommandContext,
+  type TerminalCommandPayload,
+} from '../../apps/terminal/context';
 
 // Lazily load the heavy terminal app with session tabs on the client only.
 const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
@@ -11,16 +16,41 @@ const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
   ),
 });
 
+type TerminalWrapperProps = {
+  context?: TerminalCommandPayload | null;
+  command?: string;
+  requestId?: number;
+  openApp?: (id: string) => void;
+};
+
 /**
  * Wrapper component that ensures the terminal area can scroll when content
  * overflows. The actual indicator/scroll handling lives inside the terminal
  * app, this wrapper just provides the necessary container styles.
  */
-export default function Terminal() {
+export default function Terminal({
+  context,
+  command,
+  requestId,
+  openApp,
+}: TerminalWrapperProps) {
+  const payload = useMemo<TerminalCommandPayload | null>(() => {
+    if (!context && command === undefined && requestId === undefined) {
+      return null;
+    }
+    return {
+      ...(context ?? {}),
+      ...(command !== undefined ? { command } : {}),
+      ...(requestId !== undefined ? { requestId } : {}),
+    };
+  }, [command, context, requestId]);
+
   return (
-    <div className="h-full w-full overflow-y-auto">
-      <HelpPanel appId="terminal" />
-      <TerminalApp />
-    </div>
+    <TerminalCommandContext.Provider value={payload}>
+      <div className="h-full w-full overflow-y-auto">
+        <HelpPanel appId="terminal" />
+        <TerminalApp openApp={openApp} />
+      </div>
+    </TerminalCommandContext.Provider>
   );
 }

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -222,6 +222,7 @@ export class Desktop extends Component {
         window.addEventListener('trash-change', this.updateTrashIcon);
         document.addEventListener('keydown', this.handleGlobalShortcut);
         window.addEventListener('open-app', this.handleOpenAppEvent);
+        window.addEventListener('terminal-run-command', this.handleTerminalRunCommand);
     }
 
     componentWillUnmount() {
@@ -229,6 +230,7 @@ export class Desktop extends Component {
         document.removeEventListener('keydown', this.handleGlobalShortcut);
         window.removeEventListener('trash-change', this.updateTrashIcon);
         window.removeEventListener('open-app', this.handleOpenAppEvent);
+        window.removeEventListener('terminal-run-command', this.handleTerminalRunCommand);
     }
 
     checkForNewFolders = () => {
@@ -746,6 +748,14 @@ export class Desktop extends Component {
             const { id, ...context } = detail;
             this.openApp(id, context);
         }
+    }
+
+    handleTerminalRunCommand = (e) => {
+        const detail = e.detail || {};
+        const command = typeof detail.command === 'string' ? detail.command.trim() : '';
+        if (!command) return;
+        const requestId = typeof detail.requestId === 'number' ? detail.requestId : Date.now();
+        this.openApp('terminal', { command, requestId });
     }
 
     openApp = (objId, params) => {


### PR DESCRIPTION
## Summary
- show a “Run …” fallback in the Whisker Menu when no apps match and backend support exists
- dispatch a dedicated terminal run event and have the desktop open the terminal with the request context
- let the terminal consume the quick-run context, queueing commands until the session is ready

## Testing
- yarn lint *(fails: repository has pre-existing accessibility lint violations)*
- yarn test terminal

------
https://chatgpt.com/codex/tasks/task_e_68d81298ba60832885ffd351c3a5ab30