### PR TITLE
[apps] Add master-detail credential panel for dsniff

### DIFF
--- a/__tests__/dsniff.test.tsx
+++ b/__tests__/dsniff.test.tsx
@@ -33,10 +33,45 @@ describe('Dsniff component', () => {
   });
   it('obfuscates credentials by default and reveals on click', async () => {
     render(<Dsniff />);
-    expect(await screen.findByText('***')).toBeInTheDocument();
-    const showBtn = screen.getByText('Show');
+    const hostRow = await screen.findByTestId('domain-row-192.168.0.10');
+    expect(within(hostRow).getByText('***')).toBeInTheDocument();
+    const showBtn = within(hostRow).getByText('Show');
     fireEvent.click(showBtn);
-    expect(await screen.findByText('demo123')).toBeInTheDocument();
+    expect(within(hostRow).getByText('demo123')).toBeInTheDocument();
+  });
+
+  it('reveals credentials in the detail panel after a single host click', async () => {
+    render(<Dsniff />);
+    const hostRow = await screen.findByTestId('domain-row-192.168.0.10');
+    fireEvent.click(hostRow);
+
+    const detailPanel = await screen.findByTestId('credential-detail-panel');
+    expect(
+      within(detailPanel).getByText(/Credentials for 192\.168\.0\.10/i),
+    ).toBeInTheDocument();
+    expect(await within(detailPanel).findByText('demo123')).toBeInTheDocument();
+  });
+
+  it('maintains selection when switching between protocol tabs', async () => {
+    render(<Dsniff />);
+    const hostRow = await screen.findByTestId('domain-row-192.168.0.10');
+    fireEvent.click(hostRow);
+
+    fireEvent.click(screen.getByRole('button', { name: /^arpspoof$/i }));
+    let detailPanel = await screen.findByTestId('credential-detail-panel');
+    expect(
+      within(detailPanel).getByRole('heading', {
+        name: /credentials for 192\.168\.0\.10/i,
+      }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^urlsnarf$/i }));
+    detailPanel = await screen.findByTestId('credential-detail-panel');
+    expect(
+      within(detailPanel).getByRole('heading', {
+        name: /credentials for 192\.168\.0\.10/i,
+      }),
+    ).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- add selection context and host detail panel to the dsniff simulation so credentials appear alongside log browsing
- highlight selected sessions/hosts across tiles and tables while exposing detail panel state to other UI elements
- extend dsniff tests to cover the new master-detail interaction and navigation persistence

## Testing
- yarn test dsniff --runTestsByPath __tests__/dsniff.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d9d332f5d48328b8743a0fd2d0e4da