### PR TITLE
[apps] Add honeytoken detection to contact form

### DIFF
--- a/__tests__/contact.test.tsx
+++ b/__tests__/contact.test.tsx
@@ -18,6 +18,23 @@ describe('contact form', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('ignores honeytoken submissions', async () => {
+    const fetchMock = jest.fn();
+    const result = await processContactForm(
+      {
+        name: 'Alex',
+        email: 'alex@example.com',
+        message: 'Hello',
+        honeypot: 'filled',
+        csrfToken: 'csrf',
+        recaptchaToken: 'rc',
+      },
+      fetchMock
+    );
+    expect(result).toEqual({ success: true, ignored: true });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('success posts to api', async () => {
     const fetchMock = jest.fn().mockResolvedValue({ ok: true });
     const result = await processContactForm(
@@ -38,6 +55,6 @@ describe('contact form', () => {
         headers: expect.objectContaining({ 'X-CSRF-Token': 'csrf' }),
       })
     );
-    expect(result.success).toBe(true);
+    expect(result).toEqual({ success: true });
   });
 });


### PR DESCRIPTION
## Summary
- add a honeytoken guard and client-side rate limiting to the contact app so spammy submissions are ignored gracefully
- update the shared contact form processor to short-circuit when the honeytoken is filled and skip uploading attachments for bots
- expand contact unit tests to cover bot detection and the happy path submission

## Testing
- yarn test __tests__/contact.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9d36b32ac83288e3c5f3fe31f3198