### PR TITLE
[styles] align Tailwind fonts with brief stacks

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,6 +5,9 @@
   /* Base colors */
   --color-bg: #0f1317; /* kali background */
   --color-text: #f5f5f5; /* text on dark backgrounds */
+  /* Typography */
+  --font-ui: 'Ubuntu', 'Cantarell', 'Segoe UI', 'Roboto', 'Noto Sans', sans-serif;
+  --font-mono: 'Fira Code', 'Fira Mono', 'Ubuntu Mono', 'SFMono-Regular', 'Menlo', 'Consolas', 'Liberation Mono', 'Courier New', monospace;
   /* Brand accents */
   --color-primary: #1793d1; /* kali blue accent */
   --color-secondary: #1a1f26; /* complementary dark */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 const plugin = require('tailwindcss/plugin');
+const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
   darkMode: 'class',
@@ -113,6 +114,10 @@ module.exports = {
         flourish: 'flourish 0.6s ease-out',
         mine: 'mine 0.4s ease-in-out',
       },
+    },
+    fontFamily: {
+      sans: ['var(--font-ui)', ...defaultTheme.fontFamily.sans],
+      mono: ['var(--font-mono)', ...defaultTheme.fontFamily.mono],
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary
- add `--font-ui` and `--font-mono` variables to `styles/globals.css`
- point Tailwind's `font-sans` and `font-mono` families at the new CSS variables for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d86b404a508328a048bab0f85eea79