### PR TITLE
[ui] Strengthen toast accessibility

### DIFF
--- a/__tests__/liveRegion.test.tsx
+++ b/__tests__/liveRegion.test.tsx
@@ -1,14 +1,57 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import Toast from '../components/ui/Toast';
 import FormError from '../components/ui/FormError';
 
 describe('live region components', () => {
-  it('Toast uses polite live region', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.getElementById('live-region')?.remove();
+    const region = document.createElement('div');
+    region.id = 'live-region';
+    document.body.appendChild(region);
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+    document.getElementById('live-region')?.remove();
+  });
+
+  it('Toast defaults to status role with aria-live disabled', () => {
     const { unmount } = render(<Toast message="Saved" />);
-    const region = screen.getByRole('status');
-    expect(region).toHaveAttribute('aria-live', 'polite');
+    const region = screen
+      .getAllByRole('status')
+      .find((el) => el.getAttribute('data-tone') === 'info');
+    expect(region).toBeTruthy();
+    expect(region).toHaveAttribute('aria-live', 'off');
     unmount();
+  });
+
+  it('Toast announces through the FND-01 helper exactly once', () => {
+    const { rerender, unmount } = render(<Toast message="Saved" />);
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    const liveRegion = document.getElementById('live-region');
+    expect(liveRegion?.textContent).toBe('Saved');
+
+    rerender(<Toast message="Saved" />);
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    expect(liveRegion?.textContent).toBe('Saved');
+    unmount();
+  });
+
+  it('Toast uses alert role for error tone', () => {
+    render(<Toast message="Error" tone="error" />);
+    const [alert] = screen
+      .getAllByRole('alert')
+      .filter((el) => el.getAttribute('data-tone') === 'error');
+    expect(alert).toHaveAttribute('aria-live', 'off');
   });
 
   it('FormError announces politely', () => {

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,47 +1,200 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState, useId } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+import { announceToLiveRegion } from '../../utils/fnd01LiveRegion';
+
+type ToastTone = 'info' | 'error';
 
 interface ToastProps {
   message: string;
+  tone?: ToastTone;
   actionLabel?: string;
   onAction?: () => void;
   onClose?: () => void;
   duration?: number;
 }
 
+const GLOBAL_DISMISS_KEYS = new Set(['Escape']);
+
+const isTimedDuration = (duration: number | undefined) =>
+  Number.isFinite(duration) && (duration ?? 0) > 0;
+
 const Toast: React.FC<ToastProps> = ({
   message,
+  tone = 'info',
   actionLabel,
   onAction,
   onClose,
   duration = 6000,
 }) => {
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startTimeRef = useRef<number | null>(null);
+  const remainingRef = useRef<number>(duration);
   const [visible, setVisible] = useState(false);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const dismissible = typeof onClose === 'function';
+  const timed = dismissible && isTimedDuration(duration);
+  const dismissHintId = useId();
+
+  useFocusTrap(containerRef, Boolean(actionLabel && onAction));
 
   useEffect(() => {
-    setVisible(true);
+    remainingRef.current = duration;
+  }, [duration]);
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setVisible(true);
+      return;
+    }
+    const raf = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(raf);
+  }, [prefersReducedMotion]);
+
+  const clearTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const close = useCallback(() => {
+    clearTimer();
+    onClose?.();
+  }, [clearTimer, onClose]);
+
+  const startTimer = useCallback(() => {
+    if (!timed) return;
+    clearTimer();
+    startTimeRef.current = Date.now();
     timeoutRef.current = setTimeout(() => {
-      onClose && onClose();
-    }, duration);
-    return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+      onClose?.();
+    }, remainingRef.current);
+  }, [clearTimer, onClose, timed]);
+
+  const pauseTimer = useCallback(() => {
+    if (!timed || !timeoutRef.current || startTimeRef.current === null) return;
+    const elapsed = Date.now() - startTimeRef.current;
+    remainingRef.current = Math.max(0, remainingRef.current - elapsed);
+    clearTimer();
+  }, [clearTimer, timed]);
+
+  const resumeTimer = useCallback(() => {
+    if (!timed) return;
+    if (remainingRef.current <= 0) {
+      close();
+      return;
+    }
+    startTimer();
+  }, [close, startTimer, timed]);
+
+  useEffect(() => {
+    if (!timed) return;
+    startTimer();
+    return clearTimer;
+  }, [clearTimer, startTimer, timed]);
+
+  useEffect(() => {
+    const cleanup = announceToLiveRegion(message, tone === 'error' ? 'assertive' : 'polite');
+    return cleanup;
+  }, [message, tone]);
+
+  useEffect(() => {
+    if (!dismissible) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const isWithinToast = target ? containerRef.current?.contains(target) : false;
+      const isComboDismiss =
+        (event.key === '.' || event.key === '>') && (event.ctrlKey || event.metaKey);
+      if (isComboDismiss) {
+        event.preventDefault();
+        close();
+        return;
+      }
+      if (!isWithinToast) return;
+      if (GLOBAL_DISMISS_KEYS.has(event.key)) {
+        event.preventDefault();
+        event.stopPropagation();
+        close();
+      }
     };
-  }, [duration, onClose]);
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
+  }, [close, dismissible]);
+
+  const toneClasses = useMemo(
+    () =>
+      tone === 'error'
+        ? 'bg-red-900 border-red-700'
+        : 'bg-gray-900 border-gray-700',
+    [tone],
+  );
+
+  const handleMouseEnter = useCallback(() => {
+    pauseTimer();
+  }, [pauseTimer]);
+
+  const handleMouseLeave = useCallback(() => {
+    resumeTimer();
+  }, [resumeTimer]);
+
+  const handleFocus = useCallback(() => {
+    pauseTimer();
+  }, [pauseTimer]);
+
+  const handleBlur = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
+    if (event.currentTarget.contains(event.relatedTarget as Node)) return;
+    resumeTimer();
+  }, [resumeTimer]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!dismissible) return;
+      if (GLOBAL_DISMISS_KEYS.has(event.key)) {
+        event.preventDefault();
+        event.stopPropagation();
+        close();
+      }
+    },
+    [close, dismissible],
+  );
+
+  const role = tone === 'error' ? 'alert' : 'status';
+  const ariaLive = 'off';
 
   return (
     <div
-      role="status"
-      aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      ref={containerRef}
+      role={role}
+      aria-live={ariaLive}
+      aria-atomic="true"
+      data-tone={tone}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform text-white border px-4 py-3 rounded-md shadow-md flex items-center gap-4 transition-transform duration-150 ease-in-out motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none ${
+        visible ? 'translate-y-0' : '-translate-y-full'
+      } ${toneClasses}`.trim()}
     >
       <span>{message}</span>
       {onAction && actionLabel && (
         <button
+          type="button"
           onClick={onAction}
-          className="ml-4 underline focus:outline-none"
+          aria-describedby={dismissible ? dismissHintId : undefined}
+          className="ml-2 underline focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
         >
           {actionLabel}
         </button>
+      )}
+      {dismissible && (
+        <span id={dismissHintId} className="sr-only" aria-live="off">
+          Press Escape or Control plus Period to dismiss
+        </span>
       )}
     </div>
   );

--- a/utils/fnd01LiveRegion.ts
+++ b/utils/fnd01LiveRegion.ts
@@ -1,0 +1,57 @@
+import { useCallback } from 'react';
+
+type PolitenessSetting = 'polite' | 'assertive';
+
+const LIVE_REGION_ID = 'live-region';
+let token = 0;
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+const clearTimer = () => {
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+};
+
+const updateRegionAttributes = (region: HTMLElement, politeness: PolitenessSetting) => {
+  const desiredRole = politeness === 'assertive' ? 'alert' : 'status';
+  if (region.getAttribute('role') !== desiredRole) {
+    region.setAttribute('role', desiredRole);
+  }
+  if (region.getAttribute('aria-live') !== politeness) {
+    region.setAttribute('aria-live', politeness);
+  }
+};
+
+export const announceToLiveRegion = (
+  message: string,
+  politeness: PolitenessSetting = 'polite',
+) => {
+  if (typeof window === 'undefined') return () => {};
+  const region = document.getElementById(LIVE_REGION_ID);
+  if (!region) return () => {};
+
+  token += 1;
+  const currentToken = token;
+  updateRegionAttributes(region, politeness);
+  clearTimer();
+  region.textContent = '';
+
+  flushTimer = setTimeout(() => {
+    if (currentToken !== token) return;
+    region.textContent = message;
+  }, 40);
+
+  return () => {
+    if (currentToken !== token) return;
+    clearTimer();
+    if (region.textContent === message) {
+      region.textContent = '';
+    }
+  };
+};
+
+export const useLiveRegionAnnouncer = (politeness: PolitenessSetting = 'polite') =>
+  useCallback((message: string) => announceToLiveRegion(message, politeness), [politeness]);
+
+export type { PolitenessSetting as LiveRegionPoliteness };


### PR DESCRIPTION
## Summary
- route toast announcements through the FND-01 live-region helper and add keyboard dismissal shortcuts
- pause auto-dismiss timers on hover/focus while respecting reduced motion and limiting focus traps to actionable toasts
- extend live region tests to verify helper behaviour and role semantics

## Testing
- yarn test liveRegion

------
https://chatgpt.com/codex/tasks/task_e_68d9c81aacc8832897f0c6cb1ebf5009