### PR TITLE
[http] add auth header builder with masking

### DIFF
--- a/__tests__/httpAuth.test.tsx
+++ b/__tests__/httpAuth.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Auth, { buildBasicHeader, buildBearerHeader } from '../apps/http/components/Auth';
+import { HTTPBuilder } from '../apps/http/index';
+
+describe('Authorization header helpers', () => {
+  it('buildBearerHeader trims whitespace and generates a header', () => {
+    expect(buildBearerHeader('  abc123  ')).toBe('Authorization: Bearer abc123');
+  });
+
+  it('buildBasicHeader encodes credentials using base64', () => {
+    const header = buildBasicHeader('alice', 'secret');
+    expect(header).toBe('Authorization: Basic YWxpY2U6c2VjcmV0');
+  });
+
+  it('throws when required inputs are missing', () => {
+    expect(() => buildBearerHeader('   ')).toThrow('A bearer token is required.');
+    expect(() => buildBasicHeader('', 'secret')).toThrow('A username is required.');
+    expect(() => buildBasicHeader('alice', '')).toThrow('A password is required.');
+  });
+});
+
+describe('Auth component', () => {
+  it('surfaces validation errors when inputs are missing', () => {
+    const onChange = jest.fn();
+    render(<Auth onSanitizedHeaderChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText('Scheme'), { target: { value: 'bearer' } });
+    const tokenInput = screen.getByLabelText('Bearer token');
+    fireEvent.blur(tokenInput);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a bearer token to generate the header.');
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('masks sensitive values in the UI and callbacks', () => {
+    const onChange = jest.fn();
+    render(<Auth onSanitizedHeaderChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText('Scheme'), { target: { value: 'bearer' } });
+    const tokenInput = screen.getByLabelText('Bearer token');
+    fireEvent.change(tokenInput, { target: { value: 'super-secret-token' } });
+
+    expect(screen.getByText('Authorization: Bearer <hidden>')).toBeInTheDocument();
+    expect(screen.queryByText('super-secret-token')).not.toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith('Authorization: Bearer <hidden>');
+  });
+});
+
+describe('HTTP builder integration', () => {
+  it('includes masked headers in the command preview', () => {
+    render(<HTTPBuilder />);
+
+    fireEvent.change(screen.getByLabelText('Scheme'), { target: { value: 'basic' } });
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'admin' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'passw0rd!' } });
+
+    const preview = screen.getByText(/curl -X GET/);
+    expect(preview.textContent).toContain('Authorization: Basic <hidden>');
+    expect(preview.textContent).not.toContain('admin');
+    expect(preview.textContent).not.toContain('passw0rd!');
+  });
+});

--- a/apps/http/components/Auth.tsx
+++ b/apps/http/components/Auth.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+type AuthStrategy = 'none' | 'bearer' | 'basic';
+
+export const buildBearerHeader = (token: string): string => {
+  const normalized = token.trim();
+  if (!normalized) {
+    throw new Error('A bearer token is required.');
+  }
+
+  return `Authorization: Bearer ${normalized}`;
+};
+
+const encodeBase64 = (value: string): string => {
+  if (typeof globalThis !== 'undefined') {
+    if (typeof globalThis.btoa === 'function') {
+      try {
+        return globalThis.btoa(value);
+      } catch (error) {
+        const encoder = new TextEncoder();
+        const bytes = encoder.encode(value);
+        let binary = '';
+        bytes.forEach((byte) => {
+          binary += String.fromCharCode(byte);
+        });
+        return globalThis.btoa(binary);
+      }
+    }
+
+    if (typeof (globalThis as typeof globalThis & { Buffer?: typeof Buffer }).Buffer !== 'undefined') {
+      return (globalThis as typeof globalThis & { Buffer: typeof Buffer }).Buffer.from(value, 'utf-8').toString('base64');
+    }
+  }
+
+  throw new Error('Base64 encoding is not available in this environment.');
+};
+
+export const buildBasicHeader = (username: string, password: string): string => {
+  const normalizedUsername = username.trim();
+  if (!normalizedUsername) {
+    throw new Error('A username is required.');
+  }
+
+  if (!password) {
+    throw new Error('A password is required.');
+  }
+
+  const encoded = encodeBase64(`${normalizedUsername}:${password}`);
+  return `Authorization: Basic ${encoded}`;
+};
+
+export interface AuthProps {
+  onSanitizedHeaderChange: (header: string | null) => void;
+}
+
+const Auth: React.FC<AuthProps> = ({ onSanitizedHeaderChange }) => {
+  const [strategy, setStrategy] = useState<AuthStrategy>('none');
+  const [bearerToken, setBearerToken] = useState('');
+  const [basicUsername, setBasicUsername] = useState('');
+  const [basicPassword, setBasicPassword] = useState('');
+  const [bearerTouched, setBearerTouched] = useState(false);
+  const [basicUsernameTouched, setBasicUsernameTouched] = useState(false);
+  const [basicPasswordTouched, setBasicPasswordTouched] = useState(false);
+
+  const resetTouchedState = useCallback(() => {
+    setBearerTouched(false);
+    setBasicUsernameTouched(false);
+    setBasicPasswordTouched(false);
+  }, []);
+
+  const actualHeader = useMemo(() => {
+    try {
+      if (strategy === 'bearer') {
+        return buildBearerHeader(bearerToken);
+      }
+
+      if (strategy === 'basic') {
+        return buildBasicHeader(basicUsername, basicPassword);
+      }
+    } catch (error) {
+      return null;
+    }
+
+    return null;
+  }, [strategy, bearerToken, basicUsername, basicPassword]);
+
+  const sanitizedHeader = useMemo(() => {
+    if (!actualHeader) {
+      return null;
+    }
+
+    if (strategy === 'bearer') {
+      return 'Authorization: Bearer <hidden>';
+    }
+
+    if (strategy === 'basic') {
+      return 'Authorization: Basic <hidden>';
+    }
+
+    return null;
+  }, [actualHeader, strategy]);
+
+  useEffect(() => {
+    onSanitizedHeaderChange(sanitizedHeader);
+  }, [onSanitizedHeaderChange, sanitizedHeader]);
+
+  useEffect(() => {
+    resetTouchedState();
+  }, [strategy, resetTouchedState]);
+
+  const bearerError = strategy === 'bearer' && bearerTouched && !bearerToken.trim();
+  const basicUsernameError = strategy === 'basic' && basicUsernameTouched && !basicUsername.trim();
+  const basicPasswordError = strategy === 'basic' && basicPasswordTouched && !basicPassword;
+
+  return (
+    <section aria-labelledby="auth-section-title" className="space-y-3">
+      <div>
+        <h2 id="auth-section-title" className="text-lg font-semibold text-white">
+          Authorization Header
+        </h2>
+        <p className="text-sm text-gray-400">
+          Choose an auth scheme to generate a sanitized Authorization header for your curl command.
+        </p>
+      </div>
+
+      <label className="block text-sm font-medium" htmlFor="auth-strategy">
+        Scheme
+      </label>
+      <select
+        id="auth-strategy"
+        className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+        value={strategy}
+        onChange={(event) => setStrategy(event.target.value as AuthStrategy)}
+      >
+        <option value="none">None</option>
+        <option value="bearer">Bearer Token</option>
+        <option value="basic">Basic (username &amp; password)</option>
+      </select>
+
+      {strategy === 'bearer' && (
+        <div className="space-y-1">
+          <label className="block text-sm font-medium" htmlFor="bearer-token">
+            Bearer token
+          </label>
+          <input
+            id="bearer-token"
+            type="password"
+            className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+            value={bearerToken}
+            onChange={(event) => setBearerToken(event.target.value)}
+            onBlur={() => setBearerTouched(true)}
+            autoComplete="off"
+            aria-invalid={bearerError}
+          />
+          {bearerError && (
+            <p role="alert" className="text-xs text-red-400">
+              Enter a bearer token to generate the header.
+            </p>
+          )}
+        </div>
+      )}
+
+      {strategy === 'basic' && (
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <label className="block text-sm font-medium" htmlFor="basic-username">
+              Username
+            </label>
+            <input
+              id="basic-username"
+              type="text"
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+              value={basicUsername}
+              onChange={(event) => setBasicUsername(event.target.value)}
+              onBlur={() => setBasicUsernameTouched(true)}
+              autoComplete="off"
+              aria-invalid={basicUsernameError}
+            />
+            {basicUsernameError && (
+              <p role="alert" className="text-xs text-red-400">
+                A username is required for basic auth.
+              </p>
+            )}
+          </div>
+          <div className="space-y-1">
+            <label className="block text-sm font-medium" htmlFor="basic-password">
+              Password
+            </label>
+            <input
+              id="basic-password"
+              type="password"
+              className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
+              value={basicPassword}
+              onChange={(event) => setBasicPassword(event.target.value)}
+              onBlur={() => setBasicPasswordTouched(true)}
+              autoComplete="off"
+              aria-invalid={basicPasswordError}
+            />
+            {basicPasswordError && (
+              <p role="alert" className="text-xs text-red-400">
+                A password is required for basic auth.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="rounded border border-gray-800 bg-black p-3">
+        <p className="text-xs uppercase tracking-wide text-gray-400">Header preview</p>
+        {sanitizedHeader ? (
+          <code className="mt-1 block font-mono text-sm text-green-400">{sanitizedHeader}</code>
+        ) : (
+          <p className="mt-1 text-sm text-gray-500">
+            Provide credentials to generate a sanitized header. Secrets stay only in this form.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default Auth;

--- a/apps/http/index.tsx
+++ b/apps/http/index.tsx
@@ -1,12 +1,27 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import Auth from './components/Auth';
 
-const HTTPBuilder: React.FC = () => {
+export const HTTPBuilder: React.FC = () => {
   const [method, setMethod] = useState('GET');
   const [url, setUrl] = useState('');
-  const command = `curl -X ${method} ${url}`.trim();
+  const [authHeader, setAuthHeader] = useState<string | null>(null);
+
+  const command = useMemo(() => {
+    const parts = ['curl', '-X', method];
+
+    if (url.trim()) {
+      parts.push(url.trim());
+    }
+
+    if (authHeader) {
+      parts.push(`-H "${authHeader}"`);
+    }
+
+    return parts.join(' ');
+  }, [authHeader, method, url]);
 
   return (
     <div className="h-full bg-gray-900 p-4 text-white overflow-auto">
@@ -23,7 +38,7 @@ const HTTPBuilder: React.FC = () => {
         </a>
         .
       </p>
-      <form onSubmit={(e) => e.preventDefault()} className="mb-4 space-y-4">
+      <form onSubmit={(e) => e.preventDefault()} className="mb-4 space-y-6">
         <div>
           <label htmlFor="http-method" className="mb-1 block text-sm font-medium">
             Method
@@ -52,6 +67,7 @@ const HTTPBuilder: React.FC = () => {
             onChange={(e) => setUrl(e.target.value)}
           />
         </div>
+        <Auth onSanitizedHeaderChange={setAuthHeader} />
       </form>
       <div>
         <h2 className="mb-2 text-lg">Command Preview</h2>


### PR DESCRIPTION
## Summary
- add an authentication form that builds sanitized Bearer and Basic Authorization headers without leaking secrets
- integrate the auth builder into the HTTP Request Builder command preview
- cover header helpers, masking behaviour, and integration with dedicated Jest tests

## Testing
- yarn test httpAuth
- yarn lint *(fails: pre-existing jsx-a11y/no-top-level-window errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d366ae288328a536e2e26011cb25