### PR TITLE
[menu] refresh kali menu hierarchy

### DIFF
--- a/__tests__/menuCategoryMap.test.ts
+++ b/__tests__/menuCategoryMap.test.ts
@@ -1,0 +1,54 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import categoryMap from '../applications/menu/category-map.json';
+import synonyms from '../applications/menu/synonyms.json';
+
+describe('menu category mapping', () => {
+  it('captures every desktop entry with keyword support', () => {
+    const desktopDir = join(process.cwd(), 'applications', 'menu', 'desktop-files');
+    const desktopCount = readdirSync(desktopDir).filter((file) => file.endsWith('.desktop')).length;
+
+    expect(categoryMap.desktopFiles).toBe(desktopCount);
+    expect(categoryMap.apps).toHaveLength(desktopCount);
+    expect(categoryMap.missingCategories).toHaveLength(0);
+
+    const keywordCoverage: Array<{ id: string; missing: string[] }> = [];
+    for (const app of categoryMap.apps) {
+      expect(app.keywords.length).toBeGreaterThan(0);
+      const expected = (synonyms as Record<string, string[]>)[app.id] || [];
+      const lowerKeywords = app.keywords.map((kw: string) => kw.toLowerCase());
+      const missing = expected.filter((token) => {
+        const value = token.toLowerCase();
+        return !lowerKeywords.some((kw) => kw.includes(value) || value.includes(kw));
+      });
+      if (missing.length > 0) {
+        keywordCoverage.push({ id: app.id, missing });
+      }
+    }
+
+    expect(keywordCoverage).toHaveLength(0);
+  });
+
+  it('provides summaries for each top-level category', () => {
+    const categoryIds = categoryMap.categories.map((category: { id: string }) => category.id);
+    const expectedTopLevel = [
+      'kali-usual-applications',
+      'kali-reconnaissance',
+      'kali-initial-access',
+      'kali-execution',
+      'kali-privilege-escalation',
+      'kali-credential-access',
+      'kali-discovery',
+      'kali-collection',
+      'kali-command-and-control',
+      'kali-exfiltration',
+      'kali-forensics',
+    ];
+
+    expectedTopLevel.forEach((id) => {
+      expect(categoryIds).toContain(id);
+    });
+  });
+});
+

--- a/applications/menu/alacarte/applications.menu
+++ b/applications/menu/alacarte/applications.menu
@@ -1,0 +1,257 @@
+<?xml version="1.0"?>
+<!DOCTYPE Menu PUBLIC "-//freedesktop//DTD Menu 1.0//EN" "http://www.freedesktop.org/standards/menu-spec/1.0/menu.dtd">
+<Menu>
+  <Name>Applications</Name>
+  <Comment>User custom menu aligning with Kali portfolio hierarchy</Comment>
+  <Layout>
+    <Menuname>Usual Applications</Menuname>
+    <Menuname>Reconnaissance</Menuname>
+    <Menuname>Initial Access</Menuname>
+    <Menuname>Execution</Menuname>
+    <Menuname>Privilege Escalation</Menuname>
+    <Menuname>Credential Access</Menuname>
+    <Menuname>Discovery</Menuname>
+    <Menuname>Collection</Menuname>
+    <Menuname>Command and Control</Menuname>
+    <Menuname>Exfiltration</Menuname>
+    <Menuname>Forensics</Menuname>
+    <Merge type="all"/>
+  </Layout>
+
+  <Menu>
+    <Name>Usual Applications</Name>
+    <Directory>kali-usual-applications.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-usual-applications</Category>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Reconnaissance</Name>
+    <Directory>kali-reconnaissance.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-reconnaissance</Category>
+      </And>
+    </Include>
+    <Menu>
+      <Name>Identity Information</Name>
+      <Directory>kali-identity-information.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-identity-information</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Network Information</Name>
+      <Directory>kali-network-information.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-network-information</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Web Scanning</Name>
+      <Directory>kali-web-scanning.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-web-scanning</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Web Vulnerability Scanning</Name>
+      <Directory>kali-web-vulnerability-scanning.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-web-vulnerability-scanning</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>WiFi</Name>
+      <Directory>kali-wifi-credential-access.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-wifi-credential-access</Category>
+        </And>
+      </Include>
+    </Menu>
+  </Menu>
+
+  <Menu>
+    <Name>Initial Access</Name>
+    <Directory>kali-initial-access.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-initial-access</Category>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Execution</Name>
+    <Directory>kali-execution.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-execution</Category>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Privilege Escalation</Name>
+    <Directory>kali-privilege-escalation.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-privilege-escalation</Category>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Credential Access</Name>
+    <Directory>kali-credential-access.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-credential-access</Category>
+      </And>
+    </Include>
+    <Menu>
+      <Name>OS Credential Dumping</Name>
+      <Directory>kali-os-credential-dumping.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-os-credential-dumping</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Brute Force</Name>
+      <Directory>kali-brute-force.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-brute-force</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Password Cracking</Name>
+      <Directory>kali-password-cracking.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-password-cracking</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Pass-the-Hash</Name>
+      <Directory>kali-pass-the-hash.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-pass-the-hash</Category>
+        </And>
+      </Include>
+    </Menu>
+  </Menu>
+
+  <Menu>
+    <Name>Discovery</Name>
+    <Directory>kali-discovery.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-discovery</Category>
+      </And>
+    </Include>
+    <Menu>
+      <Name>Network Service Discovery</Name>
+      <Directory>kali-network-service-discovery.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-network-service-discovery</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Network Sniffing</Name>
+      <Directory>kali-network-sniffing.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-network-sniffing</Category>
+        </And>
+      </Include>
+    </Menu>
+  </Menu>
+
+  <Menu>
+    <Name>Collection</Name>
+    <Directory>kali-collection.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-collection</Category>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Command and Control</Name>
+    <Directory>kali-command-and-control.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-command-and-control</Category>
+      </And>
+    </Include>
+    <Menu>
+      <Name>Non-Application Layer Protocol</Name>
+      <Directory>kali-non-application-layer-protocol.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-non-application-layer-protocol</Category>
+        </And>
+      </Include>
+    </Menu>
+  </Menu>
+
+  <Menu>
+    <Name>Exfiltration</Name>
+    <Directory>kali-exfiltration.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-exfiltration</Category>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Forensics</Name>
+    <Directory>kali-forensics.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-forensics</Category>
+      </And>
+    </Include>
+    <Menu>
+      <Name>Digital Forensics</Name>
+      <Directory>kali-digital-forensics.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-digital-forensics</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Sleuth Kit Suite</Name>
+      <Directory>kali-sleuth-kit-suite.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-sleuth-kit-suite</Category>
+        </And>
+      </Include>
+    </Menu>
+  </Menu>
+</Menu>
+

--- a/applications/menu/category-map.json
+++ b/applications/menu/category-map.json
@@ -1,0 +1,688 @@
+{
+  "generatedAt": "2025-09-29T03:01:27.484Z",
+  "desktopFiles": 16,
+  "hierarchyVersion": "2024.3",
+  "reference": "https://www.kali.org/docs/general-use/menu/",
+  "apps": [
+    {
+      "id": "kali-autopsy",
+      "file": "kali-autopsy.desktop",
+      "name": "Autopsy (Simulated)",
+      "genericName": "Digital Forensics Suite",
+      "comment": "Simulated Autopsy case explorer with walk-through datasets",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/autopsy",
+      "icon": "kali-autopsy",
+      "portfolioApp": "autopsy",
+      "package": "autopsy",
+      "keywords": [
+        "forensics",
+        "autopsy",
+        "sleuth kit",
+        "case manager"
+      ],
+      "categories": [
+        {
+          "id": "kali-collection",
+          "name": "11 - Collection",
+          "children": []
+        },
+        {
+          "id": "kali-forensics",
+          "name": "15 - Forensics",
+          "children": [
+            {
+              "id": "kali-digital-forensics",
+              "name": "• Digital Forensics"
+            },
+            {
+              "id": "kali-sleuth-kit-suite",
+              "name": "• Sleuth Kit Suite"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "kali-evidence-vault",
+      "file": "kali-evidence-vault.desktop",
+      "name": "Evidence Vault (Simulated)",
+      "genericName": "Case Evidence Organizer",
+      "comment": "Guided evidence tagging and chain of custody simulator",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/evidence-vault",
+      "icon": "folder-documents",
+      "portfolioApp": "evidence-vault",
+      "package": null,
+      "keywords": [
+        "evidence",
+        "chain of custody",
+        "case management",
+        "vault"
+      ],
+      "categories": [
+        {
+          "id": "kali-collection",
+          "name": "11 - Collection",
+          "children": []
+        },
+        {
+          "id": "kali-forensics",
+          "name": "15 - Forensics",
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "kali-files",
+      "file": "kali-files.desktop",
+      "name": "Files (Simulated)",
+      "genericName": "File Manager",
+      "comment": "Opens the Kali portfolio file explorer simulation",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/file-explorer",
+      "icon": "system-file-manager",
+      "portfolioApp": "file-explorer",
+      "package": null,
+      "keywords": [
+        "files",
+        "file manager",
+        "browser",
+        "explorer"
+      ],
+      "categories": [
+        {
+          "id": "kali-usual-applications",
+          "name": "Usual Applications",
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "kali-hydra",
+      "file": "kali-hydra.desktop",
+      "name": "Hydra (Simulated)",
+      "genericName": "Network Login Cracker",
+      "comment": "Guided Hydra credential testing lab with safe targets",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/hydra",
+      "icon": "kali-hydra",
+      "portfolioApp": "hydra",
+      "package": "hydra",
+      "keywords": [
+        "password spray",
+        "hydra",
+        "brute force",
+        "login cracker"
+      ],
+      "categories": [
+        {
+          "id": "kali-credential-access",
+          "name": "08 - Credential Access",
+          "children": [
+            {
+              "id": "kali-brute-force",
+              "name": "• Brute Force"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "kali-john",
+      "file": "kali-john.desktop",
+      "name": "John the Ripper (Simulated)",
+      "genericName": "Password Cracker",
+      "comment": "Portfolio walk-through of John the Ripper cracking workflows",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/john",
+      "icon": "kali-john",
+      "portfolioApp": "john",
+      "package": "john",
+      "keywords": [
+        "password cracker",
+        "john the ripper",
+        "hash cracking",
+        "wordlist"
+      ],
+      "categories": [
+        {
+          "id": "kali-credential-access",
+          "name": "08 - Credential Access",
+          "children": [
+            {
+              "id": "kali-password-cracking",
+              "name": "• Password Cracking"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "kali-metasploit-framework",
+      "file": "kali-metasploit-framework.desktop",
+      "name": "Metasploit Framework (Simulated)",
+      "genericName": "Exploit Development Platform",
+      "comment": "Metasploit simulation with safe modules and reporting",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/metasploit",
+      "icon": "kali-metasploit-framework",
+      "portfolioApp": "metasploit",
+      "package": "metasploit-framework",
+      "keywords": [
+        "metasploit",
+        "msfconsole",
+        "exploit dev",
+        "payloads"
+      ],
+      "categories": [
+        {
+          "id": "kali-initial-access",
+          "name": "03 - Initial Access",
+          "children": []
+        },
+        {
+          "id": "kali-execution",
+          "name": "04 - Execution",
+          "children": []
+        },
+        {
+          "id": "kali-privilege-escalation",
+          "name": "06 - Privilege Escalation",
+          "children": []
+        },
+        {
+          "id": "kali-command-and-control",
+          "name": "12 - Command and Control",
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "kali-mimikatz",
+      "file": "kali-mimikatz.desktop",
+      "name": "Mimikatz (Simulated)",
+      "genericName": "Credential Access Toolkit",
+      "comment": "Portfolio demonstration of Mimikatz credential dumping techniques",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/mimikatz",
+      "icon": "kali-mimikatz",
+      "portfolioApp": "mimikatz",
+      "package": "mimikatz",
+      "keywords": [
+        "credential dumping",
+        "mimikatz",
+        "pass the hash",
+        "windows"
+      ],
+      "categories": [
+        {
+          "id": "kali-credential-access",
+          "name": "08 - Credential Access",
+          "children": [
+            {
+              "id": "kali-os-credential-dumping",
+              "name": "• OS Credential Dumping"
+            },
+            {
+              "id": "kali-pass-the-hash",
+              "name": "• Pass-the-Hash"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "kali-netcat",
+      "file": "kali-netcat.desktop",
+      "name": "Netcat (Simulated)",
+      "genericName": "Network Swiss Army Knife",
+      "comment": "Simulated netcat sessions highlighting command and control patterns",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/netcat",
+      "icon": "kali-netcat",
+      "portfolioApp": "netcat",
+      "package": "netcat-traditional",
+      "keywords": [
+        "netcat",
+        "nc",
+        "reverse shell",
+        "tunneling"
+      ],
+      "categories": [
+        {
+          "id": "kali-command-and-control",
+          "name": "12 - Command and Control",
+          "children": [
+            {
+              "id": "kali-non-application-layer-protocol",
+              "name": "• Non-Application Layer Protocol"
+            }
+          ]
+        },
+        {
+          "id": "kali-exfiltration",
+          "name": "13 - Exfiltration",
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "kali-nikto",
+      "file": "kali-nikto.desktop",
+      "name": "Nikto (Simulated)",
+      "genericName": "Web Vulnerability Scanner",
+      "comment": "Simulated Nikto HTTP scanner with curated findings",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/nikto",
+      "icon": "kali-nikto",
+      "portfolioApp": "nikto",
+      "package": "nikto",
+      "keywords": [
+        "web scanner",
+        "nikto",
+        "http audit",
+        "owasp"
+      ],
+      "categories": [
+        {
+          "id": "kali-reconnaissance",
+          "name": "01 - Reconnaissance",
+          "children": [
+            {
+              "id": "kali-web-vulnerability-scanning",
+              "name": "• Web Vulnerability Scanning"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "kali-nmap",
+      "file": "kali-nmap.desktop",
+      "name": "Nmap (Simulated)",
+      "genericName": "Network Scanner",
+      "comment": "Portfolio simulator for the Nmap network mapper",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/nmap-nse",
+      "icon": "kali-nmap",
+      "portfolioApp": "nmap-nse",
+      "package": "nmap",
+      "keywords": [
+        "port scan",
+        "network mapper",
+        "nmap",
+        "nse",
+        "inventory"
+      ],
+      "categories": [
+        {
+          "id": "kali-reconnaissance",
+          "name": "01 - Reconnaissance",
+          "children": [
+            {
+              "id": "kali-network-information",
+              "name": "• Network Information"
+            }
+          ]
+        },
+        {
+          "id": "kali-discovery",
+          "name": "09 - Discovery",
+          "children": [
+            {
+              "id": "kali-network-service-discovery",
+              "name": "• Network Service Discovery"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "kali-reaver",
+      "file": "kali-reaver.desktop",
+      "name": "Reaver (Simulated)",
+      "genericName": "WPS Credential Tester",
+      "comment": "Simulation of a Reaver WPS audit with defensive tips",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/reaver",
+      "icon": "kali-reaver",
+      "portfolioApp": "reaver",
+      "package": "reaver",
+      "keywords": [
+        "wps",
+        "wifi",
+        "reaver",
+        "wireless cracking"
+      ],
+      "categories": [
+        {
+          "id": "kali-reconnaissance",
+          "name": "01 - Reconnaissance",
+          "children": [
+            {
+              "id": "kali-wifi-credential-access",
+              "name": "• WiFi"
+            }
+          ]
+        },
+        {
+          "id": "kali-credential-access",
+          "name": "08 - Credential Access",
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "kali-recon-ng",
+      "file": "kali-recon-ng.desktop",
+      "name": "Recon-ng (Simulated)",
+      "genericName": "Web Recon Framework",
+      "comment": "Simulated Recon-ng workspace builder with preloaded modules",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/reconng",
+      "icon": "kali-recon-ng",
+      "portfolioApp": "reconng",
+      "package": "recon-ng",
+      "keywords": [
+        "osint",
+        "web recon",
+        "recon-ng",
+        "modules"
+      ],
+      "categories": [
+        {
+          "id": "kali-reconnaissance",
+          "name": "01 - Reconnaissance",
+          "children": [
+            {
+              "id": "kali-web-scanning",
+              "name": "• Web Scanning"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "kali-terminal",
+      "file": "kali-terminal.desktop",
+      "name": "Terminal (Simulated)",
+      "genericName": "Command Shell",
+      "comment": "Launches the Kali portfolio terminal simulator",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/terminal",
+      "icon": "utilities-terminal",
+      "portfolioApp": "terminal",
+      "package": null,
+      "keywords": [
+        "terminal",
+        "shell",
+        "console",
+        "command line"
+      ],
+      "categories": [
+        {
+          "id": "kali-usual-applications",
+          "name": "Usual Applications",
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "kali-theharvester",
+      "file": "kali-theharvester.desktop",
+      "name": "theHarvester (Simulated)",
+      "genericName": "OSINT Enumerator",
+      "comment": "Simulated theHarvester OSINT runs with exportable reports",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/theharvester",
+      "icon": "kali-theharvester",
+      "portfolioApp": "theharvester",
+      "package": "theharvester",
+      "keywords": [
+        "osint",
+        "email harvest",
+        "theharvester",
+        "enumeration"
+      ],
+      "categories": [
+        {
+          "id": "kali-reconnaissance",
+          "name": "01 - Reconnaissance",
+          "children": [
+            {
+              "id": "kali-identity-information",
+              "name": "• Identity Information"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "kali-volatility",
+      "file": "kali-volatility.desktop",
+      "name": "Volatility (Simulated)",
+      "genericName": "Memory Forensics Toolkit",
+      "comment": "Portfolio labs covering Volatility memory analysis pipelines",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/volatility",
+      "icon": "kali-volatility",
+      "portfolioApp": "volatility",
+      "package": "volatility3",
+      "keywords": [
+        "memory forensics",
+        "volatility",
+        "ram dump",
+        "analysis"
+      ],
+      "categories": [
+        {
+          "id": "kali-collection",
+          "name": "11 - Collection",
+          "children": []
+        },
+        {
+          "id": "kali-forensics",
+          "name": "15 - Forensics",
+          "children": [
+            {
+              "id": "kali-digital-forensics",
+              "name": "• Digital Forensics"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "kali-wireshark",
+      "file": "kali-wireshark.desktop",
+      "name": "Wireshark (Simulated)",
+      "genericName": "Network Protocol Analyzer",
+      "comment": "Packet capture simulations showcasing Wireshark workflows",
+      "exec": "/usr/bin/env xdg-open https://unnippillil.com/apps/wireshark",
+      "icon": "org.wireshark.Wireshark",
+      "portfolioApp": "wireshark",
+      "package": "wireshark",
+      "keywords": [
+        "packet capture",
+        "wireshark",
+        "sniffer",
+        "pcap"
+      ],
+      "categories": [
+        {
+          "id": "kali-discovery",
+          "name": "09 - Discovery",
+          "children": [
+            {
+              "id": "kali-network-sniffing",
+              "name": "• Network Sniffing"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "categories": [
+    {
+      "id": "kali-usual-applications",
+      "name": "Usual Applications",
+      "appCount": 2,
+      "apps": [
+        "kali-files",
+        "kali-terminal"
+      ],
+      "children": []
+    },
+    {
+      "id": "kali-reconnaissance",
+      "name": "01 - Reconnaissance",
+      "appCount": 5,
+      "apps": [
+        "kali-nikto",
+        "kali-nmap",
+        "kali-reaver",
+        "kali-recon-ng",
+        "kali-theharvester"
+      ],
+      "children": [
+        {
+          "id": "kali-identity-information",
+          "name": "• Identity Information"
+        },
+        {
+          "id": "kali-network-information",
+          "name": "• Network Information"
+        },
+        {
+          "id": "kali-web-scanning",
+          "name": "• Web Scanning"
+        },
+        {
+          "id": "kali-web-vulnerability-scanning",
+          "name": "• Web Vulnerability Scanning"
+        },
+        {
+          "id": "kali-wifi-credential-access",
+          "name": "• WiFi"
+        }
+      ]
+    },
+    {
+      "id": "kali-initial-access",
+      "name": "03 - Initial Access",
+      "appCount": 1,
+      "apps": [
+        "kali-metasploit-framework"
+      ],
+      "children": []
+    },
+    {
+      "id": "kali-execution",
+      "name": "04 - Execution",
+      "appCount": 1,
+      "apps": [
+        "kali-metasploit-framework"
+      ],
+      "children": []
+    },
+    {
+      "id": "kali-privilege-escalation",
+      "name": "06 - Privilege Escalation",
+      "appCount": 1,
+      "apps": [
+        "kali-metasploit-framework"
+      ],
+      "children": []
+    },
+    {
+      "id": "kali-credential-access",
+      "name": "08 - Credential Access",
+      "appCount": 4,
+      "apps": [
+        "kali-hydra",
+        "kali-john",
+        "kali-mimikatz",
+        "kali-reaver"
+      ],
+      "children": [
+        {
+          "id": "kali-os-credential-dumping",
+          "name": "• OS Credential Dumping"
+        },
+        {
+          "id": "kali-brute-force",
+          "name": "• Brute Force"
+        },
+        {
+          "id": "kali-password-cracking",
+          "name": "• Password Cracking"
+        },
+        {
+          "id": "kali-pass-the-hash",
+          "name": "• Pass-the-Hash"
+        }
+      ]
+    },
+    {
+      "id": "kali-discovery",
+      "name": "09 - Discovery",
+      "appCount": 2,
+      "apps": [
+        "kali-nmap",
+        "kali-wireshark"
+      ],
+      "children": [
+        {
+          "id": "kali-network-service-discovery",
+          "name": "• Network Service Discovery"
+        },
+        {
+          "id": "kali-network-sniffing",
+          "name": "• Network Sniffing"
+        }
+      ]
+    },
+    {
+      "id": "kali-collection",
+      "name": "11 - Collection",
+      "appCount": 3,
+      "apps": [
+        "kali-autopsy",
+        "kali-evidence-vault",
+        "kali-volatility"
+      ],
+      "children": []
+    },
+    {
+      "id": "kali-command-and-control",
+      "name": "12 - Command and Control",
+      "appCount": 2,
+      "apps": [
+        "kali-metasploit-framework",
+        "kali-netcat"
+      ],
+      "children": [
+        {
+          "id": "kali-non-application-layer-protocol",
+          "name": "• Non-Application Layer Protocol"
+        }
+      ]
+    },
+    {
+      "id": "kali-exfiltration",
+      "name": "13 - Exfiltration",
+      "appCount": 1,
+      "apps": [
+        "kali-netcat"
+      ],
+      "children": []
+    },
+    {
+      "id": "kali-forensics",
+      "name": "15 - Forensics",
+      "appCount": 3,
+      "apps": [
+        "kali-autopsy",
+        "kali-evidence-vault",
+        "kali-volatility"
+      ],
+      "children": [
+        {
+          "id": "kali-digital-forensics",
+          "name": "• Digital Forensics"
+        },
+        {
+          "id": "kali-sleuth-kit-suite",
+          "name": "• Sleuth Kit Suite"
+        }
+      ]
+    }
+  ],
+  "missingCategories": []
+}

--- a/applications/menu/desktop-directories/kali-brute-force.directory
+++ b/applications/menu/desktop-directories/kali-brute-force.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• Brute Force
+Name[es]=• Fuerza Bruta
+Name[fr]=• Attaque par force brute
+Name[de]=• Brute-Force-Angriff
+Name[pt]=• Força Bruta
+Name[zh_CN]=• 暴力破解
+Type=Directory
+Icon=kali-brute-force

--- a/applications/menu/desktop-directories/kali-collection.directory
+++ b/applications/menu/desktop-directories/kali-collection.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=11 - Collection
+Name[es]=11 - Recopilación
+Name[fr]=11 - Collecte
+Name[de]=11 - Sammlung
+Name[pt]=11 - Coleta
+Name[zh_CN]=11 - 收集
+Type=Directory
+Icon=kali-collection

--- a/applications/menu/desktop-directories/kali-command-and-control.directory
+++ b/applications/menu/desktop-directories/kali-command-and-control.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=12 - Command and Control
+Name[es]=12 - Comando y Control
+Name[fr]=12 - Commandement et Contrôle
+Name[de]=12 - Befehl und Kontrolle
+Name[pt]=12 - Comando e Controle
+Name[zh_CN]=12 - 指挥控制
+Type=Directory
+Icon=kali-command-and-control

--- a/applications/menu/desktop-directories/kali-credential-access.directory
+++ b/applications/menu/desktop-directories/kali-credential-access.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=08 - Credential Access
+Name[es]=08 - Acceso a Credenciales
+Name[fr]=08 - Accès aux Identifiants
+Name[de]=08 - Zugriff auf Zugangsdaten
+Name[pt]=08 - Acesso a Credenciais
+Name[zh_CN]=08 - 凭证访问
+Type=Directory
+Icon=kali-credential-access

--- a/applications/menu/desktop-directories/kali-digital-forensics.directory
+++ b/applications/menu/desktop-directories/kali-digital-forensics.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• Digital Forensics
+Name[es]=• Análisis forense digital
+Name[fr]=• Criminalistique Numérique
+Name[de]=• Digitale Forensik
+Name[pt]=• Análise forense digital
+Name[zh_CN]=• 数字取证
+Type=Directory
+Icon=kali-digital-forensics

--- a/applications/menu/desktop-directories/kali-discovery.directory
+++ b/applications/menu/desktop-directories/kali-discovery.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=09 - Discovery
+Name[es]=09 - Descubrimiento
+Name[fr]=09 - Découverte
+Name[de]=09 - Entdeckung
+Name[pt]=09 - Descoberta
+Name[zh_CN]=09 - 发现
+Type=Directory
+Icon=kali-discovery

--- a/applications/menu/desktop-directories/kali-execution.directory
+++ b/applications/menu/desktop-directories/kali-execution.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=04 - Execution
+Name[es]=04 - Ejecución
+Name[fr]=04 - Exécution
+Name[de]=04 - Ausführung
+Name[pt]=04 - Execução
+Name[zh_CN]=04 - 执行
+Type=Directory
+Icon=kali-execution

--- a/applications/menu/desktop-directories/kali-exfiltration.directory
+++ b/applications/menu/desktop-directories/kali-exfiltration.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=13 - Exfiltration
+Name[es]=13 - Exfiltración
+Name[fr]=13 - Exfiltration
+Name[de]=13 - Exfiltration
+Name[pt]=13 - Exfiltração
+Name[zh_CN]=13 - 渗漏
+Type=Directory
+Icon=kali-exfiltration

--- a/applications/menu/desktop-directories/kali-forensics.directory
+++ b/applications/menu/desktop-directories/kali-forensics.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=15 - Forensics
+Name[es]=15 - Análisis forense
+Name[fr]=15 - Criminalistique
+Name[de]=15 - Forensik
+Name[pt]=15 - Análise forense
+Name[zh_CN]=15 - 数字取证
+Type=Directory
+Icon=kali-forensics

--- a/applications/menu/desktop-directories/kali-identity-information.directory
+++ b/applications/menu/desktop-directories/kali-identity-information.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• Identity Information
+Name[es]=• Información de Identidad
+Name[fr]=• Informations d'identité
+Name[de]=• Identitätsinformationen
+Name[pt]=• Informações de Identidade
+Name[zh_CN]=• 身份信息
+Type=Directory
+Icon=kali-identity-information

--- a/applications/menu/desktop-directories/kali-initial-access.directory
+++ b/applications/menu/desktop-directories/kali-initial-access.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=03 - Initial Access
+Name[es]=03 - Acceso Inicial
+Name[fr]=03 - Accès Initial
+Name[de]=03 - Erster Zugriff
+Name[pt]=03 - Acesso Inicial
+Name[zh_CN]=03 - 初始访问
+Type=Directory
+Icon=kali-initial-access

--- a/applications/menu/desktop-directories/kali-menu.directory
+++ b/applications/menu/desktop-directories/kali-menu.directory
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Kali Linux Tools
+Name[es]=Herramientas de Kali Linux
+Name[fr]=Outils Kali Linux
+Name[de]=Kali-Linux-Werkzeuge
+Name[pt]=Ferramentas do Kali Linux
+Name[zh_CN]=Kali Linux 工具
+Type=Directory
+Icon=kali-menu
+

--- a/applications/menu/desktop-directories/kali-network-information.directory
+++ b/applications/menu/desktop-directories/kali-network-information.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• Network Information
+Name[es]=• Información de Red
+Name[fr]=• Informations sur le réseau
+Name[de]=• Netzwerk-Informationen
+Name[pt]=• Informações de Rede
+Name[zh_CN]=• 网络信息
+Type=Directory
+Icon=kali-network-information

--- a/applications/menu/desktop-directories/kali-network-service-discovery.directory
+++ b/applications/menu/desktop-directories/kali-network-service-discovery.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• Network Service Discovery
+Name[es]=• Descubrimiento de Servicios de Red
+Name[fr]=• Découverte de Services Réseau
+Name[de]=• Netzwerkdienst-Erkennung
+Name[pt]=• Descoberta de Serviços de Rede
+Name[zh_CN]=• 网络服务发现
+Type=Directory
+Icon=kali-network-service-discovery

--- a/applications/menu/desktop-directories/kali-network-sniffing.directory
+++ b/applications/menu/desktop-directories/kali-network-sniffing.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• Network Sniffing
+Name[es]=• Sniffing de Red
+Name[fr]=• Sniffing de Réseau
+Name[de]=• Netzwerk-Sniffing
+Name[pt]=• Sniffing de Rede
+Name[zh_CN]=• 网络嗅探
+Type=Directory
+Icon=kali-network-sniffing

--- a/applications/menu/desktop-directories/kali-non-application-layer-protocol.directory
+++ b/applications/menu/desktop-directories/kali-non-application-layer-protocol.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• Non-Application Layer Protocol
+Name[es]=• Protocolo fuera de Capa de Aplicación
+Name[fr]=• Protocole Non-Couche Application
+Name[de]=• Nicht-Anwendungsschicht-Protokoll
+Name[pt]=• Protocolo fora da camada de aplicação
+Name[zh_CN]=• 非应用层协议
+Type=Directory
+Icon=kali-non-application-layer-protocol

--- a/applications/menu/desktop-directories/kali-os-credential-dumping.directory
+++ b/applications/menu/desktop-directories/kali-os-credential-dumping.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• OS Credential Dumping
+Name[es]=• Extracción de Credenciales del SO
+Name[fr]=• Dumping des identifiants du OS
+Name[de]=• Betriebssystem-Zugangsdatenextraktion
+Name[pt]=• Extração de Credenciais do SO
+Name[zh_CN]=• 操作系统凭据转储
+Type=Directory
+Icon=kali-os-credential-dumping

--- a/applications/menu/desktop-directories/kali-pass-the-hash.directory
+++ b/applications/menu/desktop-directories/kali-pass-the-hash.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• Pass-the-Hash
+Name[es]=• Pass-the-Hash
+Name[fr]=• Pass-the-Hash
+Name[de]=• Pass-the-Hash
+Name[pt]=• Pass-the-Hash
+Name[zh_CN]=• Pass-the-Hash
+Type=Directory
+Icon=kali-pass-the-hash

--- a/applications/menu/desktop-directories/kali-password-cracking.directory
+++ b/applications/menu/desktop-directories/kali-password-cracking.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• Password Cracking
+Name[es]=• Descifrado de Contraseñas
+Name[fr]=• Craquage de Mots de Passe
+Name[de]=• Passwort-Knacken
+Name[pt]=• Quebra de Senhas
+Name[zh_CN]=• 破解密码
+Type=Directory
+Icon=kali-password-cracking

--- a/applications/menu/desktop-directories/kali-privilege-escalation.directory
+++ b/applications/menu/desktop-directories/kali-privilege-escalation.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=06 - Privilege Escalation
+Name[es]=06 - Escalada de Privilegios
+Name[fr]=06 - Escalade de Privilèges
+Name[de]=06 - Privilegien Erweiterung
+Name[pt]=06 - Elevação de Privilégios
+Name[zh_CN]=06 - 权限提升
+Type=Directory
+Icon=kali-privilege-escalation

--- a/applications/menu/desktop-directories/kali-reconnaissance.directory
+++ b/applications/menu/desktop-directories/kali-reconnaissance.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=01 - Reconnaissance
+Name[es]=01 - Reconocimiento
+Name[fr]=01 - Reconnaissance
+Name[de]=01 - Erkennung
+Name[pt]=01 - Reconhecimento
+Name[zh_CN]=01 - 侦察
+Type=Directory
+Icon=kali-reconnaissance

--- a/applications/menu/desktop-directories/kali-sleuth-kit-suite.directory
+++ b/applications/menu/desktop-directories/kali-sleuth-kit-suite.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• Sleuth Kit Suite
+Name[es]=• Kits de forensia
+Name[fr]=• Suites Criminalistique
+Name[de]=• Forensik-Werkzeugsammlungen
+Name[pt]=• Kits forenses
+Name[zh_CN]=• 数字取证套件
+Type=Directory
+Icon=kali-sleuth-kit-suite

--- a/applications/menu/desktop-directories/kali-usual-applications.directory
+++ b/applications/menu/desktop-directories/kali-usual-applications.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Usual Applications
+Name[es]=Aplicationes habituales
+Name[fr]=Applications habituelles
+Name[de]=Übliche Anwendungen
+Name[pt]=Aplicações habituais
+Name[zh_CN]=常用程序
+Type=Directory
+Icon=kali-usual-applications

--- a/applications/menu/desktop-directories/kali-web-scanning.directory
+++ b/applications/menu/desktop-directories/kali-web-scanning.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• Web Scanning
+Name[es]=• Escaneo Web
+Name[fr]=• Analyse Web
+Name[de]=• Web-Scannen
+Name[pt]=• Varredura Web
+Name[zh_CN]=• 网络扫描
+Type=Directory
+Icon=kali-web-scanning

--- a/applications/menu/desktop-directories/kali-web-vulnerability-scanning.directory
+++ b/applications/menu/desktop-directories/kali-web-vulnerability-scanning.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• Web Vulnerability Scanning
+Name[es]=• Escaneo de Vulnerabilidades Web
+Name[fr]=• Analyse de Vulnérabilités Web
+Name[de]=• Web-Schwachstellen-Scannen
+Name[pt]=• Varredura de Vulnerabilidades Web
+Name[zh_CN]=• Web 漏洞扫描
+Type=Directory
+Icon=kali-web-vulnerability-scanning

--- a/applications/menu/desktop-directories/kali-wifi-credential-access.directory
+++ b/applications/menu/desktop-directories/kali-wifi-credential-access.directory
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=• WiFi
+Name[es]=• WiFi
+Name[fr]=• WiFi
+Name[de]=• WiFi
+Name[pt]=• WiFi
+Name[zh_CN]=• WiFi
+Type=Directory
+Icon=kali-wifi-credential-access

--- a/applications/menu/desktop-files/kali-autopsy.desktop
+++ b/applications/menu/desktop-files/kali-autopsy.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Name=Autopsy (Simulated)
+GenericName=Digital Forensics Suite
+Comment=Simulated Autopsy case explorer with walk-through datasets
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/autopsy
+Icon=kali-autopsy
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-sleuth-kit-suite;kali-digital-forensics;kali-forensics;kali-collection;
+Keywords=forensics;autopsy;sleuth kit;case manager;
+X-Kali-Package=autopsy
+X-Kali-Simulation=true
+X-Portfolio-App=autopsy
+
+

--- a/applications/menu/desktop-files/kali-evidence-vault.desktop
+++ b/applications/menu/desktop-files/kali-evidence-vault.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Name=Evidence Vault (Simulated)
+GenericName=Case Evidence Organizer
+Comment=Guided evidence tagging and chain of custody simulator
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/evidence-vault
+Icon=folder-documents
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-collection;kali-forensics;
+Keywords=evidence;chain of custody;case management;vault;
+X-Kali-Simulation=true
+X-Portfolio-App=evidence-vault
+

--- a/applications/menu/desktop-files/kali-files.desktop
+++ b/applications/menu/desktop-files/kali-files.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Name=Files (Simulated)
+GenericName=File Manager
+Comment=Opens the Kali portfolio file explorer simulation
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/file-explorer
+Icon=system-file-manager
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=Utility;FileManager;kali-usual-applications;
+Keywords=files;file manager;browser;explorer;
+X-Kali-Simulation=true
+X-Portfolio-App=file-explorer
+

--- a/applications/menu/desktop-files/kali-hydra.desktop
+++ b/applications/menu/desktop-files/kali-hydra.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=Hydra (Simulated)
+GenericName=Network Login Cracker
+Comment=Guided Hydra credential testing lab with safe targets
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/hydra
+Icon=kali-hydra
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-brute-force;kali-credential-access;
+Keywords=password spray;hydra;brute force;login cracker;
+X-Kali-Package=hydra
+X-Kali-Simulation=true
+X-Portfolio-App=hydra
+

--- a/applications/menu/desktop-files/kali-john.desktop
+++ b/applications/menu/desktop-files/kali-john.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=John the Ripper (Simulated)
+GenericName=Password Cracker
+Comment=Portfolio walk-through of John the Ripper cracking workflows
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/john
+Icon=kali-john
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-password-cracking;kali-credential-access;
+Keywords=password cracker;john the ripper;hash cracking;wordlist;
+X-Kali-Package=john
+X-Kali-Simulation=true
+X-Portfolio-App=john
+

--- a/applications/menu/desktop-files/kali-metasploit-framework.desktop
+++ b/applications/menu/desktop-files/kali-metasploit-framework.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=Metasploit Framework (Simulated)
+GenericName=Exploit Development Platform
+Comment=Metasploit simulation with safe modules and reporting
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/metasploit
+Icon=kali-metasploit-framework
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-initial-access;kali-execution;kali-privilege-escalation;kali-command-and-control;
+Keywords=metasploit;msfconsole;exploit dev;payloads;
+X-Kali-Package=metasploit-framework
+X-Kali-Simulation=true
+X-Portfolio-App=metasploit
+

--- a/applications/menu/desktop-files/kali-mimikatz.desktop
+++ b/applications/menu/desktop-files/kali-mimikatz.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=Mimikatz (Simulated)
+GenericName=Credential Access Toolkit
+Comment=Portfolio demonstration of Mimikatz credential dumping techniques
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/mimikatz
+Icon=kali-mimikatz
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-pass-the-hash;kali-os-credential-dumping;kali-credential-access;
+Keywords=credential dumping;mimikatz;pass the hash;windows;
+X-Kali-Package=mimikatz
+X-Kali-Simulation=true
+X-Portfolio-App=mimikatz
+

--- a/applications/menu/desktop-files/kali-netcat.desktop
+++ b/applications/menu/desktop-files/kali-netcat.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=Netcat (Simulated)
+GenericName=Network Swiss Army Knife
+Comment=Simulated netcat sessions highlighting command and control patterns
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/netcat
+Icon=kali-netcat
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-non-application-layer-protocol;kali-command-and-control;kali-exfiltration;
+Keywords=netcat;nc;reverse shell;tunneling;
+X-Kali-Package=netcat-traditional
+X-Kali-Simulation=true
+X-Portfolio-App=netcat
+

--- a/applications/menu/desktop-files/kali-nikto.desktop
+++ b/applications/menu/desktop-files/kali-nikto.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=Nikto (Simulated)
+GenericName=Web Vulnerability Scanner
+Comment=Simulated Nikto HTTP scanner with curated findings
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/nikto
+Icon=kali-nikto
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-web-vulnerability-scanning;kali-reconnaissance;
+Keywords=web scanner;nikto;http audit;owasp;
+X-Kali-Package=nikto
+X-Kali-Simulation=true
+X-Portfolio-App=nikto
+

--- a/applications/menu/desktop-files/kali-nmap.desktop
+++ b/applications/menu/desktop-files/kali-nmap.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Name=Nmap (Simulated)
+GenericName=Network Scanner
+Comment=Portfolio simulator for the Nmap network mapper
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/nmap-nse
+Icon=kali-nmap
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-network-information;kali-network-service-discovery;kali-reconnaissance;kali-discovery;
+Keywords=port scan;network mapper;nmap;nse;inventory;
+X-Kali-Package=nmap
+X-Kali-Simulation=true
+X-Portfolio-App=nmap-nse
+
+

--- a/applications/menu/desktop-files/kali-reaver.desktop
+++ b/applications/menu/desktop-files/kali-reaver.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=Reaver (Simulated)
+GenericName=WPS Credential Tester
+Comment=Simulation of a Reaver WPS audit with defensive tips
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/reaver
+Icon=kali-reaver
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-wifi-credential-access;kali-credential-access;kali-reconnaissance;
+Keywords=wps;wifi;reaver;wireless cracking;
+X-Kali-Package=reaver
+X-Kali-Simulation=true
+X-Portfolio-App=reaver
+

--- a/applications/menu/desktop-files/kali-recon-ng.desktop
+++ b/applications/menu/desktop-files/kali-recon-ng.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=Recon-ng (Simulated)
+GenericName=Web Recon Framework
+Comment=Simulated Recon-ng workspace builder with preloaded modules
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/reconng
+Icon=kali-recon-ng
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-web-scanning;kali-reconnaissance;
+Keywords=osint;web recon;recon-ng;modules;
+X-Kali-Package=recon-ng
+X-Kali-Simulation=true
+X-Portfolio-App=reconng
+

--- a/applications/menu/desktop-files/kali-terminal.desktop
+++ b/applications/menu/desktop-files/kali-terminal.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Name=Terminal (Simulated)
+GenericName=Command Shell
+Comment=Launches the Kali portfolio terminal simulator
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/terminal
+Icon=utilities-terminal
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=System;Utility;kali-usual-applications;
+Keywords=terminal;shell;console;command line;
+X-Kali-Simulation=true
+X-Portfolio-App=terminal
+

--- a/applications/menu/desktop-files/kali-theharvester.desktop
+++ b/applications/menu/desktop-files/kali-theharvester.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=theHarvester (Simulated)
+GenericName=OSINT Enumerator
+Comment=Simulated theHarvester OSINT runs with exportable reports
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/theharvester
+Icon=kali-theharvester
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-identity-information;kali-reconnaissance;
+Keywords=osint;email harvest;theharvester;enumeration;
+X-Kali-Package=theharvester
+X-Kali-Simulation=true
+X-Portfolio-App=theharvester
+

--- a/applications/menu/desktop-files/kali-volatility.desktop
+++ b/applications/menu/desktop-files/kali-volatility.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Name=Volatility (Simulated)
+GenericName=Memory Forensics Toolkit
+Comment=Portfolio labs covering Volatility memory analysis pipelines
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/volatility
+Icon=kali-volatility
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-digital-forensics;kali-forensics;kali-collection;
+Keywords=memory forensics;volatility;ram dump;analysis;
+X-Kali-Package=volatility3
+X-Kali-Simulation=true
+X-Portfolio-App=volatility
+
+

--- a/applications/menu/desktop-files/kali-wireshark.desktop
+++ b/applications/menu/desktop-files/kali-wireshark.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Name=Wireshark (Simulated)
+GenericName=Network Protocol Analyzer
+Comment=Packet capture simulations showcasing Wireshark workflows
+Exec=/usr/bin/env xdg-open https://unnippillil.com/apps/wireshark
+Icon=org.wireshark.Wireshark
+StartupNotify=false
+Terminal=false
+Type=Application
+Categories=kali-network-sniffing;kali-discovery;
+Keywords=packet capture;wireshark;sniffer;pcap;
+X-Kali-Package=wireshark
+X-Kali-Simulation=true
+X-Portfolio-App=wireshark
+

--- a/applications/menu/hierarchy.json
+++ b/applications/menu/hierarchy.json
@@ -1,0 +1,297 @@
+{
+  "version": "2024.3",
+  "reference": "https://www.kali.org/docs/general-use/menu/",
+  "categories": [
+    {
+      "id": "kali-usual-applications",
+      "name": "Usual Applications",
+      "translations": {
+        "es": "Aplicaciones habituales",
+        "fr": "Applications habituelles",
+        "de": "Übliche Anwendungen",
+        "pt": "Aplicações habituais",
+        "zh_CN": "常用程序"
+      },
+      "children": []
+    },
+    {
+      "id": "kali-reconnaissance",
+      "name": "01 - Reconnaissance",
+      "translations": {
+        "es": "01 - Reconocimiento",
+        "fr": "01 - Reconnaissance",
+        "de": "01 - Erkennung",
+        "pt": "01 - Reconhecimento",
+        "zh_CN": "01 - 侦察"
+      },
+      "children": [
+        {
+          "id": "kali-identity-information",
+          "name": "• Identity Information",
+          "translations": {
+            "es": "• Información de Identidad",
+            "fr": "• Informations d'identité",
+            "de": "• Identitätsinformationen",
+            "pt": "• Informações de Identidade",
+            "zh_CN": "• 身份信息"
+          }
+        },
+        {
+          "id": "kali-network-information",
+          "name": "• Network Information",
+          "translations": {
+            "es": "• Información de Red",
+            "fr": "• Informations sur le réseau",
+            "de": "• Netzwerk-Informationen",
+            "pt": "• Informações de Rede",
+            "zh_CN": "• 网络信息"
+          }
+        },
+        {
+          "id": "kali-web-scanning",
+          "name": "• Web Scanning",
+          "translations": {
+            "es": "• Escaneo Web",
+            "fr": "• Analyse Web",
+            "de": "• Web-Scannen",
+            "pt": "• Varredura Web",
+            "zh_CN": "• 网络扫描"
+          }
+        },
+        {
+          "id": "kali-web-vulnerability-scanning",
+          "name": "• Web Vulnerability Scanning",
+          "translations": {
+            "es": "• Escaneo de Vulnerabilidades Web",
+            "fr": "• Analyse de Vulnérabilités Web",
+            "de": "• Web-Schwachstellen-Scannen",
+            "pt": "• Varredura de Vulnerabilidades Web",
+            "zh_CN": "• Web 漏洞扫描"
+          }
+        },
+        {
+          "id": "kali-wifi-credential-access",
+          "name": "• WiFi",
+          "translations": {
+            "es": "• WiFi",
+            "fr": "• WiFi",
+            "de": "• WiFi",
+            "pt": "• WiFi",
+            "zh_CN": "• WiFi"
+          }
+        }
+      ]
+    },
+    {
+      "id": "kali-initial-access",
+      "name": "03 - Initial Access",
+      "translations": {
+        "es": "03 - Acceso Inicial",
+        "fr": "03 - Accès Initial",
+        "de": "03 - Erster Zugriff",
+        "pt": "03 - Acesso Inicial",
+        "zh_CN": "03 - 初始访问"
+      },
+      "children": []
+    },
+    {
+      "id": "kali-execution",
+      "name": "04 - Execution",
+      "translations": {
+        "es": "04 - Ejecución",
+        "fr": "04 - Exécution",
+        "de": "04 - Ausführung",
+        "pt": "04 - Execução",
+        "zh_CN": "04 - 执行"
+      },
+      "children": []
+    },
+    {
+      "id": "kali-privilege-escalation",
+      "name": "06 - Privilege Escalation",
+      "translations": {
+        "es": "06 - Escalada de Privilegios",
+        "fr": "06 - Escalade de Privilèges",
+        "de": "06 - Privilegien Erweiterung",
+        "pt": "06 - Elevação de Privilégios",
+        "zh_CN": "06 - 权限提升"
+      },
+      "children": []
+    },
+    {
+      "id": "kali-credential-access",
+      "name": "08 - Credential Access",
+      "translations": {
+        "es": "08 - Acceso a Credenciales",
+        "fr": "08 - Accès aux Identifiants",
+        "de": "08 - Zugriff auf Zugangsdaten",
+        "pt": "08 - Acesso a Credenciais",
+        "zh_CN": "08 - 凭证访问"
+      },
+      "children": [
+        {
+          "id": "kali-os-credential-dumping",
+          "name": "• OS Credential Dumping",
+          "translations": {
+            "es": "• Extracción de Credenciales del SO",
+            "fr": "• Dumping des identifiants du OS",
+            "de": "• Betriebssystem-Zugangsdatenextraktion",
+            "pt": "• Extração de Credenciais do SO",
+            "zh_CN": "• 操作系统凭据转储"
+          }
+        },
+        {
+          "id": "kali-brute-force",
+          "name": "• Brute Force",
+          "translations": {
+            "es": "• Fuerza Bruta",
+            "fr": "• Attaque par force brute",
+            "de": "• Brute-Force-Angriff",
+            "pt": "• Força Bruta",
+            "zh_CN": "• 暴力破解"
+          }
+        },
+        {
+          "id": "kali-password-cracking",
+          "name": "• Password Cracking",
+          "translations": {
+            "es": "• Descifrado de Contraseñas",
+            "fr": "• Craquage de Mots de Passe",
+            "de": "• Passwort-Knacken",
+            "pt": "• Quebra de Senhas",
+            "zh_CN": "• 破解密码"
+          }
+        },
+        {
+          "id": "kali-pass-the-hash",
+          "name": "• Pass-the-Hash",
+          "translations": {
+            "es": "• Pass-the-Hash",
+            "fr": "• Pass-the-Hash",
+            "de": "• Pass-the-Hash",
+            "pt": "• Pass-the-Hash",
+            "zh_CN": "• Pass-the-Hash"
+          }
+        }
+      ]
+    },
+    {
+      "id": "kali-discovery",
+      "name": "09 - Discovery",
+      "translations": {
+        "es": "09 - Descubrimiento",
+        "fr": "09 - Découverte",
+        "de": "09 - Entdeckung",
+        "pt": "09 - Descoberta",
+        "zh_CN": "09 - 发现"
+      },
+      "children": [
+        {
+          "id": "kali-network-service-discovery",
+          "name": "• Network Service Discovery",
+          "translations": {
+            "es": "• Descubrimiento de Servicios de Red",
+            "fr": "• Découverte de Services Réseau",
+            "de": "• Netzwerkdienst-Erkennung",
+            "pt": "• Descoberta de Serviços de Rede",
+            "zh_CN": "• 网络服务发现"
+          }
+        },
+        {
+          "id": "kali-network-sniffing",
+          "name": "• Network Sniffing",
+          "translations": {
+            "es": "• Sniffing de Red",
+            "fr": "• Sniffing de Réseau",
+            "de": "• Netzwerk-Sniffing",
+            "pt": "• Sniffing de Rede",
+            "zh_CN": "• 网络嗅探"
+          }
+        }
+      ]
+    },
+    {
+      "id": "kali-collection",
+      "name": "11 - Collection",
+      "translations": {
+        "es": "11 - Recopilación",
+        "fr": "11 - Collecte",
+        "de": "11 - Sammlung",
+        "pt": "11 - Coleta",
+        "zh_CN": "11 - 收集"
+      },
+      "children": []
+    },
+    {
+      "id": "kali-command-and-control",
+      "name": "12 - Command and Control",
+      "translations": {
+        "es": "12 - Comando y Control",
+        "fr": "12 - Commandement et Contrôle",
+        "de": "12 - Befehl und Kontrolle",
+        "pt": "12 - Comando e Controle",
+        "zh_CN": "12 - 指挥控制"
+      },
+      "children": [
+        {
+          "id": "kali-non-application-layer-protocol",
+          "name": "• Non-Application Layer Protocol",
+          "translations": {
+            "es": "• Protocolo fuera de Capa de Aplicación",
+            "fr": "• Protocole Non-Couche Application",
+            "de": "• Nicht-Anwendungsschicht-Protokoll",
+            "pt": "• Protocolo fora da camada de aplicação",
+            "zh_CN": "• 非应用层协议"
+          }
+        }
+      ]
+    },
+    {
+      "id": "kali-exfiltration",
+      "name": "13 - Exfiltration",
+      "translations": {
+        "es": "13 - Exfiltración",
+        "fr": "13 - Exfiltration",
+        "de": "13 - Exfiltration",
+        "pt": "13 - Exfiltração",
+        "zh_CN": "13 - 渗漏"
+      },
+      "children": []
+    },
+    {
+      "id": "kali-forensics",
+      "name": "15 - Forensics",
+      "translations": {
+        "es": "15 - Análisis forense",
+        "fr": "15 - Criminalistique",
+        "de": "15 - Forensik",
+        "pt": "15 - Análise forense",
+        "zh_CN": "15 - 数字取证"
+      },
+      "children": [
+        {
+          "id": "kali-digital-forensics",
+          "name": "• Digital Forensics",
+          "translations": {
+            "es": "• Análisis forense digital",
+            "fr": "• Criminalistique Numérique",
+            "de": "• Digitale Forensik",
+            "pt": "• Análise forense digital",
+            "zh_CN": "• 数字取证"
+          }
+        },
+        {
+          "id": "kali-sleuth-kit-suite",
+          "name": "• Sleuth Kit Suite",
+          "translations": {
+            "es": "• Kits de forensia",
+            "fr": "• Suites Criminalistique",
+            "de": "• Forensik-Werkzeugsammlungen",
+            "pt": "• Kits forenses",
+            "zh_CN": "• 数字取证套件"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/applications/menu/synonyms.json
+++ b/applications/menu/synonyms.json
@@ -1,0 +1,18 @@
+{
+  "kali-autopsy": ["autopsy", "sleuth kit", "case manager"],
+  "kali-evidence-vault": ["evidence", "chain of custody", "vault"],
+  "kali-files": ["file manager", "explorer", "browser"],
+  "kali-hydra": ["hydra", "brute force", "login"],
+  "kali-john": ["john the ripper", "hash", "password"],
+  "kali-metasploit-framework": ["metasploit", "msfconsole", "payload"],
+  "kali-mimikatz": ["mimikatz", "pass the hash", "credential"],
+  "kali-nikto": ["nikto", "web scanner", "http"],
+  "kali-nmap": ["nmap", "network mapper", "port"],
+  "kali-netcat": ["netcat", "reverse shell", "tunnel"],
+  "kali-reaver": ["reaver", "wps", "wifi"],
+  "kali-recon-ng": ["recon-ng", "osint", "recon"],
+  "kali-terminal": ["terminal", "shell", "command"],
+  "kali-theharvester": ["theharvester", "email", "osint"],
+  "kali-volatility": ["volatility", "memory", "ram"],
+  "kali-wireshark": ["wireshark", "packet", "sniffer"]
+}

--- a/menus/kali-applications.menu
+++ b/menus/kali-applications.menu
@@ -1,0 +1,256 @@
+<?xml version="1.0"?>
+<!DOCTYPE Menu PUBLIC "-//freedesktop//DTD Menu 1.0//EN" "http://www.freedesktop.org/standards/menu-spec/1.0/menu.dtd">
+<Menu>
+  <Name>Applications</Name>
+  <Layout>
+    <Menuname>Usual Applications</Menuname>
+    <Menuname>Reconnaissance</Menuname>
+    <Menuname>Initial Access</Menuname>
+    <Menuname>Execution</Menuname>
+    <Menuname>Privilege Escalation</Menuname>
+    <Menuname>Credential Access</Menuname>
+    <Menuname>Discovery</Menuname>
+    <Menuname>Collection</Menuname>
+    <Menuname>Command and Control</Menuname>
+    <Menuname>Exfiltration</Menuname>
+    <Menuname>Forensics</Menuname>
+    <Merge type="all"/>
+  </Layout>
+
+  <Menu>
+    <Name>Usual Applications</Name>
+    <Directory>kali-usual-applications.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-usual-applications</Category>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Reconnaissance</Name>
+    <Directory>kali-reconnaissance.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-reconnaissance</Category>
+      </And>
+    </Include>
+    <Menu>
+      <Name>Identity Information</Name>
+      <Directory>kali-identity-information.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-identity-information</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Network Information</Name>
+      <Directory>kali-network-information.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-network-information</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Web Scanning</Name>
+      <Directory>kali-web-scanning.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-web-scanning</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Web Vulnerability Scanning</Name>
+      <Directory>kali-web-vulnerability-scanning.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-web-vulnerability-scanning</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>WiFi</Name>
+      <Directory>kali-wifi-credential-access.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-wifi-credential-access</Category>
+        </And>
+      </Include>
+    </Menu>
+  </Menu>
+
+  <Menu>
+    <Name>Initial Access</Name>
+    <Directory>kali-initial-access.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-initial-access</Category>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Execution</Name>
+    <Directory>kali-execution.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-execution</Category>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Privilege Escalation</Name>
+    <Directory>kali-privilege-escalation.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-privilege-escalation</Category>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Credential Access</Name>
+    <Directory>kali-credential-access.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-credential-access</Category>
+      </And>
+    </Include>
+    <Menu>
+      <Name>OS Credential Dumping</Name>
+      <Directory>kali-os-credential-dumping.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-os-credential-dumping</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Brute Force</Name>
+      <Directory>kali-brute-force.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-brute-force</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Password Cracking</Name>
+      <Directory>kali-password-cracking.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-password-cracking</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Pass-the-Hash</Name>
+      <Directory>kali-pass-the-hash.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-pass-the-hash</Category>
+        </And>
+      </Include>
+    </Menu>
+  </Menu>
+
+  <Menu>
+    <Name>Discovery</Name>
+    <Directory>kali-discovery.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-discovery</Category>
+      </And>
+    </Include>
+    <Menu>
+      <Name>Network Service Discovery</Name>
+      <Directory>kali-network-service-discovery.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-network-service-discovery</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Network Sniffing</Name>
+      <Directory>kali-network-sniffing.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-network-sniffing</Category>
+        </And>
+      </Include>
+    </Menu>
+  </Menu>
+
+  <Menu>
+    <Name>Collection</Name>
+    <Directory>kali-collection.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-collection</Category>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Command and Control</Name>
+    <Directory>kali-command-and-control.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-command-and-control</Category>
+      </And>
+    </Include>
+    <Menu>
+      <Name>Non-Application Layer Protocol</Name>
+      <Directory>kali-non-application-layer-protocol.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-non-application-layer-protocol</Category>
+        </And>
+      </Include>
+    </Menu>
+  </Menu>
+
+  <Menu>
+    <Name>Exfiltration</Name>
+    <Directory>kali-exfiltration.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-exfiltration</Category>
+      </And>
+    </Include>
+  </Menu>
+
+  <Menu>
+    <Name>Forensics</Name>
+    <Directory>kali-forensics.directory</Directory>
+    <Include>
+      <And>
+        <Category>kali-forensics</Category>
+      </And>
+    </Include>
+    <Menu>
+      <Name>Digital Forensics</Name>
+      <Directory>kali-digital-forensics.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-digital-forensics</Category>
+        </And>
+      </Include>
+    </Menu>
+    <Menu>
+      <Name>Sleuth Kit Suite</Name>
+      <Directory>kali-sleuth-kit-suite.directory</Directory>
+      <Include>
+        <And>
+          <Category>kali-sleuth-kit-suite</Category>
+        </And>
+      </Include>
+    </Menu>
+  </Menu>
+</Menu>
+

--- a/menus/xfce-applications.menu
+++ b/menus/xfce-applications.menu
@@ -1,0 +1,45 @@
+<!DOCTYPE Menu PUBLIC "-//freedesktop//DTD Menu 1.0//EN"
+  "http://www.freedesktop.org/standards/menu-spec/1.0/menu.dtd">
+
+<Menu>
+  <Name>Xfce</Name>
+
+  <DefaultAppDirs/>
+  <DefaultDirectoryDirs/>
+  <DefaultMergeDirs/>
+
+  <Include>
+    <Category>X-Xfce-Toplevel</Category>
+  </Include>
+
+  <Layout>
+    <Filename>xfce4-run.desktop</Filename>
+    <Separator/>
+    <Filename>xfce4-terminal-emulator.desktop</Filename>
+    <Filename>xfce4-file-manager.desktop</Filename>
+    <Filename>xfce4-mail-reader.desktop</Filename>
+    <Filename>xfce4-web-browser.desktop</Filename>
+    <Separator/>
+    <Menuname>Settings</Menuname>
+    <Menuname>Usual Applications</Menuname>
+    <Menuname>Kali Linux</Menuname>
+    <Separator/>
+    <Merge type="all"/>
+    <Separator/>
+    <Filename>xfce4-about.desktop</Filename>
+    <Filename>xfce4-session-logout.desktop</Filename>
+  </Layout>
+
+  <Menu>
+    <Name>Usual Applications</Name>
+    <Directory>usual-apps.directory</Directory>
+    <MergeFile>applications.menu</MergeFile>
+  </Menu>
+
+  <Menu>
+    <Name>Kali Linux</Name>
+    <Directory>kali-menu.directory</Directory>
+    <MergeFile>kali-applications.menu</MergeFile>
+  </Menu>
+</Menu>
+

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
     "verify:all": "node scripts/verify.mjs",
-    "dedupe:fix": "yarn dedupe"
+    "dedupe:fix": "yarn dedupe",
+    "menu:audit": "node scripts/menu/audit-categories.mjs"
   },
   "engines": {
     "node": "20"

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,83 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: kali-linux-portfolio\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Usual Applications"
+msgstr "Übliche Anwendungen"
+
+msgid "01 - Reconnaissance"
+msgstr "01 - Erkennung"
+
+msgid "• Identity Information"
+msgstr "• Identitätsinformationen"
+
+msgid "• Network Information"
+msgstr "• Netzwerk-Informationen"
+
+msgid "• Web Scanning"
+msgstr "• Web-Scannen"
+
+msgid "• Web Vulnerability Scanning"
+msgstr "• Web-Schwachstellen-Scannen"
+
+msgid "• WiFi"
+msgstr "• WiFi"
+
+msgid "03 - Initial Access"
+msgstr "03 - Erster Zugriff"
+
+msgid "04 - Execution"
+msgstr "04 - Ausführung"
+
+msgid "06 - Privilege Escalation"
+msgstr "06 - Privilegien Erweiterung"
+
+msgid "08 - Credential Access"
+msgstr "08 - Zugriff auf Zugangsdaten"
+
+msgid "• OS Credential Dumping"
+msgstr "• Betriebssystem-Zugangsdatenextraktion"
+
+msgid "• Brute Force"
+msgstr "• Brute-Force-Angriff"
+
+msgid "• Password Cracking"
+msgstr "• Passwort-Knacken"
+
+msgid "• Pass-the-Hash"
+msgstr "• Pass-the-Hash"
+
+msgid "09 - Discovery"
+msgstr "09 - Entdeckung"
+
+msgid "• Network Service Discovery"
+msgstr "• Netzwerkdienst-Erkennung"
+
+msgid "• Network Sniffing"
+msgstr "• Netzwerk-Sniffing"
+
+msgid "11 - Collection"
+msgstr "11 - Sammlung"
+
+msgid "12 - Command and Control"
+msgstr "12 - Befehl und Kontrolle"
+
+msgid "• Non-Application Layer Protocol"
+msgstr "• Nicht-Anwendungsschicht-Protokoll"
+
+msgid "13 - Exfiltration"
+msgstr "13 - Exfiltration"
+
+msgid "15 - Forensics"
+msgstr "15 - Forensik"
+
+msgid "• Digital Forensics"
+msgstr "• Digitale Forensik"
+
+msgid "• Sleuth Kit Suite"
+msgstr "• Forensik-Werkzeugsammlungen"
+

--- a/po/en.po
+++ b/po/en.po
@@ -1,0 +1,83 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: kali-linux-portfolio\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Usual Applications"
+msgstr "Usual Applications"
+
+msgid "01 - Reconnaissance"
+msgstr "01 - Reconnaissance"
+
+msgid "• Identity Information"
+msgstr "• Identity Information"
+
+msgid "• Network Information"
+msgstr "• Network Information"
+
+msgid "• Web Scanning"
+msgstr "• Web Scanning"
+
+msgid "• Web Vulnerability Scanning"
+msgstr "• Web Vulnerability Scanning"
+
+msgid "• WiFi"
+msgstr "• WiFi"
+
+msgid "03 - Initial Access"
+msgstr "03 - Initial Access"
+
+msgid "04 - Execution"
+msgstr "04 - Execution"
+
+msgid "06 - Privilege Escalation"
+msgstr "06 - Privilege Escalation"
+
+msgid "08 - Credential Access"
+msgstr "08 - Credential Access"
+
+msgid "• OS Credential Dumping"
+msgstr "• OS Credential Dumping"
+
+msgid "• Brute Force"
+msgstr "• Brute Force"
+
+msgid "• Password Cracking"
+msgstr "• Password Cracking"
+
+msgid "• Pass-the-Hash"
+msgstr "• Pass-the-Hash"
+
+msgid "09 - Discovery"
+msgstr "09 - Discovery"
+
+msgid "• Network Service Discovery"
+msgstr "• Network Service Discovery"
+
+msgid "• Network Sniffing"
+msgstr "• Network Sniffing"
+
+msgid "11 - Collection"
+msgstr "11 - Collection"
+
+msgid "12 - Command and Control"
+msgstr "12 - Command and Control"
+
+msgid "• Non-Application Layer Protocol"
+msgstr "• Non-Application Layer Protocol"
+
+msgid "13 - Exfiltration"
+msgstr "13 - Exfiltration"
+
+msgid "15 - Forensics"
+msgstr "15 - Forensics"
+
+msgid "• Digital Forensics"
+msgstr "• Digital Forensics"
+
+msgid "• Sleuth Kit Suite"
+msgstr "• Sleuth Kit Suite"
+

--- a/po/es.po
+++ b/po/es.po
@@ -1,0 +1,83 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: kali-linux-portfolio\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Usual Applications"
+msgstr "Aplicaciones habituales"
+
+msgid "01 - Reconnaissance"
+msgstr "01 - Reconocimiento"
+
+msgid "• Identity Information"
+msgstr "• Información de Identidad"
+
+msgid "• Network Information"
+msgstr "• Información de Red"
+
+msgid "• Web Scanning"
+msgstr "• Escaneo Web"
+
+msgid "• Web Vulnerability Scanning"
+msgstr "• Escaneo de Vulnerabilidades Web"
+
+msgid "• WiFi"
+msgstr "• WiFi"
+
+msgid "03 - Initial Access"
+msgstr "03 - Acceso Inicial"
+
+msgid "04 - Execution"
+msgstr "04 - Ejecución"
+
+msgid "06 - Privilege Escalation"
+msgstr "06 - Escalada de Privilegios"
+
+msgid "08 - Credential Access"
+msgstr "08 - Acceso a Credenciales"
+
+msgid "• OS Credential Dumping"
+msgstr "• Extracción de Credenciales del SO"
+
+msgid "• Brute Force"
+msgstr "• Fuerza Bruta"
+
+msgid "• Password Cracking"
+msgstr "• Descifrado de Contraseñas"
+
+msgid "• Pass-the-Hash"
+msgstr "• Pass-the-Hash"
+
+msgid "09 - Discovery"
+msgstr "09 - Descubrimiento"
+
+msgid "• Network Service Discovery"
+msgstr "• Descubrimiento de Servicios de Red"
+
+msgid "• Network Sniffing"
+msgstr "• Sniffing de Red"
+
+msgid "11 - Collection"
+msgstr "11 - Recopilación"
+
+msgid "12 - Command and Control"
+msgstr "12 - Comando y Control"
+
+msgid "• Non-Application Layer Protocol"
+msgstr "• Protocolo fuera de Capa de Aplicación"
+
+msgid "13 - Exfiltration"
+msgstr "13 - Exfiltración"
+
+msgid "15 - Forensics"
+msgstr "15 - Análisis forense"
+
+msgid "• Digital Forensics"
+msgstr "• Análisis forense digital"
+
+msgid "• Sleuth Kit Suite"
+msgstr "• Kits de forensia"
+

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,0 +1,83 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: kali-linux-portfolio\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Usual Applications"
+msgstr "Applications habituelles"
+
+msgid "01 - Reconnaissance"
+msgstr "01 - Reconnaissance"
+
+msgid "• Identity Information"
+msgstr "• Informations d'identité"
+
+msgid "• Network Information"
+msgstr "• Informations sur le réseau"
+
+msgid "• Web Scanning"
+msgstr "• Analyse Web"
+
+msgid "• Web Vulnerability Scanning"
+msgstr "• Analyse de Vulnérabilités Web"
+
+msgid "• WiFi"
+msgstr "• WiFi"
+
+msgid "03 - Initial Access"
+msgstr "03 - Accès Initial"
+
+msgid "04 - Execution"
+msgstr "04 - Exécution"
+
+msgid "06 - Privilege Escalation"
+msgstr "06 - Escalade de Privilèges"
+
+msgid "08 - Credential Access"
+msgstr "08 - Accès aux Identifiants"
+
+msgid "• OS Credential Dumping"
+msgstr "• Dumping des identifiants du OS"
+
+msgid "• Brute Force"
+msgstr "• Attaque par force brute"
+
+msgid "• Password Cracking"
+msgstr "• Craquage de Mots de Passe"
+
+msgid "• Pass-the-Hash"
+msgstr "• Pass-the-Hash"
+
+msgid "09 - Discovery"
+msgstr "09 - Découverte"
+
+msgid "• Network Service Discovery"
+msgstr "• Découverte de Services Réseau"
+
+msgid "• Network Sniffing"
+msgstr "• Sniffing de Réseau"
+
+msgid "11 - Collection"
+msgstr "11 - Collecte"
+
+msgid "12 - Command and Control"
+msgstr "12 - Commandement et Contrôle"
+
+msgid "• Non-Application Layer Protocol"
+msgstr "• Protocole Non-Couche Application"
+
+msgid "13 - Exfiltration"
+msgstr "13 - Exfiltration"
+
+msgid "15 - Forensics"
+msgstr "15 - Criminalistique"
+
+msgid "• Digital Forensics"
+msgstr "• Criminalistique Numérique"
+
+msgid "• Sleuth Kit Suite"
+msgstr "• Suites Criminalistique"
+

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,0 +1,83 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: kali-linux-portfolio\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Usual Applications"
+msgstr "Aplicações habituais"
+
+msgid "01 - Reconnaissance"
+msgstr "01 - Reconhecimento"
+
+msgid "• Identity Information"
+msgstr "• Informações de Identidade"
+
+msgid "• Network Information"
+msgstr "• Informações de Rede"
+
+msgid "• Web Scanning"
+msgstr "• Varredura Web"
+
+msgid "• Web Vulnerability Scanning"
+msgstr "• Varredura de Vulnerabilidades Web"
+
+msgid "• WiFi"
+msgstr "• WiFi"
+
+msgid "03 - Initial Access"
+msgstr "03 - Acesso Inicial"
+
+msgid "04 - Execution"
+msgstr "04 - Execução"
+
+msgid "06 - Privilege Escalation"
+msgstr "06 - Elevação de Privilégios"
+
+msgid "08 - Credential Access"
+msgstr "08 - Acesso a Credenciais"
+
+msgid "• OS Credential Dumping"
+msgstr "• Extração de Credenciais do SO"
+
+msgid "• Brute Force"
+msgstr "• Força Bruta"
+
+msgid "• Password Cracking"
+msgstr "• Quebra de Senhas"
+
+msgid "• Pass-the-Hash"
+msgstr "• Pass-the-Hash"
+
+msgid "09 - Discovery"
+msgstr "09 - Descoberta"
+
+msgid "• Network Service Discovery"
+msgstr "• Descoberta de Serviços de Rede"
+
+msgid "• Network Sniffing"
+msgstr "• Sniffing de Rede"
+
+msgid "11 - Collection"
+msgstr "11 - Coleta"
+
+msgid "12 - Command and Control"
+msgstr "12 - Comando e Controle"
+
+msgid "• Non-Application Layer Protocol"
+msgstr "• Protocolo fora da camada de aplicação"
+
+msgid "13 - Exfiltration"
+msgstr "13 - Exfiltração"
+
+msgid "15 - Forensics"
+msgstr "15 - Análise forense"
+
+msgid "• Digital Forensics"
+msgstr "• Análise forense digital"
+
+msgid "• Sleuth Kit Suite"
+msgstr "• Kits forenses"
+

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,0 +1,83 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: kali-linux-portfolio\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Usual Applications"
+msgstr "常用程序"
+
+msgid "01 - Reconnaissance"
+msgstr "01 - 侦察"
+
+msgid "• Identity Information"
+msgstr "• 身份信息"
+
+msgid "• Network Information"
+msgstr "• 网络信息"
+
+msgid "• Web Scanning"
+msgstr "• 网络扫描"
+
+msgid "• Web Vulnerability Scanning"
+msgstr "• Web 漏洞扫描"
+
+msgid "• WiFi"
+msgstr "• WiFi"
+
+msgid "03 - Initial Access"
+msgstr "03 - 初始访问"
+
+msgid "04 - Execution"
+msgstr "04 - 执行"
+
+msgid "06 - Privilege Escalation"
+msgstr "06 - 权限提升"
+
+msgid "08 - Credential Access"
+msgstr "08 - 凭证访问"
+
+msgid "• OS Credential Dumping"
+msgstr "• 操作系统凭据转储"
+
+msgid "• Brute Force"
+msgstr "• 暴力破解"
+
+msgid "• Password Cracking"
+msgstr "• 破解密码"
+
+msgid "• Pass-the-Hash"
+msgstr "• Pass-the-Hash"
+
+msgid "09 - Discovery"
+msgstr "09 - 发现"
+
+msgid "• Network Service Discovery"
+msgstr "• 网络服务发现"
+
+msgid "• Network Sniffing"
+msgstr "• 网络嗅探"
+
+msgid "11 - Collection"
+msgstr "11 - 收集"
+
+msgid "12 - Command and Control"
+msgstr "12 - 指挥控制"
+
+msgid "• Non-Application Layer Protocol"
+msgstr "• 非应用层协议"
+
+msgid "13 - Exfiltration"
+msgstr "13 - 渗漏"
+
+msgid "15 - Forensics"
+msgstr "15 - 数字取证"
+
+msgid "• Digital Forensics"
+msgstr "• 数字取证"
+
+msgid "• Sleuth Kit Suite"
+msgstr "• 数字取证套件"
+

--- a/scripts/menu/audit-categories.mjs
+++ b/scripts/menu/audit-categories.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join, extname, basename } from 'node:path';
+
+const ROOT = process.cwd();
+const DESKTOP_DIR = join(ROOT, 'applications', 'menu', 'desktop-files');
+const HIERARCHY_PATH = join(ROOT, 'applications', 'menu', 'hierarchy.json');
+const SYNONYMS_PATH = join(ROOT, 'applications', 'menu', 'synonyms.json');
+const OUTPUT_PATH = join(ROOT, 'applications', 'menu', 'category-map.json');
+
+
+const parseDesktopFile = (content) => {
+  const data = {};
+  const lines = content.split(/\r?\n/);
+  for (const line of lines) {
+    if (!line || line.startsWith('#') || line.startsWith('[')) continue;
+    const idx = line.indexOf('=');
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    data[key] = value;
+  }
+  return data;
+};
+
+const loadJson = (path) => JSON.parse(readFileSync(path, 'utf8'));
+
+const hierarchy = loadJson(HIERARCHY_PATH);
+const synonyms = loadJson(SYNONYMS_PATH);
+
+const categoryIndex = new Map();
+const parentIndex = new Map();
+
+const registerNode = (node, parentId = null) => {
+  if (!node || !node.id) return;
+  categoryIndex.set(node.id, { id: node.id, name: node.name, translations: node.translations || {} });
+  parentIndex.set(node.id, parentId);
+  if (Array.isArray(node.children)) {
+    node.children.forEach((child) => registerNode(child, node.id));
+  }
+};
+
+hierarchy.categories.forEach((node) => registerNode(node));
+
+const getAncestry = (categoryId) => {
+  const ancestry = [];
+  let current = categoryId;
+  while (current) {
+    const node = categoryIndex.get(current);
+    if (!node) break;
+    ancestry.unshift(node);
+    current = parentIndex.get(current);
+  }
+  return ancestry;
+};
+
+const desktopFiles = readdirSync(DESKTOP_DIR).filter((file) => extname(file) === '.desktop');
+const missingCategories = new Map();
+const categoryAppMap = new Map();
+const apps = [];
+const synonymIssues = [];
+
+for (const file of desktopFiles.sort()) {
+  const fullPath = join(DESKTOP_DIR, file);
+  const parsed = parseDesktopFile(readFileSync(fullPath, 'utf8'));
+  const appId = basename(file, '.desktop');
+  const keywords = (parsed.Keywords || '')
+    .split(';')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .map((item) => item.toLowerCase());
+  const categories = (parsed.Categories || '')
+    .split(';')
+    .map((item) => item.trim())
+    .filter((item) => item.startsWith('kali-'));
+
+  const topLevelMap = new Map();
+  for (const categoryId of categories) {
+    const ancestry = getAncestry(categoryId);
+    if (ancestry.length === 0) {
+      const list = missingCategories.get(categoryId) || [];
+      list.push(appId);
+      missingCategories.set(categoryId, list);
+      continue;
+    }
+    const top = ancestry[0];
+    let topEntry = topLevelMap.get(top.id);
+    if (!topEntry) {
+      topEntry = { id: top.id, name: top.name, children: new Map() };
+      topLevelMap.set(top.id, topEntry);
+    }
+    for (let index = 1; index < ancestry.length; index += 1) {
+      const child = ancestry[index];
+      if (!topEntry.children.has(child.id)) {
+        topEntry.children.set(child.id, { id: child.id, name: child.name });
+      }
+    }
+    const bucket = categoryAppMap.get(top.id) || new Set();
+    bucket.add(appId);
+    categoryAppMap.set(top.id, bucket);
+  }
+
+  const expectedSynonyms = synonyms[appId] || [];
+  const keywordValues = new Set(keywords);
+  const missing = expectedSynonyms.filter((synonym) => {
+    const candidate = synonym.toLowerCase();
+    return !Array.from(keywordValues).some((kw) => kw.includes(candidate) || candidate.includes(kw));
+  });
+  if (missing.length > 0) {
+    synonymIssues.push({ appId, missing });
+  }
+
+  apps.push({
+    id: appId,
+    file,
+    name: parsed.Name || null,
+    genericName: parsed.GenericName || null,
+    comment: parsed.Comment || null,
+    exec: parsed.Exec || null,
+    icon: parsed.Icon || null,
+    portfolioApp: parsed['X-Portfolio-App'] || null,
+    package: parsed['X-Kali-Package'] || null,
+    keywords,
+    categories: Array.from(topLevelMap.values()).map((entry) => ({
+      id: entry.id,
+      name: entry.name,
+      children: Array.from(entry.children.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    })).sort((a, b) => a.name.localeCompare(b.name)),
+  });
+}
+
+if (synonymIssues.length > 0) {
+  const details = synonymIssues
+    .map((issue) => `${issue.appId}: ${issue.missing.join(', ')}`)
+    .join('\n');
+  throw new Error(`Synonym validation failed for the following desktop entries:\n${details}`);
+}
+
+const categorySummary = hierarchy.categories.map((category) => {
+  const appsForCategory = Array.from(categoryAppMap.get(category.id) || []).sort();
+  return {
+    id: category.id,
+    name: category.name,
+    appCount: appsForCategory.length,
+    apps: appsForCategory,
+    children: (category.children || []).map((child) => ({ id: child.id, name: child.name })),
+  };
+});
+
+const result = {
+  generatedAt: new Date().toISOString(),
+  desktopFiles: apps.length,
+  hierarchyVersion: hierarchy.version,
+  reference: hierarchy.reference,
+  apps: apps.sort((a, b) => a.name.localeCompare(b.name)),
+  categories: categorySummary,
+  missingCategories: Array.from(missingCategories.entries()).map(([id, sources]) => ({
+    id,
+    apps: sources.sort(),
+  })),
+};
+
+writeFileSync(OUTPUT_PATH, `${JSON.stringify(result, null, 2)}\n`);
+
+console.log(`Wrote category map with ${apps.length} desktop entries to ${OUTPUT_PATH}`);
+


### PR DESCRIPTION
## Summary
- add simulated Kali .desktop entries with portfolio commands, keywords, and translations for the refreshed menu structure
- codify the MITRE-aligned hierarchy in JSON, wire xfce/alacarte menu XML, and generate language packs for the new categories
- add a node audit script plus Jest coverage to enforce category mapping and keyword synonym checks

## Testing
- yarn test menuCategoryMap
- yarn menu:audit


------
https://chatgpt.com/codex/tasks/task_e_68d9f238c7f88328a904595c6d6685e4