### PR TITLE
[mimikatz] add structured output view parsing

### DIFF
--- a/__tests__/mimikatzOutputView.test.tsx
+++ b/__tests__/mimikatzOutputView.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import OutputView, { parseOutputBlocks } from '../apps/mimikatz/components/OutputView';
+
+describe('parseOutputBlocks', () => {
+  const rawOutput = `Authentication Id : 0 ; 123 (00000000:0000007B)
+Session           : Interactive from 1
+User Name         : alice
+Domain            : CONTOSO
+Logon Server      : CONTOSO
+Logon Time        : 5/14/2024 1:23:45 PM
+SID               : S-1-5-21-123456789-123456789-123456789-1001
+
+        msv :
+         [00000003] Primary
+         * Username : alice
+         * Domain   : CONTOSO
+         * NTLM     : <redacted>
+         * SHA1     : <redacted>
+        tspkg :
+         * Username : alice
+         * Domain   : CONTOSO
+         * Password : (null)
+
+Authentication Id : 0 ; 999 (00000000:000003E7)
+Session           : Service from 0
+User Name         : SYSTEM
+Domain            : NT AUTHORITY
+Logon Server      : (null)
+Logon Time        : 5/14/2024 1:23:45 PM
+SID               : S-1-5-18
+
+        msv :
+         [00000003] Primary
+         * Username : SYSTEM
+         * Domain   : NT AUTHORITY
+         * NTLM     : <redacted>
+         * SHA1     : <redacted>
+        tspkg :
+         * Username : SYSTEM
+         * Domain   : NT AUTHORITY
+         * Password : (null)`;
+
+  test('splits logon sessions into metadata-aware blocks', () => {
+    const blocks = parseOutputBlocks(rawOutput);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].metadata).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'User Name', value: 'alice' }),
+        expect.objectContaining({ label: 'Domain', value: 'CONTOSO' }),
+      ]),
+    );
+    expect(blocks[0].copyText).not.toMatch(/\s+$/);
+    expect(blocks[1].title).toMatch(/SYSTEM/);
+  });
+});
+
+describe('OutputView component', () => {
+  const writeText = jest.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    Object.assign(navigator, { clipboard: { writeText } });
+    writeText.mockClear();
+  });
+
+  test('renders collapsible output blocks and copies clean text', async () => {
+    const output = `Authentication Id : 0 ; 111 (00000000:0000006F)\nSession : Interactive from 1\nUser Name : demo\nDomain : LAB\n\n        msv :\n         * Username : demo`;
+
+    render(<OutputView output={output} />);
+
+    const toggle = screen
+      .getAllByRole('button', { name: /demo/i })
+      .find((btn) => btn.getAttribute('aria-controls')) as HTMLButtonElement;
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText(/msv/i)).toBeInTheDocument();
+
+    const copyButton = screen.getByLabelText('Copy block demo @ LAB');
+    await act(async () => {
+      fireEvent.click(copyButton);
+    });
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Authentication Id : 0 ; 111'));
+  });
+
+  test('shows placeholder when there is no output', () => {
+    render(<OutputView output="" emptyPlaceholder={<span>No runs yet</span>} />);
+    expect(screen.getByText('No runs yet')).toBeInTheDocument();
+  });
+});

--- a/apps/mimikatz/components/OutputView.tsx
+++ b/apps/mimikatz/components/OutputView.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import React, { useCallback, useMemo, useState } from 'react';
+
+interface MetadataEntry {
+  label: string;
+  value: string;
+}
+
+export interface ParsedBlock {
+  id: string;
+  title: string;
+  metadata: MetadataEntry[];
+  lines: string[];
+  copyText: string;
+}
+
+const KNOWN_LABELS: MetadataEntry['label'][] = [
+  'Authentication Id',
+  'Session',
+  'User Name',
+  'Domain',
+  'Logon Server',
+  'Logon Time',
+  'SID',
+];
+
+const splitIntoBlocks = (text: string): string[] => {
+  const cleaned = text.replace(/\r/g, '').trim();
+  if (!cleaned) {
+    return [];
+  }
+  const hasAuthId = /\bAuthentication Id\s*:/i.test(cleaned);
+  if (!hasAuthId) {
+    return [cleaned];
+  }
+  return cleaned.split(/\n(?=Authentication Id\s*:)/i);
+};
+
+const extractValue = (block: string, label: string): string => {
+  const regex = new RegExp(`${label}\\s*:\\s*(.*)`, 'i');
+  const match = block.match(regex);
+  return match ? match[1].trim() : '';
+};
+
+export const parseOutputBlocks = (text: string): ParsedBlock[] => {
+  const blocks = splitIntoBlocks(text);
+  return blocks.map((block, index) => {
+    const metadata = KNOWN_LABELS.reduce<MetadataEntry[]>((entries, label) => {
+      const value = extractValue(block, label);
+      if (value) {
+        entries.push({ label, value });
+      }
+      return entries;
+    }, []);
+
+    const user = metadata.find((entry) => entry.label === 'User Name')?.value;
+    const domain = metadata.find((entry) => entry.label === 'Domain')?.value;
+    const session = metadata.find((entry) => entry.label === 'Session')?.value;
+    const authId = metadata.find((entry) => entry.label === 'Authentication Id')?.value;
+
+    const titleParts = [
+      user ? (domain ? `${user} @ ${domain}` : user) : undefined,
+      session,
+      authId ? `ID ${authId}` : undefined,
+    ].filter(Boolean) as string[];
+
+    const title = titleParts.length ? titleParts[0]! : `Logon Session ${index + 1}`;
+
+    const lines = block
+      .split(/\n/)
+      .map((line) => line.replace(/\s+$/g, ''));
+
+    const copyText = lines.join('\n').trimEnd();
+
+    return {
+      id: authId ? authId.toLowerCase() : `session-${index}`,
+      title,
+      metadata,
+      lines,
+      copyText,
+    };
+  });
+};
+
+interface OutputViewProps {
+  output: string;
+  emptyPlaceholder?: React.ReactNode;
+}
+
+const OutputView: React.FC<OutputViewProps> = ({ output, emptyPlaceholder }) => {
+  const blocks = useMemo(() => parseOutputBlocks(output), [output]);
+  const [open, setOpen] = useState<Record<string, boolean>>(() => {
+    const initial: Record<string, boolean> = {};
+    if (blocks[0]) {
+      initial[blocks[0].id] = true;
+    }
+    return initial;
+  });
+
+  const toggle = useCallback((id: string) => {
+    setOpen((prev) => ({ ...prev, [id]: !prev[id] }));
+  }, []);
+
+  const copyBlock = useCallback((text: string) => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      return;
+    }
+    void navigator.clipboard.writeText(text).catch(() => undefined);
+  }, []);
+
+  if (!blocks.length) {
+    return (
+      <div className="text-sm text-purple-200 bg-black/60 border border-purple-700 rounded p-4">
+        {emptyPlaceholder ?? 'No output captured yet.'}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {blocks.map((block) => {
+        const isOpen = !!open[block.id];
+        const panelId = `output-panel-${block.id}`;
+
+        return (
+          <div
+            key={block.id}
+            className="border border-purple-700 bg-black/70 rounded shadow-sm overflow-hidden"
+          >
+            <div className="flex items-center justify-between gap-2 px-3 py-2 bg-purple-800/60">
+              <button
+                type="button"
+                className="text-left flex-1"
+                aria-expanded={isOpen}
+                aria-controls={panelId}
+                onClick={() => toggle(block.id)}
+              >
+                <div className="font-semibold text-purple-100">{block.title}</div>
+                <div className="text-xs text-purple-200">
+                  {block.metadata
+                    .filter((entry) => entry.label !== 'Authentication Id')
+                    .slice(0, 2)
+                    .map((entry) => (
+                      <span key={entry.label} className="block">
+                        {entry.label}: {entry.value}
+                      </span>
+                    ))}
+                </div>
+              </button>
+              <button
+                type="button"
+                className="text-xs font-semibold text-purple-100 border border-purple-300/60 rounded px-2 py-1 hover:bg-purple-700"
+                onClick={() => copyBlock(block.copyText)}
+                aria-label={`Copy block ${block.title}`}
+              >
+                Copy
+              </button>
+            </div>
+            {isOpen && (
+              <pre
+                id={panelId}
+                className="px-3 py-2 text-xs text-green-200 font-mono whitespace-pre-wrap bg-black/80"
+              >
+                {block.lines.join('\n')}
+              </pre>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default OutputView;


### PR DESCRIPTION
## Summary
- add an OutputView component that parses logon session output into collapsible blocks with copy controls
- add unit coverage for parsing logic and clipboard interaction

## Testing
- yarn test mimikatzOutputView.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9d3484bb08328b96a000c26d1faaf