### PR TITLE
[panel] Virtualize launcher grid navigation

### DIFF
--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -62,10 +62,28 @@ export class UbuntuApp extends Component {
                     " p-1 m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none w-24 h-20 flex flex-col justify-start items-center text-center text-xs font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
+                onKeyDown={(e) => {
+                    if (typeof this.props.onKeyDown === 'function') {
+                        this.props.onKeyDown(e);
+                    }
+                    if (!e.defaultPrevented && (e.key === 'Enter' || e.key === ' ')) {
+                        e.preventDefault();
+                        this.openApp();
+                    }
+                }}
                 tabIndex={this.props.disabled ? -1 : 0}
-                onMouseEnter={this.handlePrefetch}
-                onFocus={this.handlePrefetch}
+                onMouseEnter={(event) => {
+                    this.handlePrefetch();
+                    if (typeof this.props.onMouseEnter === 'function') {
+                        this.props.onMouseEnter(event);
+                    }
+                }}
+                onFocus={(event) => {
+                    this.handlePrefetch();
+                    if (typeof this.props.onFocus === 'function') {
+                        this.props.onFocus(event);
+                    }
+                }}
             >
                 <Image
                     width={40}


### PR DESCRIPTION
## Summary
- virtualize the main "All applications" grid with react-window for smoother scrolling while keeping favorites and recent sections intact
- add keyboard navigation enhancements and typeahead shortcuts so focus can move predictably across rows and jump by letter
- expose keydown and focus hooks from UbuntuApp to announce focused apps to screen readers as tiles render

## Testing
- yarn lint *(fails: pre-existing accessibility lint errors in unrelated app files)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c86039108328a89e05714f1bf561