### PR TITLE
[ui] add brightness quick settings control

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,17 +1,28 @@
 "use client";
 
+import Image from 'next/image';
+import { ChangeEvent, useEffect } from 'react';
+
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
 
 interface Props {
   open: boolean;
 }
 
+const BRIGHTNESS_MIN = 40;
+const BRIGHTNESS_MAX = 100;
+
+const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean';
+const isTheme = (value: unknown): value is 'light' | 'dark' => value === 'light' || value === 'dark';
+const isBrightness = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= BRIGHTNESS_MIN && value <= BRIGHTNESS_MAX;
+
 const QuickSettings = ({ open }: Props) => {
-  const [theme, setTheme] = usePersistentState('qs-theme', 'light');
-  const [sound, setSound] = usePersistentState('qs-sound', true);
-  const [online, setOnline] = usePersistentState('qs-online', true);
-  const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const [theme, setTheme] = usePersistentState<'light' | 'dark'>('qs-theme', 'light', isTheme);
+  const [sound, setSound] = usePersistentState<boolean>('qs-sound', true, isBoolean);
+  const [online, setOnline] = usePersistentState<boolean>('qs-online', true, isBoolean);
+  const [reduceMotion, setReduceMotion] = usePersistentState<boolean>('qs-reduce-motion', false, isBoolean);
+  const [brightness, setBrightness] = usePersistentState<number>('qs-brightness', BRIGHTNESS_MAX, isBrightness);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -21,36 +32,125 @@ const QuickSettings = ({ open }: Props) => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
 
+  useEffect(() => {
+    document.documentElement.style.setProperty('--screen-brightness', String(brightness / 100));
+  }, [brightness]);
+
+  const handleBrightnessChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setBrightness(Number(event.target.value));
+  };
+
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
-        open ? '' : 'hidden'
+      className={`absolute top-9 right-3 w-72 rounded-xl glass p-4 text-sm text-white/90 transition-all duration-150 ${
+        open ? 'opacity-100 translate-y-0' : 'pointer-events-none -translate-y-2 opacity-0'
       }`}
+      aria-hidden={!open}
     >
-      <div className="px-4 pb-2">
-        <button
-          className="w-full flex justify-between"
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-        >
-          <span>Theme</span>
-          <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
-        </button>
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
-        <input
-          type="checkbox"
-          checked={reduceMotion}
-          onChange={() => setReduceMotion(!reduceMotion)}
-        />
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Image
+              src="/themes/Kali/panel/emblem-system-symbolic.svg"
+              alt="Theme settings"
+              width={20}
+              height={20}
+              className="opacity-80"
+            />
+            <span>Theme</span>
+          </div>
+          <button
+            type="button"
+            className="rounded-md border border-white/10 bg-white/10 px-3 py-1 text-xs font-semibold text-white transition hover:bg-white/20"
+            onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          >
+            {theme === 'light' ? 'Light' : 'Dark'}
+          </button>
+        </div>
+
+        <div>
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <Image
+                src="/themes/Kali/panel/display-brightness-symbolic.svg"
+                alt="Brightness"
+                width={20}
+                height={20}
+                className="opacity-80"
+              />
+              <span>Brightness</span>
+            </div>
+            <span className="text-xs text-white/70">{brightness}%</span>
+          </div>
+          <input
+            id="quick-settings-brightness"
+            aria-label="Screen brightness"
+            type="range"
+            min={BRIGHTNESS_MIN}
+            max={BRIGHTNESS_MAX}
+            step={1}
+            value={brightness}
+            onChange={handleBrightnessChange}
+            className="h-1 w-full cursor-pointer accent-kali-accent"
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Image
+              src="/themes/Kali/panel/audio-volume-medium-symbolic.svg"
+              alt="Sound"
+              width={20}
+              height={20}
+              className="opacity-80"
+            />
+            <span>Sound</span>
+          </div>
+          <input
+            type="checkbox"
+            checked={sound}
+            onChange={() => setSound(!sound)}
+            className="h-5 w-5 cursor-pointer accent-kali-accent"
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Image
+              src="/themes/Kali/panel/network-wireless-signal-good-symbolic.svg"
+              alt="Network"
+              width={20}
+              height={20}
+              className="opacity-80"
+            />
+            <span>Network</span>
+          </div>
+          <input
+            type="checkbox"
+            checked={online}
+            onChange={() => setOnline(!online)}
+            className="h-5 w-5 cursor-pointer accent-kali-accent"
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Image
+              src="/themes/Kali/panel/process-working-symbolic.svg"
+              alt="Reduced motion"
+              width={20}
+              height={20}
+              className="opacity-80"
+            />
+            <span>Reduced motion</span>
+          </div>
+          <input
+            type="checkbox"
+            checked={reduceMotion}
+            onChange={() => setReduceMotion(!reduceMotion)}
+            className="h-5 w-5 cursor-pointer accent-kali-accent"
+          />
+        </div>
       </div>
     </div>
   );

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -42,7 +42,10 @@ export default function BackgroundImage() {
     }, [bgImageName, useKaliWallpaper]);
 
     return (
-        <div className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full">
+        <div
+            className="bg-ubuntu-img absolute -z-10 top-0 right-0 overflow-hidden h-full w-full"
+            style={{ filter: 'brightness(var(--screen-brightness, 1))' }}
+        >
             {useKaliWallpaper || bgImageName === 'kali-gradient' ? (
                 <KaliWallpaper />
             ) : (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,6 +5,7 @@
   /* Base colors */
   --color-bg: #0f1317; /* kali background */
   --color-text: #f5f5f5; /* text on dark backgrounds */
+  --screen-brightness: 1;
   /* Brand accents */
   --color-primary: #1793d1; /* kali blue accent */
   --color-secondary: #1a1f26; /* complementary dark */

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -9,6 +9,12 @@
   .transition-active {
     @apply transition ease-out duration-100;
   }
+  .glass {
+    @apply border border-white/10 shadow-kali-panel;
+    background-color: color-mix(in srgb, var(--color-bg), transparent 55%);
+    -webkit-backdrop-filter: blur(18px);
+    backdrop-filter: blur(18px);
+  }
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- add Kali panel icons and a brightness slider to quick settings while persisting preferences
- style the quick settings container with the shared glass utility and accent-colored switches
- introduce a reusable glass utility and screen brightness CSS variable to dim the wallpaper

## Testing
- [ ] yarn lint *(fails: existing jsx-a11y/control-has-associated-label errors across apps and public game scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68d89d5942e88328a51f2afc67697420