### PR TITLE
[ui] Align accent CSS variables with Kali tokens

### DIFF
--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -1,6 +1,6 @@
 .windowFrame {
   position: relative;
-  border: 1px solid var(--color-window-border);
+  border: 1px solid var(--kali-border, var(--color-window-border));
   border-radius: var(--radius-6);
   box-shadow: var(--shadow-2);
   overflow: hidden;
@@ -14,7 +14,7 @@
   left: 0;
   right: 0;
   height: 2px;
-  background: var(--color-window-accent);
+  background: var(--kali-blue, var(--color-window-accent));
   opacity: 0;
   pointer-events: none;
   border-top-left-radius: calc(var(--radius-6) - 1px);

--- a/components/menu/PlacesMenu.tsx
+++ b/components/menu/PlacesMenu.tsx
@@ -45,8 +45,8 @@ const resolveKaliIcon = (id: string): string | undefined => {
 
 const PlacesMenu: React.FC<PlacesMenuProps> = ({ heading = 'Places', items }) => {
   return (
-    <nav aria-label={heading} className="w-56 select-none text-sm text-white">
-      <header className="px-3 pb-2 text-xs font-semibold uppercase tracking-wide text-ubt-grey">
+    <nav aria-label={heading} className="w-56 select-none text-sm" style={{ color: 'var(--kali-text)' }}>
+      <header className="px-3 pb-2 text-xs font-semibold uppercase tracking-wide opacity-80">
         {heading}
       </header>
       <ul className="space-y-1">
@@ -63,7 +63,7 @@ const PlacesMenu: React.FC<PlacesMenuProps> = ({ heading = 'Places', items }) =>
               <button
                 type="button"
                 onClick={handleClick}
-                className="flex w-full items-center gap-3 rounded px-3 py-2 text-left transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-ubb-orange"
+                className="flex w-full items-center gap-3 rounded px-3 py-2 text-left transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-[var(--kali-focus-ring)]"
               >
                 <img
                   src={src}

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -393,7 +393,7 @@ const WhiskerMenu: React.FC = () => {
       {isVisible && (
         <div
           ref={menuRef}
-          className={`absolute left-0 mt-1 z-50 flex w-[520px] bg-ub-grey text-white shadow-lg rounded-md overflow-hidden transition-all duration-200 ease-out ${
+          className={`absolute left-0 mt-1 z-50 flex w-[520px] rounded-md border border-[var(--kali-panel-border)] bg-[var(--kali-panel)]/95 text-[var(--kali-text)] shadow-lg backdrop-blur transition-all duration-200 ease-out ${
             isOpen ? 'opacity-100 translate-y-0 scale-100' : 'pointer-events-none opacity-0 -translate-y-2 scale-95'
           }`}
           style={{ transitionDuration: `${TRANSITION_DURATION}ms` }}
@@ -406,7 +406,7 @@ const WhiskerMenu: React.FC = () => {
         >
           <div
             ref={categoryListRef}
-            className="flex max-h-80 w-64 flex-col gap-1 overflow-y-auto bg-gray-900 p-3"
+            className="flex max-h-80 w-64 flex-col gap-1 overflow-y-auto bg-black/40 p-3"
             role="listbox"
             aria-label="Application categories"
             tabIndex={0}
@@ -419,8 +419,8 @@ const WhiskerMenu: React.FC = () => {
                   categoryButtonRefs.current[index] = el;
                 }}
                 type="button"
-                className={`flex items-center gap-3 rounded px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-ubb-orange focus:ring-offset-2 focus:ring-offset-gray-900 ${
-                  category === cat.id ? 'bg-gray-700/80' : 'hover:bg-gray-700/60'
+                className={`flex items-center gap-3 rounded px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-[var(--kali-focus-ring)] focus:ring-offset-2 focus:ring-offset-gray-900 ${
+                  category === cat.id ? 'bg-white/10' : 'hover:bg-white/5'
                 }`}
                 role="option"
                 aria-selected={category === cat.id}
@@ -444,12 +444,14 @@ const WhiskerMenu: React.FC = () => {
                 </span>
               </button>
             ))}
-            <div className="mt-4 border-t border-gray-700 pt-3">
-              <p className="text-xs uppercase tracking-wide text-gray-400 mb-2">Kali Linux Groups</p>
-              <ul className="space-y-1 text-sm">
+            <div className="mt-4 border-t border-[var(--kali-panel-border)] pt-3">
+              <p className="mb-2 text-xs uppercase tracking-wide text-gray-300/80">Kali Linux Groups</p>
+              <ul className="space-y-1 text-sm text-gray-200">
                 {KALI_CATEGORIES.map((cat) => (
-                  <li key={cat.id} className="flex items-baseline text-gray-300">
-                    <span className="font-mono text-ubt-blue mr-2 w-8">{cat.number}</span>
+                  <li key={cat.id} className="flex items-baseline">
+                    <span className="mr-2 w-8 font-mono" style={{ color: 'var(--kali-blue)' }}>
+                      {cat.number}
+                    </span>
                     <span>{cat.label}</span>
                   </li>
                 ))}
@@ -472,7 +474,7 @@ const WhiskerMenu: React.FC = () => {
                 <div
                   key={app.id}
                   className={`rounded transition ring-offset-2 ${
-                    idx === highlight ? 'ring-2 ring-ubb-orange ring-offset-gray-900' : 'ring-0'
+                    idx === highlight ? 'ring-2 ring-[var(--kali-focus-ring)] ring-offset-gray-900' : 'ring-0'
                   }`}
                 >
                   <UbuntuApp

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -19,18 +19,18 @@ export default class Navbar extends Component {
 
 		render() {
 			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
-						<WhiskerMenu />
-						<PerformanceGraph />
-					</div>
-					<div
-						className={
-							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-						}
-					>
-						<Clock />
-					</div>
+                                <div className="main-navbar-vp absolute top-0 right-0 w-screen border-b border-[var(--kali-panel-border)] bg-[var(--kali-panel)]/95 text-[var(--kali-text)] shadow-md backdrop-blur-md flex flex-nowrap justify-between items-center text-sm select-none z-50">
+                                        <div className="flex items-center">
+                                                <WhiskerMenu />
+                                                <PerformanceGraph />
+                                        </div>
+                                        <div
+                                                className={
+                                                        'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1 text-[var(--kali-text)]'
+                                                }
+                                        >
+                                                <Clock />
+                                        </div>
 					<button
 						type="button"
 						id="status-bar"
@@ -38,14 +38,12 @@ export default class Navbar extends Component {
 						onClick={() => {
 							this.setState({ status_card: !this.state.status_card });
 						}}
-						className={
-							'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-						}
-					>
-						<Status />
-						<QuickSettings open={this.state.status_card} />
-					</button>
-				</div>
+                                                className="relative pr-3 pl-3 rounded-md outline-none transition duration-100 ease-in-out border-b-2 border-transparent text-[var(--kali-text)] focus-visible:ring-2 focus-visible:ring-[var(--kali-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--kali-panel)] py-1 hover:bg-[var(--kali-panel-highlight)]"
+                                        >
+                                                <Status />
+                                                <QuickSettings open={this.state.status_card} />
+                                        </button>
+                                </div>
 			);
 		}
 

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -18,7 +18,7 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center justify-between px-2 z-40" role="toolbar">
+        <div className="absolute bottom-0 left-0 w-full h-10 border-t border-[var(--kali-panel-border)] bg-[var(--kali-panel)]/95 text-[var(--kali-text)] flex items-center justify-between px-2 z-40 backdrop-blur-md" role="toolbar">
             <WorkspaceSwitcher
                 workspaces={workspaces}
                 activeWorkspace={props.activeWorkspace}
@@ -40,7 +40,7 @@ export default function Taskbar(props) {
                             data-active={isActive ? 'true' : 'false'}
                             aria-pressed={isActive}
                             onClick={() => handleClick(app)}
-                            className={`${isFocused && isActive ? 'bg-white bg-opacity-20 ' : ''}relative flex items-center mx-1 px-2 py-1 rounded hover:bg-white hover:bg-opacity-10`}
+                            className={`${isFocused && isActive ? 'bg-[var(--kali-panel-highlight)] ' : ''}relative flex items-center mx-1 px-2 py-1 rounded-md transition focus-visible:ring-2 focus-visible:ring-[var(--kali-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--kali-panel)] hover:bg-[var(--kali-panel-highlight)]`}
                         >
                             <Image
                                 width={24}
@@ -50,12 +50,12 @@ export default function Taskbar(props) {
                                 alt=""
                                 sizes="24px"
                             />
-                            <span className="ml-1 text-sm text-white whitespace-nowrap">{app.title}</span>
+                            <span className="ml-1 text-sm text-[var(--kali-text)] whitespace-nowrap">{app.title}</span>
                             {isActive && (
                                 <span
                                     aria-hidden="true"
                                     data-testid="running-indicator"
-                                    className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 bg-white rounded"
+                                    className="absolute bottom-0 left-1/2 -translate-x-1/2 w-2 h-0.5 rounded bg-[var(--kali-blue)]"
                                 />
                             )}
                         </button>

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -154,7 +154,7 @@ const NotificationBell: React.FC = () => {
         aria-expanded={isOpen}
         aria-controls={panelId}
         onClick={togglePanel}
-        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey transition focus:border-ubb-orange focus:outline-none focus:ring-0 hover:bg-white hover:bg-opacity-10"
+        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-[var(--kali-text)] transition focus-visible:ring-2 focus-visible:ring-[var(--kali-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--kali-panel)] hover:bg-[var(--kali-panel-highlight)]"
       >
         <svg
           aria-hidden="true"
@@ -167,7 +167,7 @@ const NotificationBell: React.FC = () => {
           <path d="M7 12a3 3 0 006 0H7z" />
         </svg>
         {unreadCount > 0 && (
-          <span className="absolute -top-1.5 -right-1.5 min-w-[1.5rem] rounded-full bg-ubb-orange px-1 text-center text-[0.65rem] font-semibold leading-5 text-white">
+          <span className="absolute -top-1.5 -right-1.5 min-w-[1.5rem] rounded-full px-1 text-center text-[0.65rem] font-semibold leading-5 text-white" style={{ background: 'var(--kali-blue)' }}>
             {unreadCount > 99 ? '99+' : unreadCount}
           </span>
         )}
@@ -180,37 +180,38 @@ const NotificationBell: React.FC = () => {
           aria-modal="false"
           aria-labelledby={headingId}
           tabIndex={-1}
-          className="absolute right-0 z-50 mt-2 w-72 max-h-96 overflow-hidden rounded-md border border-white/10 bg-ub-grey/95 text-ubt-grey shadow-xl backdrop-blur"
+          className="absolute right-0 z-50 mt-2 w-72 max-h-96 overflow-hidden rounded-md border border-[var(--kali-panel-border)] bg-[var(--kali-panel)]/95 text-[var(--kali-text)] shadow-xl backdrop-blur"
         >
-          <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
-            <h2 id={headingId} className="text-sm font-semibold text-white">
+          <div className="flex items-center justify-between border-b border-[var(--kali-panel-border)] px-4 py-2">
+            <h2 id={headingId} className="text-sm font-semibold" style={{ color: 'var(--kali-text)' }}>
               Notifications
             </h2>
             <button
               type="button"
               onClick={handleDismissAll}
               disabled={notifications.length === 0}
-              className="text-xs font-medium text-ubb-orange transition disabled:cursor-not-allowed disabled:text-ubt-grey disabled:text-opacity-50"
+              className="text-xs font-medium transition disabled:cursor-not-allowed disabled:opacity-50"
+              style={{ color: 'var(--kali-blue)' }}
             >
               Dismiss all
             </button>
           </div>
           <div className="max-h-80 overflow-y-auto">
             {notifications.length === 0 ? (
-              <p className="px-4 py-6 text-center text-sm text-ubt-grey text-opacity-80">
+              <p className="px-4 py-6 text-center text-sm opacity-80" style={{ color: 'var(--kali-text)' }}>
                 You&apos;re all caught up.
               </p>
             ) : (
-              <ul role="list" className="divide-y divide-white/10">
+              <ul role="list" className="divide-y divide-[var(--kali-panel-border)]">
                 {formattedNotifications.map(notification => (
-                  <li key={notification.id} className="px-4 py-3 text-sm text-white">
-                    <p className="font-medium">{notification.title}</p>
+                  <li key={notification.id} className="px-4 py-3 text-sm" style={{ color: 'var(--kali-text)' }}>
+                    <p className="font-medium" style={{ color: 'var(--kali-text)' }}>{notification.title}</p>
                     {notification.body && (
-                      <p className="mt-1 text-xs text-ubt-grey text-opacity-80">
+                      <p className="mt-1 text-xs opacity-80" style={{ color: 'var(--kali-text)' }}>
                         {notification.body}
                       </p>
                     )}
-                    <div className="mt-2 flex items-center justify-between text-[0.65rem] uppercase tracking-wide text-ubt-grey text-opacity-70">
+                    <div className="mt-2 flex items-center justify-between text-[0.65rem] uppercase tracking-wide opacity-70" style={{ color: 'var(--kali-text)' }}>
                       <span>{notification.appId}</span>
                       <time dateTime={notification.formattedTime}>{notification.readableTime}</time>
                     </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,9 +17,9 @@
   --color-border: #2a2e36; /* subtle borders */
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
-  --color-focus-ring: var(--color-accent);
-  --color-selection: var(--color-accent);
-  --color-control-accent: var(--color-accent);
+  --color-focus-ring: var(--kali-focus-ring, var(--color-accent));
+  --color-selection: var(--kali-selection, var(--color-accent));
+  --color-control-accent: var(--kali-control-accent, var(--color-accent));
   --kali-text: #f5f5f5;
   accent-color: var(--color-control-accent);
 }
@@ -76,7 +76,7 @@ html[data-theme='matrix'] {
 }
 
 ::selection {
-  background: color-mix(in srgb, var(--color-primary) 65%, var(--kali-bg));
+  background: var(--color-selection);
   color: var(--kali-text);
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -36,6 +36,10 @@
   --kali-panel: rgba(26, 31, 38, 0.9);
   --kali-panel-border: rgba(255, 255, 255, 0.08);
   --kali-panel-highlight: rgba(255, 255, 255, 0.05);
+  --kali-border: rgba(255, 255, 255, 0.08);
+  --kali-focus-ring: var(--kali-blue);
+  --kali-selection: rgba(23, 147, 209, 0.35);
+  --kali-control-accent: var(--kali-blue);
   --kali-terminal-green: #00ff00;
   --kali-terminal-text: #f5f5f5;
 
@@ -97,6 +101,14 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --kali-blue: #ffff00;
+  --kali-blue-dark: #b29b00;
+  --kali-blue-glow: rgba(255, 255, 0, 0.35);
+  --kali-panel-border: rgba(255, 255, 0, 0.6);
+  --kali-border: rgba(255, 255, 0, 0.6);
+  --kali-focus-ring: #ffff00;
+  --kali-selection: rgba(255, 255, 0, 0.35);
+  --kali-control-accent: #ffff00;
 }
 
 /* Dyslexia-friendly fonts */
@@ -136,5 +148,13 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --kali-blue: #ffff00;
+    --kali-blue-dark: #b29b00;
+    --kali-blue-glow: rgba(255, 255, 0, 0.35);
+    --kali-panel-border: rgba(255, 255, 0, 0.6);
+    --kali-border: rgba(255, 255, 0, 0.6);
+    --kali-focus-ring: #ffff00;
+    --kali-selection: rgba(255, 255, 0, 0.35);
+    --kali-control-accent: #ffff00;
   }
 }


### PR DESCRIPTION
## Summary
- replace the accent settings effect with logic that drives the new `--kali-*` token family and derived shades
- expose fallback values for the new tokens and apply them throughout navbar, taskbar, and window chrome consumers
- refresh menu and notification components to read the new accent variables for focus, borders, and badges

## Testing
- Attempted `yarn lint` *(hangs in container, terminated after no output)*

------
https://chatgpt.com/codex/tasks/task_e_68d89d3f860c8328842e90098341c0a8