### PR TITLE
[evidence-vault] async checksum verifier

### DIFF
--- a/__tests__/evidenceVaultVerifier.test.ts
+++ b/__tests__/evidenceVaultVerifier.test.ts
@@ -1,0 +1,97 @@
+import { webcrypto } from 'crypto';
+import { TextEncoder } from 'util';
+
+import {
+  EvidenceFileMetadata,
+  computeChecksum,
+  normalizeChecksum,
+  verifyEvidenceFiles,
+} from '../apps/evidence-vault/utils/checksums';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var crypto: Crypto;
+}
+
+beforeAll(() => {
+  if (!globalThis.crypto?.subtle) {
+    globalThis.crypto = webcrypto as unknown as Crypto;
+  }
+});
+
+const encoder = new TextEncoder();
+
+const cloneBuffer = (input: Uint8Array) =>
+  input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength);
+
+describe('verifyEvidenceFiles', () => {
+  it('processes 1k evidence records accurately without blocking', async () => {
+    const files: EvidenceFileMetadata[] = [];
+    for (let i = 0; i < 1000; i += 1) {
+      const payload = encoder.encode(`file-${i}`);
+      const buffer = cloneBuffer(payload);
+      const expectedChecksum = await computeChecksum(buffer, 'SHA-256');
+      files.push({
+        id: `file-${i}`,
+        name: `file-${i}.txt`,
+        expectedChecksum,
+        buffer,
+        algorithm: 'SHA-256',
+      });
+    }
+
+    const onProgress = jest.fn();
+    const { summary, results } = await verifyEvidenceFiles(files, {
+      batchSize: 64,
+      batchDelayMs: 0,
+      onProgress,
+    });
+
+    expect(onProgress).toHaveBeenCalledTimes(1000);
+    expect(summary.match).toBe(1000);
+    expect(summary.mismatch).toBe(0);
+    expect(summary.error).toBe(0);
+    expect(summary.skipped).toBe(0);
+    expect(results[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('flags mismatched checksums and preserves formatting', async () => {
+    const payload = encoder.encode('evidence-blob');
+    const buffer = cloneBuffer(payload);
+    const expectedChecksum = await computeChecksum(buffer, 'SHA-256');
+
+    const sanitized = normalizeChecksum(expectedChecksum);
+    const mismatched = (sanitized[0] === '0' ? '1' : '0') + sanitized.slice(1);
+    const formattedMismatch = `${mismatched.slice(0, 10)} ${mismatched.slice(10)}`;
+
+    const files: EvidenceFileMetadata[] = [
+      {
+        id: 'expected-match',
+        name: 'match.bin',
+        expectedChecksum,
+        buffer,
+        algorithm: 'SHA-256',
+      },
+      {
+        id: 'expected-mismatch',
+        name: 'mismatch.bin',
+        expectedChecksum: formattedMismatch,
+        buffer,
+        algorithm: 'SHA-256',
+      },
+    ];
+
+    const { summary, results } = await verifyEvidenceFiles(files, {
+      batchSize: 2,
+      batchDelayMs: 0,
+    });
+
+    expect(summary.match).toBe(1);
+    expect(summary.mismatch).toBe(1);
+    const mismatchResult = results.find((r) => r.id === 'expected-mismatch');
+    expect(mismatchResult?.status).toBe('mismatch');
+    expect(mismatchResult?.expectedChecksum).toBe(formattedMismatch);
+    expect(normalizeChecksum(mismatchResult?.expectedChecksum || '')).toBe(mismatched);
+  });
+});
+

--- a/apps/evidence-vault/components/Verifier.tsx
+++ b/apps/evidence-vault/components/Verifier.tsx
@@ -1,0 +1,288 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  EvidenceFileMetadata,
+  VerificationProgress,
+  VerificationStatus,
+  verifyEvidenceFiles,
+} from '../utils/checksums';
+
+type FileState = VerificationStatus | 'pending' | 'verifying';
+
+interface FileStatusEntry {
+  id: string;
+  name: string;
+  expectedChecksum: string;
+  status: FileState;
+  actualChecksum?: string;
+  durationMs?: number;
+  message?: string;
+}
+
+interface VerifierProps {
+  files: EvidenceFileMetadata[];
+  batchSize?: number;
+}
+
+const statusStyles: Record<FileState, { label: string; className: string }> = {
+  pending: { label: 'Pending', className: 'bg-gray-700 text-gray-100' },
+  verifying: { label: 'Verifying', className: 'bg-blue-500 text-white' },
+  match: { label: 'Verified', className: 'bg-green-600 text-white' },
+  mismatch: { label: 'Mismatch', className: 'bg-yellow-500 text-gray-900' },
+  error: { label: 'Error', className: 'bg-red-600 text-white' },
+  skipped: { label: 'Skipped', className: 'bg-gray-500 text-gray-100' },
+};
+
+const createInitialMap = (files: EvidenceFileMetadata[]): Record<string, FileStatusEntry> => {
+  const map: Record<string, FileStatusEntry> = {};
+  files.forEach((file) => {
+    map[file.id] = {
+      id: file.id,
+      name: file.name,
+      expectedChecksum: file.expectedChecksum,
+      status: 'pending',
+    };
+  });
+  return map;
+};
+
+const roundDuration = (value?: number) => {
+  if (typeof value !== 'number') {
+    return undefined;
+  }
+  if (value < 1) {
+    return '<1';
+  }
+  return value.toFixed(0);
+};
+
+const Verifier: React.FC<VerifierProps> = ({ files, batchSize }) => {
+  const [statuses, setStatuses] = useState<Record<string, FileStatusEntry>>(() =>
+    createInitialMap(files),
+  );
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<{ processed: number; total: number }>(
+    () => ({ processed: 0, total: files.length }),
+  );
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    setStatuses((prev) => {
+      const next = createInitialMap(files);
+      Object.keys(next).forEach((id) => {
+        if (prev[id]) {
+          next[id] = { ...next[id], ...prev[id], status: prev[id].status };
+        }
+      });
+      return next;
+    });
+    setProgress((prev) => ({ processed: Math.min(prev.processed, files.length), total: files.length }));
+  }, [files]);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const updateStatus = useCallback((id: string, patch: Partial<FileStatusEntry>) => {
+    setStatuses((prev) => {
+      const current = prev[id];
+      if (!current) {
+        return prev;
+      }
+      return {
+        ...prev,
+        [id]: { ...current, ...patch },
+      };
+    });
+  }, []);
+
+  const handleFileStart = useCallback((fileId: string) => {
+    updateStatus(fileId, { status: 'verifying', actualChecksum: undefined, durationMs: undefined, message: undefined });
+  }, [updateStatus]);
+
+  const handleProgress = useCallback(
+    ({ processed, total, result }: VerificationProgress) => {
+      setProgress({ processed, total });
+      const patch: Partial<FileStatusEntry> = {
+        status: result.status,
+        actualChecksum: result.actualChecksum,
+        durationMs: result.durationMs,
+        message: result.message,
+      };
+      updateStatus(result.id, patch);
+    },
+    [updateStatus],
+  );
+
+  const runVerification = useCallback(async () => {
+    if (files.length === 0) {
+      return;
+    }
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setIsRunning(true);
+    setError(null);
+    setProgress({ processed: 0, total: files.length });
+    setStatuses((prev) => {
+      const next = { ...prev };
+      files.forEach((file) => {
+        const current = next[file.id];
+        if (current) {
+          next[file.id] = {
+            ...current,
+            status: 'pending',
+            actualChecksum: undefined,
+            durationMs: undefined,
+            message: undefined,
+          };
+        }
+      });
+      return next;
+    });
+
+    try {
+      await verifyEvidenceFiles(files, {
+        batchSize,
+        signal: controller.signal,
+        onFileStart: (file) => handleFileStart(file.id),
+        onProgress: handleProgress,
+      });
+    } catch (err) {
+      if ((err as DOMException)?.name !== 'AbortError') {
+        setError(err instanceof Error ? err.message : 'Verification failed');
+      }
+    } finally {
+      setIsRunning(false);
+      abortRef.current = null;
+    }
+  }, [batchSize, files, handleFileStart, handleProgress]);
+
+  const cancelVerification = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setIsRunning(false);
+  }, []);
+
+  const summary = useMemo(() => {
+    const counts: Record<FileState, number> = {
+      pending: 0,
+      verifying: 0,
+      match: 0,
+      mismatch: 0,
+      error: 0,
+      skipped: 0,
+    };
+    Object.values(statuses).forEach((entry) => {
+      counts[entry.status] += 1;
+    });
+    return counts;
+  }, [statuses]);
+
+  const progressPercent = useMemo(() => {
+    if (progress.total === 0) {
+      return 0;
+    }
+    return Math.round((progress.processed / progress.total) * 100);
+  }, [progress]);
+
+  const orderedFiles = useMemo(
+    () =>
+      files
+        .map((file) => statuses[file.id])
+        .filter((entry): entry is FileStatusEntry => Boolean(entry)),
+    [files, statuses],
+  );
+
+  return (
+    <div className="bg-gray-900 text-white p-4 space-y-4 rounded-lg border border-gray-800">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Checksum Verifier</h2>
+          <p className="text-sm text-gray-400">
+            Validate evidence integrity without blocking the interface. Files are processed in
+            batches and progress updates appear instantly.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className="px-3 py-1 rounded bg-blue-600 disabled:bg-blue-900 disabled:cursor-not-allowed"
+            onClick={runVerification}
+            disabled={isRunning || files.length === 0}
+          >
+            {isRunning ? 'Verifying…' : 'Start Verification'}
+          </button>
+          <button
+            type="button"
+            className="px-3 py-1 rounded bg-gray-700 disabled:bg-gray-800 disabled:cursor-not-allowed"
+            onClick={cancelVerification}
+            disabled={!isRunning}
+          >
+            Cancel
+          </button>
+        </div>
+      </header>
+
+      <section className="space-y-2">
+        <div className="h-2 bg-gray-800 rounded">
+          <div
+            className="h-2 rounded bg-green-500 transition-all duration-200"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+        <div className="text-sm text-gray-300 flex justify-between">
+          <span>
+            {progress.processed}/{progress.total} processed ({progressPercent}% complete)
+          </span>
+          <span>
+            {summary.match} verified • {summary.mismatch} mismatched • {summary.error} errors •{' '}
+            {summary.skipped} skipped
+          </span>
+        </div>
+      </section>
+
+      {error && <div className="text-sm text-red-400">{error}</div>}
+
+      <section>
+        <h3 className="text-md font-medium mb-2">File status</h3>
+        <div className="max-h-72 overflow-auto divide-y divide-gray-800 border border-gray-800 rounded">
+          {orderedFiles.map((entry) => (
+            <article key={entry.id} className="p-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <p className="font-medium text-sm">{entry.name}</p>
+                <p className="text-xs text-gray-400 break-all">
+                  Expected: <span className="font-mono">{entry.expectedChecksum}</span>
+                </p>
+                {entry.actualChecksum && (
+                  <p className="text-xs text-gray-400 break-all">
+                    Actual: <span className="font-mono">{entry.actualChecksum}</span>
+                  </p>
+                )}
+                {entry.message && (
+                  <p className="text-xs text-red-400">{entry.message}</p>
+                )}
+              </div>
+              <div className="flex flex-col items-start sm:items-end gap-1 min-w-[120px]">
+                <span className={`px-2 py-1 rounded-full text-xs font-semibold ${statusStyles[entry.status].className}`}>
+                  {statusStyles[entry.status].label}
+                </span>
+                {typeof entry.durationMs === 'number' && (
+                  <span className="text-[0.65rem] text-gray-400">
+                    {roundDuration(entry.durationMs)} ms
+                  </span>
+                )}
+              </div>
+            </article>
+          ))}
+          {orderedFiles.length === 0 && (
+            <div className="p-4 text-sm text-gray-400">No files queued for verification.</div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default Verifier;
+

--- a/apps/evidence-vault/utils/checksums.ts
+++ b/apps/evidence-vault/utils/checksums.ts
@@ -1,0 +1,227 @@
+export type SupportedAlgorithm = 'SHA-256' | 'SHA-1' | 'SHA-384' | 'SHA-512';
+
+export interface EvidenceFileMetadata {
+  id: string;
+  name: string;
+  expectedChecksum: string;
+  algorithm?: SupportedAlgorithm;
+  size?: number;
+  /** Optional in-memory buffer for the evidence item. */
+  buffer?: ArrayBuffer;
+  /** Optional blob or file reference provided by the user. */
+  file?: File | Blob;
+  /** Optional URL to fetch the evidence content from. */
+  source?: string;
+}
+
+export type VerificationStatus = 'match' | 'mismatch' | 'error' | 'skipped';
+
+export interface FileVerificationResult {
+  id: string;
+  status: VerificationStatus;
+  expectedChecksum: string;
+  actualChecksum?: string;
+  durationMs: number;
+  message?: string;
+}
+
+export interface VerificationSummary {
+  match: number;
+  mismatch: number;
+  error: number;
+  skipped: number;
+}
+
+export interface VerificationProgress {
+  processed: number;
+  total: number;
+  result: FileVerificationResult;
+}
+
+export interface VerifyEvidenceOptions {
+  batchSize?: number;
+  batchDelayMs?: number;
+  signal?: AbortSignal;
+  onFileStart?: (file: EvidenceFileMetadata, index: number) => void;
+  onProgress?: (progress: VerificationProgress) => void;
+}
+
+const DEFAULT_BATCH_SIZE = 25;
+const DEFAULT_BATCH_DELAY = 12;
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    if (ms <= 0) {
+      resolve();
+    } else {
+      setTimeout(resolve, ms);
+    }
+  });
+
+let cachedSubtle: SubtleCrypto | null = null;
+
+const subtleFromEnvironment = (): SubtleCrypto | null => {
+  if (cachedSubtle) {
+    return cachedSubtle;
+  }
+  if (typeof globalThis !== 'undefined' && globalThis.crypto?.subtle) {
+    cachedSubtle = globalThis.crypto.subtle;
+    return cachedSubtle;
+  }
+  return null;
+};
+
+const toNodeAlgorithm = (algorithm: SupportedAlgorithm) => {
+  switch (algorithm) {
+    case 'SHA-1':
+      return 'sha1';
+    case 'SHA-384':
+      return 'sha384';
+    case 'SHA-512':
+      return 'sha512';
+    case 'SHA-256':
+    default:
+      return 'sha256';
+  }
+};
+
+export const normalizeChecksum = (value: string) => value.replace(/\s+/g, '').toLowerCase();
+
+export const computeChecksum = async (
+  buffer: ArrayBuffer,
+  algorithm: SupportedAlgorithm = 'SHA-256',
+): Promise<string> => {
+  const subtle = subtleFromEnvironment();
+  if (subtle) {
+    const digestBuffer = await subtle.digest(algorithm, buffer);
+    const view = new Uint8Array(digestBuffer);
+    let result = '';
+    for (let i = 0; i < view.length; i += 1) {
+      const hex = view[i].toString(16).padStart(2, '0');
+      result += hex;
+    }
+    return result;
+  }
+
+  if (typeof process !== 'undefined' && process.versions?.node) {
+    const cryptoModule: any = await import('node:crypto').catch(() => import('crypto'));
+    if (cryptoModule?.webcrypto?.subtle && !cachedSubtle) {
+      cachedSubtle = cryptoModule.webcrypto.subtle;
+      return computeChecksum(buffer, algorithm);
+    }
+    if (typeof cryptoModule?.createHash === 'function') {
+      const nodeAlgorithm = toNodeAlgorithm(algorithm);
+      const hash = cryptoModule.createHash(nodeAlgorithm);
+      hash.update(new Uint8Array(buffer));
+      return hash.digest('hex');
+    }
+  }
+
+  throw new Error('WebCrypto subtle API is unavailable in this environment');
+};
+
+const loadBuffer = async (
+  file: EvidenceFileMetadata,
+  signal?: AbortSignal,
+): Promise<ArrayBuffer | null> => {
+  if (file.buffer) {
+    return file.buffer;
+  }
+  if (file.file) {
+    return file.file.arrayBuffer();
+  }
+  if (file.source) {
+    try {
+      const response = await fetch(file.source, { signal });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch source (status ${response.status})`);
+      }
+      return await response.arrayBuffer();
+    } catch (err) {
+      throw new Error(
+        err instanceof Error ? err.message : 'Failed to fetch remote evidence source',
+      );
+    }
+  }
+  return null;
+};
+
+const initialSummary = (): VerificationSummary => ({ match: 0, mismatch: 0, error: 0, skipped: 0 });
+
+export const verifyEvidenceFiles = async (
+  files: EvidenceFileMetadata[],
+  options: VerifyEvidenceOptions = {},
+) => {
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  const batchDelayMs = options.batchDelayMs ?? DEFAULT_BATCH_DELAY;
+  const summary = initialSummary();
+  const results: FileVerificationResult[] = [];
+  const total = files.length;
+  let processed = 0;
+
+  for (let offset = 0; offset < files.length; offset += batchSize) {
+    if (options.signal?.aborted) {
+      throw new DOMException('Verification aborted', 'AbortError');
+    }
+    const batch = files.slice(offset, offset + batchSize);
+    for (let index = 0; index < batch.length; index += 1) {
+      const file = batch[index];
+      const absoluteIndex = offset + index;
+      options.onFileStart?.(file, absoluteIndex);
+
+      const startedAt = (typeof performance !== 'undefined' && performance.now()) || Date.now();
+      let status: VerificationStatus = 'skipped';
+      let actualChecksum: string | undefined;
+      let message: string | undefined;
+
+      try {
+        const buffer = await loadBuffer(file, options.signal);
+        if (!buffer) {
+          status = 'skipped';
+          message = 'No data available for checksum validation';
+        } else {
+          actualChecksum = await computeChecksum(buffer, file.algorithm);
+          const expected = normalizeChecksum(file.expectedChecksum);
+          const actual = normalizeChecksum(actualChecksum);
+          status = actual === expected ? 'match' : 'mismatch';
+          if (status === 'mismatch') {
+            message = 'Checksum mismatch';
+          }
+        }
+      } catch (err) {
+        status = 'error';
+        message = err instanceof Error ? err.message : 'Unknown verification error';
+      }
+
+      const finishedAt = (typeof performance !== 'undefined' && performance.now()) || Date.now();
+      const durationMs = finishedAt - startedAt;
+      processed += 1;
+
+      const result: FileVerificationResult = {
+        id: file.id,
+        status,
+        expectedChecksum: file.expectedChecksum,
+        actualChecksum,
+        durationMs,
+        message,
+      };
+      results.push(result);
+      summary[status] += 1;
+
+      options.onProgress?.({ processed, total, result });
+
+      if (options.signal?.aborted) {
+        throw new DOMException('Verification aborted', 'AbortError');
+      }
+    }
+
+    if (offset + batchSize < files.length) {
+      await sleep(batchDelayMs);
+    }
+  }
+
+  return { results, summary };
+};
+
+export type VerificationRun = Awaited<ReturnType<typeof verifyEvidenceFiles>>;
+


### PR DESCRIPTION
## Summary
- add a dedicated checksum verifier component for the Evidence Vault that processes files in batches and surfaces live progress with per-file statuses
- introduce reusable checksum utilities with WebCrypto and Node fallbacks to keep verification responsive across environments
- cover the verification workflow with a Jest suite that exercises 1k-record batches and mismatch handling

## Testing
- yarn test evidenceVaultVerifier

------
https://chatgpt.com/codex/tasks/task_e_68d9d34610648328aea1d40e7be3457a