### PR TITLE
[desktop] notify trash listeners after cleanup

### DIFF
--- a/components/apps/trash/index.tsx
+++ b/components/apps/trash/index.tsx
@@ -35,14 +35,24 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     } catch {
       data = [];
     }
-    data = data.filter((item) => now - item.closedAt <= ms);
-    localStorage.setItem('window-trash', JSON.stringify(data));
-    setItems(data);
+    const filtered = data.filter((item) => now - item.closedAt <= ms);
+    localStorage.setItem('window-trash', JSON.stringify(filtered));
+    if (filtered.length !== data.length && typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('trash-change'));
+    }
+    setItems(filtered);
   }, []);
+
+  const notifyChange = () => {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('trash-change'));
+    }
+  };
 
   const persist = (next: TrashItem[]) => {
     setItems(next);
     localStorage.setItem('window-trash', JSON.stringify(next));
+    notifyChange();
   };
 
   const restore = useCallback(() => {

--- a/components/menu/PlacesMenu.tsx
+++ b/components/menu/PlacesMenu.tsx
@@ -4,7 +4,7 @@ export type PlacesMenuItem = {
   id: string;
   label: string;
   icon: string;
-  onSelect?: () => void;
+  onSelect?: () => void | Promise<void>;
 };
 
 export interface PlacesMenuProps {
@@ -43,6 +43,43 @@ const resolveKaliIcon = (id: string): string | undefined => {
   return KALI_ICON_MAP[normalizedId];
 };
 
+const dispatchTrashChange = () => {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event('trash-change'));
+  }
+};
+
+const isTrashEmptyAction = (id: string) => {
+  const normalized = id.toLowerCase();
+  return normalized.includes('trash') && normalized.includes('empty');
+};
+
+const notifyWhenSettled = (maybePromise: unknown) => {
+  if (
+    maybePromise &&
+    typeof (maybePromise as PromiseLike<unknown>).then === 'function'
+  ) {
+    const promise = maybePromise as PromiseLike<unknown> & {
+      finally?: (onFinally: () => void) => PromiseLike<unknown>;
+    };
+
+    if (typeof promise.finally === 'function') {
+      promise.finally(dispatchTrashChange);
+    } else {
+      promise.then(
+        () => dispatchTrashChange(),
+        error => {
+          dispatchTrashChange();
+          throw error;
+        },
+      );
+    }
+    return true;
+  }
+
+  return false;
+};
+
 const PlacesMenu: React.FC<PlacesMenuProps> = ({ heading = 'Places', items }) => {
   return (
     <nav aria-label={heading} className="w-56 select-none text-sm text-white">
@@ -55,7 +92,14 @@ const PlacesMenu: React.FC<PlacesMenuProps> = ({ heading = 'Places', items }) =>
           const src = kaliIcon ?? item.icon;
 
           const handleClick = () => {
-            item.onSelect?.();
+            const result = item.onSelect?.();
+            if (!isTrashEmptyAction(item.id)) {
+              return;
+            }
+
+            if (!notifyWhenSettled(result)) {
+              dispatchTrashChange();
+            }
           };
 
           return (


### PR DESCRIPTION
## Summary
- dispatch the global trash-change event when the Places menu triggers its empty-trash action, including async handlers
- emit trash-change notifications when the trash app prunes or persists items so the desktop icon stays in sync

## Testing
- yarn lint *(fails: repository has hundreds of pre-existing accessibility and browser-global lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d86b6581f88328bcd8b87757fcc280