### PR TITLE
[desktop] improve Kali wallpaper handling

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1081,7 +1081,7 @@ export class Desktop extends Component {
                 </div>
 
                 {/* Background Image */}
-                <BackgroundImage />
+                <BackgroundImage bg_image_name={this.props.bg_image_name} />
 
                 {/* Ubuntu Side Menu Bar */}
                 <SideBar apps={apps}

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -1,21 +1,67 @@
 "use client";
 
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react';
 import { useSettings } from '../../hooks/useSettings';
 import KaliWallpaper from './kali-wallpaper';
 
-export default function BackgroundImage() {
-    const { bgImageName, useKaliWallpaper } = useSettings();
+const KALI_WALLPAPER_KEYS = new Set(['kali-gradient', 'kali-theme', 'kali']);
+
+export default function BackgroundImage({ bg_image_name: legacyBgImageName, showDragon }) {
+    const { bgImageName, wallpaper, useKaliWallpaper } = useSettings();
     const [needsOverlay, setNeedsOverlay] = useState(false);
 
+    const normalizedLegacy = useMemo(() => {
+        if (typeof legacyBgImageName !== 'string') return undefined;
+        return legacyBgImageName.trim();
+    }, [legacyBgImageName]);
+
+    const resolvedWallpaperName = useMemo(() => {
+        if (useKaliWallpaper) {
+            return 'kali-gradient';
+        }
+
+        if (bgImageName && KALI_WALLPAPER_KEYS.has(bgImageName)) {
+            return 'kali-gradient';
+        }
+
+        if (normalizedLegacy && KALI_WALLPAPER_KEYS.has(normalizedLegacy)) {
+            return 'kali-gradient';
+        }
+
+        if (wallpaper) {
+            return wallpaper;
+        }
+
+        if (bgImageName) {
+            return bgImageName;
+        }
+
+        if (normalizedLegacy) {
+            return normalizedLegacy;
+        }
+
+        return 'wall-2';
+    }, [bgImageName, normalizedLegacy, useKaliWallpaper, wallpaper]);
+
+    const kaliActive = useKaliWallpaper || KALI_WALLPAPER_KEYS.has(resolvedWallpaperName);
+    const shouldShowDragon = typeof showDragon === 'boolean' ? showDragon : true;
+
     useEffect(() => {
-        if (useKaliWallpaper || bgImageName === 'kali-gradient') {
+        if (kaliActive) {
             setNeedsOverlay(false);
             return;
         }
+
+        if (!resolvedWallpaperName) {
+            setNeedsOverlay(false);
+            return;
+        }
+
+        let cancelled = false;
         const img = new Image();
-        img.src = `/wallpapers/${bgImageName}.webp`;
+        img.src = `/wallpapers/${resolvedWallpaperName}.webp`;
         img.onload = () => {
+            if (cancelled) return;
             const canvas = document.createElement('canvas');
             canvas.width = img.width;
             canvas.height = img.height;
@@ -32,31 +78,38 @@ export default function BackgroundImage() {
             }
             const avgR = r / count, avgG = g / count, avgB = b / count;
             const toLinear = (c) => {
-                c /= 255;
-                return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+                const normalized = c / 255;
+                return normalized <= 0.03928 ? normalized / 12.92 : Math.pow((normalized + 0.055) / 1.055, 2.4);
             };
             const lum = 0.2126 * toLinear(avgR) + 0.7152 * toLinear(avgG) + 0.0722 * toLinear(avgB);
-            const contrast = (1.05) / (lum + 0.05); // white text luminance is 1
+            const contrast = 1.05 / (lum + 0.05); // white text luminance is 1
             setNeedsOverlay(contrast < 4.5);
         };
-    }, [bgImageName, useKaliWallpaper]);
+
+        return () => {
+            cancelled = true;
+        };
+    }, [kaliActive, resolvedWallpaperName]);
 
     return (
         <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
-            {useKaliWallpaper || bgImageName === 'kali-gradient' ? (
-                <KaliWallpaper />
+            {kaliActive ? (
+                <KaliWallpaper showDragon={shouldShowDragon} />
             ) : (
                 <>
                     <img
-                        src={`/wallpapers/${bgImageName}.webp`}
+                        src={`/wallpapers/${resolvedWallpaperName}.webp`}
                         alt=""
                         className="w-full h-full object-cover"
                     />
                     {needsOverlay && (
-                        <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>
+                        <div
+                            className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent"
+                            aria-hidden="true"
+                        ></div>
                     )}
                 </>
             )}
         </div>
-    )
+    );
 }


### PR DESCRIPTION
## Summary
- render the Kali gradient wallpaper directly from BackgroundImage when the active wallpaper or legacy bg_image_name selects the Kali theme
- support optionally hiding the centered dragon SVG and preserve existing wallpaper choices through the legacy prop while continuing to use the settings store
- plumb the desktop bg_image_name into BackgroundImage so legacy selections remain intact when toggling the Kali theme

## Testing
- yarn lint *(fails: large number of existing jsx-a11y and no-top-level-window lint errors in unrelated files)*
- yarn test --runTestsByPath __tests__/themePersistence.test.ts *(fails: jsdom localStorage origin error in settingsStore getUseKaliWallpaper)*

------
https://chatgpt.com/codex/tasks/task_e_68d86b652294832889bbb1d34aa58da4