### PR TITLE
[components] Relax SafeDraggable props typing

### DIFF
--- a/components/base/SafeDraggable.tsx
+++ b/components/base/SafeDraggable.tsx
@@ -5,7 +5,7 @@ import type { CSSProperties, ReactElement } from 'react';
 import Draggable from 'react-draggable';
 import type { DraggableProps } from 'react-draggable';
 
-export type SafeDraggableProps = DraggableProps & {
+export type SafeDraggableProps = Partial<DraggableProps> & {
   children: ReactElement;
 };
 


### PR DESCRIPTION
## Summary
- allow SafeDraggable to accept partial react-draggable props so optional values no longer block usage

## Testing
- [ ] yarn lint *(fails due to existing accessibility lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d988e5d8d0832894da39602ef12b4f