### PR TITLE
[desktop] guard draggable initialization until client mount

### DIFF
--- a/apps/ettercap/components/ArpDiagram.tsx
+++ b/apps/ettercap/components/ArpDiagram.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useState } from 'react';
-import Draggable, { DraggableEvent, DraggableData } from 'react-draggable';
+import type { DraggableEvent, DraggableData } from 'react-draggable';
+import SafeDraggable from '../../../components/base/SafeDraggable';
 
 interface NodeData {
   x: number;
@@ -36,7 +37,7 @@ export default function ArpDiagram() {
         <path d={getLine('attacker', 'gateway')} stroke="#f87171" strokeWidth={2} />
       </svg>
       {Object.entries(nodes).map(([key, node]) => (
-        <Draggable
+        <SafeDraggable
           key={key}
           grid={[6, 6]}
           bounds="parent"
@@ -46,7 +47,7 @@ export default function ArpDiagram() {
           <div className="absolute w-10 h-10 rounded-full bg-gray-700 border border-white flex items-center justify-center text-[10px]">
             {node.label}
           </div>
-        </Draggable>
+        </SafeDraggable>
       ))}
     </div>
   );

--- a/components/apps/battleship.js
+++ b/components/apps/battleship.js
@@ -1,5 +1,7 @@
+'use client';
+
 import React, { useState, useEffect, useCallback } from 'react';
-import Draggable from 'react-draggable';
+import SafeDraggable from '../base/SafeDraggable';
 import {
   MonteCarloAI,
   RandomSalvoAI,
@@ -452,7 +454,7 @@ const Battleship = () => {
             <div className="relative border border-ub-dark-grey" style={{width:BOARD_SIZE*CELL,height:BOARD_SIZE*CELL}}>
               {renderBoard(playerBoard)}
                 {ships.map((ship,i)=>(
-                  <Draggable
+                  <SafeDraggable
                     key={ship.id}
                     grid={[CELL,CELL]}
                     position={{x:(ship.x||0)*CELL,y:(ship.y||0)*CELL}}
@@ -466,7 +468,7 @@ const Battleship = () => {
                       style={{width:(ship.dir===0?ship.len:1)*CELL,height:(ship.dir===1?ship.len:1)*CELL}}
                       onDoubleClick={()=>rotateShip(ship.id)}
                     />
-                  </Draggable>
+                  </SafeDraggable>
                 ))}
             </div>
             <div className="flex flex-col space-y-2">

--- a/components/base/SafeDraggable.tsx
+++ b/components/base/SafeDraggable.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { cloneElement, useEffect, useRef, useState } from 'react';
+import type { CSSProperties, ReactElement } from 'react';
+import Draggable from 'react-draggable';
+import type { DraggableProps } from 'react-draggable';
+
+export type SafeDraggableProps = DraggableProps & {
+  children: ReactElement;
+};
+
+const getFallbackTransform = (position: SafeDraggableProps['position']) => {
+  if (position) {
+    return `translate(${position.x}px, ${position.y}px)`;
+  }
+  return null;
+};
+
+export default function SafeDraggable({
+  children,
+  nodeRef: externalNodeRef,
+  ...rest
+}: SafeDraggableProps) {
+  const fallbackRef = useRef<HTMLElement | SVGElement | null>(null);
+  const resolvedNodeRef = externalNodeRef ?? fallbackRef;
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    setEnabled(true);
+  }, []);
+
+  const baseStyle = ((children.props as { style?: CSSProperties }).style ?? {}) as CSSProperties;
+
+  if (!enabled) {
+    const transform = getFallbackTransform(rest.position);
+    const fallbackStyle: CSSProperties =
+      transform == null
+        ? baseStyle
+        : {
+            ...baseStyle,
+            transform: baseStyle.transform
+              ? `${baseStyle.transform} ${transform}`
+              : transform,
+          };
+
+    return cloneElement(children, {
+      ref: resolvedNodeRef,
+      style: fallbackStyle,
+    });
+  }
+
+  return (
+    <Draggable {...rest} nodeRef={resolvedNodeRef}>
+      {cloneElement(children, {
+        ref: resolvedNodeRef,
+        style: baseStyle,
+      })}
+    </Draggable>
+  );
+}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 import NextImage from 'next/image';
-import Draggable from 'react-draggable';
+import SafeDraggable from './SafeDraggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
@@ -633,7 +633,7 @@ export class Window extends Component {
                         }}
                     />
                 )}
-                <Draggable
+                <SafeDraggable
                     axis="both"
                     handle=".bg-ub-window-title"
                     grid={this.props.snapEnabled ? [8, 8] : [1, 1]}
@@ -693,7 +693,7 @@ export class Window extends Component {
                                 openApp={this.props.openApp}
                                 context={this.props.context} />)}
                     </div>
-                </Draggable >
+                </SafeDraggable>
             </>
         )
     }


### PR DESCRIPTION
## Summary
- add a SafeDraggable wrapper that waits for client mount before enabling react-draggable
- update window, Battleship, and Ettercap ARP diagram components to use the wrapper so drag start no longer crashes

## Testing
- npx eslint components/base/SafeDraggable.tsx components/apps/battleship.js apps/ettercap/components/ArpDiagram.tsx --max-warnings=0
- yarn test window --watch=false


------
https://chatgpt.com/codex/tasks/task_e_68d96a89b8d483288982348f76e25e9f