### PR TITLE
[media] defer YouTube embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,15 @@ These external domains are whitelisted in the default CSP. Update this list when
 | `open.spotify.com` | Spotify embeds |
 | `vercel.live` | Vercel toolbar |
 
+### Functional cookies
+
+Only two functional cookies are set by the portfolio and both are scoped to specific features:
+
+| Cookie | Scope | Purpose |
+| --- | --- | --- |
+| `csrfToken` | `/api/contact` | HttpOnly CSRF token issued when the contact form requests a token. It is validated against the `x-csrf-token` header on form submission. |
+| `third_party_cookie_test` | Client-side check in `ExternalFrame` | Non-persistent probe to detect whether the browser blocks third-party cookies before embedding remote tooling. |
+
 **Notes for prod hardening**
 - Review `connect-src` and `frame-src` to ensure only required domains are present for your deployment.
 - Consider removing `'unsafe-inline'` from `style-src` once all inline styles are eliminated.

--- a/apps/youtube/components/ComparePlayers.tsx
+++ b/apps/youtube/components/ComparePlayers.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { loadYouTubeIframeApi } from '../utils/loadIframeApi';
 
 function parseVideoId(input: string): string {
   try {
@@ -26,16 +27,25 @@ const ComparePlayers = () => {
   const [rightPlayer, setRightPlayer] = useState<any>(null);
   const [ready, setReady] = useState(false);
 
+  const shouldLoadApi = leftId !== '' || rightId !== '';
+
   useEffect(() => {
-    if (window.YT) {
-      setReady(true);
-      return;
+    if (!shouldLoadApi) {
+      setReady(false);
+      return () => {};
     }
-    const tag = document.createElement('script');
-    tag.src = 'https://www.youtube.com/iframe_api';
-    window.onYouTubeIframeAPIReady = () => setReady(true);
-    document.body.appendChild(tag);
-  }, []);
+
+    if (typeof window === 'undefined') {
+      return () => {};
+    }
+
+    if ((window as any).YT?.Player) {
+      setReady(true);
+      return () => {};
+    }
+
+    return loadYouTubeIframeApi(() => setReady(true));
+  }, [shouldLoadApi]);
 
   useEffect(() => {
     if (!ready || !leftId || !leftDiv.current) return;
@@ -80,18 +90,26 @@ const ComparePlayers = () => {
   return (
     <div className="p-4 text-white">
       <div className="mb-4 flex gap-2">
-        <input
-          className="w-full rounded bg-gray-800 p-2"
-          placeholder="Left video ID or URL"
-          value={leftId}
-          onChange={(e) => setLeftId(parseVideoId(e.target.value))}
-        />
-        <input
-          className="w-full rounded bg-gray-800 p-2"
-          placeholder="Right video ID or URL"
-          value={rightId}
-          onChange={(e) => setRightId(parseVideoId(e.target.value))}
-        />
+        <label className="w-full">
+          <span className="sr-only">Left video ID or URL</span>
+          <input
+            className="w-full rounded bg-gray-800 p-2"
+            placeholder="Left video ID or URL"
+            aria-label="Left video ID or URL"
+            value={leftId}
+            onChange={(e) => setLeftId(parseVideoId(e.target.value))}
+          />
+        </label>
+        <label className="w-full">
+          <span className="sr-only">Right video ID or URL</span>
+          <input
+            className="w-full rounded bg-gray-800 p-2"
+            placeholder="Right video ID or URL"
+            aria-label="Right video ID or URL"
+            value={rightId}
+            onChange={(e) => setRightId(parseVideoId(e.target.value))}
+          />
+        </label>
       </div>
       <div className="flex flex-col gap-4 md:flex-row">
         <div className="flex-1">

--- a/apps/youtube/utils/loadIframeApi.ts
+++ b/apps/youtube/utils/loadIframeApi.ts
@@ -1,0 +1,45 @@
+let loading = false;
+let ready = false;
+const callbacks: Array<() => void> = [];
+
+export function loadYouTubeIframeApi(onReady: () => void) {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const win = window as typeof window & {
+    YT?: { Player?: unknown };
+    onYouTubeIframeAPIReady?: () => void;
+  };
+
+  if (win.YT?.Player) {
+    ready = true;
+  }
+
+  if (ready) {
+    onReady();
+    return () => {};
+  }
+
+  callbacks.push(onReady);
+
+  if (!loading) {
+    loading = true;
+    win.onYouTubeIframeAPIReady = () => {
+      ready = true;
+      const pending = callbacks.splice(0, callbacks.length);
+      pending.forEach((cb) => cb());
+    };
+
+    const script = document.createElement('script');
+    script.src = 'https://www.youtube.com/iframe_api';
+    script.async = true;
+    script.dataset.ytApi = 'true';
+    document.body.appendChild(script);
+  }
+
+  return () => {
+    const index = callbacks.indexOf(onReady);
+    if (index >= 0) callbacks.splice(index, 1);
+  };
+}

--- a/components/media/Video.tsx
+++ b/components/media/Video.tsx
@@ -1,0 +1,217 @@
+import Image from 'next/image';
+import React, {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+export type ActivationReason = 'interaction' | 'visible';
+
+export type RenderOptions = {
+  autoPlay: boolean;
+  enableApi: boolean;
+  iframeRef: React.RefObject<HTMLIFrameElement>;
+  setEnableApi: (value: boolean) => void;
+};
+
+export type KeyCommand = 'space' | 'escape';
+
+export type KeyCommandOptions = RenderOptions & {
+  iframe: HTMLIFrameElement | null;
+};
+
+interface VideoProps {
+  poster: string;
+  title: string;
+  className?: string;
+  aspectRatio?: string;
+  placeholderLabel?: string;
+  overlay?: ReactNode;
+  loadOnVisible?: boolean;
+  activateOnMount?: ActivationReason | null;
+  enableApiByDefault?: boolean;
+  onActivate?: (reason: ActivationReason) => void;
+  onEnableApiChange?: (next: boolean) => void;
+  renderEmbed: (options: RenderOptions) => ReactNode;
+  onKeyCommand?: (command: KeyCommand, options: KeyCommandOptions) => void;
+}
+
+const Video: React.FC<VideoProps> = ({
+  poster,
+  title,
+  className,
+  aspectRatio = '16 / 9',
+  placeholderLabel = 'Play video',
+  overlay,
+  loadOnVisible = true,
+  activateOnMount = null,
+  enableApiByDefault = false,
+  onActivate,
+  onEnableApiChange,
+  renderEmbed,
+  onKeyCommand,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [active, setActive] = useState(false);
+  const [autoPlay, setAutoPlay] = useState(false);
+  const [enableApi, setEnableApi] = useState(enableApiByDefault);
+  const hasLoadedRef = useRef(false);
+  const mountActivationRef = useRef<ActivationReason | null>(null);
+
+  const activate = useCallback(
+    (reason: ActivationReason) => {
+      if (reason === 'visible') {
+        if (hasLoadedRef.current) {
+          return;
+        }
+        hasLoadedRef.current = true;
+        setActive(true);
+        setAutoPlay(false);
+        onActivate?.(reason);
+        return;
+      }
+
+      if (!hasLoadedRef.current) {
+        hasLoadedRef.current = true;
+        setActive(true);
+      }
+      setAutoPlay(true);
+      setEnableApi(true);
+      onActivate?.(reason);
+      requestAnimationFrame(() => {
+        containerRef.current?.focus();
+      });
+    },
+    [onActivate],
+  );
+
+  useEffect(() => {
+    if (!activateOnMount) {
+      mountActivationRef.current = null;
+      return;
+    }
+    if (mountActivationRef.current === activateOnMount) {
+      return;
+    }
+    mountActivationRef.current = activateOnMount;
+    activate(activateOnMount);
+  }, [activateOnMount, activate]);
+
+  useEffect(() => {
+    if (!loadOnVisible) return;
+    if (hasLoadedRef.current) return;
+    const node = containerRef.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            activate('visible');
+          }
+        });
+      },
+      { threshold: 0.25 },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [activate, loadOnVisible]);
+
+  useEffect(() => {
+    onEnableApiChange?.(enableApi);
+  }, [enableApi, onEnableApiChange]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!active) {
+        if (event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter') {
+          event.preventDefault();
+          activate('interaction');
+        }
+        return;
+      }
+
+      if (!onKeyCommand) return;
+
+      if (event.key === ' ' || event.key === 'Spacebar') {
+        event.preventDefault();
+        onKeyCommand('space', {
+          autoPlay,
+          enableApi,
+          iframeRef,
+          setEnableApi,
+          iframe: iframeRef.current,
+        });
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        onKeyCommand('escape', {
+          autoPlay,
+          enableApi,
+          iframeRef,
+          setEnableApi,
+          iframe: iframeRef.current,
+        });
+      }
+    },
+    [activate, active, autoPlay, enableApi, onKeyCommand],
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative isolate overflow-hidden focus:outline-none ${className ?? ''}`.trim()}
+      style={{ aspectRatio }}
+      tabIndex={0}
+      role="group"
+      aria-label={title}
+      onKeyDown={handleKeyDown}
+    >
+      {!active && (
+        <button
+          type="button"
+          className="absolute inset-0 flex h-full w-full items-center justify-center bg-black/40 transition focus:outline-none"
+          onClick={() => activate('interaction')}
+          aria-label={placeholderLabel}
+        >
+          <Image
+            src={poster}
+            alt=""
+            fill
+            sizes="(max-width: 768px) 100vw, 50vw"
+            className="object-cover"
+            priority={false}
+          />
+          <div aria-hidden className="relative z-10 flex flex-col items-center gap-2 text-white">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="64"
+              height="64"
+              viewBox="0 0 68 48"
+              className="drop-shadow-lg"
+            >
+              <path
+                d="M66.52 7.43a8 8 0 00-5.62-5.66C55.47.8 34 0.8 34 0.8S12.53.8 7.1 1.77A8 8 0 001.48 7.43 83.4 83.4 0 000 24a83.4 83.4 0 001.48 16.57 8 8 0 005.62 5.66c5.43.97 26.9.97 26.9.97s21.47 0 26.9-.97a8 8 0 005.62-5.66A83.4 83.4 0 0068 24a83.4 83.4 0 00-1.48-16.57z"
+                fill="#f00"
+              />
+              <path d="M45 24L27 14v20z" fill="#fff" />
+            </svg>
+            <span className="text-sm font-medium">{placeholderLabel}</span>
+          </div>
+        </button>
+      )}
+
+      {active && (
+        <div className="absolute inset-0">
+          {renderEmbed({ autoPlay, enableApi, iframeRef, setEnableApi })}
+          {overlay}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Video;

--- a/components/media/YouTube.tsx
+++ b/components/media/YouTube.tsx
@@ -1,0 +1,227 @@
+import React, {
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import Video, { KeyCommandOptions, RenderOptions } from './Video';
+
+type PosterQuality =
+  | 'default'
+  | 'mqdefault'
+  | 'hqdefault'
+  | 'sddefault'
+  | 'maxresdefault';
+
+type YouTubeProps = {
+  videoId: string;
+  title: string;
+  className?: string;
+  aspectRatio?: string;
+  posterQuality?: PosterQuality;
+  start?: number;
+  end?: number;
+  autoPlay?: boolean;
+  loadOnVisible?: boolean;
+};
+
+type PlayerCommand = () => void;
+
+const YT_ORIGIN = 'https://www.youtube-nocookie.com';
+
+const YouTube: React.FC<YouTubeProps> = ({
+  videoId,
+  title,
+  className,
+  aspectRatio,
+  posterQuality = 'hqdefault',
+  start,
+  end,
+  autoPlay = false,
+  loadOnVisible = true,
+}) => {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [origin, setOrigin] = useState<string | null>(null);
+  const [playerReady, setPlayerReady] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const pendingCommandRef = useRef<PlayerCommand | null>(null);
+  const lastEnableApiRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setOrigin(window.location.origin);
+  }, []);
+
+  useEffect(() => {
+    setPlayerReady(false);
+    setIsPlaying(false);
+    pendingCommandRef.current = null;
+  }, [videoId]);
+
+  const poster = useMemo(
+    () => `${'https://i.ytimg.com/vi/'}${videoId}/${posterQuality}.jpg`,
+    [videoId, posterQuality],
+  );
+
+  const sendCommand = useCallback((command: 'playVideo' | 'pauseVideo' | 'stopVideo') => {
+    const iframe = iframeRef.current;
+    if (!iframe?.contentWindow) return;
+    iframe.contentWindow.postMessage(
+      JSON.stringify({ event: 'command', func: command, args: [] }),
+      YT_ORIGIN,
+    );
+  }, []);
+
+  const flushPending = useCallback(() => {
+    if (!playerReady) return;
+    const pending = pendingCommandRef.current;
+    if (pending) {
+      pendingCommandRef.current = null;
+      pending();
+    }
+  }, [playerReady]);
+
+  useEffect(() => {
+    flushPending();
+  }, [flushPending, playerReady]);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (typeof event.data !== 'string') return;
+      if (
+        !event.origin.includes('youtube-nocookie.com') &&
+        !event.origin.includes('youtube.com')
+      ) {
+        return;
+      }
+
+      let data: any;
+      try {
+        data = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+
+      if (!data || typeof data !== 'object') return;
+
+      switch (data.event) {
+        case 'onReady':
+          setPlayerReady(true);
+          break;
+        case 'infoDelivery': {
+          const state = data?.info?.playerState;
+          if (typeof state === 'number') {
+            setIsPlaying(state === 1);
+          }
+          break;
+        }
+        default:
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  const handleKeyCommand = useCallback(
+    (command: 'space' | 'escape', { enableApi, setEnableApi }: KeyCommandOptions) => {
+      const execute: PlayerCommand = () => {
+        if (command === 'space') {
+          if (isPlaying) {
+            sendCommand('pauseVideo');
+          } else {
+            sendCommand('playVideo');
+          }
+        } else {
+          sendCommand('stopVideo');
+        }
+      };
+
+      if (!enableApi) {
+        setEnableApi(true);
+        pendingCommandRef.current = execute;
+        return;
+      }
+
+      if (!playerReady) {
+        pendingCommandRef.current = execute;
+        return;
+      }
+
+      execute();
+    },
+    [isPlaying, playerReady, sendCommand],
+  );
+
+  const renderEmbed = useCallback(
+    ({
+      autoPlay: shouldAutoplay,
+      enableApi,
+      iframeRef: passedIframeRef,
+    }: RenderOptions) => {
+      if (lastEnableApiRef.current !== enableApi) {
+        lastEnableApiRef.current = enableApi;
+        setPlayerReady(false);
+      }
+
+      const params = new URLSearchParams({
+        modestbranding: '1',
+        rel: '0',
+        playsinline: '1',
+      });
+      if (shouldAutoplay) params.set('autoplay', '1');
+      if (enableApi) params.set('enablejsapi', '1');
+      if (typeof start === 'number') params.set('start', Math.max(0, Math.floor(start)).toString());
+      if (typeof end === 'number') params.set('end', Math.max(0, Math.floor(end)).toString());
+      if (origin) params.set('origin', origin);
+
+      const src = `${YT_ORIGIN}/embed/${videoId}?${params.toString()}`;
+
+      return (
+        <iframe
+          key={`${videoId}-${enableApi ? 'api' : 'basic'}`}
+          ref={(node) => {
+            iframeRef.current = node;
+            if (passedIframeRef) {
+              (passedIframeRef as MutableRefObject<HTMLIFrameElement | null>).current = node;
+            }
+          }}
+          title={title}
+          src={src}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+          className="h-full w-full border-0"
+          referrerPolicy="no-referrer"
+          sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-presentation"
+          loading="lazy"
+        />
+      );
+    },
+    [end, origin, start, title, videoId],
+  );
+
+  return (
+    <Video
+      poster={poster}
+      title={title}
+      className={className}
+      aspectRatio={aspectRatio}
+      loadOnVisible={loadOnVisible}
+      activateOnMount={autoPlay ? 'interaction' : null}
+      renderEmbed={(options) => renderEmbed(options)}
+      onEnableApiChange={(next) => {
+        if (!next) {
+          setPlayerReady(false);
+          pendingCommandRef.current = null;
+        }
+      }}
+      onKeyCommand={(command, { enableApi, setEnableApi }) =>
+        handleKeyCommand(command, { enableApi, setEnableApi })
+      }
+    />
+  );
+};
+
+export default YouTube;

--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import YouTube from '../components/media/YouTube';
 
 interface Video {
   id: string;
@@ -37,25 +38,33 @@ const VideoGallery: React.FC = () => {
     v.title.toLowerCase().includes(query.toLowerCase())
   );
 
+  const selectedVideo = useMemo(
+    () => (playing ? videos.find((video) => video.id === playing) ?? null : null),
+    [playing, videos],
+  );
+
   return (
     <main className="p-4">
-      <input
-        type="text"
-        placeholder="Search videos..."
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        className="mb-4 w-full max-w-md px-4 py-2 border rounded"
-      />
+      <label className="mb-4 block max-w-md">
+        <span className="sr-only">Search videos</span>
+        <input
+          type="text"
+          placeholder="Search videos..."
+          aria-label="Search videos"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="w-full rounded border px-4 py-2"
+        />
+      </label>
       {playing && (
-        <div className="mb-4 w-full max-w-2xl aspect-video">
-          <iframe
-            title="Selected video"
-            className="w-full h-full"
-            src={`https://www.youtube-nocookie.com/embed/${playing}`}
-            sandbox="allow-scripts allow-popups"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            referrerPolicy="no-referrer"
-            allowFullScreen
+        <div className="mb-4 w-full max-w-2xl">
+          <YouTube
+            key={playing}
+            videoId={playing}
+            title={selectedVideo?.title ?? 'YouTube video'}
+            className="h-full w-full"
+            aspectRatio="16 / 9"
+            autoPlay
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- add a shared media/Video component that defers iframe creation until intersection or interaction and wires keyboard controls
- create a privacy-enhanced media/YouTube wrapper that swaps thumbnails for nocookie embeds, drives postMessage playback, and exposes autoplay hooks for callers
- update YouTube utilities/apps to lazy load the iframe API on demand, adopt the new component in the video gallery, and document the remaining functional cookies

## Testing
- `npx eslint components/media apps/youtube/components apps/youtube/utils pages/video-gallery.tsx --max-warnings=0`


------
https://chatgpt.com/codex/tasks/task_e_68d9c812bba88328ae9a533d1792da4b