### PR TITLE
[ui] unify active window focus ring

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -652,7 +652,6 @@ export class Window extends Component {
                             this.state.maximized ? 'duration-300' : '',
                             this.props.minimized ? 'opacity-0 invisible duration-200' : '',
                             this.state.grabbed ? 'opacity-70' : '',
-                            this.state.snapPreview ? 'ring-2 ring-blue-400' : '',
                             this.props.isFocused ? 'z-30' : 'z-20',
                             'opened-window overflow-hidden min-w-1/4 min-h-1/4 main-window absolute flex flex-col window-shadow',
                             styles.windowFrame,

--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -5,6 +5,11 @@
   box-shadow: var(--shadow-2);
   overflow: hidden;
   transition: filter var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+  outline: none;
+}
+
+.windowFrame:focus-visible {
+  outline: none;
 }
 
 .windowFrame::before {
@@ -23,12 +28,17 @@
   z-index: 2;
 }
 
+.windowFrameActive {
+  box-shadow: var(--shadow-2), var(--focus-ring-window);
+  filter: none;
+}
+
 .windowFrameActive::before {
   opacity: 1;
 }
 
 .windowFrameInactive {
-  filter: brightness(0.85);
+  filter: brightness(0.85) saturate(0.9);
 }
 
 .windowFrameMaximized {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -85,6 +85,10 @@ html[data-theme='matrix'] {
   outline-offset: 2px;
 }
 
+.opened-window:focus-visible {
+  outline: none;
+}
+
 html {
   scrollbar-color: var(--kali-border, var(--color-border)) transparent;
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -80,6 +80,8 @@
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
+  --focus-ring-window: 0 0 0 1px rgba(23, 147, 209, 0.85),
+    0 0 0 6px rgba(23, 147, 209, 0.25);
 }
 
 /* High contrast theme */


### PR DESCRIPTION
## Summary
- add a shared focus ring design token for windows and reuse it in the shell
- highlight the active window with the token while dimming inactive frames
- drop ad-hoc tailwind rings so the shell relies on the shared styling

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da1bfc5c8483289b3ab7fa0bc77e52