### PR TITLE
[tests] align window snap height expectations

### DIFF
--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -1,6 +1,12 @@
 import React, { act } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Window from '../components/base/window';
+import { DESKTOP_TOP_PADDING, SNAP_BOTTOM_INSET } from '../utils/uiConstants';
+
+const computeSnappedHeightPercent = () => {
+  const availableHeight = window.innerHeight - DESKTOP_TOP_PADDING - SNAP_BOTTOM_INSET;
+  return (availableHeight / window.innerHeight) * 100;
+};
 
 const setViewport = (width: number, height: number) => {
   Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: width });
@@ -201,7 +207,7 @@ describe('Window snapping finalize and release', () => {
 
     expect(ref.current!.state.snapped).toBe('left');
     expect(ref.current!.state.width).toBeCloseTo(50);
-    const expectedHeight = ((window.innerHeight - 28) / window.innerHeight) * 100;
+    const expectedHeight = computeSnappedHeightPercent();
     expect(ref.current!.state.height).toBeCloseTo(expectedHeight, 5);
     expect(winEl.style.transform).toBe('translate(0px, 0px)');
   });
@@ -244,7 +250,7 @@ describe('Window snapping finalize and release', () => {
 
     expect(ref.current!.state.snapped).toBe('right');
     expect(ref.current!.state.width).toBeCloseTo(50);
-    const expectedHeight = ((window.innerHeight - 28) / window.innerHeight) * 100;
+    const expectedHeight = computeSnappedHeightPercent();
     expect(ref.current!.state.height).toBeCloseTo(expectedHeight, 5);
     expect(winEl.style.transform).toBe(`translate(${window.innerWidth / 2}px, 0px)`);
   });
@@ -328,7 +334,7 @@ describe('Window snapping finalize and release', () => {
     });
 
     expect(ref.current!.state.snapped).toBe('left');
-    const snappedHeight = ((window.innerHeight - 28) / window.innerHeight) * 100;
+    const snappedHeight = computeSnappedHeightPercent();
     expect(ref.current!.state.height).toBeCloseTo(snappedHeight, 5);
 
     const keyboardEvent = {
@@ -390,7 +396,7 @@ describe('Window snapping finalize and release', () => {
     });
 
     expect(ref.current!.state.snapped).toBe('left');
-    const snappedHeight = ((window.innerHeight - 28) / window.innerHeight) * 100;
+    const snappedHeight = computeSnappedHeightPercent();
     expect(ref.current!.state.height).toBeCloseTo(snappedHeight, 5);
 
     act(() => {

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -7,12 +7,11 @@ import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
 import styles from './window.module.css';
-import { DESKTOP_TOP_PADDING, WINDOW_TOP_INSET } from '../../utils/uiConstants';
+import { DESKTOP_TOP_PADDING, SNAP_BOTTOM_INSET, WINDOW_TOP_INSET } from '../../utils/uiConstants';
 
 const EDGE_THRESHOLD_MIN = 48;
 const EDGE_THRESHOLD_MAX = 160;
 const EDGE_THRESHOLD_RATIO = 0.05;
-const SNAP_BOTTOM_INSET = 28;
 
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 

--- a/utils/uiConstants.ts
+++ b/utils/uiConstants.ts
@@ -1,3 +1,4 @@
 export const NAVBAR_HEIGHT = 56;
 export const DESKTOP_TOP_PADDING = NAVBAR_HEIGHT + 8;
 export const WINDOW_TOP_INSET = 8;
+export const SNAP_BOTTOM_INSET = 28;


### PR DESCRIPTION
## Summary
- share the snap bottom inset constant in `utils/uiConstants` so production code and tests use the same value
- update the window snapping tests to derive their expected heights from the shared desktop padding and inset constants

## Testing
- yarn lint
- yarn test --watch=false --runInBand __tests__/window.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9fe29199c83289ed72e829f403aca