### PR TITLE
[nessus] Add summary export buttons

### DIFF
--- a/__tests__/nessusSummaryDashboard.test.tsx
+++ b/__tests__/nessusSummaryDashboard.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toPng } from 'html-to-image';
+import SummaryDashboard, { buildSummaryRows } from '../apps/nessus/components/SummaryDashboard';
+import { Severity } from '../apps/nessus/types';
+
+jest.mock('html-to-image', () => ({
+  toPng: jest.fn(() => Promise.resolve('data:image/png;base64,exported')),
+}));
+
+const mockCreateObjectURL = jest.fn(() => 'blob:mock');
+const mockRevokeObjectURL = jest.fn();
+const anchorClick = jest
+  .spyOn(HTMLAnchorElement.prototype, 'click')
+  .mockImplementation(() => undefined);
+
+type SeverityRecord = Record<Severity, boolean>;
+
+describe('SummaryDashboard exports', () => {
+  beforeAll(() => {
+    (global.URL as any).createObjectURL = mockCreateObjectURL;
+    (global.URL as any).revokeObjectURL = mockRevokeObjectURL;
+  });
+
+  beforeEach(() => {
+    mockCreateObjectURL.mockClear();
+    mockRevokeObjectURL.mockClear();
+  });
+
+  afterAll(() => {
+    anchorClick.mockRestore();
+  });
+
+  const summary: Record<Severity, number> = {
+    Critical: 7,
+    High: 5,
+    Medium: 3,
+    Low: 2,
+    Info: 1,
+  };
+
+  const severityFilters: SeverityRecord = {
+    Critical: true,
+    High: false,
+    Medium: true,
+    Low: true,
+    Info: true,
+  };
+
+  it('buildSummaryRows zeroes filtered severities for display/export parity', () => {
+    const rows = buildSummaryRows(summary, severityFilters);
+    const highRow = rows.find((row) => row.severity === 'High');
+    expect(highRow).toBeDefined();
+    expect(highRow?.count).toBe(0);
+    expect(highRow?.included).toBe(false);
+  });
+
+  it('exports CSV with counts matching rendered cards', async () => {
+    const onExport = jest.fn();
+    render(
+      <SummaryDashboard
+        summary={summary}
+        trend={[17, 18]}
+        filters={{ severity: severityFilters, tags: ['compliance'] }}
+        onExport={onExport}
+      />,
+    );
+
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: /export csv/i }));
+
+    const csvCall = onExport.mock.calls.find((call) => call[0] === 'csv');
+    expect(csvCall).toBeDefined();
+    const csv = csvCall?.[1] as string;
+    const lines = csv.split('\n');
+
+    const dataLines = lines.filter((line) =>
+      ['Critical', 'High', 'Medium', 'Low', 'Info'].some((label) =>
+        line.startsWith(`${label},`),
+      ),
+    );
+
+    dataLines.forEach((line) => {
+      const [severity, count, included] = line.split(',');
+      const card = screen.getByTestId(`summary-card-${severity}`);
+      expect(card).toHaveTextContent(count);
+      const filterState = severityFilters[severity as Severity];
+      expect(included).toBe(filterState ? 'true' : 'false');
+    });
+
+    expect(lines[0]).toContain('Active Severities');
+    expect(lines[0]).toContain('Critical|Medium|Low|Info');
+  });
+
+  it('exports JSON snapshot aligned with cards and trend', async () => {
+    const onExport = jest.fn();
+    render(
+      <SummaryDashboard
+        summary={summary}
+        trend={[17, 18]}
+        filters={{ severity: severityFilters, tags: ['pci'] }}
+        onExport={onExport}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /export json/i }));
+
+    const jsonCall = onExport.mock.calls.find((call) => call[0] === 'json');
+    expect(jsonCall).toBeDefined();
+    const snapshot = JSON.parse(jsonCall?.[1] as string) as ReturnType<typeof JSON.parse>;
+
+    const totalFromCards = ['Critical', 'High', 'Medium', 'Low', 'Info'].reduce(
+      (acc, sev) => acc + Number(screen.getByTestId(`summary-card-${sev}`).textContent?.match(/\d+/)?.[0] ?? 0),
+      0,
+    );
+
+    expect(snapshot.summary).toHaveLength(5);
+    snapshot.summary.forEach((entry: { severity: Severity; count: number; included: boolean }) => {
+      const card = screen.getByTestId(`summary-card-${entry.severity}`);
+      expect(card).toHaveTextContent(String(entry.count));
+      expect(entry.included).toBe(severityFilters[entry.severity]);
+    });
+
+    expect(snapshot.totals.overall).toBe(totalFromCards);
+    expect(snapshot.totals.trend).toEqual([17, 18]);
+    expect(snapshot.filters.tags).toEqual(['pci']);
+  });
+
+  it('exports image using html-to-image snapshot', async () => {
+    const onExport = jest.fn();
+    render(
+      <SummaryDashboard
+        summary={summary}
+        trend={[10, 12]}
+        filters={{ severity: severityFilters, tags: [] }}
+        onExport={onExport}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /export image/i }));
+
+    expect(toPng).toHaveBeenCalledTimes(1);
+    const imgCall = onExport.mock.calls.find((call) => call[0] === 'image');
+    expect(imgCall?.[1]).toBe('data:image/png;base64,exported');
+  });
+});

--- a/apps/nessus/components/SummaryDashboard.tsx
+++ b/apps/nessus/components/SummaryDashboard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo, useRef } from 'react';
+import { toPng } from 'html-to-image';
 import { Severity, severities } from '../types';
 
 const colors: Record<Severity, string> = {
@@ -14,9 +15,92 @@ const colors: Record<Severity, string> = {
 interface Props {
   summary: Record<Severity, number>;
   trend: number[];
+  filters?: {
+    severity?: Record<Severity, boolean>;
+    tags?: string[];
+  };
+  onExport?: (type: 'csv' | 'json' | 'image', payload: string) => void;
 }
 
-export default function SummaryDashboard({ summary, trend }: Props) {
+export interface SummaryRow {
+  severity: Severity;
+  count: number;
+  included: boolean;
+}
+
+export const buildSummaryRows = (
+  summary: Record<Severity, number>,
+  severityFilters?: Record<Severity, boolean>,
+): SummaryRow[] =>
+  severities.map((severity) => {
+    const included = severityFilters ? Boolean(severityFilters[severity]) : true;
+    const value = summary[severity] ?? 0;
+    return {
+      severity,
+      count: included ? value : 0,
+      included,
+    };
+  });
+
+export const formatSummaryCsv = (
+  rows: SummaryRow[],
+  tags: string[],
+  trend: number[],
+): string => {
+  const activeSeverities = rows
+    .filter((row) => row.included)
+    .map((row) => row.severity)
+    .join('|');
+  const filtersLine = `Active Severities,${activeSeverities || 'None'}`;
+  const tagsLine = `Selected Tags,${tags.length > 0 ? tags.join('|') : 'All'}`;
+  const header = 'Severity,Count,Included';
+  const entries = rows.map(
+    (row) => `${row.severity},${row.count},${row.included ? 'true' : 'false'}`,
+  );
+  const totals = `Trend,${trend.join('|')},`;
+  return [filtersLine, tagsLine, header, ...entries, totals].join('\n');
+};
+
+export const formatSummaryJson = (
+  rows: SummaryRow[],
+  tags: string[],
+  trend: number[],
+) =>
+  JSON.stringify(
+    {
+      filters: {
+        severities: rows
+          .filter((row) => row.included)
+          .map((row) => row.severity),
+        tags,
+      },
+      summary: rows.map(({ severity, count, included }) => ({
+        severity,
+        count,
+        included,
+      })),
+      totals: {
+        overall: rows.reduce((acc, row) => acc + row.count, 0),
+        trend,
+      },
+    },
+    null,
+    2,
+  );
+
+const triggerDownload = (filename: string, content: string, mime: string) => {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.download = filename;
+  link.href = url;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+};
+
+export default function SummaryDashboard({ summary, trend, filters, onExport }: Props) {
   const max = Math.max(1, ...trend);
   const width = 100;
   const height = 24;
@@ -29,13 +113,59 @@ export default function SummaryDashboard({ summary, trend }: Props) {
     })
     .join(' ');
 
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const rows = useMemo(
+    () => buildSummaryRows(summary, filters?.severity),
+    [summary, filters?.severity],
+  );
+
+  const tags = filters?.tags ?? [];
+
+  const handleCsvExport = () => {
+    const csv = formatSummaryCsv(rows, tags, trend);
+    onExport?.('csv', csv);
+    triggerDownload('nessus-summary.csv', csv, 'text/csv;charset=utf-8');
+  };
+
+  const handleJsonExport = () => {
+    const json = formatSummaryJson(rows, tags, trend);
+    onExport?.('json', json);
+    triggerDownload('nessus-summary.json', json, 'application/json');
+  };
+
+  const handleImageExport = async () => {
+    if (!containerRef.current) return;
+    try {
+      const dataUrl = await toPng(containerRef.current);
+      onExport?.('image', dataUrl);
+      const link = document.createElement('a');
+      link.download = 'nessus-summary.png';
+      link.href = dataUrl;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } catch {
+      // ignore errors
+    }
+  };
+
   return (
-    <div className="space-y-4">
+    <div ref={containerRef} className="space-y-4">
       <div className="grid grid-cols-5 gap-2">
-        {severities.map((sev) => (
-          <div key={sev} className={`p-2 rounded ${colors[sev]}`}>
-            <div className="text-xs">{sev}</div>
-            <div className="text-lg font-bold">{summary[sev]}</div>
+        {rows.map((row) => (
+          <div
+            key={row.severity}
+            data-testid={`summary-card-${row.severity}`}
+            className={`p-2 rounded ${colors[row.severity]} ${
+              row.included ? '' : 'opacity-50'
+            }`}
+          >
+            <div className="text-xs flex items-center justify-between">
+              <span>{row.severity}</span>
+              {!row.included && <span className="text-[10px] uppercase">Filtered</span>}
+            </div>
+            <div className="text-lg font-bold">{row.count}</div>
           </div>
         ))}
       </div>
@@ -44,6 +174,29 @@ export default function SummaryDashboard({ summary, trend }: Props) {
           <path d={d} fill="none" stroke="#3b82f6" strokeWidth={2} />
         </svg>
       )}
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={handleCsvExport}
+          className="px-3 py-1 bg-gray-700 rounded"
+        >
+          Export CSV
+        </button>
+        <button
+          type="button"
+          onClick={handleJsonExport}
+          className="px-3 py-1 bg-gray-700 rounded"
+        >
+          Export JSON
+        </button>
+        <button
+          type="button"
+          onClick={handleImageExport}
+          className="px-3 py-1 bg-gray-700 rounded"
+        >
+          Export Image
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/nessus/index.tsx
+++ b/apps/nessus/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useEffect, useRef, useState, useMemo } from 'react';
-import { toPng } from 'html-to-image';
 import TrendChart from './components/TrendChart';
 import SummaryDashboard from './components/SummaryDashboard';
 import FindingCard from './components/FindingCard';
@@ -33,7 +32,6 @@ const Nessus: React.FC = () => {
     Info: 0,
   });
   const [trend, setTrend] = useState<number[]>([]);
-  const chartRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
   const PAGE_SIZE = 50;
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
@@ -151,19 +149,6 @@ const Nessus: React.FC = () => {
     }
   };
 
-  const exportChart = async () => {
-    if (!chartRef.current) return;
-    try {
-      const dataUrl = await toPng(chartRef.current);
-      const link = document.createElement('a');
-      link.download = 'nessus-summary.png';
-      link.href = dataUrl;
-      link.click();
-    } catch {
-      // ignore
-    }
-  };
-
   return (
     <div className="p-4 bg-gray-900 text-white min-h-screen space-y-6">
       <h1 className="text-2xl">Nessus Demo</h1>
@@ -214,16 +199,11 @@ const Nessus: React.FC = () => {
 
       <section>
         <h2 className="text-xl mb-2">Executive Summary</h2>
-        <div ref={chartRef}>
-          <SummaryDashboard summary={summary} trend={trend} />
-        </div>
-        <button
-          type="button"
-          onClick={exportChart}
-          className="mt-4 px-4 py-2 bg-blue-700 rounded"
-        >
-          Export
-        </button>
+        <SummaryDashboard
+          summary={summary}
+          trend={trend}
+          filters={{ severity: severityFilters, tags: tagFilters }}
+        />
       </section>
       <section>
         <h2 className="text-xl mb-2">Trends</h2>


### PR DESCRIPTION
## Summary
- add CSV, JSON, and image export actions to the Nessus summary dashboard and share helper utilities
- pass active severity and tag filters into the dashboard so exports mirror the visible data
- cover the export helpers with Jest tests to confirm aggregates stay in sync with the UI

## Testing
- yarn test __tests__/nessusSummaryDashboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9d3572d8c832881208699df9f5906