### PR TITLE
[apps] Enhance HTTP builder with raw preview

### DIFF
--- a/__tests__/http-builder.test.ts
+++ b/__tests__/http-builder.test.ts
@@ -1,0 +1,80 @@
+import { buildCurlCommand, buildRawRequest } from '../apps/http/utils';
+
+describe('HTTP builder exports', () => {
+  test('builds curl command with method, url, and headers', () => {
+    const command = buildCurlCommand({
+      method: 'POST',
+      url: 'https://example.com/login',
+      headers: [
+        { key: 'Content-Type', value: 'application/json' },
+        { key: ' X-Custom ', value: '  token  ' },
+        { key: '', value: 'ignored' },
+      ],
+      body: '',
+    });
+
+    expect(command).toContain("-X 'POST'");
+    expect(command).toContain("--url 'https://example.com/login'");
+    expect(command).toContain("-H 'Content-Type: application/json'");
+    expect(command).toContain("-H 'X-Custom: token'");
+    expect(command).not.toContain('ignored');
+  });
+
+  test('serializes JSON bodies with --data-raw', () => {
+    const jsonBody = '{\n  "name": "demo"\n}';
+    const command = buildCurlCommand({
+      method: 'PUT',
+      url: 'https://api.example.com/profile',
+      headers: [{ key: 'Content-Type', value: 'application/json' }],
+      body: jsonBody,
+    });
+
+    expect(command).toContain("--data-raw '{\n  \"name\": \"demo\"\n}'");
+  });
+
+  test('uses --data-binary for binary payloads and escapes them safely', () => {
+    const binaryBody = '\u0000\u0001Hi\u001f';
+    const command = buildCurlCommand({
+      method: 'POST',
+      url: 'https://example.com/upload',
+      headers: [{ key: 'Content-Type', value: 'application/octet-stream' }],
+      body: binaryBody,
+    });
+
+    expect(command).toContain("--data-binary $'\\x00\\x01Hi\\x1f'");
+    expect(command).not.toContain('--data-raw');
+  });
+});
+
+describe('Raw request preview', () => {
+  test('derives path and adds host header when available', () => {
+    const raw = buildRawRequest({
+      method: 'GET',
+      url: 'https://security.local:8443/path?q=1',
+      headers: [{ key: 'Accept', value: 'application/json' }],
+      body: '',
+    });
+
+    expect(raw).toContain('GET /path?q=1 HTTP/1.1');
+    expect(raw).toContain('Host: security.local:8443');
+    expect(raw).toContain('Accept: application/json');
+  });
+
+  test('respects custom host header and preserves body', () => {
+    const raw = buildRawRequest({
+      method: 'PATCH',
+      url: 'https://example.com/resources',
+      headers: [
+        { key: 'Host', value: 'api.example.net' },
+        { key: 'Content-Type', value: 'application/json' },
+      ],
+      body: '{"patched":true}\u0000',
+    });
+
+    const lines = raw.split('\n');
+    expect(lines[0]).toBe('PATCH /resources HTTP/1.1');
+    expect(lines[1]).toBe('Host: api.example.net');
+    expect(lines[2]).toBe('Content-Type: application/json');
+    expect(raw.endsWith('{"patched":true}\u0000')).toBe(true);
+  });
+});

--- a/apps/http/index.tsx
+++ b/apps/http/index.tsx
@@ -1,64 +1,230 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import { buildCurlCommand, buildRawRequest, HeaderEntry } from './utils';
+
+type HeaderRow = HeaderEntry & { id: string };
+
+const createHeaderRow = (id: number): HeaderRow => ({
+  id: id.toString(),
+  key: '',
+  value: '',
+});
 
 const HTTPBuilder: React.FC = () => {
   const [method, setMethod] = useState('GET');
   const [url, setUrl] = useState('');
-  const command = `curl -X ${method} ${url}`.trim();
+  const [headers, setHeaders] = useState<HeaderRow[]>([createHeaderRow(0)]);
+  const [body, setBody] = useState('');
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'error'>('idle');
+  const headerIdRef = useRef(1);
+
+  const requestState = useMemo(
+    () => ({
+      method,
+      url,
+      headers: headers.map(({ key, value }) => ({ key, value })),
+      body,
+    }),
+    [method, url, headers, body],
+  );
+
+  const command = useMemo(() => buildCurlCommand(requestState), [requestState]);
+  const rawRequest = useMemo(() => buildRawRequest(requestState), [requestState]);
+
+  const hasRequestDetails = useMemo(() => {
+    if (url.trim().length > 0 || body.length > 0) {
+      return true;
+    }
+
+    return headers.some((header) => header.key.trim().length > 0 || header.value.trim().length > 0);
+  }, [url, body, headers]);
+
+  const handleHeaderChange = (id: string, field: 'key' | 'value', value: string) => {
+    setHeaders((prev) =>
+      prev.map((header) =>
+        header.id === id
+          ? {
+              ...header,
+              [field]: value,
+            }
+          : header,
+      ),
+    );
+  };
+
+  const handleAddHeader = () => {
+    setHeaders((prev) => [...prev, createHeaderRow(headerIdRef.current++)]);
+  };
+
+  const handleRemoveHeader = (id: string) => {
+    setHeaders((prev) => {
+      const next = prev.filter((header) => header.id !== id);
+      return next.length > 0 ? next : [createHeaderRow(headerIdRef.current++)];
+    });
+  };
+
+  const handleExport = async () => {
+    if (!hasRequestDetails) {
+      return;
+    }
+
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(command);
+        setCopyStatus('copied');
+        setTimeout(() => setCopyStatus('idle'), 2000);
+      } else {
+        throw new Error('Clipboard API unavailable');
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('Unable to copy curl command', error);
+      setCopyStatus('error');
+      setTimeout(() => setCopyStatus('idle'), 4000);
+    }
+  };
 
   return (
-    <div className="h-full bg-gray-900 p-4 text-white overflow-auto">
+    <div className="h-full overflow-auto bg-gray-900 p-4 text-white">
       <h1 className="mb-4 text-2xl">HTTP Request Builder</h1>
-      <p className="mb-4 text-sm text-yellow-300">
+      <p className="mb-6 text-sm text-yellow-300">
         Build a curl command without sending any requests. Learn more at{' '}
         <a
           href="https://curl.se/"
           target="_blank"
           rel="noopener noreferrer"
-          className="underline text-blue-400"
+          className="text-blue-400 underline"
         >
           the curl project page
         </a>
         .
       </p>
-      <form onSubmit={(e) => e.preventDefault()} className="mb-4 space-y-4">
-        <div>
-          <label htmlFor="http-method" className="mb-1 block text-sm font-medium">
-            Method
-          </label>
-          <select
-            id="http-method"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={method}
-            onChange={(e) => setMethod(e.target.value)}
-          >
-            <option value="GET">GET</option>
-            <option value="POST">POST</option>
-            <option value="PUT">PUT</option>
-            <option value="DELETE">DELETE</option>
-          </select>
-        </div>
-        <div>
-          <label htmlFor="http-url" className="mb-1 block text-sm font-medium">
-            URL
-          </label>
-          <input
-            id="http-url"
-            type="text"
-            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-          />
+      <form onSubmit={(event) => event.preventDefault()} className="space-y-6">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <div className="space-y-4">
+            <div>
+              <label htmlFor="http-method" className="mb-1 block text-sm font-medium">
+                Method
+              </label>
+              <select
+                id="http-method"
+                className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+                value={method}
+                onChange={(event) => setMethod(event.target.value)}
+              >
+                <option value="GET">GET</option>
+                <option value="POST">POST</option>
+                <option value="PUT">PUT</option>
+                <option value="DELETE">DELETE</option>
+                <option value="PATCH">PATCH</option>
+                <option value="HEAD">HEAD</option>
+                <option value="OPTIONS">OPTIONS</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="http-url" className="mb-1 block text-sm font-medium">
+                URL
+              </label>
+              <input
+                id="http-url"
+                type="text"
+                className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+                value={url}
+                onChange={(event) => setUrl(event.target.value)}
+                placeholder="https://example.com/api"
+              />
+            </div>
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <label className="text-sm font-medium">Headers</label>
+                <button
+                  type="button"
+                  onClick={handleAddHeader}
+                  className="rounded bg-blue-600 px-2 py-1 text-xs font-semibold text-white hover:bg-blue-500"
+                >
+                  Add header
+                </button>
+              </div>
+              <div className="space-y-2">
+                {headers.map((header) => (
+                  <div key={header.id} className="flex flex-col gap-2 md:flex-row md:items-center">
+                    <input
+                      type="text"
+                      className="flex-1 rounded border border-gray-700 bg-gray-800 p-2 text-white"
+                      placeholder="Header"
+                      value={header.key}
+                      onChange={(event) => handleHeaderChange(header.id, 'key', event.target.value)}
+                    />
+                    <input
+                      type="text"
+                      className="flex-1 rounded border border-gray-700 bg-gray-800 p-2 text-white"
+                      placeholder="Value"
+                      value={header.value}
+                      onChange={(event) => handleHeaderChange(header.id, 'value', event.target.value)}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveHeader(header.id)}
+                      className="self-start rounded border border-red-700 px-2 py-1 text-xs font-semibold text-red-300 hover:bg-red-900/40 md:self-auto"
+                      aria-label="Remove header"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div>
+              <label htmlFor="http-body" className="mb-1 block text-sm font-medium">
+                Body
+              </label>
+              <textarea
+                id="http-body"
+                className="h-48 w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+                value={body}
+                onChange={(event) => setBody(event.target.value)}
+                placeholder={`{
+  "example": true
+}`}
+              />
+            </div>
+          </div>
+          <div className="space-y-4">
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <h2 className="text-lg font-semibold">curl export</h2>
+                <button
+                  type="button"
+                  onClick={handleExport}
+                  disabled={!hasRequestDetails}
+                  className={`rounded px-3 py-1 text-sm font-semibold text-white transition-colors ${
+                    hasRequestDetails ? 'bg-green-600 hover:bg-green-500' : 'bg-gray-700 text-gray-400'
+                  }`}
+                >
+                  Copy command
+                </button>
+              </div>
+              <pre className="whitespace-pre-wrap break-all rounded bg-black p-3 font-mono text-green-400">
+                {hasRequestDetails ? command : '# Fill in the form to generate a command'}
+              </pre>
+              {copyStatus === 'copied' && (
+                <p className="mt-2 text-xs text-green-300">Command copied to clipboard.</p>
+              )}
+              {copyStatus === 'error' && (
+                <p className="mt-2 text-xs text-red-300">Unable to copy. Please copy manually.</p>
+              )}
+            </div>
+            <div>
+              <h2 className="mb-2 text-lg font-semibold">Raw Request Preview</h2>
+              <pre className="whitespace-pre-wrap break-words rounded bg-black p-3 font-mono text-blue-300">
+                {hasRequestDetails ? rawRequest : '# Request line, headers, and body will appear here'}
+              </pre>
+            </div>
+          </div>
         </div>
       </form>
-      <div>
-        <h2 className="mb-2 text-lg">Command Preview</h2>
-        <pre className="overflow-auto rounded bg-black p-2 font-mono text-green-400">
-          {command || '# Fill in the form to generate a command'}
-        </pre>
-      </div>
     </div>
   );
 };

--- a/apps/http/utils.ts
+++ b/apps/http/utils.ts
@@ -1,0 +1,147 @@
+export interface HeaderEntry {
+  key: string;
+  value: string;
+}
+
+export interface RequestState {
+  method: string;
+  url: string;
+  headers: HeaderEntry[];
+  body: string;
+}
+
+const HTTP_VERSION = 'HTTP/1.1';
+
+const CONTROL_CHARS_REGEX = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/;
+
+const escapeSingleQuotes = (value: string): string => {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+};
+
+const escapeForCStyle = (value: string): string => {
+  let result = '';
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    const code = value.charCodeAt(i);
+
+    switch (char) {
+      case '\\':
+        result += '\\\\';
+        break;
+      case "'":
+        result += "\\'";
+        break;
+      case '\n':
+        result += '\\n';
+        break;
+      case '\r':
+        result += '\\r';
+        break;
+      case '\t':
+        result += '\\t';
+        break;
+      case '\b':
+        result += '\\b';
+        break;
+      case '\f':
+        result += '\\f';
+        break;
+      case '\v':
+        result += '\\v';
+        break;
+      default:
+        if (code < 32 || code === 127) {
+          result += `\\x${code.toString(16).padStart(2, '0')}`;
+        } else {
+          result += char;
+        }
+    }
+  }
+
+  return `$'${result}'`;
+};
+
+const isBinaryBody = (body: string): boolean => {
+  return CONTROL_CHARS_REGEX.test(body);
+};
+
+const normalizeHeaders = (headers: HeaderEntry[]): HeaderEntry[] => {
+  return headers
+    .map((header) => ({
+      key: header.key.trim(),
+      value: header.value.trim(),
+    }))
+    .filter((header) => header.key.length > 0);
+};
+
+const getHostFromHeaders = (headers: HeaderEntry[]): string | undefined => {
+  const hostHeader = headers.find((header) => header.key.toLowerCase() === 'host');
+  return hostHeader?.value;
+};
+
+const getPathFromUrl = (url: string): { host?: string; path: string } => {
+  if (!url) {
+    return { path: '/' };
+  }
+
+  try {
+    const parsed = new URL(url);
+    const path = `${parsed.pathname || '/'}${parsed.search}` || '/';
+    return { host: parsed.host, path: path || '/' };
+  } catch (error) {
+    if (url.startsWith('/')) {
+      return { path: url };
+    }
+    return { path: '/', host: undefined };
+  }
+};
+
+export const buildCurlCommand = ({ method, url, headers, body }: RequestState): string => {
+  const sanitizedHeaders = normalizeHeaders(headers);
+  const parts: string[] = ['curl'];
+
+  if (method) {
+    parts.push('-X', escapeSingleQuotes(method));
+  }
+
+  if (url) {
+    parts.push('--url', escapeSingleQuotes(url));
+  }
+
+  sanitizedHeaders.forEach((header) => {
+    parts.push('-H', escapeSingleQuotes(`${header.key}: ${header.value}`));
+  });
+
+  if (body.length > 0) {
+    if (isBinaryBody(body)) {
+      parts.push('--data-binary', escapeForCStyle(body));
+    } else {
+      parts.push('--data-raw', escapeSingleQuotes(body));
+    }
+  }
+
+  return parts.join(' ');
+};
+
+export const buildRawRequest = ({ method, url, headers, body }: RequestState): string => {
+  const sanitizedHeaders = normalizeHeaders(headers);
+  const { host: urlHost, path } = getPathFromUrl(url);
+  const lines: string[] = [`${method || 'GET'} ${path} ${HTTP_VERSION}`];
+
+  const hostHeader = getHostFromHeaders(sanitizedHeaders);
+  if (urlHost && !hostHeader) {
+    lines.push(`Host: ${urlHost}`);
+  }
+
+  sanitizedHeaders.forEach((header) => {
+    lines.push(`${header.key}: ${header.value}`);
+  });
+
+  if (body.length > 0) {
+    lines.push('', body);
+  }
+
+  return lines.join('\n');
+};
+
+export { normalizeHeaders, isBinaryBody };


### PR DESCRIPTION
## Summary
- add header/body controls and a raw request preview pane to the HTTP request builder
- build curl exports that include headers and binary-safe payload handling
- cover curl and raw request exports with targeted unit tests

## Testing
- yarn test http-builder

------
https://chatgpt.com/codex/tasks/task_e_68d9d365e79c832888563e6ac4c3ebda