### PR TITLE
[chrome-extension] guard scripts for ssr

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,37 +1,41 @@
-function getMedias() {
-  return Array.from(document.querySelectorAll('video, audio'));
-}
+(function initContentScript(global) {
+  if (!global || !global.document) return;
 
-function propagate(message) {
-  document.querySelectorAll('iframe').forEach((frame) => {
-    try {
-      frame.contentWindow.postMessage(message, '*');
-    } catch (e) {
-      // ignore cross-origin access errors
+  const { document } = global;
+
+  function getMedias() {
+    return Array.from(document.querySelectorAll('video, audio'));
+  }
+
+  function propagate(message) {
+    document.querySelectorAll('iframe').forEach((frame) => {
+      try {
+        frame.contentWindow?.postMessage(message, '*');
+      } catch (e) {
+        // ignore cross-origin access errors
+      }
+    });
+  }
+
+  chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+    if (msg.type === 'status') {
+      const list = getMedias().map((m) => ({
+        src: m.currentSrc || m.src,
+        playing: !m.paused,
+      }));
+      propagate({ type: 'status' });
+      sendResponse(list);
+    } else if (msg.type === 'play' || msg.type === 'pause') {
+      getMedias().forEach((m) => {
+        try {
+          msg.type === 'play' ? m.play() : m.pause();
+        } catch (e) {}
+      });
+      propagate({ type: msg.type });
     }
   });
-}
 
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  if (msg.type === 'status') {
-    const list = getMedias().map((m) => ({
-      src: m.currentSrc || m.src,
-      playing: !m.paused,
-    }));
-    propagate({ type: 'status' });
-    sendResponse(list);
-  } else if (msg.type === 'play' || msg.type === 'pause') {
-    getMedias().forEach((m) => {
-      try {
-        msg.type === 'play' ? m.play() : m.pause();
-      } catch (e) {}
-    });
-    propagate({ type: msg.type });
-  }
-});
-
-if (typeof window !== 'undefined') {
-  window.addEventListener('message', (ev) => {
+  global.addEventListener('message', (ev) => {
     const data = ev.data;
     if (!data || !data.type) return;
     if (data.type === 'play' || data.type === 'pause') {
@@ -46,7 +50,10 @@ if (typeof window !== 'undefined') {
         src: m.currentSrc || m.src,
         playing: !m.paused,
       }));
-      (ev.source as Window).postMessage({ type: 'statusResponse', list }, '*');
+      const { source } = ev;
+      if (source && typeof source.postMessage === 'function') {
+        source.postMessage({ type: 'statusResponse', list }, '*');
+      }
     }
   });
-}
+})(typeof globalThis !== 'undefined' ? globalThis : undefined);

--- a/chrome-extension/pip.js
+++ b/chrome-extension/pip.js
@@ -1,35 +1,38 @@
-const omnibox =
-  typeof document !== 'undefined'
-    ? document.getElementById('omnibox')
-    : null;
-const playBtn =
-  typeof document !== 'undefined' ? document.getElementById('play') : null;
-const pauseBtn =
-  typeof document !== 'undefined' ? document.getElementById('pause') : null;
+(function initPopup() {
+  if (typeof document === 'undefined') return;
 
-function refresh() {
-  chrome.runtime.sendMessage({ type: 'query' }, (response) => {
-    if (!Array.isArray(response) || !playBtn || !pauseBtn) return;
-    const anyPlaying = response.some((tab) =>
-      tab.medias.some((m) => m.playing),
-    );
-    playBtn.disabled = anyPlaying;
-    pauseBtn.disabled = !anyPlaying;
-  });
-}
+  const omnibox = document.getElementById('omnibox');
+  const playBtn = document.getElementById('play');
+  const pauseBtn = document.getElementById('pause');
 
-playBtn?.addEventListener('click', () => {
-  chrome.runtime.sendMessage({ type: 'control', action: 'play' });
-});
-
-pauseBtn?.addEventListener('click', () => {
-  chrome.runtime.sendMessage({ type: 'control', action: 'pause' });
-});
-
-chrome.runtime.onMessage.addListener((msg) => {
-  if (msg.type === 'refresh') {
-    refresh();
+  if (!playBtn || !pauseBtn) {
+    return;
   }
-});
 
-refresh();
+  function refresh() {
+    chrome.runtime.sendMessage({ type: 'query' }, (response) => {
+      if (!Array.isArray(response)) return;
+      const anyPlaying = response.some((tab) =>
+        tab.medias.some((m) => m.playing),
+      );
+      playBtn.disabled = anyPlaying;
+      pauseBtn.disabled = !anyPlaying;
+    });
+  }
+
+  playBtn.addEventListener('click', () => {
+    chrome.runtime.sendMessage({ type: 'control', action: 'play' });
+  });
+
+  pauseBtn.addEventListener('click', () => {
+    chrome.runtime.sendMessage({ type: 'control', action: 'pause' });
+  });
+
+  chrome.runtime.onMessage.addListener((msg) => {
+    if (msg.type === 'refresh') {
+      refresh();
+    }
+  });
+
+  refresh();
+})();


### PR DESCRIPTION
## Summary
- wrap the media control content script in a guarded initializer to avoid top-level window/document usage and remove the stray TS cast
- encapsulate the PiP popup UI wiring in an init IIFE so globals are only accessed when the DOM is available

## Testing
- yarn eslint chrome-extension/pip.js
- yarn eslint chrome-extension/content.js
- yarn lint *(fails: pre-existing accessibility and no-top-level-window violations in unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f8a757d483289472a1fec0f85033