### PR TITLE
[desktop] Add invisible resize handles

### DIFF
--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -51,12 +51,83 @@
   height: 28px;
 }
 
-.windowYBorder {
-  height: calc(100% - 10px);
-  width: calc(100% + 10px);
+.resizeHandles {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
 }
 
-.windowXBorder {
-  height: calc(100% + 10px);
-  width: calc(100% - 10px);
+.resizeHandle {
+  position: absolute;
+  pointer-events: auto;
+  background: transparent;
+  user-select: none;
+  touch-action: none;
+}
+
+.handleNorth,
+.handleSouth {
+  left: 12px;
+  right: 12px;
+  height: 8px;
+}
+
+.handleNorth {
+  top: -4px;
+  cursor: ns-resize;
+}
+
+.handleSouth {
+  bottom: -4px;
+  cursor: ns-resize;
+}
+
+.handleEast,
+.handleWest {
+  top: 12px;
+  bottom: 12px;
+  width: 8px;
+}
+
+.handleEast {
+  right: -4px;
+  cursor: ew-resize;
+}
+
+.handleWest {
+  left: -4px;
+  cursor: ew-resize;
+}
+
+.handleNorthEast,
+.handleNorthWest,
+.handleSouthEast,
+.handleSouthWest {
+  width: 12px;
+  height: 12px;
+}
+
+.handleNorthEast {
+  top: -6px;
+  right: -6px;
+  cursor: nesw-resize;
+}
+
+.handleNorthWest {
+  top: -6px;
+  left: -6px;
+  cursor: nwse-resize;
+}
+
+.handleSouthEast {
+  bottom: -6px;
+  right: -6px;
+  cursor: nwse-resize;
+}
+
+.handleSouthWest {
+  bottom: -6px;
+  left: -6px;
+  cursor: nesw-resize;
 }


### PR DESCRIPTION
## Summary
- replace the legacy window border helpers with a dedicated resize handle overlay
- add eight invisible hit targets sized for edges and corners with appropriate resize cursors
- update styles so the handles sit above content without capturing unrelated clicks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da1bfd44d08328800e6dccdcd6703a