### PR TITLE
[ui] sync performance graph accent with theme

### DIFF
--- a/__tests__/performanceGraph.test.tsx
+++ b/__tests__/performanceGraph.test.tsx
@@ -1,0 +1,54 @@
+import { render, waitFor } from '@testing-library/react';
+
+import PerformanceGraph from '../components/ui/PerformanceGraph';
+
+const createMatchMedia = (matches: boolean) => (query: string): MediaQueryList => ({
+  matches: query === '(prefers-reduced-motion: reduce)' ? matches : false,
+  media: query,
+  onchange: null,
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  dispatchEvent: jest.fn(),
+});
+
+describe('PerformanceGraph', () => {
+  beforeEach(() => {
+    document.documentElement.style.removeProperty('--kali-accent');
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: createMatchMedia(false),
+    });
+  });
+
+  it('uses the CSS accent variable when available', async () => {
+    document.documentElement.style.setProperty('--kali-accent', '#ff0000');
+
+    const { container } = render(<PerformanceGraph />);
+
+    await waitFor(() => {
+      const stops = container.querySelectorAll('stop');
+      expect(stops.length).toBeGreaterThanOrEqual(2);
+      expect(stops[0]).toHaveAttribute('stop-color', '#ff0000');
+      expect(stops[1]).toHaveAttribute('stop-color', '#ff0000');
+    });
+  });
+
+  it('keeps a static path when reduced motion is preferred', async () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: createMatchMedia(true),
+    });
+
+    const { container } = render(<PerformanceGraph />);
+    const path = container.querySelector('path');
+
+    expect(path?.getAttribute('d')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(path?.getAttribute('d')).toBeTruthy();
+    });
+  });
+});
+

--- a/components/ui/PerformanceGraph.tsx
+++ b/components/ui/PerformanceGraph.tsx
@@ -4,6 +4,12 @@ const SAMPLE_INTERVAL = 1000;
 const MAX_POINTS = 32;
 const GRAPH_HEIGHT = 18;
 const GRAPH_WIDTH = 80;
+const DEFAULT_ACCENT = '#1793d1';
+
+function sanitizeAccent(value: string | null | undefined) {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : DEFAULT_ACCENT;
+}
 
 function usePrefersReducedMotion() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
@@ -49,12 +55,29 @@ type PerformanceGraphProps = {
 
 const PerformanceGraph: React.FC<PerformanceGraphProps> = ({ className }) => {
   const prefersReducedMotion = usePrefersReducedMotion();
+  const [accentColor, setAccentColor] = useState<string>(DEFAULT_ACCENT);
   const [points, setPoints] = useState<number[]>(() =>
     Array.from({ length: MAX_POINTS }, (_, index) => 0.32 + (index % 3) * 0.04)
   );
   const timeoutRef = useRef<number | ReturnType<typeof setTimeout> | null>(null);
   const frameRef = useRef<number | null>(null);
   const lastSampleRef = useRef<number>(typeof performance !== 'undefined' ? performance.now() : 0);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+
+    const rootStyle = getComputedStyle(document.documentElement);
+    const accent =
+      rootStyle.getPropertyValue('--kali-accent') ||
+      rootStyle.getPropertyValue('--color-primary') ||
+      DEFAULT_ACCENT;
+
+    const nextAccent = sanitizeAccent(accent);
+
+    setAccentColor(prev => (prev === nextAccent ? prev : nextAccent));
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -143,8 +166,8 @@ const PerformanceGraph: React.FC<PerformanceGraphProps> = ({ className }) => {
       >
         <defs>
           <linearGradient id="kaliSpark" x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stopColor="#61a3ff" stopOpacity="0.9" />
-            <stop offset="100%" stopColor="#1f4aa8" stopOpacity="0.25" />
+            <stop offset="0%" stopColor={accentColor} stopOpacity="0.9" />
+            <stop offset="100%" stopColor={accentColor} stopOpacity="0.25" />
           </linearGradient>
         </defs>
         <path


### PR DESCRIPTION
## Summary
- read the Kali accent CSS variable at runtime for the performance graph gradient with an SSR-friendly fallback
- reuse the accent color for gradient stops so the stroke reflects active theming
- add a focused test to confirm the accent integration and reduced-motion static path behaviour

## Testing
- [x] yarn test performanceGraph --runTestsByPath __tests__/performanceGraph.test.tsx

## Flags
- none

------
https://chatgpt.com/codex/tasks/task_e_68d89d561d1c83288d107ab5f1c46b80