### PR TITLE
[beef] Add client-side tag management

### DIFF
--- a/__tests__/apps/beef/filterVictims.test.ts
+++ b/__tests__/apps/beef/filterVictims.test.ts
@@ -1,0 +1,28 @@
+import { PRELOADED_VICTIMS } from '../../../apps/beef/data/victims';
+import { filterVictimsByTags } from '../../../apps/beef/utils/filterVictims';
+
+describe('filterVictimsByTags', () => {
+  it('returns all victims when no tags are selected', () => {
+    const result = filterVictimsByTags(PRELOADED_VICTIMS, []);
+    expect(result).toHaveLength(PRELOADED_VICTIMS.length);
+  });
+
+  it('filters victims by a single tag', () => {
+    const result = filterVictimsByTags(PRELOADED_VICTIMS, ['priority']);
+    const ids = result.map((victim) => victim.id);
+    expect(ids).toEqual(expect.arrayContaining(['vic-001', 'vic-003']));
+    expect(ids).not.toContain('vic-004');
+  });
+
+  it('requires victims to match all selected tags', () => {
+    const result = filterVictimsByTags(PRELOADED_VICTIMS, ['internal', 'tablet']);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('vic-002');
+  });
+
+  it('normalizes tag casing and whitespace before filtering', () => {
+    const result = filterVictimsByTags(PRELOADED_VICTIMS, ['  PRIORITY  ', 'TrAveL']);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('vic-003');
+  });
+});

--- a/apps/beef/components/TagBar.tsx
+++ b/apps/beef/components/TagBar.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+
+interface TagBarProps {
+  tags: string[];
+  onAddTag?: (tag: string) => void;
+  onRemoveTag?: (tag: string) => void;
+  onToggleTag?: (tag: string) => void;
+  selectedTags?: string[];
+  label?: string;
+  placeholder?: string;
+  className?: string;
+}
+
+const toKey = (value: string) => value.toLowerCase();
+
+const TagBar: React.FC<TagBarProps> = ({
+  tags,
+  onAddTag,
+  onRemoveTag,
+  onToggleTag,
+  selectedTags = [],
+  label,
+  placeholder = 'Add tag',
+  className = '',
+}) => {
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const normalizedTags = useMemo(() => new Set(tags.map(toKey)), [tags]);
+  const selected = useMemo(() => new Set(selectedTags.map(toKey)), [selectedTags]);
+  const canAddTag = typeof onAddTag === 'function';
+
+  const resetDraft = () => {
+    setDraft('');
+    setError(null);
+  };
+
+  const handleAdd = () => {
+    if (!canAddTag) {
+      return;
+    }
+    const normalized = draft.trim().toLowerCase();
+    if (!normalized) {
+      setError('Enter a tag before adding.');
+      return;
+    }
+    if (normalizedTags.has(normalized)) {
+      setError('Tag already exists.');
+      return;
+    }
+    onAddTag?.(normalized);
+    resetDraft();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleAdd();
+    }
+  };
+
+  const handleRemove = (event: React.MouseEvent<HTMLButtonElement>, tag: string) => {
+    event.stopPropagation();
+    onRemoveTag?.(tag);
+  };
+
+  const renderTag = (tag: string) => {
+    const normalized = toKey(tag);
+    const isSelected = selected.has(normalized);
+    const toggleable = typeof onToggleTag === 'function';
+
+    return (
+      <div
+        key={tag}
+        className={`flex items-center gap-1 rounded-full border px-2 py-1 text-xs transition-colors ${
+          isSelected ? 'border-ub-primary bg-ub-primary/60 text-white' : 'border-gray-600 bg-gray-800 text-gray-100'
+        }`}
+      >
+        <button
+          type="button"
+          onClick={toggleable ? () => onToggleTag?.(tag) : undefined}
+          disabled={!toggleable}
+          className={`focus:outline-none ${toggleable ? 'hover:underline' : ''}`}
+        >
+          {tag}
+        </button>
+        {onRemoveTag && (
+          <button
+            type="button"
+            aria-label={`Remove tag ${tag}`}
+            onClick={(event) => handleRemove(event, tag)}
+            className="focus:outline-none text-gray-300 hover:text-white"
+          >
+            ×
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className={`flex flex-col gap-1 ${className}`}>
+      {label && <span className="text-[11px] uppercase tracking-wide text-gray-300">{label}</span>}
+      <div className="flex flex-wrap items-center gap-2">
+        {canAddTag && (
+          <div className="flex items-center gap-1">
+            <input
+              value={draft}
+              onChange={(event) => {
+                setDraft(event.target.value);
+                setError(null);
+              }}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
+              className="h-7 rounded bg-gray-900 px-2 text-xs text-gray-100 focus:outline-none focus:ring-2 focus:ring-ub-primary"
+            />
+            <button
+              type="button"
+              onClick={handleAdd}
+              className="h-7 rounded bg-ub-primary px-2 text-xs font-semibold text-white"
+            >
+              Add
+            </button>
+          </div>
+        )}
+        {tags.length === 0 && <span className="text-xs italic text-gray-400">No tags yet.</span>}
+        {tags.map((tag) => renderTag(tag))}
+      </div>
+      {error && <span className="text-[11px] text-red-300">{error}</span>}
+    </div>
+  );
+};
+
+export default TagBar;

--- a/apps/beef/data/victims.ts
+++ b/apps/beef/data/victims.ts
@@ -1,0 +1,53 @@
+export type VictimRecord = {
+  id: string;
+  name: string;
+  ip: string;
+  browser: string;
+  os: string;
+  lastSeen: string;
+  status: 'online' | 'offline';
+  tags: string[];
+};
+
+export const PRELOADED_VICTIMS: VictimRecord[] = [
+  {
+    id: 'vic-001',
+    name: 'Intranet Finance Portal',
+    ip: '10.0.5.21',
+    browser: 'Chrome 121',
+    os: 'Windows 11',
+    lastSeen: '2m ago',
+    status: 'online',
+    tags: ['finance', 'internal', 'priority'],
+  },
+  {
+    id: 'vic-002',
+    name: 'Human Resources Tablet',
+    ip: '10.0.8.14',
+    browser: 'Edge 118',
+    os: 'Windows 10',
+    lastSeen: '12m ago',
+    status: 'online',
+    tags: ['hr', 'internal', 'tablet'],
+  },
+  {
+    id: 'vic-003',
+    name: 'Executive Laptop',
+    ip: '10.0.12.4',
+    browser: 'Safari 17',
+    os: 'macOS 14',
+    lastSeen: '45m ago',
+    status: 'offline',
+    tags: ['executive', 'travel', 'priority'],
+  },
+  {
+    id: 'vic-004',
+    name: 'QA Lab Workstation',
+    ip: '10.0.30.16',
+    browser: 'Firefox 122',
+    os: 'Ubuntu 23.10',
+    lastSeen: '5m ago',
+    status: 'online',
+    tags: ['qa', 'lab'],
+  },
+];

--- a/apps/beef/index.tsx
+++ b/apps/beef/index.tsx
@@ -1,10 +1,15 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Image from 'next/image';
 import BeefApp from '../../components/apps/beef';
+import TagBar from './components/TagBar';
+import { PRELOADED_VICTIMS } from './data/victims';
+import { filterVictimsByTags } from './utils/filterVictims';
 
 type Severity = 'Low' | 'Medium' | 'High';
+
+type TagState = Record<string, string[]>;
 
 interface LogEntry {
   time: string;
@@ -12,11 +17,41 @@ interface LogEntry {
   message: string;
 }
 
+const STORAGE_KEY = 'beef-victim-tags';
+
 const severityStyles: Record<Severity, { icon: string; color: string }> = {
   Low: { icon: '🟢', color: 'bg-green-700' },
   Medium: { icon: '🟡', color: 'bg-yellow-700' },
   High: { icon: '🔴', color: 'bg-red-700' },
 };
+
+const normalizeTag = (tag: string) => tag.trim().toLowerCase();
+
+const mergeUniqueTags = (base: string[], extra: string[] = []) => {
+  const seen = new Set<string>();
+  base.forEach((tag) => {
+    const normalized = normalizeTag(tag);
+    if (normalized) {
+      seen.add(normalized);
+    }
+  });
+  extra.forEach((tag) => {
+    const normalized = normalizeTag(tag);
+    if (normalized) {
+      seen.add(normalized);
+    }
+  });
+  return Array.from(seen);
+};
+
+const buildBaseTagState = (): TagState =>
+  PRELOADED_VICTIMS.reduce<TagState>((acc, victim) => {
+    acc[victim.id] = mergeUniqueTags(victim.tags);
+    return acc;
+  }, {});
+
+const cloneTagState = (state: TagState): TagState =>
+  Object.fromEntries(Object.entries(state).map(([key, tags]) => [key, [...tags]]));
 
 const BeefPage: React.FC = () => {
   const [logs] = useState<LogEntry[]>([
@@ -24,6 +59,117 @@ const BeefPage: React.FC = () => {
     { time: '10:00:02', severity: 'Medium', message: 'Payload delivered' },
     { time: '10:00:03', severity: 'High', message: 'Sensitive data exfil attempt' },
   ]);
+  const [storageLoaded, setStorageLoaded] = useState(false);
+  const [activeFilters, setActiveFilters] = useState<string[]>([]);
+
+  const baseTagState = useMemo(() => buildBaseTagState(), []);
+  const [tagState, setTagState] = useState<TagState>(() => cloneTagState(baseTagState));
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return;
+      }
+      const parsed = JSON.parse(raw) as unknown;
+      if (!parsed || typeof parsed !== 'object') {
+        return;
+      }
+
+      const stored = parsed as Record<string, string[]>;
+      setTagState(() => {
+        const next = cloneTagState(baseTagState);
+        Object.entries(stored).forEach(([victimId, tags]) => {
+          if (!Array.isArray(tags)) {
+            return;
+          }
+          next[victimId] = mergeUniqueTags(next[victimId] ?? [], tags);
+        });
+        return next;
+      });
+    } catch {
+      // ignore storage errors
+    } finally {
+      setStorageLoaded(true);
+    }
+  }, [baseTagState]);
+
+  useEffect(() => {
+    if (!storageLoaded) {
+      return;
+    }
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(tagState));
+    } catch {
+      // ignore write failures
+    }
+  }, [tagState, storageLoaded]);
+
+  const victimsWithTags = useMemo(
+    () =>
+      PRELOADED_VICTIMS.map((victim) => ({
+        ...victim,
+        tags: tagState[victim.id] ?? [],
+      })),
+    [tagState],
+  );
+
+  const availableTags = useMemo(() => {
+    const set = new Set<string>();
+    Object.values(tagState).forEach((tags) => {
+      tags.forEach((tag) => set.add(tag));
+    });
+    return Array.from(set).sort();
+  }, [tagState]);
+
+  useEffect(() => {
+    setActiveFilters((prev) => {
+      const filtered = prev.filter((tag) => availableTags.includes(tag));
+      return filtered.length === prev.length ? prev : filtered;
+    });
+  }, [availableTags]);
+
+  const filteredVictims = useMemo(
+    () => filterVictimsByTags(victimsWithTags, activeFilters),
+    [victimsWithTags, activeFilters],
+  );
+
+  const handleAddTag = (victimId: string, tag: string) => {
+    setTagState((prev) => {
+      const current = prev[victimId] ?? [];
+      if (current.includes(tag)) {
+        return prev;
+      }
+      return {
+        ...prev,
+        [victimId]: [...current, tag],
+      };
+    });
+  };
+
+  const handleRemoveTag = (victimId: string, tag: string) => {
+    setTagState((prev) => {
+      const current = prev[victimId] ?? [];
+      if (!current.includes(tag)) {
+        return prev;
+      }
+      const nextTags = current.filter((value) => value !== tag);
+      return {
+        ...prev,
+        [victimId]: nextTags,
+      };
+    });
+  };
+
+  const toggleFilterTag = (tag: string) => {
+    setActiveFilters((prev) =>
+      prev.includes(tag) ? prev.filter((value) => value !== tag) : [...prev, tag],
+    );
+  };
+
+  const clearFilters = () => setActiveFilters([]);
+
+  const totalVictims = PRELOADED_VICTIMS.length;
 
   return (
     <div className="bg-ub-cool-grey text-white h-full w-full flex flex-col">
@@ -51,8 +197,99 @@ const BeefPage: React.FC = () => {
         </div>
       </header>
 
-      <div className="p-4 flex-1 overflow-auto">
-        <BeefApp />
+      <div className="p-4 flex-1 overflow-auto space-y-6">
+        <section className="rounded-lg border border-gray-700 bg-black/40 p-4 shadow-inner">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="max-w-xl space-y-1">
+              <h2 className="text-lg font-semibold">Victim Directory</h2>
+              <p className="text-xs text-gray-300">
+                Tags are stored locally in your browser so you can experiment without real network traffic.
+              </p>
+            </div>
+            <div className="flex w-full flex-col gap-2 md:w-80">
+              <TagBar
+                label="Filter by tag"
+                tags={availableTags}
+                selectedTags={activeFilters}
+                onToggleTag={toggleFilterTag}
+                className="md:items-end"
+              />
+              <div className="flex items-center justify-between text-xs text-gray-300">
+                <span>
+                  Showing {filteredVictims.length} of {totalVictims}
+                </span>
+                <button
+                  type="button"
+                  onClick={clearFilters}
+                  disabled={activeFilters.length === 0}
+                  className={`rounded px-2 py-1 font-semibold transition-colors ${
+                    activeFilters.length === 0
+                      ? 'cursor-not-allowed bg-gray-700 text-gray-400'
+                      : 'bg-ub-primary text-white hover:bg-ub-primary/80'
+                  }`}
+                >
+                  Clear filters
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {filteredVictims.map((victim) => (
+              <article
+                key={victim.id}
+                className="rounded-lg border border-gray-700 bg-gray-900/60 p-4 shadow transition-shadow hover:shadow-lg"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <h3 className="text-base font-semibold">{victim.name}</h3>
+                    <p className="text-xs text-gray-400">
+                      {victim.ip} · {victim.browser}
+                    </p>
+                  </div>
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                      victim.status === 'online'
+                        ? 'bg-green-700/80 text-green-100'
+                        : 'bg-gray-700 text-gray-200'
+                    }`}
+                  >
+                    {victim.status === 'online' ? 'Online' : 'Offline'}
+                  </span>
+                </div>
+                <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-gray-300">
+                  <div>
+                    <dt className="text-[10px] uppercase tracking-wide text-gray-400">OS</dt>
+                    <dd className="text-sm text-white">{victim.os}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-[10px] uppercase tracking-wide text-gray-400">Last seen</dt>
+                    <dd className="text-sm text-white">{victim.lastSeen}</dd>
+                  </div>
+                </dl>
+                <TagBar
+                  className="mt-3"
+                  label="Tags"
+                  tags={victim.tags}
+                  selectedTags={activeFilters}
+                  onAddTag={(tag) => handleAddTag(victim.id, tag)}
+                  onRemoveTag={(tag) => handleRemoveTag(victim.id, tag)}
+                  onToggleTag={toggleFilterTag}
+                />
+              </article>
+            ))}
+          </div>
+
+          {filteredVictims.length === 0 && (
+            <p className="mt-6 text-sm text-gray-300">
+              No victims match the selected tags. Try clearing the filters or adding a new tag to any victim.
+            </p>
+          )}
+        </section>
+
+        <section className="rounded-lg border border-gray-700 bg-black/40 p-4">
+          <BeefApp />
+        </section>
       </div>
 
       <div className="border-t border-gray-700 font-mono text-sm">

--- a/apps/beef/utils/filterVictims.ts
+++ b/apps/beef/utils/filterVictims.ts
@@ -1,0 +1,34 @@
+import { VictimRecord } from '../data/victims';
+
+const normalize = (value: string) => value.trim().toLowerCase();
+
+export const filterVictimsByTags = (
+  victims: VictimRecord[],
+  requiredTags: string[],
+): VictimRecord[] => {
+  if (!requiredTags.length) {
+    return victims;
+  }
+
+  const normalizedRequired = Array.from(
+    new Set(
+      requiredTags
+        .map((tag) => normalize(tag))
+        .filter((tag) => tag.length > 0),
+    ),
+  );
+
+  if (!normalizedRequired.length) {
+    return victims;
+  }
+
+  return victims.filter((victim) => {
+    const victimTags = new Set(
+      (victim.tags || [])
+        .map((tag) => normalize(tag))
+        .filter((tag) => tag.length > 0),
+    );
+
+    return normalizedRequired.every((tag) => victimTags.has(tag));
+  });
+};


### PR DESCRIPTION
## Summary
- add a reusable TagBar component to manage victim tags in the BeEF lab UI
- persist victim tag state locally and enable tag-based filtering of the directory
- preload victim fixtures and add Jest coverage for the tag filtering helper

## Testing
- yarn test filterVictims

------
https://chatgpt.com/codex/tasks/task_e_68d9d3346fc48328bb1bb1f09d70f15a