### PR TITLE
[settings] Add favorites and dock import/export

### DIFF
--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -291,10 +291,10 @@ export function Settings() {
                 onChange={async (e) => {
                     const file = e.target.files && e.target.files[0];
                     if (!file) return;
-                    const text = await file.text();
-                    await importSettingsData(text);
                     try {
-                        const parsed = JSON.parse(text);
+                        const text = await file.text();
+                        const result = await importSettingsData(text);
+                        const parsed = result?.settings ?? JSON.parse(text);
                         if (parsed.accent !== undefined) setAccent(parsed.accent);
                         if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
                         if (parsed.density !== undefined) setDensity(parsed.density);

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -81,7 +81,23 @@ class AllApplications extends React.Component {
             favorites,
             recents,
         });
+
+        window.addEventListener('launcher:favorites-updated', this.handleExternalFavoritesUpdate);
     }
+
+    componentWillUnmount() {
+        window.removeEventListener('launcher:favorites-updated', this.handleExternalFavoritesUpdate);
+    }
+
+    handleExternalFavoritesUpdate = (event) => {
+        const detail = event?.detail;
+        const incoming = Array.isArray(detail) ? detail : [];
+        const sourceApps = this.state.unfilteredApps.length ? this.state.unfilteredApps : this.state.apps;
+        const availableIds = new Set(sourceApps.map((app) => app.id));
+        const favorites = sanitizeIds(incoming, availableIds);
+        persistIds(FAVORITES_KEY, favorites);
+        this.setState({ favorites });
+    };
 
     handleChange = (e) => {
         const value = e.target.value;

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -7,25 +7,44 @@ export interface SessionWindow {
   y: number;
 }
 
+export interface DesktopLauncherState {
+  favorites: string[];
+  ordering: string[];
+}
+
 export interface DesktopSession {
   windows: SessionWindow[];
   wallpaper: string;
   dock: string[];
+  launcher?: DesktopLauncherState;
 }
 
 const initialSession: DesktopSession = {
   windows: [],
   wallpaper: defaults.wallpaper,
   dock: [],
+  launcher: {
+    favorites: [],
+    ordering: [],
+  },
 };
 
 function isSession(value: unknown): value is DesktopSession {
   if (!value || typeof value !== 'object') return false;
   const s = value as DesktopSession;
+  const launcher = (s as DesktopSession).launcher;
+  const launcherValid =
+    launcher === undefined ||
+    (
+      typeof launcher === 'object' &&
+      Array.isArray((launcher as DesktopLauncherState).favorites ?? []) &&
+      Array.isArray((launcher as DesktopLauncherState).ordering ?? [])
+    );
   return (
     Array.isArray(s.windows) &&
     typeof s.wallpaper === 'string' &&
-    Array.isArray(s.dock)
+    Array.isArray(s.dock) &&
+    launcherValid
   );
 }
 


### PR DESCRIPTION
## Summary
- extend the settings store to serialize favorites, dock pins, and launcher ordering with schema validation and change notifications
- have the desktop session and launcher react to imported favorites/pins while persisting launcher metadata
- surface import feedback in both settings UIs and reuse the helper return shape

## Testing
- not run (known repository lint/test failures)

------
https://chatgpt.com/codex/tasks/task_e_68d8129dbd2c83288113e4898b03c9cb