### PR TITLE
[screen] Improve booting power control accessibility

### DIFF
--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -19,11 +19,16 @@ function BootingScreen(props) {
                 sizes="(max-width: 768px) 50vw, 25vw"
                 priority
             />
-            <div className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer" onClick={props.turnOn} >
+            <button
+                type="button"
+                aria-label="Power on Kali desktop"
+                onClick={props.turnOn}
+                className="w-10 h-10 flex justify-center items-center rounded-full border border-transparent outline-none cursor-pointer transition hover:border-[var(--color-accent)] focus-visible:border-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            >
                 {(props.isShutDown
-                    ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><Image width={32} height={32} className="w-8" src="/themes/Yaru/status/power-button.svg" alt="Power Button" sizes="32px" priority/></div>
-                    : <Image width={40} height={40} className={" w-10 " + (props.visible ? " animate-spin " : "")} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" sizes="40px" priority/>)}
-            </div>
+                    ? <Image width={32} height={32} className="w-8" src="/themes/Kali/panel/power-button.svg" alt="Power Button" sizes="32px" priority/>
+                    : <div className={"w-10 h-10 rounded-full border-4 border-white/20 border-t-[var(--color-accent)] " + (props.visible ? "animate-spin" : "")}></div>)}
+            </button>
             <Image
                 width={200}
                 height={100}


### PR DESCRIPTION
## Summary
- swap the boot screen power icon to the Kali theme asset and keep it accessible with an aria label
- restyle the power control focus and hover states to use the Kali accent border
- replace the loading image with an accent-colored spinner while the desktop boots

## Testing
- [ ] yarn lint (blocked: command hung in container)


------
https://chatgpt.com/codex/tasks/task_e_68d89d4e4e548328b0159ac9f3da59f0