### PR TITLE
[ssh] add compatibility hints and tests

### DIFF
--- a/__tests__/ssh/compatHints.test.tsx
+++ b/__tests__/ssh/compatHints.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CompatHints, {
+  ProfileKey,
+  SelectionState,
+  assessCompatibility,
+  osProfiles,
+} from '../../apps/ssh/components/CompatHints';
+
+describe('CompatHints knowledge base', () => {
+  it('confirms compatibility for modern OpenSSH defaults', () => {
+    const selection: SelectionState = {
+      kex: 'curve25519-sha256',
+      hostKey: 'ssh-ed25519',
+      cipher: 'chacha20-poly1305@openssh.com',
+      mac: 'hmac-sha2-512-etm@openssh.com',
+    };
+    const result = assessCompatibility('ubuntu-22-04', selection);
+    expect(result.every((entry) => entry.isCompatible)).toBe(true);
+  });
+
+  it('suggests alternatives when newer algorithms miss older OpenSSH builds', () => {
+    const selection: SelectionState = {
+      cipher: 'chacha20-poly1305@openssh.com',
+      mac: 'hmac-md5',
+    };
+    const result = assessCompatibility('rhel-7', selection);
+    const cipherStatus = result.find((entry) => entry.category === 'cipher');
+    const macStatus = result.find((entry) => entry.category === 'mac');
+
+    expect(cipherStatus?.isCompatible).toBe(false);
+    expect(cipherStatus?.alternatives).toContain('aes256-ctr');
+    expect(macStatus?.isCompatible).toBe(false);
+    expect(macStatus?.alternatives).toContain('hmac-sha2-256');
+  });
+
+  it('captures Dropbear limitations for curve25519 hybrids', () => {
+    const selection: SelectionState = {
+      kex: 'sntrup761x25519-sha512@openssh.com',
+      hostKey: 'rsa-sha2-512',
+    };
+    const result = assessCompatibility('alpine-3-17', selection);
+    const kexStatus = result.find((entry) => entry.category === 'kex');
+    const hostKeyStatus = result.find((entry) => entry.category === 'hostKey');
+
+    expect(kexStatus?.isCompatible).toBe(false);
+    expect(kexStatus?.alternatives).toContain('curve25519-sha256');
+    expect(hostKeyStatus?.isCompatible).toBe(false);
+    expect(hostKeyStatus?.alternatives).toContain('ssh-ed25519');
+  });
+});
+
+describe('CompatHints component rendering', () => {
+  const renderWithProfile = (profileKey: ProfileKey, selection: SelectionState) =>
+    render(<CompatHints profileKey={profileKey} selection={selection} />);
+
+  it('shows an encouragement when everything is supported', () => {
+    const profileKey: ProfileKey = 'debian-10';
+    const recommended = osProfiles[profileKey].recommended ?? {};
+    const selection: SelectionState = {
+      kex: recommended.kex?.[0],
+      hostKey: recommended.hostKey?.[0],
+      cipher: recommended.cipher?.[0],
+      mac: recommended.mac?.[0],
+    };
+
+    renderWithProfile(profileKey, selection);
+    expect(screen.getByText(/All selected algorithms are supported/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/OpenSSH 7.9p1/).length).toBeGreaterThan(0);
+  });
+
+  it('renders warnings with alternative suggestions', () => {
+    renderWithProfile('windows-2019', { kex: 'sntrup761x25519-sha512@openssh.com' });
+    expect(
+      screen.getByText(/sntrup761x25519-sha512@openssh.com/i, { selector: 'code' })
+    ).toBeInTheDocument();
+    const suggestion = screen.getByText(/curve25519-sha256/i, { selector: 'code' });
+    expect(suggestion).toBeInTheDocument();
+    expect(screen.getByText(/not available on Windows Server 2019/i)).toBeInTheDocument();
+  });
+
+  it('prompts the user to select algorithms when none are chosen', () => {
+    renderWithProfile('ubuntu-22-04', {});
+    expect(screen.getByText(/Select algorithms above/i)).toBeInTheDocument();
+  });
+});

--- a/apps/ssh/components/CompatHints.tsx
+++ b/apps/ssh/components/CompatHints.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import React, { useMemo } from 'react';
+
+export const algorithmFields = [
+  { id: 'kex', label: 'Key exchange (KexAlgorithms)' },
+  { id: 'hostKey', label: 'Host key (HostKeyAlgorithms)' },
+  { id: 'cipher', label: 'Cipher (-c)' },
+  { id: 'mac', label: 'Message authentication (MACs)' },
+] as const;
+
+export type AlgorithmCategory = (typeof algorithmFields)[number]['id'];
+
+export type SelectionState = Partial<Record<AlgorithmCategory, string | undefined>>;
+
+export const algorithmLibrary: Record<AlgorithmCategory, string[]> = {
+  kex: [
+    'sntrup761x25519-sha512@openssh.com',
+    'curve25519-sha256',
+    'curve25519-sha256@libssh.org',
+    'ecdh-sha2-nistp256',
+    'ecdh-sha2-nistp384',
+    'diffie-hellman-group-exchange-sha256',
+    'diffie-hellman-group14-sha1',
+  ],
+  hostKey: [
+    'ssh-ed25519',
+    'ecdsa-sha2-nistp256',
+    'ecdsa-sha2-nistp384',
+    'rsa-sha2-512',
+    'rsa-sha2-256',
+    'ssh-rsa',
+  ],
+  cipher: [
+    'chacha20-poly1305@openssh.com',
+    'aes256-gcm@openssh.com',
+    'aes128-gcm@openssh.com',
+    'aes256-ctr',
+    'aes128-ctr',
+    'aes128-cbc',
+    '3des-cbc',
+  ],
+  mac: [
+    'hmac-sha2-512-etm@openssh.com',
+    'hmac-sha2-256-etm@openssh.com',
+    'umac-128-etm@openssh.com',
+    'hmac-sha2-512',
+    'hmac-sha2-256',
+    'hmac-sha1',
+    'hmac-md5',
+  ],
+};
+
+export interface OSProfile {
+  name: string;
+  release: string;
+  algorithms: Record<AlgorithmCategory, string[]>;
+  recommended?: Partial<Record<AlgorithmCategory, string[]>>;
+  notes?: string[];
+}
+
+export const osProfiles = {
+  'ubuntu-22-04': {
+    name: 'Ubuntu 22.04 LTS',
+    release: 'OpenSSH 8.9p1',
+    algorithms: {
+      kex: [
+        'sntrup761x25519-sha512@openssh.com',
+        'curve25519-sha256',
+        'curve25519-sha256@libssh.org',
+        'ecdh-sha2-nistp256',
+        'ecdh-sha2-nistp384',
+      ],
+      hostKey: [
+        'ssh-ed25519',
+        'ecdsa-sha2-nistp256',
+        'ecdsa-sha2-nistp384',
+        'rsa-sha2-512',
+        'rsa-sha2-256',
+      ],
+      cipher: [
+        'chacha20-poly1305@openssh.com',
+        'aes256-gcm@openssh.com',
+        'aes128-gcm@openssh.com',
+        'aes256-ctr',
+        'aes128-ctr',
+      ],
+      mac: [
+        'hmac-sha2-512-etm@openssh.com',
+        'hmac-sha2-256-etm@openssh.com',
+        'umac-128-etm@openssh.com',
+      ],
+    },
+    recommended: {
+      kex: ['sntrup761x25519-sha512@openssh.com', 'curve25519-sha256'],
+      hostKey: ['ssh-ed25519'],
+      cipher: ['chacha20-poly1305@openssh.com', 'aes256-gcm@openssh.com'],
+      mac: ['hmac-sha2-512-etm@openssh.com'],
+    },
+    notes: [
+      'Modern OpenSSH defaults already prefer sntrup and curve25519 key exchange.',
+      'Legacy RSA-SHA1 and MD5 algorithms are disabled.',
+    ],
+  } satisfies OSProfile,
+  'debian-10': {
+    name: 'Debian 10 Buster',
+    release: 'OpenSSH 7.9p1',
+    algorithms: {
+      kex: [
+        'curve25519-sha256',
+        'curve25519-sha256@libssh.org',
+        'ecdh-sha2-nistp256',
+        'diffie-hellman-group-exchange-sha256',
+      ],
+      hostKey: [
+        'ssh-ed25519',
+        'ecdsa-sha2-nistp256',
+        'rsa-sha2-512',
+        'rsa-sha2-256',
+      ],
+      cipher: [
+        'chacha20-poly1305@openssh.com',
+        'aes256-gcm@openssh.com',
+        'aes128-gcm@openssh.com',
+        'aes256-ctr',
+        'aes128-ctr',
+      ],
+      mac: [
+        'hmac-sha2-512-etm@openssh.com',
+        'hmac-sha2-256-etm@openssh.com',
+        'umac-128-etm@openssh.com',
+        'hmac-sha2-512',
+        'hmac-sha2-256',
+      ],
+    },
+    recommended: {
+      kex: ['curve25519-sha256'],
+      hostKey: ['ssh-ed25519', 'ecdsa-sha2-nistp256'],
+      cipher: ['chacha20-poly1305@openssh.com', 'aes256-gcm@openssh.com'],
+      mac: ['hmac-sha2-512-etm@openssh.com'],
+    },
+    notes: [
+      'GCM and chacha20 ciphers are available, but sntrup key exchange arrived in newer releases.',
+      'Older HMACs remain for backward compatibility; prefer the -etm variants when possible.',
+    ],
+  } satisfies OSProfile,
+  'rhel-7': {
+    name: 'RHEL / CentOS 7',
+    release: 'OpenSSH 7.4p1',
+    algorithms: {
+      kex: [
+        'curve25519-sha256',
+        'ecdh-sha2-nistp256',
+        'diffie-hellman-group-exchange-sha256',
+        'diffie-hellman-group14-sha1',
+      ],
+      hostKey: [
+        'ecdsa-sha2-nistp256',
+        'rsa-sha2-512',
+        'rsa-sha2-256',
+        'ssh-rsa',
+      ],
+      cipher: ['aes256-ctr', 'aes128-ctr', 'aes128-cbc', '3des-cbc'],
+      mac: ['hmac-sha2-512', 'hmac-sha2-256', 'hmac-sha1'],
+    },
+    recommended: {
+      kex: ['curve25519-sha256', 'ecdh-sha2-nistp256'],
+      hostKey: ['ecdsa-sha2-nistp256', 'rsa-sha2-512'],
+      cipher: ['aes256-ctr', 'aes128-ctr'],
+      mac: ['hmac-sha2-512', 'hmac-sha2-256'],
+    },
+    notes: [
+      'Chacha20 and GCM ciphers are not present until newer OpenSSH releases.',
+      'RSA-SHA1 and MD5 HMACs may still exist but should be avoided if FIPS is enabled.',
+    ],
+  } satisfies OSProfile,
+  'alpine-3-17': {
+    name: 'Alpine 3.17',
+    release: 'Dropbear 2022.82',
+    algorithms: {
+      kex: ['curve25519-sha256', 'ecdh-sha2-nistp256', 'diffie-hellman-group14-sha1'],
+      hostKey: ['ssh-ed25519', 'ecdsa-sha2-nistp256'],
+      cipher: ['chacha20-poly1305@openssh.com', 'aes256-ctr', 'aes128-ctr'],
+      mac: ['hmac-sha2-256', 'hmac-sha1'],
+    },
+    recommended: {
+      kex: ['curve25519-sha256'],
+      hostKey: ['ssh-ed25519'],
+      cipher: ['chacha20-poly1305@openssh.com'],
+      mac: ['hmac-sha2-256'],
+    },
+    notes: [
+      'Dropbear ships a smaller algorithm set; stick to curve25519 or diffie-hellman-group14.',
+      'Only CTR or chacha20 ciphers are compiled in by default.',
+    ],
+  } satisfies OSProfile,
+  'windows-2019': {
+    name: 'Windows Server 2019',
+    release: 'Win32-OpenSSH 8.1',
+    algorithms: {
+      kex: ['curve25519-sha256', 'ecdh-sha2-nistp256', 'diffie-hellman-group14-sha1'],
+      hostKey: ['ssh-ed25519', 'ecdsa-sha2-nistp256', 'rsa-sha2-512'],
+      cipher: ['aes256-gcm@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr', 'aes128-ctr'],
+      mac: ['hmac-sha2-512-etm@openssh.com', 'hmac-sha2-256-etm@openssh.com'],
+    },
+    recommended: {
+      kex: ['curve25519-sha256'],
+      hostKey: ['ecdsa-sha2-nistp256', 'ssh-ed25519'],
+      cipher: ['aes256-gcm@openssh.com', 'aes128-gcm@openssh.com'],
+      mac: ['hmac-sha2-512-etm@openssh.com'],
+    },
+    notes: [
+      'Win32-OpenSSH inherits most OpenSSH defaults but lacks sntrup hybrids.',
+      'Legacy SSH-RSA is disabled when the system enforces modern cryptography policies.',
+    ],
+  } satisfies OSProfile,
+} satisfies Record<string, OSProfile>;
+
+export type ProfileKey = keyof typeof osProfiles;
+
+export interface CategoryAssessment {
+  category: AlgorithmCategory;
+  selected?: string;
+  isCompatible: boolean;
+  supported: string[];
+  alternatives: string[];
+}
+
+const fieldLabels = algorithmFields.reduce<Record<AlgorithmCategory, string>>((acc, field) => {
+  acc[field.id] = field.label;
+  return acc;
+}, {} as Record<AlgorithmCategory, string>);
+
+const unique = (values: string[]) => Array.from(new Set(values));
+
+export function assessCompatibility(profileKey: ProfileKey, selection: SelectionState): CategoryAssessment[] {
+  const profile = osProfiles[profileKey];
+  return algorithmFields.map((field) => {
+    const supported = profile.algorithms[field.id] ?? [];
+    const selected = selection[field.id];
+    const isCompatible = !selected || supported.includes(selected);
+    const preferred = profile.recommended?.[field.id] ?? [];
+    const alternatives = !isCompatible
+      ? unique([...preferred, ...supported]).filter((alg) => alg !== selected).slice(0, 4)
+      : [];
+
+    return {
+      category: field.id,
+      selected: selected ?? undefined,
+      isCompatible,
+      supported,
+      alternatives,
+    };
+  });
+}
+
+interface CompatHintsProps {
+  profileKey: ProfileKey;
+  selection: SelectionState;
+}
+
+const CompatHints: React.FC<CompatHintsProps> = ({ profileKey, selection }) => {
+  const profile = osProfiles[profileKey];
+
+  const assessments = useMemo(() => assessCompatibility(profileKey, selection), [profileKey, selection]);
+  const warnings = assessments.filter((item) => item.selected && !item.isCompatible);
+  const hasSelection = algorithmFields.some((field) => !!selection[field.id]);
+
+  if (!profile) {
+    return null;
+  }
+
+  return (
+    <section aria-live="polite" className="mt-6 border-t border-gray-800 pt-4">
+      <header className="flex flex-col gap-1">
+        <h3 className="text-lg font-semibold text-sky-200">Compatibility hints</h3>
+        <p className="text-xs uppercase tracking-wide text-slate-300">
+          {profile.name} · {profile.release}
+        </p>
+      </header>
+
+      {warnings.length > 0 ? (
+        <div className="mt-3 space-y-3">
+          {warnings.map((warning) => (
+            <div
+              key={warning.category}
+              className="rounded border border-yellow-500/70 bg-yellow-950/40 p-3 text-yellow-100"
+            >
+              <p className="font-medium text-yellow-200">{fieldLabels[warning.category]}</p>
+              <p className="text-sm">
+                <code className="rounded bg-black/50 px-1 py-0.5 text-xs">{warning.selected}</code> is not
+                available on {profile.name}.
+              </p>
+              {warning.alternatives.length > 0 && (
+                <p className="text-sm">
+                  Try{' '}
+                  {warning.alternatives.map((alt, index) => (
+                    <React.Fragment key={alt}>
+                      {index > 0 ? ', ' : ''}
+                      <code className="rounded bg-black/50 px-1 py-0.5 text-xs">{alt}</code>
+                    </React.Fragment>
+                  ))}
+                  .
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : hasSelection ? (
+        <div className="mt-3 rounded border border-emerald-600/60 bg-emerald-900/30 p-3 text-emerald-100">
+          <p className="font-medium text-emerald-200">All selected algorithms are supported.</p>
+          <p className="text-xs text-emerald-100/80">{profile.release}</p>
+        </div>
+      ) : (
+        <p className="mt-3 text-sm text-slate-300">
+          Select algorithms above to verify their compatibility with {profile.name}.
+        </p>
+      )}
+
+      {profile.notes?.length ? (
+        <ul className="mt-3 list-disc space-y-1 pl-5 text-xs text-slate-300">
+          {profile.notes.map((note) => (
+            <li key={note}>{note}</li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+};
+
+export default CompatHints;

--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -1,73 +1,180 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import CompatHints, {
+  ProfileKey,
+  SelectionState,
+  algorithmFields,
+  algorithmLibrary,
+  osProfiles,
+} from './components/CompatHints';
+
+const profileKeys = Object.keys(osProfiles) as ProfileKey[];
+
+const getRecommendedSelection = (profileKey: ProfileKey): SelectionState => {
+  const recommended = osProfiles[profileKey].recommended ?? {};
+  return {
+    kex: recommended.kex?.[0],
+    hostKey: recommended.hostKey?.[0],
+    cipher: recommended.cipher?.[0],
+    mac: recommended.mac?.[0],
+  };
+};
 
 const SSHBuilder: React.FC = () => {
+  const [profileKey, setProfileKey] = useState<ProfileKey>(profileKeys[0]);
+  const [selection, setSelection] = useState<SelectionState>(() => getRecommendedSelection(profileKeys[0]));
   const [user, setUser] = useState('');
   const [host, setHost] = useState('');
   const [port, setPort] = useState('');
-  const command = `ssh ${user ? `${user}@` : ''}${host}${port ? ` -p ${port}` : ''}`.trim();
+
+  const updateAlgorithm = (category: typeof algorithmFields[number]['id']) =>
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const value = event.target.value;
+      setSelection((prev) => ({
+        ...prev,
+        [category]: value === '' ? undefined : value,
+      }));
+    };
+
+  const applyRecommended = () => {
+    setSelection(getRecommendedSelection(profileKey));
+  };
+
+  const command = useMemo(() => {
+    const parts = ['ssh'];
+
+    if (selection.kex) {
+      parts.push(`-o KexAlgorithms=${selection.kex}`);
+    }
+    if (selection.hostKey) {
+      parts.push(`-o HostKeyAlgorithms=${selection.hostKey}`);
+    }
+    if (selection.cipher) {
+      parts.push(`-c ${selection.cipher}`);
+    }
+    if (selection.mac) {
+      parts.push(`-o MACs=${selection.mac}`);
+    }
+    if (port) {
+      parts.push(`-p ${port}`);
+    }
+
+    const destination = host ? `${user ? `${user}@` : ''}${host}` : '';
+    if (destination) {
+      parts.push(destination);
+    }
+
+    return parts.join(' ').trim();
+  }, [host, port, selection.cipher, selection.hostKey, selection.kex, selection.mac, user]);
 
   return (
-    <div className="h-full bg-gray-900 p-4 text-white overflow-auto">
+    <div className="h-full overflow-auto bg-gray-900 p-4 text-white">
       <h1 className="mb-4 text-2xl">SSH Command Builder</h1>
-      <p className="mb-4 text-sm text-yellow-300">
-        Generate an SSH command without executing it. Learn more at{' '}
-        <a
-          href="https://www.openssh.com/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline text-blue-400"
-        >
-          the OpenSSH project page
-        </a>
-        .
+      <p className="mb-6 text-sm text-yellow-300">
+        Craft SSH connection commands safely. This builder never executes anything—it helps explore options and
+        compatibility before you connect.
       </p>
-      <form onSubmit={(e) => e.preventDefault()} className="mb-4 space-y-4">
-        <div>
-          <label htmlFor="ssh-user" className="mb-1 block text-sm font-medium">
-            Username
-          </label>
-          <input
-            id="ssh-user"
-            type="text"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={user}
-            onChange={(e) => setUser(e.target.value)}
-          />
-        </div>
-        <div>
-          <label htmlFor="ssh-host" className="mb-1 block text-sm font-medium">
-            Host
-          </label>
-          <input
-            id="ssh-host"
-            type="text"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={host}
-            onChange={(e) => setHost(e.target.value)}
-          />
-        </div>
-        <div>
-          <label htmlFor="ssh-port" className="mb-1 block text-sm font-medium">
-            Port (optional)
-          </label>
-          <input
-            id="ssh-port"
-            type="number"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={port}
-            onChange={(e) => setPort(e.target.value)}
-          />
-        </div>
+      <form onSubmit={(e) => e.preventDefault()} className="mb-6 grid gap-6 lg:grid-cols-2">
+        <fieldset className="space-y-4">
+          <legend className="text-lg font-semibold text-sky-200">Connection details</legend>
+          <div>
+            <label htmlFor="ssh-user" className="mb-1 block text-sm font-medium">
+              Username
+            </label>
+            <input
+              id="ssh-user"
+              type="text"
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+              value={user}
+              onChange={(e) => setUser(e.target.value)}
+              placeholder="kali"
+            />
+          </div>
+          <div>
+            <label htmlFor="ssh-host" className="mb-1 block text-sm font-medium">
+              Host
+            </label>
+            <input
+              id="ssh-host"
+              type="text"
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+              value={host}
+              onChange={(e) => setHost(e.target.value)}
+              placeholder="10.10.10.42"
+            />
+          </div>
+          <div>
+            <label htmlFor="ssh-port" className="mb-1 block text-sm font-medium">
+              Port (optional)
+            </label>
+            <input
+              id="ssh-port"
+              type="number"
+              min="1"
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+              value={port}
+              onChange={(e) => setPort(e.target.value)}
+              placeholder="22"
+            />
+          </div>
+        </fieldset>
+        <fieldset className="space-y-4">
+          <legend className="text-lg font-semibold text-sky-200">Compatibility profile</legend>
+          <div>
+            <label htmlFor="ssh-profile" className="mb-1 block text-sm font-medium">
+              Target server OS
+            </label>
+            <select
+              id="ssh-profile"
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+              value={profileKey}
+              onChange={(event) => setProfileKey(event.target.value as ProfileKey)}
+            >
+              {profileKeys.map((key) => (
+                <option key={key} value={key}>
+                  {osProfiles[key].name} · {osProfiles[key].release}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={applyRecommended}
+              className="mt-2 rounded border border-sky-500 px-2 py-1 text-xs font-semibold text-sky-200 transition hover:bg-sky-600/20"
+            >
+              Load recommended algorithms
+            </button>
+          </div>
+          {algorithmFields.map((field) => (
+            <div key={field.id}>
+              <label htmlFor={`ssh-${field.id}`} className="mb-1 block text-sm font-medium">
+                {field.label}
+              </label>
+              <select
+                id={`ssh-${field.id}`}
+                value={selection[field.id] ?? ''}
+                onChange={updateAlgorithm(field.id)}
+                className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+              >
+                <option value="">Auto negotiate</option>
+                {algorithmLibrary[field.id].map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ))}
+        </fieldset>
       </form>
       <div>
         <h2 className="mb-2 text-lg">Command Preview</h2>
-        <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
+        <pre className="overflow-auto rounded bg-black p-3 font-mono text-green-400">
           {command || '# Fill in the form to generate a command'}
         </pre>
       </div>
+      <CompatHints profileKey={profileKey} selection={selection} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a compatibility knowledge base and hint component for SSH algorithm negotiation
- update the SSH command builder UI with OS presets, algorithm selectors, and recommendations
- add Jest coverage for the compatibility evaluator and warning rendering

## Testing
- yarn test compatHints

------
https://chatgpt.com/codex/tasks/task_e_68d9d3649a30832892530c299373db40