### PR TITLE
[navbar] Coordinate applications and places menus

### DIFF
--- a/components/menu/PlacesDropdown.tsx
+++ b/components/menu/PlacesDropdown.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import Image from 'next/image';
+import React, { useCallback, useEffect, useId, useMemo, useRef } from 'react';
+import PlacesMenu, { PlacesMenuItem } from './PlacesMenu';
+
+type PlacesDropdownProps = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  items: PlacesMenuItem[];
+  className?: string;
+};
+
+const PlacesDropdown: React.FC<PlacesDropdownProps> = ({
+  isOpen,
+  onOpenChange,
+  items,
+  className,
+}) => {
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const buttonId = useId();
+  const menuId = `${buttonId}-menu`;
+
+  const close = useCallback(() => {
+    onOpenChange(false);
+  }, [onOpenChange]);
+
+  const toggle = useCallback(() => {
+    onOpenChange(!isOpen);
+  }, [isOpen, onOpenChange]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node | null;
+      if (
+        target &&
+        (menuRef.current?.contains(target) || buttonRef.current?.contains(target))
+      ) {
+        return;
+      }
+      close();
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+    };
+  }, [close, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [close, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const firstButton = menuRef.current?.querySelector('button');
+    if (firstButton instanceof HTMLElement) {
+      firstButton.focus({ preventScroll: true });
+    } else {
+      menuRef.current?.focus({ preventScroll: true });
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen) return;
+    buttonRef.current?.focus({ preventScroll: true });
+  }, [isOpen]);
+
+  const menuItems = useMemo(
+    () =>
+      items.map(item => ({
+        ...item,
+        onSelect: () => {
+          item.onSelect?.();
+          close();
+        },
+      })),
+    [close, items],
+  );
+
+  return (
+    <div className={`relative inline-flex ${className ?? ''}`}>
+      <button
+        ref={buttonRef}
+        id={buttonId}
+        type="button"
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        aria-controls={menuId}
+        onClick={toggle}
+        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 focus:border-ubb-orange"
+      >
+        <Image
+          src="/themes/Kali/places/user-home.svg"
+          alt=""
+          width={16}
+          height={16}
+          className="inline mr-1 h-4 w-4"
+        />
+        Places
+      </button>
+      <div
+        ref={menuRef}
+        id={menuId}
+        role="menu"
+        aria-labelledby={buttonId}
+        tabIndex={-1}
+        className={`absolute left-0 mt-1 w-56 overflow-hidden rounded-md border border-black/20 bg-ub-grey text-white shadow-lg transition-all duration-150 ease-out ${
+          isOpen
+            ? 'pointer-events-auto opacity-100 translate-y-0'
+            : 'pointer-events-none opacity-0 -translate-y-2'
+        }`}
+      >
+        <div className="p-3">
+          <PlacesMenu items={menuItems} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PlacesDropdown;
+

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -5,49 +5,102 @@ import QuickSettings from '../ui/QuickSettings';
 import NotificationBell from '../ui/NotificationBell';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import PerformanceGraph from '../ui/PerformanceGraph';
+import PlacesDropdown from '../menu/PlacesDropdown';
+
+const BASE_PLACES = [
+        { id: 'home', label: 'Home', icon: '/themes/Kali/places/user-home.svg', path: 'home/kali' },
+        { id: 'desktop', label: 'Desktop', icon: '/themes/Kali/places/user-desktop.svg', path: 'home/kali/Desktop' },
+        { id: 'documents', label: 'Documents', icon: '/themes/Kali/places/folder-documents.svg', path: 'home/kali/Documents' },
+        { id: 'downloads', label: 'Downloads', icon: '/themes/Kali/places/folder-downloads.svg', path: 'home/kali/Downloads' },
+        { id: 'pictures', label: 'Pictures', icon: '/themes/Kali/places/folder-pictures.svg', path: 'home/kali/Pictures' },
+        { id: 'videos', label: 'Videos', icon: '/themes/Kali/places/folder-videos.svg', path: 'home/kali/Videos' }
+];
 
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
+        constructor() {
+                super();
                 this.state = {
-                        status_card: false,
-                        applicationsMenuOpen: false,
-                        placesMenuOpen: false
+                        openMenu: null,
+                        statusCard: false
                 };
+                this.placesMenuItems = BASE_PLACES.map((item) => ({
+                        id: item.id,
+                        label: item.label,
+                        icon: item.icon,
+                        onSelect: () => this.openPlace(item.path)
+                }));
         }
 
-		render() {
-			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
-						<WhiskerMenu />
-						<PerformanceGraph />
-					</div>
-					<div
-						className={
-							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
+        openPlace = (path) => {
+                if (typeof window === 'undefined') return;
+                window.dispatchEvent(new CustomEvent('open-app', { detail: { id: 'files', path } }));
+        };
+
+        handleMenuOpenChange = (menu, isOpen) => {
+                this.setState((prev) => {
+                        if (isOpen) {
+                                const nextState = { openMenu: menu };
+                                if (prev.statusCard) {
+                                        nextState.statusCard = false;
+                                }
+                                return nextState;
+                        }
+                        if (prev.openMenu === menu) {
+                                return { openMenu: null };
+                        }
+                        return null;
+                });
+        };
+
+        toggleStatusCard = () => {
+                this.setState((prev) => ({
+                        statusCard: !prev.statusCard,
+                        openMenu: null
+                }));
+        };
+
+                render() {
+                        const { openMenu, statusCard } = this.state;
+                        return (
+                                <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                        <div className="flex items-center">
+                                                <WhiskerMenu
+                                                        className="mr-1"
+                                                        isOpen={openMenu === 'applications'}
+                                                        onOpenChange={(isOpen) => this.handleMenuOpenChange('applications', isOpen)}
+                                                />
+                                                <PlacesDropdown
+                                                        className="mr-2"
+                                                        isOpen={openMenu === 'places'}
+                                                        onOpenChange={(isOpen) => this.handleMenuOpenChange('places', isOpen)}
+                                                        items={this.placesMenuItems}
+                                                />
+                                                <PerformanceGraph />
+                                        </div>
+                                        <div
+                                                className={
+                                                        'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
 						}
 					>
 						<Clock />
 					</div>
 					<button
-						type="button"
-						id="status-bar"
-						aria-label="System status"
-						onClick={() => {
-							this.setState({ status_card: !this.state.status_card });
-						}}
-						className={
-							'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-						}
-					>
-						<Status />
-						<QuickSettings open={this.state.status_card} />
-					</button>
-				</div>
-			);
-		}
+                                                type="button"
+                                                id="status-bar"
+                                                aria-label="System status"
+                                                aria-expanded={statusCard}
+                                                onClick={this.toggleStatusCard}
+                                                className={
+                                                        'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
+                                                }
+                                        >
+                                                <Status />
+                                                <QuickSettings open={statusCard} />
+                                        </button>
+                                </div>
+                        );
+                }
 
 
 }


### PR DESCRIPTION
## Summary
- replace the navbar's boolean status flag with a shared menu state that tracks the active applications or places menu and the quick settings card
- add a reusable PlacesDropdown component that mirrors the applications menu behaviour with outside-click dismissal and aria-expanded updates
- adapt WhiskerMenu to accept controlled open state so opening one menu automatically closes the other and keeps accessibility attributes in sync

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label violations in unrelated apps and legacy public scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68d86b65445c83289d94b189a74e2c94