### PR TITLE
[terminal] align terminal typography

### DIFF
--- a/apps/terminal/components/PipeSandbox.tsx
+++ b/apps/terminal/components/PipeSandbox.tsx
@@ -29,7 +29,10 @@ export default function PipeSandbox() {
   }
 
   return (
-    <div className="space-y-2 p-4">
+    <div
+      className="space-y-2 p-4"
+      style={{ fontFamily: 'var(--font-terminal)' }}
+    >
       <input
         className="w-full border px-2 py-1"
         value={command}

--- a/apps/terminal/components/Scripts.tsx
+++ b/apps/terminal/components/Scripts.tsx
@@ -103,7 +103,10 @@ const Scripts = ({ runCommand }: ScriptsProps) => {
   };
 
   return (
-    <div className="p-2 space-y-2 text-sm">
+    <div
+      className="p-2 space-y-2 text-sm"
+      style={{ fontFamily: 'var(--font-terminal)' }}
+    >
       <p className="text-xs">
         Need sample scripts?{' '}
         <a

--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -14,7 +14,7 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
         background: 'var(--kali-bg)',
         backdropFilter: 'blur(4px)',
         border: '1px solid var(--color-border)',
-        fontFamily: 'monospace',
+        fontFamily: 'var(--font-terminal)',
         fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
         lineHeight: 1.4,
         ...style,

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -308,7 +308,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
         scrollback: 1000,
         cols: 80,
         rows: 24,
-        fontFamily: '"Fira Code", monospace',
+        fontFamily: 'var(--font-terminal)',
         theme: {
           background: '#0f1317',
           foreground: '#f5f5f5',

--- a/apps/terminal/tabs/index.tsx
+++ b/apps/terminal/tabs/index.tsx
@@ -17,11 +17,16 @@ const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
   };
 
   return (
-    <TabbedWindow
+    <div
       className="h-full w-full"
-      initialTabs={[createTab()]}
-      onNewTab={createTab}
-    />
+      style={{ fontFamily: 'var(--font-terminal)' }}
+    >
+      <TabbedWindow
+        className="h-full w-full"
+        initialTabs={[createTab()]}
+        onNewTab={createTab}
+      />
+    </div>
   );
 };
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,41 @@
 @import './tokens.css';
 
+@font-face {
+  font-family: 'Fira Code';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src:
+    local('Fira Code Regular'),
+    local('FiraCode-Regular'),
+    url('https://cdn.jsdelivr.net/npm/firacode@6.2.0/distr/woff2/FiraCode-Regular.woff2')
+      format('woff2');
+}
+
+@font-face {
+  font-family: 'Fira Code';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src:
+    local('Fira Code SemiBold'),
+    local('FiraCode-SemiBold'),
+    url('https://cdn.jsdelivr.net/npm/firacode@6.2.0/distr/woff2/FiraCode-SemiBold.woff2')
+      format('woff2');
+}
+
+@font-face {
+  font-family: 'Hack';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src:
+    local('Hack Regular'),
+    local('Hack-Regular'),
+    url('https://cdn.jsdelivr.net/npm/hack-font@3.3.0/build/web/hack-regular.woff2')
+      format('woff2');
+}
+
 /* Accessible theme color palette meeting WCAG AA contrast ratios */
 :root {
   /* Base colors */
@@ -21,6 +57,9 @@
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   --kali-text: #f5f5f5;
+  --font-terminal: 'Fira Code', 'Hack', 'Source Code Pro', 'SFMono-Regular',
+    ui-monospace, 'DejaVu Sans Mono', Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
   accent-color: var(--color-control-accent);
 }
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -505,7 +505,7 @@ dialog {
 /* Ensure monospace layout for app outputs */
 textarea,
 pre {
-    font-family: monospace;
+    font-family: var(--font-terminal, monospace);
     line-height: 1.2;
 }
 


### PR DESCRIPTION
## Summary
- load Fira Code and Hack via global @font-face rules and expose a --font-terminal variable
- update terminal surfaces, xterm, and tab containers to consume the shared font family
- apply the terminal font to supporting script and pipeline helpers for consistent monospace output

## Testing
- [ ] yarn lint *(blocked: command hung in container)*
- Flags: none

------
https://chatgpt.com/codex/tasks/task_e_68d89d416fdc8328b2bcdb74f7f7a575