### PR TITLE
[nethunter] add on-screen keyboard integration

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -13,6 +13,7 @@ import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
 import KaliWallpaper from "../../components/util-components/kali-wallpaper";
+import { useOnScreenKeyboard } from "../../components/osk/OnScreenKeyboardProvider";
 
 export default function Settings() {
   const {
@@ -32,9 +33,14 @@ export default function Settings() {
     setHighContrast,
     haptics,
     setHaptics,
+    onScreenKeyboardEnabled,
+    setOnScreenKeyboardEnabled,
+    onScreenKeyboardAutoShow,
+    setOnScreenKeyboardAutoShow,
     theme,
     setTheme,
   } = useSettings();
+  const { hardwareKeyboardDetected, autoVisible } = useOnScreenKeyboard();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const tabs = [
@@ -282,6 +288,35 @@ export default function Settings() {
               ariaLabel="Haptics"
             />
           </div>
+          <div className="flex justify-center my-4 items-center">
+            <span className="mr-2 text-ubt-grey">On-screen Keyboard:</span>
+            <ToggleSwitch
+              checked={onScreenKeyboardEnabled}
+              onChange={setOnScreenKeyboardEnabled}
+              ariaLabel="Enable on-screen keyboard"
+            />
+          </div>
+          <div
+            className={`flex justify-center my-3 items-center transition-opacity ${
+              onScreenKeyboardEnabled ? "" : "opacity-40"
+            }`}
+          >
+            <span className="mr-2 text-ubt-grey text-sm">
+              Auto-show without hardware keyboard:
+            </span>
+            <ToggleSwitch
+              checked={onScreenKeyboardAutoShow}
+              onChange={setOnScreenKeyboardAutoShow}
+              ariaLabel="Auto show on-screen keyboard"
+            />
+          </div>
+          <p className="mx-auto max-w-lg px-6 text-center text-xs text-ubt-grey/70">
+            {hardwareKeyboardDetected
+              ? "Hardware keyboard detected. Use the toggle above when you need the touchscreen keyboard, or open it manually from the floating button."
+              : autoVisible
+                ? "Touch inputs will keep the NetHunter keyboard visible until focus moves away."
+                : "No hardware keyboard detected. Focusing a terminal or text field will slide the on-screen keyboard into view."}
+          </p>
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
             <button
               onClick={() => setShowKeymap(true)}

--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -9,6 +9,7 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
     <div
       ref={ref}
       data-testid="xterm-container"
+      data-osk-target="terminal"
       className={`text-white ${className}`}
       style={{
         background: 'var(--kali-bg)',
@@ -17,6 +18,8 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
         fontFamily: 'monospace',
         fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
         lineHeight: 1.4,
+        paddingBottom: 'calc(var(--osk-viewport-offset, 0px) + 0.5rem)',
+        transition: 'padding-bottom 0.25s ease',
         ...style,
       }}
       {...props}

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -395,6 +395,17 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp }, ref)
   }, []);
 
   useEffect(() => {
+    const handleKeyboardResize = () => {
+      requestAnimationFrame(() => {
+        fitRef.current?.fit();
+      });
+    };
+    window.addEventListener('oskchange' as any, handleKeyboardResize as EventListener);
+    return () =>
+      window.removeEventListener('oskchange' as any, handleKeyboardResize as EventListener);
+  }, []);
+
+  useEffect(() => {
     const listener = (e: KeyboardEvent) => {
       if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'p') {
         e.preventDefault();

--- a/components/osk/OnScreenKeyboardProvider.tsx
+++ b/components/osk/OnScreenKeyboardProvider.tsx
@@ -1,0 +1,429 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import layout from "../../nethunter/osk/layout.json";
+import { useSettings } from "../../hooks/useSettings";
+
+type ModifierKey = "Shift" | "Control" | "Alt" | "Meta";
+
+type KeyBehavior = "toggle" | "momentary";
+
+type KeyType = "char" | "modifier" | "action" | "function";
+
+interface LayoutKey {
+  label: string;
+  code: string;
+  key?: string;
+  shiftValue?: string;
+  ariaLabel?: string;
+  width?: number;
+  type: KeyType;
+  modifier?: ModifierKey;
+  behavior?: KeyBehavior;
+}
+
+interface KeyboardLayout {
+  rows: LayoutKey[][];
+}
+
+interface OnScreenKeyboardContextValue {
+  visible: boolean;
+  manualVisible: boolean;
+  autoVisible: boolean;
+  hardwareKeyboardDetected: boolean;
+  requestShow: () => void;
+  requestHide: () => void;
+}
+
+const OnScreenKeyboardContext = createContext<OnScreenKeyboardContextValue | null>(
+  null,
+);
+
+type DispatchResult = {
+  prevented: boolean;
+  element: HTMLElement | null;
+};
+
+type KeyboardEventType = "keydown" | "keyup";
+
+const TEXT_INPUT_EXCLUDE = new Set([
+  "button",
+  "submit",
+  "reset",
+  "color",
+  "file",
+  "image",
+  "checkbox",
+  "radio",
+  "range",
+  "hidden",
+]);
+
+const detectHardwareKeyboard = () => {
+  if (typeof navigator === "undefined" || typeof window === "undefined") {
+    return true;
+  }
+  const hasTouch = navigator.maxTouchPoints > 0;
+  const noHover = window.matchMedia?.("(any-hover: none)").matches ?? false;
+  if (hasTouch && noHover) {
+    return false;
+  }
+  return true;
+};
+
+const qualifiesForKeyboard = (target: HTMLElement | null) => {
+  if (!target) return false;
+  if (target.closest("[data-osk-surface]")) return false;
+  if (target.closest("[data-osk-toggle]") || target.hasAttribute("data-osk-toggle")) {
+    return false;
+  }
+  if (target.closest("[data-osk-target]")) return true;
+  if (target.hasAttribute("contenteditable") && target.getAttribute("contenteditable") !== "false") {
+    return true;
+  }
+  if (target.isContentEditable) return true;
+  if (target instanceof HTMLTextAreaElement) {
+    return !target.readOnly && !target.disabled;
+  }
+  if (target instanceof HTMLInputElement) {
+    if (target.readOnly || target.disabled) return false;
+    if (TEXT_INPUT_EXCLUDE.has(target.type)) return false;
+    return true;
+  }
+  const role = target.getAttribute("role");
+  if (role && ["textbox", "searchbox", "combobox"].includes(role)) {
+    return true;
+  }
+  return false;
+};
+
+const insertText = (element: HTMLElement, text: string) => {
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    const start = element.selectionStart ?? element.value.length;
+    const end = element.selectionEnd ?? element.value.length;
+    const nextValue = `${element.value.slice(0, start)}${text}${element.value.slice(end)}`;
+    element.value = nextValue;
+    const cursor = start + text.length;
+    element.selectionStart = cursor;
+    element.selectionEnd = cursor;
+    element.dispatchEvent(
+      new InputEvent("input", { bubbles: true, data: text, inputType: "insertText" }),
+    );
+    return;
+  }
+  if (element.isContentEditable) {
+    document.execCommand("insertText", false, text);
+  }
+};
+
+const deleteText = (element: HTMLElement) => {
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    const start = element.selectionStart ?? element.value.length;
+    const end = element.selectionEnd ?? element.value.length;
+    if (start === end && start > 0) {
+      const nextValue = `${element.value.slice(0, start - 1)}${element.value.slice(end)}`;
+      element.value = nextValue;
+      const cursor = start - 1;
+      element.selectionStart = cursor;
+      element.selectionEnd = cursor;
+    } else if (start !== end) {
+      const nextValue = `${element.value.slice(0, start)}${element.value.slice(end)}`;
+      element.value = nextValue;
+      element.selectionStart = start;
+      element.selectionEnd = start;
+    }
+    element.dispatchEvent(
+      new InputEvent("input", { bubbles: true, data: "", inputType: "deleteContentBackward" }),
+    );
+    return;
+  }
+  if (element.isContentEditable) {
+    document.execCommand("delete");
+  }
+};
+
+const computeKeyValue = (key: LayoutKey, modifiers: Set<ModifierKey>) => {
+  if (key.type === "char") {
+    if (modifiers.has("Shift") && key.shiftValue) {
+      return key.shiftValue;
+    }
+    if (key.key && key.key.length === 1) {
+      return key.key;
+    }
+    return key.key ?? key.label;
+  }
+  if (key.code === "Space") {
+    return " ";
+  }
+  return key.key ?? key.label;
+};
+
+export const useOnScreenKeyboard = () => {
+  const ctx = useContext(OnScreenKeyboardContext);
+  if (!ctx) {
+    throw new Error("useOnScreenKeyboard must be used within OnScreenKeyboardProvider");
+  }
+  return ctx;
+};
+
+export function OnScreenKeyboardProvider({ children }: { children: ReactNode }) {
+  const { onScreenKeyboardEnabled, onScreenKeyboardAutoShow } = useSettings();
+  const [manualVisible, setManualVisible] = useState(false);
+  const [autoVisible, setAutoVisible] = useState(false);
+  const [hardwareKeyboardDetected, setHardwareKeyboardDetected] = useState(
+    detectHardwareKeyboard,
+  );
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const activeModifiersRef = useRef<Set<ModifierKey>>(new Set());
+  const latchedModifiersRef = useRef<Set<ModifierKey>>(new Set());
+  const modifierSourceRef = useRef<Map<ModifierKey, LayoutKey>>(new Map());
+  const [, forceModifierRender] = useState(0);
+
+  const layoutData = layout as KeyboardLayout;
+
+  const allowAutoShow =
+    onScreenKeyboardEnabled && onScreenKeyboardAutoShow && !hardwareKeyboardDetected;
+
+  const visible = onScreenKeyboardEnabled && (manualVisible || (allowAutoShow && autoVisible));
+
+  useEffect(() => {
+    if (!onScreenKeyboardEnabled) {
+      setManualVisible(false);
+      setAutoVisible(false);
+    }
+  }, [onScreenKeyboardEnabled]);
+
+  useEffect(() => {
+    if (!allowAutoShow) {
+      setAutoVisible(false);
+    }
+  }, [allowAutoShow]);
+
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.isTrusted) {
+        setHardwareKeyboardDetected(true);
+      }
+    };
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, []);
+
+  useEffect(() => {
+    const handleFocusIn = (event: FocusEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest("[data-osk-surface]")) return;
+      if (!onScreenKeyboardEnabled) return;
+      if (allowAutoShow && qualifiesForKeyboard(target)) {
+        setAutoVisible(true);
+      } else if (!manualVisible) {
+        setAutoVisible(false);
+      }
+    };
+    document.addEventListener("focusin", handleFocusIn, true);
+    return () => document.removeEventListener("focusin", handleFocusIn, true);
+  }, [allowAutoShow, manualVisible, onScreenKeyboardEnabled]);
+
+  useEffect(() => {
+    if (!visible) {
+      document.documentElement.classList.remove("osk-visible");
+      document.documentElement.style.setProperty("--osk-viewport-offset", "0px");
+      window.dispatchEvent(
+        new CustomEvent("oskchange", { detail: { visible: false, height: 0 } }),
+      );
+      return;
+    }
+    document.documentElement.classList.add("osk-visible");
+    const element = containerRef.current;
+    if (!element) return;
+    const update = () => {
+      const height = element.offsetHeight;
+      document.documentElement.style.setProperty(
+        "--osk-viewport-offset",
+        `${height}px`,
+      );
+      window.dispatchEvent(
+        new CustomEvent("oskchange", { detail: { visible: true, height } }),
+      );
+    };
+    update();
+    const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : null;
+    observer?.observe(element);
+    window.addEventListener("resize", update);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", update);
+    };
+  }, [visible]);
+
+  const dispatchKeyEvent = useCallback(
+    (type: KeyboardEventType, keyDef: LayoutKey): DispatchResult => {
+      const activeElement = document.activeElement as HTMLElement | null;
+      if (!activeElement) return { prevented: false, element: null };
+      const modifiers = activeModifiersRef.current;
+      const keyValue = computeKeyValue(keyDef, modifiers);
+      const event = new KeyboardEvent(type, {
+        key: keyValue,
+        code: keyDef.code,
+        bubbles: true,
+        cancelable: true,
+        shiftKey: modifiers.has("Shift"),
+        ctrlKey: modifiers.has("Control"),
+        altKey: modifiers.has("Alt"),
+        metaKey: modifiers.has("Meta"),
+      });
+      const prevented = !activeElement.dispatchEvent(event);
+      return { prevented, element: activeElement };
+    },
+    [],
+  );
+
+  const releaseMomentaryModifiers = useCallback(() => {
+    const latched = latchedModifiersRef.current;
+    if (!latched.size) return;
+    latched.forEach((modifier) => {
+      const source = modifierSourceRef.current.get(modifier);
+      if (!source) return;
+      activeModifiersRef.current.delete(modifier);
+      dispatchKeyEvent("keyup", source);
+      modifierSourceRef.current.delete(modifier);
+    });
+    latched.clear();
+    forceModifierRender((v) => v + 1);
+  }, [dispatchKeyEvent]);
+
+  const toggleModifier = useCallback(
+    (keyDef: LayoutKey) => {
+      if (!keyDef.modifier) return;
+      const modifier = keyDef.modifier;
+      const isActive = activeModifiersRef.current.has(modifier);
+      if (isActive) {
+        activeModifiersRef.current.delete(modifier);
+        latchedModifiersRef.current.delete(modifier);
+        modifierSourceRef.current.delete(modifier);
+        dispatchKeyEvent("keyup", keyDef);
+      } else {
+        activeModifiersRef.current.add(modifier);
+        modifierSourceRef.current.set(modifier, keyDef);
+        if (keyDef.behavior === "momentary") {
+          latchedModifiersRef.current.add(modifier);
+        }
+        dispatchKeyEvent("keydown", keyDef);
+      }
+      forceModifierRender((v) => v + 1);
+    },
+    [dispatchKeyEvent],
+  );
+
+  const handleKey = useCallback(
+    (keyDef: LayoutKey) => {
+      if (keyDef.type === "modifier") {
+        toggleModifier(keyDef);
+        return;
+      }
+      const { prevented, element } = dispatchKeyEvent("keydown", keyDef);
+      if (!prevented && element) {
+        if (keyDef.code === "Backspace") {
+          deleteText(element);
+        } else if (keyDef.type === "char" || keyDef.code === "Space") {
+          const text = computeKeyValue(keyDef, activeModifiersRef.current);
+          insertText(element, text);
+        } else if (keyDef.code === "Enter") {
+          if (element instanceof HTMLTextAreaElement || element.isContentEditable) {
+            insertText(element, "\n");
+          }
+        }
+      }
+      dispatchKeyEvent("keyup", keyDef);
+      releaseMomentaryModifiers();
+    },
+    [dispatchKeyEvent, releaseMomentaryModifiers, toggleModifier],
+  );
+
+  const manualButtonLabel = manualVisible ? "Hide Keyboard" : "Show Keyboard";
+
+  const contextValue = useMemo<OnScreenKeyboardContextValue>(
+    () => ({
+      visible,
+      manualVisible,
+      autoVisible: allowAutoShow && autoVisible,
+      hardwareKeyboardDetected,
+      requestShow: () => setManualVisible(true),
+      requestHide: () => setManualVisible(false),
+    }),
+    [allowAutoShow, autoVisible, hardwareKeyboardDetected, manualVisible, visible],
+  );
+
+  return (
+    <OnScreenKeyboardContext.Provider value={contextValue}>
+      {children}
+      {onScreenKeyboardEnabled && (
+        <button
+          type="button"
+          data-osk-toggle
+          className="fixed right-4 z-50 rounded-full border border-ubt-cool-grey bg-gray-900/80 px-4 py-2 text-sm font-medium text-gray-100 shadow-lg backdrop-blur transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange"
+          style={{ bottom: "calc(var(--osk-viewport-offset, 0px) + 1rem)" }}
+          onClick={() => setManualVisible((value) => !value)}
+          aria-pressed={manualVisible}
+          aria-label="Toggle on-screen keyboard"
+        >
+          {manualButtonLabel}
+        </button>
+      )}
+      <div
+        className="pointer-events-none fixed bottom-0 left-0 right-0 z-40 px-3 pb-3"
+        aria-hidden={!visible}
+      >
+        <div
+          ref={containerRef}
+          data-osk-surface
+          className={`mx-auto max-w-6xl rounded-2xl border border-ubt-cool-grey bg-gray-950/95 p-3 shadow-2xl backdrop-blur-md transition-all duration-300 ease-out ${
+            visible ? "pointer-events-auto opacity-100 translate-y-0" : "pointer-events-none opacity-0 translate-y-8"
+          }`}
+        >
+          <div className="space-y-2">
+            {layoutData.rows.map((row, rowIndex) => (
+              <div key={`osk-row-${rowIndex}`} className="flex gap-2">
+                {row.map((keyDef) => {
+                  const width = keyDef.width ?? 1;
+                  const isActive =
+                    keyDef.type === "modifier" &&
+                    keyDef.modifier &&
+                    activeModifiersRef.current.has(keyDef.modifier);
+                  return (
+                    <button
+                      key={`${keyDef.code}-${keyDef.label}`}
+                      type="button"
+                      tabIndex={-1}
+                      className={`flex select-none items-center justify-center rounded-md border border-ubt-cool-grey bg-gray-900/90 px-2 py-2 text-sm font-medium uppercase tracking-wide text-gray-100 shadow-inner transition-colors duration-150 focus:outline-none ${
+                        isActive ? "border-ub-orange bg-ub-orange/80 text-black" : "hover:bg-gray-800/70"
+                      }`}
+                      style={{ flex: width, minWidth: `${width * 2.25}rem` }}
+                      aria-label={keyDef.ariaLabel ?? keyDef.label}
+                      onPointerDown={(event) => {
+                        event.preventDefault();
+                        handleKey(keyDef);
+                      }}
+                    >
+                      {keyDef.label}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </OnScreenKeyboardContext.Provider>
+  );
+}

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -22,6 +22,10 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getOnScreenKeyboardEnabled as loadOnScreenKeyboardEnabled,
+  setOnScreenKeyboardEnabled as saveOnScreenKeyboardEnabled,
+  getOnScreenKeyboardAutoShow as loadOnScreenKeyboardAutoShow,
+  setOnScreenKeyboardAutoShow as saveOnScreenKeyboardAutoShow,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -66,6 +70,8 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  onScreenKeyboardEnabled: boolean;
+  onScreenKeyboardAutoShow: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -78,6 +84,8 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setOnScreenKeyboardEnabled: (value: boolean) => void;
+  setOnScreenKeyboardAutoShow: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -94,6 +102,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  onScreenKeyboardEnabled: defaults.onScreenKeyboardEnabled,
+  onScreenKeyboardAutoShow: defaults.onScreenKeyboardAutoShow,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -106,6 +116,8 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setOnScreenKeyboardEnabled: () => {},
+  setOnScreenKeyboardAutoShow: () => {},
   setTheme: () => {},
 });
 
@@ -121,6 +133,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [onScreenKeyboardEnabled, setOnScreenKeyboardEnabled] = useState<boolean>(
+    defaults.onScreenKeyboardEnabled,
+  );
+  const [onScreenKeyboardAutoShow, setOnScreenKeyboardAutoShow] = useState<boolean>(
+    defaults.onScreenKeyboardAutoShow,
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -137,6 +155,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setOnScreenKeyboardEnabled(await loadOnScreenKeyboardEnabled());
+      setOnScreenKeyboardAutoShow(await loadOnScreenKeyboardAutoShow());
       setTheme(loadTheme());
     })();
   }, []);
@@ -250,6 +270,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveOnScreenKeyboardEnabled(onScreenKeyboardEnabled);
+  }, [onScreenKeyboardEnabled]);
+
+  useEffect(() => {
+    saveOnScreenKeyboardAutoShow(onScreenKeyboardAutoShow);
+  }, [onScreenKeyboardAutoShow]);
+
   const bgImageName = useKaliWallpaper ? 'kali-gradient' : wallpaper;
 
   return (
@@ -267,6 +295,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        onScreenKeyboardEnabled,
+        onScreenKeyboardAutoShow,
         theme,
         setAccent,
         setWallpaper,
@@ -279,6 +309,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setOnScreenKeyboardEnabled,
+        setOnScreenKeyboardAutoShow,
         setTheme,
       }}
     >

--- a/nethunter/osk/layout.json
+++ b/nethunter/osk/layout.json
@@ -1,0 +1,579 @@
+{
+  "meta": {
+    "name": "NetHunter Extended",
+    "version": 1,
+    "description": "Desktop-style keyboard with function keys and dedicated modifier rows"
+  },
+  "rows": [
+    [
+      {
+        "label": "Esc",
+        "code": "Escape",
+        "key": "Escape",
+        "type": "action",
+        "ariaLabel": "Escape",
+        "width": 1.2
+      },
+      {
+        "label": "F1",
+        "code": "F1",
+        "key": "F1",
+        "type": "function"
+      },
+      {
+        "label": "F2",
+        "code": "F2",
+        "key": "F2",
+        "type": "function"
+      },
+      {
+        "label": "F3",
+        "code": "F3",
+        "key": "F3",
+        "type": "function"
+      },
+      {
+        "label": "F4",
+        "code": "F4",
+        "key": "F4",
+        "type": "function"
+      },
+      {
+        "label": "F5",
+        "code": "F5",
+        "key": "F5",
+        "type": "function"
+      },
+      {
+        "label": "F6",
+        "code": "F6",
+        "key": "F6",
+        "type": "function"
+      },
+      {
+        "label": "F7",
+        "code": "F7",
+        "key": "F7",
+        "type": "function"
+      },
+      {
+        "label": "F8",
+        "code": "F8",
+        "key": "F8",
+        "type": "function"
+      },
+      {
+        "label": "F9",
+        "code": "F9",
+        "key": "F9",
+        "type": "function"
+      },
+      {
+        "label": "F10",
+        "code": "F10",
+        "key": "F10",
+        "type": "function"
+      },
+      {
+        "label": "F11",
+        "code": "F11",
+        "key": "F11",
+        "type": "function"
+      },
+      {
+        "label": "F12",
+        "code": "F12",
+        "key": "F12",
+        "type": "function"
+      },
+      {
+        "label": "Del",
+        "code": "Delete",
+        "key": "Delete",
+        "type": "action",
+        "ariaLabel": "Delete",
+        "width": 1.2
+      }
+    ],
+    [
+      {
+        "label": "`",
+        "code": "Backquote",
+        "key": "`",
+        "shiftValue": "~",
+        "type": "char"
+      },
+      {
+        "label": "1",
+        "code": "Digit1",
+        "key": "1",
+        "shiftValue": "!",
+        "type": "char"
+      },
+      {
+        "label": "2",
+        "code": "Digit2",
+        "key": "2",
+        "shiftValue": "@",
+        "type": "char"
+      },
+      {
+        "label": "3",
+        "code": "Digit3",
+        "key": "3",
+        "shiftValue": "#",
+        "type": "char"
+      },
+      {
+        "label": "4",
+        "code": "Digit4",
+        "key": "4",
+        "shiftValue": "$",
+        "type": "char"
+      },
+      {
+        "label": "5",
+        "code": "Digit5",
+        "key": "5",
+        "shiftValue": "%",
+        "type": "char"
+      },
+      {
+        "label": "6",
+        "code": "Digit6",
+        "key": "6",
+        "shiftValue": "^",
+        "type": "char"
+      },
+      {
+        "label": "7",
+        "code": "Digit7",
+        "key": "7",
+        "shiftValue": "&",
+        "type": "char"
+      },
+      {
+        "label": "8",
+        "code": "Digit8",
+        "key": "8",
+        "shiftValue": "*",
+        "type": "char"
+      },
+      {
+        "label": "9",
+        "code": "Digit9",
+        "key": "9",
+        "shiftValue": "(",
+        "type": "char"
+      },
+      {
+        "label": "0",
+        "code": "Digit0",
+        "key": "0",
+        "shiftValue": ")",
+        "type": "char"
+      },
+      {
+        "label": "-",
+        "code": "Minus",
+        "key": "-",
+        "shiftValue": "_",
+        "type": "char"
+      },
+      {
+        "label": "=",
+        "code": "Equal",
+        "key": "=",
+        "shiftValue": "+",
+        "type": "char"
+      },
+      {
+        "label": "Backspace",
+        "code": "Backspace",
+        "key": "Backspace",
+        "type": "action",
+        "ariaLabel": "Backspace",
+        "width": 2
+      }
+    ],
+    [
+      {
+        "label": "Tab",
+        "code": "Tab",
+        "key": "Tab",
+        "type": "action",
+        "ariaLabel": "Tab",
+        "width": 1.6
+      },
+      {
+        "label": "Q",
+        "code": "KeyQ",
+        "key": "q",
+        "shiftValue": "Q",
+        "type": "char"
+      },
+      {
+        "label": "W",
+        "code": "KeyW",
+        "key": "w",
+        "shiftValue": "W",
+        "type": "char"
+      },
+      {
+        "label": "E",
+        "code": "KeyE",
+        "key": "e",
+        "shiftValue": "E",
+        "type": "char"
+      },
+      {
+        "label": "R",
+        "code": "KeyR",
+        "key": "r",
+        "shiftValue": "R",
+        "type": "char"
+      },
+      {
+        "label": "T",
+        "code": "KeyT",
+        "key": "t",
+        "shiftValue": "T",
+        "type": "char"
+      },
+      {
+        "label": "Y",
+        "code": "KeyY",
+        "key": "y",
+        "shiftValue": "Y",
+        "type": "char"
+      },
+      {
+        "label": "U",
+        "code": "KeyU",
+        "key": "u",
+        "shiftValue": "U",
+        "type": "char"
+      },
+      {
+        "label": "I",
+        "code": "KeyI",
+        "key": "i",
+        "shiftValue": "I",
+        "type": "char"
+      },
+      {
+        "label": "O",
+        "code": "KeyO",
+        "key": "o",
+        "shiftValue": "O",
+        "type": "char"
+      },
+      {
+        "label": "P",
+        "code": "KeyP",
+        "key": "p",
+        "shiftValue": "P",
+        "type": "char"
+      },
+      {
+        "label": "[",
+        "code": "BracketLeft",
+        "key": "[",
+        "shiftValue": "{",
+        "type": "char"
+      },
+      {
+        "label": "]",
+        "code": "BracketRight",
+        "key": "]",
+        "shiftValue": "}",
+        "type": "char"
+      },
+      {
+        "label": "\\",
+        "code": "Backslash",
+        "key": "\\",
+        "shiftValue": "|",
+        "type": "char",
+        "width": 1.6
+      }
+    ],
+    [
+      {
+        "label": "Caps",
+        "code": "CapsLock",
+        "key": "CapsLock",
+        "type": "action",
+        "ariaLabel": "Caps Lock",
+        "width": 1.9
+      },
+      {
+        "label": "A",
+        "code": "KeyA",
+        "key": "a",
+        "shiftValue": "A",
+        "type": "char"
+      },
+      {
+        "label": "S",
+        "code": "KeyS",
+        "key": "s",
+        "shiftValue": "S",
+        "type": "char"
+      },
+      {
+        "label": "D",
+        "code": "KeyD",
+        "key": "d",
+        "shiftValue": "D",
+        "type": "char"
+      },
+      {
+        "label": "F",
+        "code": "KeyF",
+        "key": "f",
+        "shiftValue": "F",
+        "type": "char"
+      },
+      {
+        "label": "G",
+        "code": "KeyG",
+        "key": "g",
+        "shiftValue": "G",
+        "type": "char"
+      },
+      {
+        "label": "H",
+        "code": "KeyH",
+        "key": "h",
+        "shiftValue": "H",
+        "type": "char"
+      },
+      {
+        "label": "J",
+        "code": "KeyJ",
+        "key": "j",
+        "shiftValue": "J",
+        "type": "char"
+      },
+      {
+        "label": "K",
+        "code": "KeyK",
+        "key": "k",
+        "shiftValue": "K",
+        "type": "char"
+      },
+      {
+        "label": "L",
+        "code": "KeyL",
+        "key": "l",
+        "shiftValue": "L",
+        "type": "char"
+      },
+      {
+        "label": ";",
+        "code": "Semicolon",
+        "key": ";",
+        "shiftValue": ":",
+        "type": "char"
+      },
+      {
+        "label": "'",
+        "code": "Quote",
+        "key": "'",
+        "shiftValue": "\"",
+        "type": "char"
+      },
+      {
+        "label": "Enter",
+        "code": "Enter",
+        "key": "Enter",
+        "type": "action",
+        "ariaLabel": "Enter",
+        "width": 2.2
+      }
+    ],
+    [
+      {
+        "label": "Shift",
+        "code": "ShiftLeft",
+        "key": "Shift",
+        "type": "modifier",
+        "modifier": "Shift",
+        "behavior": "momentary",
+        "ariaLabel": "Left Shift",
+        "width": 2.2
+      },
+      {
+        "label": "Z",
+        "code": "KeyZ",
+        "key": "z",
+        "shiftValue": "Z",
+        "type": "char"
+      },
+      {
+        "label": "X",
+        "code": "KeyX",
+        "key": "x",
+        "shiftValue": "X",
+        "type": "char"
+      },
+      {
+        "label": "C",
+        "code": "KeyC",
+        "key": "c",
+        "shiftValue": "C",
+        "type": "char"
+      },
+      {
+        "label": "V",
+        "code": "KeyV",
+        "key": "v",
+        "shiftValue": "V",
+        "type": "char"
+      },
+      {
+        "label": "B",
+        "code": "KeyB",
+        "key": "b",
+        "shiftValue": "B",
+        "type": "char"
+      },
+      {
+        "label": "N",
+        "code": "KeyN",
+        "key": "n",
+        "shiftValue": "N",
+        "type": "char"
+      },
+      {
+        "label": "M",
+        "code": "KeyM",
+        "key": "m",
+        "shiftValue": "M",
+        "type": "char"
+      },
+      {
+        "label": ",",
+        "code": "Comma",
+        "key": ",",
+        "shiftValue": "<",
+        "type": "char"
+      },
+      {
+        "label": ".",
+        "code": "Period",
+        "key": ".",
+        "shiftValue": ">",
+        "type": "char"
+      },
+      {
+        "label": "/",
+        "code": "Slash",
+        "key": "/",
+        "shiftValue": "?",
+        "type": "char"
+      },
+      {
+        "label": "Shift",
+        "code": "ShiftRight",
+        "key": "Shift",
+        "type": "modifier",
+        "modifier": "Shift",
+        "behavior": "momentary",
+        "ariaLabel": "Right Shift",
+        "width": 2.4
+      }
+    ],
+    [
+      {
+        "label": "Ctrl",
+        "code": "ControlLeft",
+        "key": "Control",
+        "type": "modifier",
+        "modifier": "Control",
+        "behavior": "toggle",
+        "ariaLabel": "Left Control",
+        "width": 1.6
+      },
+      {
+        "label": "Alt",
+        "code": "AltLeft",
+        "key": "Alt",
+        "type": "modifier",
+        "modifier": "Alt",
+        "behavior": "toggle",
+        "ariaLabel": "Left Alt",
+        "width": 1.5
+      },
+      {
+        "label": "Fn",
+        "code": "ContextMenu",
+        "key": "ContextMenu",
+        "type": "action",
+        "ariaLabel": "Menu",
+        "width": 1.5
+      },
+      {
+        "label": "Space",
+        "code": "Space",
+        "key": " ",
+        "type": "char",
+        "ariaLabel": "Space",
+        "width": 6.2
+      },
+      {
+        "label": "Alt",
+        "code": "AltRight",
+        "key": "Alt",
+        "type": "modifier",
+        "modifier": "Alt",
+        "behavior": "toggle",
+        "ariaLabel": "Right Alt",
+        "width": 1.5
+      },
+      {
+        "label": "Ctrl",
+        "code": "ControlRight",
+        "key": "Control",
+        "type": "modifier",
+        "modifier": "Control",
+        "behavior": "toggle",
+        "ariaLabel": "Right Control",
+        "width": 1.6
+      },
+      {
+        "label": "\u25c0",
+        "code": "ArrowLeft",
+        "key": "ArrowLeft",
+        "type": "action",
+        "ariaLabel": "Arrow Left",
+        "width": 1.2
+      },
+      {
+        "label": "\u25b2",
+        "code": "ArrowUp",
+        "key": "ArrowUp",
+        "type": "action",
+        "ariaLabel": "Arrow Up",
+        "width": 1.2
+      },
+      {
+        "label": "\u25bc",
+        "code": "ArrowDown",
+        "key": "ArrowDown",
+        "type": "action",
+        "ariaLabel": "Arrow Down",
+        "width": 1.2
+      },
+      {
+        "label": "\u25b6",
+        "code": "ArrowRight",
+        "key": "ArrowRight",
+        "type": "action",
+        "ariaLabel": "Arrow Right",
+        "width": 1.2
+      }
+    ]
+  ]
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -15,6 +15,7 @@ import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import NotificationCenter from '../components/common/NotificationCenter';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
+import { OnScreenKeyboardProvider } from '../components/osk/OnScreenKeyboardProvider';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
@@ -158,23 +159,25 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <NotificationCenter>
-            <PipPortalProvider>
-              <div aria-live="polite" id="live-region" />
-              <Component {...pageProps} />
-              <ShortcutOverlay />
-              <Analytics
-                beforeSend={(e) => {
-                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                  const evt = e;
-                  if (evt.metadata?.email) delete evt.metadata.email;
-                  return e;
-                }}
-              />
+          <OnScreenKeyboardProvider>
+            <NotificationCenter>
+              <PipPortalProvider>
+                <div aria-live="polite" id="live-region" />
+                <Component {...pageProps} />
+                <ShortcutOverlay />
+                <Analytics
+                  beforeSend={(e) => {
+                    if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                    const evt = e;
+                    if (evt.metadata?.email) delete evt.metadata.email;
+                    return e;
+                  }}
+                />
 
-              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-            </PipPortalProvider>
-          </NotificationCenter>
+                {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+              </PipPortalProvider>
+            </NotificationCenter>
+          </OnScreenKeyboardProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -15,6 +15,8 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  onScreenKeyboardEnabled: true,
+  onScreenKeyboardAutoShow: true,
 };
 
 export async function getAccent() {
@@ -114,6 +116,28 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getOnScreenKeyboardEnabled() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.onScreenKeyboardEnabled;
+  const stored = window.localStorage.getItem('osk-enabled');
+  return stored === null ? DEFAULT_SETTINGS.onScreenKeyboardEnabled : stored === 'true';
+}
+
+export async function setOnScreenKeyboardEnabled(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('osk-enabled', value ? 'true' : 'false');
+}
+
+export async function getOnScreenKeyboardAutoShow() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.onScreenKeyboardAutoShow;
+  const stored = window.localStorage.getItem('osk-auto-show');
+  return stored === null ? DEFAULT_SETTINGS.onScreenKeyboardAutoShow : stored === 'true';
+}
+
+export async function setOnScreenKeyboardAutoShow(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('osk-auto-show', value ? 'true' : 'false');
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -150,6 +174,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
   window.localStorage.removeItem('use-kali-wallpaper');
+  window.localStorage.removeItem('osk-enabled');
+  window.localStorage.removeItem('osk-auto-show');
 }
 
 export async function exportSettings() {
@@ -177,6 +203,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getOnScreenKeyboardEnabled(),
+    getOnScreenKeyboardAutoShow(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -192,6 +220,8 @@ export async function exportSettings() {
     haptics,
     useKaliWallpaper,
     theme,
+    onScreenKeyboardEnabled,
+    onScreenKeyboardAutoShow,
   });
 }
 
@@ -217,6 +247,8 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    onScreenKeyboardEnabled,
+    onScreenKeyboardAutoShow,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -229,6 +261,10 @@ export async function importSettings(json) {
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
+  if (onScreenKeyboardEnabled !== undefined)
+    await setOnScreenKeyboardEnabled(onScreenKeyboardEnabled);
+  if (onScreenKeyboardAutoShow !== undefined)
+    await setOnScreenKeyboardAutoShow(onScreenKeyboardAutoShow);
   if (theme !== undefined) setTheme(theme);
 }
 


### PR DESCRIPTION
## Summary
- add a reusable NetHunter on-screen keyboard provider backed by the new layout with function keys and modifier rows
- persist on-screen keyboard preferences and surface toggles in Settings, including auto-show logic when no hardware keyboard is detected
- coordinate the terminal container and global app shell with the OSK so focus and resizing stay in sync

## Testing
- yarn lint *(fails: repository already reports numerous control-has-associated-label violations in legacy apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f1fb3630832889e730ee8b13bb67