### PR TITLE
[ui] Add focus ring utility for menu buttons

### DIFF
--- a/components/menu/ApplicationsMenu.tsx
+++ b/components/menu/ApplicationsMenu.tsx
@@ -97,7 +97,7 @@ const ApplicationsMenu: React.FC<ApplicationsMenuProps> = ({ activeCategory, onS
               <button
                 type="button"
                 onClick={() => onSelect(category.id)}
-                className={`flex w-full items-center gap-3 rounded px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
+                className={`focus-ring flex w-full items-center gap-3 rounded px-3 py-2 text-left transition ${
                   isActive ? 'bg-gray-700 text-white' : 'bg-transparent hover:bg-gray-700/60'
                 }`}
                 aria-pressed={isActive}

--- a/components/menu/PlacesMenu.tsx
+++ b/components/menu/PlacesMenu.tsx
@@ -63,7 +63,7 @@ const PlacesMenu: React.FC<PlacesMenuProps> = ({ heading = 'Places', items }) =>
               <button
                 type="button"
                 onClick={handleClick}
-                className="flex w-full items-center gap-3 rounded px-3 py-2 text-left transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-ubb-orange"
+                className="focus-ring flex w-full items-center gap-3 rounded px-3 py-2 text-left transition hover:bg-gray-700"
               >
                 <img
                   src={src}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,7 @@
   --color-focus-ring: var(--color-accent);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
+  --kali-focus: var(--color-focus-ring);
   --kali-text: #f5f5f5;
   accent-color: var(--color-control-accent);
 }
@@ -82,6 +83,11 @@ html[data-theme='matrix'] {
 
 *:focus-visible {
   outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.focus-ring {
+  outline: 2px solid var(--kali-focus);
   outline-offset: 2px;
 }
 


### PR DESCRIPTION
## Summary
- add a reusable `.focus-ring` helper that pulls from the Kali focus color token
- apply the new focus outline class to the Applications and Places menu buttons

## Testing
- yarn lint *(fails: pre-existing jsx-a11y/control-has-associated-label errors across apps and public assets)*

------
https://chatgpt.com/codex/tasks/task_e_68d86b3fba708328b1ba02965259f93a