### PR TITLE
[ettercap] fix draggable typing for arp diagram

### DIFF
--- a/apps/ettercap/components/ArpDiagram.tsx
+++ b/apps/ettercap/components/ArpDiagram.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import React, { useState } from 'react';
-import Draggable, { DraggableEvent, DraggableData } from 'react-draggable';
+import type { DraggableEvent, DraggableData } from 'react-draggable';
+
+import SafeDraggable from './SafeDraggable';
 
 interface NodeData {
   x: number;
@@ -36,7 +38,7 @@ export default function ArpDiagram() {
         <path d={getLine('attacker', 'gateway')} stroke="#f87171" strokeWidth={2} />
       </svg>
       {Object.entries(nodes).map(([key, node]) => (
-        <Draggable
+        <SafeDraggable
           key={key}
           grid={[6, 6]}
           bounds="parent"
@@ -46,7 +48,7 @@ export default function ArpDiagram() {
           <div className="absolute w-10 h-10 rounded-full bg-gray-700 border border-white flex items-center justify-center text-[10px]">
             {node.label}
           </div>
-        </Draggable>
+        </SafeDraggable>
       ))}
     </div>
   );

--- a/apps/ettercap/components/SafeDraggable.tsx
+++ b/apps/ettercap/components/SafeDraggable.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import React from 'react';
+import Draggable from 'react-draggable';
+
+type DraggableComponentProps = React.ComponentProps<typeof Draggable>;
+type SafeDraggableProps = React.PropsWithChildren<DraggableComponentProps>;
+
+export default function SafeDraggable({ children, ...props }: SafeDraggableProps) {
+  if (typeof window === 'undefined') {
+    return <>{children}</>;
+  }
+
+  return <Draggable {...props}>{children}</Draggable>;
+}


### PR DESCRIPTION
## Summary
- add a SafeDraggable wrapper for Ettercap's ARP diagram to defer to `react-draggable` only in the browser
- update the ARP diagram component to use the new wrapper so drag props remain type-safe

## Testing
- [x] yarn tsc --noEmit --pretty false
- [x] CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d98c4caea08328a4cf0fa6017f856d