### PR TITLE
[desktop] Increase icon sizing and spacing

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -42,23 +42,26 @@ export class UbuntuApp extends Component {
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
                 className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
-                    " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
+                    " p-2 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-24 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active pointer-events-auto "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
                 tabIndex={this.props.disabled ? -1 : 0}
                 onMouseEnter={this.handlePrefetch}
                 onFocus={this.handlePrefetch}
+                title={this.props.name}
             >
                 <Image
-                    width={40}
-                    height={40}
-                    className="mb-1 w-10"
+                    width={64}
+                    height={64}
+                    className="mb-2 h-16 w-16"
                     src={this.props.icon.replace('./', '/')}
                     alt={"Kali " + this.props.name}
-                    sizes="40px"
+                    sizes="64px"
                 />
-                {this.props.displayName || this.props.name}
+                <span className="mt-1 block w-full px-1 text-center text-xs font-normal text-white truncate">
+                    {this.props.displayName || this.props.name}
+                </span>
 
             </div>
         )

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -590,8 +590,8 @@ export class Desktop extends Component {
 
     renderDesktopApps = () => {
         if (Object.keys(this.state.closed_windows).length === 0) return;
-        let appsJsx = [];
-        apps.forEach((app, index) => {
+        const appsJsx = [];
+        apps.forEach((app) => {
             if (this.state.desktop_apps.includes(app.id)) {
 
                 const props = {
@@ -608,7 +608,15 @@ export class Desktop extends Component {
                 );
             }
         });
-        return appsJsx;
+        if (!appsJsx.length) return null;
+        return (
+            <div
+                className="absolute inset-0 flex flex-wrap content-start items-start gap-[96px] p-10"
+                data-context="desktop-area"
+            >
+                {appsJsx}
+            </div>
+        );
     }
 
     renderWindows = () => {


### PR DESCRIPTION
## Summary
- enlarge the shared UbuntuApp icon rendering to 64px with truncated labels for single-line titles
- arrange desktop shortcuts in a flex grid with 96px gaps while keeping drag and context menu data attributes intact

## Testing
- yarn lint *(fails: pre-existing accessibility violations across multiple apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d86b6bece08328b9cfa854228ac3c8