### PR TITLE
[mimikatz] Add offline redaction preview

### DIFF
--- a/apps/mimikatz/offline/components/Redactor.test.tsx
+++ b/apps/mimikatz/offline/components/Redactor.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import Redactor, { redactSecrets } from './Redactor';
+
+describe('redactSecrets', () => {
+  it('masks hashes, tickets, and passwords with placeholders', () => {
+    const sample = [
+      'NTLM : 8846f7eaee8fb117ad06bdd830b7586c',
+      'Kerberos Ticket : doEuUTSgAQIDBAUGBwgJCg==',
+      'Password : SuperSecret!23',
+      'Token: FEDCBA9876543210FEDCBA9876543210',
+    ].join('\n');
+
+    const sanitized = redactSecrets(sample);
+
+    expect(sanitized).not.toContain('8846f7eaee8fb117ad06bdd830b7586c');
+    expect(sanitized).toContain('NTLM : ********');
+
+    expect(sanitized).not.toContain('doEuUTSgAQIDBAUGBwgJCg==');
+    expect(sanitized).toContain('Kerberos Ticket : ********');
+
+    expect(sanitized).not.toContain('SuperSecret!23');
+    expect(sanitized).toContain('Password : ********');
+
+    expect(sanitized).not.toContain('FEDCBA9876543210FEDCBA9876543210');
+    expect(sanitized).toContain('Token: ********');
+  });
+
+  it('does not redact benign identifiers', () => {
+    const sample = ['User : Administrator', 'Ticket cache: user@EXAMPLE.COM'].join('\n');
+
+    const sanitized = redactSecrets(sample);
+
+    expect(sanitized).toContain('Administrator');
+    expect(sanitized).toContain('Ticket cache: user@EXAMPLE.COM');
+  });
+});
+
+describe('Redactor component', () => {
+  it('toggles between sanitized and original text', () => {
+    const sample = 'Password : SuperSecret!23';
+    render(<Redactor initialValue={sample} />);
+
+    const preview = screen.getByLabelText(/Redactor preview/i);
+    expect(preview).toHaveTextContent('Password : ********');
+
+    const toggle = screen.getByRole('checkbox', { name: /Toggle redaction/i });
+    fireEvent.click(toggle);
+    expect(preview).toHaveTextContent(sample);
+
+    fireEvent.click(toggle);
+    expect(preview).toHaveTextContent('Password : ********');
+  });
+});

--- a/apps/mimikatz/offline/components/Redactor.tsx
+++ b/apps/mimikatz/offline/components/Redactor.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+
+const DEFAULT_PLACEHOLDER = '********';
+
+interface RedactionRule {
+  pattern: RegExp;
+}
+
+const REDACTION_RULES: RedactionRule[] = [
+  {
+    pattern: /((?:NTLM|NTLMv2|LM)\s*(?:hash)?\s*[:=]\s*)([0-9a-f]{16,})/gi,
+  },
+  {
+    pattern: /((?:SHA1|SHA256|MD5)\s*(?:hash)?\s*[:=]\s*)([0-9a-f]{20,})/gi,
+  },
+  {
+    pattern: /((?:AES(?:128|256)?(?:-CTS-HMAC-SHA1-96)?)\s*(?:key|hash)?\s*[:=]\s*)([0-9a-f]{32,})/gi,
+  },
+  {
+    pattern: /((?:DPAPI|MasterKey|Credential)\s*(?:Key|Secret|Hash)?\s*[:=]\s*)([0-9a-f]{32,})/gi,
+  },
+  {
+    pattern: /((?:Kerberos\s+)?(?:TGT|TGS|Ticket)[^:=\n]*[:=]\s*)([A-Za-z0-9+/=]{20,})/gi,
+  },
+  {
+    pattern: /((?:Token|Secret)\s*[:=]\s*)([A-Fa-f0-9]{16,})/g,
+  },
+  {
+    pattern: /((?:Password|Passphrase)\s*[:=]\s*)(?!\(null\)|<blank>|not set)([^\s]{4,})/gi,
+  },
+];
+
+export const redactSecrets = (input: string, placeholder = DEFAULT_PLACEHOLDER): string => {
+  if (!input) {
+    return input;
+  }
+
+  return REDACTION_RULES.reduce((text, rule) => {
+    return text.replace(rule.pattern, (_, prefix: string) => `${prefix}${placeholder}`);
+  }, input);
+};
+
+interface RedactorProps {
+  initialValue?: string;
+  placeholder?: string;
+  className?: string;
+}
+
+const Redactor: React.FC<RedactorProps> = ({
+  initialValue = '',
+  placeholder = DEFAULT_PLACEHOLDER,
+  className = '',
+}) => {
+  const [isEnabled, setIsEnabled] = useState(true);
+  const [text, setText] = useState(initialValue);
+
+  useEffect(() => {
+    setText(initialValue);
+  }, [initialValue]);
+
+  const sanitized = useMemo(() => redactSecrets(text, placeholder), [text, placeholder]);
+  const preview = isEnabled ? sanitized : text;
+
+  return (
+    <section
+      className={`bg-ub-dark border border-gray-700 rounded-lg p-4 flex flex-col gap-3 ${className}`.trim()}
+      aria-label="Mimikatz dump redactor"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Redaction preview</h2>
+          <p className="text-xs text-gray-300">
+            Paste Mimikatz output and toggle redaction to review sanitized text.
+          </p>
+        </div>
+        <label className="flex items-center gap-2 text-sm text-gray-200">
+          <input
+            type="checkbox"
+            className="accent-purple-500 h-4 w-4"
+            checked={isEnabled}
+            onChange={(event) => setIsEnabled(event.target.checked)}
+            aria-label="Toggle redaction"
+          />
+          Redaction enabled
+        </label>
+      </div>
+      <label className="flex flex-col gap-2 text-sm text-gray-200">
+        <span className="font-medium">Raw dump</span>
+        <textarea
+          value={text}
+          onChange={(event) => setText(event.target.value)}
+          placeholder="Paste mimikatz.log contents here..."
+          className="min-h-[160px] w-full rounded border border-gray-700 bg-black/70 p-3 font-mono text-sm text-green-300 shadow-inner focus:outline-none focus:ring-2 focus:ring-purple-500"
+          aria-label="Raw dump input"
+        />
+      </label>
+      <div className="flex flex-col gap-2">
+        <span className="text-xs uppercase tracking-wide text-gray-400">
+          {isEnabled ? 'Sanitized preview' : 'Original text'}
+        </span>
+        <pre
+          aria-label="Redactor preview"
+          className="max-h-64 overflow-auto whitespace-pre-wrap rounded border border-gray-700 bg-black/80 p-3 font-mono text-sm text-green-200"
+        >
+          {preview || 'Nothing to display'}
+        </pre>
+      </div>
+    </section>
+  );
+};
+
+export default Redactor;

--- a/components/apps/mimikatz/offline/index.js
+++ b/components/apps/mimikatz/offline/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Redactor from '../../../../apps/mimikatz/offline/components/Redactor';
 
 const parseDump = (text) => {
   const lines = text.split(/\r?\n/);
@@ -23,6 +24,7 @@ const parseDump = (text) => {
 const MimikatzOffline = () => {
   const [credentials, setCredentials] = useState([]);
   const [error, setError] = useState('');
+  const [rawDump, setRawDump] = useState('');
 
   const handleFile = (e) => {
     const file = e.target.files?.[0];
@@ -31,17 +33,19 @@ const MimikatzOffline = () => {
       .text()
       .then((text) => {
         const parsed = parseDump(text);
+        setRawDump(text);
         setCredentials(parsed);
         setError(parsed.length ? '' : 'No credentials found');
       })
       .catch(() => {
         setError('Failed to read file');
         setCredentials([]);
+        setRawDump('');
       });
   };
 
   return (
-    <div className="h-full w-full flex flex-col p-4 bg-ub-cool-grey text-white">
+    <div className="h-full w-full flex flex-col gap-4 p-4 bg-ub-cool-grey text-white overflow-hidden">
       <h1 className="text-xl mb-4">Mimikatz Offline</h1>
       <input
         type="file"
@@ -50,17 +54,23 @@ const MimikatzOffline = () => {
         className="mb-4"
       />
       {error && <div className="text-red-400 text-sm mb-2">{error}</div>}
-      <ul className="space-y-2 overflow-auto">
-        {credentials.map((c, idx) => (
-          <li key={idx} className="bg-ub-dark p-2 rounded">
-            <div>User: {c.user}</div>
-            <div>Password: {c.password}</div>
-          </li>
-        ))}
-      </ul>
-      {!credentials.length && !error && (
-        <div className="text-sm text-gray-300">No credentials parsed</div>
-      )}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:gap-6 flex-1 min-h-0">
+        <div className="flex flex-col min-h-0">
+          <h2 className="text-lg font-semibold mb-2">Parsed credentials</h2>
+          <ul className="space-y-2 overflow-auto pr-1">
+            {credentials.map((c, idx) => (
+              <li key={idx} className="bg-ub-dark p-2 rounded">
+                <div>User: {c.user}</div>
+                <div>Password: {c.password}</div>
+              </li>
+            ))}
+          </ul>
+          {!credentials.length && !error && (
+            <div className="text-sm text-gray-300">No credentials parsed</div>
+          )}
+        </div>
+        <Redactor initialValue={rawDump} />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a client redactor component that masks hashes, Kerberos tickets, and passwords with toggleable redaction
- show the sanitized preview alongside parsed credentials in the Mimikatz offline workflow
- cover the redaction rules and UI toggle behaviour with focused unit tests

## Testing
- yarn test -- apps/mimikatz/offline/components/Redactor.test.tsx
- yarn lint *(fails: repository has numerous pre-existing jsx-a11y/control-has-associated-label violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d34b05c083288ba9c0d2a5691606