### PR TITLE
[screen] Add lock screen unlock button focus improvements

### DIFF
--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
 import KaliWallpaper from '../util-components/kali-wallpaper';
@@ -7,16 +7,77 @@ export default function LockScreen(props) {
 
     const { bgImageName, useKaliWallpaper } = useSettings();
     const useKaliTheme = useKaliWallpaper || bgImageName === 'kali-gradient';
+    const lockScreenRef = useRef(null);
+    const unlockButtonRef = useRef(null);
 
-    if (props.isLocked) {
-        window.addEventListener('click', props.unLockScreen);
-        window.addEventListener('keypress', props.unLockScreen);
-    };
+    useEffect(() => {
+        if (!props.isLocked) {
+            return;
+        }
+
+        const handleWindowClick = (event) => {
+            // Allow the unlock button to handle its own click without double invocation.
+            if (event.target === unlockButtonRef.current) {
+                return;
+            }
+            props.unLockScreen(event);
+        };
+
+        const handleKeyDown = (event) => {
+            if (event.key === 'Tab') {
+                const focusableSelectors = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+                const focusableElements = lockScreenRef.current
+                    ? Array.from(lockScreenRef.current.querySelectorAll(focusableSelectors))
+                        .filter((el) => !el.hasAttribute('disabled'))
+                    : [];
+
+                if (focusableElements.length === 0) {
+                    event.preventDefault();
+                    return;
+                }
+
+                const firstElement = focusableElements[0];
+                const lastElement = focusableElements[focusableElements.length - 1];
+
+                if (event.shiftKey) {
+                    if (document.activeElement === firstElement) {
+                        event.preventDefault();
+                        lastElement.focus();
+                    }
+                } else if (document.activeElement === lastElement) {
+                    event.preventDefault();
+                    firstElement.focus();
+                }
+            }
+
+            if (event.key === 'Enter') {
+                props.unLockScreen(event);
+            }
+        };
+
+        window.addEventListener('click', handleWindowClick);
+
+        const container = lockScreenRef.current;
+        container?.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            window.removeEventListener('click', handleWindowClick);
+            container?.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [props.isLocked, props.unLockScreen]);
+
+    useEffect(() => {
+        if (props.isLocked && unlockButtonRef.current) {
+            unlockButtonRef.current.focus();
+        }
+    }, [props.isLocked]);
 
     return (
         <div
             id="ubuntu-lock-screen"
             style={{ zIndex: "100", contentVisibility: 'auto' }}
+            ref={lockScreenRef}
+            tabIndex={-1}
             className={(props.isLocked ? " visible translate-y-0 " : " invisible -translate-y-full ") + " absolute outline-none bg-black bg-opacity-90 transform duration-500 select-none top-0 right-0 overflow-hidden m-0 p-0 h-screen w-screen"}>
             {useKaliTheme ? (
                 <KaliWallpaper
@@ -36,8 +97,16 @@ export default function LockScreen(props) {
                 <div className="mt-4 text-xl font-medium">
                     <Clock onlyDay={true} />
                 </div>
-                <div className=" mt-16 text-base">
-                    Click or Press a key to unlock
+                <div className="mt-16 flex flex-col items-center gap-4 text-base">
+                    <span>Press Enter or use the button below to unlock.</span>
+                    <button
+                        type="button"
+                        ref={unlockButtonRef}
+                        onClick={props.unLockScreen}
+                        className="rounded-full bg-blue-500 px-6 py-2 text-lg font-semibold text-white shadow-lg transition hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300 focus:ring-offset-2 focus:ring-offset-transparent"
+                    >
+                        Unlock
+                    </button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add a dedicated Unlock button that calls `unLockScreen` and auto-focuses when the lock screen appears
- trap keyboard focus inside the lock screen overlay and update the helper text to mention Enter/button usage

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label violations throughout apps/ and public/ assets)*

------
https://chatgpt.com/codex/tasks/task_e_68d89d5209a88328a57825e88bb10eb6