### PR TITLE
[ui] Align window shell styling with shared tokens

### DIFF
--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -1,8 +1,6 @@
 .windowFrame {
+  @apply border-window shadow-window;
   position: relative;
-  border: 1px solid var(--color-window-border);
-  border-radius: var(--radius-6);
-  box-shadow: var(--shadow-2);
   overflow: hidden;
   transition: filter var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
 }

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -164,7 +164,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
 
   return (
     <div
-      className={`flex flex-col w-full h-full ${className}`.trim()}
+      className={`flex flex-col w-full h-full border-window shadow-window ${className}`.trim()}
       tabIndex={0}
       onKeyDown={onKeyDown}
     >

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -20,6 +20,19 @@
   }
 }
 
+@layer components {
+  .border-window {
+    border: 1px solid var(--color-window-border);
+    border-radius: var(--radius-6);
+  }
+
+  .shadow-window {
+    box-shadow: var(--shadow-2);
+    -webkit-box-shadow: var(--shadow-2);
+    -moz-box-shadow: var(--shadow-2);
+  }
+}
+
 @layer base {
   button {
     @apply transition-hover transition-active;


### PR DESCRIPTION
## Summary
- add shared `border-window` and `shadow-window` utility classes backed by the window design tokens
- update the tabbed window shell and core window frame to consume the shared classes for consistent chrome

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da1bf91d288328ac6dac6cf64c1b9b