### PR TITLE
[ui] refresh window chrome gradients

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -635,7 +635,7 @@ export class Window extends Component {
                 )}
                 <Draggable
                     axis="both"
-                    handle=".bg-ub-window-title"
+                    handle='[data-window-handle="true"]'
                     grid={this.props.snapEnabled ? [8, 8] : [1, 1]}
                     scale={1}
                     onStart={this.changeCursorToMove}
@@ -676,6 +676,7 @@ export class Window extends Component {
                             onBlur={this.releaseGrab}
                             grabbed={this.state.grabbed}
                             onPointerDown={this.focusWindow}
+                            isFocused={this.props.isFocused}
                         />
                         <WindowEditButtons
                             minimize={this.minimizeWindow}
@@ -702,10 +703,17 @@ export class Window extends Component {
 export default Window
 
 // Window's title bar
-export function WindowTopBar({ title, onKeyDown, onBlur, grabbed, onPointerDown }) {
+export function WindowTopBar({ title, onKeyDown, onBlur, grabbed, onPointerDown, isFocused }) {
+    const titleBarClassName = [
+        styles.windowTitlebar,
+        isFocused ? styles.windowTitlebarActive : styles.windowTitlebarInactive,
+        'relative px-3 text-white w-full select-none flex items-center'
+    ].join(' ');
+
     return (
         <div
-            className={`${styles.windowTitlebar} relative bg-ub-window-title px-3 text-white w-full select-none flex items-center`}
+            data-window-handle="true"
+            className={titleBarClassName}
             tabIndex={0}
             role="button"
             aria-grabbed={grabbed}

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -1,10 +1,19 @@
 .windowFrame {
   position: relative;
-  border: 1px solid var(--color-window-border);
+  border: 1px solid var(--kali-border, var(--color-window-border));
   border-radius: var(--radius-6);
   box-shadow: var(--shadow-2);
   overflow: hidden;
-  transition: filter var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--kali-panel) 75%, transparent) 0%,
+    color-mix(in srgb, var(--kali-bg-solid) 90%, transparent) 100%
+  );
+  transition:
+    filter var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease,
+    background var(--motion-fast) ease,
+    border-color var(--motion-fast) ease;
 }
 
 .windowFrame::before {
@@ -27,7 +36,20 @@
   opacity: 1;
 }
 
+.windowFrameActive {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--kali-panel) 80%, transparent) 0%,
+    color-mix(in srgb, var(--kali-bg-solid) 85%, transparent) 100%
+  );
+}
+
 .windowFrameInactive {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--kali-bg-solid) 92%, transparent) 0%,
+    color-mix(in srgb, var(--color-bg) 95%, transparent) 100%
+  );
   filter: brightness(0.85);
 }
 
@@ -45,6 +67,23 @@
   border-top-right-radius: calc(var(--radius-6) - 1px);
   position: relative;
   z-index: 1;
+  border-bottom: 1px solid var(--kali-border, var(--color-window-border));
+}
+
+.windowTitlebarActive {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--kali-blue) 35%, var(--kali-panel)) 0%,
+    color-mix(in srgb, var(--kali-blue-dark) 55%, var(--kali-bg-solid)) 100%
+  );
+}
+
+.windowTitlebarInactive {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--kali-bg-solid) 88%, transparent) 0%,
+    color-mix(in srgb, var(--color-bg) 98%, transparent) 100%
+  );
 }
 
 .windowControls {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -36,6 +36,7 @@
   --kali-panel: rgba(26, 31, 38, 0.9);
   --kali-panel-border: rgba(255, 255, 255, 0.08);
   --kali-panel-highlight: rgba(255, 255, 255, 0.05);
+  --kali-border: var(--kali-panel-border);
   --kali-terminal-green: #00ff00;
   --kali-terminal-text: #f5f5f5;
 


### PR DESCRIPTION
## Summary
- update window chrome to use Kali border tokens and gradient backgrounds for active and inactive states
- add inactive styling for unfocused windows and expose focus state to the title bar handle
- define the shared `--kali-border` token so window chrome can share the border color

## Testing
- yarn lint *(fails: existing accessibility label violations in various apps and legacy public assets)*

------
https://chatgpt.com/codex/tasks/task_e_68d86b69dae883288e65ba67b4ad9705