### PR TITLE
[core] Inline toolbar icons and enforce icon import linting

### DIFF
--- a/components/ToolbarIcons.tsx
+++ b/components/ToolbarIcons.tsx
@@ -1,56 +1,93 @@
-import Image from 'next/image';
+import type { SVGProps } from 'react';
 
-export function CloseIcon() {
+type ToolbarIconProps = SVGProps<SVGSVGElement> & {
+  'aria-label'?: string;
+};
+
+type IconDefaults = {
+  defaultSize: number;
+  viewBox: string;
+};
+
+const applyIconDefaults = (
+  props: ToolbarIconProps,
+  { defaultSize, viewBox }: IconDefaults,
+) => {
+  const {
+    'aria-label': ariaLabel,
+    'aria-hidden': ariaHidden,
+    role,
+    focusable,
+    width,
+    height,
+    viewBox: viewBoxProp,
+    ...rest
+  } = props;
+
+  const finalProps: ToolbarIconProps = {
+    ...rest,
+    role: role ?? 'img',
+    focusable: focusable ?? 'false',
+    width: width ?? defaultSize,
+    height: height ?? defaultSize,
+    viewBox: viewBoxProp ?? viewBox,
+  };
+
+  if (ariaLabel) {
+    finalProps['aria-label'] = ariaLabel;
+  }
+
+  const computedHidden =
+    ariaHidden !== undefined ? ariaHidden : ariaLabel ? undefined : true;
+
+  if (computedHidden !== undefined) {
+    finalProps['aria-hidden'] = computedHidden;
+  }
+
+  return finalProps;
+};
+
+export function CloseIcon(props: ToolbarIconProps = {}) {
   return (
-    <Image
-      src="/themes/Yaru/window/window-close-symbolic.svg"
-      alt="Close"
-      width={16}
-      height={16}
-    />
+    <svg {...applyIconDefaults(props, { defaultSize: 16, viewBox: '0 0 16 16' })}>
+      <path
+        d="M4.795 3.912l-.883.883.147.146L7.117 8 4.06 11.059l-.147.146.883.883.146-.147L8 8.883l3.059 3.058.146.147.883-.883-.147-.146L8.883 8l3.058-3.059.147-.146-.883-.883-.146.147L8 7.117 4.941 4.06z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
   );
 }
 
-export function MinimizeIcon() {
+export function MinimizeIcon(props: ToolbarIconProps = {}) {
   return (
-    <Image
-      src="/themes/Yaru/window/window-minimize-symbolic.svg"
-      alt="Minimize"
-      width={16}
-      height={16}
-    />
+    <svg {...applyIconDefaults(props, { defaultSize: 16, viewBox: '0 0 16 16' })}>
+      <path d="M4 10v1h8v-1z" fill="currentColor" />
+    </svg>
   );
 }
 
-export function MaximizeIcon() {
+export function MaximizeIcon(props: ToolbarIconProps = {}) {
   return (
-    <Image
-      src="/themes/Yaru/window/window-maximize-symbolic.svg"
-      alt="Maximize"
-      width={16}
-      height={16}
-    />
+    <svg {...applyIconDefaults(props, { defaultSize: 16, viewBox: '0 0 16 16' })}>
+      <path d="M4 4v8h8V4zm1 1h6v6H5z" fill="currentColor" />
+    </svg>
   );
 }
 
-export function RestoreIcon() {
+export function RestoreIcon(props: ToolbarIconProps = {}) {
   return (
-    <Image
-      src="/themes/Yaru/window/window-restore-symbolic.svg"
-      alt="Restore"
-      width={16}
-      height={16}
-    />
+    <svg {...applyIconDefaults(props, { defaultSize: 16, viewBox: '0 0 16 16' })}>
+      <path d="M4 6v6h6V6zm1 1h4v4H5z" fill="currentColor" />
+      <path d="M6 4v1h5v5h1V4z" fill="currentColor" opacity={0.5} />
+    </svg>
   );
 }
 
-export function PinIcon() {
+export function PinIcon(props: ToolbarIconProps = {}) {
   return (
-    <Image
-      src="/themes/Yaru/window/window-pin-symbolic.svg"
-      alt="Pin"
-      width={16}
-      height={16}
-    />
+    <svg {...applyIconDefaults(props, { defaultSize: 16, viewBox: '0 0 24 24' })}>
+      <path d="M16 9V4h-1V2H9v2H8v5L5 12v2h6v7l1 1 1-1v-7h6v-2l-3-3Z" fill="currentColor" />
+    </svg>
   );
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,49 @@ import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
 
 const compat = new FlatCompat();
 
+const ICON_BUNDLE_IMPORT_WARNINGS = [
+  {
+    name: 'lucide-react',
+    message: 'Import lucide icons from "lucide-react/icons/<IconName>" to avoid bundling the full library.',
+  },
+  {
+    name: '@heroicons/react/20/solid',
+    message: 'Import Heroicons individually, e.g. "@heroicons/react/20/solid/IconName".',
+  },
+  {
+    name: '@heroicons/react/20/outline',
+    message: 'Import Heroicons individually, e.g. "@heroicons/react/20/outline/IconName".',
+  },
+  {
+    name: '@heroicons/react/24/solid',
+    message: 'Import Heroicons individually, e.g. "@heroicons/react/24/solid/IconName".',
+  },
+  {
+    name: '@heroicons/react/24/outline',
+    message: 'Import Heroicons individually, e.g. "@heroicons/react/24/outline/IconName".',
+  },
+  {
+    name: '@radix-ui/react-icons',
+    message: 'Import Radix icons from "@radix-ui/react-icons/<IconName>" to keep bundles slim.',
+  },
+  {
+    name: '@tabler/icons-react',
+    message: 'Import Tabler icons individually via "@tabler/icons-react/<IconName>".',
+  },
+  {
+    name: '@phosphor-icons/react',
+    message: 'Import Phosphor icons via "@phosphor-icons/react/<style>/<IconName>".',
+  },
+  {
+    name: '@phosphor-icons/react/dist/ssr',
+    message: 'Import Phosphor icons via "@phosphor-icons/react/<style>/<IconName>".',
+  },
+  {
+    name: 'react-icons',
+    message: 'Import icons from specific React Icons sub-packages instead of the root entry.',
+  },
+];
+
 const config = [
   { ignores: ['components/apps/Chrome/index.tsx'] },
   {
@@ -25,6 +68,7 @@ const config = [
       '@next/next/no-page-custom-font': 'off',
       '@next/next/no-img-element': 'off',
       'jsx-a11y/control-has-associated-label': 'error',
+      'no-restricted-imports': ['error', { paths: ICON_BUNDLE_IMPORT_WARNINGS }],
     },
   }),
 ];


### PR DESCRIPTION
## Summary
- replace the toolbar window control icons with lean inline SVG components that default to aria-hidden when decorative
- add an ESLint restriction list that blocks importing entire icon bundles so only per-icon modules are used
- run the production build to capture the updated bundle size report

## Testing
- yarn lint *(fails: long-standing accessibility violations in unrelated apps)*
- CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d9c85162a883288436b39b3650f578