### PR TITLE
[ui] Update boot splash with Kali branding

### DIFF
--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -2,40 +2,73 @@ import React from 'react'
 import Image from 'next/image'
 
 function BootingScreen(props) {
+    const isVisible = props.visible || props.isShutDown
 
     return (
         <div
             style={{
-                ...(props.visible || props.isShutDown ? { zIndex: "100" } : { zIndex: "-20" }),
+                ...(isVisible ? { zIndex: '100' } : { zIndex: '-20' }),
                 contentVisibility: 'auto',
             }}
-            className={(props.visible || props.isShutDown ? " visible opacity-100" : " invisible opacity-0 ") + " absolute duration-500 select-none flex flex-col justify-around items-center top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen bg-black"}>
-            <Image
-                width={400}
-                height={400}
-                className="md:w-1/4 w-1/2"
-                src="/themes/Yaru/status/cof_orange_hex.svg"
-                alt="Ubuntu Logo"
-                sizes="(max-width: 768px) 50vw, 25vw"
-                priority
-            />
-            <div className="w-10 h-10 flex justify-center items-center rounded-full outline-none cursor-pointer" onClick={props.turnOn} >
-                {(props.isShutDown
-                    ? <div className="bg-white rounded-full flex justify-center items-center w-10 h-10 hover:bg-gray-300"><Image width={32} height={32} className="w-8" src="/themes/Yaru/status/power-button.svg" alt="Power Button" sizes="32px" priority/></div>
-                    : <Image width={40} height={40} className={" w-10 " + (props.visible ? " animate-spin " : "")} src="/themes/Yaru/status/process-working-symbolic.svg" alt="Ubuntu Process Symbol" sizes="40px" priority/>)}
+            className={(isVisible ? ' visible opacity-100' : ' invisible opacity-0') + ' absolute duration-500 select-none flex flex-col items-center justify-between top-0 right-0 overflow-hidden m-0 h-screen w-screen bg-black'}
+        >
+            <div className="flex-1 flex flex-col items-center justify-center gap-8 md:gap-10 px-4 text-center">
+                <Image
+                    width={320}
+                    height={320}
+                    className="w-36 md:w-48 drop-shadow-[0_0_35px_rgba(23,147,209,0.6)]"
+                    src="/themes/Kali/panel/emblem-system-symbolic.svg"
+                    alt="Kali Linux dragon emblem"
+                    sizes="(max-width: 768px) 40vw, 20vw"
+                    priority
+                />
+                <div className="flex flex-col items-center gap-4">
+                    <Image
+                        width={420}
+                        height={160}
+                        className="w-56 md:w-72"
+                        src="/themes/Kali/panel/kali-wordmark.svg"
+                        alt="Kali Linux wordmark"
+                        sizes="(max-width: 768px) 65vw, 30vw"
+                        priority
+                    />
+                    <p className="text-sky-200/80 uppercase tracking-[0.35em] text-[0.55rem] md:text-xs">
+                        The quieter you become, the more you are able to hear.
+                    </p>
+                </div>
+                <div
+                    className="w-12 h-12 flex justify-center items-center rounded-full outline-none cursor-pointer transition hover:bg-slate-800/40"
+                    onClick={props.turnOn}
+                >
+                    {props.isShutDown ? (
+                        <div className="bg-white/10 border border-sky-500/50 rounded-full flex justify-center items-center w-12 h-12 hover:bg-slate-800/50">
+                            <Image
+                                width={36}
+                                height={36}
+                                className="w-8 md:w-9"
+                                src="/themes/Kali/panel/power-button.svg"
+                                alt="Power button"
+                                sizes="36px"
+                                priority
+                            />
+                        </div>
+                    ) : (
+                        <Image
+                            width={44}
+                            height={44}
+                            className={(props.visible ? 'animate-spin ' : '') + 'w-10 md:w-11'}
+                            src="/themes/Kali/panel/process-working-symbolic.svg"
+                            alt="Boot progress spinner"
+                            sizes="44px"
+                            priority
+                        />
+                    )}
+                </div>
             </div>
-            <Image
-                width={200}
-                height={100}
-                className="md:w-1/5 w-1/2"
-                src="/themes/Yaru/status/ubuntu_white_hex.svg"
-                alt="Kali Linux Name"
-                sizes="(max-width: 768px) 50vw, 20vw"
-            />
-            <div className="text-white mb-4">
-                <a className="underline" href="https://www.linkedin.com/in/unnippillil/" rel="noopener noreferrer" target="_blank">linkedin</a>
-                <span className="font-bold mx-1">|</span>
-                <a href="https://github.com/Alex-Unnippillil" rel="noopener noreferrer" target="_blank" className="underline">github</a>
+            <div className="text-slate-300 mb-6 text-sm">
+                <a className="underline decoration-sky-500/60 decoration-2 underline-offset-4" href="https://www.linkedin.com/in/unnippillil/" rel="noopener noreferrer" target="_blank">linkedin</a>
+                <span className="font-bold mx-2 text-slate-500">|</span>
+                <a href="https://github.com/Alex-Unnippillil" rel="noopener noreferrer" target="_blank" className="underline decoration-sky-500/60 decoration-2 underline-offset-4">github</a>
             </div>
         </div>
     )

--- a/public/themes/Kali/panel/kali-wordmark.svg
+++ b/public/themes/Kali/panel/kali-wordmark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 120" fill="none">
+  <rect x="4" y="4" width="352" height="112" rx="14" ry="14" stroke="#1793d1" stroke-width="8" fill="rgba(23,147,209,0.05)" />
+  <path d="M54 86V34h16.5l21 24.5L113 34h17v52h-17V62l-16.5 20h-6L74 62v24H54zM156 86L134 34h19l10.5 26.5L174 34h18l-22 52h-14zM208 34h18v52h-18V34zM244 34h56v14h-19v38h-18V48h-19V34zM308 86V34h18v52h-18z" fill="#1793d1" />
+</svg>


### PR DESCRIPTION
## Summary
- swap the booting screen logo, spinner, and wordmark to use the Kali panel assets and add a Kali-styled wordmark
- restyle the boot splash layout to center the dragon emblem, add the Kali tagline, and refresh link styling

## Testing
- yarn lint *(fails: pre-existing jsx-a11y control-has-associated-label and no-top-level-window errors throughout legacy apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d89d4cb6f083288418f6fd96933873