### PR TITLE
[screen] Refresh top panel layout

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,53 +1,281 @@
-import React, { Component } from 'react';
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import NotificationBell from '../ui/NotificationBell';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import PerformanceGraph from '../ui/PerformanceGraph';
+import apps from '../../apps.config';
+import styles from './navbar.module.css';
 
+const QUICK_LAUNCH_IDS = ['terminal', 'vscode', 'chrome'];
 
-export default class Navbar extends Component {
-	constructor() {
-		super();
-                this.state = {
-                        status_card: false,
-                        applicationsMenuOpen: false,
-                        placesMenuOpen: false
-                };
+const QUICK_LAUNCH_ITEMS = QUICK_LAUNCH_IDS.map((id) => {
+  const match = apps.find((app) => app.id === id);
+  if (!match) return null;
+  const icon = typeof match.icon === 'string' && match.icon.startsWith('./')
+    ? match.icon.replace('./', '/')
+    : match.icon;
+  return {
+    id: match.id,
+    title: match.title,
+    icon,
+  };
+}).filter(Boolean);
+
+const DEFAULT_WORKSPACE_STATE = {
+  activeWorkspace: 0,
+  workspaces: [],
+};
+
+const formatWorkspaceAriaLabel = (workspace) => {
+  const count = Number(workspace?.openWindows) || 0;
+  if (!count) return workspace.label;
+  const suffix = count === 1 ? 'window' : 'windows';
+  return `${workspace.label}, ${count} ${suffix}`;
+};
+
+const normalizeWorkspaceDetail = (detail) => {
+  if (!detail || !Array.isArray(detail.workspaces)) {
+    return DEFAULT_WORKSPACE_STATE;
+  }
+  const activeWorkspace =
+    typeof detail.activeWorkspace === 'number' ? detail.activeWorkspace : 0;
+  return {
+    activeWorkspace,
+    workspaces: detail.workspaces.map((workspace, index) => ({
+      id: typeof workspace.id === 'number' ? workspace.id : index,
+      label: workspace.label || `Workspace ${index + 1}`,
+      openWindows: Number(workspace.openWindows) || 0,
+    })),
+  };
+};
+
+const dispatchWorkspaceChange = (workspaceId) => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent('set-active-workspace', { detail: workspaceId }),
+  );
+};
+
+const dispatchOpenApp = (appId) => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent('open-app', { detail: appId }));
+};
+
+const Navbar = ({ lockScreen, shutDown }) => {
+  const [statusOpen, setStatusOpen] = useState(false);
+  const [workspaceState, setWorkspaceState] = useState(DEFAULT_WORKSPACE_STATE);
+  const statusRef = useRef(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const handleSummary = (event) => {
+      const nextState = normalizeWorkspaceDetail(event.detail);
+      setWorkspaceState((prev) => {
+        if (
+          prev.activeWorkspace === nextState.activeWorkspace &&
+          prev.workspaces.length === nextState.workspaces.length &&
+          prev.workspaces.every((workspace, index) => {
+            const next = nextState.workspaces[index];
+            return (
+              workspace &&
+              next &&
+              workspace.id === next.id &&
+              workspace.label === next.label &&
+              workspace.openWindows === next.openWindows
+            );
+          })
+        ) {
+          return prev;
         }
+        return nextState;
+      });
+    };
 
-		render() {
-			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
-						<WhiskerMenu />
-						<PerformanceGraph />
-					</div>
-					<div
-						className={
-							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-						}
-					>
-						<Clock />
-					</div>
-					<button
-						type="button"
-						id="status-bar"
-						aria-label="System status"
-						onClick={() => {
-							this.setState({ status_card: !this.state.status_card });
-						}}
-						className={
-							'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-						}
-					>
-						<Status />
-						<QuickSettings open={this.state.status_card} />
-					</button>
-				</div>
-			);
-		}
+    window.addEventListener('workspace-summary', handleSummary);
+    return () => {
+      window.removeEventListener('workspace-summary', handleSummary);
+    };
+  }, []);
 
+  useEffect(() => {
+    if (!statusOpen || typeof window === 'undefined') return undefined;
 
-}
+    const handlePointerDown = (event) => {
+      if (!statusRef.current) return;
+      if (!statusRef.current.contains(event.target)) {
+        setStatusOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        setStatusOpen(false);
+      }
+    };
+
+    window.addEventListener('mousedown', handlePointerDown);
+    window.addEventListener('touchstart', handlePointerDown);
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('mousedown', handlePointerDown);
+      window.removeEventListener('touchstart', handlePointerDown);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [statusOpen]);
+
+  const handleQuickLaunch = useCallback((appId) => {
+    dispatchOpenApp(appId);
+  }, []);
+
+  const handleWorkspaceSelect = useCallback((workspaceId) => {
+    dispatchWorkspaceChange(workspaceId);
+  }, []);
+
+  const handleToggleStatus = useCallback(() => {
+    setStatusOpen((prev) => !prev);
+  }, []);
+
+  const handleLock = useCallback(() => {
+    if (typeof lockScreen === 'function') {
+      lockScreen();
+    }
+  }, [lockScreen]);
+
+  const handleShutDown = useCallback(() => {
+    if (typeof shutDown === 'function') {
+      shutDown();
+    }
+  }, [shutDown]);
+
+  return (
+    <header className={styles.navbar} role="banner">
+      <div className={`${styles.section} ${styles.menuSection}`}>
+        <WhiskerMenu />
+      </div>
+      <div
+        className={`${styles.section} ${styles.quickLaunchSection}`}
+        aria-label="Quick launch"
+      >
+        <div className={styles.quickLaunchList} role="group">
+          {QUICK_LAUNCH_ITEMS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className={styles.quickLaunchButton}
+              onClick={() => handleQuickLaunch(item.id)}
+              aria-label={`Open ${item.title}`}
+              title={item.title}
+            >
+              <Image
+                src={item.icon}
+                alt=""
+                width={24}
+                height={24}
+                className={styles.icon}
+                sizes="24px"
+              />
+              <span className={styles.srOnly}>{item.title}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className={`${styles.section} ${styles.workspaceSection}`}>
+        <PerformanceGraph className={styles.performanceGraph} />
+        {workspaceState.workspaces.length > 0 && (
+          <div
+            className={styles.workspaceList}
+            role="radiogroup"
+            aria-label="Workspaces"
+          >
+            {workspaceState.workspaces.map((workspace, index) => {
+              const isActive = workspace.id === workspaceState.activeWorkspace;
+              const badge = workspace.openWindows > 0;
+              return (
+                <button
+                  key={workspace.id}
+                  type="button"
+                  role="radio"
+                  aria-checked={isActive}
+                  tabIndex={isActive ? 0 : -1}
+                  aria-label={formatWorkspaceAriaLabel(workspace)}
+                  onClick={() => handleWorkspaceSelect(workspace.id)}
+                  className={`${styles.workspaceButton} ${
+                    isActive ? styles.workspaceButtonActive : ''
+                  }`}
+                  data-active={isActive ? 'true' : 'false'}
+                >
+                  <span aria-hidden="true">{index + 1}</span>
+                  {badge && !isActive && (
+                    <span className={styles.workspaceBadge} aria-hidden="true">
+                      {workspace.openWindows}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+      <div className={`${styles.section} ${styles.statusSection}`}>
+        <NotificationBell />
+        <div className={styles.statusToggle} ref={statusRef}>
+          <button
+            type="button"
+            id="status-bar"
+            className={styles.statusButton}
+            aria-haspopup="dialog"
+            aria-expanded={statusOpen}
+            onClick={handleToggleStatus}
+          >
+            <Status />
+          </button>
+          <QuickSettings open={statusOpen} />
+        </div>
+      </div>
+      <div className={`${styles.section} ${styles.clockSection}`}>
+        <Clock />
+      </div>
+      <div className={`${styles.section} ${styles.powerSection}`}>
+        <button
+          type="button"
+          className={styles.powerButton}
+          onClick={handleLock}
+        >
+          <Image
+            src="/themes/Yaru/status/changes-prevent-symbolic.svg"
+            alt=""
+            width={20}
+            height={20}
+            className={styles.icon}
+            sizes="20px"
+          />
+          <span>Lock</span>
+        </button>
+        <button
+          type="button"
+          className={styles.powerButton}
+          onClick={handleShutDown}
+        >
+          <Image
+            src="/themes/Kali/panel/power-button.svg"
+            alt=""
+            width={20}
+            height={20}
+            className={styles.icon}
+            sizes="20px"
+          />
+          <span>Power</span>
+        </button>
+      </div>
+    </header>
+  );
+};
+
+export default Navbar;

--- a/components/screen/navbar.module.css
+++ b/components/screen/navbar.module.css
@@ -1,0 +1,337 @@
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: calc(var(--space-1) + 2px) calc(var(--space-4));
+  background-color: var(--kali-panel, rgba(26, 31, 38, 0.88));
+  color: var(--color-text, #f5f5f5);
+  border-bottom: 1px solid var(--kali-panel-border, rgba(255, 255, 255, 0.1));
+  box-shadow: 0 18px 42px -24px color-mix(in srgb, var(--color-inverse, #000) 50%, transparent);
+  box-sizing: border-box;
+  min-height: var(--panel-height, 3rem);
+  backdrop-filter: blur(18px);
+  isolation: isolate;
+}
+
+.navbar::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 1px;
+  background: var(--kali-panel-highlight, rgba(255, 255, 255, 0.06));
+  pointer-events: none;
+}
+
+.section {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.menuSection {
+  flex-shrink: 0;
+}
+
+.quickLaunchSection {
+  flex-shrink: 0;
+}
+
+.quickLaunchList {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.quickLaunchButton {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: max(var(--hit-area, 32px), 2.5rem);
+  height: max(var(--hit-area, 32px), 2.5rem);
+  border-radius: var(--radius-md, 4px);
+  border: 1px solid transparent;
+  background-color: color-mix(in srgb, var(--kali-panel-highlight, rgba(255, 255, 255, 0.06)) 55%, transparent);
+  color: inherit;
+  transition: background-color var(--motion-fast, 150ms) ease, border-color var(--motion-fast, 150ms) ease, transform var(--motion-fast, 150ms) ease;
+}
+
+.quickLaunchButton:hover,
+.quickLaunchButton:focus-visible {
+  background-color: color-mix(in srgb, var(--color-text, #f5f5f5) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-text, #f5f5f5) 25%, transparent);
+}
+
+.quickLaunchButton:focus-visible {
+  outline: 2px solid var(--color-focus-ring, #1793d1);
+  outline-offset: 2px;
+}
+
+.quickLaunchButton:active {
+  transform: scale(0.96);
+}
+
+.workspaceSection {
+  flex: 1 1 auto;
+  justify-content: center;
+  gap: var(--space-3);
+}
+
+.performanceGraph {
+  margin-right: var(--space-2);
+}
+
+.workspaceList {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: calc(var(--space-1) / 2) var(--space-1);
+  border-radius: var(--radius-round, 9999px);
+  border: 1px solid color-mix(in srgb, var(--kali-panel-border, rgba(255, 255, 255, 0.12)) 90%, transparent);
+  background-color: color-mix(in srgb, var(--kali-panel-highlight, rgba(255, 255, 255, 0.08)) 65%, transparent);
+  min-width: 0;
+}
+
+.workspaceButton {
+  position: relative;
+  min-width: 2rem;
+  padding: calc(var(--space-1) / 2) var(--space-1);
+  border-radius: var(--radius-round, 9999px);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--color-text, #f5f5f5) 85%, transparent);
+  background: transparent;
+  border: 1px solid transparent;
+  transition: background-color var(--motion-fast, 150ms) ease, color var(--motion-fast, 150ms) ease, border-color var(--motion-fast, 150ms) ease;
+}
+
+.workspaceButton:hover,
+.workspaceButton:focus-visible {
+  background-color: color-mix(in srgb, var(--color-text, #f5f5f5) 15%, transparent);
+  color: var(--color-text, #f5f5f5);
+  border-color: color-mix(in srgb, var(--color-text, #f5f5f5) 28%, transparent);
+}
+
+.workspaceButton:focus-visible {
+  outline: 2px solid var(--color-focus-ring, #1793d1);
+  outline-offset: 2px;
+}
+
+.workspaceButtonActive {
+  background-color: color-mix(in srgb, var(--color-primary, #1793d1) 65%, var(--color-bg, #0f1317));
+  border-color: color-mix(in srgb, var(--color-primary, #1793d1) 55%, transparent);
+  color: color-mix(in srgb, var(--color-bg, #0f1317) 15%, var(--color-text, #f5f5f5));
+}
+
+.workspaceBadge {
+  position: absolute;
+  top: -0.35rem;
+  right: -0.35rem;
+  min-width: 1.1rem;
+  padding: 0 0.25rem;
+  border-radius: var(--radius-round, 9999px);
+  font-size: 0.65rem;
+  line-height: 1.1rem;
+  background: color-mix(in srgb, var(--color-primary, #1793d1) 75%, transparent);
+  color: var(--color-bg, #0f1317);
+}
+
+.statusSection {
+  flex-shrink: 0;
+}
+
+.statusToggle {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.statusButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: calc(var(--space-1) / 2) var(--space-2);
+  border-radius: var(--radius-md, 4px);
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  transition: background-color var(--motion-fast, 150ms) ease, border-color var(--motion-fast, 150ms) ease;
+}
+
+.statusButton:hover,
+.statusButton:focus-visible {
+  background-color: color-mix(in srgb, var(--color-text, #f5f5f5) 12%, transparent);
+  border-color: color-mix(in srgb, var(--color-text, #f5f5f5) 25%, transparent);
+}
+
+.statusButton:focus-visible {
+  outline: 2px solid var(--color-focus-ring, #1793d1);
+  outline-offset: 2px;
+}
+
+.clockSection {
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.powerSection {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-shrink: 0;
+}
+
+.powerButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: calc(var(--space-1) / 2) var(--space-2);
+  min-width: max(var(--hit-area, 32px), 2.5rem);
+  border-radius: var(--radius-md, 4px);
+  border: 1px solid color-mix(in srgb, var(--kali-panel-border, rgba(255, 255, 255, 0.12)) 85%, transparent);
+  background: color-mix(in srgb, var(--kali-panel-highlight, rgba(255, 255, 255, 0.08)) 75%, transparent);
+  color: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: background-color var(--motion-fast, 150ms) ease, border-color var(--motion-fast, 150ms) ease, transform var(--motion-fast, 150ms) ease;
+}
+
+.powerButton:hover,
+.powerButton:focus-visible {
+  background: color-mix(in srgb, var(--color-primary, #1793d1) 20%, transparent);
+  border-color: color-mix(in srgb, var(--color-primary, #1793d1) 45%, transparent);
+}
+
+.powerButton:focus-visible {
+  outline: 2px solid var(--color-focus-ring, #1793d1);
+  outline-offset: 2px;
+}
+
+.powerButton:active {
+  transform: scale(0.97);
+}
+
+.icon {
+  display: block;
+  width: 1.35rem;
+  height: 1.35rem;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 960px) {
+  .navbar {
+    gap: var(--space-2);
+    padding: calc(var(--space-1) + 2px) var(--space-3);
+  }
+
+  .workspaceSection {
+    justify-content: flex-start;
+  }
+
+  .powerButton {
+    padding-inline: var(--space-1);
+    gap: 0.2rem;
+    font-size: 0.8rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .navbar {
+    flex-wrap: wrap;
+    row-gap: var(--space-2);
+  }
+
+  .workspaceSection {
+    order: 6;
+    width: 100%;
+    justify-content: center;
+  }
+
+  .powerSection {
+    order: 5;
+  }
+
+  .clockSection {
+    order: 4;
+  }
+
+  .statusSection {
+    order: 3;
+  }
+
+  .quickLaunchSection {
+    order: 2;
+  }
+
+  .menuSection {
+    order: 1;
+  }
+}
+
+:global(.high-contrast) .navbar {
+  background: var(--color-bg, #000);
+  border-bottom: 2px solid var(--color-text, #fff);
+  box-shadow: none;
+}
+
+:global(.high-contrast) .navbar::after {
+  background: var(--color-text, #fff);
+  opacity: 0.7;
+}
+
+:global(.high-contrast) .quickLaunchButton,
+:global(.high-contrast) .workspaceList,
+:global(.high-contrast) .powerButton {
+  background: transparent;
+  border-color: var(--color-text, #fff);
+}
+
+:global(.high-contrast) .quickLaunchButton:hover,
+:global(.high-contrast) .powerButton:hover,
+:global(.high-contrast) .workspaceButton:hover,
+:global(.high-contrast) .workspaceButton:focus-visible,
+:global(.high-contrast) .statusButton:hover,
+:global(.high-contrast) .statusButton:focus-visible {
+  background: var(--color-text, #fff);
+  color: var(--color-bg, #000);
+}
+
+:global(.high-contrast) .workspaceButtonActive {
+  background: var(--color-text, #fff);
+  color: var(--color-bg, #000);
+  border-color: var(--color-text, #fff);
+}
+
+:global(.high-contrast) .workspaceBadge {
+  background: var(--color-text, #fff);
+  color: var(--color-bg, #000);
+}
+
+@media (prefers-contrast: more) {
+  .navbar {
+    background: color-mix(in srgb, var(--color-bg, #000) 85%, var(--color-text, #fff) 15%);
+    border-bottom: 2px solid color-mix(in srgb, var(--color-text, #fff) 80%, transparent);
+    box-shadow: none;
+  }
+}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -23,9 +23,16 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
-        open ? '' : 'hidden'
-      }`}
+      className={`absolute min-w-[14rem] rounded-md py-4 ${open ? '' : 'hidden'} border shadow-lg`}
+      style={{
+        top: 'calc(100% + var(--space-1))',
+        right: 0,
+        backgroundColor: 'var(--kali-panel)',
+        borderColor: 'var(--kali-panel-border)',
+        boxShadow:
+          '0 20px 40px -24px color-mix(in srgb, var(--color-inverse, #000) 55%, transparent)',
+      }}
+      data-open={open ? 'true' : 'false'}
     >
       <div className="px-4 pb-2">
         <button

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -33,9 +33,10 @@
   --kali-blue-dark: #0f6fa1;
   --kali-blue-glow: rgba(23, 147, 209, 0.35);
   --kali-bg-solid: #0f1317;
-  --kali-panel: rgba(26, 31, 38, 0.9);
-  --kali-panel-border: rgba(255, 255, 255, 0.08);
-  --kali-panel-highlight: rgba(255, 255, 255, 0.05);
+  --panel-height: calc(max(var(--hit-area), 2.5rem) + var(--space-1));
+  --kali-panel: color-mix(in srgb, var(--color-surface) 90%, transparent);
+  --kali-panel-border: color-mix(in srgb, var(--color-text) 18%, transparent);
+  --kali-panel-highlight: color-mix(in srgb, var(--color-text) 12%, transparent);
   --kali-terminal-green: #00ff00;
   --kali-terminal-text: #f5f5f5;
 
@@ -97,6 +98,9 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --kali-panel: color-mix(in srgb, var(--color-bg) 92%, var(--color-text) 8%);
+  --kali-panel-border: var(--color-text);
+  --kali-panel-highlight: color-mix(in srgb, var(--color-text) 70%, transparent);
 }
 
 /* Dyslexia-friendly fonts */
@@ -136,5 +140,8 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --kali-panel: color-mix(in srgb, var(--color-bg) 90%, var(--color-text) 10%);
+    --kali-panel-border: color-mix(in srgb, var(--color-text) 80%, transparent);
+    --kali-panel-highlight: color-mix(in srgb, var(--color-text) 60%, transparent);
   }
 }


### PR DESCRIPTION
## Summary
- rework the desktop navbar with translucent Kali styling, quick launch icons, workspace controls, and a power section
- introduce a CSS module and token updates so the panel honors theme, density, and high-contrast settings
- emit workspace events from the desktop so the navbar stays in sync without overlapping app windows

## Testing
- yarn lint *(fails: repository already contains hundreds of accessibility lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d8129bbdf88328badbd5534943d01e