### PR TITLE
[radare2] add navigation history controls

### DIFF
--- a/__tests__/radare2Navigation.test.tsx
+++ b/__tests__/radare2Navigation.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import Radare2 from '../components/apps/radare2';
+import sample from '../apps/radare2/sample.json';
+
+describe('Radare2 navigation', () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  beforeEach(() => {
+    window.localStorage.setItem('r2HelpDismissed', 'true');
+  });
+
+  it('tracks seek history and allows stepping back', async () => {
+    render(<Radare2 initialData={sample} />);
+
+    await screen.findByText('0x1000: push rbp');
+    await screen.findByText('Xrefs for 0x1000');
+
+    fireEvent.change(screen.getByPlaceholderText('seek 0x...'), {
+      target: { value: '0x1004' },
+    });
+    fireEvent.click(screen.getByText('Seek'));
+
+    await screen.findByText('Xrefs for 0x1004');
+
+    const backButton = screen.getByRole('button', { name: 'Back' });
+    expect(backButton).not.toBeDisabled();
+
+    fireEvent.click(backButton);
+
+    await screen.findByText('Xrefs for 0x1000');
+  });
+
+  it('seeks through xrefs and trims forward history on new jumps', async () => {
+    render(<Radare2 initialData={sample} />);
+
+    await screen.findByText('0x1000: push rbp');
+
+    fireEvent.change(screen.getByPlaceholderText('seek 0x...'), {
+      target: { value: '0x1004' },
+    });
+    fireEvent.click(screen.getByText('Seek'));
+
+    const xrefSection = screen.getByText('Xrefs for 0x1004').parentElement;
+    if (!xrefSection) {
+      throw new Error('Xref section not found');
+    }
+
+    const seekToButton = within(xrefSection).getByRole('button', { name: 'Seek to' });
+    fireEvent.click(seekToButton);
+
+    await screen.findByText('Xrefs for 0x1009');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    await screen.findByText('Xrefs for 0x1004');
+
+    fireEvent.change(screen.getByPlaceholderText('find'), {
+      target: { value: '0x100a' },
+    });
+    fireEvent.click(screen.getByText('Find'));
+
+    await screen.findByText('Xrefs for 0x100a');
+
+    expect(screen.getByRole('button', { name: 'Forward' })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a reducer-backed navigation history to the Radare2 app with seek controls on xrefs
- expose Back/Forward UI actions and wire strings, xrefs, and seek/find inputs through the shared navigator
- cover navigation history behavior with new tests

## Testing
- yarn lint *(fails: repository has numerous pre-existing accessibility and window reference violations)*
- yarn test --watch=false *(fails: unrelated suites like YouTube and nmap currently fail in main)*
- yarn test --watch=false --runTestsByPath __tests__/radare2Navigation.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9d36c57348328a4c0382f9ca0a7f5