### PR TITLE
[ui] Persist quick settings feature flags

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,25 +1,29 @@
 "use client";
 
-import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import { useMemo } from 'react';
+import { useFeatureFlags } from '../../hooks/useFeatureFlags';
 
 interface Props {
   open: boolean;
 }
 
 const QuickSettings = ({ open }: Props) => {
-  const [theme, setTheme] = usePersistentState('qs-theme', 'light');
-  const [sound, setSound] = usePersistentState('qs-sound', true);
-  const [online, setOnline] = usePersistentState('qs-online', true);
-  const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const {
+    ready,
+    theme,
+    toggleThemeMode,
+    sound,
+    setSoundEnabled,
+    networkEnabled,
+    setNetworkEnabled,
+    reducedMotion,
+    setReducedMotionEnabled,
+    highContrast,
+    setHighContrastEnabled,
+  } = useFeatureFlags();
 
-  useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-  }, [theme]);
-
-  useEffect(() => {
-    document.documentElement.classList.toggle('reduce-motion', reduceMotion);
-  }, [reduceMotion]);
+  const isDark = useMemo(() => theme === 'dark', [theme]);
+  const networkLabel = networkEnabled ? 'Online' : 'Offline';
 
   return (
     <div
@@ -30,26 +34,56 @@ const QuickSettings = ({ open }: Props) => {
       <div className="px-4 pb-2">
         <button
           className="w-full flex justify-between"
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          type="button"
+          aria-pressed={isDark}
+          onClick={toggleThemeMode}
+          disabled={!ready}
         >
           <span>Theme</span>
-          <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
+          <span>{isDark ? 'Dark' : 'Light'}</span>
         </button>
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+        <input
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSoundEnabled(!sound)}
+          disabled={!ready}
+          aria-label="Toggle system sound"
+        />
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-ubt-grey">{networkLabel}</span>
+          <input
+            type="checkbox"
+            checked={networkEnabled}
+            onChange={() => setNetworkEnabled(!networkEnabled)}
+            disabled={!ready}
+            aria-label="Toggle external network access"
+          />
+        </div>
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>
         <input
           type="checkbox"
-          checked={reduceMotion}
-          onChange={() => setReduceMotion(!reduceMotion)}
+          checked={reducedMotion}
+          onChange={() => setReducedMotionEnabled(!reducedMotion)}
+          disabled={!ready}
+          aria-label="Toggle reduced motion"
+        />
+      </div>
+      <div className="px-4 pt-2 flex justify-between">
+        <span>High contrast</span>
+        <input
+          type="checkbox"
+          checked={highContrast}
+          onChange={() => setHighContrastEnabled(!highContrast)}
+          disabled={!ready}
+          aria-label="Toggle high contrast mode"
         />
       </div>
     </div>

--- a/hooks/useFeatureFlags.tsx
+++ b/hooks/useFeatureFlags.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { QUICK_SETTINGS_STORAGE_KEY } from '../lib/version';
+import { useSettings } from './useSettings';
+import { isDarkTheme } from '../utils/theme';
+
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+type ThemeMode = 'light' | 'dark';
+
+type FeatureFlagsState = {
+  theme: ThemeMode;
+  sound: boolean;
+  networkEnabled: boolean;
+  reducedMotion: boolean;
+  highContrast: boolean;
+};
+
+type FeatureFlagsContextValue = FeatureFlagsState & {
+  ready: boolean;
+  setThemeMode: (mode: ThemeMode) => void;
+  toggleThemeMode: () => void;
+  setSoundEnabled: (enabled: boolean) => void;
+  setNetworkEnabled: (enabled: boolean) => void;
+  setReducedMotionEnabled: (enabled: boolean) => void;
+  setHighContrastEnabled: (enabled: boolean) => void;
+};
+
+const noop = () => {
+  throw new Error('useFeatureFlags must be used within a FeatureFlagsProvider');
+};
+
+const defaultState: FeatureFlagsContextValue = {
+  theme: 'light',
+  sound: true,
+  networkEnabled: false,
+  reducedMotion: false,
+  highContrast: false,
+  ready: false,
+  setThemeMode: noop,
+  toggleThemeMode: noop,
+  setSoundEnabled: noop,
+  setNetworkEnabled: noop,
+  setReducedMotionEnabled: noop,
+  setHighContrastEnabled: noop,
+};
+
+const FeatureFlagsContext = createContext<FeatureFlagsContextValue>(defaultState);
+
+const validateTheme = (value: unknown): value is ThemeMode =>
+  value === 'light' || value === 'dark';
+
+const validateBoolean = (value: unknown): value is boolean => typeof value === 'boolean';
+
+const parseStoredState = (raw: string | null): Partial<FeatureFlagsState> | null => {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const state: Partial<FeatureFlagsState> = {};
+    if (validateTheme((parsed as Record<string, unknown>).theme)) {
+      state.theme = (parsed as Record<string, ThemeMode>).theme;
+    }
+    if (validateBoolean((parsed as Record<string, unknown>).sound)) {
+      state.sound = Boolean((parsed as Record<string, boolean>).sound);
+    }
+    if (validateBoolean((parsed as Record<string, unknown>).networkEnabled)) {
+      state.networkEnabled = Boolean(
+        (parsed as Record<string, boolean>).networkEnabled,
+      );
+    }
+    if (validateBoolean((parsed as Record<string, unknown>).reducedMotion)) {
+      state.reducedMotion = Boolean(
+        (parsed as Record<string, boolean>).reducedMotion,
+      );
+    }
+    if (validateBoolean((parsed as Record<string, unknown>).highContrast)) {
+      state.highContrast = Boolean(
+        (parsed as Record<string, boolean>).highContrast,
+      );
+    }
+    return state;
+  } catch {
+    return null;
+  }
+};
+
+export const FeatureFlagsProvider = ({ children }: { children: ReactNode }) => {
+  const {
+    reducedMotion: settingsReducedMotion,
+    setReducedMotion,
+    highContrast: settingsHighContrast,
+    setHighContrast,
+    allowNetwork,
+    setAllowNetwork,
+    theme: settingsTheme,
+    setTheme,
+  } = useSettings();
+
+  const [state, setState] = useState<FeatureFlagsState>(() => ({
+    theme: isDarkTheme(settingsTheme) ? 'dark' : 'light',
+    sound: true,
+    networkEnabled: allowNetwork,
+    reducedMotion: settingsReducedMotion,
+    highContrast: settingsHighContrast,
+  }));
+
+  const [ready, setReady] = useState(false);
+
+  const applyTheme = useCallback(
+    (mode: ThemeMode) => {
+      setState((prev) => ({ ...prev, theme: mode }));
+      setTheme(mode === 'dark' ? 'dark' : 'default');
+    },
+    [setTheme],
+  );
+
+  const applySound = useCallback((enabled: boolean) => {
+    setState((prev) => ({ ...prev, sound: enabled }));
+  }, []);
+
+  const applyNetwork = useCallback(
+    (enabled: boolean) => {
+      setState((prev) => ({ ...prev, networkEnabled: enabled }));
+      setAllowNetwork(enabled);
+    },
+    [setAllowNetwork],
+  );
+
+  const applyReducedMotion = useCallback(
+    (enabled: boolean) => {
+      setState((prev) => ({ ...prev, reducedMotion: enabled }));
+      setReducedMotion(enabled);
+    },
+    [setReducedMotion],
+  );
+
+  const applyHighContrast = useCallback(
+    (enabled: boolean) => {
+      setState((prev) => ({ ...prev, highContrast: enabled }));
+      setHighContrast(enabled);
+    },
+    [setHighContrast],
+  );
+
+  useIsomorphicLayoutEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = parseStoredState(window.localStorage.getItem(QUICK_SETTINGS_STORAGE_KEY));
+    if (stored?.theme) {
+      applyTheme(stored.theme);
+    }
+    if (typeof stored?.sound === 'boolean') {
+      applySound(stored.sound);
+    }
+    if (typeof stored?.networkEnabled === 'boolean') {
+      applyNetwork(stored.networkEnabled);
+    }
+    if (typeof stored?.reducedMotion === 'boolean') {
+      applyReducedMotion(stored.reducedMotion);
+    }
+    if (typeof stored?.highContrast === 'boolean') {
+      applyHighContrast(stored.highContrast);
+    }
+    setReady(true);
+  }, [applyTheme, applySound, applyNetwork, applyReducedMotion, applyHighContrast]);
+
+  useEffect(() => {
+    setState((prev) =>
+      prev.networkEnabled === allowNetwork
+        ? prev
+        : { ...prev, networkEnabled: allowNetwork },
+    );
+  }, [allowNetwork]);
+
+  useEffect(() => {
+    setState((prev) =>
+      prev.reducedMotion === settingsReducedMotion
+        ? prev
+        : { ...prev, reducedMotion: settingsReducedMotion },
+    );
+  }, [settingsReducedMotion]);
+
+  useEffect(() => {
+    setState((prev) =>
+      prev.highContrast === settingsHighContrast
+        ? prev
+        : { ...prev, highContrast: settingsHighContrast },
+    );
+  }, [settingsHighContrast]);
+
+  useEffect(() => {
+    const nextTheme = isDarkTheme(settingsTheme) ? 'dark' : 'light';
+    setState((prev) => (prev.theme === nextTheme ? prev : { ...prev, theme: nextTheme }));
+  }, [settingsTheme]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!ready || typeof document === 'undefined') return;
+    const root = document.documentElement;
+    const isDark = state.theme === 'dark';
+    root.classList.toggle('qs-theme-dark', isDark);
+    root.classList.toggle('qs-theme-light', !isDark);
+    root.classList.toggle('qs-sound-muted', !state.sound);
+    root.classList.toggle('qs-network-offline', !state.networkEnabled);
+    root.classList.toggle('qs-reduced-motion', state.reducedMotion);
+    root.classList.toggle('qs-high-contrast', state.highContrast);
+    root.classList.toggle('dark', isDark);
+    root.classList.toggle('reduced-motion', state.reducedMotion);
+    root.classList.toggle('high-contrast', state.highContrast);
+  }, [
+    ready,
+    state.theme,
+    state.sound,
+    state.networkEnabled,
+    state.reducedMotion,
+    state.highContrast,
+  ]);
+
+  useEffect(() => {
+    if (!ready || typeof window === 'undefined') return;
+    try {
+      const payload: FeatureFlagsState = {
+        theme: state.theme,
+        sound: state.sound,
+        networkEnabled: state.networkEnabled,
+        reducedMotion: state.reducedMotion,
+        highContrast: state.highContrast,
+      };
+      window.localStorage.setItem(
+        QUICK_SETTINGS_STORAGE_KEY,
+        JSON.stringify(payload),
+      );
+    } catch {
+      // ignore write errors
+    }
+  }, [ready, state]);
+
+  const value = useMemo<FeatureFlagsContextValue>(
+    () => ({
+      ...state,
+      ready,
+      setThemeMode: applyTheme,
+      toggleThemeMode: () => applyTheme(state.theme === 'dark' ? 'light' : 'dark'),
+      setSoundEnabled: applySound,
+      setNetworkEnabled: applyNetwork,
+      setReducedMotionEnabled: applyReducedMotion,
+      setHighContrastEnabled: applyHighContrast,
+    }),
+    [state, ready, applyTheme, applySound, applyNetwork, applyReducedMotion, applyHighContrast],
+  );
+
+  return (
+    <FeatureFlagsContext.Provider value={value}>
+      {children}
+    </FeatureFlagsContext.Provider>
+  );
+};
+
+export const useFeatureFlags = () => useContext(FeatureFlagsContext);

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,0 +1,10 @@
+'use client';
+
+import packageJson from '../package.json';
+
+const FALLBACK_VERSION = '0.0.0';
+
+export const APP_VERSION: string =
+  process.env.NEXT_PUBLIC_APP_VERSION || packageJson.version || FALLBACK_VERSION;
+
+export const QUICK_SETTINGS_STORAGE_KEY = `quick-settings:${APP_VERSION}`;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,6 +11,7 @@ import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
+import { FeatureFlagsProvider } from '../hooks/useFeatureFlags';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import NotificationCenter from '../components/common/NotificationCenter';
 import PipPortalProvider from '../components/common/PipPortal';
@@ -158,23 +159,25 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <NotificationCenter>
-            <PipPortalProvider>
-              <div aria-live="polite" id="live-region" />
-              <Component {...pageProps} />
-              <ShortcutOverlay />
-              <Analytics
-                beforeSend={(e) => {
-                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                  const evt = e;
-                  if (evt.metadata?.email) delete evt.metadata.email;
-                  return e;
-                }}
-              />
+          <FeatureFlagsProvider>
+            <NotificationCenter>
+              <PipPortalProvider>
+                <div aria-live="polite" id="live-region" />
+                <Component {...pageProps} />
+                <ShortcutOverlay />
+                <Analytics
+                  beforeSend={(e) => {
+                    if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                    const evt = e;
+                    if (evt.metadata?.email) delete evt.metadata.email;
+                    return e;
+                  }}
+                />
 
-              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-            </PipPortalProvider>
-          </NotificationCenter>
+                {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+              </PipPortalProvider>
+            </NotificationCenter>
+          </FeatureFlagsProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- add a feature flag context that lazily hydrates quick settings state from versioned localStorage keys
- reflect quick setting toggles on the root element to avoid hydration flashes and share state across the app
- wire the navbar quick settings panel to the shared context and expose a high-contrast toggle

## Testing
- [ ] yarn lint *(fails: existing jsx-a11y label violations in unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c819285883289bbf68e0ae2297b7