### PR TITLE
[ettercap] Add lint worker and shared filter state

### DIFF
--- a/__tests__/ettercap.test.tsx
+++ b/__tests__/ettercap.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FilterEditor from '../apps/ettercap/components/FilterEditor';
+import FilterPreview from '../apps/ettercap/components/FilterPreview';
+import { EttercapFilterProvider } from '../apps/ettercap/components/FilterStateProvider';
+
+const lintFilter = (code: string) => {
+  const messages: { line: number; message: string }[] = [];
+  const lines = code.split(/\n/);
+
+  lines.forEach((line, idx) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) return;
+    const [command, ...rest] = trimmed.split(/\s+/);
+    const lineNumber = idx + 1;
+
+    if (command !== 'drop' && command !== 'replace') {
+      messages.push({ line: lineNumber, message: `Unknown command "${command}"` });
+      return;
+    }
+
+    if (command === 'drop') {
+      if (rest.length === 0) {
+        messages.push({ line: lineNumber, message: 'drop requires a pattern to remove' });
+      }
+      return;
+    }
+
+    if (rest.length < 2) {
+      messages.push({
+        line: lineNumber,
+        message: 'replace requires a pattern and a replacement',
+      });
+    } else if (rest.length > 2) {
+      messages.push({ line: lineNumber, message: 'replace only accepts two parameters' });
+    }
+  });
+
+  return messages;
+};
+
+class MockWorker {
+  private listeners = new Set<(event: MessageEvent<{ type: string; messages: ReturnType<typeof lintFilter> }>) => void>();
+
+  postMessage(data: { type: string; code: string }) {
+    if (data.type !== 'lint') return;
+    const messages = lintFilter(data.code ?? '');
+    const event = { data: { type: 'lint', messages } } as MessageEvent<{
+      type: string;
+      messages: ReturnType<typeof lintFilter>;
+    }>;
+    this.listeners.forEach((listener) => listener(event));
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent<any>) => void) {
+    if (type !== 'message') return;
+    this.listeners.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: MessageEvent<any>) => void) {
+    if (type !== 'message') return;
+    this.listeners.delete(listener);
+  }
+
+  terminate() {
+    this.listeners.clear();
+  }
+}
+
+describe('Ettercap filter editor', () => {
+  beforeEach(() => {
+    (global as any).Worker = MockWorker;
+    window.localStorage?.clear?.();
+  });
+
+  afterEach(() => {
+    delete (global as any).Worker;
+  });
+
+  it('updates lint warnings when the script changes', async () => {
+    const user = userEvent.setup();
+    render(
+      <EttercapFilterProvider>
+        <FilterEditor />
+      </EttercapFilterProvider>,
+    );
+
+    await screen.findByText(/No lint warnings detected/i);
+
+    const textarea = screen.getByLabelText(/filter script/i);
+    await user.clear(textarea);
+    await user.type(textarea, 'foo');
+
+    await waitFor(() =>
+      expect(screen.getByText(/Unknown command "foo"/i)).toBeInTheDocument(),
+    );
+
+    await user.clear(textarea);
+    await user.type(textarea, 'drop foo');
+
+    await waitFor(() =>
+      expect(screen.getByText(/No lint warnings detected/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('keeps preview and lint state in sync with edits', async () => {
+    const user = userEvent.setup();
+    render(
+      <EttercapFilterProvider>
+        <FilterEditor />
+        <FilterPreview />
+      </EttercapFilterProvider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId('ettercap-after-list')).queryByText('DNS query example.com'),
+      ).not.toBeInTheDocument(),
+    );
+
+    const textarea = screen.getByLabelText(/filter script/i);
+    await user.clear(textarea);
+    await user.type(textarea, 'replace example.com test.org');
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId('ettercap-after-list')).getByText('DNS query test.org'),
+      ).toBeInTheDocument(),
+    );
+
+    expect(
+      within(screen.getByTestId('ettercap-before-list')).getByText('DNS query example.com'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/No lint warnings detected/i)).toBeInTheDocument();
+  });
+});

--- a/apps/ettercap/components/FilterPreview.tsx
+++ b/apps/ettercap/components/FilterPreview.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React from 'react';
+import { useEttercapFilterState } from './FilterStateProvider';
+
+export default function FilterPreview() {
+  const { beforePackets, filteredPackets } = useEttercapFilterState();
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <div>
+        <h3 className="mb-2 font-bold">Before</h3>
+        <ul
+          className="space-y-1 rounded border border-gray-800 bg-gray-900 p-2 font-mono text-sm"
+          data-testid="ettercap-before-list"
+        >
+          {beforePackets.map((packet, idx) => (
+            <li key={`${packet}-${idx}`}>{packet}</li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h3 className="mb-2 font-bold">After</h3>
+        <ul
+          className="space-y-1 rounded border border-gray-800 bg-gray-900 p-2 font-mono text-sm"
+          data-testid="ettercap-after-list"
+        >
+          {filteredPackets.map((packet, idx) => (
+            <li key={`${packet}-${idx}`}>{packet}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/ettercap/components/FilterStateProvider.tsx
+++ b/apps/ettercap/components/FilterStateProvider.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import React, {
+  PropsWithChildren,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+import { DEFAULT_SAMPLES, EXAMPLE_PACKETS } from '../constants';
+import applyFilters from '../utils/applyFilters';
+
+export interface LintMessage {
+  line: number;
+  message: string;
+}
+
+interface EttercapFilterContextValue {
+  filterText: string;
+  setFilterText: (value: string) => void;
+  beforePackets: readonly string[];
+  filteredPackets: readonly string[];
+  lintMessages: LintMessage[];
+  isLinting: boolean;
+}
+
+const EttercapFilterContext = createContext<EttercapFilterContextValue | null>(
+  null,
+);
+
+export const EttercapFilterProvider = ({
+  children,
+}: PropsWithChildren<unknown>) => {
+  const [filterText, setFilterText] = usePersistentState(
+    'ettercap-filter-text',
+    DEFAULT_SAMPLES[0].code,
+  );
+  const [lintMessages, setLintMessages] = useState<LintMessage[]>([]);
+  const [isLinting, setIsLinting] = useState(false);
+  const workerRef = useRef<Worker | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const worker = new Worker(new URL('../filterLint.worker.ts', import.meta.url));
+    workerRef.current = worker;
+
+    const handleMessage = (event: MessageEvent<{ type: string; messages: LintMessage[] }>) => {
+      if (event.data?.type !== 'lint') return;
+      setLintMessages(event.data.messages);
+      setIsLinting(false);
+    };
+
+    worker.addEventListener('message', handleMessage);
+
+    return () => {
+      worker.removeEventListener('message', handleMessage);
+      workerRef.current = null;
+      worker.terminate();
+    };
+  }, []);
+
+  useEffect(() => {
+    const worker = workerRef.current;
+    if (!worker) return;
+    setIsLinting(true);
+    worker.postMessage({ type: 'lint', code: filterText });
+  }, [filterText]);
+
+  const filteredPackets = useMemo(
+    () => applyFilters(filterText, EXAMPLE_PACKETS),
+    [filterText],
+  );
+
+  const value = useMemo<EttercapFilterContextValue>(
+    () => ({
+      filterText,
+      setFilterText,
+      beforePackets: EXAMPLE_PACKETS,
+      filteredPackets,
+      lintMessages,
+      isLinting,
+    }),
+    [filterText, filteredPackets, lintMessages, isLinting, setFilterText],
+  );
+
+  return (
+    <EttercapFilterContext.Provider value={value}>
+      {children}
+    </EttercapFilterContext.Provider>
+  );
+};
+
+export const useEttercapFilterState = () => {
+  const ctx = useContext(EttercapFilterContext);
+  if (!ctx) {
+    throw new Error('useEttercapFilterState must be used within EttercapFilterProvider');
+  }
+  return ctx;
+};

--- a/apps/ettercap/constants.ts
+++ b/apps/ettercap/constants.ts
@@ -1,0 +1,15 @@
+export interface SampleFilter {
+  name: string;
+  code: string;
+}
+
+export const DEFAULT_SAMPLES: SampleFilter[] = [
+  { name: 'Drop DNS', code: 'drop DNS' },
+  { name: 'Replace example.com', code: 'replace example.com test.com' },
+];
+
+export const EXAMPLE_PACKETS = [
+  'DNS query example.com',
+  'HTTP GET /index.html',
+  'SSH handshake from 10.0.0.1',
+];

--- a/apps/ettercap/filterLint.worker.ts
+++ b/apps/ettercap/filterLint.worker.ts
@@ -1,0 +1,64 @@
+interface LintMessage {
+  line: number;
+  message: string;
+}
+
+const lintEttercapFilter = (code: string): LintMessage[] => {
+  const messages: LintMessage[] = [];
+  const lines = code.split(/\n/);
+
+  lines.forEach((line, idx) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      return;
+    }
+
+    const [command, ...rest] = trimmed.split(/\s+/);
+    const lineNumber = idx + 1;
+
+    if (command !== 'drop' && command !== 'replace') {
+      messages.push({
+        line: lineNumber,
+        message: `Unknown command "${command}"`,
+      });
+      return;
+    }
+
+    if (command === 'drop') {
+      if (rest.length === 0) {
+        messages.push({
+          line: lineNumber,
+          message: 'drop requires a pattern to remove',
+        });
+      }
+      return;
+    }
+
+    if (rest.length < 2) {
+      messages.push({
+        line: lineNumber,
+        message: 'replace requires a pattern and a replacement',
+      });
+    } else if (rest.length > 2) {
+      messages.push({
+        line: lineNumber,
+        message: 'replace only accepts two parameters',
+      });
+    }
+  });
+
+  return messages;
+};
+
+self.onmessage = (event: MessageEvent<{ type: string; code: string }>) => {
+  const { type, code } = event.data || {};
+  if (type !== 'lint') return;
+
+  const messages = lintEttercapFilter(code || '');
+  (self as unknown as DedicatedWorkerGlobalScope).postMessage({
+    type: 'lint',
+    messages,
+  });
+};
+
+export {};

--- a/apps/ettercap/index.tsx
+++ b/apps/ettercap/index.tsx
@@ -2,6 +2,8 @@
 
 import React, { useEffect, useState } from 'react';
 import FilterEditor from './components/FilterEditor';
+import FilterPreview from './components/FilterPreview';
+import { EttercapFilterProvider } from './components/FilterStateProvider';
 import LogPane, { LogEntry } from './components/LogPane';
 import ArpDiagram from './components/ArpDiagram';
 
@@ -54,7 +56,10 @@ export default function EttercapPage() {
       {started && <ArpDiagram />}
 
       <h1 className="mt-6 mb-4 text-xl font-bold">Ettercap Filter Editor</h1>
-      <FilterEditor />
+      <EttercapFilterProvider>
+        <FilterEditor />
+        <FilterPreview />
+      </EttercapFilterProvider>
     </div>
   );
 }

--- a/apps/ettercap/utils/applyFilters.ts
+++ b/apps/ettercap/utils/applyFilters.ts
@@ -1,0 +1,22 @@
+export const applyFilters = (text: string, packets: string[]) => {
+  let result = packets;
+  text
+    .split(/\n+/)
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .forEach((line) => {
+      const [cmd, ...rest] = line.split(/\s+/);
+      if (cmd === 'drop') {
+        const pattern = rest.join(' ');
+        result = result.filter((p) => !p.includes(pattern));
+      } else if (cmd === 'replace') {
+        const [pattern, replacement] = rest;
+        if (pattern && replacement !== undefined) {
+          result = result.map((p) => p.split(pattern).join(replacement));
+        }
+      }
+    });
+  return result;
+};
+
+export default applyFilters;


### PR DESCRIPTION
## Summary
- centralize the Ettercap filter editor state so the script text, lint status, and previews stay in sync
- add a dedicated worker-powered linter that surfaces inline warnings for unsupported commands and argument issues
- render a shared preview panel and cover the new workflow with unit tests

## Testing
- yarn test ettercap.test.tsx --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d9d34ca4548328b0370c2357079112