### PR TITLE
[metasploit] Cache module metadata and facet search

### DIFF
--- a/apps/metasploit/__tests__/cache.test.ts
+++ b/apps/metasploit/__tests__/cache.test.ts
@@ -1,0 +1,48 @@
+import type { Module } from '../types';
+
+const sampleModules: Module[] = [
+  {
+    name: 'auxiliary/test/sample',
+    description: 'Sample module',
+    type: 'auxiliary',
+    severity: 'low',
+    platform: 'linux',
+    tags: ['sample'],
+  },
+  {
+    name: 'exploit/test/sample',
+    description: 'Exploit example',
+    type: 'exploit',
+    severity: 'high',
+    platform: 'windows',
+    tags: ['windows'],
+  },
+];
+
+describe('module cache', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('hydrates the cache after the first load and reuses it', async () => {
+    const { calculateRevision, ensureModuleCache, readModuleCache, clearModuleCache } = await import(
+      '../cache'
+    );
+
+    await clearModuleCache();
+
+    const revision = calculateRevision(sampleModules);
+    const firstLoad = await ensureModuleCache(sampleModules, revision);
+    expect(firstLoad.source).toBe('seed');
+    expect(firstLoad.modules).toHaveLength(sampleModules.length);
+
+    const payload = await readModuleCache();
+    expect(payload).not.toBeNull();
+    expect(payload?.modules).toHaveLength(sampleModules.length);
+    expect(payload?.revision).toBe(revision);
+
+    const secondLoad = await ensureModuleCache(sampleModules, revision);
+    expect(secondLoad.source).toBe('cache');
+    expect(secondLoad.modules).toHaveLength(sampleModules.length);
+  });
+});

--- a/apps/metasploit/__tests__/cacheFallback.test.ts
+++ b/apps/metasploit/__tests__/cacheFallback.test.ts
@@ -1,0 +1,31 @@
+import type { Module } from '../types';
+
+const sampleModules: Module[] = [
+  {
+    name: 'auxiliary/test/offline',
+    description: 'Offline path',
+    type: 'auxiliary',
+    severity: 'low',
+  },
+];
+
+describe('module cache offline fallback', () => {
+  afterEach(() => {
+    jest.dontMock('../../../utils/safeIDB');
+    jest.resetModules();
+  });
+
+  it('falls back to seed data when IndexedDB is unavailable', async () => {
+    jest.resetModules();
+    jest.doMock('../../../utils/safeIDB', () => ({
+      getDb: () => null,
+    }));
+
+    const { ensureModuleCache, calculateRevision } = await import('../cache');
+    const revision = calculateRevision(sampleModules);
+    const result = await ensureModuleCache(sampleModules, revision);
+
+    expect(result.source).toBe('seed');
+    expect(result.modules).toEqual(sampleModules);
+  });
+});

--- a/apps/metasploit/__tests__/search.test.ts
+++ b/apps/metasploit/__tests__/search.test.ts
@@ -1,0 +1,64 @@
+import type { Module } from '../types';
+import { buildSearchIndex, computeFacets, filterModules } from '../search';
+
+const modules: Module[] = [
+  {
+    name: 'auxiliary/scanner/ftp/login',
+    description: 'FTP login scanner for Linux targets',
+    type: 'auxiliary',
+    severity: 'medium',
+    platform: 'linux',
+    tags: ['ftp', 'scanner'],
+  },
+  {
+    name: 'exploit/windows/smb/ms17_010',
+    description: 'MS17-010 EternalBlue exploit',
+    type: 'exploit',
+    severity: 'critical',
+    platform: 'windows',
+    tags: ['smb', 'windows'],
+  },
+  {
+    name: 'post/multi/gather/ssh_creds',
+    description: 'Harvests SSH credentials',
+    type: 'post',
+    severity: 'low',
+    platform: 'multi',
+    tags: ['ssh', 'creds'],
+  },
+];
+
+describe('metasploit search utilities', () => {
+  it('computes facet options from module metadata', () => {
+    const facets = computeFacets(modules);
+    expect(facets.types).toEqual(['auxiliary', 'exploit', 'post']);
+    expect(facets.platforms).toEqual(['linux', 'multi', 'windows']);
+    expect(facets.tags).toContain('ftp');
+    expect(facets.tags).toContain('smb');
+  });
+
+  it('filters modules using query and facet combinations', () => {
+    const index = buildSearchIndex(modules);
+    const filtered = filterModules(index, {
+      query: 'smb',
+      type: 'exploit',
+      platform: 'windows',
+      tag: 'smb',
+    });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].name).toBe('exploit/windows/smb/ms17_010');
+  });
+
+  it('returns modules when query matches description despite different casing', () => {
+    const index = buildSearchIndex(modules);
+    const filtered = filterModules(index, {
+      query: 'SSH CREDENTIALS',
+      type: 'post',
+      platform: 'multi',
+    });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].name).toBe('post/multi/gather/ssh_creds');
+  });
+});

--- a/apps/metasploit/cache.ts
+++ b/apps/metasploit/cache.ts
@@ -1,0 +1,71 @@
+import type { Module, ModuleCachePayload, ModuleSource } from './types';
+import { getDb } from '../../utils/safeIDB';
+
+const DB_NAME = 'metasploit-modules';
+const STORE_NAME = 'module-metadata';
+const CACHE_KEY = 'modules';
+
+type OpenDbResult = Awaited<ReturnType<typeof getDb>>;
+
+async function openModuleDb(): Promise<OpenDbResult> {
+  const dbPromise = getDb(DB_NAME, 1, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    },
+  });
+
+  return dbPromise ?? null;
+}
+
+export function calculateRevision(modules: Module[]): string {
+  let hash = 0;
+  for (const entry of modules) {
+    const data = `${entry.name}|${entry.type}|${entry.platform ?? ''}|${
+      entry.severity ?? ''
+    }|${(entry.tags ?? []).join(',')}|${entry.description}`;
+    for (let i = 0; i < data.length; i += 1) {
+      hash = (hash << 5) - hash + data.charCodeAt(i);
+      hash |= 0; // Convert to 32bit integer
+    }
+  }
+  return `v${hash >>> 0}`;
+}
+
+export async function readModuleCache(): Promise<ModuleCachePayload | null> {
+  const db = await openModuleDb();
+  if (!db) return null;
+  const payload = (await db.get(STORE_NAME, CACHE_KEY)) as ModuleCachePayload | undefined;
+  return payload ?? null;
+}
+
+export async function writeModuleCache(payload: ModuleCachePayload): Promise<boolean> {
+  const db = await openModuleDb();
+  if (!db) return false;
+  await db.put(STORE_NAME, payload, CACHE_KEY);
+  return true;
+}
+
+export async function clearModuleCache(): Promise<void> {
+  const db = await openModuleDb();
+  if (!db) return;
+  await db.delete(STORE_NAME, CACHE_KEY);
+}
+
+export async function ensureModuleCache(
+  seedModules: Module[],
+  revision: string,
+): Promise<{ modules: Module[]; source: ModuleSource }> {
+  try {
+    const cached = await readModuleCache();
+    if (cached && cached.revision === revision && cached.modules?.length) {
+      return { modules: cached.modules, source: 'cache' };
+    }
+
+    await writeModuleCache({ revision, modules: seedModules });
+    return { modules: seedModules, source: 'seed' };
+  } catch (error) {
+    return { modules: seedModules, source: 'seed' };
+  }
+}

--- a/apps/metasploit/search.ts
+++ b/apps/metasploit/search.ts
@@ -1,0 +1,73 @@
+import type { Module } from './types';
+
+export interface SearchIndexEntry {
+  module: Module;
+  haystack: string;
+}
+
+export interface SearchFilters {
+  query?: string;
+  tag?: string;
+  type?: string;
+  platform?: string;
+}
+
+export interface FacetOptions {
+  tags: string[];
+  types: string[];
+  platforms: string[];
+}
+
+export function buildSearchIndex(modules: Module[]): SearchIndexEntry[] {
+  return modules.map((module) => ({
+    module,
+    haystack: [
+      module.name,
+      module.description,
+      module.platform ?? '',
+      ...(module.tags ?? []),
+    ]
+      .join(' ')
+      .toLowerCase(),
+  }));
+}
+
+export function computeFacets(modules: Module[]): FacetOptions {
+  const tags = new Set<string>();
+  const types = new Set<string>();
+  const platforms = new Set<string>();
+
+  modules.forEach((module) => {
+    module.tags?.forEach((tag) => tags.add(tag));
+    if (module.type) types.add(module.type);
+    if (module.platform) platforms.add(module.platform);
+  });
+
+  const sort = (values: Set<string>) => Array.from(values).sort((a, b) => a.localeCompare(b));
+
+  return {
+    tags: sort(tags),
+    types: sort(types),
+    platforms: sort(platforms),
+  };
+}
+
+export function filterModules(
+  index: SearchIndexEntry[],
+  filters: SearchFilters,
+): Module[] {
+  const query = filters.query?.trim().toLowerCase() ?? '';
+  const tag = filters.tag ?? '';
+  const type = filters.type ?? '';
+  const platform = filters.platform ?? '';
+
+  return index
+    .filter(({ module, haystack }) => {
+      if (type && module.type !== type) return false;
+      if (platform && module.platform !== platform) return false;
+      if (tag && !(module.tags ?? []).includes(tag)) return false;
+      if (query && !haystack.includes(query)) return false;
+      return true;
+    })
+    .map(({ module }) => module);
+}

--- a/apps/metasploit/types.ts
+++ b/apps/metasploit/types.ts
@@ -1,0 +1,16 @@
+export interface Module {
+  name: string;
+  description: string;
+  type: string;
+  severity: string;
+  platform?: string;
+  tags?: string[];
+  [key: string]: unknown;
+}
+
+export type ModuleSource = 'cache' | 'seed';
+
+export interface ModuleCachePayload {
+  revision: string;
+  modules: Module[];
+}


### PR DESCRIPTION
## Summary
- cache Metasploit module metadata in IndexedDB with revision hashing to reuse data offline
- refactor the Metasploit app search to use cached data with platform/type facets and empty state messaging
- add unit tests covering cache hydration, offline fallback, and combined facet filtering helpers

## Testing
- yarn test --runTestsByPath apps/metasploit/__tests__/cache.test.ts apps/metasploit/__tests__/cacheFallback.test.ts apps/metasploit/__tests__/search.test.ts
- npx eslint apps/metasploit/index.tsx apps/metasploit/cache.ts apps/metasploit/search.ts apps/metasploit/types.ts


------
https://chatgpt.com/codex/tasks/task_e_68d9d33582548328801dbb0c657d08cb