### PR TITLE
[base] Fix SafeDraggable props typing

### DIFF
--- a/components/base/SafeDraggable.tsx
+++ b/components/base/SafeDraggable.tsx
@@ -5,7 +5,7 @@ import type { CSSProperties, ReactElement } from 'react';
 import Draggable from 'react-draggable';
 import type { DraggableProps } from 'react-draggable';
 
-export type SafeDraggableProps = DraggableProps & {
+export type SafeDraggableProps = Partial<DraggableProps> & {
   children: ReactElement;
 };
 


### PR DESCRIPTION
## Summary
- allow SafeDraggable to accept partial react-draggable props so optional values remain optional

## Testing
- yarn eslint components/base/SafeDraggable.tsx apps/ettercap/components/ArpDiagram.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d988b49bbc832885ccb8c76f5c89f1