### PR TITLE
[tooling] skip node_modules in lint-changed script

### DIFF
--- a/scripts/lint-changed.mjs
+++ b/scripts/lint-changed.mjs
@@ -70,6 +70,9 @@ const collectChangedFiles = () => {
     .forEach((file) => files.add(file));
 
   return Array.from(files).filter((file) => {
+    if (file.split(path.sep).includes('node_modules')) {
+      return false;
+    }
     const ext = path.extname(file);
     return ESLINT_FILE_EXTENSIONS.has(ext);
   });


### PR DESCRIPTION
## Summary
- skip files inside node_modules when collecting lint targets so the helper never passes vendored code to ESLint

## Testing
- yarn lint
- CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68da0fe0b8888328a5a8e577fc35cb5f