### PR TITLE
[menu] Add keyboard and backdrop handling to Places menu

### DIFF
--- a/__tests__/PlacesMenu.test.tsx
+++ b/__tests__/PlacesMenu.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import PlacesMenu, { PlacesMenuItem } from '../components/menu/PlacesMenu';
+
+describe('PlacesMenu keyboard interactions', () => {
+  const baseItem: PlacesMenuItem = {
+    id: 'home',
+    label: 'Home',
+    icon: '/themes/Kali/places/user-home.svg',
+  };
+
+  test('Enter triggers onSelect and closes the menu', () => {
+    const onSelect = jest.fn();
+    const onClose = jest.fn();
+
+    render(
+      <PlacesMenu
+        heading="Places"
+        items={[{ ...baseItem, onSelect }]}
+        onClose={onClose}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: /home/i });
+    fireEvent.keyDown(button, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('ArrowRight opens the location in a new window', () => {
+    const onSelect = jest.fn();
+    const onClose = jest.fn();
+
+    render(
+      <PlacesMenu
+        heading="Places"
+        items={[{ ...baseItem, onSelect }]}
+        onClose={onClose}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: /home/i });
+    fireEvent.keyDown(button, { key: 'ArrowRight' });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith({ openInNewWindow: true });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('Escape closes the menu without selecting an item', () => {
+    const onSelect = jest.fn();
+    const onClose = jest.fn();
+
+    render(
+      <PlacesMenu
+        heading="Places"
+        items={[{ ...baseItem, onSelect }]}
+        onClose={onClose}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: /home/i });
+    fireEvent.keyDown(button, { key: 'Escape' });
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking the backdrop closes the menu', () => {
+    const onSelect = jest.fn();
+    const onClose = jest.fn();
+
+    render(
+      <PlacesMenu
+        heading="Places"
+        items={[{ ...baseItem, onSelect }]}
+        onClose={onClose}
+      />,
+    );
+
+    const backdrop = screen.getByTestId('places-menu-backdrop');
+    fireEvent.click(backdrop);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/components/menu/PlacesMenu.tsx
+++ b/components/menu/PlacesMenu.tsx
@@ -4,12 +4,16 @@ export type PlacesMenuItem = {
   id: string;
   label: string;
   icon: string;
-  onSelect?: () => void;
+  onSelect?: (options?: { openInNewWindow?: boolean }) => void;
 };
 
 export interface PlacesMenuProps {
   heading?: string;
   items: PlacesMenuItem[];
+  onClose?: () => void;
+  containerClassName?: string;
+  panelClassName?: string;
+  backdropClassName?: string;
 }
 
 const KALI_ICON_MAP: Record<string, string> = {
@@ -43,8 +47,15 @@ const resolveKaliIcon = (id: string): string | undefined => {
   return KALI_ICON_MAP[normalizedId];
 };
 
-const PlacesMenu: React.FC<PlacesMenuProps> = ({ heading = 'Places', items }) => {
-  return (
+const PlacesMenu: React.FC<PlacesMenuProps> = ({
+  heading = 'Places',
+  items,
+  onClose,
+  containerClassName = 'fixed inset-0 z-50 flex items-start justify-center p-4 sm:justify-start',
+  panelClassName = 'relative z-10',
+  backdropClassName = 'absolute inset-0 bg-black/40 backdrop-blur-sm',
+}) => {
+  const menuContent = (
     <nav aria-label={heading} className="w-56 select-none text-sm text-white">
       <header className="px-3 pb-2 text-xs font-semibold uppercase tracking-wide text-ubt-grey">
         {heading}
@@ -54,15 +65,34 @@ const PlacesMenu: React.FC<PlacesMenuProps> = ({ heading = 'Places', items }) =>
           const kaliIcon = resolveKaliIcon(item.id);
           const src = kaliIcon ?? item.icon;
 
-          const handleClick = () => {
-            item.onSelect?.();
+          const activateItem = (options?: { openInNewWindow?: boolean }) => {
+            if (options) {
+              item.onSelect?.(options);
+            } else {
+              item.onSelect?.();
+            }
+            onClose?.();
+          };
+
+          const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              activateItem();
+            } else if (event.key === 'ArrowRight') {
+              event.preventDefault();
+              activateItem({ openInNewWindow: true });
+            } else if (event.key === 'Escape') {
+              event.preventDefault();
+              onClose?.();
+            }
           };
 
           return (
             <li key={item.id}>
               <button
                 type="button"
-                onClick={handleClick}
+                onClick={() => activateItem()}
+                onKeyDown={handleKeyDown}
                 className="flex w-full items-center gap-3 rounded px-3 py-2 text-left transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-ubb-orange"
               >
                 <img
@@ -94,7 +124,32 @@ const PlacesMenu: React.FC<PlacesMenuProps> = ({ heading = 'Places', items }) =>
         })}
       </ul>
     </nav>
+  );
 
+  if (!onClose) {
+    return menuContent;
+  }
+
+  return (
+    <div className={containerClassName} role="dialog" aria-modal="true">
+      <div
+        data-testid="places-menu-backdrop"
+        className={backdropClassName}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        className={panelClassName}
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+        onMouseDown={(event) => {
+          event.stopPropagation();
+        }}
+      >
+        {menuContent}
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- add keyboard handlers to PlacesMenu so Enter, ArrowRight, and Escape trigger the expected actions
- render a backdrop when the menu is closable and close it on outside clicks
- cover the new interactions with focused unit tests

## Testing
- yarn test PlacesMenu

------
https://chatgpt.com/codex/tasks/task_e_68d86b65371c8328ac446a43f53d5d70