### PR TITLE
[screen] Polish lock screen hero

### DIFF
--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -29,15 +29,63 @@ export default function LockScreen(props) {
                     className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
                 />
             )}
-            <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
-                <div className=" text-7xl">
-                    <Clock onlyTime={true} />
-                </div>
-                <div className="mt-4 text-xl font-medium">
-                    <Clock onlyDay={true} />
-                </div>
-                <div className=" mt-16 text-base">
-                    Click or Press a key to unlock
+            <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white px-6">
+                <div
+                    className="relative flex flex-col items-center text-center gap-6 px-10 py-12 md:px-16 md:py-14 backdrop-blur-xl"
+                    style={{
+                        background: 'var(--kali-panel)',
+                        borderRadius: '24px',
+                        border: '1px solid var(--kali-panel-border)',
+                        boxShadow: '0 0 45px var(--kali-blue-glow)',
+                    }}
+                >
+                    <div className="flex flex-col items-center gap-3">
+                        <div
+                            className="h-24 w-24 md:h-28 md:w-28 rounded-full overflow-hidden border"
+                            style={{
+                                borderColor: 'var(--kali-panel-highlight)',
+                                boxShadow: '0 0 25px var(--kali-blue-glow)',
+                                background: 'radial-gradient(circle at 30% 30%, color-mix(in srgb, var(--kali-blue), transparent 10%) 0%, color-mix(in srgb, var(--kali-blue), transparent 40%) 45%, transparent 100%)',
+                            }}
+                        >
+                            <img
+                                src="/favicon.svg"
+                                alt="Kali user avatar"
+                                className="h-full w-full object-cover opacity-90"
+                            />
+                        </div>
+                        <div className="flex flex-col items-center gap-1">
+                            <p className="text-2xl font-semibold tracking-wide uppercase" style={{ color: 'var(--kali-text)' }}>
+                                kali
+                            </p>
+                            <p className="text-sm font-medium text-[color:rgba(255,255,255,0.75)] max-w-[20ch]">
+                                The quieter you become, the more you are able to hear.
+                            </p>
+                        </div>
+                    </div>
+                    <div
+                        className="h-px w-full"
+                        style={{
+                            background: 'linear-gradient(90deg, transparent, var(--kali-blue), transparent)',
+                            boxShadow: '0 0 20px var(--kali-blue-glow)',
+                        }}
+                    />
+                    <div className="text-7xl font-light tracking-tight drop-shadow-lg">
+                        <Clock onlyTime={true} />
+                    </div>
+                    <div className="text-xl font-medium opacity-80">
+                        <Clock onlyDay={true} />
+                    </div>
+                    <div
+                        className="h-px w-3/4"
+                        style={{
+                            background: 'linear-gradient(90deg, transparent, var(--kali-blue), transparent)',
+                            boxShadow: '0 0 16px var(--kali-blue-glow)',
+                        }}
+                    />
+                    <div className="text-base tracking-wide uppercase text-[color:rgba(255,255,255,0.85)]">
+                        Click or press a key to unlock
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- wrap the lock screen content in a translucent Kali-styled panel with avatar, username, and tagline above the clock
- add accent-colored separators and glow effects using the new Kali design tokens while keeping the blurred wallpaper backdrop

## Testing
- [x] yarn lint *(fails: existing accessibility violations across multiple apps in the monorepo)*

------
https://chatgpt.com/codex/tasks/task_e_68d89d512b488328bbb2acc9b2c9409c