### PR TITLE
[core] Reset error boundary after child changes

### DIFF
--- a/__tests__/ErrorBoundary.test.tsx
+++ b/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import ErrorBoundary from '../components/core/ErrorBoundary';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+
+interface ProblemChildProps {
+  shouldThrow?: boolean;
+}
+
+const ProblemChild = ({ shouldThrow }: ProblemChildProps) => {
+  if (shouldThrow) {
+    throw new Error('Boom');
+  }
+
+  return <p>All good</p>;
+};
+
+describe('ErrorBoundary', () => {
+  const originalConsoleError = console.error;
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+    jest.restoreAllMocks();
+  });
+
+  it('renders fallback UI when an error is thrown', () => {
+    render(
+      <ErrorBoundary>
+        <ProblemChild shouldThrow />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong.');
+    expect(screen.getByText(/please refresh/i)).toBeInTheDocument();
+  });
+
+  it('recovers and renders children again when they change after an error', async () => {
+    const { rerender } = render(
+      <ErrorBoundary>
+        <ProblemChild shouldThrow />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    rerender(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('All good')).toBeInTheDocument();
+  });
+});
+

--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -25,6 +25,12 @@ class ErrorBoundary extends Component<Props, State> {
     log.error('ErrorBoundary caught an error', { error, errorInfo });
   }
 
+  componentDidUpdate(prevProps: Props) {
+    if (this.state.hasError && prevProps.children !== this.props.children) {
+      this.setState({ hasError: false });
+    }
+  }
+
   render() {
     if (this.state.hasError) {
       return (


### PR DESCRIPTION
## Summary
- reset the shared error boundary state when its children change so users can recover without a full refresh
- add regression tests covering the fallback UI and recovery behavior

## Testing
- [x] yarn test ErrorBoundary.test.tsx
- [ ] yarn lint

## Flags
- [ ] NEXT_PUBLIC_ENABLE_ANALYTICS
- [ ] FEATURE_TOOL_APIS


------
https://chatgpt.com/codex/tasks/task_e_68da103423b08328b0e8102ac8b9e1d1