### PR TITLE
[menu] refine applications category styling

### DIFF
--- a/components/menu/ApplicationsMenu.tsx
+++ b/components/menu/ApplicationsMenu.tsx
@@ -97,11 +97,19 @@ const ApplicationsMenu: React.FC<ApplicationsMenuProps> = ({ activeCategory, onS
               <button
                 type="button"
                 onClick={() => onSelect(category.id)}
-                className={`flex w-full items-center gap-3 rounded px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
-                  isActive ? 'bg-gray-700 text-white' : 'bg-transparent hover:bg-gray-700/60'
+                className={`relative flex w-full items-center gap-3 overflow-hidden rounded px-2 py-1 text-left transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
+                  isActive
+                    ? 'bg-kali-menu-hover text-white'
+                    : 'bg-transparent text-white/80 hover:bg-kali-menu-hover hover:text-white'
                 }`}
                 aria-pressed={isActive}
               >
+                <span
+                  aria-hidden="true"
+                  className={`pointer-events-none absolute left-0 top-0 h-full w-0.5 bg-kali-accent transition-opacity ${
+                    isActive ? 'opacity-100' : 'opacity-0'
+                  }`}
+                />
                 <CategoryIcon categoryId={category.id} label={category.label} />
                 <span className="text-sm font-medium">{category.label}</span>
               </button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,7 @@
   --color-focus-ring: var(--color-accent);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
+  --color-menu-hover: color-mix(in srgb, var(--color-primary) 24%, var(--color-bg) 76%);
   --kali-text: #f5f5f5;
   accent-color: var(--color-control-accent);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,6 +36,7 @@ module.exports = {
         'ubt-gedit-dark': 'var(--color-ubt-gedit-dark)',
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
+        'kali-menu-hover': 'var(--color-menu-hover)',
         kali: {
           background: 'var(--color-bg)',
           text: 'var(--color-text)',


### PR DESCRIPTION
## Summary
- tighten the Kali applications category buttons with consistent padding and hover styling
- add a left-edge accent indicator for the active category item
- expose the menu hover color token for Tailwind to use in the component

## Testing
- yarn dev

------
https://chatgpt.com/codex/tasks/task_e_68d86b57d064832897b10ba52d44aefd