### PR TITLE
[desktop] expand app context menu actions

### DIFF
--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -13,14 +13,6 @@ function AppMenu(props) {
         }
     }
 
-    const handlePin = () => {
-        if (props.pinned) {
-            props.unpinApp && props.unpinApp()
-        } else {
-            props.pinApp && props.pinApp()
-        }
-    }
-
     return (
         <div
             id="app-menu"
@@ -32,12 +24,48 @@ function AppMenu(props) {
         >
             <button
                 type="button"
-                onClick={handlePin}
+                onClick={() => {
+                    if (props.isFavorite) {
+                        props.onRemoveFavorite && props.onRemoveFavorite()
+                    } else {
+                        props.onAddFavorite && props.onAddFavorite()
+                    }
+                }}
                 role="menuitem"
-                aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
+                aria-label={props.isFavorite ? 'Remove from Favorites' : 'Add to Favorites'}
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
-                <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
+                <span className="ml-5">{props.isFavorite ? 'Remove from Favorites' : 'Add to Favorites'}</span>
+            </button>
+            <button
+                type="button"
+                onClick={() => {
+                    if (props.pinned) {
+                        props.unpinApp && props.unpinApp()
+                    } else {
+                        props.pinApp && props.pinApp()
+                    }
+                }}
+                role="menuitem"
+                aria-label={props.pinned ? 'Remove from Panel' : 'Add to Panel'}
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">{props.pinned ? 'Remove from Panel' : 'Add to Panel'}</span>
+            </button>
+            <button
+                type="button"
+                onClick={() => {
+                    if (props.onDesktop) {
+                        props.onRemoveDesktop && props.onRemoveDesktop()
+                    } else {
+                        props.onAddDesktop && props.onAddDesktop()
+                    }
+                }}
+                role="menuitem"
+                aria-label={props.onDesktop ? 'Remove from Desktop' : 'Add to Desktop'}
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700"
+            >
+                <span className="ml-5">{props.onDesktop ? 'Remove from Desktop' : 'Add to Desktop'}</span>
             </button>
         </div>
     )


### PR DESCRIPTION
## Summary
- add dedicated favorites, panel, and desktop actions to the app context menu
- migrate pinned and favorites persistence to the new kali-* storage keys with deduping and legacy fallback
- ensure the all apps view preloads built-in favourites into the new storage key

## Testing
- yarn lint *(fails: pre-existing jsx-a11y control-has-associated-label and no-top-level-window violations in unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d86b59010c832899b4e8c1c4c6a0f6