### PR TITLE
[nethunter] add car mode dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ play/pause and track controls include keyboard hotkeys.
 | Metasploit | /apps/metasploit | Security Tool (simulated) |
 | Metasploit Post | /apps/metasploit-post | Security Tool (simulated) |
 | Mimikatz | /apps/mimikatz | Security Tool (simulated) |
+| NetHunter | /apps/nethunter | Security Tool (simulated) |
 | Nessus | /apps/nessus | Security Tool (simulated) |
 | Nmap NSE | /apps/nmap-nse | Security Tool (simulated) |
 | OpenVAS | /apps/openvas | Security Tool (simulated) |

--- a/apps.config.js
+++ b/apps.config.js
@@ -68,6 +68,7 @@ const WeatherWidgetApp = createDynamicApp('weather_widget', 'Weather Widget');
 const InputLabApp = createDynamicApp('input-lab', 'Input Lab');
 const SubnetCalculatorApp = createDynamicApp('subnet-calculator', 'Subnet Calculator');
 const GhidraApp = createDynamicApp('ghidra', 'Ghidra');
+const NetHunterApp = createDynamicApp('nethunter', 'NetHunter');
 
 const StickyNotesApp = createDynamicApp('sticky_notes', 'Sticky Notes');
 const TrashApp = createDynamicApp('trash', 'Trash');
@@ -163,6 +164,7 @@ const displayInputLab = createDisplay(InputLabApp);
 const displaySubnetCalculator = createDisplay(SubnetCalculatorApp);
 
 const displayGhidra = createDisplay(GhidraApp);
+const displayNetHunter = createDisplay(NetHunterApp);
 
 const displayAutopsy = createDisplay(AutopsyApp);
 const displayPluginManager = createDisplay(PluginManagerApp);
@@ -869,6 +871,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayGhidra,
+  },
+  {
+    id: 'nethunter',
+    title: 'NetHunter',
+    icon: '/themes/Yaru/apps/nethunter.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayNetHunter,
   },
   {
     id: 'mimikatz',

--- a/apps/nethunter/hooks/useOrientation.ts
+++ b/apps/nethunter/hooks/useOrientation.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+type Orientation = 'portrait' | 'landscape';
+
+const getOrientation = (): Orientation => {
+  if (typeof window === 'undefined') {
+    return 'landscape';
+  }
+
+  if (window.screen?.orientation?.type) {
+    const type = window.screen.orientation.type;
+    if (type.includes('portrait')) {
+      return 'portrait';
+    }
+    if (type.includes('landscape')) {
+      return 'landscape';
+    }
+  }
+
+  return window.innerWidth >= window.innerHeight ? 'landscape' : 'portrait';
+};
+
+export function useOrientation(): Orientation {
+  const [orientation, setOrientation] = useState<Orientation>(getOrientation);
+
+  useEffect(() => {
+    const handleChange = () => setOrientation(getOrientation());
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.addEventListener('resize', handleChange);
+
+    const screenOrientation = window.screen?.orientation;
+    screenOrientation?.addEventListener?.('change', handleChange);
+
+    return () => {
+      window.removeEventListener('resize', handleChange);
+      screenOrientation?.removeEventListener?.('change', handleChange);
+    };
+  }, []);
+
+  return orientation;
+}
+
+export default useOrientation;

--- a/apps/nethunter/index.module.css
+++ b/apps/nethunter/index.module.css
@@ -1,0 +1,121 @@
+.root {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  color: var(--color-text);
+  background: linear-gradient(160deg, var(--kali-bg-solid) 0%, var(--color-ub-drk-abrgn) 100%);
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+  justify-content: space-between;
+}
+
+.title {
+  font-size: 1.65rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.titleBadge {
+  background: color-mix(in srgb, var(--kali-blue) 25%, transparent);
+  color: var(--kali-blue);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-round);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.modeSwitcher {
+  display: inline-flex;
+  background: color-mix(in srgb, var(--kali-panel) 80%, transparent);
+  border: 1px solid var(--kali-panel-border);
+  border-radius: var(--radius-round);
+  padding: var(--space-1);
+  gap: var(--space-1);
+}
+
+.modeButton {
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-round);
+  font-weight: 600;
+  min-width: 120px;
+  cursor: pointer;
+  transition: background var(--motion-fast) ease, color var(--motion-fast) ease;
+}
+
+.modeButton[aria-pressed='true'] {
+  background: color-mix(in srgb, var(--kali-blue) 35%, var(--kali-panel));
+  color: var(--color-bg);
+}
+
+.content {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.standardPanel {
+  background: color-mix(in srgb, var(--kali-panel) 95%, transparent);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--kali-panel-border);
+  padding: var(--space-5);
+  display: grid;
+  gap: var(--space-4);
+  box-shadow: var(--shadow-2);
+}
+
+.standardGrid {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.standardCard {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--kali-panel-border);
+  background: color-mix(in srgb, var(--color-ub-lite-abrgn) 70%, transparent);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.standardCard h3 {
+  font-size: 1.1rem;
+  color: var(--kali-blue);
+}
+
+.standardCard ul {
+  display: grid;
+  gap: var(--space-2);
+  font-size: 0.95rem;
+  color: color-mix(in srgb, var(--color-text), transparent 20%);
+}
+
+.feedback {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: 0.95rem;
+}
+
+.feedback output {
+  font-weight: 600;
+  color: var(--kali-blue);
+}
+
+.carMode {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}

--- a/apps/nethunter/index.tsx
+++ b/apps/nethunter/index.tsx
@@ -1,0 +1,295 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import useOrientation from './hooks/useOrientation';
+import Dashboard, { DashboardTile } from './ui/Dashboard';
+import QuickActionBar, { QuickToggle } from './ui/QuickActionBar';
+import styles from './index.module.css';
+
+type Mode = 'desktop' | 'car';
+
+const carPrimaryTiles: DashboardTile[] = [
+  {
+    id: 'navigation',
+    icon: '🧭',
+    title: 'Navigation',
+    description: 'Plan secure routes, sync with offline maps, and broadcast ETA updates.',
+    actions: [
+      {
+        id: 'start-trip',
+        label: 'Start secure trip',
+        detail: 'Uses offline maps and safe checkpoints.',
+        tone: 'primary',
+      },
+      {
+        id: 'share-eta',
+        label: 'Share ETA to team',
+        detail: 'Send encrypted 15-minute updates.',
+      },
+      {
+        id: 'safe-parking',
+        label: 'Find safe parking',
+        detail: 'Filters lots with trusted Wi-Fi and CCTV.',
+      },
+    ],
+  },
+  {
+    id: 'comms',
+    icon: '📡',
+    title: 'Comms & Briefings',
+    description: 'Hands-free messaging presets and rapid threat briefings.',
+    actions: [
+      {
+        id: 'call-soc',
+        label: 'Call SOC on speaker',
+        detail: 'Instantly opens secure VoIP channel.',
+        tone: 'primary',
+      },
+      {
+        id: 'quick-brief',
+        label: 'Listen to latest threat brief',
+        detail: '2 minute audio summary from HQ.',
+      },
+      {
+        id: 'send-checkin',
+        label: 'Send status check-in',
+        detail: 'Pre-filled voice note with location snippet.',
+      },
+    ],
+  },
+  {
+    id: 'tools',
+    icon: '🛠️',
+    title: 'Rapid tools',
+    description: 'Launch on-device scanners tuned for vehicle deployments.',
+    actions: [
+      {
+        id: 'bluetooth-sweep',
+        label: 'Bluetooth sweep',
+        detail: 'Scan for rogue beacons within 30m.',
+        tone: 'primary',
+      },
+      {
+        id: 'wifi-capture',
+        label: 'Capture Wi-Fi handshake',
+        detail: 'Queues sample for offline analysis.',
+      },
+      {
+        id: 'vehicle-diagnostics',
+        label: 'Vehicle diagnostics',
+        detail: 'Reads CAN bus overlays and alerts.',
+        tone: 'alert',
+      },
+    ],
+  },
+];
+
+const carSecondaryTiles: DashboardTile[] = [
+  {
+    id: 'intel',
+    icon: '🗂️',
+    title: 'Intel packets',
+    description: 'Quick access to recon notes and recent findings.',
+    actions: [
+      {
+        id: 'open-playbook',
+        label: 'Open mission playbook',
+        detail: 'Highlights next objectives.',
+      },
+      {
+        id: 'annotate-findings',
+        label: 'Add roadside finding',
+        detail: 'Voice-to-text with timestamp.',
+      },
+    ],
+  },
+  {
+    id: 'safety',
+    icon: '🛡️',
+    title: 'Safety net',
+    description: 'Emergency protocols and fail-safe toggles.',
+    actions: [
+      {
+        id: 'panic',
+        label: 'Trigger safe abort',
+        detail: 'Notifies HQ and locks device.',
+        tone: 'alert',
+      },
+      {
+        id: 'dash-cam',
+        label: 'Start dash capture',
+        detail: 'Records to encrypted volume.',
+      },
+    ],
+  },
+  {
+    id: 'automation',
+    icon: '🤖',
+    title: 'Automation queue',
+    description: 'Preview tasks scheduled for the next checkpoint.',
+    actions: [
+      {
+        id: 'review-queue',
+        label: 'Review queued scripts',
+        detail: 'Approve or snooze automation.',
+      },
+      {
+        id: 'handoff',
+        label: 'Prep handoff package',
+        detail: 'Compile findings for next operator.',
+      },
+    ],
+  },
+];
+
+const quickTogglePresets: QuickToggle[] = [
+  {
+    id: 'voice-control',
+    label: 'Voice control',
+    detail: 'Wake phrase "Kali, assist"',
+    active: true,
+  },
+  {
+    id: 'do-not-disturb',
+    label: 'Do not disturb',
+    detail: 'Only priority contacts alert',
+    active: false,
+  },
+  {
+    id: 'night-mode',
+    label: 'Night mode',
+    detail: 'Dim UI and reduce glare',
+    active: false,
+  },
+  {
+    id: 'auto-record',
+    label: 'Auto record findings',
+    detail: 'Capture voice notes when stationary',
+    active: true,
+  },
+];
+
+const desktopModules = [
+  {
+    title: 'Recon toolkit',
+    capabilities: [
+      'GPS trail mapper with signal strength overlay',
+      'BLE sweeper for rogue beacons',
+      'Wi-Fi survey with car mount calibration',
+    ],
+  },
+  {
+    title: 'Engagement planner',
+    capabilities: [
+      'Mission timeline and asset checklist',
+      'Offline field notes with voice transcription',
+      'Team sync with encrypted status updates',
+    ],
+  },
+  {
+    title: 'Post-engagement',
+    capabilities: [
+      'One-click evidence export to Evidence Vault',
+      'Report templates with auto-filled metadata',
+      'Handoff packages for SOC review',
+    ],
+  },
+];
+
+const NetHunterApp: React.FC = () => {
+  const [mode, setMode] = useState<Mode>('desktop');
+  const [toggles, setToggles] = useState<QuickToggle[]>(quickTogglePresets);
+  const [lastAction, setLastAction] = useState('Ready for next action.');
+  const orientation = useOrientation();
+
+  const handleToggle = (id: string) => {
+    setToggles((items) =>
+      items.map((toggle) =>
+        toggle.id === id ? { ...toggle, active: !toggle.active } : toggle
+      )
+    );
+  };
+
+  const statusMessage = useMemo(() => {
+    return mode === 'car'
+      ? `Orientation: ${orientation}. ${lastAction}`
+      : lastAction;
+  }, [lastAction, mode, orientation]);
+
+  const handleAction = (tileId: string, actionId: string) => {
+    const actionSummary = `${tileId.replace(/-/g, ' ')} · ${actionId.replace(/-/g, ' ')}`;
+    setLastAction(`Selected ${actionSummary}`);
+  };
+
+  return (
+    <div className={styles.root}>
+      <header className={styles.header}>
+        <div className={styles.title}>
+          <span aria-hidden="true">🐉</span>
+          <span>Kali NetHunter Command</span>
+          <span className={styles.titleBadge}>{mode === 'car' ? 'Car mode' : 'Desktop mode'}</span>
+        </div>
+        <nav className={styles.modeSwitcher} aria-label="Display mode">
+          <button
+            type="button"
+            className={styles.modeButton}
+            aria-pressed={mode === 'desktop'}
+            onClick={() => setMode('desktop')}
+          >
+            Desktop
+          </button>
+          <button
+            type="button"
+            className={styles.modeButton}
+            aria-pressed={mode === 'car'}
+            onClick={() => setMode('car')}
+          >
+            Car mode
+          </button>
+        </nav>
+      </header>
+      <div className={styles.content}>
+        {mode === 'desktop' ? (
+          <section className={styles.standardPanel}>
+            <div className={styles.feedback}>
+              <h2>NetHunter mission console</h2>
+              <p>
+                Curate toolkits, review mission data, and configure car mode presets before deploying to the field.
+              </p>
+              <output>{statusMessage}</output>
+            </div>
+            <div className={styles.standardGrid}>
+              {desktopModules.map((module) => (
+                <article key={module.title} className={styles.standardCard}>
+                  <h3>{module.title}</h3>
+                  <ul>
+                    {module.capabilities.map((capability) => (
+                      <li key={capability}>{capability}</li>
+                    ))}
+                  </ul>
+                </article>
+              ))}
+            </div>
+          </section>
+        ) : (
+          <div className={styles.carMode}>
+            <Dashboard
+              primaryTiles={carPrimaryTiles}
+              secondaryTiles={carSecondaryTiles}
+              orientation={orientation}
+              onAction={handleAction}
+              statusMessage={statusMessage}
+            />
+            <QuickActionBar
+              toggles={toggles}
+              onToggle={handleToggle}
+              orientation={orientation}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default NetHunterApp;

--- a/apps/nethunter/ui/Dashboard.module.css
+++ b/apps/nethunter/ui/Dashboard.module.css
@@ -1,0 +1,58 @@
+.dashboard {
+  width: 100%;
+  display: grid;
+  gap: var(--space-4);
+  background: color-mix(in srgb, var(--kali-bg-solid) 85%, transparent);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--kali-panel-border);
+  padding: var(--space-5);
+  box-shadow: var(--shadow-2);
+}
+
+.dashboardLandscape {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.dashboardPortrait {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.statusBanner {
+  grid-column: 1 / -1;
+  background: color-mix(in srgb, var(--kali-blue) 35%, var(--kali-panel));
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  color: var(--color-bg);
+  font-size: 1.05rem;
+}
+
+.statusAccent {
+  font-size: 2rem;
+}
+
+.statusText {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.statusText strong {
+  font-weight: 700;
+}
+
+.secondaryRow {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: var(--space-4);
+}
+
+.secondaryLandscape {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.secondaryPortrait {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}

--- a/apps/nethunter/ui/Dashboard.tsx
+++ b/apps/nethunter/ui/Dashboard.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import Tile, { TileAction } from './Tile';
+import styles from './Dashboard.module.css';
+
+type Orientation = 'portrait' | 'landscape';
+
+export interface DashboardTile {
+  id: string;
+  icon: string;
+  title: string;
+  description: string;
+  actions: TileAction[];
+}
+
+interface DashboardProps {
+  primaryTiles: DashboardTile[];
+  secondaryTiles: DashboardTile[];
+  orientation: Orientation;
+  onAction?: (tileId: string, actionId: string) => void;
+  statusMessage?: string;
+}
+
+const Dashboard: React.FC<DashboardProps> = ({
+  primaryTiles,
+  secondaryTiles,
+  orientation,
+  statusMessage,
+  onAction,
+}) => {
+  const dashboardClass = `${styles.dashboard} ${
+    orientation === 'portrait' ? styles.dashboardPortrait : styles.dashboardLandscape
+  }`;
+
+  const secondaryClass = `${styles.secondaryRow} ${
+    orientation === 'portrait' ? styles.secondaryPortrait : styles.secondaryLandscape
+  }`;
+
+  return (
+    <section className={dashboardClass}>
+      <div className={styles.statusBanner} role="status" aria-live="polite">
+        <span className={styles.statusAccent} aria-hidden="true">
+          🚗
+        </span>
+        <div className={styles.statusText}>
+          <strong>Car mode optimized</strong>
+          <span>{statusMessage ?? 'Large controls and adaptive layout ready for the road.'}</span>
+        </div>
+      </div>
+      {primaryTiles.map((tile) => (
+        <Tile
+          key={tile.id}
+          {...tile}
+          onAction={(actionId) => onAction?.(tile.id, actionId)}
+        />
+      ))}
+      <div className={secondaryClass}>
+        {secondaryTiles.map((tile) => (
+          <Tile
+            key={tile.id}
+            {...tile}
+            onAction={(actionId) => onAction?.(tile.id, actionId)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default Dashboard;

--- a/apps/nethunter/ui/QuickActionBar.module.css
+++ b/apps/nethunter/ui/QuickActionBar.module.css
@@ -1,0 +1,72 @@
+.bar {
+  margin-top: var(--space-5);
+  background: color-mix(in srgb, var(--kali-panel) 90%, transparent);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--kali-panel-border);
+  padding: var(--space-4);
+  display: flex;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  box-shadow: var(--shadow-2);
+}
+
+.barPortrait {
+  flex-direction: column;
+}
+
+.barLandscape {
+  flex-direction: row;
+}
+
+.toggle {
+  flex: 1 1 220px;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--kali-panel-border);
+  background: color-mix(in srgb, var(--color-ub-lite-abrgn) 80%, transparent);
+  min-height: calc(var(--hit-area) * 1.4);
+  cursor: pointer;
+  transition: border var(--motion-fast) ease, background var(--motion-fast) ease;
+}
+
+.toggleActive {
+  background: color-mix(in srgb, var(--kali-blue) 30%, var(--kali-panel));
+  border-color: color-mix(in srgb, var(--kali-blue) 70%, transparent);
+  color: var(--color-bg);
+}
+
+.toggleText {
+  flex: 1;
+}
+
+.toggleLabel {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.toggleDetail {
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--color-text), transparent 35%);
+}
+
+.statePill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-round);
+  padding: 0 var(--space-3);
+  min-width: 72px;
+  min-height: calc(var(--hit-area) * 0.75);
+  font-size: 0.85rem;
+  background: color-mix(in srgb, var(--kali-panel) 75%, transparent);
+  border: 1px solid var(--kali-panel-border);
+}
+
+.toggleActive .statePill {
+  background: color-mix(in srgb, var(--kali-blue) 60%, var(--kali-panel));
+  border-color: transparent;
+  color: var(--color-bg);
+}

--- a/apps/nethunter/ui/QuickActionBar.tsx
+++ b/apps/nethunter/ui/QuickActionBar.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import styles from './QuickActionBar.module.css';
+import type { TileTone } from './Tile';
+
+type Orientation = 'portrait' | 'landscape';
+
+export interface QuickToggle {
+  id: string;
+  label: string;
+  detail: string;
+  active: boolean;
+  tone?: TileTone;
+}
+
+interface QuickActionBarProps {
+  toggles: QuickToggle[];
+  onToggle: (id: string) => void;
+  orientation: Orientation;
+}
+
+const QuickActionBar: React.FC<QuickActionBarProps> = ({ toggles, onToggle, orientation }) => {
+  return (
+    <div
+      className={`${styles.bar} ${
+        orientation === 'portrait' ? styles.barPortrait : styles.barLandscape
+      }`}
+      role="group"
+      aria-label="Quick controls"
+    >
+      {toggles.map((toggle) => (
+        <button
+          key={toggle.id}
+          type="button"
+          className={`${styles.toggle} ${toggle.active ? styles.toggleActive : ''}`}
+          onClick={() => onToggle(toggle.id)}
+          aria-pressed={toggle.active}
+        >
+          <div className={styles.toggleText}>
+            <span className={styles.toggleLabel}>{toggle.label}</span>
+            <span className={styles.toggleDetail}>{toggle.detail}</span>
+          </div>
+          <span className={styles.statePill}>{toggle.active ? 'On' : 'Off'}</span>
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default QuickActionBar;

--- a/apps/nethunter/ui/Tile.module.css
+++ b/apps/nethunter/ui/Tile.module.css
@@ -1,0 +1,108 @@
+.tile {
+  background: linear-gradient(145deg, var(--kali-panel) 0%, var(--color-ub-cool-grey) 100%);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--kali-panel-border);
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  justify-content: space-between;
+  box-shadow: var(--shadow-2);
+  transition: transform var(--motion-medium) ease, box-shadow var(--motion-medium) ease;
+  min-height: 220px;
+}
+
+.tile:focus-visible,
+.tile:hover {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--kali-blue), transparent 40%);
+  transform: translateY(-2px);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.icon {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--kali-blue) 20%, transparent);
+  color: var(--kali-blue);
+  font-size: 1.75rem;
+}
+
+.title {
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--kali-blue);
+}
+
+.description {
+  font-size: 0.95rem;
+  color: color-mix(in srgb, var(--color-text), transparent 15%);
+}
+
+.actions {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.actionButton {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  background: color-mix(in srgb, var(--kali-panel) 70%, transparent);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--kali-panel-border);
+  padding: var(--space-4);
+  min-height: calc(var(--hit-area) * 1.6);
+  width: 100%;
+  transition: background var(--motion-fast) ease, border var(--motion-fast) ease;
+  font-size: 1.05rem;
+  font-weight: 500;
+}
+
+.actionButton span {
+  display: block;
+}
+
+.actionButton:focus-visible,
+.actionButton:hover {
+  outline: none;
+  border-color: color-mix(in srgb, var(--kali-blue) 80%, transparent);
+  background: color-mix(in srgb, var(--kali-blue) 25%, var(--kali-panel));
+}
+
+.actionMeta {
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--color-text), transparent 35%);
+}
+
+.primary {
+  background: color-mix(in srgb, var(--kali-blue) 35%, var(--kali-panel));
+  border-color: color-mix(in srgb, var(--kali-blue) 60%, transparent);
+  color: var(--color-bg);
+}
+
+.primary:hover,
+.primary:focus-visible {
+  color: var(--color-bg);
+  border-color: var(--kali-blue);
+}
+
+.alert {
+  background: color-mix(in srgb, var(--game-color-danger) 25%, var(--kali-panel));
+  border-color: color-mix(in srgb, var(--game-color-danger) 50%, transparent);
+}
+
+.alert:hover,
+.alert:focus-visible {
+  border-color: var(--game-color-danger);
+}

--- a/apps/nethunter/ui/Tile.tsx
+++ b/apps/nethunter/ui/Tile.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import styles from './Tile.module.css';
+
+export type TileTone = 'default' | 'primary' | 'alert';
+
+export interface TileAction {
+  id: string;
+  label: string;
+  detail?: string;
+  tone?: TileTone;
+  onSelect?: (id: string) => void;
+}
+
+export interface TileProps {
+  icon: string;
+  title: string;
+  description: string;
+  actions: TileAction[];
+  onAction?: (actionId: string) => void;
+}
+
+const Tile: React.FC<TileProps> = ({ icon, title, description, actions, onAction }) => {
+  const handleClick = (action: TileAction) => {
+    action.onSelect?.(action.id);
+    onAction?.(action.id);
+  };
+
+  return (
+    <article className={styles.tile} aria-label={title}>
+      <header className={styles.header}>
+        <span aria-hidden="true" className={styles.icon}>
+          {icon}
+        </span>
+        <div>
+          <h2 className={styles.title}>{title}</h2>
+          <p className={styles.description}>{description}</p>
+        </div>
+      </header>
+      <div className={styles.actions}>
+        {actions.map((action) => (
+          <button
+            key={action.id}
+            type="button"
+            className={`${styles.actionButton} ${
+              action.tone === 'primary'
+                ? styles.primary
+                : action.tone === 'alert'
+                ? styles.alert
+                : ''
+            }`}
+            onClick={() => handleClick(action)}
+          >
+            <span>{action.label}</span>
+            {action.detail && <span className={styles.actionMeta}>{action.detail}</span>}
+          </button>
+        ))}
+      </div>
+    </article>
+  );
+};
+
+export default Tile;

--- a/components/apps/nethunter/index.tsx
+++ b/components/apps/nethunter/index.tsx
@@ -1,0 +1,15 @@
+import dynamic from 'next/dynamic';
+import React from 'react';
+
+const NetHunterApp = dynamic(() => import('../../../apps/nethunter'), {
+  ssr: false,
+  loading: () => (
+    <div className="p-4 text-sm text-gray-200">Loading NetHunter console…</div>
+  ),
+});
+
+const NetHunter = () => <NetHunterApp />;
+
+export const displayNetHunter = () => <NetHunter />;
+
+export default NetHunter;

--- a/docs/nethunter-car-mode.md
+++ b/docs/nethunter-car-mode.md
@@ -1,0 +1,32 @@
+# NetHunter Car Mode Dashboard
+
+NetHunter now includes a dual-mode console designed for Kali-themed desktop and in-vehicle workflows. Car mode delivers oversized, glanceable controls while automatically adapting to orientation changes so it remains usable on horizontal or vertical mounts.
+
+## Feature summary
+
+- **Shared design tokens** – All NetHunter UI components use the global Kali/Yaru design tokens so colors, radii, spacing, and elevation match the desktop shell.
+- **Car mode dashboard** – Large navigation, communication, and tooling tiles surface the most common actions with single-tap execution.
+- **Quick action bar** – A persistent strip of toggles (voice control, DND, night mode, auto-record) uses `var(--hit-area)` sizing to maintain accessible tap targets.
+- **Auto-rotation awareness** – Layouts automatically switch between portrait and landscape grid densities using the `useOrientation` hook that listens to `screen.orientation` and resize events.
+- **Simplified interactions** – Descriptive copy, pronounced icons, and status banners provide continuous feedback without requiring precise pointer input.
+
+## Desktop vs. car workflows
+
+| Mode | Purpose | Highlights |
+| --- | --- | --- |
+| Desktop | Configure missions before travel | Toolkit overview cards, live status output, and mission planning tips. |
+| Car mode | Operate while mounted in-vehicle | Tile-based dashboard with orientation-aware layout and quick toggles. |
+
+## Testing checklist
+
+1. Open **NetHunter** from the applications grid.
+2. Switch between **Desktop** and **Car mode** using the toggle in the header.
+3. Resize the window (or rotate a tablet) and confirm the car dashboard reflows between portrait and landscape grids.
+4. Activate quick toggles and verify the status banner updates with the latest action summary.
+
+## Screenshots
+
+- `public/screenshots/nethunter-car-mode.png` – Car mode dashboard in landscape layout.
+- `public/screenshots/nethunter-desktop.png` – Desktop console overview.
+
+Update the screenshots when the UI changes materially.

--- a/pages/apps/nethunter.jsx
+++ b/pages/apps/nethunter.jsx
@@ -1,0 +1,5 @@
+import NetHunterApp from '../../apps/nethunter';
+
+export default function NetHunterPage() {
+  return <NetHunterApp />;
+}

--- a/public/themes/Yaru/apps/nethunter.svg
+++ b/public/themes/Yaru/apps/nethunter.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="NetHunter icon">
+  <defs>
+    <linearGradient id="nethunter-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f1317" />
+      <stop offset="100%" stop-color="#1a1f26" />
+    </linearGradient>
+    <linearGradient id="nethunter-accent" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1793d1" />
+      <stop offset="100%" stop-color="#0f6fa1" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="8" ry="8" fill="url(#nethunter-bg)" />
+  <path
+    d="M12 46c6-12 12-18 20-18s14 6 20 18c-6 4-12 6-20 6s-14-2-20-6z"
+    fill="rgba(23,147,209,0.25)"
+  />
+  <path
+    d="M32 14c6 0 12 3 16 8-4 3-8 5-16 5s-12-2-16-5c4-5 10-8 16-8z"
+    fill="url(#nethunter-accent)"
+  />
+  <path
+    d="M20 28c4 2 8 3 12 3s8-1 12-3l4 6c-5 3-10 4-16 4s-11-1-16-4l4-6z"
+    fill="#0f6fa1"
+    opacity="0.85"
+  />
+  <circle cx="32" cy="32" r="6" fill="#0f1317" stroke="#1793d1" stroke-width="2" />
+  <path
+    d="M32 27l3 5-3 5-3-5 3-5z"
+    fill="#1793d1"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- add a NetHunter dual-mode app with a desktop console and car dashboard that uses large token-driven tiles and quick toggles
- implement a reusable orientation hook plus UI building blocks styled with shared Kali/Yaru design tokens
- document the new workflows, register the app in the catalogue, and add a themed NetHunter icon and route

## Testing
- `yarn lint` *(hangs in this environment; command was interrupted after no output)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f1fdb3f08328a09da8c8fb1e547e