### PR TITLE
[desktop] fix missing desktop padding constant

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -22,6 +22,7 @@ import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { addRecentApp } from '../../utils/recentStorage';
+import { DESKTOP_TOP_PADDING } from '../../utils/uiConstants';
 import { useSnapSetting } from '../../hooks/usePersistentState';
 import {
     clampWindowTopPosition,


### PR DESCRIPTION
## Summary
- import the DESKTOP_TOP_PADDING constant into the desktop screen to resolve the runtime reference error when rendering the desktop

## Testing
- yarn lint --max-warnings=2


------
https://chatgpt.com/codex/tasks/task_e_68da0ea3dab08328890e8641d9ddb8ca