### PR TITLE
[ui] Improve system volume control accessibility

### DIFF
--- a/components/ui/VolumeControl.tsx
+++ b/components/ui/VolumeControl.tsx
@@ -1,8 +1,22 @@
 "use client";
 
 import Image from "next/image";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  ChangeEvent,
+  FC,
+  KeyboardEvent,
+  MouseEvent,
+  WheelEvent,
+} from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import usePersistentState from "../../hooks/usePersistentState";
+import DelayedTooltip from "./DelayedTooltip";
 
 const ICONS = {
   muted: "/themes/Yaru/status/audio-volume-muted-symbolic.svg",
@@ -14,6 +28,15 @@ const ICONS = {
 type VolumeLevel = keyof typeof ICONS;
 
 const clamp = (value: number) => Math.min(1, Math.max(0, value));
+const STEP = 0.05;
+const EVENT_NAME = "kali:player-volume";
+
+type VolumeChangeSource = "control" | "external";
+
+type VolumeEventDetail = {
+  volume: number;
+  source?: VolumeChangeSource;
+};
 
 interface VolumeControlProps {
   className?: string;
@@ -24,7 +47,7 @@ const isValidVolume = (value: unknown): value is number =>
 
 const formatPercent = (value: number) => `${Math.round(value * 100)}%`;
 
-const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
+const VolumeControl: FC<VolumeControlProps> = ({ className = "" }) => {
   const [volume, setVolume] = usePersistentState<number>(
     "system-volume",
     () => 0.7,
@@ -33,6 +56,9 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const sliderRef = useRef<HTMLInputElement>(null);
+  const programmaticUpdateRef = useRef(false);
+  const programmaticResetTimerRef = useRef<number | null>(null);
+  const lastChangeSourceRef = useRef<VolumeChangeSource>("control");
 
   const level: VolumeLevel = useMemo(() => {
     if (volume <= 0.001) return "muted";
@@ -42,32 +68,114 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
   }, [volume]);
 
   const setClampedVolume = useCallback(
-    (value: number | ((current: number) => number)) => {
+    (
+      value: number | ((current: number) => number),
+      source: VolumeChangeSource = "control",
+    ) => {
+      lastChangeSourceRef.current = source;
       setVolume((prev) => {
         const nextValue = typeof value === "function" ? value(prev) : value;
-        return Number(clamp(nextValue).toFixed(2));
+        const clampedValue = clamp(nextValue);
+        const snapped = Math.round(clampedValue / STEP) * STEP;
+        const normalized = Number(snapped.toFixed(2));
+        return normalized === prev ? prev : normalized;
       });
     },
     [setVolume],
   );
 
-  const handleToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const emitVolumeChange = useCallback(
+    (value: number, source: VolumeChangeSource) => {
+      if (typeof window === "undefined") return;
+      window.dispatchEvent(
+        new CustomEvent<VolumeEventDetail>(EVENT_NAME, {
+          detail: { volume: value, source },
+        }),
+      );
+    },
+    [],
+  );
+
+  const syncMediaElements = useCallback(
+    (value: number) => {
+      if (typeof document === "undefined") return;
+      const mediaElements = document.querySelectorAll<HTMLMediaElement>(
+        "audio, video",
+      );
+      if (mediaElements.length === 0) {
+        programmaticUpdateRef.current = false;
+        return;
+      }
+
+      programmaticUpdateRef.current = true;
+      mediaElements.forEach((element) => {
+        if (element.dataset.ignoreSystemVolume === "true") {
+          return;
+        }
+        if (Math.abs(element.volume - value) > 0.001) {
+          element.volume = value;
+        }
+      });
+
+      if (typeof window !== "undefined") {
+        if (programmaticResetTimerRef.current !== null) {
+          window.clearTimeout(programmaticResetTimerRef.current);
+        }
+        programmaticResetTimerRef.current = window.setTimeout(() => {
+          programmaticUpdateRef.current = false;
+          programmaticResetTimerRef.current = null;
+        }, 0);
+      } else {
+        programmaticUpdateRef.current = false;
+      }
+    },
+    [],
+  );
+
+  const handleToggle = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     setOpen((prev) => !prev);
   };
 
-  const handleWheel = (event: React.WheelEvent<HTMLButtonElement | HTMLDivElement>) => {
+  const handleWheel = (
+    event: WheelEvent<HTMLButtonElement | HTMLDivElement>,
+  ) => {
     event.preventDefault();
     event.stopPropagation();
     const direction = event.deltaY > 0 ? -1 : 1;
-    const delta = (event.shiftKey ? 0.02 : 0.05) * direction;
-    setClampedVolume((current) => current + delta);
+    const delta = (event.shiftKey ? STEP / 2 : STEP) * direction;
+    setClampedVolume((current) => current + delta, "control");
   };
 
-  const handleRangeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRangeChange = (event: ChangeEvent<HTMLInputElement>) => {
     event.stopPropagation();
-    const next = Number(event.target.value) / 100;
-    setClampedVolume(next);
+    const next = Number.parseFloat(event.target.value);
+    if (Number.isNaN(next)) return;
+    setClampedVolume(next, "control");
+  };
+
+  const handleSliderKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    switch (event.key) {
+      case "ArrowLeft":
+      case "ArrowDown":
+        event.preventDefault();
+        setClampedVolume((current) => current - STEP, "control");
+        break;
+      case "ArrowRight":
+      case "ArrowUp":
+        event.preventDefault();
+        setClampedVolume((current) => current + STEP, "control");
+        break;
+      case "Home":
+        event.preventDefault();
+        setClampedVolume(0, "control");
+        break;
+      case "End":
+        event.preventDefault();
+        setClampedVolume(1, "control");
+        break;
+      default:
+    }
   };
 
   useEffect(() => {
@@ -100,32 +208,108 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
     }
   }, [open]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const handleVolumeEvent = (event: Event) => {
+      const detail = (event as CustomEvent<VolumeEventDetail>).detail;
+      if (!detail) return;
+      if (detail.source === "control") return;
+      const next = detail.volume;
+      if (typeof next !== "number" || Number.isNaN(next)) return;
+      setClampedVolume(next, "external");
+    };
+
+    window.addEventListener(EVENT_NAME, handleVolumeEvent as EventListener);
+    return () => {
+      window.removeEventListener(
+        EVENT_NAME,
+        handleVolumeEvent as EventListener,
+      );
+    };
+  }, [setClampedVolume]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return undefined;
+
+    const handleMediaVolumeChange = (event: Event) => {
+      const media = event.target as HTMLMediaElement | null;
+      if (!media || programmaticUpdateRef.current) return;
+      if (media.dataset.ignoreSystemVolume === "true") return;
+      const next = clamp(media.volume);
+      setClampedVolume(next, "external");
+      emitVolumeChange(next, "external");
+    };
+
+    document.addEventListener("volumechange", handleMediaVolumeChange, true);
+    return () => {
+      document.removeEventListener(
+        "volumechange",
+        handleMediaVolumeChange,
+        true,
+      );
+    };
+  }, [emitVolumeChange, setClampedVolume]);
+
+  useEffect(() => {
+    return () => {
+      if (
+        typeof window !== "undefined" &&
+        programmaticResetTimerRef.current !== null
+      ) {
+        window.clearTimeout(programmaticResetTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    syncMediaElements(volume);
+    if (lastChangeSourceRef.current === "control") {
+      emitVolumeChange(volume, "control");
+    }
+    lastChangeSourceRef.current = "external";
+  }, [emitVolumeChange, syncMediaElements, volume]);
+
   return (
     <div
       ref={rootRef}
       className={`relative flex items-center ${className}`.trim()}
       onWheel={handleWheel}
     >
-      <button
-        type="button"
-        className="flex h-6 w-6 items-center justify-center rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
-        aria-label={`Volume ${formatPercent(volume)}`}
-        aria-haspopup="true"
-        aria-expanded={open}
-        title={`Volume ${formatPercent(volume)}`}
-        onClick={handleToggle}
-        onPointerDown={(event) => event.stopPropagation()}
+      <DelayedTooltip
+        content={
+          <span aria-hidden="true">{`Volume ${formatPercent(volume)}`}</span>
+        }
       >
-        <Image
-          width={16}
-          height={16}
-          src={ICONS[level]}
-          alt={`${level} volume`}
-          className="status-symbol h-4 w-4"
-          draggable={false}
-          sizes="16px"
-        />
-      </button>
+        {({ ref, onMouseEnter, onMouseLeave, onFocus, onBlur }) => (
+          <button
+            type="button"
+            ref={(node) => {
+              ref(node);
+            }}
+            className="flex h-6 w-6 items-center justify-center rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+            aria-label={`Volume ${formatPercent(volume)}`}
+            aria-haspopup="true"
+            aria-expanded={open}
+            onClick={handleToggle}
+            onPointerDown={(event) => event.stopPropagation()}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+            onFocus={onFocus}
+            onBlur={onBlur}
+          >
+            <Image
+              width={16}
+              height={16}
+              src={ICONS[level]}
+              alt={`${level} volume`}
+              className="status-symbol h-4 w-4"
+              draggable={false}
+              sizes="16px"
+            />
+          </button>
+        )}
+      </DelayedTooltip>
       {open && (
         <div
           className="absolute bottom-full right-0 z-50 mb-2 min-w-[9rem] rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-2 text-xs text-white shadow-lg"
@@ -141,15 +325,17 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
             ref={sliderRef}
             type="range"
             min={0}
-            max={100}
-            step={1}
-            value={Math.round(volume * 100)}
+            max={1}
+            step={STEP}
+            value={Number(volume.toFixed(2))}
             aria-valuemin={0}
-            aria-valuemax={100}
-            aria-valuenow={Math.round(volume * 100)}
+            aria-valuemax={1}
+            aria-valuenow={Number(volume.toFixed(2))}
+            aria-valuetext={`Volume ${formatPercent(volume)}`}
             aria-label="Volume level"
             className="h-1 w-full cursor-pointer accent-ubt-blue"
             onChange={handleRangeChange}
+            onKeyDown={handleSliderKeyDown}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- refactor the volume control to use a native range slider with a 0.05 step, aria-valuetext, and explicit keyboard handling for Left/Right/Home/End
- add UI-TOOLTIP-01 integration so the current level is shown on hover without duplicating announcements
- synchronize slider updates with media elements and publish/listen for global volume changes to keep the player state aligned

## Testing
- npx eslint components/ui/VolumeControl.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d9c8231ee88328b07fccb564fc0636