### PR TITLE
[styles] add kali theme tokens

### DIFF
--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -25,19 +25,6 @@
   --color-ub-dark-grey: #2a2e36;
   --color-bg: #0f1317;
   --color-text: #F5F5F5;
-  --kali-bg: rgba(15, 19, 23, 0.85);
-  --kali-blue: #1793d1;
-
-  /* Kali theme tokens */
-  --kali-blue: #1793d1;
-  --kali-blue-dark: #0f6fa1;
-  --kali-blue-glow: rgba(23, 147, 209, 0.35);
-  --kali-bg-solid: #0f1317;
-  --kali-panel: rgba(26, 31, 38, 0.9);
-  --kali-panel-border: rgba(255, 255, 255, 0.08);
-  --kali-panel-highlight: rgba(255, 255, 255, 0.05);
-  --kali-terminal-green: #00ff00;
-  --kali-terminal-text: #f5f5f5;
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
@@ -80,6 +67,20 @@
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
+
+  /* Kali theme tokens */
+  --kali-bg: rgba(15, 19, 23, 0.85);
+  --kali-bg-solid: #0f1317;
+  --kali-text: #f5f5f5;
+  --kali-border: rgba(255, 255, 255, 0.08);
+  --kali-blue: #1793d1;
+  --kali-blue-dark: #0f6fa1;
+  --kali-blue-glow: rgba(23, 147, 209, 0.35);
+  --kali-panel: rgba(26, 31, 38, 0.9);
+  --kali-panel-border: rgba(255, 255, 255, 0.08);
+  --kali-panel-highlight: rgba(255, 255, 255, 0.05);
+  --kali-terminal-green: #00ff00;
+  --kali-terminal-text: #f5f5f5;
 }
 
 /* High contrast theme */


### PR DESCRIPTION
## Summary
- group the Kali theme tokens at the end of the :root block in `styles/tokens.css`
- add missing Kali text and border variables needed by the theme styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d86b3bed808328b57b60dc472be24c