### PR TITLE
[screen] add accessible keyboard shortcut modal

### DIFF
--- a/__tests__/shortcut-selector.test.jsx
+++ b/__tests__/shortcut-selector.test.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ShortcutSelector, { DEFAULT_SHORTCUTS } from '../components/screen/shortcut-selector';
+
+describe('ShortcutSelector modal', () => {
+    const originalClipboard = navigator.clipboard;
+    let restoreClipboard;
+
+    beforeEach(() => {
+        if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+            const spy = jest
+                .spyOn(navigator.clipboard, 'writeText')
+                .mockResolvedValue(undefined);
+            restoreClipboard = () => spy.mockRestore();
+        } else {
+            const stub = { writeText: jest.fn().mockResolvedValue(undefined) };
+            Object.defineProperty(navigator, 'clipboard', {
+                configurable: true,
+                value: stub,
+            });
+            restoreClipboard = () => {
+                if (!originalClipboard) {
+                    delete navigator.clipboard;
+                }
+            };
+        }
+    });
+
+    afterEach(() => {
+        if (typeof restoreClipboard === 'function') {
+            restoreClipboard();
+        }
+        if (originalClipboard) {
+            Object.defineProperty(navigator, 'clipboard', {
+                configurable: true,
+                value: originalClipboard,
+            });
+        }
+        restoreClipboard = undefined;
+    });
+
+    const renderModal = (props = {}) =>
+        render(<ShortcutSelector onClose={jest.fn()} shortcuts={DEFAULT_SHORTCUTS} {...props} />);
+
+    test('filters shortcuts when searching by description', async () => {
+        const user = userEvent.setup();
+        renderModal();
+
+        const search = await screen.findByRole('searchbox', { name: /search shortcuts/i });
+        await waitFor(() => expect(search).toHaveFocus());
+
+        await user.type(search, 'clipboard');
+
+        const items = screen.getAllByRole('listitem');
+        expect(items).toHaveLength(1);
+        expect(items[0]).toHaveTextContent(/open the clipboard manager/i);
+        expect(
+            screen.queryByText(/switch between open apps$/i, { selector: 'p' })
+        ).not.toBeInTheDocument();
+    });
+
+    test('copies shortcut text to the clipboard', async () => {
+        const user = userEvent.setup();
+        renderModal();
+
+        const copyButton = await screen.findByRole('button', {
+            name: /copy open the clipboard manager/i,
+        });
+
+        await user.click(copyButton);
+
+        expect(
+            await screen.findByText(/copied ctrl \+ shift \+ v to clipboard\./i)
+        ).toBeInTheDocument();
+    });
+
+    test('keeps focus trapped within the modal dialog', async () => {
+        const user = userEvent.setup();
+        renderModal();
+
+        const search = await screen.findByRole('searchbox', { name: /search shortcuts/i });
+        await waitFor(() => expect(search).toHaveFocus());
+
+        const copyButtons = screen.getAllByRole('button', { name: /^copy/i });
+        const closeButton = screen.getByRole('button', { name: /^close$/i });
+        const lastCopy = copyButtons[copyButtons.length - 1];
+
+        lastCopy.focus();
+        expect(lastCopy).toHaveFocus();
+
+        await user.tab();
+        expect(closeButton).toHaveFocus();
+
+        await user.tab();
+        expect(search).toHaveFocus();
+    });
+});

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -1,79 +1,315 @@
-import React from 'react';
-import UbuntuApp from '../base/ubuntu_app';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Modal from '../base/Modal';
 
-class ShortcutSelector extends React.Component {
-    constructor() {
-        super();
-        this.state = {
-            query: '',
-            apps: [],
-            unfilteredApps: [],
-        };
+export const DEFAULT_SHORTCUTS = [
+    {
+        id: 'show-overlay',
+        description: 'Show keyboard shortcut overlay',
+        keys: ['?'],
+        keywords: ['help', 'keyboard'],
+    },
+    {
+        id: 'window-switcher',
+        description: 'Switch between open apps',
+        keys: ['Alt', 'Tab'],
+        keywords: ['switch', 'apps', 'task switcher'],
+    },
+    {
+        id: 'window-switcher-reverse',
+        description: 'Switch between open apps (reverse order)',
+        keys: ['Alt', 'Shift', 'Tab'],
+        keywords: ['previous', 'window', 'reverse'],
+    },
+    {
+        id: 'cycle-app-windows',
+        description: 'Cycle windows of the focused app',
+        keys: ['Alt', '`'],
+        keywords: ['backtick', 'tilde', 'window'],
+    },
+    {
+        id: 'clipboard-manager',
+        description: 'Open the clipboard manager',
+        keys: ['Ctrl', 'Shift', 'V'],
+        keywords: ['clipboard', 'history', 'paste'],
+    },
+    {
+        id: 'snap-left',
+        description: 'Snap the focused window to the left',
+        keys: ['Super', 'ArrowLeft'],
+        keywords: ['tile', 'arrange', 'left', 'windows'],
+    },
+    {
+        id: 'snap-right',
+        description: 'Snap the focused window to the right',
+        keys: ['Super', 'ArrowRight'],
+        keywords: ['tile', 'arrange', 'right', 'windows'],
+    },
+    {
+        id: 'maximize-window',
+        description: 'Maximize the focused window',
+        keys: ['Super', 'ArrowUp'],
+        keywords: ['tile', 'arrange', 'top', 'maximize'],
+    },
+    {
+        id: 'minimize-window',
+        description: 'Minimize or restore the focused window',
+        keys: ['Super', 'ArrowDown'],
+        keywords: ['tile', 'arrange', 'bottom', 'minimize'],
+    },
+    {
+        id: 'keyboard-context-menu',
+        description: 'Open the desktop context menu',
+        keys: ['Shift', 'F10'],
+        keywords: ['menu', 'context', 'accessibility'],
+    },
+];
+
+const KEY_LABELS = {
+    default: {
+        Alt: 'Alt',
+        Shift: 'Shift',
+        Ctrl: 'Ctrl',
+        Super: 'Super',
+        Meta: 'Super',
+        Tab: 'Tab',
+        F10: 'F10',
+        ArrowLeft: '←',
+        ArrowRight: '→',
+        ArrowUp: '↑',
+        ArrowDown: '↓',
+    },
+    mac: {
+        Alt: '⌥',
+        Shift: '⇧',
+        Ctrl: '⌃',
+        Super: '⌘',
+        Meta: '⌘',
+        Tab: '⇥',
+        F10: 'F10',
+        ArrowLeft: '←',
+        ArrowRight: '→',
+        ArrowUp: '↑',
+        ArrowDown: '↓',
+    },
+};
+
+const KEYWORD_ALIASES = {
+    default: {
+        Super: ['super', 'windows', 'win', 'meta'],
+        Ctrl: ['ctrl', 'control'],
+        Alt: ['alt', 'option'],
+    },
+    mac: {
+        Super: ['super', 'command', 'cmd', '⌘'],
+        Ctrl: ['control', 'ctrl', '⌃'],
+        Alt: ['option', '⌥', 'alt'],
+    },
+};
+
+const detectPlatform = () => {
+    if (typeof navigator === 'undefined') return 'default';
+    const platform = navigator.platform?.toLowerCase?.() || '';
+    const userAgent = navigator.userAgent?.toLowerCase?.() || '';
+    if (platform.includes('mac') || userAgent.includes('mac os')) {
+        return 'mac';
     }
+    return 'default';
+};
 
-    componentDidMount() {
-        const { apps = [], games = [] } = this.props;
-        const combined = [...apps];
-        games.forEach((game) => {
-            if (!combined.some((app) => app.id === game.id)) combined.push(game);
-        });
-        this.setState({ apps: combined, unfilteredApps: combined });
+const formatKey = (key, platform) => {
+    const labels = KEY_LABELS[platform] || KEY_LABELS.default;
+    if (labels[key]) return labels[key];
+    if (key.length === 1) return key.toUpperCase();
+    if (key.startsWith('Arrow')) {
+        const arrows = labels[key];
+        if (arrows) return arrows;
     }
+    return key;
+};
 
-    handleChange = (e) => {
-        const value = e.target.value;
-        const { unfilteredApps } = this.state;
-        const apps =
-            value === '' || value === null
-                ? unfilteredApps
-                : unfilteredApps.filter((app) =>
-                      app.title.toLowerCase().includes(value.toLowerCase())
-                  );
-        this.setState({ query: value, apps });
-    };
+const formatShortcut = (keys, platform) =>
+    keys
+        .map((key) => formatKey(key, platform))
+        .join(platform === 'mac' ? '' : ' + ')
+        .replace(/([⌘⌥⌃⇧])(?=[^\s+])/g, '$1');
 
-    selectApp = (id) => {
-        if (typeof this.props.onSelect === 'function') {
-            this.props.onSelect(id);
+const getSearchableText = (shortcut, platform) => {
+    const labels = KEY_LABELS[platform] || KEY_LABELS.default;
+    const aliasMap = KEYWORD_ALIASES[platform] || KEYWORD_ALIASES.default;
+    const keyText = shortcut.keys
+        .map((key) => {
+            const base = labels[key] || key;
+            const aliases = aliasMap[key] || [];
+            return [base, key, ...aliases].join(' ');
+        })
+        .join(' ');
+    const keywordText = (shortcut.keywords || []).join(' ');
+    return `${shortcut.description} ${keyText} ${keywordText}`.toLowerCase();
+};
+
+const ShortcutSelector = ({ onClose, shortcuts = DEFAULT_SHORTCUTS }) => {
+    const [query, setQuery] = useState('');
+    const [platform, setPlatform] = useState('default');
+    const [copiedId, setCopiedId] = useState(null);
+    const [feedback, setFeedback] = useState('');
+    const searchRef = useRef(null);
+
+    useEffect(() => {
+        setPlatform(detectPlatform());
+    }, []);
+
+    useEffect(() => {
+        if (searchRef.current) {
+            searchRef.current.focus();
         }
-    };
+    }, []);
 
-    renderApps = () => {
-        const apps = this.state.apps || [];
-        return apps.map((app) => (
-            <UbuntuApp
-                key={app.id}
-                name={app.title}
-                id={app.id}
-                icon={app.icon}
-                openApp={() => this.selectApp(app.id)}
-                disabled={app.disabled}
-                prefetch={app.screen?.prefetch}
-            />
-        ));
-    };
+    useEffect(() => {
+        if (!copiedId) return;
+        const timer = setTimeout(() => {
+            setCopiedId(null);
+        }, 2000);
+        return () => clearTimeout(timer);
+    }, [copiedId]);
 
-    render() {
-        return (
-            <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
-                <input
-                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
-                    placeholder="Search"
-                    value={this.state.query}
-                    onChange={this.handleChange}
-                />
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-6 pb-10 place-items-center">
-                    {this.renderApps()}
-                </div>
-                <button
-                    className="mb-8 px-4 py-2 rounded bg-black bg-opacity-20 text-white"
-                    onClick={this.props.onClose}
-                >
-                    Cancel
-                </button>
-            </div>
+    useEffect(() => {
+        if (!feedback) return;
+        const timer = setTimeout(() => {
+            setFeedback('');
+        }, 2500);
+        return () => clearTimeout(timer);
+    }, [feedback]);
+
+    const normalizedQuery = query.trim().toLowerCase();
+
+    const filteredShortcuts = useMemo(() => {
+        if (!normalizedQuery) return shortcuts;
+        return shortcuts.filter((shortcut) =>
+            getSearchableText(shortcut, platform).includes(normalizedQuery)
         );
-    }
-}
+    }, [normalizedQuery, platform, shortcuts]);
+
+    const handleCopy = useCallback(
+        async (shortcut) => {
+            const text = formatShortcut(shortcut.keys, platform);
+            try {
+                if (
+                    typeof navigator !== 'undefined' &&
+                    navigator.clipboard &&
+                    typeof navigator.clipboard.writeText === 'function'
+                ) {
+                    await navigator.clipboard.writeText(text);
+                    setCopiedId(shortcut.id);
+                    setFeedback(`Copied ${text} to clipboard.`);
+                } else {
+                    throw new Error('Clipboard API unavailable');
+                }
+            } catch (error) {
+                setFeedback(
+                    'Copy is not supported in this browser. Select the shortcut text and use your copy keys.'
+                );
+            }
+        },
+        [platform]
+    );
+
+    const handleSearchChange = (event) => {
+        setQuery(event.target.value);
+    };
+
+    return (
+        <Modal isOpen onClose={onClose}>
+            <div className="fixed inset-0 z-[60] flex items-center justify-center px-4 py-10">
+                <div
+                    className="absolute inset-0 bg-black bg-opacity-70"
+                    aria-hidden="true"
+                    onClick={onClose}
+                />
+                <div
+                    className="relative z-10 w-full max-w-3xl overflow-hidden rounded-lg bg-ub-grey text-white shadow-2xl"
+                    onClick={(event) => event.stopPropagation()}
+                >
+                    <div className="flex flex-col gap-4 px-6 py-5">
+                        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                            <div>
+                                <h2 className="text-xl font-semibold">Keyboard shortcuts</h2>
+                                <p className="text-sm text-white/70">
+                                    Open this selector from the desktop context menu (right-click or press Shift+F10),
+                                    then choose “Create Shortcut…”. Press Esc to close this window.
+                                </p>
+                            </div>
+                            <button
+                                type="button"
+                                onClick={onClose}
+                                className="self-start rounded bg-white/15 px-3 py-1 text-sm font-medium text-white transition hover:bg-white/25 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+                            >
+                                Close
+                            </button>
+                        </div>
+                        <div>
+                            <label htmlFor="shortcut-search" className="sr-only">
+                                Search shortcuts
+                            </label>
+                            <input
+                                ref={searchRef}
+                                id="shortcut-search"
+                                type="search"
+                                value={query}
+                                onChange={handleSearchChange}
+                                placeholder="Search by action or key"
+                                className="w-full rounded border border-white/20 bg-black/30 px-4 py-2 text-sm text-white placeholder-white/50 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-400"
+                            />
+                        </div>
+                        <div role="status" aria-live="polite" className="sr-only">
+                            {feedback}
+                        </div>
+                        <div className="max-h-[60vh] overflow-y-auto rounded-md border border-white/10 bg-black/20">
+                            {filteredShortcuts.length > 0 ? (
+                                <ul className="divide-y divide-white/10">
+                                    {filteredShortcuts.map((shortcut) => {
+                                        const display = formatShortcut(shortcut.keys, platform);
+                                        const isCopied = copiedId === shortcut.id;
+                                        return (
+                                            <li
+                                                key={shortcut.id}
+                                                className="flex flex-col gap-3 p-4 md:flex-row md:items-center md:justify-between"
+                                            >
+                                                <div>
+                                                    <p className="font-medium">{shortcut.description}</p>
+                                                    <p className="mt-1 font-mono text-sm text-white/80">
+                                                        {display}
+                                                    </p>
+                                                </div>
+                                                <div className="flex items-center gap-3">
+                                                    {isCopied ? (
+                                                        <span className="text-xs uppercase tracking-wide text-emerald-300" role="status">
+                                                            Copied
+                                                        </span>
+                                                    ) : null}
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => handleCopy(shortcut)}
+                                                        className="rounded border border-white/30 px-3 py-1 text-sm font-medium transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+                                                    >
+                                                        Copy
+                                                        <span className="sr-only"> {shortcut.description}</span>
+                                                    </button>
+                                                </div>
+                                            </li>
+                                        );
+                                    })}
+                                </ul>
+                            ) : (
+                                <p className="px-4 py-10 text-center text-sm text-white/70">
+                                    No shortcuts match “{query}”. Try a different search term.
+                                </p>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </Modal>
+    );
+};
 
 export default ShortcutSelector;


### PR DESCRIPTION
## Summary
- replace the desktop shortcut selector with an accessible keyboard-shortcuts modal featuring search, OS-aware key labels, copy feedback, and usage guidance
- add unit tests that cover search filtering, copy announcements, and focus trapping for the modal dialog

## Testing
- yarn test shortcut-selector

------
https://chatgpt.com/codex/tasks/task_e_68d9c867eb98832881f62bb2288b093e