### PR TITLE
[firefox] set kali docs homepage and toolbar

### DIFF
--- a/__tests__/firefox.test.tsx
+++ b/__tests__/firefox.test.tsx
@@ -12,9 +12,9 @@ describe('Firefox app', () => {
   it('renders the default address', () => {
     render(<Firefox />);
     const input = screen.getByLabelText('Address');
-    expect(input).toHaveValue('https://developer.mozilla.org/');
+    expect(input).toHaveValue('https://www.kali.org/docs/');
     const frame = screen.getByTitle('Firefox');
-    expect(frame).toHaveAttribute('src', 'https://developer.mozilla.org/');
+    expect(frame).toHaveAttribute('src', 'https://www.kali.org/docs/');
   });
 
   it('navigates to entered urls', async () => {
@@ -27,5 +27,15 @@ describe('Firefox app', () => {
     const frame = await screen.findByTitle('Firefox');
     expect(frame).toHaveAttribute('src', 'https://example.com/');
     expect(localStorage.getItem('firefox:last-url')).toBe('https://example.com/');
+  });
+
+  it('opens bookmarks when clicked', async () => {
+    const user = userEvent.setup();
+    render(<Firefox />);
+    const bookmark = await screen.findByRole('button', { name: 'Kali NetHunter' });
+    await user.click(bookmark);
+    const frame = await screen.findByTitle('Firefox');
+    expect(frame).toHaveAttribute('src', 'https://www.kali.org/get-kali/#kali-platforms');
+    expect(localStorage.getItem('firefox:last-url')).toBe('https://www.kali.org/get-kali/#kali-platforms');
   });
 });

--- a/components/apps/firefox/index.tsx
+++ b/components/apps/firefox/index.tsx
@@ -1,8 +1,19 @@
 import React, { FormEvent, useMemo, useState } from 'react';
 
-const DEFAULT_URL = 'https://developer.mozilla.org/';
+const DEFAULT_URL = 'https://www.kali.org/docs/';
 const STORAGE_KEY = 'firefox:last-url';
 const START_URL_KEY = 'firefox:start-url';
+
+const BOOKMARKS = [
+  { label: 'OffSec', url: 'https://www.offsec.com/?utm_source=kali&utm_medium=os&utm_campaign=firefox' },
+  { label: 'Kali Linux', url: 'https://www.kali.org/' },
+  { label: 'Kali Tools', url: 'https://www.kali.org/tools/' },
+  { label: 'Kali Docs', url: 'https://www.kali.org/docs/' },
+  { label: 'Kali Forums', url: 'https://forums.kali.org/' },
+  { label: 'Kali NetHunter', url: 'https://www.kali.org/get-kali/#kali-platforms' },
+  { label: 'Exploit-DB', url: 'https://www.exploit-db.com/' },
+  { label: 'GoogleHackingDB', url: 'https://www.exploit-db.com/google-hacking-database' },
+];
 
 const normaliseUrl = (value: string) => {
   const trimmed = value.trim();
@@ -87,6 +98,18 @@ const Firefox: React.FC = () => {
           Go
         </button>
       </form>
+      <nav className="flex flex-wrap gap-1 border-b border-gray-800 bg-gray-900 px-3 py-2 text-xs">
+        {BOOKMARKS.map((bookmark) => (
+          <button
+            key={bookmark.url}
+            type="button"
+            onClick={() => updateAddress(bookmark.url)}
+            className="rounded bg-gray-800 px-3 py-1 font-medium text-gray-200 transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          >
+            {bookmark.label}
+          </button>
+        ))}
+      </nav>
       <div className="flex-1 bg-black">
         <iframe
           key={address}


### PR DESCRIPTION
## Summary
- update the Firefox simulation to open the Kali Linux documentation by default
- add a toolbar of Kali and OffSec bookmarks that update the address bar when clicked
- extend unit coverage to validate the new defaults and bookmark navigation

## Testing
- CI=1 yarn test firefox

------
https://chatgpt.com/codex/tasks/task_e_68d9f00702b88328bd3008d37c982ee0