### PR TITLE
[desktop] enable draggable desktop icons

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -31,6 +31,18 @@ export class UbuntuApp extends Component {
     }
 
     render() {
+        const {
+            draggable = true,
+            isBeingDragged = false,
+            onPointerDown,
+            onPointerMove,
+            onPointerUp,
+            onPointerCancel,
+            style,
+        } = this.props;
+
+        const dragging = this.state.dragging || isBeingDragged;
+
         return (
             <div
                 role="button"
@@ -38,10 +50,15 @@ export class UbuntuApp extends Component {
                 aria-disabled={this.props.disabled}
                 data-context="app"
                 data-app-id={this.props.id}
-                draggable
+                draggable={draggable}
                 onDragStart={this.handleDragStart}
                 onDragEnd={this.handleDragEnd}
-                className={(this.state.launching ? " app-icon-launch " : "") + (this.state.dragging ? " opacity-70 " : "") +
+                onPointerDown={onPointerDown}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+                onPointerCancel={onPointerCancel}
+                style={style}
+                className={(this.state.launching ? " app-icon-launch " : "") + (dragging ? " opacity-70 " : "") +
                     " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}


### PR DESCRIPTION
## Summary
- add desktop icon position management with pointer dragging support and local persistence
- update UbuntuApp to interoperate with pointer-based dragging cues
- store and clamp icon coordinates so layouts survive reloads and viewport changes

## Testing
- [ ] yarn lint (fails: repository has pre-existing accessibility violations)


------
https://chatgpt.com/codex/tasks/task_e_68d9b56fa8988328a75c5b744cedb792