### PR TITLE
[terminal] Improve terminal window responsiveness

### DIFF
--- a/apps.config.js
+++ b/apps.config.js
@@ -636,6 +636,9 @@ const apps = [
     favourite: true,
     desktop_shortcut: false,
     screen: displayTerminal,
+    resizable: true,
+    defaultWidth: 68,
+    defaultHeight: 72,
   },
   {
     // VSCode app uses a Stack iframe, so no editor dependencies are required

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -480,8 +480,8 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
           </div>
         </div>
       )}
-      <div className="flex flex-col h-full">
-        <div className="flex items-center gap-2 bg-gray-800 p-1">
+      <div className="flex h-full flex-col">
+        <div className="flex flex-wrap items-center gap-2 bg-gray-800 p-2">
           <button onClick={handleCopy} aria-label="Copy">
             <CopyIcon />
           </button>
@@ -492,13 +492,11 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
             <SettingsIcon />
           </button>
         </div>
-        <div className="relative">
+        <div className="relative flex-1 min-h-0">
           <TerminalContainer
             ref={containerRef}
-            className="resize overflow-hidden font-mono"
+            className="h-full w-full overflow-hidden font-mono"
             style={{
-              width: '80ch',
-              height: '24em',
               fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
               lineHeight: 1.4,
             }}


### PR DESCRIPTION
## Summary
- reduce the terminal app's default window footprint so it launches at a more comfortable size
- update the in-window layout so the xterm surface flexes with the window and allows safe resizing across viewports

## Testing
- yarn lint *(fails: pre-existing accessibility and no-top-level-window violations across unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d97bb004208328833a9d441c475bfb