### PR TITLE
[john] add rule sandbox simulation

### DIFF
--- a/__tests__/john-rule-sandbox.test.ts
+++ b/__tests__/john-rule-sandbox.test.ts
@@ -1,0 +1,54 @@
+import {
+  estimateRuleSet,
+  simulateRuleSetAsync,
+} from '../modules/john/rule-sandbox';
+
+describe('john rule sandbox simulator', () => {
+  it('estimates candidates for common rule set patterns', () => {
+    const result = estimateRuleSet({
+      baseWords: ['password', 'hello'],
+      rules: [':', 'c', '$[0-9]'],
+    });
+
+    expect(result.ruleBreakdown).toHaveLength(3);
+    expect(result.totalCandidates).toBe(24);
+    expect(result.ruleBreakdown.map((entry) => entry.candidates)).toEqual([2, 2, 20]);
+  });
+
+  it('supports combined prefix, suffix and duplicate steps', () => {
+    const result = estimateRuleSet({
+      baseWords: ['test'],
+      rules: ['^!$!', '^![0-1]d'],
+    });
+
+    expect(result.ruleBreakdown).toHaveLength(2);
+    expect(result.totalCandidates).toBe(3);
+    expect(result.ruleBreakdown[0].candidates).toBe(1);
+    expect(result.ruleBreakdown[1].candidates).toBe(2);
+  });
+
+  it('chunks long simulations to avoid blocking the UI thread', async () => {
+    jest.useFakeTimers();
+    try {
+      const rules = Array.from({ length: 5 }, (_, index) => `$[0-${index}]`);
+      const promise = simulateRuleSetAsync(
+        { baseWords: ['one'], rules },
+        { chunkSize: 1 }
+      );
+
+      let resolved = false;
+      promise.then(() => {
+        resolved = true;
+      });
+
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      jest.runAllTimers();
+      await promise;
+      expect(resolved).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/apps/john/index.tsx
+++ b/apps/john/index.tsx
@@ -1,7 +1,11 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import AuditSimulator from './components/AuditSimulator';
+import type {
+  RuleSimulationResult,
+  SimulationProgress,
+} from '../../modules/john/rule-sandbox';
 
 interface HashItem {
   hash: string;
@@ -44,7 +48,18 @@ const generateIncremental = (length: number, limit = 100) => {
   return results;
 };
 
+const DEFAULT_BASE_WORDS = `password
+letmein
+summer2024`;
+
+const DEFAULT_RULES = `:
+c
+$[0-9]
+^!
+d`;
+
 const JohnApp: React.FC = () => {
+  const [view, setView] = useState<'cracking' | 'sandbox'>('cracking');
   const [mode, setMode] = useState<'single' | 'incremental' | 'wordlist'>('wordlist');
   const [wordlist, setWordlist] = useState(DEFAULT_WORDLIST);
   const [singleValue, setSingleValue] = useState('password');
@@ -54,6 +69,16 @@ const JohnApp: React.FC = () => {
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [startTime, setStartTime] = useState<number | null>(null);
   const [eta, setEta] = useState('00:00');
+  const [sandboxBase, setSandboxBase] = useState(DEFAULT_BASE_WORDS);
+  const [sandboxRules, setSandboxRules] = useState(DEFAULT_RULES);
+  const [sandboxResult, setSandboxResult] = useState<RuleSimulationResult | null>(null);
+  const [sandboxProgress, setSandboxProgress] = useState<SimulationProgress | null>(null);
+  const [sandboxRunning, setSandboxRunning] = useState(false);
+  const [sandboxError, setSandboxError] = useState<string | null>(null);
+
+  const workerRef = useRef<Worker | null>(null);
+  const activeJobRef = useRef<number | null>(null);
+  const requestIdRef = useRef(0);
 
   const start = () => {
     const candidates =
@@ -153,123 +178,293 @@ const JohnApp: React.FC = () => {
     }
   }, [overallProgress, running, startTime]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const worker = new Worker(
+      new URL('../../workers/john-rule-sandbox.worker.ts', import.meta.url)
+    );
+    workerRef.current = worker;
+    const listener = (event: MessageEvent) => {
+      const data = event.data as
+        | { id: number; type: 'progress'; payload: SimulationProgress }
+        | { id: number; type: 'result'; payload: RuleSimulationResult }
+        | { id: number; type: 'error'; error: string };
+      if (data.id !== activeJobRef.current) return;
+      if (data.type === 'progress') {
+        setSandboxProgress(data.payload);
+      } else if (data.type === 'result') {
+        setSandboxResult(data.payload);
+        setSandboxRunning(false);
+        setSandboxError(null);
+        activeJobRef.current = null;
+      } else if (data.type === 'error') {
+        setSandboxError(data.error);
+        setSandboxRunning(false);
+        activeJobRef.current = null;
+      }
+    };
+    worker.addEventListener('message', listener);
+
+    return () => {
+      worker.removeEventListener('message', listener);
+      worker.terminate();
+      workerRef.current = null;
+    };
+  }, []);
+
+  const runSandboxSimulation = () => {
+    const worker = workerRef.current;
+    if (!worker) return;
+    const baseWords = sandboxBase.split(/\r?\n/);
+    const rules = sandboxRules.split(/\r?\n/);
+    const jobId = requestIdRef.current + 1;
+    requestIdRef.current = jobId;
+    activeJobRef.current = jobId;
+    setSandboxRunning(true);
+    setSandboxResult(null);
+    setSandboxError(null);
+    setSandboxProgress(null);
+    worker.postMessage({
+      id: jobId,
+      type: 'simulate',
+      payload: { baseWords, rules },
+    });
+  };
+
   return (
-    <div className="h-full w-full p-4 bg-gray-900 text-white flex flex-col gap-4">
+    <div className="h-full w-full p-4 bg-gray-900 text-white flex flex-col gap-4 overflow-y-auto">
       <p className="text-xs text-yellow-300">Demo only – simulated cracking.</p>
-      <div className="flex flex-wrap gap-4 items-center">
-        <div className="flex gap-2">
-          {modes.map((m) => (
-            <button
-              key={m.key}
-              type="button"
-              onClick={() => setMode(m.key)}
-              className={`px-2 py-1 rounded-full border text-sm ${
-                mode === m.key
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-200 text-black dark:bg-gray-700 dark:text-white'
-              }`}
-            >
-              {m.label}
-            </button>
-          ))}
-        </div>
-        {mode === 'single' && (
-          <input
-            type="text"
-            value={singleValue}
-            onChange={(e) => setSingleValue(e.target.value)}
-            className="text-black px-2 py-1 rounded"
-            aria-label="Single candidate"
-          />
-        )}
-        {mode === 'wordlist' && (
-          <textarea
-            value={wordlist}
-            onChange={(e) => setWordlist(e.target.value)}
-            className="flex-1 text-black p-1 rounded min-h-[80px]"
-            aria-label="Wordlist"
-          />
-        )}
-        {mode === 'incremental' && (
-          <label className="flex items-center gap-2">
-            Length:
-            <input
-              type="number"
-              min={1}
-              max={5}
-              value={incLength}
-              onChange={(e) => setIncLength(parseInt(e.target.value, 10) || 1)}
-              className="w-16 text-black px-1 py-0.5 rounded"
-            />
-          </label>
-        )}
+      <div className="flex gap-2">
         <button
           type="button"
-          onClick={start}
-          disabled={running}
-          className="px-4 py-1 bg-blue-600 rounded"
+          onClick={() => setView('cracking')}
+          className={`px-3 py-1 rounded-full text-sm border ${
+            view === 'cracking'
+              ? 'bg-blue-600 border-blue-500'
+              : 'bg-gray-200 text-black border-gray-300 dark:bg-gray-700 dark:text-white'
+          }`}
         >
-          Start
+          Cracking demo
+        </button>
+        <button
+          type="button"
+          onClick={() => setView('sandbox')}
+          className={`px-3 py-1 rounded-full text-sm border ${
+            view === 'sandbox'
+              ? 'bg-blue-600 border-blue-500'
+              : 'bg-gray-200 text-black border-gray-300 dark:bg-gray-700 dark:text-white'
+          }`}
+        >
+          Rule sandbox
         </button>
       </div>
 
-      <div className="bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-2 rounded">
-        <div className="w-full bg-gray-400 dark:bg-gray-600 rounded h-2">
-          <div
-            className="h-2 bg-blue-500 rounded"
-            style={{ width: `${overallProgress}%` }}
-          />
-        </div>
-        <div className="text-xs text-center mt-1">ETA: {eta}</div>
-      </div>
-
-      <ul className="space-y-1 font-mono">
-        {hashes.map((h) => (
-          <li
-            key={h.hash}
-            className="bg-gray-800 rounded px-2 h-9 flex items-center justify-between text-xs sm:text-sm"
-          >
-            <span className="truncate">{h.hash}</span>
-            {h.status === 'cracked' ? (
-              <div className="flex items-center gap-2">
-                <span className="truncate">{h.password}</span>
-                <span
-                  className={`px-2 py-0.5 rounded-full text-xs ${
-                    strengthClass[h.strength!]
-                  }`}
-                >
-                  {h.strength}
-                </span>
+        {view === 'cracking' && (
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-wrap gap-4 items-center">
+              <div className="flex gap-2">
+                {modes.map((m) => (
+                  <button
+                    key={m.key}
+                    type="button"
+                    onClick={() => setMode(m.key)}
+                    className={`px-2 py-1 rounded-full border text-sm ${
+                      mode === m.key
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-200 text-black dark:bg-gray-700 dark:text-white'
+                    }`}
+                  >
+                    {m.label}
+                  </button>
+                ))}
               </div>
-            ) : h.status === 'failed' ? (
-              <span className="px-2 py-0.5 rounded-full bg-red-200 text-red-800 dark:bg-red-800 dark:text-red-200 text-xs">
-                Failed
-              </span>
-            ) : (
-              <span className="px-2 py-0.5 rounded-full bg-gray-500 text-gray-100 text-xs">
-                Pending
-              </span>
-            )}
-          </li>
-        ))}
-      </ul>
+              {mode === 'single' && (
+                <input
+                  type="text"
+                  value={singleValue}
+                  onChange={(e) => setSingleValue(e.target.value)}
+                  className="text-black px-2 py-1 rounded"
+                  aria-label="Single candidate"
+                />
+              )}
+              {mode === 'wordlist' && (
+                <textarea
+                  value={wordlist}
+                  onChange={(e) => setWordlist(e.target.value)}
+                  className="flex-1 text-black p-1 rounded min-h-[80px]"
+                  aria-label="Wordlist"
+                />
+              )}
+              {mode === 'incremental' && (
+                <label className="flex items-center gap-2">
+                  Length:
+                  <input
+                    type="number"
+                    min={1}
+                    max={5}
+                    value={incLength}
+                    onChange={(e) => setIncLength(parseInt(e.target.value, 10) || 1)}
+                    className="w-16 text-black px-1 py-0.5 rounded"
+                  />
+                </label>
+              )}
+              <button
+                type="button"
+                onClick={start}
+                disabled={running}
+                className="px-4 py-1 bg-blue-600 rounded"
+              >
+                Start
+              </button>
+            </div>
 
-      {message && (
-        <div
-          className={`p-2 rounded text-sm ${
-            message.type === 'success'
-              ? 'bg-green-200 text-green-800 dark:bg-green-800 dark:text-green-200'
-              : 'bg-red-200 text-red-800 dark:bg-red-800 dark:text-red-200'
-          }`}
-        >
-          {message.text}
+        <div className="bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-2 rounded">
+          <div className="w-full bg-gray-400 dark:bg-gray-600 rounded h-2">
+            <div
+              className="h-2 bg-blue-500 rounded"
+              style={{ width: `${overallProgress}%` }}
+            />
+          </div>
+          <div className="text-xs text-center mt-1">ETA: {eta}</div>
+        </div>
+
+        <ul className="space-y-1 font-mono">
+          {hashes.map((h) => (
+            <li
+              key={h.hash}
+              className="bg-gray-800 rounded px-2 h-9 flex items-center justify-between text-xs sm:text-sm"
+            >
+              <span className="truncate">{h.hash}</span>
+              {h.status === 'cracked' ? (
+                <div className="flex items-center gap-2">
+                  <span className="truncate">{h.password}</span>
+                  <span
+                    className={`px-2 py-0.5 rounded-full text-xs ${
+                      strengthClass[h.strength!]
+                    }`}
+                  >
+                    {h.strength}
+                  </span>
+                </div>
+              ) : h.status === 'failed' ? (
+                <span className="px-2 py-0.5 rounded-full bg-red-200 text-red-800 dark:bg-red-800 dark:text-red-200 text-xs">
+                  Failed
+                </span>
+              ) : (
+                <span className="px-2 py-0.5 rounded-full bg-gray-500 text-gray-100 text-xs">
+                  Pending
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+
+        {message && (
+          <div
+            className={`p-2 rounded text-sm ${
+              message.type === 'success'
+                ? 'bg-green-200 text-green-800 dark:bg-green-800 dark:text-green-200'
+                : 'bg-red-200 text-red-800 dark:bg-red-800 dark:text-red-200'
+            }`}
+          >
+            {message.text}
+          </div>
+        )}
+
+        <AuditSimulator />
         </div>
       )}
 
-      <AuditSimulator />
+      {view === 'sandbox' && (
+        <div className="bg-gray-800 rounded p-4 flex flex-col gap-4">
+          <div>
+            <h2 className="text-lg font-semibold">Rule sandbox</h2>
+            <p className="text-xs text-gray-300">
+              Enter a small base wordlist and a set of transformation rules to estimate how many candidates
+              a campaign would generate. The calculation runs in a worker so you can experiment without
+              blocking the UI.
+            </p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col gap-2 text-sm">
+              <span className="uppercase tracking-wide text-gray-300">Base words</span>
+              <textarea
+                value={sandboxBase}
+                onChange={(event) => setSandboxBase(event.target.value)}
+                className="min-h-[140px] rounded border border-gray-600 bg-gray-900 p-2 text-white"
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm">
+              <span className="uppercase tracking-wide text-gray-300">Rule set</span>
+              <textarea
+                value={sandboxRules}
+                onChange={(event) => setSandboxRules(event.target.value)}
+                className="min-h-[140px] rounded border border-gray-600 bg-gray-900 p-2 text-white"
+              />
+              <span className="text-xs text-gray-400">
+                Supported commands: <code>:</code> (identity), <code>c</code> (capitalize), <code>u</code>{' '}
+                (uppercase), <code>l</code> (lowercase), <code>d</code> (duplicate), <code>^</code> and{' '}
+                <code>$</code> for prefix/suffix, including ranges like <code>$[0-9]</code>.
+              </span>
+            </label>
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-sm">
+            <button
+              type="button"
+              onClick={runSandboxSimulation}
+              disabled={sandboxRunning}
+              className="px-4 py-1 rounded bg-blue-600 disabled:opacity-60"
+            >
+              {sandboxRunning ? 'Simulating…' : 'Estimate candidates'}
+            </button>
+            {sandboxProgress && (
+              <span className="text-xs text-gray-300">
+                {sandboxProgress.completed}/{sandboxProgress.total} rules processed
+              </span>
+            )}
+            {sandboxError && <span className="text-xs text-red-400">{sandboxError}</span>}
+          </div>
+          {sandboxProgress && (
+            <div className="bg-gray-700 rounded h-2 w-full overflow-hidden">
+              <div
+                className="bg-blue-500 h-2"
+                style={{
+                  width:
+                    sandboxProgress.total === 0
+                      ? '0%'
+                      : `${Math.min(
+                          100,
+                          Math.round((sandboxProgress.completed / sandboxProgress.total) * 100)
+                        )}%`,
+                }}
+              />
+            </div>
+          )}
+          {sandboxResult && (
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="text-sm uppercase tracking-wide text-gray-300">Estimated total</span>
+                <span className="text-xl font-semibold">
+                  {sandboxResult.totalCandidates.toLocaleString()}
+                </span>
+              </div>
+              <div className="bg-gray-900 rounded border border-gray-700 divide-y divide-gray-800">
+                {sandboxResult.ruleBreakdown.map((entry) => (
+                  <div key={entry.rule} className="flex items-center justify-between px-3 py-2 text-sm">
+                    <span className="font-mono text-gray-300">{entry.rule}</span>
+                    <span>{entry.candidates.toLocaleString()}</span>
+                  </div>
+                ))}
+                {sandboxResult.ruleBreakdown.length === 0 && (
+                  <div className="px-3 py-2 text-sm text-gray-400">No valid rules processed.</div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };
 
 export default JohnApp;
-

--- a/modules/john/rule-sandbox.ts
+++ b/modules/john/rule-sandbox.ts
@@ -1,0 +1,218 @@
+export type SimpleRuleToken =
+  | { type: 'noop' }
+  | { type: 'capitalize' }
+  | { type: 'uppercase' }
+  | { type: 'lowercase' }
+  | { type: 'duplicate' }
+  | { type: 'reverse' }
+  | { type: 'append'; values: string[] }
+  | { type: 'prepend'; values: string[] };
+
+export interface RuleSimulationInput {
+  baseWords: string[];
+  rules: string[];
+}
+
+export interface RuleBreakdownEntry {
+  rule: string;
+  candidates: number;
+}
+
+export interface RuleSimulationResult {
+  totalCandidates: number;
+  ruleBreakdown: RuleBreakdownEntry[];
+}
+
+const RANGE_EXPRESSIONS: Record<string, string[]> = {
+  '?d': Array.from({ length: 10 }, (_, i) => String(i)),
+  '?l': Array.from({ length: 26 }, (_, i) => String.fromCharCode(97 + i)),
+  '?u': Array.from({ length: 26 }, (_, i) => String.fromCharCode(65 + i)),
+};
+
+const toUniqueList = (input: string[]): string[] => Array.from(new Set(input.filter(Boolean)));
+
+const expandCharacterSet = (set: string): string[] => {
+  const values: string[] = [];
+  for (let i = 0; i < set.length; i += 1) {
+    const char = set[i];
+    const next = set[i + 1];
+    const nextNext = set[i + 2];
+    if (next === '-' && nextNext) {
+      const start = char.charCodeAt(0);
+      const end = nextNext.charCodeAt(0);
+      const step = start <= end ? 1 : -1;
+      for (let code = start; step > 0 ? code <= end : code >= end; code += step) {
+        values.push(String.fromCharCode(code));
+      }
+      i += 2;
+    } else {
+      values.push(char);
+    }
+  }
+  return toUniqueList(values);
+};
+
+export const parseRule = (input: string): SimpleRuleToken[] => {
+  const trimmed = input.trim();
+  if (!trimmed || trimmed.startsWith('#')) return [];
+
+  const tokens: SimpleRuleToken[] = [];
+  for (let i = 0; i < trimmed.length; i += 1) {
+    const char = trimmed[i];
+    if (char === '\\') {
+      i += 1; // skip escaped character
+      continue;
+    }
+    if (char === ':') {
+      tokens.push({ type: 'noop' });
+    } else if (char === 'c') {
+      tokens.push({ type: 'capitalize' });
+    } else if (char === 'u') {
+      tokens.push({ type: 'uppercase' });
+    } else if (char === 'l') {
+      tokens.push({ type: 'lowercase' });
+    } else if (char === 'd') {
+      tokens.push({ type: 'duplicate' });
+    } else if (char === 'r') {
+      tokens.push({ type: 'reverse' });
+    } else if (char === '^' || char === '$') {
+      const next = trimmed[i + 1];
+      if (next === '[') {
+        const endIdx = trimmed.indexOf(']', i + 2);
+        if (endIdx !== -1) {
+          const set = trimmed.slice(i + 2, endIdx);
+          const values = expandCharacterSet(set);
+          tokens.push({ type: char === '^' ? 'prepend' : 'append', values });
+          i = endIdx;
+          continue;
+        }
+      }
+      if (next) {
+        tokens.push({ type: char === '^' ? 'prepend' : 'append', values: [next] });
+        i += 1;
+      }
+    } else if (char === '[') {
+      const endIdx = trimmed.indexOf(']', i + 1);
+      if (endIdx !== -1) {
+        const set = trimmed.slice(i + 1, endIdx);
+        const values = expandCharacterSet(set);
+        tokens.push({ type: 'append', values });
+        i = endIdx;
+      }
+    } else {
+      const ahead = trimmed.slice(i, i + 2);
+      if (RANGE_EXPRESSIONS[ahead]) {
+        tokens.push({ type: 'append', values: RANGE_EXPRESSIONS[ahead] });
+        i += 1;
+      }
+    }
+  }
+  return tokens;
+};
+
+const computeMultiplierForToken = (token: SimpleRuleToken): number => {
+  if (token.type === 'append' || token.type === 'prepend') {
+    return token.values.length || 1;
+  }
+  return 1;
+};
+
+export const estimateRuleCandidates = (
+  baseWords: string[],
+  ruleTokens: SimpleRuleToken[]
+): number => {
+  if (baseWords.length === 0 || ruleTokens.length === 0) {
+    return 0;
+  }
+  const multiplier = ruleTokens.reduce(
+    (acc, token) => acc * computeMultiplierForToken(token),
+    1
+  );
+  return baseWords.length * multiplier;
+};
+
+export const estimateRuleSet = ({
+  baseWords,
+  rules,
+}: RuleSimulationInput): RuleSimulationResult => {
+  const sanitizedBase = toUniqueList(
+    baseWords.map((word) => word.trim()).filter((word) => word.length > 0)
+  );
+  const sanitizedRules = rules
+    .map((rule) => rule.trim())
+    .filter((rule) => rule.length > 0 && !rule.startsWith('#'));
+
+  const breakdown: RuleBreakdownEntry[] = [];
+  let totalCandidates = 0;
+
+  sanitizedRules.forEach((rule) => {
+    const tokens = parseRule(rule);
+    if (tokens.length === 0) return;
+    const count = estimateRuleCandidates(sanitizedBase, tokens);
+    breakdown.push({ rule, candidates: count });
+    totalCandidates += count;
+  });
+
+  return { totalCandidates, ruleBreakdown: breakdown };
+};
+
+export interface SimulationProgress {
+  completed: number;
+  total: number;
+  totalCandidates: number;
+}
+
+export interface SimulationOptions {
+  chunkSize?: number;
+  progress?: (progress: SimulationProgress) => void;
+}
+
+export const simulateRuleSetAsync = (
+  input: RuleSimulationInput,
+  options: SimulationOptions = {}
+): Promise<RuleSimulationResult> => {
+  const { chunkSize = 20, progress } = options;
+  const { baseWords, rules } = input;
+  const sanitizedBase = toUniqueList(
+    baseWords.map((word) => word.trim()).filter((word) => word.length > 0)
+  );
+  const sanitizedRules = rules
+    .map((rule) => rule.trim())
+    .filter((rule) => rule.length > 0 && !rule.startsWith('#'));
+
+  return new Promise<RuleSimulationResult>((resolve) => {
+    if (sanitizedBase.length === 0 || sanitizedRules.length === 0) {
+      resolve({ totalCandidates: 0, ruleBreakdown: [] });
+      return;
+    }
+
+    const breakdown: RuleBreakdownEntry[] = [];
+    let totalCandidates = 0;
+    let index = 0;
+
+    const processChunk = () => {
+      const end = Math.min(index + Math.max(1, chunkSize), sanitizedRules.length);
+      for (; index < end; index += 1) {
+        const rule = sanitizedRules[index];
+        const tokens = parseRule(rule);
+        if (tokens.length === 0) continue;
+        const candidates = estimateRuleCandidates(sanitizedBase, tokens);
+        totalCandidates += candidates;
+        breakdown.push({ rule, candidates });
+      }
+      progress?.({
+        completed: index,
+        total: sanitizedRules.length,
+        totalCandidates,
+      });
+      if (index < sanitizedRules.length) {
+        setTimeout(processChunk, 0);
+      } else {
+        resolve({ totalCandidates, ruleBreakdown: breakdown });
+      }
+    };
+
+    processChunk();
+  });
+};
+

--- a/workers/john-rule-sandbox.worker.ts
+++ b/workers/john-rule-sandbox.worker.ts
@@ -1,0 +1,57 @@
+import {
+  RuleSimulationInput,
+  SimulationProgress,
+  simulateRuleSetAsync,
+} from '../modules/john/rule-sandbox';
+
+interface SimulationMessage {
+  id: number;
+  type: 'simulate';
+  payload: RuleSimulationInput;
+}
+
+interface ProgressMessage {
+  id: number;
+  type: 'progress';
+  payload: SimulationProgress;
+}
+
+interface ResultMessage {
+  id: number;
+  type: 'result';
+  payload: Awaited<ReturnType<typeof simulateRuleSetAsync>>;
+}
+
+interface ErrorMessage {
+  id: number;
+  type: 'error';
+  error: string;
+}
+
+const ctx: DedicatedWorkerGlobalScope = self as unknown as DedicatedWorkerGlobalScope;
+
+ctx.onmessage = async (event: MessageEvent<SimulationMessage>) => {
+  const { id, type, payload } = event.data;
+  if (type !== 'simulate') return;
+
+  try {
+    const result = await simulateRuleSetAsync(payload, {
+      chunkSize: 25,
+      progress: (progress) => {
+        const message: ProgressMessage = { id, type: 'progress', payload: progress };
+        ctx.postMessage(message);
+      },
+    });
+    const message: ResultMessage = { id, type: 'result', payload: result };
+    ctx.postMessage(message);
+  } catch (error) {
+    const message: ErrorMessage = {
+      id,
+      type: 'error',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+    ctx.postMessage(message);
+  }
+};
+
+export {}; // ensure module scope


### PR DESCRIPTION
## Summary
- add a worker-backed rule sandbox alongside the existing cracking demo in the John app
- implement shared utilities to parse simple rule syntax and estimate candidate totals asynchronously
- cover the estimator with unit tests for common rules and asynchronous chunking

## Testing
- yarn test john-rule-sandbox

------
https://chatgpt.com/codex/tasks/task_e_68d9d35301248328bef2ecdba20d6d43