### PR TITLE
[performance] unify dynamic helper skeleton fallback

### DIFF
--- a/__tests__/frogger.config.test.ts
+++ b/__tests__/frogger.config.test.ts
@@ -1,4 +1,4 @@
-jest.mock('next/dynamic', () => jest.fn(() => () => null));
+jest.mock('@/utils/dynamic', () => jest.fn(() => () => null));
 jest.mock('../components/apps/x', () => ({ displayX: () => null }));
 
 import { games } from '../apps.config';

--- a/__tests__/snake.config.test.ts
+++ b/__tests__/snake.config.test.ts
@@ -1,4 +1,4 @@
-jest.mock('next/dynamic', () => jest.fn(() => () => null));
+jest.mock('@/utils/dynamic', () => jest.fn(() => () => null));
 jest.mock('../components/apps/x', () => ({ displayX: () => null }));
 import { games } from '../apps.config';
 

--- a/apps/radare2/components/GraphView.tsx
+++ b/apps/radare2/components/GraphView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import dynamic from "next/dynamic";
+import dynamic from "@/utils/dynamic";
 
 interface Block {
   addr: string;
@@ -13,9 +13,8 @@ interface GraphViewProps {
   theme: string;
 }
 
-const ForceGraph2D = dynamic(
-  () => import("react-force-graph").then((mod) => mod.ForceGraph2D),
-  { ssr: false },
+const ForceGraph2D = dynamic(() =>
+  import("react-force-graph").then((mod) => mod.ForceGraph2D),
 );
 
 const GraphView: React.FC<GraphViewProps> = ({ blocks, theme }) => {

--- a/apps/recon-ng/components/DataModelExplorer.tsx
+++ b/apps/recon-ng/components/DataModelExplorer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
 interface EntityNode {
   id: string;
@@ -15,9 +15,8 @@ interface EntityLink {
   label?: string;
 }
 
-const ForceGraph2D = dynamic(
-  () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
-  { ssr: false }
+const ForceGraph2D = dynamic(() =>
+  import('react-force-graph').then((mod) => mod.ForceGraph2D),
 );
 
 const mockData = {

--- a/apps/recon-ng/components/ModulePlanner.tsx
+++ b/apps/recon-ng/components/ModulePlanner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import usePersistentState from '../../../hooks/usePersistentState';
 
 interface ModuleDef {
@@ -19,9 +19,8 @@ const MODULES: Record<string, ModuleDef> = {
 const moduleNames = Object.keys(MODULES);
 const WORKSPACES = ['default', 'testing', 'production'];
 
-const ForceGraph2D = dynamic(
-  () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
-  { ssr: false },
+const ForceGraph2D = dynamic(() =>
+  import('react-force-graph').then((mod) => mod.ForceGraph2D),
 );
 
 const ModulePlanner: React.FC = () => {

--- a/apps/wireshark/components/FlowGraph.tsx
+++ b/apps/wireshark/components/FlowGraph.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useEffect, useMemo, useRef } from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import { toPng } from 'html-to-image';
 import type cytoscape from 'cytoscape';
 
@@ -10,15 +10,12 @@ interface CytoscapeComponentProps {
   cy: (cy: cytoscape.Core) => void;
 }
 
-const CytoscapeComponent = dynamic(
-  async () => {
-    const cytoscape = (await import('cytoscape')).default;
-    const coseBilkent = (await import('cytoscape-cose-bilkent')).default;
-    cytoscape.use(coseBilkent);
-    return (await import('react-cytoscapejs')).default;
-  },
-  { ssr: false }
-) as React.ComponentType<CytoscapeComponentProps>;
+const CytoscapeComponent = dynamic(async () => {
+  const cytoscape = (await import('cytoscape')).default;
+  const coseBilkent = (await import('cytoscape-cose-bilkent')).default;
+  cytoscape.use(coseBilkent);
+  return (await import('react-cytoscapejs')).default;
+}) as React.ComponentType<CytoscapeComponentProps>;
 
 interface Packet {
   src: string;

--- a/components/apps/calculator.js
+++ b/components/apps/calculator.js
@@ -1,10 +1,7 @@
 import '../../utils/decimal';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Calculator = dynamic(() => import('../../apps/calculator'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Calculator = dynamic(() => import('../../apps/calculator'));
 
 export default Calculator;
 

--- a/components/apps/project-gallery.tsx
+++ b/components/apps/project-gallery.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import projectsData from '../../data/projects.json';
 
 interface Project {
@@ -21,7 +21,7 @@ interface Props {
   openApp?: (id: string) => void;
 }
 
-const Editor = dynamic(() => import('@monaco-editor/react'), { ssr: false });
+const Editor = dynamic(() => import('@monaco-editor/react'));
 
 const STORAGE_KEY = 'project-gallery-filters';
 const STORAGE_FILE = 'project-gallery-filters.json';

--- a/components/apps/quote/index.tsx
+++ b/components/apps/quote/index.tsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const QuoteApp = dynamic(() => import('../../../apps/quote'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const QuoteApp = dynamic(() => import('../../../apps/quote'));
 
 export default QuoteApp;
 

--- a/components/apps/reconng/index.js
+++ b/components/apps/reconng/index.js
@@ -4,20 +4,17 @@ import React, {
   useRef,
   useMemo,
 } from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import usePersistentState from '../../../hooks/usePersistentState';
 import ReportTemplates from './components/ReportTemplates';
 import { useSettings } from '../../../hooks/useSettings';
 
-const CytoscapeComponent = dynamic(
-  async () => {
-    const cytoscape = (await import('cytoscape')).default;
-    const coseBilkent = (await import('cytoscape-cose-bilkent')).default;
-    cytoscape.use(coseBilkent);
-    return (await import('react-cytoscapejs')).default;
-  },
-  { ssr: false },
-);
+const CytoscapeComponent = dynamic(async () => {
+  const cytoscape = (await import('cytoscape')).default;
+  const coseBilkent = (await import('cytoscape-cose-bilkent')).default;
+  cytoscape.use(coseBilkent);
+  return (await import('react-cytoscapejs')).default;
+});
 
 // Built-in modules with simple schemas and canned demo data. Each schema defines
 // the expected input type, a demo generator for offline usage, and an optional

--- a/components/apps/sticky_notes/index.tsx
+++ b/components/apps/sticky_notes/index.tsx
@@ -1,8 +1,5 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const StickyNotes = dynamic(() => import('../../../apps/sticky_notes'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const StickyNotes = dynamic(() => import('../../../apps/sticky_notes'));
 
 export default StickyNotes;

--- a/components/apps/subnet-calculator.tsx
+++ b/components/apps/subnet-calculator.tsx
@@ -1,12 +1,5 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const SubnetCalculator = dynamic(() => import('../../apps/subnet-calculator'), {
-  ssr: false,
-  loading: () => (
-    <div className="flex h-full w-full items-center justify-center bg-ub-cool-grey text-white">
-      Loading Subnet Calculator...
-    </div>
-  ),
-});
+const SubnetCalculator = dynamic(() => import('../../apps/subnet-calculator'));
 
 export default SubnetCalculator;

--- a/components/apps/terminal.tsx
+++ b/components/apps/terminal.tsx
@@ -1,15 +1,8 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import HelpPanel from '../HelpPanel';
 
 // Lazily load the heavy terminal app with session tabs on the client only.
-const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'), {
-  ssr: false,
-  loading: () => (
-    <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-      Loading Terminal...
-    </div>
-  ),
-});
+const TerminalApp = dynamic(() => import('../../apps/terminal/tabs'));
 
 /**
  * Wrapper component that ensures the terminal area can scroll when content

--- a/components/apps/vscode.jsx
+++ b/components/apps/vscode.jsx
@@ -1,11 +1,11 @@
 'use client';
 
 import React, { useState, useEffect, useMemo } from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import apps from '../../apps.config';
 
 // Load the actual VSCode app lazily so no editor dependencies are required
-const VsCode = dynamic(() => import('../../apps/vscode'), { ssr: false });
+const VsCode = dynamic(() => import('../../apps/vscode'));
 
 // Simple fuzzy match: returns true if query characters appear in order
 function fuzzyMatch(text, query) {

--- a/components/apps/weather.js
+++ b/components/apps/weather.js
@@ -1,11 +1,8 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
 // Dynamically load the full Weather application. This remains the default
 // export so existing imports continue to work.
-const WeatherApp = dynamic(() => import('../../apps/weather'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const WeatherApp = dynamic(() => import('../../apps/weather'));
 
 /**
  * A provider agnostic weather fetcher with basic service worker caching.

--- a/components/apps/weather_widget.js
+++ b/components/apps/weather_widget.js
@@ -1,8 +1,5 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const WeatherWidget = dynamic(() => import('../../apps/weather_widget'));
 
 export default WeatherWidget;

--- a/components/apps/wireshark/FlowDiagram.js
+++ b/components/apps/wireshark/FlowDiagram.js
@@ -1,10 +1,9 @@
 'use client';
 import React, { useMemo } from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const ForceGraph2D = dynamic(
-  () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
-  { ssr: false }
+const ForceGraph2D = dynamic(() =>
+  import('react-force-graph').then((mod) => mod.ForceGraph2D),
 );
 
 const FlowDiagram = ({ packets }) => {

--- a/components/base/Skeleton.tsx
+++ b/components/base/Skeleton.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+interface SkeletonProps {
+  /**
+   * Optional className to further customize the skeleton container. This keeps
+   * the base styling consistent with the Kali desktop theme while allowing
+   * individual apps to tweak sizing if they need to.
+   */
+  className?: string;
+  /**
+   * Accessible label announced by screen readers. Defaults to a generic
+   * "Loading" message when not provided.
+   */
+  label?: string;
+}
+
+const baseClasses = [
+  'flex h-full min-h-[120px] w-full items-center justify-center',
+  'rounded-md border border-kali-border/60 bg-kali-surface/50',
+  'text-kali-muted motion-safe:animate-pulse',
+].join(' ');
+
+const Skeleton: React.FC<SkeletonProps> = ({ className = '', label = 'Loading' }) => {
+  const classes = className ? `${baseClasses} ${className}` : baseClasses;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      className={classes}
+    >
+      <div className="flex items-center gap-3">
+        <span className="inline-flex h-3 w-3 rounded-full bg-kali-accent motion-safe:animate-ping" aria-hidden />
+        <span className="text-sm font-medium tracking-wide uppercase text-kali-muted">
+          {label}
+        </span>
+      </div>
+      <span className="sr-only">{`${label} content`}</span>
+    </div>
+  );
+};
+
+export default Skeleton;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1,11 +1,10 @@
 "use client";
 
 import React, { Component } from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
 const BackgroundImage = dynamic(
     () => import('../util-components/background-image'),
-    { ssr: false }
 );
 import apps, { games } from '../../apps.config';
 import Window from '../base/window';

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,5 @@
 import { TextEncoder, TextDecoder } from 'util';
+jest.mock('@/utils/dynamic', () => jest.fn(() => () => null));
 // Polyfill structuredClone before requiring modules that depend on it
 // @ts-ignore
 if (typeof global.structuredClone !== 'function') {

--- a/pages/apps/2048.jsx
+++ b/pages/apps/2048.jsx
@@ -1,8 +1,5 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Page2048 = dynamic(() => import('../../apps/2048'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Page2048 = dynamic(() => import('../../apps/2048'));
 
 export default Page2048;

--- a/pages/apps/ascii-art.jsx
+++ b/pages/apps/ascii-art.jsx
@@ -1,8 +1,5 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const AsciiArt = dynamic(() => import('../../apps/ascii-art'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const AsciiArt = dynamic(() => import('../../apps/ascii-art'));
 
 export default AsciiArt;

--- a/pages/apps/autopsy.jsx
+++ b/pages/apps/autopsy.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Autopsy = dynamic(() => import('../../apps/autopsy'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Autopsy = dynamic(() => import('../../apps/autopsy'));
 
 export default function AutopsyPage() {
   return <Autopsy />;

--- a/pages/apps/beef.jsx
+++ b/pages/apps/beef.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Beef = dynamic(() => import('../../apps/beef'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Beef = dynamic(() => import('../../apps/beef'));
 
 export default function BeefPage() {
   return <Beef />;

--- a/pages/apps/blackjack.jsx
+++ b/pages/apps/blackjack.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Blackjack = dynamic(() => import('../../apps/blackjack'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Blackjack = dynamic(() => import('../../apps/blackjack'));
 
 export default function BlackjackPage() {
   return <Blackjack />;

--- a/pages/apps/calculator.jsx
+++ b/pages/apps/calculator.jsx
@@ -1,10 +1,7 @@
 import '../../utils/decimal';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Calculator = dynamic(() => import('../../apps/calculator'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Calculator = dynamic(() => import('../../apps/calculator'));
 
 export default function CalculatorPage() {
   return <Calculator />;

--- a/pages/apps/checkers.jsx
+++ b/pages/apps/checkers.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Checkers = dynamic(() => import('../../apps/checkers'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Checkers = dynamic(() => import('../../apps/checkers'));
 
 export default function CheckersPage() {
   return <Checkers />;

--- a/pages/apps/connect-four.jsx
+++ b/pages/apps/connect-four.jsx
@@ -1,8 +1,5 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const ConnectFour = dynamic(() => import('../../apps/connect-four'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const ConnectFour = dynamic(() => import('../../apps/connect-four'));
 
 export default ConnectFour;

--- a/pages/apps/contact.jsx
+++ b/pages/apps/contact.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const ContactApp = dynamic(() => import('../../apps/contact'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const ContactApp = dynamic(() => import('../../apps/contact'));
 
 export default function ContactPage() {
   return <ContactApp />;

--- a/pages/apps/converter.jsx
+++ b/pages/apps/converter.jsx
@@ -1,9 +1,6 @@
-import dynamic from "next/dynamic";
+import dynamic from "@/utils/dynamic";
 
-const Converter = dynamic(() => import("../../apps/converter"), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Converter = dynamic(() => import("../../apps/converter"));
 
 export default function ConverterPage() {
   return <Converter />;

--- a/pages/apps/figlet.jsx
+++ b/pages/apps/figlet.jsx
@@ -1,8 +1,5 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const FigletPage = dynamic(() => import('../../apps/figlet'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const FigletPage = dynamic(() => import('../../apps/figlet'));
 
 export default FigletPage;

--- a/pages/apps/firefox.jsx
+++ b/pages/apps/firefox.jsx
@@ -1,8 +1,5 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const FirefoxApp = dynamic(() => import('../../apps/firefox'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const FirefoxApp = dynamic(() => import('../../apps/firefox'));
 
 export default FirefoxApp;

--- a/pages/apps/http.jsx
+++ b/pages/apps/http.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const HTTPPreview = dynamic(() => import('../../apps/http'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const HTTPPreview = dynamic(() => import('../../apps/http'));
 
 export default function HTTPPage() {
   return <HTTPPreview />;

--- a/pages/apps/input-lab.jsx
+++ b/pages/apps/input-lab.jsx
@@ -1,6 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const InputLab = dynamic(() => import('../../apps/input-lab'), { ssr: false });
+const InputLab = dynamic(() => import('../../apps/input-lab'));
 
 export default function InputLabPage() {
   return <InputLab />;

--- a/pages/apps/john.jsx
+++ b/pages/apps/john.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const John = dynamic(() => import('../../apps/john'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const John = dynamic(() => import('../../apps/john'));
 
 export default function JohnPage() {
   return <John />;

--- a/pages/apps/kismet.jsx
+++ b/pages/apps/kismet.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Kismet = dynamic(() => import('../../apps/kismet'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Kismet = dynamic(() => import('../../apps/kismet'));
 
 export default function KismetPage() {
   return <Kismet />;

--- a/pages/apps/metasploit-post.jsx
+++ b/pages/apps/metasploit-post.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const MetasploitPost = dynamic(() => import('../../apps/metasploit-post'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const MetasploitPost = dynamic(() => import('../../apps/metasploit-post'));
 
 export default function MetasploitPostPage() {
   return <MetasploitPost />;

--- a/pages/apps/metasploit.jsx
+++ b/pages/apps/metasploit.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Metasploit = dynamic(() => import('../../apps/metasploit'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Metasploit = dynamic(() => import('../../apps/metasploit'));
 
 export default function MetasploitPage() {
   return <Metasploit />;

--- a/pages/apps/mimikatz/offline.jsx
+++ b/pages/apps/mimikatz/offline.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const MimikatzOffline = dynamic(() => import('../../../apps/mimikatz/offline'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const MimikatzOffline = dynamic(() => import('../../../apps/mimikatz/offline'));
 
 export default function MimikatzOfflinePage() {
   return <MimikatzOffline />;

--- a/pages/apps/minesweeper.jsx
+++ b/pages/apps/minesweeper.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Minesweeper = dynamic(() => import('../../apps/minesweeper'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Minesweeper = dynamic(() => import('../../apps/minesweeper'));
 
 export default function MinesweeperPage() {
   return <Minesweeper />;

--- a/pages/apps/nmap-nse.jsx
+++ b/pages/apps/nmap-nse.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const NmapNSE = dynamic(() => import('../../apps/nmap-nse'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const NmapNSE = dynamic(() => import('../../apps/nmap-nse'));
 
 export default function NmapNSEPage() {
   return <NmapNSE />;

--- a/pages/apps/password_generator.jsx
+++ b/pages/apps/password_generator.jsx
@@ -1,10 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const PasswordGenerator = dynamic(() => import('../../apps/password_generator'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const PasswordGenerator = dynamic(() => import('../../apps/password_generator'));
 
 export default function PasswordGeneratorPage() {
   return <PasswordGenerator getDailySeed={() => getDailySeed('password_generator')} />;

--- a/pages/apps/phaser_matter.jsx
+++ b/pages/apps/phaser_matter.jsx
@@ -1,10 +1,7 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const PhaserMatter = dynamic(() => import('../../apps/phaser_matter'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const PhaserMatter = dynamic(() => import('../../apps/phaser_matter'));
 
 export default function PhaserMatterPage() {
   return <PhaserMatter getDailySeed={() => getDailySeed('phaser_matter')} />;

--- a/pages/apps/pinball.jsx
+++ b/pages/apps/pinball.jsx
@@ -1,8 +1,5 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Pinball = dynamic(() => import('../../apps/pinball'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Pinball = dynamic(() => import('../../apps/pinball'));
 
 export default Pinball;

--- a/pages/apps/project-gallery.jsx
+++ b/pages/apps/project-gallery.jsx
@@ -1,8 +1,5 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const ProjectGalleryApp = dynamic(() => import('../../apps/project-gallery/pages'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const ProjectGalleryApp = dynamic(() => import('../../apps/project-gallery/pages'));
 
 export default ProjectGalleryApp;

--- a/pages/apps/qr.jsx
+++ b/pages/apps/qr.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const QRApp = dynamic(() => import('../../apps/qr'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const QRApp = dynamic(() => import('../../apps/qr'));
 
 export default function QRPage() {
   return <QRApp />;

--- a/pages/apps/settings.jsx
+++ b/pages/apps/settings.jsx
@@ -1,6 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
+const SettingsApp = dynamic(() => import('../../apps/settings'));
 
 export default function SettingsPage() {
   return <SettingsApp />;

--- a/pages/apps/simon.jsx
+++ b/pages/apps/simon.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Simon = dynamic(() => import('../../apps/simon'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Simon = dynamic(() => import('../../apps/simon'));
 
 export default function SimonPage() {
   return <Simon />;

--- a/pages/apps/sokoban.jsx
+++ b/pages/apps/sokoban.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const Sokoban = dynamic(() => import('../../apps/sokoban'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Sokoban = dynamic(() => import('../../apps/sokoban'));
 
 const SokobanPage = () => (
   <Sokoban getDailySeed={() => getDailySeed('sokoban')} />

--- a/pages/apps/solitaire.jsx
+++ b/pages/apps/solitaire.jsx
@@ -1,8 +1,5 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const PageSolitaire = dynamic(() => import('../../apps/solitaire'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const PageSolitaire = dynamic(() => import('../../apps/solitaire'));
 
 export default PageSolitaire;

--- a/pages/apps/spotify.jsx
+++ b/pages/apps/spotify.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const SpotifyApp = dynamic(() => import('../../apps/spotify'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const SpotifyApp = dynamic(() => import('../../apps/spotify'));
 
 export default SpotifyApp;
 

--- a/pages/apps/ssh.jsx
+++ b/pages/apps/ssh.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const SSHPreview = dynamic(() => import('../../apps/ssh'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const SSHPreview = dynamic(() => import('../../apps/ssh'));
 
 export default function SSHPage() {
   return <SSHPreview />;

--- a/pages/apps/sticky_notes.jsx
+++ b/pages/apps/sticky_notes.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const StickyNotes = dynamic(() => import('../../apps/sticky_notes'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const StickyNotes = dynamic(() => import('../../apps/sticky_notes'));
 
 export default function StickyNotesPage() {
   return <StickyNotes />;

--- a/pages/apps/subnet-calculator.jsx
+++ b/pages/apps/subnet-calculator.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const SubnetCalculator = dynamic(() => import('../../apps/subnet-calculator'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const SubnetCalculator = dynamic(() => import('../../apps/subnet-calculator'));
 
 export default function SubnetCalculatorPage() {
   return <SubnetCalculator />;

--- a/pages/apps/timer_stopwatch.jsx
+++ b/pages/apps/timer_stopwatch.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const TimerStopwatch = dynamic(() => import('../../apps/timer_stopwatch'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const TimerStopwatch = dynamic(() => import('../../apps/timer_stopwatch'));
 
 export default function TimerStopwatchPage() {
   return <TimerStopwatch />;

--- a/pages/apps/tower-defense.jsx
+++ b/pages/apps/tower-defense.jsx
@@ -1,8 +1,5 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const TowerDefense = dynamic(() => import('../../apps/tower-defense'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const TowerDefense = dynamic(() => import('../../apps/tower-defense'));
 
 export default TowerDefense;

--- a/pages/apps/volatility.jsx
+++ b/pages/apps/volatility.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Volatility = dynamic(() => import('../../apps/volatility'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Volatility = dynamic(() => import('../../apps/volatility'));
 
 export default function VolatilityPage() {
   return <Volatility />;

--- a/pages/apps/vscode.jsx
+++ b/pages/apps/vscode.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const VSCode = dynamic(() => import('../../apps/vscode'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const VSCode = dynamic(() => import('../../apps/vscode'));
 
 export default function VSCodePage() {
   return <VSCode />;

--- a/pages/apps/weather.jsx
+++ b/pages/apps/weather.jsx
@@ -1,4 +1,4 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
 const WeatherApp = dynamic(
   () =>
@@ -6,10 +6,6 @@ const WeatherApp = dynamic(
       console.error('Failed to load Weather app', err);
       throw err;
     }),
-  {
-    ssr: false,
-    loading: () => <p>Loading...</p>,
-  }
 );
 
 export default WeatherApp;

--- a/pages/apps/weather_widget.jsx
+++ b/pages/apps/weather_widget.jsx
@@ -1,10 +1,7 @@
 import { useEffect, useState } from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const WeatherWidget = dynamic(() => import('../../apps/weather_widget'));
 
 // Display stored unit preference and the browser's location consent status.
 export default function WeatherWidgetPage() {

--- a/pages/apps/wireshark.jsx
+++ b/pages/apps/wireshark.jsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Wireshark = dynamic(() => import('../../apps/wireshark'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Wireshark = dynamic(() => import('../../apps/wireshark'));
 
 export default function WiresharkPage() {
   return <Wireshark />;

--- a/pages/apps/word_search.jsx
+++ b/pages/apps/word_search.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
 
-const WordSearch = dynamic(
-  () => import('../../apps/word_search'),
-  { ssr: false, loading: () => <p>Loading...</p> },
-);
+const WordSearch = dynamic(() => import('../../apps/word_search'));
 
 export default function WordSearchPage() {
   return <WordSearch getDailySeed={() => getDailySeed('word_search')} />;

--- a/pages/apps/x.jsx
+++ b/pages/apps/x.jsx
@@ -1,8 +1,5 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const PageX = dynamic(() => import('../../apps/x'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const PageX = dynamic(() => import('../../apps/x'));
 
 export default PageX;

--- a/pages/games/blackjack/index.tsx
+++ b/pages/games/blackjack/index.tsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const Blackjack = dynamic(() => import('../../../games/blackjack'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const Blackjack = dynamic(() => import('../../../games/blackjack'));
 
 export default function BlackjackGamePage() {
   return <Blackjack />;

--- a/pages/games/blackjack/trainer.tsx
+++ b/pages/games/blackjack/trainer.tsx
@@ -1,9 +1,6 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
-const BlackjackTrainer = dynamic(() => import('../../../games/blackjack/trainer'), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const BlackjackTrainer = dynamic(() => import('../../../games/blackjack/trainer'));
 
 export default function BlackjackTrainerPage() {
   return <BlackjackTrainer />;

--- a/pages/games/breakout/editor.tsx
+++ b/pages/games/breakout/editor.tsx
@@ -1,9 +1,6 @@
-import dynamic from "next/dynamic";
+import dynamic from "@/utils/dynamic";
 
-const BreakoutEditor = dynamic(() => import("../../../games/breakout/editor"), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
+const BreakoutEditor = dynamic(() => import("../../../games/breakout/editor"));
 
 export default function BreakoutEditorPage() {
   return <BreakoutEditor />;

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,4 +1,4 @@
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 import Meta from '../components/SEO/Meta';
 import BetaBadge from '../components/BetaBadge';
 
@@ -9,7 +9,6 @@ const Ubuntu = dynamic(
       throw err;
     }),
   {
-    ssr: false,
     loading: () => null,
   }
 );
@@ -20,7 +19,6 @@ const InstallButton = dynamic(
       throw err;
     }),
   {
-    ssr: false,
     loading: () => null,
   }
 );

--- a/pages/recon/graph.tsx
+++ b/pages/recon/graph.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
 
 interface CytoscapeNode {
   data: { id: string; label: string };
@@ -30,9 +30,8 @@ interface GraphLink {
   target: string;
 }
 
-const ForceGraph2D = dynamic(
-  () => import('react-force-graph').then((mod) => mod.ForceGraph2D),
-  { ssr: false },
+const ForceGraph2D = dynamic(() =>
+  import('react-force-graph').then((mod) => mod.ForceGraph2D),
 );
 
 const ReconGraph: React.FC = () => {

--- a/utils/createDynamicApp.js
+++ b/utils/createDynamicApp.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import dynamic from 'next/dynamic';
+import dynamic from '@/utils/dynamic';
+import Skeleton from '@/components/base/Skeleton';
 import { logEvent } from './analytics';
 
 export const createDynamicApp = (id, title) =>
@@ -21,19 +22,12 @@ export const createDynamicApp = (id, title) =>
       }
     },
     {
-      ssr: false,
-      loading: () => (
-        <div className="h-full w-full flex items-center justify-center bg-ub-cool-grey text-white">
-          {`Loading ${title}...`}
-        </div>
-      ),
+      loading: () => <Skeleton label={`Loading ${title}`} />,
     }
   );
 
 export const createDisplay = (Component) => {
-  const DynamicComponent = dynamic(() => Promise.resolve({ default: Component }), {
-    ssr: false,
-  });
+  const DynamicComponent = dynamic(() => Promise.resolve({ default: Component }));
   const Display = (addFolder, openApp, context) => {
     const extraProps =
       context && typeof context === 'object' ? context : undefined;

--- a/utils/dynamic.tsx
+++ b/utils/dynamic.tsx
@@ -1,0 +1,28 @@
+import type { DynamicOptions, Loader } from 'next/dynamic';
+import nextDynamic from 'next/dynamic';
+import Skeleton from '@/components/base/Skeleton';
+
+type LoaderOrOptions<P> = DynamicOptions<P> | Loader<P>;
+
+export default function dynamic<P = {}>(
+  dynamicOptions: LoaderOrOptions<P>,
+  options?: DynamicOptions<P>,
+) {
+  if (typeof dynamicOptions === 'function') {
+    return nextDynamic(dynamicOptions as Loader<P>, {
+      ...(options ?? {}),
+      ssr: false,
+      loading: options?.loading ?? (() => <Skeleton />),
+    });
+  }
+
+  const { loading, ...rest } = dynamicOptions;
+  const { loading: loadingOverride, ...optionRest } = options ?? {};
+
+  return nextDynamic({
+    ...rest,
+    ...optionRest,
+    ssr: false,
+    loading: loadingOverride ?? loading ?? (() => <Skeleton />),
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared Skeleton component and utils/dynamic wrapper to enforce ssr: false with a consistent loading fallback
- update createDynamicApp, desktop shell, and heavy graph/video apps/pages to consume the new helper instead of next/dynamic
- mock the helper in Jest setup so config tests keep stubbing lazy modules

## Testing
- yarn lint (fails: pre-existing accessibility and browser globals warnings)
- yarn test --runTestsByPath __tests__/radare2Guide.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d9c811c95483289df83f9df79f15aa