### PR TITLE
[ui] Improve ModuleCard loading and status badges

### DIFF
--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -1,5 +1,7 @@
 import Image from 'next/image';
-import { ModuleMetadata } from '../modules/metadata';
+import { useState } from 'react';
+
+import { ModuleBadge, ModuleMetadata } from '../modules/metadata';
 
 interface ModuleCardProps {
   module: ModuleMetadata;
@@ -24,36 +26,89 @@ function highlight(text: string, query: string | undefined) {
   );
 }
 
+const ACTION_ICONS = [
+  {
+    src: '/themes/Yaru/status/about.svg',
+    alt: 'Details',
+  },
+  {
+    src: '/themes/Yaru/status/download.svg',
+    alt: 'Run',
+  },
+];
+
+const CARD_BASE_CLASSES =
+  'relative flex w-full items-start justify-between rounded border p-3 text-left transition focus:outline-none hover:bg-gray-50 focus-visible:bg-gray-50 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2';
+
+const BADGE_BASE_CLASSES =
+  'pointer-events-none absolute -left-px -top-px flex h-6 items-center rounded-br px-2 text-xs font-semibold uppercase tracking-wide';
+
+const BADGE_CONFIG: Record<ModuleBadge, { label: string; text: string; className: string }> = {
+  beta: {
+    label: 'Beta module',
+    text: 'Beta',
+    className: 'bg-amber-500 text-white',
+  },
+  popular: {
+    label: 'Popular module',
+    text: 'Popular',
+    className: 'bg-sky-500 text-white',
+  },
+};
+
+function IconWithSkeleton({ src, alt }: { src: string; alt: string }) {
+  const [loaded, setLoaded] = useState(false);
+
+  return (
+    <span className="relative flex h-6 w-6 items-center justify-center">
+      {!loaded && (
+        <span
+          className="absolute inset-0 animate-pulse rounded bg-gray-200"
+          aria-hidden="true"
+        />
+      )}
+      <Image
+        src={src}
+        alt={alt}
+        width={24}
+        height={24}
+        className={`transition-opacity duration-300 ${loaded ? 'opacity-100' : 'opacity-0'}`}
+        onLoad={() => setLoaded(true)}
+      />
+    </span>
+  );
+}
+
 export default function ModuleCard({
   module,
   onSelect,
   selected,
   query,
 }: ModuleCardProps) {
+  const badge = module.badge ? BADGE_CONFIG[module.badge] : undefined;
+
   return (
     <button
       onClick={() => onSelect(module)}
-      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
-        selected ? 'bg-gray-100' : ''
-      }`}
+      className={`${CARD_BASE_CLASSES} ${selected ? 'bg-gray-100' : ''}`}
     >
+      {badge && (
+        <span
+          aria-label={badge.label}
+          className={`${BADGE_BASE_CLASSES} ${badge.className}`}
+        >
+          <span className="sr-only">{badge.label}</span>
+          <span aria-hidden="true">{badge.text}</span>
+        </span>
+      )}
       <div className="flex-1 pr-2 font-mono">
         <h3 className="font-bold">{highlight(module.name, query)}</h3>
         <p className="text-sm">{highlight(module.description, query)}</p>
       </div>
       <div className="flex flex-col gap-2 items-center">
-        <Image
-          src="/themes/Yaru/status/about.svg"
-          alt="Details"
-          width={24}
-          height={24}
-        />
-        <Image
-          src="/themes/Yaru/status/download.svg"
-          alt="Run"
-          width={24}
-          height={24}
-        />
+        {ACTION_ICONS.map((icon) => (
+          <IconWithSkeleton key={icon.src} src={icon.src} alt={icon.alt} />
+        ))}
       </div>
     </button>
   );

--- a/modules/metadata.ts
+++ b/modules/metadata.ts
@@ -4,11 +4,15 @@ export interface ModuleOption {
   description: string;
 }
 
+export type ModuleBadge = 'beta' | 'popular';
+
 export interface ModuleMetadata {
   name: string;
   description: string;
   tags: string[];
   options: ModuleOption[];
+  /** Optional badge to surface module status in the UI. */
+  badge?: ModuleBadge;
 }
 
 const MODULES: Record<string, ModuleMetadata> = {
@@ -16,6 +20,7 @@ const MODULES: Record<string, ModuleMetadata> = {
     name: 'getsystem',
     description: 'Attempt to elevate your privilege to that of local system.',
     tags: ['privilege', 'elevation'],
+    badge: 'popular',
     options: [
       {
         name: 'SESSION',
@@ -57,6 +62,7 @@ const MODULES: Record<string, ModuleMetadata> = {
     name: 'hashdump',
     description: 'Dump password hashes from the SAM database.',
     tags: ['credentials', 'dump'],
+    badge: 'beta',
     options: [
       {
         name: 'SESSION',


### PR DESCRIPTION
## Summary
- add loading skeletons around ModuleCard action icons to avoid CLS while assets stream in
- add optional beta and popular badge ribbons with accessible labels and focus-visible parity with hover styles
- extend module metadata to surface badge states for featured modules

## Testing
- yarn lint *(fails: existing jsx-a11y/control-has-associated-label violations in multiple legacy app components and public game scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c83d40a08328a1c7a65edc14b076