### PR TITLE
[pages] Remove loading screen messages

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -10,7 +10,7 @@ const Ubuntu = dynamic(
     }),
   {
     ssr: false,
-    loading: () => <p>Loading Ubuntu...</p>,
+    loading: () => null,
   }
 );
 const InstallButton = dynamic(
@@ -21,7 +21,7 @@ const InstallButton = dynamic(
     }),
   {
     ssr: false,
-    loading: () => <p>Loading install options...</p>,
+    loading: () => null,
   }
 );
 


### PR DESCRIPTION
## Summary
- remove the loading fallback messages from the home page dynamic imports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9862c59b08328bb283f1fad1e9b91