### PR TITLE
[calculator] refresh calculator interface

### DIFF
--- a/apps/calculator/components/FormulaEditor.tsx
+++ b/apps/calculator/components/FormulaEditor.tsx
@@ -35,29 +35,48 @@ export default function FormulaEditor() {
   };
 
   return (
-    <div id="formulas" className="formulas hidden">
-      <div className="space-y-1">
-        <input
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Name"
-          className="h-8 w-full"
-        />
-        <input
-          value={expr}
-          onChange={(e) => setExpr(e.target.value)}
-          placeholder="Expression"
-          className="h-8 w-full"
-        />
-        <button onClick={save} className="btn h-8 w-full">
-          Save
+    <div
+      id="formulas"
+      className="formulas hidden space-y-4 rounded-2xl border border-dashed border-white/10 bg-[#15171d] p-4 text-sm text-slate-200 shadow-inner"
+    >
+      <div className="space-y-2">
+        <div className="grid gap-2 sm:grid-cols-2">
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Name"
+            className="rounded-lg border border-white/10 bg-[#0f1117] px-3 py-2 text-sm font-semibold text-slate-100 placeholder:text-slate-500 focus:border-[#f97316] focus:outline-none focus:ring-2 focus:ring-[#f97316]"
+          />
+          <input
+            value={expr}
+            onChange={(e) => setExpr(e.target.value)}
+            placeholder="Expression"
+            className="rounded-lg border border-white/10 bg-[#0f1117] px-3 py-2 text-sm font-mono text-slate-100 placeholder:text-slate-500 focus:border-[#f97316] focus:outline-none focus:ring-2 focus:ring-[#f97316]"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={save}
+          className="inline-flex w-full items-center justify-center rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-slate-200 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#15171d]"
+        >
+          Save formula
         </button>
-        {error && <div className="text-red-500">{error}</div>}
+        {error && <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-300">{error}</div>}
       </div>
-      <ul>
+      <ul className="space-y-2">
+        {formulas.length === 0 && (
+          <li className="text-xs uppercase tracking-[0.3em] text-slate-500">No formulas saved</li>
+        )}
         {formulas.map((f, i) => (
           <li key={i}>
-            <button onClick={() => insert(f)}>{f.name}</button>
+            <button
+              type="button"
+              onClick={() => insert(f)}
+              className="flex w-full items-center justify-between rounded-xl bg-white/5 px-3 py-2 text-left font-semibold text-slate-100 transition hover:bg-white/10"
+            >
+              <span>{f.name}</span>
+              <span className="font-mono text-xs text-slate-400">{f.expr}</span>
+            </button>
           </li>
         ))}
       </ul>

--- a/apps/calculator/components/MemorySlots.tsx
+++ b/apps/calculator/components/MemorySlots.tsx
@@ -46,25 +46,62 @@ export default function MemorySlots() {
   };
 
   return (
-    <div className="memory-slots">
-      <div className="memory-form">
+    <div className="memory-slots space-y-3 rounded-2xl border border-white/5 bg-[#15171d] p-4 text-sm text-slate-200 shadow-inner">
+      <div className="memory-form flex items-center gap-2">
         <input
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="var"
           aria-label="variable name"
+          className="w-20 flex-1 rounded-lg border border-white/10 bg-[#0f1117] px-3 py-2 text-sm font-semibold uppercase tracking-wide text-slate-100 placeholder:text-slate-500 focus:border-[#f97316] focus:outline-none focus:ring-2 focus:ring-[#f97316]"
         />
-        <button onClick={() => { handleStore(name.trim()); setName(''); }}>Store</button>
+        <button
+          type="button"
+          onClick={() => {
+            handleStore(name.trim());
+            setName('');
+          }}
+          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-200 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#15171d]"
+        >
+          Store
+        </button>
       </div>
-      <div className="memory-list">
+      <div className="memory-list max-h-44 space-y-2 overflow-y-auto pr-1">
         {Object.entries(vars).map(([n, v]) => (
-          <div key={n} className="memory-item">
-            <button onClick={() => handleInsert(n)}>{n}</button>
-            <span className="value">{v}</span>
-            <button onClick={() => handleStore(n)} aria-label={`store ${n}`}>↲</button>
-            <button onClick={() => handleDelete(n)} aria-label={`delete ${n}`}>×</button>
+          <div key={n} className="memory-item flex items-center gap-2 rounded-xl bg-white/5 px-3 py-2">
+            <button
+              type="button"
+              onClick={() => handleInsert(n)}
+              className="rounded-lg bg-[#2a2d35] px-2 py-1 text-xs font-semibold uppercase tracking-wide text-[#f97316]"
+            >
+              {n}
+            </button>
+            <span className="value flex-1 truncate font-mono text-slate-100">{v}</span>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => handleStore(n)}
+                aria-label={`store ${n}`}
+                className="rounded-full bg-[#2a2d35] px-2 py-1 text-xs font-semibold text-slate-200 transition hover:bg-[#343842]"
+              >
+                ↲
+              </button>
+              <button
+                type="button"
+                onClick={() => handleDelete(n)}
+                aria-label={`delete ${n}`}
+                className="rounded-full bg-[#2a2d35] px-2 py-1 text-xs font-semibold text-[#f97316] transition hover:bg-[#3d1e0a]"
+              >
+                ×
+              </button>
+            </div>
           </div>
         ))}
+        {Object.keys(vars).length === 0 && (
+          <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
+            Memory is empty
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/calculator/components/ModeSwitcher.tsx
+++ b/apps/calculator/components/ModeSwitcher.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 
 type Mode = 'basic' | 'scientific' | 'programmer';
@@ -23,16 +23,34 @@ export default function ModeSwitcher({ onChange }: Props) {
   }, [mode, onChange]);
 
   return (
-    <div className="mode-switcher">
-      {MODES.map((m) => (
-        <button
-          key={m}
-          aria-pressed={mode === m}
-          onClick={() => setMode(m)}
-        >
-          {m}
-        </button>
-      ))}
+    <div className="relative">
+      <label htmlFor="mode-select" className="sr-only">
+        Calculator mode
+      </label>
+      <select
+        id="mode-select"
+        value={mode}
+        onChange={(event) => setMode(event.target.value as Mode)}
+        className="appearance-none rounded-xl border border-white/10 bg-[#2a2d35] py-2 pl-3 pr-10 text-sm font-semibold capitalize text-slate-100 shadow-inner focus:border-[#f97316] focus:outline-none focus:ring-2 focus:ring-[#f97316]"
+      >
+        {MODES.map((m) => (
+          <option key={m} value={m} className="bg-[#1f212a] capitalize">
+            {m}
+          </option>
+        ))}
+      </select>
+      <svg
+        className="pointer-events-none absolute right-3 top-1/2 h-3 w-3 -translate-y-1/2 text-slate-400"
+        viewBox="0 0 12 8"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M2 2l4 4 4-4" />
+      </svg>
     </div>
   );
 }

--- a/apps/calculator/components/Tape.tsx
+++ b/apps/calculator/components/Tape.tsx
@@ -28,29 +28,41 @@ export default function Tape({ entries }: TapeProps) {
   }, []);
 
   return (
-    <div ref={containerRef} className="tape font-mono max-h-40 overflow-y-auto">
+    <div
+      ref={containerRef}
+      className="tape max-h-48 space-y-2 overflow-y-auto rounded-2xl border border-white/5 bg-[#15171d] p-4 font-mono text-sm text-slate-200 shadow-inner"
+    >
+      {entries.length === 0 && (
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
+          Tape is empty
+        </p>
+      )}
       {entries.map(({ expr, result }, i) => (
         <div
           key={i}
-          className="p-1 odd:bg-black/20 even:bg-black/10 flex items-center gap-2"
+          className="flex items-center gap-3 rounded-xl bg-white/5 px-3 py-2"
         >
-          <div className="flex-1">
-            {expr} = {result}
+          <div className="flex-1 truncate">
+            {expr} = <span className="text-[#f97316]">{result}</span>
           </div>
-          <button
-            className="text-xs px-1 py-0.5 bg-black/20 rounded"
-            onClick={() => handleRecall(result)}
-            aria-label="recall result"
-          >
-            Ans
-          </button>
-          <button
-            className="text-xs px-1 py-0.5 bg-black/20 rounded"
-            onClick={() => handleCopy(result)}
-            aria-label="copy result"
-          >
-            Copy
-          </button>
+          <div className="flex items-center gap-1 text-xs">
+            <button
+              className="rounded-full bg-[#2a2d35] px-3 py-1 font-semibold uppercase tracking-wide text-slate-200 transition hover:bg-[#343842]"
+              onClick={() => handleRecall(result)}
+              aria-label="recall result"
+              type="button"
+            >
+              Ans
+            </button>
+            <button
+              className="rounded-full bg-[#2a2d35] px-3 py-1 font-semibold uppercase tracking-wide text-slate-200 transition hover:bg-[#343842]"
+              onClick={() => handleCopy(result)}
+              aria-label="copy result"
+              type="button"
+            >
+              Copy
+            </button>
+          </div>
         </div>
       ))}
     </div>

--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect } from 'react';
+import { type ReactNode, useEffect } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
 import ModeSwitcher from './components/ModeSwitcher';
 import MemorySlots from './components/MemorySlots';
@@ -22,8 +22,58 @@ export default function Calculator() {
       ),
   );
 
-  const btnCls =
-    'btn min-h-12 w-12 transition-transform duration-150 hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black focus-visible:ring-white';
+  const baseBtnCls =
+    'btn flex items-center justify-center font-semibold transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]';
+  const keypadBtnCls =
+    `${baseBtnCls} h-14 rounded-xl border border-white/5 bg-[#2a2d35] text-lg text-slate-100 shadow-sm hover:-translate-y-0.5 hover:bg-[#343842]`;
+  const pillUtilityBtnCls =
+    `${baseBtnCls} h-10 rounded-full border border-white/10 bg-white/5 px-4 text-sm uppercase tracking-wide text-slate-200 shadow-none hover:bg-white/10`;
+
+  const keypadRows: Array<
+    Array<{
+      label: ReactNode;
+      value?: string;
+      action?: string;
+      keyBinding?: string;
+      ariaLabel: string;
+      extraClassName?: string;
+    }>
+  > = [
+    [
+      { label: '(', value: '(', keyBinding: '(', ariaLabel: 'left parenthesis' },
+      { label: ')', value: ')', keyBinding: ')', ariaLabel: 'right parenthesis' },
+      {
+        label: <span className="text-xs font-medium uppercase tracking-[0.3em]">mod</span>,
+        value: 'mod(',
+        ariaLabel: 'modulus',
+      },
+      { label: 'π', value: 'pi', keyBinding: 'p', ariaLabel: 'pi constant' },
+    ],
+    [
+      { label: '7', value: '7', keyBinding: '7', ariaLabel: 'seven' },
+      { label: '8', value: '8', keyBinding: '8', ariaLabel: 'eight' },
+      { label: '9', value: '9', keyBinding: '9', ariaLabel: 'nine' },
+      { label: '÷', value: '/', keyBinding: '/', ariaLabel: 'divide' },
+    ],
+    [
+      { label: '4', value: '4', keyBinding: '4', ariaLabel: 'four' },
+      { label: '5', value: '5', keyBinding: '5', ariaLabel: 'five' },
+      { label: '6', value: '6', keyBinding: '6', ariaLabel: 'six' },
+      { label: '×', value: '*', keyBinding: '*', ariaLabel: 'multiply' },
+    ],
+    [
+      { label: '1', value: '1', keyBinding: '1', ariaLabel: 'one' },
+      { label: '2', value: '2', keyBinding: '2', ariaLabel: 'two' },
+      { label: '3', value: '3', keyBinding: '3', ariaLabel: 'three' },
+      { label: '−', value: '-', keyBinding: '-', ariaLabel: 'subtract' },
+    ],
+    [
+      { label: '0', value: '0', keyBinding: '0', ariaLabel: 'zero' },
+      { label: '.', value: '.', keyBinding: '.', ariaLabel: 'decimal point' },
+      { label: '%', value: '%', keyBinding: '%', ariaLabel: 'percent' },
+      { label: '+', value: '+', keyBinding: '+', ariaLabel: 'add' },
+    ],
+  ];
 
   useEffect(() => {
     let evaluate: any;
@@ -188,153 +238,270 @@ export default function Calculator() {
     load();
   }, [setHistory]);
 
-    return (
-    <div className="calculator !bg-[var(--kali-bg)]">
-      <ModeSwitcher />
-            <input id="display" className="display h-12" />
-      <button id="toggle-precise" className="toggle h-12" aria-pressed="false" aria-label="toggle precise mode">Precise Mode: Off</button>
-      <button id="toggle-scientific" className="toggle h-12" aria-pressed="false" aria-label="toggle scientific mode">Scientific</button>
-      <button id="toggle-programmer" className="toggle h-12" aria-pressed="false" aria-label="toggle programmer mode">Programmer</button>
-      <button id="toggle-history" className="toggle h-12" aria-pressed="false" aria-label="toggle history">History</button>
-      <button id="toggle-formulas" className="toggle h-12" aria-pressed="false" aria-label="toggle formulas">Formulas</button>
-      <div className="memory-grid grid grid-cols-3" aria-label="memory functions">
-        <button className={btnCls} data-action="mplus" aria-label="add to memory">M+</button>
-        <button className={btnCls} data-action="mminus" aria-label="subtract from memory">M&minus;</button>
-        <button className={btnCls} data-action="mr" aria-label="recall memory">MR</button>
-      </div>
-      <MemorySlots />
-      <div className="button-grid grid grid-cols-4 font-mono" aria-label="calculator keypad">
-        <button className={btnCls} data-value="7" data-key="7" aria-label="seven">7</button>
-        <button className={btnCls} data-value="8" data-key="8" aria-label="eight">8</button>
-        <button className={btnCls} data-value="9" data-key="9" aria-label="nine">9</button>
-        <button className={btnCls} data-value="/" data-key="/" aria-label="divide">
-          <svg
-            viewBox="0 0 24 24"
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-          >
-            <circle cx="12" cy="6" r="1.5" fill="currentColor" stroke="none" />
-            <line x1="5" y1="12" x2="19" y2="12" />
-            <circle cx="12" cy="18" r="1.5" fill="currentColor" stroke="none" />
-          </svg>
-        </button>
-        <button className={btnCls} data-value="4" data-key="4" aria-label="four">4</button>
-        <button className={btnCls} data-value="5" data-key="5" aria-label="five">5</button>
-        <button className={btnCls} data-value="6" data-key="6" aria-label="six">6</button>
-        <button className={btnCls} data-value="*" data-key="*" aria-label="multiply">
-          <svg
-            viewBox="0 0 24 24"
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-          >
-            <line x1="6" y1="6" x2="18" y2="18" />
-            <line x1="18" y1="6" x2="6" y2="18" />
-          </svg>
-        </button>
-        <button className={btnCls} data-value="1" data-key="1" aria-label="one">1</button>
-        <button className={btnCls} data-value="2" data-key="2" aria-label="two">2</button>
-        <button className={btnCls} data-value="3" data-key="3" aria-label="three">3</button>
-        <button className={btnCls} data-value="-" data-key="-" aria-label="subtract">
-          <svg
-            viewBox="0 0 24 24"
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-          >
-            <line x1="5" y1="12" x2="19" y2="12" />
-          </svg>
-        </button>
-        <button className={btnCls} data-value="0" data-key="0" aria-label="zero">0</button>
-        <button className={btnCls} data-value="." data-key="." aria-label="decimal point">.</button>
-        <button className={btnCls} data-action="equals" data-key="= Enter" aria-label="equals">=</button>
-        <button className={btnCls} data-value="+" data-key="+" aria-label="add">
-          <svg
-            viewBox="0 0 24 24"
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-          >
-            <line x1="12" y1="5" x2="12" y2="19" />
-            <line x1="5" y1="12" x2="19" y2="12" />
-          </svg>
-        </button>
-      <button className={`${btnCls} span-two w-full`} data-action="clear" data-key="Escape c" aria-label="clear">
-        <svg
-          viewBox="0 0 24 24"
-          className="w-6 h-6"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
+  return (
+    <div className="calculator mx-auto flex w-full max-w-lg flex-col gap-6 rounded-3xl bg-[#1f212a] p-6 text-slate-100 shadow-[0_35px_80px_-30px_rgba(15,15,20,0.9)]">
+      <header className="flex items-center justify-between text-sm text-slate-300">
+        <button
+          type="button"
+          onClick={() => {
+            const display = document.getElementById('display') as HTMLInputElement | null;
+            if (display) display.value = display.value.slice(0, -1);
+          }}
+          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-slate-200 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
         >
-          <path d="M3 6h18" />
-          <path d="M8 6V4h8v2" />
-          <path d="M19 6l-1 14H6L5 6" />
-          <path d="M10 11v6" />
-          <path d="M14 11v6" />
-        </svg>
-      </button>
-      <button className={`${btnCls} span-two w-full`} data-action="backspace" data-key="Backspace" aria-label="backspace">
-        <svg
-          viewBox="0 0 24 24"
-          className="w-6 h-6"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
+          <svg
+            className="h-4 w-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M3 6h18" />
+            <path d="M8 6V4h8v2" />
+            <path d="M19 6l-1 14H6L5 6" />
+            <path d="M10 11v6" />
+            <path d="M14 11v6" />
+          </svg>
+          Undo
+        </button>
+        <div className="flex items-center gap-3">
+          <ModeSwitcher />
+          <div className="flex items-center gap-1 text-slate-500">
+            <button
+              id="toggle-history"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-transparent text-slate-400 transition hover:border-white/10 hover:text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
+              aria-pressed="false"
+              aria-label="toggle history"
+            >
+              <span className="sr-only">Toggle history</span>
+              <svg
+                className="h-5 w-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              >
+                <path d="M8 6h13" />
+                <path d="M8 12h13" />
+                <path d="M8 18h13" />
+                <path d="M3 6h.01" />
+                <path d="M3 12h.01" />
+                <path d="M3 18h.01" />
+              </svg>
+            </button>
+            <button
+              id="toggle-formulas"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-transparent text-slate-400 transition hover:border-white/10 hover:text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
+              aria-pressed="false"
+              aria-label="toggle formulas"
+            >
+              <span className="sr-only">Toggle formulas</span>
+              <svg
+                className="h-5 w-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              >
+                <path d="M4 4h16" />
+                <path d="M4 10h10" />
+                <path d="M4 16h7" />
+                <path d="M4 22h4" />
+                <path d="M14 10l6 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className="space-y-3 rounded-2xl border border-white/5 bg-[#15171d] p-4 shadow-inner">
+        <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-500">
+          <span>Expression</span>
+          <span>Result</span>
+        </div>
+        <input
+          id="display"
+          className="display w-full bg-transparent text-right text-3xl font-semibold tracking-wide text-white placeholder:text-slate-600 focus:outline-none"
+          placeholder="0"
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-xs font-medium uppercase tracking-wide text-slate-300">
+        <button
+          id="toggle-precise"
+          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
+          aria-pressed="false"
+          aria-label="toggle precise mode"
         >
-          <path d="M12 19h8a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-8L7 12l5 7z" />
-          <path d="M14 9l3 3-3 3" />
-          <path d="M11 9l-3 3 3 3" />
-        </svg>
-      </button>
+          Precise
+        </button>
+        <button
+          id="toggle-scientific"
+          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
+          aria-pressed="false"
+          aria-label="toggle scientific mode"
+        >
+          Scientific
+        </button>
+        <button
+          id="toggle-programmer"
+          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
+          aria-pressed="false"
+          aria-label="toggle programmer mode"
+        >
+          Programmer
+        </button>
       </div>
-        <div id="scientific" className="scientific hidden grid grid-cols-3 gap-1.5" aria-label="scientific functions">
-        <button className={btnCls} data-value="sin(" aria-label="sine">sin</button>
-        <button className={btnCls} data-value="cos(" aria-label="cosine">cos</button>
-        <button className={btnCls} data-value="tan(" aria-label="tangent">tan</button>
-        <button className={btnCls} data-value="sqrt(" aria-label="square root">√</button>
-        <button className={btnCls} data-value="(" data-key="(" aria-label="left parenthesis">(</button>
-        <button className={btnCls} data-value=")" data-key=")" aria-label="right parenthesis">)</button>
+
+      <div className="flex flex-wrap items-start gap-3">
+        <div className="flex w-full items-center justify-end gap-2">
+          <button
+            className={pillUtilityBtnCls}
+            data-action="clear"
+            data-key="Escape c"
+            aria-label="clear"
+          >
+            Clear
+          </button>
+          <button
+            className={pillUtilityBtnCls}
+            data-action="backspace"
+            data-key="Backspace"
+            aria-label="backspace"
+          >
+            Back
+          </button>
+        </div>
+        <div className="grid flex-1 grid-cols-4 gap-3" aria-label="calculator keypad">
+          {keypadRows.map((row, rowIndex) =>
+            row.map((btn, columnIndex) => (
+              <button
+                key={`${rowIndex}-${columnIndex}`}
+                className={`${keypadBtnCls} ${btn.extraClassName ?? ''}`.trim()}
+                {...(btn.value ? { 'data-value': btn.value } : {})}
+                {...(btn.action ? { 'data-action': btn.action } : {})}
+                {...(btn.keyBinding ? { 'data-key': btn.keyBinding } : {})}
+                aria-label={btn.ariaLabel}
+              >
+                {btn.label}
+              </button>
+            )),
+          )}
+        </div>
+        <button
+          className={`${baseBtnCls} h-full min-h-[7.5rem] rounded-2xl bg-[#f97316] text-3xl font-bold text-slate-950 shadow-lg shadow-[#f97316]/40 transition hover:brightness-110`}
+          data-action="equals"
+          data-key="= Enter"
+          aria-label="equals"
+        >
+          =
+        </button>
       </div>
-        <div id="programmer" className="programmer hidden grid gap-1.5" aria-label="programmer functions">
-        <select id="base-select" defaultValue="10" className="h-12">
-          <option value="2">Bin</option>
-          <option value="8">Oct</option>
-          <option value="10">Dec</option>
+
+      <div id="scientific" className="scientific hidden grid grid-cols-3 gap-2 rounded-2xl border border-white/5 bg-white/5 p-4 text-sm uppercase tracking-wide text-slate-200" aria-label="scientific functions">
+        <button className={keypadBtnCls} data-value="sin(" aria-label="sine">
+          sin
+        </button>
+        <button className={keypadBtnCls} data-value="cos(" aria-label="cosine">
+          cos
+        </button>
+        <button className={keypadBtnCls} data-value="tan(" aria-label="tangent">
+          tan
+        </button>
+        <button className={keypadBtnCls} data-value="sqrt(" aria-label="square root">
+          √
+        </button>
+        <button className={keypadBtnCls} data-value="(" data-key="(" aria-label="left parenthesis">
+          (
+        </button>
+        <button className={keypadBtnCls} data-value=")" data-key=")" aria-label="right parenthesis">
+          )
+        </button>
+      </div>
+
+      <div id="programmer" className="programmer hidden grid gap-2 rounded-2xl border border-white/5 bg-white/5 p-4 text-sm uppercase tracking-wide text-slate-200" aria-label="programmer functions">
+        <label className="text-xs font-semibold text-slate-400" htmlFor="base-select">
+          Number base
+        </label>
+        <select
+          id="base-select"
+          defaultValue="10"
+          className="h-11 rounded-xl border border-white/10 bg-[#12151b] px-3 text-sm font-medium text-slate-100 focus:border-[#f97316] focus:outline-none focus:ring-2 focus:ring-[#f97316]"
+        >
+          <option value="2">Binary</option>
+          <option value="8">Octal</option>
+          <option value="10">Decimal</option>
           <option value="16">Hex</option>
         </select>
-        <button className={btnCls} data-value="&amp;" data-key="&amp;" aria-label="bitwise and">&amp;</button>
-        <button className={btnCls} data-value="|" data-key="|" aria-label="bitwise or">|</button>
-        <button className={btnCls} data-value="^" data-key="^" aria-label="bitwise xor">^</button>
-        <button className={btnCls} data-value="~" data-key="~" aria-label="bitwise not">~</button>
-        <button className={btnCls} data-value="<<" data-key="&lt;" aria-label="left shift">&lt;&lt;</button>
-        <button className={btnCls} data-value=">>" data-key="&gt;" aria-label="right shift">&gt;&gt;</button>
-      <button className={btnCls} data-action="ans" aria-label="previous answer">Ans</button>
-      <button id="print-tape" className={btnCls} data-action="print" aria-label="print tape">Print</button>
-        <div id="paren-indicator" />
+        <div className="grid grid-cols-3 gap-2 pt-2">
+          <button className={keypadBtnCls} data-value="&amp;" data-key="&amp;" aria-label="bitwise and">
+            &amp;
+          </button>
+          <button className={keypadBtnCls} data-value="|" data-key="|" aria-label="bitwise or">
+            |
+          </button>
+          <button className={keypadBtnCls} data-value="^" data-key="^" aria-label="bitwise xor">
+            ^
+          </button>
+          <button className={keypadBtnCls} data-value="~" data-key="~" aria-label="bitwise not">
+            ~
+          </button>
+          <button className={keypadBtnCls} data-value="<<" data-key="&lt;" aria-label="left shift">
+            &lt;&lt;
+          </button>
+          <button className={keypadBtnCls} data-value=">>" data-key="&gt;" aria-label="right shift">
+            &gt;&gt;
+          </button>
+        </div>
+        <div className="flex gap-2 pt-2">
+          <button className={keypadBtnCls} data-action="ans" aria-label="previous answer">
+            Ans
+          </button>
+          <button id="print-tape" className={keypadBtnCls} data-action="print" aria-label="print tape">
+            Print
+          </button>
+        </div>
+        <div id="paren-indicator" className="mt-2 h-1 rounded-full bg-white/10" />
       </div>
-      <FormulaEditor />
-      <div id="history" className="history hidden" aria-live="polite">
-        {history.map(({ expr, result }, i) => (
-          <div key={i} className="history-entry">
-            {expr} = {result}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="space-y-4">
+          <div id="history" className="history hidden space-y-2 rounded-2xl border border-white/5 bg-white/5 p-4 text-sm text-slate-200" aria-live="polite">
+            {history.length === 0 && (
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
+                No history yet
+              </p>
+            )}
+            {history.map(({ expr, result }, i) => (
+              <div key={i} className="history-entry flex items-center justify-between gap-2 rounded-xl bg-black/20 px-3 py-2">
+                <span className="font-mono text-sm text-slate-100">{expr}</span>
+                <span className="font-semibold text-[#f97316]">{result}</span>
+              </div>
+            ))}
           </div>
-        ))}
+          <Tape entries={history} />
+        </div>
+        <div className="space-y-4">
+          <div className="memory-grid grid grid-cols-3 gap-2" aria-label="memory functions">
+            <button className={keypadBtnCls} data-action="mplus" aria-label="add to memory">
+              M+
+            </button>
+            <button className={keypadBtnCls} data-action="mminus" aria-label="subtract from memory">
+              M−
+            </button>
+            <button className={keypadBtnCls} data-action="mr" aria-label="recall memory">
+              MR
+            </button>
+          </div>
+          <MemorySlots />
+          <FormulaEditor />
+        </div>
       </div>
-      <Tape entries={history} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- redesign the calculator window with a toolbar, modern display styling, and reorganized keypad to mirror the reference look
- restyle the mode switcher, memory slots, tape, and formulas panels to match the refreshed dark theme

## Testing
- yarn lint *(fails: existing jsx-a11y and no-top-level-window violations in other apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d97da8e20c8328957ea28b5e0d8c0a