### PR TITLE
[desktop] move workspace switcher to top panel

### DIFF
--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -5,25 +5,65 @@ import QuickSettings from '../ui/QuickSettings';
 import NotificationBell from '../ui/NotificationBell';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import PerformanceGraph from '../ui/PerformanceGraph';
-
+import WorkspaceSwitcher from '../panel/WorkspaceSwitcher';
 
 export default class Navbar extends Component {
-	constructor() {
-		super();
+        constructor() {
+                super();
                 this.state = {
                         status_card: false,
                         applicationsMenuOpen: false,
-                        placesMenuOpen: false
+                        placesMenuOpen: false,
+                        workspaces: [],
+                        activeWorkspace: 0
                 };
         }
 
-		render() {
-			return (
-				<div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
-					<div className="flex items-center">
-						<WhiskerMenu />
-						<PerformanceGraph />
-					</div>
+        componentDidMount() {
+                if (typeof window !== 'undefined') {
+                        window.addEventListener('workspace-state', this.handleWorkspaceStateUpdate);
+                        window.dispatchEvent(new CustomEvent('workspace-request'));
+                }
+        }
+
+        componentWillUnmount() {
+                if (typeof window !== 'undefined') {
+                        window.removeEventListener('workspace-state', this.handleWorkspaceStateUpdate);
+                }
+        }
+
+        handleWorkspaceStateUpdate = (event) => {
+                const detail = event?.detail || {};
+                const { workspaces, activeWorkspace } = detail;
+                this.setState({
+                        workspaces: Array.isArray(workspaces) ? workspaces : [],
+                        activeWorkspace: typeof activeWorkspace === 'number' ? activeWorkspace : 0
+                });
+        };
+
+        handleWorkspaceSelect = (workspaceId) => {
+                if (typeof workspaceId !== 'number') return;
+                this.setState({ activeWorkspace: workspaceId });
+                if (typeof window !== 'undefined') {
+                        window.dispatchEvent(new CustomEvent('workspace-select', { detail: { workspaceId } }));
+                }
+        };
+
+                render() {
+                        const { workspaces, activeWorkspace } = this.state;
+                        return (
+                                <div className="main-navbar-vp absolute top-0 right-0 w-screen shadow-md flex flex-nowrap justify-between items-center bg-ub-grey text-ubt-grey text-sm select-none z-50">
+                                        <div className="flex items-center gap-2">
+                                                <WhiskerMenu />
+                                                {workspaces.length > 0 && (
+                                                        <WorkspaceSwitcher
+                                                                workspaces={workspaces}
+                                                                activeWorkspace={activeWorkspace}
+                                                                onSelect={this.handleWorkspaceSelect}
+                                                        />
+                                                )}
+                                                <PerformanceGraph />
+                                        </div>
 					<div
 						className={
 							'pl-2 pr-2 text-xs md:text-sm outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1'

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import Image from 'next/image';
-import WorkspaceSwitcher from '../panel/WorkspaceSwitcher';
-
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
-    const workspaces = props.workspaces || [];
 
     const handleClick = (app) => {
         const id = app.id;
@@ -18,12 +15,7 @@ export default function Taskbar(props) {
     };
 
     return (
-        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center justify-between px-2 z-40" role="toolbar">
-            <WorkspaceSwitcher
-                workspaces={workspaces}
-                activeWorkspace={props.activeWorkspace}
-                onSelect={props.onSelectWorkspace}
-            />
+        <div className="absolute bottom-0 left-0 w-full h-10 bg-black bg-opacity-50 flex items-center justify-start px-2 z-40" role="toolbar">
             <div className="flex items-center overflow-x-auto">
                 {runningApps.map(app => {
                     const isMinimized = Boolean(props.minimized_windows[app.id]);


### PR DESCRIPTION
## Summary
- surface the workspace switcher next to the Whisker menu in the top panel
- broadcast workspace state updates so the navbar stays in sync with workspace changes and selection
- remove the workspace picker from the taskbar and tidy up the folder name dialog accessibility

## Testing
- `yarn eslint components/screen/navbar.js components/screen/desktop.js components/screen/taskbar.js`


------
https://chatgpt.com/codex/tasks/task_e_68d9a8d96e4483289a03c7e6f41ea687