### PR TITLE
[volatility] Add header profile detection heuristics

### DIFF
--- a/__tests__/volatilityApp.test.tsx
+++ b/__tests__/volatilityApp.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import VolatilityApp from '../components/apps/volatility';
 
 describe('VolatilityApp demo', () => {
@@ -17,5 +17,27 @@ describe('VolatilityApp demo', () => {
 
     const heuristic = screen.getByText('suspicious');
     expect(heuristic).toHaveClass('bg-yellow-600');
+  });
+
+  test('inspects uploaded sample and surfaces profile insights', async () => {
+    render(<VolatilityApp />);
+
+    const sampleInput = screen.getByLabelText(/upload memory sample/i);
+    const file = new File(
+      [
+        'VolatilityHeader\nBuild: 19041\nMajorVersion: 10\nMachine: AMD64\nntoskrnl.exe\n',
+      ],
+      'win10.raw',
+      { type: 'application/octet-stream' }
+    );
+
+    fireEvent.change(sampleInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Windows 10 x64/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Confidence:/i)).toBeInTheDocument();
+    expect(screen.getByText(/500 ms target/i)).toBeInTheDocument();
   });
 });

--- a/__tests__/volatilityProfileDetection.test.ts
+++ b/__tests__/volatilityProfileDetection.test.ts
@@ -1,0 +1,36 @@
+import { inspectHeader } from '../components/apps/volatility/profileDetection';
+
+const encoder = new TextEncoder();
+
+describe('inspectHeader heuristics', () => {
+  const buildBuffer = (content: string) => encoder.encode(content);
+
+  test('detects Windows 10 profile with high confidence', () => {
+    const header = `VolatilityHeader\nBuild: 19041\nMajorVersion: 10\nMachine: AMD64\nntoskrnl.exe`;
+    const result = inspectHeader(buildBuffer(header));
+
+    expect(result.profile?.slug).toBe('Win10x64_19041');
+    expect(result.confidence.level).toBe('high');
+    expect(result.confidence.score).toBeGreaterThanOrEqual(0.75);
+    expect(result.note).toMatch(/19041/);
+  });
+
+  test('detects Linux Ubuntu sample', () => {
+    const header = `ELF\nLinux version 5.8.0-53-generic (buildd@lcy01) (Ubuntu 5.8.0)\nCPU: x86_64`;
+    const result = inspectHeader(buildBuffer(header));
+
+    expect(result.profile?.slug).toBe('LinuxUbuntu2004x64');
+    expect(result.confidence.level).toBe('high');
+    expect(result.family).toBe('linux');
+  });
+
+  test('falls back to suggestions when signature is ambiguous', () => {
+    const header = `Captured from Windows host\nMachine: x86\nKernel artifacts present`;
+    const result = inspectHeader(buildBuffer(header));
+
+    expect(result.profile).toBeNull();
+    expect(result.confidence.level).toBe('none');
+    expect(result.suggestions.length).toBeGreaterThan(0);
+    expect(result.note).toMatch(/Windows artefacts/i);
+  });
+});

--- a/components/apps/volatility/profileDetection.js
+++ b/components/apps/volatility/profileDetection.js
@@ -1,0 +1,252 @@
+const MAX_BYTES = 8192;
+
+const PROFILE_SIGNATURES = [
+  {
+    slug: 'Win10x64_19041',
+    label: 'Windows 10 x64 (19041)',
+    patterns: [
+      /Build\s*:?\s*19041/i,
+      /MajorVersion\s*:?\s*10/i,
+      /(Machine|Architecture)\s*:?\s*(AMD64|x64)/i,
+      /ntoskrnl\.exe/i,
+    ],
+    rationale:
+      'Win10 20H1 captures often include build 19041 along with ntoskrnl and AMD64 architecture markers.',
+  },
+  {
+    slug: 'Win7SP1x64',
+    label: 'Windows 7 SP1 x64',
+    patterns: [
+      /Build\s*:?\s*7601/i,
+      /MajorVersion\s*:?\s*6/i,
+      /MinorVersion\s*:?\s*1/i,
+      /(Machine|Architecture)\s*:?\s*(AMD64|x64)/i,
+    ],
+    rationale:
+      'Windows 7 SP1 x64 dumps surface build 7601 and a 6.1 kernel version.',
+  },
+  {
+    slug: 'Win7SP1x86',
+    label: 'Windows 7 SP1 x86',
+    patterns: [
+      /Build\s*:?\s*7601/i,
+      /MajorVersion\s*:?\s*6/i,
+      /MinorVersion\s*:?\s*1/i,
+      /(Machine|Architecture)\s*:?\s*(i386|x86)/i,
+    ],
+    rationale:
+      'Windows 7 SP1 32-bit captures highlight build 7601 with an i386 machine flag.',
+  },
+  {
+    slug: 'WinXPSP3x86',
+    label: 'Windows XP SP3 x86',
+    patterns: [
+      /Build\s*:?\s*2600/i,
+      /MajorVersion\s*:?\s*5/i,
+      /MinorVersion\s*:?\s*1/i,
+      /(Machine|Architecture)\s*:?\s*(i386|x86)/i,
+    ],
+    rationale:
+      'Windows XP SP3 headers still reference build 2600 with a 5.1 kernel.',
+  },
+  {
+    slug: 'LinuxUbuntu2004x64',
+    label: 'Linux Ubuntu 20.04 x64',
+    patterns: [
+      /Linux version\s*5\.[4-8]/i,
+      /(Ubuntu|Focal Fossa)/i,
+      /(x86_64|amd64)/i,
+    ],
+    rationale:
+      'Ubuntu 20.04 kernels identify as 5.4+ with Ubuntu or Focal strings and x86_64 architecture.',
+  },
+  {
+    slug: 'LinuxDebianx86',
+    label: 'Linux Debian x86',
+    patterns: [
+      /Linux version\s*3\./i,
+      /Debian/i,
+      /(i386|i686)/i,
+    ],
+    rationale:
+      'Debian forensic memory captures from 32-bit kernels expose Debian branding and i386 hints.',
+  },
+  {
+    slug: 'MacOS10_15',
+    label: 'macOS Catalina 10.15',
+    patterns: [
+      /Darwin Kernel Version\s*19/i,
+      /RELEASE_X86_64/i,
+      /Mac OS X 10\.15/i,
+    ],
+    rationale:
+      'macOS Catalina dumps typically embed Darwin Kernel Version 19 with RELEASE_X86_64 markers.',
+  },
+];
+
+const FAMILY_HINTS = [
+  {
+    family: 'windows',
+    patterns: [/windows/i, /ntoskrnl/i, /kdbgcontrolset/i],
+    suggestions: ['Win10x64_19041', 'Win7SP1x64', 'Win7SP1x86', 'WinXPSP3x86'],
+    note:
+      'General Windows artefacts were observed but no exact profile matched. Try common Windows profiles.',
+  },
+  {
+    family: 'linux',
+    patterns: [/linux/i, /ELF/i, /gnu/i],
+    suggestions: ['LinuxUbuntu2004x64', 'LinuxDebianx86'],
+    note:
+      'Linux kernel artefacts detected. Provide the kernel version closest to your capture.',
+  },
+  {
+    family: 'macos',
+    patterns: [/darwin/i, /mac os/i],
+    suggestions: ['MacOS10_15'],
+    note:
+      'Darwin headers found without a clear version signature. Consider popular macOS profiles.',
+  },
+];
+
+const toUniqueBySlug = (items) => {
+  const seen = new Set();
+  return items.filter((item) => {
+    if (seen.has(item.slug)) return false;
+    seen.add(item.slug);
+    return true;
+  });
+};
+
+const normalizeScore = (score) => Number(score.toFixed(2));
+
+const confidenceLevel = (score) => {
+  if (score >= 0.8) return 'high';
+  if (score >= 0.5) return 'medium';
+  if (score > 0) return 'low';
+  return 'none';
+};
+
+const toBytes = (input) => {
+  if (!input) {
+    throw new Error('Sample is empty.');
+  }
+  if (typeof input === 'string') {
+    return new TextEncoder().encode(input);
+  }
+  if (input instanceof ArrayBuffer) {
+    return new Uint8Array(input);
+  }
+  if (ArrayBuffer.isView(input)) {
+    return new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+  }
+  throw new Error('Unsupported sample type.');
+};
+
+const decodeHeader = (bytes) => {
+  const limited = bytes.subarray(0, Math.min(bytes.length, MAX_BYTES));
+  let text = '';
+  if (typeof TextDecoder !== 'undefined') {
+    const decoder = new TextDecoder('utf-8', { fatal: false });
+    text = decoder.decode(limited);
+  } else {
+    text = Array.from(limited)
+      .map((b) => (b >= 32 && b <= 126 ? String.fromCharCode(b) : ' '))
+      .join('');
+  }
+  return text.replace(/\u0000/g, ' ').trim();
+};
+
+export const inspectHeader = (input) => {
+  const bytes = toBytes(input);
+  const headerText = decodeHeader(bytes);
+
+  const matches = PROFILE_SIGNATURES.map((signature) => {
+    const matchCount = signature.patterns.reduce(
+      (count, pattern) => count + (pattern.test(headerText) ? 1 : 0),
+      0
+    );
+    const score = matchCount / signature.patterns.length;
+    return {
+      slug: signature.slug,
+      label: signature.label,
+      matchCount,
+      total: signature.patterns.length,
+      score,
+      rationale: signature.rationale,
+    };
+  }).filter((entry) => entry.matchCount > 1);
+
+  matches.sort((a, b) => b.score - a.score || b.matchCount - a.matchCount);
+
+  const bestMatch = matches[0] ?? null;
+  const baseScore = bestMatch ? normalizeScore(bestMatch.score) : 0;
+  const level = confidenceLevel(baseScore);
+
+  const ambiguousMatches = bestMatch
+    ? matches
+        .filter((entry) => entry.slug !== bestMatch.slug && entry.score >= bestMatch.score - 0.15)
+        .map((entry) => ({
+          slug: entry.slug,
+          label: entry.label,
+          confidence: normalizeScore(entry.score),
+          rationale: entry.rationale,
+        }))
+    : [];
+
+  const familyHint = FAMILY_HINTS.find((family) =>
+    family.patterns.some((pattern) => pattern.test(headerText))
+  );
+
+  let suggestions = ambiguousMatches;
+  let note = '';
+
+  if (bestMatch) {
+    note = bestMatch.rationale;
+    if (level === 'low') {
+      note += ' Confidence is low; verify with another plugin output.';
+    }
+  }
+
+  if (familyHint) {
+    if (!bestMatch) {
+      note = familyHint.note;
+    }
+    if (!bestMatch || level !== 'high') {
+      const familySuggestions = PROFILE_SIGNATURES.filter((signature) =>
+        familyHint.suggestions.includes(signature.slug)
+      ).map((signature) => ({
+        slug: signature.slug,
+        label: signature.label,
+        confidence: 0.3,
+        rationale: signature.rationale,
+      }));
+      suggestions = suggestions.concat(familySuggestions);
+    }
+  }
+
+  if (!bestMatch && !familyHint) {
+    note =
+      'No recognizable header markers were detected. You may need to select a profile manually based on the acquisition source.';
+  }
+
+  suggestions = toUniqueBySlug(suggestions);
+
+  return {
+    headerText,
+    profile: bestMatch
+      ? {
+          slug: bestMatch.slug,
+          label: bestMatch.label,
+        }
+      : null,
+    confidence: {
+      level,
+      score: normalizeScore(baseScore),
+    },
+    suggestions,
+    note,
+    family: familyHint ? familyHint.family : null,
+  };
+};
+
+export default inspectHeader;


### PR DESCRIPTION
## Summary
- add a reusable header inspection module that scores common Volatility profiles and fallback families
- surface the inferred profile, confidence, runtime, and alternative suggestions in the Volatility UI
- cover header heuristics and the new upload flow with targeted unit tests

## Testing
- yarn test --watch=false volatility
- yarn lint *(fails: repository has pre-existing accessibility and window globals lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d33deeb483289103db7fce3641af