### PR TITLE
[ui] Center navbar clock

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -18,19 +18,21 @@ export default class Navbar extends Component {
         }
 
 		render() {
-			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
-						<WhiskerMenu />
-						<PerformanceGraph />
-					</div>
-					<div
-						className={
-							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-						}
-					>
-						<Clock />
-					</div>
+                        return (
+                                <div className="main-navbar-vp relative top-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                        <div className="flex items-center">
+                                                <WhiskerMenu />
+                                                <PerformanceGraph />
+                                        </div>
+                                        <div className="absolute left-1/2 -translate-x-1/2">
+                                                <div
+                                                        className={
+                                                                'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+                                                        }
+                                                >
+                                                        <Clock />
+                                                </div>
+                                        </div>
 					<button
 						type="button"
 						id="status-bar"


### PR DESCRIPTION
## Summary
- wrap the navbar clock in an absolutely positioned container to center it
- switch the navbar positioning to relative so the clock container anchors correctly

## Testing
- [ ] Not run (not requested)

## Flags
- [ ] No flags were toggled

------
https://chatgpt.com/codex/tasks/task_e_68d86b45aa2c8328a1373ebc1cd879c6