### PR TITLE
[hashcat] Run benchmarks inside a worker with gated presets

### DIFF
--- a/apps/hashcat/__tests__/benchmark.worker.test.tsx
+++ b/apps/hashcat/__tests__/benchmark.worker.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+import Hashcat from '../index';
+import type { BenchmarkWorkerOutgoingMessage } from '../worker-types';
+
+class MockWorker {
+  public onmessage: ((event: MessageEvent<BenchmarkWorkerOutgoingMessage>) => void) | null = null;
+
+  public postMessage = jest.fn();
+
+  public terminate = jest.fn();
+
+  public addEventListener = jest.fn();
+
+  public removeEventListener = jest.fn();
+
+  emit(message: BenchmarkWorkerOutgoingMessage) {
+    this.onmessage?.({ data: message } as MessageEvent<BenchmarkWorkerOutgoingMessage>);
+  }
+}
+
+describe('Hashcat benchmark worker integration', () => {
+  let originalWorker: typeof Worker | undefined;
+  let mockWorkerInstance: MockWorker;
+  let workerConstructor: jest.Mock;
+
+  beforeEach(() => {
+    originalWorker = global.Worker;
+    workerConstructor = jest.fn(() => {
+      mockWorkerInstance = new MockWorker();
+      return mockWorkerInstance as unknown as Worker;
+    });
+    (global as unknown as { Worker: typeof Worker }).Worker = workerConstructor as unknown as typeof Worker;
+  });
+
+  afterEach(() => {
+    (global as unknown as { Worker?: typeof Worker }).Worker = originalWorker as typeof Worker;
+    jest.resetAllMocks();
+  });
+
+  it('starts a benchmark and reacts to worker progress while keeping UI interactive', async () => {
+    const { getByText, getByPlaceholderText } = render(<Hashcat />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(getByText('Start Benchmark'));
+
+    expect(workerConstructor).toHaveBeenCalledTimes(1);
+    expect(mockWorkerInstance.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'start',
+        payload: expect.objectContaining({ scenario: expect.any(String) }),
+      }),
+    );
+
+    act(() => {
+      mockWorkerInstance.emit({
+        type: 'progress',
+        progress: 42,
+        eta: '00:30',
+        speed: 2400,
+        recovered: 0,
+        log: 'GPU0 applying best64 ruleset',
+        scenario: 'Quick audit',
+      });
+    });
+
+    expect(getByText('ETA: 00:30')).toBeInTheDocument();
+
+    const dictInput = getByPlaceholderText('rockyou.txt') as HTMLInputElement;
+    fireEvent.change(dictInput, { target: { value: 'demo.txt' } });
+    expect(dictInput.value).toBe('demo.txt');
+  });
+
+  it('sends stop to the worker and updates the summary', async () => {
+    const { getByText, getByTestId } = render(<Hashcat />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(getByText('Start Benchmark'));
+    fireEvent.click(getByText('Stop Benchmark'));
+
+    expect(mockWorkerInstance.postMessage).toHaveBeenLastCalledWith({ type: 'stop' });
+    expect(getByTestId('benchmark-summary').textContent).toMatch(/Stop requested/);
+  });
+
+  it('terminates the worker on unmount', async () => {
+    const { unmount } = render(<Hashcat />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockWorkerInstance.terminate).not.toHaveBeenCalled();
+    unmount();
+    expect(mockWorkerInstance.terminate).toHaveBeenCalled();
+  });
+});

--- a/apps/hashcat/worker-types.ts
+++ b/apps/hashcat/worker-types.ts
@@ -1,0 +1,43 @@
+export interface BenchmarkPresetConfig {
+  key: string;
+  label: string;
+  description: string;
+  durationMs: number;
+  steps: number;
+  speedRange: [number, number];
+  recoveredHashes: number;
+  sampleLogs: string[];
+  scenario: string;
+  heavy?: boolean;
+}
+
+export interface BenchmarkStartPayload {
+  scenario: string;
+  durationMs: number;
+  steps: number;
+  speedRange: [number, number];
+  recoveredHashes: number;
+  sampleLogs: string[];
+}
+
+export type BenchmarkWorkerIncomingMessage =
+  | { type: 'start'; payload: BenchmarkStartPayload }
+  | { type: 'stop' };
+
+export type BenchmarkWorkerOutgoingMessage =
+  | {
+      type: 'progress';
+      progress: number;
+      eta: string;
+      speed: number;
+      recovered: number;
+      log: string;
+      scenario: string;
+    }
+  | {
+      type: 'complete';
+      recovered: number;
+      summary: string;
+      scenario: string;
+    }
+  | { type: 'stopped'; scenario: string };

--- a/workers/hashcatBenchmark.worker.ts
+++ b/workers/hashcatBenchmark.worker.ts
@@ -1,0 +1,102 @@
+import type {
+  BenchmarkStartPayload,
+  BenchmarkWorkerIncomingMessage,
+  BenchmarkWorkerOutgoingMessage,
+} from '../apps/hashcat/worker-types';
+
+const ctx: DedicatedWorkerGlobalScope = self as unknown as DedicatedWorkerGlobalScope;
+
+let timer: ReturnType<typeof setInterval> | null = null;
+let activeScenario = 'benchmark';
+let peakSpeed = 0;
+
+const clearTimer = () => {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+};
+
+const formatEta = (ms: number) => {
+  const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = (totalSeconds % 60).toString().padStart(2, '0');
+  return `${minutes}:${seconds}`;
+};
+
+const send = (message: BenchmarkWorkerOutgoingMessage) => {
+  ctx.postMessage(message);
+};
+
+const handleStop = () => {
+  const scenario = activeScenario;
+  clearTimer();
+  send({ type: 'stopped', scenario });
+};
+
+const startBenchmark = (config: BenchmarkStartPayload) => {
+  clearTimer();
+  activeScenario = config.scenario;
+  peakSpeed = 0;
+
+  const startTime = Date.now();
+  const stepSize = 100 / Math.max(config.steps, 1);
+  const interval = Math.max(Math.floor(config.durationMs / Math.max(config.steps, 1)), 200);
+  let progress = 0;
+  let step = 0;
+
+  timer = setInterval(() => {
+    step += 1;
+    progress = Math.min(100, progress + stepSize);
+    const elapsed = Date.now() - startTime;
+    const remaining = Math.max(config.durationMs - elapsed, 0);
+    const speedRange = config.speedRange;
+    const speed = Math.round(
+      speedRange[0] + Math.random() * (speedRange[1] - speedRange[0])
+    );
+    peakSpeed = Math.max(peakSpeed, speed);
+
+    const recovered = Math.min(
+      config.recoveredHashes,
+      Math.round((config.recoveredHashes * progress) / 100),
+    );
+
+    const logIndex = step % config.sampleLogs.length;
+    const log = config.sampleLogs[logIndex] || `Processing chunk ${step}`;
+
+    send({
+      type: 'progress',
+      progress,
+      eta: formatEta(remaining),
+      speed,
+      recovered,
+      log,
+      scenario: config.scenario,
+    });
+
+    if (progress >= 100) {
+      clearTimer();
+      send({
+        type: 'complete',
+        recovered: config.recoveredHashes,
+        summary: `Completed ${config.scenario} preset — peak ${peakSpeed} MH/s`,
+        scenario: config.scenario,
+      });
+    }
+  }, interval);
+};
+
+ctx.onmessage = ({ data }: MessageEvent<BenchmarkWorkerIncomingMessage>) => {
+  if (data.type === 'start') {
+    startBenchmark(data.payload);
+    return;
+  }
+
+  if (data.type === 'stop') {
+    handleStop();
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- move the hashcat benchmark simulation into a dedicated Web Worker and stream updates via postMessage
- add gated benchmark presets and UI controls to keep heavy simulations opt-in and show live status
- cover the worker lifecycle with React Testing Library tests

## Testing
- [ ] yarn lint *(fails with existing accessibility violations unrelated to this change)*
- [ ] yarn test --watch=false --runInBand *(fails because of pre-existing YouTube app tests; new worker tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d3417c648328bcc5aa515c709d2d