### PR TITLE
[nmap-nse] Improve script browser grouping and help

### DIFF
--- a/__tests__/nmapNsePageClient.test.tsx
+++ b/__tests__/nmapNsePageClient.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NmapNSE from '../apps/nmap-nse';
+
+const mockScripts = {
+  discovery: [
+    {
+      name: 'http-title',
+      description: 'Fetches page titles from HTTP services.',
+      example: 'Example output for http-title',
+    },
+    {
+      name: 'ssh-hostkey',
+      description: 'Retrieves the SSH host key.',
+      example: 'Example output for ssh-hostkey',
+    },
+  ],
+  vuln: [
+    {
+      name: 'smb-vuln-ms17-010',
+      description: 'Detects MS17-010 SMB vulnerabilities.',
+      example: 'Example output for smb-vuln-ms17-010',
+    },
+  ],
+};
+
+describe('NmapNSE page script browser', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({
+        json: () => Promise.resolve(mockScripts),
+      } as unknown as Response);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('filters scripts by category facet instantly', async () => {
+    render(<NmapNSE />);
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+
+    expect(await screen.findByRole('button', { name: /http-title/i })).toBeInTheDocument();
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /filter by vuln/i })
+    );
+
+    expect(screen.getByRole('button', { name: /smb-vuln-ms17-010/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /http-title/i })).not.toBeInTheDocument();
+  });
+
+  it('shows inline help for the selected script', async () => {
+    render(<NmapNSE />);
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+
+    await userEvent.click(await screen.findByRole('button', { name: /http-title/i }));
+
+    const helpPanel = await screen.findByTestId('script-help-panel');
+    expect(helpPanel).toHaveTextContent('Fetches page titles from HTTP services.');
+    expect(helpPanel).toHaveTextContent('Example output for http-title');
+  });
+});
+


### PR DESCRIPTION
## Summary
- load the NSE script catalog as grouped categories and add client-side filtering chips
- keep the active script highlighted with inline help and sample output inside the picker
- add focused unit tests that cover category filtering and inline help rendering

## Testing
- yarn test --runTestsByPath __tests__/nmapNsePageClient.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9d35884188328b9b90fae536f1ecb