### PR TITLE
[desktop] Centralize window state handling

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -65,6 +65,11 @@ export class Window extends Component {
         this._menuOpener = null;
     }
 
+    emitSnapState = (snap) => {
+        if (typeof window === 'undefined' || !this.id) return;
+        window.dispatchEvent(new CustomEvent('window-snap-state', { detail: { id: this.id, snap } }));
+    };
+
     componentDidMount() {
         this.id = this.props.id;
         this.setDefaultWindowDimenstion();
@@ -280,14 +285,18 @@ export class Window extends Component {
                 node.style.transform = `translate(${x},${y})`;
             }
         }
+        const afterUpdate = () => {
+            this.resizeBoundries();
+            this.emitSnapState(null);
+        };
         if (this.state.lastSize) {
             this.setState({
                 width: this.state.lastSize.width,
                 height: this.state.lastSize.height,
                 snapped: null
-            }, this.resizeBoundries);
+            }, afterUpdate);
         } else {
-            this.setState({ snapped: null }, this.resizeBoundries);
+            this.setState({ snapped: null }, afterUpdate);
         }
     }
 
@@ -312,7 +321,10 @@ export class Window extends Component {
             lastSize: { width, height },
             width: percentOf(region.width, viewportWidth),
             height: percentOf(region.height, viewportHeight)
-        }, this.resizeBoundries);
+        }, () => {
+            this.resizeBoundries();
+            this.emitSnapState(position);
+        });
     }
 
     setInertBackground = () => {


### PR DESCRIPTION
## Summary
- add a WindowManagerStore to desktop.js to track z-order, focus, minimization, and snap state for windows
- wire global keyboard shortcuts for cycling focus and snapping to use the central store and dispatch snap events
- emit snap state updates from the window frame so the desktop store stays synchronized when snapping changes outside of shortcuts

## Testing
- yarn lint *(fails: pre-existing accessibility and no-top-level-window violations in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c8646b5083289ccceb822d7c1da7