### PR TITLE
[components] Refactor toggle switch for native checkbox

### DIFF
--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -1,34 +1,118 @@
 "use client";
-import React from "react";
+import React, { forwardRef, useId } from "react";
 
-interface ToggleSwitchProps {
+type LabelPosition = "left" | "right";
+
+interface ToggleSwitchProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "type" | "checked" | "onChange" | "className"
+  > {
   checked: boolean;
   onChange: (checked: boolean) => void;
   className?: string;
-  ariaLabel: string;
+  /**
+   * Optional visible label that will be associated with the control.
+   */
+  label?: React.ReactNode;
+  /**
+   * Controls whether the label appears to the left or right of the switch.
+   * Defaults to `right` to match the previous layout expectations.
+   */
+  labelPosition?: LabelPosition;
+  /**
+   * Allows styling the visible label when provided.
+   */
+  labelClassName?: string;
+  /**
+   * Backwards compatible alias for `aria-label`.
+   */
+  ariaLabel?: string;
 }
 
-export default function ToggleSwitch({
-  checked,
-  onChange,
-  className = "",
-  ariaLabel,
-}: ToggleSwitchProps) {
-  return (
-    <button
-      role="switch"
-      aria-checked={checked}
-      aria-label={ariaLabel}
-      onClick={() => onChange(!checked)}
-      className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
-        checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
-      } ${className}`.trim()}
-    >
+const ToggleSwitch = forwardRef<HTMLInputElement, ToggleSwitchProps>(
+  (
+    {
+      checked,
+      onChange,
+      className = "",
+      label,
+      labelPosition = "right",
+      labelClassName = "",
+      ariaLabel,
+      id,
+      name,
+      value = "on",
+      disabled,
+      onKeyDown,
+      ...inputProps
+    },
+    ref,
+  ) => {
+    const generatedId = useId();
+    const controlId = id ?? generatedId;
+
+    const labelMarkup = label ? (
       <span
-        className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-ub-cool-grey transition-transform duration-200 ${
-          checked ? "translate-x-5" : "translate-x-0"
+        className={`select-none text-sm text-ubt-grey ${labelClassName}`.trim()}
+      >
+        {label}
+      </span>
+    ) : null;
+
+    return (
+      <label
+        htmlFor={controlId}
+        className={`inline-flex items-center gap-2 ${
+          disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer"
         }`}
-      />
-    </button>
-  );
-}
+      >
+        {labelPosition === "left" && labelMarkup}
+        <span className="relative inline-flex items-center">
+          <input
+            ref={ref}
+            id={controlId}
+            name={name}
+            type="checkbox"
+            role="switch"
+            value={value}
+            className="peer sr-only"
+            checked={checked}
+            aria-checked={checked}
+            aria-label={ariaLabel}
+            disabled={disabled}
+            onChange={(event) => onChange(event.target.checked)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                onChange(!checked);
+              }
+              onKeyDown?.(event);
+            }}
+            {...inputProps}
+          />
+          <span
+            aria-hidden="true"
+            className={`relative inline-flex h-5 w-10 rounded-full transition-colors duration-200 ${
+              checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
+            } ${
+              disabled ? "opacity-70" : ""
+            } ${className} peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-ub-orange`.trim()}
+          >
+            <span
+              aria-hidden="true"
+              className={`pointer-events-none absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-ub-cool-grey transition-transform duration-200 ${
+                checked ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </span>
+        </span>
+        {labelPosition === "right" && labelMarkup}
+      </label>
+    );
+  },
+);
+
+ToggleSwitch.displayName = "ToggleSwitch";
+
+export default ToggleSwitch;


### PR DESCRIPTION
## Summary
- replace the button-based toggle switch with a native checkbox implementation to honor space and Enter key toggles
- expose optional labeling and form attributes so the switch can participate in submissions and offer associated text
- add focus-visible outlines and aria-checked synchronization for improved accessibility feedback

## Testing
- ⚠️ yarn lint *(hangs in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c8507cc88328be925e7728c5ca55