### PR TITLE
[seo] Sync theme-color meta with selected accent

### DIFF
--- a/components/SEO/Meta.js
+++ b/components/SEO/Meta.js
@@ -20,7 +20,7 @@ export default function Meta() {
             <meta name="language" content="English" />
             <meta name="category" content="16" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
-            <meta name="theme-color" content="#0f1317" />
+            <meta name="theme-color" content="#1793d1" data-default-accent />
 
             {/* Search Engine */}
             <meta name="image" content="images/logos/fevicon.png" />
@@ -60,6 +60,12 @@ export default function Meta() {
                         name: "Alex Unnippillil",
                         url: "https://unnippillil.com/",
                     }),
+                }}
+            />
+            <script
+                nonce={nonce}
+                dangerouslySetInnerHTML={{
+                    __html: `(() => { try { const doc = document.documentElement; if (!doc) return; const apply = (color) => { if (!color) return; const metas = document.querySelectorAll('meta[name="theme-color"]'); metas.forEach((meta) => meta.setAttribute('content', color)); }; apply(doc.dataset.accent || '#1793d1'); const observer = new MutationObserver((mutations) => { for (const mutation of mutations) { if (mutation.attributeName === 'data-accent') { apply(doc.dataset.accent); break; } } }); observer.observe(doc, { attributes: true, attributeFilter: ['data-accent'] }); doc.addEventListener('kali:accent-change', () => apply(doc.dataset.accent)); } catch (error) { /* no-op */ } })();`,
                 }}
             />
         </Head>

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -147,6 +147,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const border = shadeColor(accent, -0.2);
+    const root = document.documentElement;
     const vars: Record<string, string> = {
       '--color-ub-orange': accent,
       '--color-ub-border-orange': border,
@@ -157,7 +158,17 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       '--color-control-accent': accent,
     };
     Object.entries(vars).forEach(([key, value]) => {
-      document.documentElement.style.setProperty(key, value);
+      root.style.setProperty(key, value);
+    });
+    root.dataset.accent = accent;
+    try {
+      root.dispatchEvent(new CustomEvent('kali:accent-change', { detail: accent }));
+    } catch (error) {
+      // CustomEvent may fail in legacy browsers; ignore to avoid breaking accent updates.
+    }
+    const themeMetas = document.querySelectorAll('meta[name="theme-color"]');
+    themeMetas.forEach((meta) => {
+      meta.setAttribute('content', accent);
     });
     saveAccent(accent);
   }, [accent]);

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -13,11 +13,11 @@ class MyDocument extends Document {
   render() {
     const { nonce } = this.props;
     return (
-      <Html lang="en" data-csp-nonce={nonce}>
+      <Html lang="en" data-csp-nonce={nonce} data-accent="#1793d1">
         <Head>
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
-          <meta name="theme-color" content="#0f1317" />
+          <meta name="theme-color" content="#1793d1" />
           <script nonce={nonce} src="/theme.js" />
         </Head>
         <body>


### PR DESCRIPTION
## Summary
- expose the active accent on the root element so the theme color can be read outside React
- update the SEO meta component with a script that applies the accent to all `theme-color` tags while keeping the default Kali blue fallback
- set the document-level fallback `theme-color` meta tag to Kali blue for crawlers

## Testing
- ⚠️ `yarn lint` *(hangs in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68d89d45e0c0832895a3b9a5bad5bcf7