### PR TITLE
[ui] Update quick settings dropdown styling

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -23,7 +23,7 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute rounded-md shadow-kali-panel border border-kali-border bg-kali-menu py-4 top-full mt-2 right-3 ${
         open ? '' : 'hidden'
       }`}
     >


### PR DESCRIPTION
## Summary
- refresh the quick settings panel container with the new Kali-themed surface styles
- anchor the dropdown to the trigger button so it aligns with the updated navbar height

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d86b4b74048328a98587e25985d25d