### PR TITLE
[styles] document kali panel shadow token

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -54,6 +54,7 @@ module.exports = {
           backdrop: 'var(--kali-bg)',
         },
       },
+      // Custom shadow for Kali-style floating panels
       boxShadow: {
         'kali-panel': '0 6px 20px rgba(0,0,0,.35)',
       },


### PR DESCRIPTION
## Summary
- document the Kali panel box shadow token within the Tailwind theme config to highlight the custom styling hook

## Testing
- [x] TERM=dumb yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d86b41cd80832890cbe9d11b24ec4b