### PR TITLE
[desktop] keep icons behind open windows

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -833,7 +833,7 @@ export class Desktop extends Component {
                 top: `${position.y}px`,
                 touchAction: 'none',
                 cursor: isDragging ? 'grabbing' : 'pointer',
-                zIndex: isDragging ? 40 : 20,
+                zIndex: isDragging ? 40 : 10,
             };
 
             return (


### PR DESCRIPTION
## Summary
- lower the resting z-index for desktop icons so windows always render beneath open windows

## Testing
- ⚠️ yarn lint (cancelled after running for over a minute without completing)


------
https://chatgpt.com/codex/tasks/task_e_68d9e9dd82688328b7b8b5d4304c45af