### PR TITLE
[ui] Switch global font to Source Sans 3

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -18,11 +18,11 @@ import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
-import { Ubuntu } from 'next/font/google';
+import { Source_Sans_3 } from 'next/font/google';
 
-const ubuntu = Ubuntu({
+const sourceSans = Source_Sans_3({
   subsets: ['latin'],
-  weight: ['300', '400', '500', '700'],
+  weight: ['300', '400', '500', '600', '700'],
 });
 
 
@@ -150,7 +150,7 @@ function MyApp(props) {
   return (
     <ErrorBoundary>
       <Script src="/a2hs.js" strategy="beforeInteractive" />
-      <div className={ubuntu.className}>
+      <div className={sourceSans.className}>
         <a
           href="#app-grid"
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -27,6 +27,15 @@
 body {
   background: var(--kali-bg);
   color: var(--kali-text);
+  font-family: var(
+    --font-family-base,
+    'Source Sans 3',
+    'Source Sans Pro',
+    'Segoe UI',
+    'Helvetica Neue',
+    Arial,
+    sans-serif
+  );
 }
 
 /* Dark theme */

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -73,7 +73,7 @@
   --motion-slow: 500ms;
 
   /* Fonts */
-  --font-family-base: 'Ubuntu', sans-serif;
+  --font-family-base: 'Source Sans 3', 'Source Sans Pro', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;


### PR DESCRIPTION
## Summary
- replace the legacy Ubuntu font import in the app shell with `Source_Sans_3` from `next/font/google`
- update global CSS tokens and body fallbacks so base typography uses the new Source Sans family

## Testing
- ESLINT_USE_FLAT_CONFIG=true npx eslint pages/_app.jsx --ext .jsx --rule "@next/next/no-before-interactive-script-outside-document: off"


------
https://chatgpt.com/codex/tasks/task_e_68d89d40dc208328a1c22aabd43fd6f2