### PR TITLE
[ui] refresh navbar for Kali glass panel

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -374,19 +374,19 @@ const WhiskerMenu: React.FC = () => {
   };
 
   return (
-    <div className="relative inline-flex">
+    <div className="relative inline-flex items-center">
       <button
         ref={buttonRef}
         type="button"
         onClick={toggleMenu}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className="flex items-center gap-2 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.24em] text-kali-accent-text-strong outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-kali-accent-text-strong"
       >
         <Image
-          src="/themes/Yaru/status/decompiler-symbolic.svg"
+          src="/themes/Kali/panel/decompiler-symbolic.svg"
           alt="Menu"
           width={16}
           height={16}
-          className="inline mr-1"
+          className="h-4 w-4"
         />
         Applications
       </button>

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -19,33 +19,33 @@ export default class Navbar extends Component {
 
 		render() {
 			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
-						<WhiskerMenu />
-						<PerformanceGraph />
-					</div>
-					<div
-						className={
-							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'
-						}
-					>
-						<Clock />
-					</div>
-					<button
+                                <div className="main-navbar-vp absolute top-0 right-0 z-50 flex w-screen flex-nowrap items-center justify-between bg-kali-glass px-2 text-kali-accent-text-muted text-[11px] shadow-md glass-panel backdrop-blur-md select-none">
+                                        <div className="flex items-center gap-2">
+                                                <WhiskerMenu />
+                                                <PerformanceGraph />
+                                        </div>
+                                        <div
+                                                className={
+                                                        'px-2 py-0.5 text-[11px] font-medium text-kali-accent-text-strong transition duration-100 ease-in-out'
+                                                }
+                                        >
+                                                <Clock />
+                                        </div>
+                                        <button
 						type="button"
 						id="status-bar"
 						aria-label="System status"
 						onClick={() => {
 							this.setState({ status_card: !this.state.status_card });
 						}}
-						className={
-							'relative pr-3 pl-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-ubb-orange py-1 '
-						}
-					>
-						<Status />
-						<QuickSettings open={this.state.status_card} />
-					</button>
-				</div>
+                                                className={
+                                                        'relative px-2 py-0.5 outline-none transition duration-100 ease-in-out border-b-2 border-transparent focus:border-kali-accent-text-strong'
+                                                }
+                                        >
+                                                <Status />
+                                                <QuickSettings open={this.state.status_card} />
+                                        </button>
+                                </div>
 			);
 		}
 

--- a/components/ui/VolumeControl.tsx
+++ b/components/ui/VolumeControl.tsx
@@ -5,10 +5,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import usePersistentState from "../../hooks/usePersistentState";
 
 const ICONS = {
-  muted: "/themes/Yaru/status/audio-volume-muted-symbolic.svg",
-  low: "/themes/Yaru/status/audio-volume-low-symbolic.svg",
-  medium: "/themes/Yaru/status/audio-volume-medium-symbolic.svg",
-  high: "/themes/Yaru/status/audio-volume-high-symbolic.svg",
+  muted: "/themes/Kali/panel/audio-volume-medium-symbolic.svg",
+  low: "/themes/Kali/panel/audio-volume-medium-symbolic.svg",
+  medium: "/themes/Kali/panel/audio-volume-medium-symbolic.svg",
+  high: "/themes/Kali/panel/audio-volume-medium-symbolic.svg",
 } as const;
 
 type VolumeLevel = keyof typeof ICONS;
@@ -108,7 +108,7 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
     >
       <button
         type="button"
-        className="flex h-6 w-6 items-center justify-center rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+        className="flex h-5 w-5 items-center justify-center rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kali-accent-text-strong"
         aria-label={`Volume ${formatPercent(volume)}`}
         aria-haspopup="true"
         aria-expanded={open}
@@ -121,21 +121,21 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
           height={16}
           src={ICONS[level]}
           alt={`${level} volume`}
-          className="status-symbol h-4 w-4"
+          className={`status-symbol h-4 w-4${level === "muted" ? " opacity-50" : ""}`}
           draggable={false}
           sizes="16px"
         />
       </button>
       {open && (
         <div
-          className="absolute bottom-full right-0 z-50 mb-2 min-w-[9rem] rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-2 text-xs text-white shadow-lg"
+          className="absolute bottom-full right-0 z-50 mb-2 min-w-[9rem] rounded-md border border-white/10 bg-kali-glass px-3 py-2 text-xs text-kali-accent-text-strong shadow-lg backdrop-blur-md"
           onClick={(event) => event.stopPropagation()}
           onPointerDown={(event) => event.stopPropagation()}
           onWheel={handleWheel}
         >
-          <div className="mb-2 flex items-center justify-between text-[11px] uppercase tracking-wide text-gray-200">
+          <div className="mb-2 flex items-center justify-between text-[11px] uppercase tracking-wide text-kali-accent-text-muted">
             <span>Volume</span>
-            <span className="font-semibold text-white">{formatPercent(volume)}</span>
+            <span className="font-semibold text-kali-accent-text-strong">{formatPercent(volume)}</span>
           </div>
           <input
             ref={sliderRef}
@@ -148,7 +148,7 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
             aria-valuemax={100}
             aria-valuenow={Math.round(volume * 100)}
             aria-label="Volume level"
-            className="h-1 w-full cursor-pointer accent-ubt-blue"
+            className="h-1 w-full cursor-pointer accent-kali-accent-text-strong"
             onChange={handleRangeChange}
           />
         </div>

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -38,36 +38,40 @@ export default function Status() {
   }, []);
 
   return (
-    <div className="flex justify-center items-center">
+    <div className="flex items-center gap-2 text-kali-accent-text-strong">
       <span
-        className="mx-1.5 relative"
+        className="relative flex items-center"
         title={online ? (allowNetwork ? 'Online' : 'Online (requests blocked)') : 'Offline'}
       >
         <Image
           width={16}
           height={16}
-          src={online ? "/themes/Yaru/status/network-wireless-signal-good-symbolic.svg" : "/themes/Yaru/status/network-wireless-signal-none-symbolic.svg"}
+          src={
+            online
+              ? "/themes/Kali/panel/network-wireless-signal-good-symbolic.svg"
+              : "/themes/Kali/panel/network-wireless-signal-none-symbolic.svg"
+          }
           alt={online ? "online" : "offline"}
-          className="inline status-symbol w-4 h-4"
+          className="status-symbol h-4 w-4"
           sizes="16px"
         />
         {!allowNetwork && (
           <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
         )}
       </span>
-      <VolumeControl className="mx-1.5" />
-      <span className="mx-1.5">
+      <VolumeControl className="text-kali-accent-text-strong" />
+      <span className="flex items-center">
         <Image
           width={16}
           height={16}
-          src="/themes/Yaru/status/battery-good-symbolic.svg"
-          alt="ubuntu battry"
-          className="inline status-symbol w-4 h-4"
+          src="/themes/Kali/panel/battery-good-symbolic.svg"
+          alt="battery status"
+          className="status-symbol h-4 w-4"
           sizes="16px"
         />
       </span>
-      <span className="mx-1">
-        <SmallArrow angle="down" className=" status-symbol" />
+      <span className="flex items-center">
+        <SmallArrow angle="down" className="status-symbol text-kali-accent-text-muted" />
       </span>
     </div>
   );

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,14 @@ body{
     color: var(--color-text);
 }
 
+.glass-panel {
+    background: var(--kali-glass, rgba(26, 31, 38, 0.9));
+    -webkit-backdrop-filter: blur(16px);
+    backdrop-filter: blur(16px);
+    border-bottom: 1px solid var(--kali-panel-border);
+    box-shadow: inset 0 1px 0 var(--kali-glass-highlight);
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -36,6 +36,10 @@
   --kali-panel: rgba(26, 31, 38, 0.9);
   --kali-panel-border: rgba(255, 255, 255, 0.08);
   --kali-panel-highlight: rgba(255, 255, 255, 0.05);
+  --kali-glass: color-mix(in srgb, var(--kali-panel) 90%, transparent);
+  --kali-glass-highlight: rgba(255, 255, 255, 0.06);
+  --kali-accent-text-strong: color-mix(in srgb, var(--kali-blue) 75%, var(--kali-text) 25%);
+  --kali-accent-text-muted: color-mix(in srgb, var(--kali-blue) 55%, var(--kali-text) 45%);
   --kali-terminal-green: #00ff00;
   --kali-terminal-text: #f5f5f5;
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,6 +36,9 @@ module.exports = {
         'ubt-gedit-dark': 'var(--color-ubt-gedit-dark)',
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
+        'kali-glass': 'var(--kali-glass)',
+        'kali-accent-text-strong': 'var(--kali-accent-text-strong)',
+        'kali-accent-text-muted': 'var(--kali-accent-text-muted)',
         kali: {
           background: 'var(--color-bg)',
           text: 'var(--color-text)',


### PR DESCRIPTION
## Summary
- add Kali glass surface utility and accent text tokens for Kali panel styling
- tighten navbar spacing, uppercase the applications launcher, and adopt Kali panel icons
- refresh status widgets with Kali volume popover styling and accent-aware colors

## Testing
- yarn lint *(fails: pre-existing accessibility and no-top-level-window violations across legacy apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d89d53ebe8832893452306acd1cb00