### PR TITLE
[menu] Refresh Kali whisker toggle

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -379,16 +379,16 @@ const WhiskerMenu: React.FC = () => {
         ref={buttonRef}
         type="button"
         onClick={toggleMenu}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className="glass-interactive"
       >
         <Image
-          src="/themes/Yaru/status/decompiler-symbolic.svg"
-          alt="Menu"
-          width={16}
-          height={16}
-          className="inline mr-1"
+          src="/themes/Kali/panel/decompiler-symbolic.svg"
+          alt="Kali menu"
+          width={18}
+          height={18}
+          className="h-4 w-4 shrink-0"
         />
-        Applications
+        <span>Kali Menu</span>
       </button>
       {isVisible && (
         <div

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -11,6 +11,31 @@
   }
 }
 
+@layer components {
+  .glass-interactive {
+    @apply inline-flex items-center gap-2 rounded-md border border-transparent px-3 py-1.5 text-sm font-medium leading-5;
+    background-color: color-mix(in srgb, var(--kali-panel) 82%, transparent);
+    border-color: color-mix(in srgb, var(--kali-panel-border) 65%, transparent);
+    backdrop-filter: blur(12px);
+    color: var(--color-text);
+    min-height: 2.5rem;
+    transition: background-color var(--motion-fast) ease, border-color var(--motion-fast) ease,
+      box-shadow var(--motion-fast) ease, color var(--motion-fast) ease;
+  }
+
+  .glass-interactive:hover,
+  .glass-interactive:focus-visible {
+    background-color: color-mix(in srgb, var(--color-primary) 20%, var(--kali-panel) 80%);
+    border-color: color-mix(in srgb, var(--color-primary) 45%, transparent);
+    color: var(--color-text);
+  }
+
+  .glass-interactive:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 70%, transparent);
+  }
+}
+
 @layer base {
   button {
     @apply transition-hover transition-active;


### PR DESCRIPTION
## Summary
- swap the whisker toggle icon to the Kali panel asset and rename the control to "Kali Menu"
- add a reusable glass-interactive style so the toggle matches the new panel height and accent states

## Testing
- yarn lint *(fails: pre-existing jsx-a11y control-has-associated-label violations across many apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d89d55a9c08328bf5d3dfe4f636f1c