### PR TITLE
[ui] Add Kali glass utility to desktop chrome

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -19,7 +19,7 @@ export default class Navbar extends Component {
 
 		render() {
 			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                <div className="main-navbar-vp kali-glass absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center text-ubt-grey text-sm select-none z-50">
 					<div className="flex items-center">
 						<WhiskerMenu />
 						<PerformanceGraph />

--- a/components/screen/side_bar.js
+++ b/components/screen/side_bar.js
@@ -30,7 +30,7 @@ export default function SideBar(props) {
             <nav
                 aria-label="Dock"
                 className={(props.hide ? " -translate-x-full " : "") +
-                    " absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7 border-black border-opacity-60 bg-black bg-opacity-50"}
+                    " kali-glass absolute transform duration-300 select-none z-40 left-0 top-0 h-full min-h-screen w-16 flex flex-col justify-start items-center pt-7"}
             >
                 {
                     (

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -18,7 +18,7 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center justify-between px-2 z-40" role="toolbar">
+        <div className="kali-glass absolute bottom-0 left-0 w-full h-10 flex items-center justify-between px-2 z-40" role="toolbar">
             <WorkspaceSwitcher
                 workspaces={workspaces}
                 activeWorkspace={props.activeWorkspace}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -89,6 +89,14 @@ html {
   scrollbar-color: var(--kali-border, var(--color-border)) transparent;
 }
 
+/* Shared Kali glassmorphism panel */
+.kali-glass {
+  background: var(--kali-panel);
+  border: 1px solid var(--kali-panel-border);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+}
+
 ::-webkit-scrollbar {
   width: 6px;
   height: 6px;


### PR DESCRIPTION
## Summary
- add a reusable `.kali-glass` utility that encapsulates the Kali glass panel surface styling
- switch the navbar, taskbar, and sidebar surfaces to the shared utility for consistent glassmorphism treatment

## Testing
- yarn lint *(fails: existing accessibility and no-top-level-window lint violations in unrelated apps and public game bundles)*

------
https://chatgpt.com/codex/tasks/task_e_68d89d448ed483288a6fc088bdbc0959