### PR TITLE
Add bounded dragging and reset controls to Ettercap diagram

### DIFF
--- a/__tests__/ettercapArpDiagram.test.tsx
+++ b/__tests__/ettercapArpDiagram.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import ArpDiagram from '../apps/ettercap/components/ArpDiagram';
+
+const draggableInstances: Record<string, any> = {};
+
+jest.mock('react-draggable', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: ({ children, ...rest }: any) => {
+      const key = rest['data-node'] ?? `node-${Object.keys(draggableInstances).length}`;
+      draggableInstances[key] = rest;
+      return <div data-testid={`mock-draggable-${key}`}>{children}</div>;
+    },
+  };
+});
+
+describe('ArpDiagram dragging', () => {
+  beforeEach(() => {
+    Object.keys(draggableInstances).forEach((key) => {
+      delete draggableInstances[key];
+    });
+  });
+
+  it('keeps nodes within the container while dragging', () => {
+    render(<ArpDiagram />);
+
+    const victim = draggableInstances.victim;
+    expect(victim).toBeDefined();
+
+    act(() => {
+      victim.onDrag?.({} as any, { x: 999, y: 999 } as any);
+    });
+
+    const updatedVictim = draggableInstances.victim;
+    expect(updatedVictim.position.x).toBeLessThanOrEqual(280);
+    expect(updatedVictim.position.y).toBeLessThanOrEqual(160);
+  });
+
+  it('snaps positions to the grid on drag stop', () => {
+    render(<ArpDiagram />);
+
+    const attacker = draggableInstances.attacker;
+    expect(attacker).toBeDefined();
+
+    act(() => {
+      attacker.onStop?.({} as any, { x: 173, y: 58 } as any);
+    });
+
+    const updatedAttacker = draggableInstances.attacker;
+    expect(updatedAttacker.position.x % 6).toBe(0);
+    expect(updatedAttacker.position.y % 6).toBe(0);
+  });
+
+  it('resets the layout to its initial state', async () => {
+    const user = userEvent.setup();
+    render(<ArpDiagram />);
+
+    const gateway = draggableInstances.gateway;
+    expect(gateway).toBeDefined();
+
+    act(() => {
+      gateway.onStop?.({} as any, { x: 200, y: 140 } as any);
+    });
+
+    const movedGateway = draggableInstances.gateway;
+    expect(movedGateway.position.x).not.toBe(258);
+    expect(movedGateway.position.y).not.toBe(120);
+
+    const resetButton = screen.getByRole('button', { name: /reset layout/i });
+    await user.click(resetButton);
+
+    const resetGateway = draggableInstances.gateway;
+    expect(resetGateway.position.x).toBe(258);
+    expect(resetGateway.position.y).toBe(120);
+  });
+});

--- a/apps/ettercap/components/ArpDiagram.tsx
+++ b/apps/ettercap/components/ArpDiagram.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import type { DraggableEvent, DraggableData } from 'react-draggable';
 
 import SafeDraggable from './SafeDraggable';
@@ -11,46 +11,102 @@ interface NodeData {
   label: string;
 }
 
-const initialNodes: Record<string, NodeData> = {
-  victim: { x: 40, y: 120, label: 'Victim' },
-  attacker: { x: 150, y: 40, label: 'Attacker' },
-  gateway: { x: 260, y: 120, label: 'Gateway' },
+const GRID_SIZE = 6;
+const DIAGRAM_WIDTH = 320;
+const DIAGRAM_HEIGHT = 200;
+const NODE_DIAMETER = 40;
+
+const createInitialLayout = (): Record<string, NodeData> => ({
+  victim: { x: 42, y: 120, label: 'Victim' },
+  attacker: { x: 150, y: 42, label: 'Attacker' },
+  gateway: { x: 258, y: 120, label: 'Gateway' },
+});
+
+const clamp = (value: number, max: number) => Math.min(Math.max(value, 0), max);
+
+const clampPosition = (x: number, y: number) => {
+  const maxX = DIAGRAM_WIDTH - NODE_DIAMETER;
+  const maxY = DIAGRAM_HEIGHT - NODE_DIAMETER;
+  return {
+    x: clamp(x, maxX),
+    y: clamp(y, maxY),
+  };
+};
+
+const snapToGrid = (value: number, max: number) => {
+  const alignedMax = max - (max % GRID_SIZE);
+  const snapped = Math.round(value / GRID_SIZE) * GRID_SIZE;
+  return clamp(snapped, alignedMax);
+};
+
+const snapPosition = (x: number, y: number) => {
+  const maxX = DIAGRAM_WIDTH - NODE_DIAMETER;
+  const maxY = DIAGRAM_HEIGHT - NODE_DIAMETER;
+  return {
+    x: snapToGrid(x, maxX),
+    y: snapToGrid(y, maxY),
+  };
 };
 
 export default function ArpDiagram() {
-  const [nodes, setNodes] = useState<Record<string, NodeData>>(initialNodes);
+  const [nodes, setNodes] = useState<Record<string, NodeData>>(createInitialLayout);
 
-  const handleDrag = (key: string) => (_: DraggableEvent, data: DraggableData) => {
-    setNodes((n) => ({ ...n, [key]: { ...n[key], x: data.x, y: data.y } }));
-  };
+  const handleDrag = useCallback(
+    (key: string) => (_: DraggableEvent, data: DraggableData) => {
+      const clamped = clampPosition(data.x, data.y);
+      setNodes((prev) => ({ ...prev, [key]: { ...prev[key], ...clamped } }));
+    },
+    []
+  );
+
+  const handleStop = useCallback(
+    (key: string) => (_: DraggableEvent, data: DraggableData) => {
+      const clamped = clampPosition(data.x, data.y);
+      const snapped = snapPosition(clamped.x, clamped.y);
+      setNodes((prev) => ({ ...prev, [key]: { ...prev[key], ...snapped } }));
+    },
+    []
+  );
+
+  const resetLayout = () => setNodes(createInitialLayout());
 
   const getLine = (from: string, to: string) => {
     const a = nodes[from];
     const b = nodes[to];
-    return `M${a.x + 20} ${a.y + 20} L${b.x + 20} ${b.y + 20}`;
+    return `M${a.x + NODE_DIAMETER / 2} ${a.y + NODE_DIAMETER / 2} L${b.x + NODE_DIAMETER / 2} ${b.y + NODE_DIAMETER / 2}`;
   };
 
   return (
-    <div className="relative w-[320px] h-[200px] bg-gray-800 rounded mt-4">
-      <svg className="absolute inset-0 pointer-events-none" width={320} height={200}>
-        <path d={getLine('victim', 'gateway')} stroke="#fbbf24" strokeWidth={2} />
-        <path d={getLine('attacker', 'victim')} stroke="#f87171" strokeWidth={2} />
-        <path d={getLine('attacker', 'gateway')} stroke="#f87171" strokeWidth={2} />
-      </svg>
-      {Object.entries(nodes).map(([key, node]) => (
-        <SafeDraggable
-          key={key}
-          grid={[6, 6]}
-          bounds="parent"
-          position={{ x: node.x, y: node.y }}
-          onDrag={handleDrag(key)}
-        >
-          <div className="absolute w-10 h-10 rounded-full bg-gray-700 border border-white flex items-center justify-center text-[10px]">
-            {node.label}
-          </div>
-        </SafeDraggable>
-      ))}
+    <div className="flex flex-col items-start">
+      <div className="relative w-[320px] h-[200px] bg-gray-800 rounded mt-4">
+        <svg className="absolute inset-0 pointer-events-none" width={DIAGRAM_WIDTH} height={DIAGRAM_HEIGHT}>
+          <path d={getLine('victim', 'gateway')} stroke="#fbbf24" strokeWidth={2} />
+          <path d={getLine('attacker', 'victim')} stroke="#f87171" strokeWidth={2} />
+          <path d={getLine('attacker', 'gateway')} stroke="#f87171" strokeWidth={2} />
+        </svg>
+        {Object.entries(nodes).map(([key, node]) => (
+          <SafeDraggable
+            key={key}
+            grid={[GRID_SIZE, GRID_SIZE]}
+            bounds="parent"
+            position={{ x: node.x, y: node.y }}
+            onDrag={handleDrag(key)}
+            onStop={handleStop(key)}
+            data-node={key}
+          >
+            <div className="absolute w-10 h-10 rounded-full bg-gray-700 border border-white flex items-center justify-center text-[10px]">
+              {node.label}
+            </div>
+          </SafeDraggable>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={resetLayout}
+        className="mt-3 px-3 py-1 text-xs font-medium rounded border border-gray-600 bg-gray-700 text-white transition hover:bg-gray-600"
+      >
+        Reset layout
+      </button>
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- enforce bounded drag logic and grid snapping for Ettercap ARP nodes
- add a reset layout control and align initial positions with the grid
- cover bounded dragging and snapping behaviour with unit tests

## Testing
- yarn test -- ettercapArpDiagram

------
https://chatgpt.com/codex/tasks/task_e_68d9d34ba6608328a0b2f97f9ca1ff12