### PR TITLE
[plugin-manager] Persist ordering and enable toggles

### DIFF
--- a/components/apps/plugin-manager/index.tsx
+++ b/components/apps/plugin-manager/index.tsx
@@ -1,7 +1,10 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-interface PluginInfo { id: string; file: string; }
+interface PluginInfo {
+  id: string;
+  file: string;
+}
 
 interface PluginManifest {
   id: string;
@@ -9,20 +12,68 @@ interface PluginManifest {
   code: string;
 }
 
+interface PluginManagerState {
+  manifests: Record<string, PluginManifest>;
+  order: string[];
+  enabled: Record<string, boolean>;
+}
+
+const STORAGE_KEY = 'pluginManagerConfig';
+
+const defaultState: PluginManagerState = {
+  manifests: {},
+  order: [],
+  enabled: {},
+};
+
+function loadState(): PluginManagerState {
+  if (typeof window === 'undefined') {
+    return defaultState;
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored) as Partial<PluginManagerState>;
+      const manifests = parsed.manifests ?? {};
+      const order = Array.isArray(parsed.order) ? parsed.order : Object.keys(manifests);
+      const enabled = parsed.enabled ?? {};
+      return {
+        manifests,
+        order: order.filter((id) => manifests[id]),
+        enabled,
+      };
+    }
+  } catch {
+    /* ignore malformed payloads */
+  }
+
+  // migrate legacy installedPlugins storage if present
+  try {
+    const legacy = JSON.parse(localStorage.getItem('installedPlugins') || '{}');
+    if (legacy && typeof legacy === 'object') {
+      const manifests = legacy as Record<string, PluginManifest>;
+      const order = Object.keys(manifests);
+      const enabled: Record<string, boolean> = {};
+      for (const id of order) {
+        enabled[id] = true;
+      }
+      const migratedState: PluginManagerState = { manifests, order, enabled };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(migratedState));
+      localStorage.removeItem('installedPlugins');
+      return migratedState;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  return defaultState;
+}
+
 export default function PluginManager() {
   const [plugins, setPlugins] = useState<PluginInfo[]>([]);
-  const [installed, setInstalled] = useState<Record<string, PluginManifest>>(
-    () => {
-      if (typeof window !== 'undefined') {
-        try {
-          return JSON.parse(localStorage.getItem('installedPlugins') || '{}');
-        } catch {
-          return {};
-        }
-      }
-      return {};
-    }
-  );
+  const [managerState, setManagerState] = useState<PluginManagerState>(loadState);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
 
   interface LastRun {
     id: string;
@@ -47,20 +98,40 @@ export default function PluginManager() {
       .catch(() => setPlugins([]));
   }, []);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(managerState));
+    } catch {
+      /* ignore write errors */
+    }
+  }, [managerState]);
+
   const install = async (plugin: PluginInfo) => {
     const res = await fetch(`/api/plugins/${plugin.file}`);
     const manifest: PluginManifest = await res.json();
-    const updated = { ...installed, [plugin.id]: manifest };
-    setInstalled(updated);
-    localStorage.setItem('installedPlugins', JSON.stringify(updated));
+    setManagerState((prev) => {
+      const manifests = { ...prev.manifests, [plugin.id]: manifest };
+      const order = prev.order.includes(plugin.id)
+        ? prev.order
+        : [...prev.order, plugin.id];
+      const enabled = {
+        ...prev.enabled,
+        [plugin.id]: prev.enabled[plugin.id] ?? true,
+      };
+      return { manifests, order, enabled };
+    });
   };
 
-  const run = (plugin: PluginInfo) => {
-    const manifest = installed[plugin.id];
+  const run = (pluginId: string) => {
+    const manifest = managerState.manifests[pluginId];
     if (!manifest) return;
+    if (managerState.enabled[pluginId] === false) return;
     const output: string[] = [];
     const finalize = () => {
-      const result = { id: plugin.id, output };
+      const result = { id: pluginId, output };
       setLastRun(result);
       try {
         localStorage.setItem('lastPluginRun', JSON.stringify(result));
@@ -120,31 +191,180 @@ export default function PluginManager() {
     URL.revokeObjectURL(url);
   };
 
+  const togglePlugin = (pluginId: string) => {
+    setManagerState((prev) => ({
+      manifests: prev.manifests,
+      order: prev.order,
+      enabled: {
+        ...prev.enabled,
+        [pluginId]: !(prev.enabled[pluginId] !== false),
+      },
+    }));
+  };
+
+  const installedOrder = useMemo(
+    () => managerState.order.filter((id) => managerState.manifests[id]),
+    [managerState]
+  );
+
+  const isDragging = Boolean(draggingId);
+
+  const handleDrop = (sourceId: string, targetId: string | null) => {
+    setManagerState((prev) => {
+      if (!sourceId || !prev.manifests[sourceId]) {
+        return prev;
+      }
+      if (targetId === sourceId) {
+        return prev;
+      }
+      const filtered = prev.order.filter((id) => id !== sourceId && prev.manifests[id]);
+      const nextOrder = [...filtered];
+      if (targetId && sourceId !== targetId) {
+        const index = nextOrder.indexOf(targetId);
+        if (index >= 0) {
+          nextOrder.splice(index, 0, sourceId);
+        } else {
+          nextOrder.push(sourceId);
+        }
+      } else {
+        nextOrder.push(sourceId);
+      }
+      if (
+        nextOrder.length === prev.order.length &&
+        nextOrder.every((id, idx) => id === prev.order[idx])
+      ) {
+        return prev;
+      }
+      return {
+        manifests: prev.manifests,
+        order: nextOrder,
+        enabled: prev.enabled,
+      };
+    });
+  };
+
   return (
     <div className="p-4 text-white">
       <h1 className="text-xl mb-4">Plugin Catalog</h1>
-      <ul>
-        {plugins.map((p) => (
-          <li key={p.id} className="flex items-center mb-2">
-            <span className="flex-grow">{p.id}</span>
-            <button
-              className="bg-ub-orange px-2 py-1 rounded disabled:opacity-50"
-              onClick={() => install(p)}
-              disabled={installed[p.id] !== undefined}
-            >
-              {installed[p.id] ? 'Installed' : 'Install'}
-            </button>
-            {installed[p.id] && (
-              <button
-                className="bg-ub-green text-black px-2 py-1 rounded ml-2"
-                onClick={() => run(p)}
-              >
-                Run
-              </button>
+      <div className="grid gap-6 md:grid-cols-2">
+        <section>
+          <h2 className="text-lg mb-2">Available Plugins</h2>
+          <ul>
+            {plugins.map((p) => {
+              const installedManifest = managerState.manifests[p.id];
+              const enabled = managerState.enabled[p.id] !== false;
+              return (
+                <li key={p.id} className="flex items-center mb-2" data-plugin-id={p.id}>
+                  <span className="flex-grow">{p.id}</span>
+                  <button
+                    className="bg-ub-orange px-2 py-1 rounded disabled:opacity-50"
+                    onClick={() => install(p)}
+                    disabled={Boolean(installedManifest)}
+                    data-testid={`install-${p.id}`}
+                    data-plugin-id={p.id}
+                  >
+                    {installedManifest ? 'Installed' : 'Install'}
+                  </button>
+                  {installedManifest && (
+                    <button
+                      className="bg-ub-green text-black px-2 py-1 rounded ml-2 disabled:opacity-50"
+                      onClick={() => run(p.id)}
+                      disabled={!enabled}
+                      data-testid={`run-${p.id}`}
+                    >
+                      Run
+                    </button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+        <section>
+          <h2 className="text-lg mb-2">Installed Plugins</h2>
+          <p className="text-xs text-gray-300 mb-2">
+            Drag items to change their order. Use the toggle to enable or disable plugins for the next launch.
+          </p>
+          <ul
+            className="space-y-2"
+            onDragOver={(event) => {
+              if (draggingId) {
+                event.preventDefault();
+              }
+            }}
+            onDrop={(event) => {
+              if (!draggingId) return;
+              event.preventDefault();
+              handleDrop(draggingId, null);
+              setDraggingId(null);
+            }}
+            data-testid="installed-list"
+          >
+            {installedOrder.map((pluginId) => {
+              const manifest = managerState.manifests[pluginId];
+              const enabled = managerState.enabled[pluginId] !== false;
+              return (
+                <li
+                  key={pluginId}
+                  className={`flex items-center rounded border border-gray-600 px-2 py-2 bg-black/40 ${
+                    isDragging ? 'transition-colors' : ''
+                  }`}
+                  draggable
+                  onDragStart={(event) => {
+                    event.dataTransfer.setData('text/plain', pluginId);
+                    event.dataTransfer.effectAllowed = 'move';
+                    setDraggingId(pluginId);
+                  }}
+                  onDragEnd={() => setDraggingId(null)}
+                  onDragOver={(event) => {
+                    if (draggingId && draggingId !== pluginId) {
+                      event.preventDefault();
+                    }
+                  }}
+                  onDrop={(event) => {
+                    const sourceId = event.dataTransfer.getData('text/plain') || draggingId;
+                    if (!sourceId) return;
+                    event.preventDefault();
+                    handleDrop(sourceId, pluginId);
+                    setDraggingId(null);
+                  }}
+                  data-plugin-id={pluginId}
+                  data-testid={`installed-plugin-${pluginId}`}
+                  aria-grabbed={draggingId === pluginId}
+                >
+                  <span className="cursor-move select-none text-gray-300" aria-hidden="true">
+                    ☰
+                  </span>
+                  <span className="flex-grow ml-2">{pluginId}</span>
+                  <label className="flex items-center gap-2 text-xs mr-3" htmlFor={`toggle-${pluginId}`}>
+                    <span>{enabled ? 'Enabled' : 'Disabled'}</span>
+                    <input
+                      id={`toggle-${pluginId}`}
+                      type="checkbox"
+                      className="h-4 w-4"
+                      checked={enabled}
+                      onChange={() => togglePlugin(pluginId)}
+                      data-testid={`toggle-${pluginId}`}
+                      aria-label={`Toggle ${pluginId}`}
+                    />
+                  </label>
+                  <button
+                    className="bg-ub-green text-black px-2 py-1 rounded disabled:opacity-50"
+                    onClick={() => run(pluginId)}
+                    disabled={!manifest || !enabled}
+                    data-testid={`installed-run-${pluginId}`}
+                  >
+                    Run
+                  </button>
+                </li>
+              );
+            })}
+            {installedOrder.length === 0 && (
+              <li className="text-sm text-gray-400">No plugins installed yet.</li>
             )}
-          </li>
-        ))}
-      </ul>
+          </ul>
+        </section>
+      </div>
       {lastRun && (
         <div className="mt-4">
           <h2 className="text-lg mb-2">Last Run: {lastRun.id}</h2>

--- a/plugins/catalog/alpha.json
+++ b/plugins/catalog/alpha.json
@@ -1,0 +1,5 @@
+{
+  "id": "alpha",
+  "sandbox": "worker",
+  "code": "self.postMessage('alpha ready');"
+}

--- a/plugins/catalog/bravo.json
+++ b/plugins/catalog/bravo.json
@@ -1,0 +1,5 @@
+{
+  "id": "bravo",
+  "sandbox": "worker",
+  "code": "self.postMessage('bravo ready');"
+}

--- a/tests/plugin-manager.spec.ts
+++ b/tests/plugin-manager.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect, Page } from '@playwright/test';
+import path from 'path';
+
+async function getInstalledOrder(page: Page): Promise<string[]> {
+  const ids = await page
+    .locator('[data-testid^="installed-plugin-"]')
+    .evaluateAll((items) => items.map((item) => item.getAttribute('data-plugin-id')));
+
+  return ids.filter((id): id is string => Boolean(id));
+}
+
+test('reorders and toggles persist across reloads and sessions', async ({ page }, testInfo) => {
+  await page.goto('/apps/plugin-manager');
+  await page.evaluate(() => {
+    localStorage.removeItem('pluginManagerConfig');
+    localStorage.removeItem('installedPlugins');
+    localStorage.removeItem('lastPluginRun');
+  });
+  await page.reload();
+
+  const installButtons = page.locator('[data-testid^="install-"]');
+  const availableIds = await installButtons.evaluateAll((elements) =>
+    elements
+      .map((element) => element.getAttribute('data-plugin-id'))
+      .filter((id): id is string => Boolean(id))
+  );
+
+  expect(availableIds.length).toBeGreaterThanOrEqual(2);
+  const [firstInstall, secondInstall] = availableIds.slice(0, 2);
+
+  for (const pluginId of [firstInstall, secondInstall]) {
+    const installButton = page.getByTestId(`install-${pluginId}`);
+    if (!(await installButton.isDisabled())) {
+      await installButton.click();
+    }
+    await expect(installButton).toBeDisabled();
+  }
+
+  const initialOrder = await getInstalledOrder(page);
+  expect(initialOrder).toEqual([firstInstall, secondInstall]);
+
+  await page.dragAndDrop(
+    `[data-testid="installed-plugin-${secondInstall}"]`,
+    `[data-testid="installed-plugin-${firstInstall}"]`
+  );
+
+  await expect.poll(() => getInstalledOrder(page)).toEqual([secondInstall, firstInstall]);
+
+  const orderAfterReorder = await getInstalledOrder(page);
+  const [disabledTarget] = orderAfterReorder;
+
+  await page.getByTestId(`toggle-${disabledTarget}`).click();
+  await expect(page.getByTestId(`toggle-${disabledTarget}`)).not.toBeChecked();
+  await expect(page.getByTestId(`installed-run-${disabledTarget}`)).toBeDisabled();
+  await expect(page.getByTestId(`run-${disabledTarget}`)).toBeDisabled();
+
+  await page.reload();
+
+  await expect.poll(() => getInstalledOrder(page)).toEqual(orderAfterReorder);
+  await expect(page.getByTestId(`toggle-${disabledTarget}`)).not.toBeChecked();
+  await expect(page.getByTestId(`installed-run-${disabledTarget}`)).toBeDisabled();
+
+  const storagePath = path.join(testInfo.outputPath(), 'plugin-manager-state.json');
+  await page.context().storageState({ path: storagePath });
+
+  const browser = page.context().browser();
+  if (!browser) {
+    throw new Error('Browser instance not available');
+  }
+
+  const baseURL = testInfo.project.use.baseURL as string | undefined;
+  const newContext = await browser.newContext({
+    storageState: storagePath,
+    baseURL,
+  });
+
+  const newPage = await newContext.newPage();
+  await newPage.goto('/apps/plugin-manager');
+
+  await expect.poll(() => getInstalledOrder(newPage)).toEqual(orderAfterReorder);
+  await expect(newPage.getByTestId(`toggle-${disabledTarget}`)).not.toBeChecked();
+  await expect(newPage.getByTestId(`installed-run-${disabledTarget}`)).toBeDisabled();
+
+  await newContext.close();
+});


### PR DESCRIPTION
## Summary
- add persistent drag-and-drop ordering and enable toggles to the plugin manager UI
- seed the catalog with additional demo plugins for multi-item ordering
- cover reorder/toggle persistence with a Playwright integration test

## Testing
- npx eslint components/apps/plugin-manager/index.tsx tests/plugin-manager.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9d33c5a248328b0ced2c69e65ad2e