### PR TITLE
[apps] HTML rewriter editor improvements

### DIFF
--- a/__tests__/htmlRewriter.test.tsx
+++ b/__tests__/htmlRewriter.test.tsx
@@ -1,0 +1,86 @@
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+
+import HtmlRewriterApp from '../apps/html-rewriter';
+
+describe('HtmlRewriterApp', () => {
+  it('debounces evaluation when inputs change', () => {
+    jest.useFakeTimers();
+    try {
+      render(<HtmlRewriterApp />);
+
+      const htmlInput = screen.getByLabelText('Sample HTML');
+      const rewrittenOutput = screen.getByTestId('rewritten-output');
+
+      expect(rewrittenOutput.textContent).toContain('Rewritten Title');
+
+      fireEvent.change(htmlInput, { target: { value: '<p>First</p>' } });
+
+      // Before debounce duration elapses, the rewritten output should remain unchanged.
+      expect(rewrittenOutput.textContent).toContain('Rewritten Title');
+      act(() => {
+        jest.advanceTimersByTime(350);
+      });
+      expect(rewrittenOutput.textContent).toContain('Rewritten Title');
+
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      expect(rewrittenOutput.textContent).toContain('<p>First</p>');
+    } finally {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('renders accurate diff rows for replacements', () => {
+    jest.useFakeTimers();
+    try {
+      render(<HtmlRewriterApp />);
+
+      const htmlInput = screen.getByLabelText('Sample HTML');
+      const ruleInput = screen.getByLabelText('Rewrite Rules (JSON)');
+
+      fireEvent.change(htmlInput, { target: { value: '<p>Original</p>' } });
+      fireEvent.change(
+        ruleInput,
+        {
+          target: {
+            value: JSON.stringify(
+              [
+                {
+                  selector: 'p',
+                  action: 'replace',
+                  value: 'Updated',
+                },
+              ],
+              null,
+              2,
+            ),
+          },
+        },
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(400);
+      });
+
+      const rows = screen.getAllByTestId('diff-row');
+      const removedRow = rows.find((row) => row.getAttribute('data-change-type') === 'removed');
+      const addedRow = rows.find((row) => row.getAttribute('data-change-type') === 'added');
+
+      expect(removedRow).toBeTruthy();
+      expect(addedRow).toBeTruthy();
+
+      if (!removedRow || !addedRow) {
+        throw new Error('Expected diff rows were not found');
+      }
+
+      expect(within(removedRow).getByTestId('diff-before-cell').textContent).toBe('<p>Original</p>');
+      expect(within(addedRow).getByTestId('diff-after-cell').textContent).toBe('<p>Updated</p>');
+    } finally {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
+  });
+});

--- a/apps/html-rewriter/index.tsx
+++ b/apps/html-rewriter/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useMemo } from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { diffLines, type Change } from 'diff';
 
 interface Rule {
@@ -9,6 +9,18 @@ interface Rule {
   value?: string;
 }
 
+interface EvaluationState {
+  rewritten: string;
+  diff: Change[];
+  error: string | null;
+}
+
+type DiffRow = {
+  before: string;
+  after: string;
+  type: 'added' | 'removed' | 'unchanged';
+};
+
 const DEFAULT_RULES: Rule[] = [
   { selector: 'script', action: 'remove' },
   { selector: 'h1', action: 'replace', value: 'Rewritten Title' },
@@ -16,101 +28,255 @@ const DEFAULT_RULES: Rule[] = [
 
 const DEFAULT_HTML = `<h1>Hello</h1>\n<p>Sample <strong>content</strong>.</p>\n<script>alert("xss")</script>`;
 
+const EVALUATION_DELAY = 400;
+
 const serialize = (rules: Rule[]) => JSON.stringify(rules, null, 2);
+
+const parseRules = (ruleSource: string): Rule[] => {
+  const parsed = JSON.parse(ruleSource);
+  if (!Array.isArray(parsed)) {
+    throw new Error('Rules must be an array');
+  }
+  return parsed.map((item) => {
+    if (!item || typeof item !== 'object') {
+      throw new Error('Each rule must be an object');
+    }
+    const { selector, action, value } = item as Partial<Rule> & Record<string, unknown>;
+    if (typeof selector !== 'string' || selector.trim().length === 0) {
+      throw new Error('Each rule requires a selector');
+    }
+    if (action !== 'remove' && action !== 'replace') {
+      throw new Error('Action must be either "remove" or "replace"');
+    }
+    if (action === 'replace' && typeof value !== 'string') {
+      throw new Error('Replace rules require a string "value"');
+    }
+    return {
+      selector,
+      action,
+      value,
+    } as Rule;
+  });
+};
 
 const applyRules = (html: string, rules: Rule[]): string => {
   const doc = new DOMParser().parseFromString(html, 'text/html');
-  for (const r of rules) {
-    const els = Array.from(doc.querySelectorAll(r.selector));
-    if (r.action === 'remove') {
-      els.forEach((el) => el.remove());
-    } else if (r.action === 'replace') {
-      els.forEach((el) => {
-        el.textContent = r.value || '';
+  for (const rule of rules) {
+    const elements = Array.from(doc.querySelectorAll(rule.selector));
+    if (rule.action === 'remove') {
+      elements.forEach((el) => el.remove());
+    } else {
+      elements.forEach((el) => {
+        el.textContent = rule.value ?? '';
       });
     }
   }
   return doc.body.innerHTML;
 };
 
-const HtmlRewriterApp: React.FC = () => {
-  const [ruleText, setRuleText] = useState(serialize(DEFAULT_RULES));
-  const [html, setHtml] = useState(DEFAULT_HTML);
-  const [error, setError] = useState<string | null>(null);
-  const [showHelp, setShowHelp] = useState(false);
+const evaluate = (inputHtml: string, ruleSource: string): EvaluationState => {
+  try {
+    const rules = parseRules(ruleSource);
+    const rewritten = applyRules(inputHtml, rules);
+    return {
+      rewritten,
+      diff: diffLines(inputHtml, rewritten),
+      error: null,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to parse rules';
+    return {
+      rewritten: inputHtml,
+      diff: diffLines(inputHtml, inputHtml),
+      error: message,
+    };
+  }
+};
 
-  const { rewritten, diff } = useMemo(() => {
-    try {
-      const rules = JSON.parse(ruleText) as Rule[];
-      setError(null);
-      const rewritten = applyRules(html, rules);
-      const diff = diffLines(html, rewritten);
-      return { rewritten, diff };
-    } catch (e: any) {
-      setError(e.message);
-      return { rewritten: html, diff: diffLines(html, html) };
+const buildDiffRows = (changes: Change[]): DiffRow[] => {
+  const rows: DiffRow[] = [];
+  for (const change of changes) {
+    const lines = change.value.split('\n');
+    lines.forEach((line, index) => {
+      // diffLines keeps a trailing empty string when the change ends with a newline.
+      if (index === lines.length - 1 && line.length === 0) {
+        return;
+      }
+      if (change.added) {
+        rows.push({ before: '', after: line, type: 'added' });
+      } else if (change.removed) {
+        rows.push({ before: line, after: '', type: 'removed' });
+      } else {
+        rows.push({ before: line, after: line, type: 'unchanged' });
+      }
+    });
+  }
+  return rows;
+};
+
+const HtmlRewriterApp: React.FC = () => {
+  const [ruleText, setRuleText] = useState(() => serialize(DEFAULT_RULES));
+  const [html, setHtml] = useState(DEFAULT_HTML);
+  const [state, setState] = useState<EvaluationState>(() => evaluate(DEFAULT_HTML, serialize(DEFAULT_RULES)));
+  const [isEvaluating, setIsEvaluating] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
+  const skipInitialEvaluation = useRef(true);
+
+  const ruleInputId = useId();
+  const htmlInputId = useId();
+
+  useEffect(() => {
+    if (skipInitialEvaluation.current) {
+      skipInitialEvaluation.current = false;
+      return;
     }
-  }, [ruleText, html]);
+
+    setIsEvaluating(true);
+    const timer = window.setTimeout(() => {
+      setState(evaluate(html, ruleText));
+      setIsEvaluating(false);
+    }, EVALUATION_DELAY);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [html, ruleText]);
+
+  const diffRows = useMemo(() => buildDiffRows(state.diff), [state.diff]);
 
   return (
-    <div className="h-full w-full overflow-auto bg-gray-900 p-4 text-white space-y-4">
-      <h1 className="text-2xl">HTML Rewriter</h1>
-      <div className="flex gap-4 flex-col md:flex-row">
-        <div className="flex-1 flex flex-col">
-          <label className="mb-1">Rewrite Rules (JSON)</label>
+    <div className="h-full w-full overflow-auto bg-gray-900 p-4 text-white space-y-4" data-testid="html-rewriter-app">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">HTML Rewriter</h1>
+        <p className="text-sm text-gray-300">
+          Provide HTML and a list of rewrite rules to see how the document changes. Evaluation is debounced to keep typing
+          responsive.
+        </p>
+      </header>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="flex flex-col">
+          <label className="mb-1 font-medium" htmlFor={ruleInputId}>
+            Rewrite Rules (JSON)
+          </label>
           <textarea
-            className="flex-1 p-2 rounded bg-gray-800 font-mono text-sm"
+            id={ruleInputId}
+            className="min-h-[200px] flex-1 rounded bg-gray-800 p-2 font-mono text-sm text-gray-100"
+            spellCheck={false}
             value={ruleText}
-            onChange={(e) => setRuleText(e.target.value)}
+            onChange={(event) => setRuleText(event.target.value)}
+            aria-describedby={state.error ? `${ruleInputId}-error` : undefined}
           />
-          {error && <p className="text-red-400 mt-1">{error}</p>}
+          {state.error && (
+            <p id={`${ruleInputId}-error`} className="mt-2 text-sm text-red-400" role="alert">
+              {state.error}
+            </p>
+          )}
         </div>
-        <div className="flex-1 flex flex-col">
-          <label className="mb-1">Sample HTML</label>
+        <div className="flex flex-col">
+          <label className="mb-1 font-medium" htmlFor={htmlInputId}>
+            Sample HTML
+          </label>
           <textarea
-            className="flex-1 p-2 rounded bg-gray-800 font-mono text-sm"
+            id={htmlInputId}
+            className="min-h-[200px] flex-1 rounded bg-gray-800 p-2 font-mono text-sm text-gray-100"
+            spellCheck={false}
             value={html}
-            onChange={(e) => setHtml(e.target.value)}
+            onChange={(event) => setHtml(event.target.value)}
           />
+        </div>
+      </div>
+      <section aria-live="polite" className="text-sm text-gray-300">
+        {isEvaluating ? 'Updating preview…' : 'Preview is up to date.'}
+      </section>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <h2 className="text-xl mb-2">Original HTML</h2>
+          <pre
+            className="whitespace-pre-wrap rounded bg-gray-800 p-2 font-mono text-sm text-gray-100"
+            data-testid="original-output"
+          >
+            {html}
+          </pre>
+        </div>
+        <div>
+          <h2 className="text-xl mb-2">Rewritten HTML</h2>
+          <pre
+            className="whitespace-pre-wrap rounded bg-gray-800 p-2 font-mono text-sm text-gray-100"
+            data-testid="rewritten-output"
+          >
+            {state.rewritten}
+          </pre>
         </div>
       </div>
       <div>
         <h2 className="text-xl mb-2">Diff</h2>
-        <pre className="whitespace-pre-wrap bg-gray-800 p-2 rounded overflow-auto">
-          {diff.map((part: Change, i: number) => (
-            <span
-              key={i}
-              className={part.added ? 'bg-green-800' : part.removed ? 'bg-red-800 line-through' : ''}
-            >
-              {part.value}
-            </span>
-          ))}
-        </pre>
-      </div>
-      <div>
-        <h2 className="text-xl mb-2">Rewritten HTML</h2>
-        <pre className="whitespace-pre-wrap bg-gray-800 p-2 rounded overflow-auto">{rewritten}</pre>
+        <div className="overflow-auto rounded bg-gray-800" data-testid="diff-output">
+          <table className="min-w-full text-left font-mono text-sm text-gray-100" data-testid="diff-table">
+            <thead className="bg-gray-700 uppercase tracking-wide text-xs text-gray-300">
+              <tr>
+                <th className="px-3 py-2">Before</th>
+                <th className="px-3 py-2">After</th>
+              </tr>
+            </thead>
+            <tbody>
+              {diffRows.length === 0 ? (
+                <tr data-testid="diff-row" data-change-type="unchanged">
+                  <td className="px-3 py-3 text-center text-gray-400" colSpan={2}>
+                    No differences
+                  </td>
+                </tr>
+              ) : (
+                diffRows.map((row, index) => {
+                  const highlightClass =
+                    row.type === 'added'
+                      ? 'bg-green-900/40'
+                      : row.type === 'removed'
+                      ? 'bg-red-900/40'
+                      : 'bg-transparent';
+
+                  return (
+                    <tr
+                      key={index}
+                      data-testid="diff-row"
+                      data-change-type={row.type}
+                      className={`${highlightClass} border-b border-gray-700 last:border-b-0`}
+                    >
+                      <td data-testid="diff-before-cell" className="whitespace-pre-wrap px-3 py-2 align-top">
+                        {row.before}
+                      </td>
+                      <td data-testid="diff-after-cell" className="whitespace-pre-wrap px-3 py-2 align-top">
+                        {row.after}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
       <button
-        className="mt-4 px-4 py-2 bg-blue-600 rounded"
+        className="mt-4 inline-flex items-center rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
         onClick={() => setShowHelp(true)}
       >
-        Help
+        Quick help
       </button>
       {showHelp && (
-        <div className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center p-4">
-          <div className="bg-gray-900 p-4 rounded max-w-lg w-full text-left space-y-4">
-            <h2 className="text-xl">Rewrite Rule Examples</h2>
-            <p>Rules are objects with a CSS selector and an action.</p>
-            <pre className="bg-gray-800 p-2 rounded">
-{`[
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4" role="dialog" aria-modal="true">
+          <div className="w-full max-w-lg space-y-4 rounded bg-gray-900 p-6 text-left shadow-xl">
+            <h2 className="text-xl font-semibold text-white">Rule syntax</h2>
+            <p className="text-sm text-gray-200">
+              Provide an array of rules. Each rule selects matching elements and either removes them or replaces their text
+              content.
+            </p>
+            <pre className="rounded bg-gray-800 p-3 font-mono text-sm text-gray-100">{`[
   { "selector": "script", "action": "remove" },
-  { "selector": "img", "action": "replace", "value": "[image]" }
-]`}
-            </pre>
+  { "selector": "img", "action": "replace", "value": "[removed image]" }
+]`}</pre>
             <button
-              className="mt-2 px-4 py-2 bg-blue-600 rounded"
+              className="inline-flex items-center rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
               onClick={() => setShowHelp(false)}
+              autoFocus
             >
               Close
             </button>


### PR DESCRIPTION
## Summary
- refactor the HTML rewriter into a debounced editor with rule validation and clearer status messaging
- render before/after columns with a structured diff table for easier inspection
- add unit tests covering debounce timing and diff output accuracy

## Testing
- yarn test __tests__/htmlRewriter.test.tsx --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d9d36a44c08328aa751bd991bac170