### PR TITLE
[settings] Add VPN wizard with secure storage

### DIFF
--- a/__tests__/vpnParsers.test.ts
+++ b/__tests__/vpnParsers.test.ts
@@ -1,0 +1,89 @@
+import {
+  loadVpnProfile,
+  parseOpenVpnConfig,
+  parseVpnQrPayload,
+  parseWireGuardConfig,
+  persistVpnProfile,
+  profileNeedsPassphrase,
+} from "../utils/vpn";
+
+describe("VPN parsers", () => {
+  const sampleWireGuard = `
+[Interface]
+Address = 10.0.0.2/32
+PrivateKey = abcdefg1234567890=
+DNS = 1.1.1.1,8.8.8.8
+ListenPort = 51820
+
+[Peer]
+PublicKey = peerpublickey=
+AllowedIPs = 0.0.0.0/0, ::/0
+Endpoint = vpn.example.com:51820
+PresharedKey = peersharedkey=
+PersistentKeepalive = 25
+`;
+
+  const sampleOpenVpn = `
+client
+remote vpn.example.com 1194 udp
+proto udp
+port 1194
+auth-user-pass
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIB...END
+-----END CERTIFICATE-----
+</ca>
+`;
+
+  beforeEach(async () => {
+    window.localStorage.clear();
+    await new Promise<void>((resolve, reject) => {
+      const request = indexedDB.deleteDatabase("keyval-store");
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error ?? new Error("Failed to reset IDB"));
+      request.onblocked = () => resolve();
+    });
+  });
+
+  it("parses WireGuard configs into NetworkManager structures", () => {
+    const profile = parseWireGuardConfig(sampleWireGuard, "Home WG");
+    expect(profile.name).toBe("Home WG");
+    expect(profile.nmConnection.connection.type).toBe("wireguard");
+    expect(profile.nmConnection.wireguard?.listen_port).toBe(51820);
+    expect(profile.nmConnection.wireguard_peer?.[0].allowed_ips).toContain("0.0.0.0/0");
+    expect(profile.nmConnection.secrets?.["wireguard.private-key"]).toBe("abcdefg1234567890=");
+    expect(profileNeedsPassphrase(profile)).toBe(true);
+  });
+
+  it("parses OpenVPN configs including inline certificate blocks", () => {
+    const profile = parseOpenVpnConfig(sampleOpenVpn, "Work VPN");
+    expect(profile.name).toBe("Work VPN");
+    expect(profile.nmConnection.connection.type).toBe("vpn");
+    expect(profile.nmConnection.vpn?.data.remote).toBe("vpn.example.com");
+    expect(profile.nmConnection.vpn?.data.ca).toContain("BEGIN CERTIFICATE");
+    expect(profileNeedsPassphrase(profile)).toBe(false);
+  });
+
+  it("detects VPN type from QR payloads", () => {
+    const qrProfile = parseVpnQrPayload(sampleWireGuard);
+    expect(qrProfile.type).toBe("wireguard");
+    const qrProfile2 = parseVpnQrPayload(sampleOpenVpn);
+    expect(qrProfile2.type).toBe("openvpn");
+  });
+
+  it("requires a passphrase when persisting sensitive profiles", async () => {
+    const profile = parseWireGuardConfig(sampleWireGuard, "Secure WG");
+    await expect(persistVpnProfile(profile)).rejects.toThrow("passphrase");
+    await persistVpnProfile(profile, "supersecurepass");
+    const loaded = await loadVpnProfile(profile.id, "supersecurepass");
+    expect(loaded?.nmConnection.wireguard_peer?.[0].endpoint).toBe("vpn.example.com:51820");
+  });
+
+  it("persists OpenVPN profiles without a passphrase when no secrets exist", async () => {
+    const profile = parseOpenVpnConfig(sampleOpenVpn, "Public OVPN");
+    await persistVpnProfile(profile);
+    const loaded = await loadVpnProfile(profile.id);
+    expect(loaded?.nmConnection.vpn?.data.remote).toBe("vpn.example.com");
+  });
+});

--- a/apps/settings/components/network/VpnWizard.tsx
+++ b/apps/settings/components/network/VpnWizard.tsx
@@ -1,0 +1,626 @@
+"use client";
+
+import {
+  useState,
+  type InputHTMLAttributes,
+  type ReactNode,
+  type TextareaHTMLAttributes,
+} from "react";
+import {
+  OpenVpnFormValues,
+  ParsedVpnProfile,
+  VpnProfileType,
+  WireGuardFormValues,
+  decodeQrFile,
+  parseOpenVpnForm,
+  parseVpnQrPayload,
+  parseWireGuardForm,
+  persistVpnProfile,
+  profileNeedsPassphrase,
+} from "../../../../utils/vpn";
+
+const initialWireGuard: WireGuardFormValues = {
+  name: "",
+  address: "",
+  privateKey: "",
+  dns: "",
+  listenPort: "",
+  peerPublicKey: "",
+  peerEndpoint: "",
+  peerAllowedIps: "0.0.0.0/0",
+  peerPresharedKey: "",
+  persistentKeepalive: "",
+};
+
+const initialOpenVpn: OpenVpnFormValues = {
+  name: "",
+  remote: "",
+  port: "",
+  proto: "udp",
+  username: "",
+  password: "",
+  ca: "",
+  cert: "",
+  key: "",
+  tlsAuth: "",
+  extraConfig: "",
+};
+
+type WizardStep = "method" | "details" | "review";
+
+type MethodChoice = VpnProfileType | "qr";
+
+function SectionTitle({ children }: { children: string }) {
+  return <h2 className="text-lg font-semibold text-ubt-grey mb-3">{children}</h2>;
+}
+
+function FieldLabel({ htmlFor, children }: { htmlFor: string; children: string }) {
+  return (
+    <label htmlFor={htmlFor} className="block text-sm text-ubt-grey mb-1">
+      {children}
+    </label>
+  );
+}
+
+function Input(props: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      {...props}
+      className={`w-full rounded border border-ubt-cool-grey bg-ub-cool-grey px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-ubt-blue ${props.className ?? ""}`.trim()}
+    />
+  );
+}
+
+function Textarea(props: TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      {...props}
+      className={`w-full rounded border border-ubt-cool-grey bg-ub-cool-grey px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-ubt-blue ${props.className ?? ""}`.trim()}
+    />
+  );
+}
+
+function SummaryRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex flex-col border-b border-ubt-cool-grey py-2 last:border-b-0">
+      <span className="text-xs uppercase tracking-wide text-ubt-grey">{label}</span>
+      <span className="text-sm text-white break-words">{value}</span>
+    </div>
+  );
+}
+
+export default function VpnWizard() {
+  const [step, setStep] = useState<WizardStep>("method");
+  const [method, setMethod] = useState<MethodChoice | null>(null);
+  const [wireGuardValues, setWireGuardValues] = useState<WireGuardFormValues>(initialWireGuard);
+  const [openVpnValues, setOpenVpnValues] = useState<OpenVpnFormValues>(initialOpenVpn);
+  const [parsedProfile, setParsedProfile] = useState<ParsedVpnProfile | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+
+  const resetWizard = () => {
+    setStep("method");
+    setMethod(null);
+    setParsedProfile(null);
+    setStatus(null);
+    setError(null);
+    setWireGuardValues(initialWireGuard);
+    setOpenVpnValues(initialOpenVpn);
+  };
+
+  const handleMethodSelect = (choice: MethodChoice) => {
+    setMethod(choice);
+    setStep("details");
+    setParsedProfile(null);
+    setStatus(null);
+    setError(null);
+  };
+
+  const validateWireGuard = (values: WireGuardFormValues) => {
+    if (!values.name.trim()) throw new Error("Profile name is required");
+    if (!values.address.trim()) throw new Error("Interface address is required");
+    if (!values.privateKey.trim()) throw new Error("Private key is required");
+    if (!values.peerPublicKey.trim()) throw new Error("Peer public key is required");
+    if (!values.peerAllowedIps.trim()) throw new Error("Allowed IPs are required");
+  };
+
+  const validateOpenVpn = (values: OpenVpnFormValues) => {
+    if (!values.name.trim()) throw new Error("Profile name is required");
+    if (!values.remote.trim()) throw new Error("Remote host is required");
+  };
+
+  const buildProfile = async () => {
+    if (!method) return;
+    setIsBusy(true);
+    setError(null);
+    setStatus(null);
+    try {
+      if (method === "wireguard") {
+        validateWireGuard(wireGuardValues);
+        const profile = parseWireGuardForm(wireGuardValues);
+        setParsedProfile(profile);
+        setStep("review");
+      } else if (method === "openvpn") {
+        validateOpenVpn(openVpnValues);
+        const profile = parseOpenVpnForm(openVpnValues);
+        setParsedProfile(profile);
+        setStep("review");
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to parse VPN configuration";
+      setError(message);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleQrFile = async (file: File) => {
+    setIsBusy(true);
+    setError(null);
+    setStatus(null);
+    try {
+      const text = await decodeQrFile(file);
+      const profile = parseVpnQrPayload(text);
+      setParsedProfile(profile);
+      setMethod(profile.type);
+      setStep("review");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unable to decode QR code";
+      setError(message);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!parsedProfile) return;
+    setIsBusy(true);
+    setError(null);
+    setStatus(null);
+    try {
+      let passphrase: string | undefined;
+      if (profileNeedsPassphrase(parsedProfile)) {
+        if (typeof window === "undefined") {
+          throw new Error("Passphrase prompt is only available in the browser");
+        }
+        const input = window.prompt("Enter a passphrase to encrypt VPN credentials (min 8 characters):");
+        if (!input) throw new Error("Passphrase is required to store this profile");
+        if (input.length < 8) throw new Error("Passphrase must be at least 8 characters long");
+        passphrase = input;
+      }
+      await persistVpnProfile(parsedProfile, passphrase);
+      setStatus(`Saved ${parsedProfile.name}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to save VPN profile";
+      setError(message);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const renderMethodStep = () => (
+    <div className="space-y-4">
+      <SectionTitle>Select VPN profile type</SectionTitle>
+      <div className="grid gap-3 md:grid-cols-3">
+        {[
+          { key: "wireguard", label: "WireGuard", description: "Create a WireGuard profile" },
+          { key: "openvpn", label: "OpenVPN", description: "Create an OpenVPN profile" },
+          { key: "qr", label: "Import from QR", description: "Scan a VPN configuration" },
+        ].map((option) => (
+          <button
+            key={option.key}
+            type="button"
+            onClick={() => handleMethodSelect(option.key as MethodChoice)}
+            className="flex h-full flex-col rounded border border-ubt-cool-grey bg-ub-dark-grey p-4 text-left transition hover:border-ubt-blue"
+          >
+            <span className="text-base font-semibold text-white">{option.label}</span>
+            <span className="mt-2 text-sm text-ubt-grey">{option.description}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+
+  const renderWireGuardForm = () => (
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void buildProfile();
+      }}
+    >
+      <SectionTitle>WireGuard interface</SectionTitle>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <FieldLabel htmlFor="wg-name">Profile name</FieldLabel>
+          <Input
+            id="wg-name"
+            value={wireGuardValues.name}
+            onChange={(event) =>
+              setWireGuardValues((prev) => ({ ...prev, name: event.target.value }))
+            }
+            required
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="wg-address">Interface address</FieldLabel>
+          <Input
+            id="wg-address"
+            placeholder="10.0.0.2/32"
+            value={wireGuardValues.address}
+            onChange={(event) =>
+              setWireGuardValues((prev) => ({ ...prev, address: event.target.value }))
+            }
+            required
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="wg-private-key">Private key</FieldLabel>
+          <Input
+            id="wg-private-key"
+            value={wireGuardValues.privateKey}
+            onChange={(event) =>
+              setWireGuardValues((prev) => ({ ...prev, privateKey: event.target.value }))
+            }
+            required
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="wg-dns">DNS servers</FieldLabel>
+          <Input
+            id="wg-dns"
+            placeholder="1.1.1.1, 9.9.9.9"
+            value={wireGuardValues.dns}
+            onChange={(event) =>
+              setWireGuardValues((prev) => ({ ...prev, dns: event.target.value }))
+            }
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="wg-listen-port">Listen port</FieldLabel>
+          <Input
+            id="wg-listen-port"
+            placeholder="51820"
+            value={wireGuardValues.listenPort}
+            onChange={(event) =>
+              setWireGuardValues((prev) => ({ ...prev, listenPort: event.target.value }))
+            }
+          />
+        </div>
+      </div>
+
+      <SectionTitle>Peer configuration</SectionTitle>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <FieldLabel htmlFor="wg-peer-public">Peer public key</FieldLabel>
+          <Input
+            id="wg-peer-public"
+            value={wireGuardValues.peerPublicKey}
+            onChange={(event) =>
+              setWireGuardValues((prev) => ({ ...prev, peerPublicKey: event.target.value }))
+            }
+            required
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="wg-endpoint">Endpoint</FieldLabel>
+          <Input
+            id="wg-endpoint"
+            placeholder="vpn.example.com:51820"
+            value={wireGuardValues.peerEndpoint}
+            onChange={(event) =>
+              setWireGuardValues((prev) => ({ ...prev, peerEndpoint: event.target.value }))
+            }
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="wg-allowed">Allowed IPs</FieldLabel>
+          <Input
+            id="wg-allowed"
+            placeholder="0.0.0.0/0, ::/0"
+            value={wireGuardValues.peerAllowedIps}
+            onChange={(event) =>
+              setWireGuardValues((prev) => ({ ...prev, peerAllowedIps: event.target.value }))
+            }
+            required
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="wg-preshared">Preshared key</FieldLabel>
+          <Input
+            id="wg-preshared"
+            value={wireGuardValues.peerPresharedKey}
+            onChange={(event) =>
+              setWireGuardValues((prev) => ({ ...prev, peerPresharedKey: event.target.value }))
+            }
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="wg-keepalive">Persistent keepalive</FieldLabel>
+          <Input
+            id="wg-keepalive"
+            placeholder="25"
+            value={wireGuardValues.persistentKeepalive}
+            onChange={(event) =>
+              setWireGuardValues((prev) => ({ ...prev, persistentKeepalive: event.target.value }))
+            }
+          />
+        </div>
+      </div>
+      <div className="flex justify-between pt-4">
+        <button
+          type="button"
+          onClick={resetWizard}
+          className="rounded border border-ubt-cool-grey px-4 py-2 text-sm text-ubt-grey hover:border-ubt-blue hover:text-white"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={isBusy}
+          className="rounded bg-ubt-blue px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+        >
+          Continue
+        </button>
+      </div>
+    </form>
+  );
+
+  const renderOpenVpnForm = () => (
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void buildProfile();
+      }}
+    >
+      <SectionTitle>OpenVPN client</SectionTitle>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <FieldLabel htmlFor="ovpn-name">Profile name</FieldLabel>
+          <Input
+            id="ovpn-name"
+            value={openVpnValues.name}
+            onChange={(event) =>
+              setOpenVpnValues((prev) => ({ ...prev, name: event.target.value }))
+            }
+            required
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="ovpn-remote">Remote host</FieldLabel>
+          <Input
+            id="ovpn-remote"
+            placeholder="vpn.example.com"
+            value={openVpnValues.remote}
+            onChange={(event) =>
+              setOpenVpnValues((prev) => ({ ...prev, remote: event.target.value }))
+            }
+            required
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="ovpn-port">Port</FieldLabel>
+          <Input
+            id="ovpn-port"
+            placeholder="1194"
+            value={openVpnValues.port}
+            onChange={(event) =>
+              setOpenVpnValues((prev) => ({ ...prev, port: event.target.value }))
+            }
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="ovpn-proto">Protocol</FieldLabel>
+          <Input
+            id="ovpn-proto"
+            placeholder="udp"
+            value={openVpnValues.proto}
+            onChange={(event) =>
+              setOpenVpnValues((prev) => ({ ...prev, proto: event.target.value }))
+            }
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="ovpn-username">Username</FieldLabel>
+          <Input
+            id="ovpn-username"
+            value={openVpnValues.username}
+            onChange={(event) =>
+              setOpenVpnValues((prev) => ({ ...prev, username: event.target.value }))
+            }
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="ovpn-password">Password</FieldLabel>
+          <Input
+            id="ovpn-password"
+            type="password"
+            value={openVpnValues.password}
+            onChange={(event) =>
+              setOpenVpnValues((prev) => ({ ...prev, password: event.target.value }))
+            }
+          />
+        </div>
+      </div>
+      <SectionTitle>Certificates and advanced options</SectionTitle>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <FieldLabel htmlFor="ovpn-ca">CA certificate path</FieldLabel>
+          <Input
+            id="ovpn-ca"
+            value={openVpnValues.ca}
+            onChange={(event) => setOpenVpnValues((prev) => ({ ...prev, ca: event.target.value }))}
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="ovpn-cert">Client certificate path</FieldLabel>
+          <Input
+            id="ovpn-cert"
+            value={openVpnValues.cert}
+            onChange={(event) => setOpenVpnValues((prev) => ({ ...prev, cert: event.target.value }))}
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="ovpn-key">Client key path</FieldLabel>
+          <Input
+            id="ovpn-key"
+            value={openVpnValues.key}
+            onChange={(event) => setOpenVpnValues((prev) => ({ ...prev, key: event.target.value }))}
+          />
+        </div>
+        <div>
+          <FieldLabel htmlFor="ovpn-tls">TLS auth key</FieldLabel>
+          <Input
+            id="ovpn-tls"
+            value={openVpnValues.tlsAuth}
+            onChange={(event) =>
+              setOpenVpnValues((prev) => ({ ...prev, tlsAuth: event.target.value }))
+            }
+          />
+        </div>
+      </div>
+      <div>
+        <FieldLabel htmlFor="ovpn-extra">Extra directives</FieldLabel>
+        <Textarea
+          id="ovpn-extra"
+          rows={4}
+          placeholder="push "redirect-gateway"\nremote-cert-tls server"
+          value={openVpnValues.extraConfig}
+          onChange={(event) =>
+            setOpenVpnValues((prev) => ({ ...prev, extraConfig: event.target.value }))
+          }
+        />
+      </div>
+      <div className="flex justify-between pt-4">
+        <button
+          type="button"
+          onClick={resetWizard}
+          className="rounded border border-ubt-cool-grey px-4 py-2 text-sm text-ubt-grey hover:border-ubt-blue hover:text-white"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={isBusy}
+          className="rounded bg-ubt-blue px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+        >
+          Continue
+        </button>
+      </div>
+    </form>
+  );
+
+  const renderQrStep = () => (
+    <div className="space-y-4">
+      <SectionTitle>Import VPN profile from QR</SectionTitle>
+      <p className="text-sm text-ubt-grey">
+        Upload a PNG or JPEG image containing a WireGuard or OpenVPN configuration QR code. The wizard
+        will decode the QR content and map it to a NetworkManager connection.
+      </p>
+      <input
+        type="file"
+        accept="image/png,image/jpeg,image/webp"
+        aria-label="Upload VPN QR image"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          if (file) void handleQrFile(file);
+        }}
+        className="text-sm text-ubt-grey"
+      />
+      <div className="flex justify-between pt-4">
+        <button
+          type="button"
+          onClick={resetWizard}
+          className="rounded border border-ubt-cool-grey px-4 py-2 text-sm text-ubt-grey hover:border-ubt-blue hover:text-white"
+        >
+          Back
+        </button>
+      </div>
+    </div>
+  );
+
+  const renderReview = () => (
+    <div className="space-y-4">
+      {parsedProfile && (
+        <>
+          <SectionTitle>Review profile</SectionTitle>
+          <div className="rounded border border-ubt-cool-grey bg-ub-dark-grey p-4">
+            <SummaryRow label="Name" value={parsedProfile.name} />
+            <SummaryRow label="Type" value={parsedProfile.type.toUpperCase()} />
+            <SummaryRow
+              label="Autoconnect"
+              value={parsedProfile.nmConnection.connection.autoconnect ? "Enabled" : "Disabled"}
+            />
+            {parsedProfile.nmConnection.vpn && (
+              <SummaryRow
+                label="VPN settings"
+                value={<pre className="whitespace-pre-wrap text-xs text-ubt-grey">{JSON.stringify(parsedProfile.nmConnection.vpn.data, null, 2)}</pre>}
+              />
+            )}
+            {parsedProfile.nmConnection.wireguard && (
+              <SummaryRow
+                label="WireGuard"
+                value={<pre className="whitespace-pre-wrap text-xs text-ubt-grey">{JSON.stringify(parsedProfile.nmConnection.wireguard_peer, null, 2)}</pre>}
+              />
+            )}
+            <SummaryRow
+              label="Secrets stored"
+              value={profileNeedsPassphrase(parsedProfile) ? "Yes (requires passphrase)" : "No"}
+            />
+          </div>
+          {parsedProfile.warnings.length > 0 && (
+            <div className="rounded border border-yellow-700 bg-yellow-900/40 p-3 text-sm text-yellow-200">
+              <p className="font-semibold">Warnings</p>
+              <ul className="list-disc pl-5">
+                {parsedProfile.warnings.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </>
+      )}
+      <div className="flex justify-between pt-4">
+        <button
+          type="button"
+          onClick={() => setStep(method ? "details" : "method")}
+          className="rounded border border-ubt-cool-grey px-4 py-2 text-sm text-ubt-grey hover:border-ubt-blue hover:text-white"
+        >
+          Back
+        </button>
+        <div className="flex items-center gap-3">
+          {status && <span className="text-sm text-green-300">{status}</span>}
+          <button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={isBusy}
+            className="rounded bg-ubt-blue px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+          >
+            Save profile
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  const stepNumber = step === "method" ? 1 : step === "review" ? 3 : 2;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold text-white">VPN Profile Wizard</h1>
+        <span className="text-sm text-ubt-grey">Step {stepNumber} of 3</span>
+      </div>
+      {error && (
+        <div className="rounded border border-red-700 bg-red-900/40 p-3 text-sm text-red-200">{error}</div>
+      )}
+      {step === "method" && renderMethodStep()}
+      {step === "details" && method === "wireguard" && renderWireGuardForm()}
+      {step === "details" && method === "openvpn" && renderOpenVpnForm()}
+      {step === "details" && method === "qr" && renderQrStep()}
+      {step === "review" && renderReview()}
+    </div>
+  );
+}

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -13,6 +13,7 @@ import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
 import KaliWallpaper from "../../components/util-components/kali-wallpaper";
+import VpnWizard from "./components/network/VpnWizard";
 
 export default function Settings() {
   const {
@@ -41,6 +42,7 @@ export default function Settings() {
     { id: "appearance", label: "Appearance" },
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
+    { id: "network", label: "Network" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
@@ -310,18 +312,23 @@ export default function Settings() {
           </div>
         </>
       )}
-        <input
-          type="file"
-          accept="application/json"
-          ref={fileInputRef}
-          aria-label="Import settings file"
-          onChange={(e) => {
-            const file = e.target.files && e.target.files[0];
-            if (file) handleImport(file);
-            e.target.value = "";
-          }}
-          className="hidden"
-        />
+      {activeTab === "network" && (
+        <div className="px-4 py-6">
+          <VpnWizard />
+        </div>
+      )}
+      <input
+        type="file"
+        accept="application/json"
+        ref={fileInputRef}
+        aria-label="Import settings file"
+        onChange={(e) => {
+          const file = e.target.files && e.target.files[0];
+          if (file) handleImport(file);
+          e.target.value = "";
+        }}
+        className="hidden"
+      />
       <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
     </div>
   );

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,5 @@
 import { TextEncoder, TextDecoder } from 'util';
+import { webcrypto } from 'crypto';
 // Polyfill structuredClone before requiring modules that depend on it
 // @ts-ignore
 if (typeof global.structuredClone !== 'function') {
@@ -13,6 +14,13 @@ import '@testing-library/jest-dom';
 global.TextEncoder = TextEncoder;
 // @ts-ignore
 global.TextDecoder = TextDecoder as any;
+
+// Ensure WebCrypto is available for modules relying on it
+// @ts-ignore
+if (!global.crypto) {
+  // @ts-ignore
+  global.crypto = webcrypto as unknown as Crypto;
+}
 
 // Provide a minimal structuredClone polyfill for environments lacking it
 // @ts-ignore

--- a/settings/network/vpn-wizard.ui
+++ b/settings/network/vpn-wizard.ui
@@ -1,0 +1,22 @@
+{
+  "id": "vpn-wizard",
+  "title": "VPN Profile Wizard",
+  "component": "apps/settings/components/network/VpnWizard.tsx",
+  "steps": [
+    {
+      "id": "method",
+      "title": "Select VPN profile type",
+      "description": "Choose WireGuard, OpenVPN, or import from QR."
+    },
+    {
+      "id": "details",
+      "title": "Configure profile",
+      "description": "Collect interface, peer, and credential details or decode a QR payload."
+    },
+    {
+      "id": "review",
+      "title": "Review and save",
+      "description": "Summarise the mapped NetworkManager connection and persist encrypted secrets."
+    }
+  ]
+}

--- a/utils/vpn/index.ts
+++ b/utils/vpn/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./parse";
+export * from "./store";
+export * from "./qr";

--- a/utils/vpn/parse.ts
+++ b/utils/vpn/parse.ts
@@ -1,0 +1,392 @@
+import { ParsedVpnProfile, VpnProfileType, WireGuardFormValues, OpenVpnFormValues, NetworkManagerConnection } from "./types";
+
+const DEFAULT_AUTOCONNECT = false;
+
+function generateProfileId(prefix: VpnProfileType): string {
+  if (typeof globalThis !== "undefined" && globalThis.crypto && "randomUUID" in globalThis.crypto) {
+    return `${prefix}-${globalThis.crypto.randomUUID()}`;
+  }
+  try {
+    const { randomUUID } = require("node:crypto");
+    return `${prefix}-${randomUUID()}`;
+  } catch {
+    return `${prefix}-${Math.random().toString(16).slice(2, 10)}`;
+  }
+}
+
+type IniSection = Record<string, string>;
+
+type IniResult = Record<string, IniSection[]>;
+
+function parseIni(input: string): IniResult {
+  const result: IniResult = {};
+  let currentSection: IniSection | null = null;
+
+  const ensureSection = (name: string) => {
+    const key = name.toLowerCase();
+    if (!result[key]) {
+      result[key] = [];
+    }
+    currentSection = {};
+    result[key].push(currentSection);
+  };
+
+  const lines = input.split(/\r?\n/);
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#") || line.startsWith(";")) continue;
+    if (line.startsWith("[") && line.endsWith("]")) {
+      ensureSection(line.slice(1, -1));
+      continue;
+    }
+    const idx = line.indexOf("=");
+    if (idx === -1) continue;
+    if (!currentSection) {
+      // lines before any section are ignored
+      continue;
+    }
+    const key = line.slice(0, idx).trim().toLowerCase();
+    const value = line.slice(idx + 1).trim();
+    currentSection[key] = value;
+  }
+  return result;
+}
+
+function parseCsvList(value?: string): string[] | undefined {
+  if (!value) return undefined;
+  return value
+    .split(/[,\s]+/)
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
+
+function parseAddressList(value?: string): Array<{ address: string; prefix?: number }> | undefined {
+  if (!value) return undefined;
+  const addresses: Array<{ address: string; prefix?: number }> = [];
+  for (const entry of value.split(",")) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    const [addr, prefixStr] = trimmed.split("/");
+    const prefix = prefixStr ? Number(prefixStr) : undefined;
+    addresses.push({ address: addr, prefix: Number.isFinite(prefix) ? prefix : undefined });
+  }
+  return addresses.length ? addresses : undefined;
+}
+
+function normaliseName(rawName?: string, fallback = "VPN Profile"): string {
+  if (!rawName) return fallback;
+  return rawName.trim() || fallback;
+}
+
+function buildWireGuardConfig(values: WireGuardFormValues): string {
+  const lines: string[] = ["[Interface]"];
+  lines.push(`Address = ${values.address}`);
+  lines.push(`PrivateKey = ${values.privateKey}`);
+  if (values.dns) lines.push(`DNS = ${values.dns}`);
+  if (values.listenPort) lines.push(`ListenPort = ${values.listenPort}`);
+  lines.push("", "[Peer]");
+  lines.push(`PublicKey = ${values.peerPublicKey}`);
+  if (values.peerEndpoint) lines.push(`Endpoint = ${values.peerEndpoint}`);
+  lines.push(`AllowedIPs = ${values.peerAllowedIps}`);
+  if (values.peerPresharedKey) lines.push(`PresharedKey = ${values.peerPresharedKey}`);
+  if (values.persistentKeepalive) lines.push(`PersistentKeepalive = ${values.persistentKeepalive}`);
+  return lines.join("\n");
+}
+
+function parseWireGuardFromIni(config: string, explicitName?: string): ParsedVpnProfile {
+  const sections = parseIni(config);
+  const iface = sections["interface"]?.[0];
+  if (!iface) {
+    throw new Error("WireGuard config missing [Interface] section");
+  }
+  const peers = sections["peer"] ?? [];
+  if (!peers.length) {
+    throw new Error("WireGuard config requires at least one [Peer] section");
+  }
+  const privateKey = iface["privatekey"];
+  if (!privateKey) {
+    throw new Error("WireGuard interface missing PrivateKey");
+  }
+  const address = iface["address"];
+  const dnsList = parseCsvList(iface["dns"]);
+  const listenPort = iface["listenport"] ? Number(iface["listenport"]) : undefined;
+  const mtu = iface["mtu"] ? Number(iface["mtu"]) : undefined;
+  const fwmark = iface["fwmark"] ? Number(iface["fwmark"]) : undefined;
+  const profileName = normaliseName(explicitName ?? iface["name"], "WireGuard connection");
+
+  const peerRoutes = iface["peerroutes"] ? iface["peerroutes"].toLowerCase() !== "false" : true;
+
+  const nmConnection: NetworkManagerConnection = {
+    connection: {
+      id: profileName,
+      type: "wireguard",
+      autoconnect: DEFAULT_AUTOCONNECT,
+    },
+    wireguard: {
+      private_key: "ask",
+      listen_port: listenPort,
+      fwmark,
+      peer_routes: peerRoutes,
+      mtu,
+    },
+    wireguard_peer: peers.map((peer) => {
+      const allowed = parseCsvList(peer["allowedips"]);
+      const persistentKeepalive = peer["persistentkeepalive"]
+        ? Number(peer["persistentkeepalive"])
+        : undefined;
+      return {
+        public_key: peer["publickey"] ?? "",
+        endpoint: peer["endpoint"],
+        allowed_ips: allowed,
+        preshared_key: peer["presharedkey"],
+        persistent_keepalive: persistentKeepalive,
+      };
+    }),
+    ipv4: {
+      method: address ? "manual" : "auto",
+      address_data: parseAddressList(address),
+      dns: dnsList,
+    },
+    ipv6: {
+      method: "auto",
+    },
+    secrets: {
+      "wireguard.private-key": privateKey,
+      ...peers.reduce<Record<string, string>>((acc, peer, idx) => {
+        if (peer["presharedkey"]) {
+          acc[`wireguard-peer-${idx}.preshared-key`] = peer["presharedkey"];
+        }
+        return acc;
+      }, {}),
+    },
+  };
+
+  const warnings: string[] = [];
+  if (!address) {
+    warnings.push("Interface address missing; connection will rely on DHCP");
+  }
+  if (!dnsList || !dnsList.length) {
+    warnings.push("DNS servers not provided");
+  }
+
+  return {
+    id: generateProfileId("wg"),
+    name: profileName,
+    type: "wireguard",
+    nmConnection,
+    rawConfig: config.trim(),
+    warnings,
+  };
+}
+
+function buildOpenVpnConfig(values: OpenVpnFormValues): string {
+  const lines: string[] = ["client"];
+  lines.push(`remote ${values.remote}${values.port ? ` ${values.port}` : ""}`.trim());
+  if (values.proto) lines.push(`proto ${values.proto}`);
+  if (values.username || values.password) lines.push("auth-user-pass");
+  if (values.ca) lines.push(`ca ${values.ca}`);
+  if (values.cert) lines.push(`cert ${values.cert}`);
+  if (values.key) lines.push(`key ${values.key}`);
+  if (values.tlsAuth) lines.push(`tls-auth ${values.tlsAuth}`);
+  if (values.extraConfig) lines.push(values.extraConfig.trim());
+  return lines.join("\n");
+}
+
+interface OpenVpnParseResult {
+  name: string;
+  data: Record<string, string>;
+  secrets: Record<string, string>;
+  warnings: string[];
+}
+
+function parseOpenVpnLines(config: string, explicitName?: string): OpenVpnParseResult {
+  const data: Record<string, string> = {};
+  const secrets: Record<string, string> = {};
+  const warnings: string[] = [];
+  const lines = config.split(/\r?\n/);
+  let name = explicitName?.trim() ?? "OpenVPN connection";
+  let i = 0;
+  const trimmedLines = lines.map((line) => line.trim());
+  if (trimmedLines.some((line) => line.toLowerCase() === "client")) {
+    data.mode = "client";
+  }
+
+  while (i < lines.length) {
+    const rawLine = lines[i];
+    const line = rawLine.trim();
+    i += 1;
+    if (!line || line.startsWith("#") || line.startsWith(";")) continue;
+    if (line.startsWith("<") && !line.startsWith("</")) {
+      const tag = line.slice(1, line.indexOf(">")).toLowerCase();
+      const blockLines: string[] = [];
+      while (i < lines.length && !lines[i].trim().toLowerCase().startsWith(`</${tag}`)) {
+        blockLines.push(lines[i]);
+        i += 1;
+      }
+      if (i < lines.length) {
+        i += 1; // skip closing tag
+      }
+      data[tag] = blockLines.join("\n").trim();
+      continue;
+    }
+    const parts = line.split(/\s+/);
+    const key = parts[0].toLowerCase();
+    const value = parts.slice(1).join(" ");
+    switch (key) {
+      case "remote": {
+        const [host, port, proto] = parts.slice(1);
+        if (host) data.remote = host;
+        if (port && !data.port) data.port = port;
+        if (proto && !data.proto) data.proto = proto;
+        if (!explicitName) {
+          name = normaliseName(host, name);
+        }
+        break;
+      }
+      case "proto":
+        data.proto = parts[1];
+        break;
+      case "port":
+        data.port = parts[1];
+        break;
+      case "dev":
+        data.dev = parts[1];
+        break;
+      case "auth-user-pass":
+        data["auth-user-pass"] = value || "ask";
+        if (!secrets.username) {
+          secrets.username = "ask";
+          secrets.password = "ask";
+        }
+        break;
+      case "auth":
+      case "cipher":
+      case "compress":
+      case "ca":
+      case "cert":
+      case "key":
+      case "tls-auth":
+      case "tls-crypt":
+      case "remote-cert-tls":
+      case "verify-x509-name":
+      case "sndbuf":
+      case "rcvbuf":
+      case "resolv-retry":
+      case "persist-key":
+      case "persist-tun":
+      case "comp-lzo":
+        if (value) {
+          data[key] = value;
+        } else {
+          data[key] = "true";
+        }
+        break;
+      case "setenv":
+        if (parts.length >= 2) {
+          const envKey = parts[1];
+          data[`setenv:${envKey}`] = parts.slice(2).join(" ");
+        }
+        break;
+      case "auth-user-pass-verify":
+        data[key] = value;
+        break;
+      case "script-security":
+      case "keepalive":
+      case "redirect-gateway":
+        data[key] = value || "true";
+        break;
+      case "management":
+        data.management = value;
+        break;
+      default:
+        data[`extra:${key}`] = value;
+        break;
+    }
+  }
+
+  if (!data.remote) {
+    warnings.push("OpenVPN config missing remote host");
+  }
+
+  return { name: normaliseName(name, "OpenVPN connection"), data, secrets, warnings };
+}
+
+function parseOpenVpnFromConfig(config: string, explicitName?: string): ParsedVpnProfile {
+  const { name, data, secrets, warnings } = parseOpenVpnLines(config, explicitName);
+  const nmConnection: NetworkManagerConnection = {
+    connection: {
+      id: name,
+      type: "vpn",
+      autoconnect: DEFAULT_AUTOCONNECT,
+    },
+    vpn: {
+      service_type: "org.freedesktop.NetworkManager.openvpn",
+      data,
+    },
+    ipv4: {
+      method: "auto",
+    },
+    ipv6: {
+      method: "auto",
+    },
+    secrets,
+  };
+
+  return {
+    id: generateProfileId("ovpn"),
+    name,
+    type: "openvpn",
+    nmConnection,
+    rawConfig: config.trim(),
+    warnings,
+  };
+}
+
+export function parseWireGuardForm(values: WireGuardFormValues): ParsedVpnProfile {
+  const config = buildWireGuardConfig(values);
+  return parseWireGuardFromIni(config, values.name);
+}
+
+export function parseOpenVpnForm(values: OpenVpnFormValues): ParsedVpnProfile {
+  const config = buildOpenVpnConfig(values);
+  const profile = parseOpenVpnFromConfig(config, values.name);
+  if (!profile.nmConnection.secrets) {
+    profile.nmConnection.secrets = {};
+  }
+  if (values.username) {
+    profile.nmConnection.secrets.username = values.username;
+    profile.nmConnection.vpn = profile.nmConnection.vpn || {
+      service_type: "org.freedesktop.NetworkManager.openvpn",
+      data: {},
+    };
+    profile.nmConnection.vpn.data["auth-user-pass"] = "ask";
+  }
+  if (values.password) {
+    profile.nmConnection.secrets.password = values.password;
+    profile.nmConnection.vpn = profile.nmConnection.vpn || {
+      service_type: "org.freedesktop.NetworkManager.openvpn",
+      data: {},
+    };
+    profile.nmConnection.vpn.data["auth-user-pass"] = "ask";
+  }
+  return profile;
+}
+
+export function parseWireGuardConfig(config: string, name?: string): ParsedVpnProfile {
+  return parseWireGuardFromIni(config, name);
+}
+
+export function parseOpenVpnConfig(config: string, name?: string): ParsedVpnProfile {
+  return parseOpenVpnFromConfig(config, name);
+}
+
+export function parseVpnQrPayload(payload: string): ParsedVpnProfile {
+  const trimmed = payload.trim();
+  if (/\[interface\]/i.test(trimmed)) {
+    return parseWireGuardConfig(trimmed);
+  }
+  if (/^client/m.test(trimmed) || /remote\s+/i.test(trimmed)) {
+    return parseOpenVpnConfig(trimmed);
+  }
+  throw new Error("Unsupported VPN payload in QR code");
+}

--- a/utils/vpn/qr.ts
+++ b/utils/vpn/qr.ts
@@ -1,0 +1,24 @@
+import { BrowserQRCodeReader } from "@zxing/browser";
+
+let reader: BrowserQRCodeReader | null = null;
+
+function getReader() {
+  if (!reader) {
+    reader = new BrowserQRCodeReader(undefined, { delayBetweenScanAttempts: 300 });
+  }
+  return reader;
+}
+
+export async function decodeQrFile(file: File): Promise<string> {
+  if (typeof window === "undefined") {
+    throw new Error("QR decoding is only available in the browser");
+  }
+  const readerInstance = getReader();
+  const url = URL.createObjectURL(file);
+  try {
+    const result = await readerInstance.decodeFromImageUrl(url);
+    return result.getText();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/utils/vpn/store.ts
+++ b/utils/vpn/store.ts
@@ -1,0 +1,310 @@
+import { get, set, del } from "idb-keyval";
+import { ParsedVpnProfile, VpnProfileType } from "./types";
+
+export interface StoredVpnProfileMetadata {
+  id: string;
+  name: string;
+  type: VpnProfileType;
+  createdAt: string;
+  warnings: string[];
+  hasSecrets: boolean;
+}
+
+interface EncryptedPayload {
+  version: number;
+  cipher: string;
+  iv: string;
+  salt: string;
+  createdAt: string;
+}
+
+interface PlainPayload {
+  version: number;
+  profile: ParsedVpnProfile;
+  createdAt: string;
+}
+
+const PROFILE_INDEX_KEY = "vpn-profile-index";
+const PROFILE_KEY_PREFIX = "vpn-profile";
+const ENCRYPTED_KEY_PREFIX = "vpn-secret";
+const PAYLOAD_VERSION = 1;
+
+function getCrypto(): Crypto {
+  if (typeof globalThis !== "undefined" && globalThis.crypto && globalThis.crypto.subtle) {
+    return globalThis.crypto;
+  }
+  try {
+    const { webcrypto } = require("node:crypto");
+    return webcrypto as Crypto;
+  } catch {
+    throw new Error("WebCrypto API is not available in this environment");
+  }
+}
+
+function getNodeCrypto() {
+  try {
+    return require("node:crypto");
+  } catch {
+    return null;
+  }
+}
+
+function bufferToBase64(buffer: ArrayBuffer): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : buffer).toString("base64");
+  }
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+function base64ToBuffer(base64: string): ArrayBuffer {
+  if (typeof Buffer !== "undefined") {
+    const buf = Buffer.from(base64, "base64");
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  }
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+function getIndex(): StoredVpnProfileMetadata[] {
+  if (typeof window === "undefined") return [];
+  const raw = window.localStorage.getItem(PROFILE_INDEX_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as StoredVpnProfileMetadata[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function setIndex(entries: StoredVpnProfileMetadata[]) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(PROFILE_INDEX_KEY, JSON.stringify(entries));
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+async function deriveKey(passphrase: string, salt: Uint8Array) {
+  const crypto = getCrypto();
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(passphrase),
+    "PBKDF2",
+    false,
+    ["deriveKey"]
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt,
+      iterations: 250000,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    {
+      name: "AES-GCM",
+      length: 256,
+    },
+    false,
+    ["encrypt", "decrypt"]
+  );
+}
+
+function encryptWithNodeCrypto(
+  payload: PlainPayload,
+  passphrase: string,
+  saltBytes: Uint8Array,
+  ivBytes: Uint8Array
+): EncryptedPayload {
+  const nodeCrypto = getNodeCrypto();
+  if (!nodeCrypto) {
+    throw new Error("Node.js crypto module is unavailable for encryption fallback");
+  }
+  const { pbkdf2Sync, createCipheriv } = nodeCrypto;
+  const saltBuffer = Buffer.from(saltBytes);
+  const ivBuffer = Buffer.from(ivBytes);
+  const key = pbkdf2Sync(passphrase, saltBuffer, 250000, 32, "sha256");
+  const cipher = createCipheriv("aes-256-gcm", key, ivBuffer);
+  const plaintext = Buffer.from(JSON.stringify(payload), "utf8");
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  const combined = Buffer.concat([encrypted, tag]);
+  return {
+    version: PAYLOAD_VERSION,
+    cipher: combined.toString("base64"),
+    iv: ivBuffer.toString("base64"),
+    salt: saltBuffer.toString("base64"),
+    createdAt: payload.createdAt,
+  };
+}
+
+function decryptWithNodeCrypto(record: EncryptedPayload, passphrase: string): ParsedVpnProfile {
+  const nodeCrypto = getNodeCrypto();
+  if (!nodeCrypto) {
+    throw new Error("Node.js crypto module is unavailable for decryption fallback");
+  }
+  const { pbkdf2Sync, createDecipheriv } = nodeCrypto;
+  const saltBuffer = Buffer.from(record.salt, "base64");
+  const ivBuffer = Buffer.from(record.iv, "base64");
+  const fullCipher = Buffer.from(record.cipher, "base64");
+  if (fullCipher.length < 17) {
+    throw new Error("Encrypted payload is malformed");
+  }
+  const ciphertext = fullCipher.slice(0, fullCipher.length - 16);
+  const authTag = fullCipher.slice(fullCipher.length - 16);
+  const key = pbkdf2Sync(passphrase, saltBuffer, 250000, 32, "sha256");
+  const decipher = createDecipheriv("aes-256-gcm", key, ivBuffer);
+  decipher.setAuthTag(authTag);
+  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  const payload = JSON.parse(decrypted.toString("utf8")) as PlainPayload;
+  if (payload.version !== PAYLOAD_VERSION) {
+    throw new Error("Unsupported payload version");
+  }
+  return payload.profile;
+}
+
+async function encryptProfile(profile: ParsedVpnProfile, passphrase: string): Promise<EncryptedPayload> {
+  const crypto = getCrypto();
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const payload: PlainPayload = {
+    version: PAYLOAD_VERSION,
+    profile,
+    createdAt: new Date().toISOString(),
+  };
+  const data = encoder.encode(JSON.stringify(payload));
+  try {
+    const key = await deriveKey(passphrase, salt);
+    const cipherBuffer = await crypto.subtle.encrypt(
+      {
+        name: "AES-GCM",
+        iv,
+      },
+      key,
+      data
+    );
+    return {
+      version: PAYLOAD_VERSION,
+      cipher: bufferToBase64(cipherBuffer),
+      iv: bufferToBase64(iv.buffer),
+      salt: bufferToBase64(salt.buffer),
+      createdAt: payload.createdAt,
+    };
+  } catch (error) {
+    if (typeof window !== "undefined") {
+      throw error;
+    }
+    return encryptWithNodeCrypto(payload, passphrase, salt, iv);
+  }
+}
+
+async function decryptProfile(record: EncryptedPayload, passphrase: string): Promise<ParsedVpnProfile> {
+  const crypto = getCrypto();
+  const salt = new Uint8Array(base64ToBuffer(record.salt));
+  const iv = new Uint8Array(base64ToBuffer(record.iv));
+  try {
+    const key = await deriveKey(passphrase, salt);
+    const decrypted = await crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv,
+      },
+      key,
+      base64ToBuffer(record.cipher)
+    );
+    const payload = JSON.parse(decoder.decode(decrypted)) as PlainPayload;
+    if (payload.version !== PAYLOAD_VERSION) {
+      throw new Error("Unsupported payload version");
+    }
+    return payload.profile;
+  } catch (error) {
+    if (typeof window !== "undefined") {
+      throw error;
+    }
+    return decryptWithNodeCrypto(record, passphrase);
+  }
+}
+
+function hasSecrets(profile: ParsedVpnProfile): boolean {
+  const secrets = profile.nmConnection.secrets;
+  return !!secrets && Object.values(secrets).some((value) => value && value !== "ask");
+}
+
+export function profileNeedsPassphrase(profile: ParsedVpnProfile): boolean {
+  return hasSecrets(profile);
+}
+
+function profileKey(id: string) {
+  return `${PROFILE_KEY_PREFIX}:${id}`;
+}
+
+function secretKey(id: string) {
+  return `${ENCRYPTED_KEY_PREFIX}:${id}`;
+}
+
+export async function listVpnProfiles(): Promise<StoredVpnProfileMetadata[]> {
+  return getIndex();
+}
+
+export async function persistVpnProfile(profile: ParsedVpnProfile, passphrase?: string) {
+  const metadata: StoredVpnProfileMetadata = {
+    id: profile.id,
+    name: profile.name,
+    type: profile.type,
+    createdAt: new Date().toISOString(),
+    warnings: profile.warnings,
+    hasSecrets: hasSecrets(profile),
+  };
+  const index = getIndex().filter((entry) => entry.id !== profile.id);
+  index.push(metadata);
+  setIndex(index);
+
+  if (metadata.hasSecrets) {
+    if (!passphrase) {
+      throw new Error("A passphrase is required to store credentials for this profile");
+    }
+    const encrypted = await encryptProfile(profile, passphrase);
+    await set(secretKey(profile.id), encrypted);
+    await del(profileKey(profile.id));
+  } else {
+    const payload: PlainPayload = {
+      version: PAYLOAD_VERSION,
+      profile,
+      createdAt: metadata.createdAt,
+    };
+    await set(profileKey(profile.id), payload);
+    await del(secretKey(profile.id));
+  }
+}
+
+export async function loadVpnProfile(id: string, passphrase?: string): Promise<ParsedVpnProfile | null> {
+  const index = getIndex();
+  const entry = index.find((item) => item.id === id);
+  if (!entry) return null;
+  if (entry.hasSecrets) {
+    if (!passphrase) {
+      throw new Error("Passphrase required to decrypt VPN profile");
+    }
+    const record = (await get(secretKey(id))) as EncryptedPayload | undefined;
+    if (!record) return null;
+    return decryptProfile(record, passphrase);
+  }
+  const payload = (await get(profileKey(id))) as PlainPayload | undefined;
+  return payload?.profile ?? null;
+}
+
+export async function removeVpnProfile(id: string) {
+  const index = getIndex().filter((entry) => entry.id !== id);
+  setIndex(index);
+  await Promise.all([del(profileKey(id)), del(secretKey(id))]);
+}

--- a/utils/vpn/types.ts
+++ b/utils/vpn/types.ts
@@ -1,0 +1,75 @@
+export type VpnProfileType = "wireguard" | "openvpn";
+
+export interface NetworkManagerConnection {
+  connection: {
+    id: string;
+    type: "wireguard" | "vpn";
+    autoconnect: boolean;
+    uuid?: string;
+  };
+  vpn?: {
+    service_type: "org.freedesktop.NetworkManager.openvpn";
+    data: Record<string, string>;
+  };
+  wireguard?: {
+    private_key: string;
+    listen_port?: number;
+    fwmark?: number;
+    peer_routes?: boolean;
+    mtu?: number;
+  };
+  wireguard_peer?: Array<{
+    public_key: string;
+    endpoint?: string;
+    allowed_ips?: string[];
+    preshared_key?: string;
+    persistent_keepalive?: number;
+  }>;
+  ipv4?: {
+    method: "auto" | "manual" | "disabled";
+    address_data?: Array<{ address: string; prefix?: number }>;
+    dns?: string[];
+  };
+  ipv6?: {
+    method: "auto" | "manual" | "disabled";
+    address_data?: Array<{ address: string; prefix?: number }>;
+    dns?: string[];
+  };
+  secrets?: Record<string, string>;
+}
+
+export interface ParsedVpnProfile {
+  id: string;
+  name: string;
+  type: VpnProfileType;
+  nmConnection: NetworkManagerConnection;
+  rawConfig: string;
+  warnings: string[];
+}
+
+export interface WireGuardFormValues {
+  name: string;
+  address: string;
+  privateKey: string;
+  dns?: string;
+  listenPort?: string;
+  peerPublicKey: string;
+  peerEndpoint?: string;
+  peerAllowedIps: string;
+  peerPresharedKey?: string;
+  persistentKeepalive?: string;
+}
+
+export interface OpenVpnFormValues {
+  name: string;
+  remote: string;
+  port?: string;
+  proto?: string;
+  username?: string;
+  password?: string;
+  ca?: string;
+  cert?: string;
+  key?: string;
+  tlsAuth?: string;
+  extraConfig?: string;
+}


### PR DESCRIPTION
## Summary
- add a Network tab to settings with a VPN profile wizard that supports WireGuard, OpenVPN, and QR imports
- implement reusable VPN parsing, QR decoding, and encrypted credential storage utilities
- cover the new parsing and storage flows with targeted Jest tests

## Testing
- `npx jest __tests__/vpnParsers.test.ts --runInBand --testPathPatterns=__tests__/vpnParsers.test.ts`
- `yarn lint` *(fails: repository already has pre-existing accessibility lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f1f3664c8328b9d5e277c916da5b