### PR TITLE
[settings] Improve settings drawer accessibility

### DIFF
--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useFocusTrap from '../hooks/useFocusTrap';
 import { getUnlockedThemes } from '../utils/theme';
 import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
+import { getQuickSettings, setQuickSettings } from '../utils/quickSettingsStore';
 
 interface Props {
   highScore?: number;
@@ -8,50 +10,217 @@ interface Props {
 
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
-  const unlocked = getUnlockedThemes(highScore);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const unlocked = useMemo(() => getUnlockedThemes(highScore), [highScore]);
   const { accent, setAccent, theme, setTheme } = useSettings();
+  const hasInteractedRef = useRef(false);
+  const overflowRef = useRef<string>();
+
+  useFocusTrap(dialogRef, open);
+
+  const persistTheme = useCallback(
+    (value: string) => {
+      setQuickSettings({ theme: value });
+    },
+    [],
+  );
+
+  const persistAccent = useCallback(
+    (value: string) => {
+      setQuickSettings({ accent: value });
+    },
+    [],
+  );
+
+  const handleOpen = () => {
+    hasInteractedRef.current = true;
+    setOpen(true);
+  };
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  const applyStoredValues = useCallback(() => {
+    const stored = getQuickSettings();
+    const storedTheme = unlocked.includes(stored.theme) ? stored.theme : unlocked[0] ?? 'default';
+    const storedAccent = ACCENT_OPTIONS.includes(stored.accent)
+      ? stored.accent
+      : ACCENT_OPTIONS[0];
+
+    if (storedTheme && storedTheme !== theme) {
+      setTheme(storedTheme);
+    }
+    if (storedAccent && storedAccent !== accent) {
+      setAccent(storedAccent);
+    }
+  }, [accent, setAccent, setTheme, theme, unlocked]);
+
+  useEffect(() => {
+    if (!open) return;
+    applyStoredValues();
+  }, [open, applyStoredValues]);
+
+  useEffect(() => {
+    if (!open) return;
+    const focusTimer = window.setTimeout(() => {
+      closeButtonRef.current?.focus();
+    }, 0);
+    return () => {
+      window.clearTimeout(focusTimer);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, handleClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    overflowRef.current = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = overflowRef.current ?? '';
+    };
+  }, [open]);
+
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      return;
+    }
+    if (!open && hasInteractedRef.current) {
+      triggerRef.current?.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!ACCENT_OPTIONS.includes(accent)) return;
+    persistAccent(accent);
+  }, [accent, persistAccent]);
+
+  useEffect(() => {
+    if (!unlocked.includes(theme)) return;
+    persistTheme(theme);
+  }, [persistTheme, theme, unlocked]);
+
+  const handleThemeChange = useCallback(
+    (nextTheme: string) => {
+      if (!unlocked.includes(nextTheme)) return;
+      if (theme !== nextTheme) {
+        setTheme(nextTheme);
+      }
+      persistTheme(nextTheme);
+    },
+    [persistTheme, setTheme, theme, unlocked],
+  );
+
+  const handleAccentChange = useCallback(
+    (nextAccent: string) => {
+      if (!ACCENT_OPTIONS.includes(nextAccent)) return;
+      if (accent !== nextAccent) {
+        setAccent(nextAccent);
+      }
+      persistAccent(nextAccent);
+    },
+    [accent, persistAccent, setAccent],
+  );
 
   return (
     <div>
-      <button aria-label="settings" onClick={() => setOpen(!open)}>
+      <button
+        ref={triggerRef}
+        aria-label="settings"
+        type="button"
+        onClick={open ? handleClose : handleOpen}
+      >
         Settings
       </button>
       {open && (
-        <div role="dialog">
-          <label>
-            Theme
-            <select
-              aria-label="theme-select"
-              value={theme}
-              onChange={(e) => setTheme(e.target.value)}
-            >
-              {unlocked.map((t) => (
-                <option key={t} value={t}>
-                  {t}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            Accent
-            <div
-              aria-label="accent-color-picker"
-              role="radiogroup"
-              className="flex gap-2 mt-1"
-            >
-              {ACCENT_OPTIONS.map((c) => (
-                <button
-                  key={c}
-                  aria-label={`select-accent-${c}`}
-                  role="radio"
-                  aria-checked={accent === c}
-                  onClick={() => setAccent(c)}
-                  className={`w-6 h-6 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
-                  style={{ backgroundColor: c }}
-                />
-              ))}
+        <div className="fixed inset-0 z-50">
+          <div
+            className="absolute inset-0 bg-black/40"
+            role="presentation"
+            onClick={handleClose}
+          />
+          <div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="settings-drawer-title"
+            className="absolute right-0 top-0 h-full w-full max-w-sm bg-ub-cool-grey text-white shadow-xl"
+          >
+            <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+              <h2 id="settings-drawer-title" className="text-lg font-semibold">
+                Settings
+              </h2>
+              <button
+                ref={closeButtonRef}
+                type="button"
+                className="rounded px-2 py-1 text-sm font-medium hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue"
+                onClick={handleClose}
+              >
+                Close
+              </button>
             </div>
-          </label>
+            <div className="flex h-[calc(100%-3.5rem)] flex-col gap-4 overflow-y-auto px-4 py-6">
+              <label className="flex flex-col gap-2 text-sm">
+                <span className="text-xs uppercase tracking-wide text-white/70">
+                  Theme
+                </span>
+                <select
+                  aria-label="theme-select"
+                  className="rounded border border-white/10 bg-black/20 px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue"
+                  value={theme}
+                  onChange={(e) => handleThemeChange(e.target.value)}
+                >
+                  {unlocked.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="flex flex-col gap-2 text-sm">
+                <span className="text-xs uppercase tracking-wide text-white/70">
+                  Accent
+                </span>
+                <div
+                  aria-label="accent-color-picker"
+                  role="radiogroup"
+                  className="flex flex-wrap gap-3"
+                >
+                  {ACCENT_OPTIONS.map((c) => (
+                    <button
+                      key={c}
+                      type="button"
+                      aria-label={`select-accent-${c}`}
+                      role="radio"
+                      aria-checked={accent === c}
+                      onClick={() => handleAccentChange(c)}
+                      className={`h-8 w-8 rounded-full border-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ubt-blue ${
+                        accent === c ? 'border-white shadow-inner shadow-white/40' : 'border-transparent'
+                      }`}
+                      style={{ backgroundColor: c }}
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/utils/quickSettingsStore.ts
+++ b/utils/quickSettingsStore.ts
@@ -1,0 +1,101 @@
+"use client";
+
+export interface QuickSettingsState {
+  theme: string;
+  accent: string;
+}
+
+const STORAGE_KEY = 'quick-settings';
+const DEFAULT_STATE: QuickSettingsState = {
+  theme: 'default',
+  accent: '#1793d1',
+};
+
+let hasStorageListener = false;
+const listeners = new Set<(state: QuickSettingsState) => void>();
+
+function parseState(raw: string | null): QuickSettingsState {
+  if (!raw) return { ...DEFAULT_STATE };
+  try {
+    const parsed = JSON.parse(raw) as Partial<QuickSettingsState>;
+    return {
+      ...DEFAULT_STATE,
+      ...parsed,
+    };
+  } catch {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+function readState(): QuickSettingsState {
+  if (typeof window === 'undefined') {
+    return { ...DEFAULT_STATE };
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return parseState(raw);
+  } catch {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+function writeState(next: QuickSettingsState): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // ignore write errors
+  }
+}
+
+function emit(state: QuickSettingsState): void {
+  listeners.forEach((listener) => {
+    listener(state);
+  });
+}
+
+function ensureStorageListener(): void {
+  if (hasStorageListener || typeof window === 'undefined') return;
+  window.addEventListener('storage', (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    emit(parseState(event.newValue));
+  });
+  hasStorageListener = true;
+}
+
+export function getQuickSettings(): QuickSettingsState {
+  return readState();
+}
+
+export function setQuickSettings(
+  update: Partial<QuickSettingsState>,
+): QuickSettingsState {
+  const current = readState();
+  const next: QuickSettingsState = {
+    ...current,
+    ...update,
+  };
+  writeState(next);
+  emit(next);
+  return next;
+}
+
+export function subscribeToQuickSettings(
+  listener: (state: QuickSettingsState) => void,
+): () => void {
+  ensureStorageListener();
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function resetQuickSettings(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore remove errors
+  }
+  emit({ ...DEFAULT_STATE });
+}


### PR DESCRIPTION
## Summary
- refactor the settings drawer into an accessible modal with focus trapping, escape handling, and scroll locking
- persist selected theme and accent through a dedicated quick settings store so values return when reopened

## Testing
- `yarn lint` *(fails: pre-existing jsx-a11y and no-top-level-window violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c84c174483289df9755ff29842e2