### PR TITLE
[ui] unify whisker menu motion tokens

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -25,7 +25,7 @@ type CategoryDefinitionBase = {
   icon: string;
 } & CategorySource;
 
-const TRANSITION_DURATION = 180;
+const MENU_TRANSITION_FALLBACK_MS = 190;
 const RECENT_STORAGE_KEY = 'recentApps';
 const CATEGORY_STORAGE_KEY = 'whisker-menu-category';
 
@@ -243,11 +243,23 @@ const WhiskerMenu: React.FC = () => {
     setIsOpen(false);
   };
 
+  const readMenuTransitionDuration = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return MENU_TRANSITION_FALLBACK_MS;
+    }
+    const rawValue = window
+      .getComputedStyle(document.documentElement)
+      .getPropertyValue('--whisker-menu-transition-duration');
+    const parsed = Number.parseFloat(rawValue);
+    return Number.isFinite(parsed) ? parsed : MENU_TRANSITION_FALLBACK_MS;
+  }, []);
+
   useEffect(() => {
     if (!isOpen && isVisible) {
+      const menuTransitionDuration = readMenuTransitionDuration();
       hideTimer.current = setTimeout(() => {
         setIsVisible(false);
-      }, TRANSITION_DURATION);
+      }, menuTransitionDuration);
       return () => {
         if (hideTimer.current) clearTimeout(hideTimer.current);
       };
@@ -264,7 +276,7 @@ const WhiskerMenu: React.FC = () => {
         hideTimer.current = null;
       }
     };
-  }, [isOpen, isVisible]);
+  }, [isOpen, isVisible, readMenuTransitionDuration]);
 
   const showMenu = useCallback(() => {
     setIsVisible(true);
@@ -373,7 +385,7 @@ const WhiskerMenu: React.FC = () => {
         ref={buttonRef}
         type="button"
         onClick={toggleMenu}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className="pl-3 pr-3 outline-none transition whisker-menu-motion border-b-2 border-transparent py-1"
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"
@@ -387,10 +399,9 @@ const WhiskerMenu: React.FC = () => {
       {isVisible && (
         <div
           ref={menuRef}
-          className={`absolute top-full left-1/2 mt-3 z-50 flex max-h-[80vh] w-[min(100vw-1.5rem,680px)] -translate-x-1/2 flex-col overflow-x-hidden overflow-y-auto rounded-xl border border-[#1f2a3a] bg-[#0b121c] text-white shadow-[0_20px_40px_rgba(0,0,0,0.45)] transition-all duration-200 ease-out sm:left-0 sm:mt-1 sm:w-[680px] sm:max-h-[440px] sm:-translate-x-0 sm:flex-row sm:overflow-hidden ${
+          className={`absolute top-full left-1/2 mt-3 z-50 flex max-h-[80vh] w-[min(100vw-1.5rem,680px)] -translate-x-1/2 flex-col overflow-x-hidden overflow-y-auto rounded-xl border border-[#1f2a3a] bg-[#0b121c] text-white shadow-[0_20px_40px_rgba(0,0,0,0.45)] transition-all whisker-menu-motion sm:left-0 sm:mt-1 sm:w-[680px] sm:max-h-[440px] sm:-translate-x-0 sm:flex-row sm:overflow-hidden ${
             isOpen ? 'opacity-100 translate-y-0 scale-100' : 'pointer-events-none opacity-0 -translate-y-2 scale-95'
           }`}
-          style={{ transitionDuration: `${TRANSITION_DURATION}ms` }}
           tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {
@@ -418,7 +429,7 @@ const WhiskerMenu: React.FC = () => {
                     categoryButtonRefs.current[index] = el;
                   }}
                   type="button"
-                  className={`group flex items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1724] ${
+                  className={`group flex items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition whisker-menu-motion focus:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1724] ${
                     category === cat.id
                       ? 'bg-[#162236] text-white shadow-[inset_2px_0_0_#53b9ff]'
                       : 'text-gray-300 hover:bg-[#152133] hover:text-white'
@@ -463,7 +474,7 @@ const WhiskerMenu: React.FC = () => {
                     key={app.id}
                     type="button"
                     onClick={() => openSelectedApp(app.id)}
-                    className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#122136] text-white transition hover:-translate-y-0.5 hover:bg-[#1b2d46] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1a29]"
+                    className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#122136] text-white transition whisker-menu-motion hover:-translate-y-0.5 hover:bg-[#1b2d46] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1a29]"
                     aria-label={`Open ${app.title}`}
                   >
                     <Image
@@ -522,7 +533,7 @@ const WhiskerMenu: React.FC = () => {
                     <li key={app.id}>
                       <button
                         type="button"
-                        className={`flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1a29] ${
+                        className={`flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm transition whisker-menu-motion focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1a29] ${
                           idx === highlight
                             ? 'bg-[#162438] text-white shadow-[0_0_0_1px_rgba(83,185,255,0.35)]'
                             : 'text-gray-200 hover:bg-[#142132]'

--- a/docs/motion-tokens.md
+++ b/docs/motion-tokens.md
@@ -1,0 +1,10 @@
+# Motion tokens for the Whisker menu
+
+The Whisker menu uses shared motion primitives so opening, closing, and list view transitions stay synchronized.
+
+- `--whisker-menu-transition-duration`: declared in `styles/tokens.css`, currently `190ms` to stay inside the 180–200ms Ubuntu desktop guidance range.
+- `--whisker-menu-transition-easing`: declared in `styles/tokens.css`, currently `cubic-bezier(0.4, 0, 0.2, 1)` (the standard material-inspired ease).
+- `.whisker-menu-motion`: defined in `styles/index.css`. Apply this class alongside a `transition` or `transition-all` utility to hook into the shared duration and easing without redefining them inline.
+- `MENU_TRANSITION_FALLBACK_MS`: a TypeScript constant inside `components/menu/WhiskerMenu.tsx` that mirrors the CSS duration. The component reads the CSS custom property on the client; the fallback keeps SSR logic safe if the variable is unavailable.
+
+When creating new interactions around the menu, reuse `.whisker-menu-motion` or read the same custom properties so close timers and animations stay in sync.

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,11 @@ body{
     color: var(--color-text);
 }
 
+.whisker-menu-motion {
+    transition-duration: var(--whisker-menu-transition-duration);
+    transition-timing-function: var(--whisker-menu-transition-easing);
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -71,6 +71,9 @@
   --motion-fast: 150ms;
   --motion-medium: 300ms;
   --motion-slow: 500ms;
+  /* Whisker menu motion */
+  --whisker-menu-transition-duration: 190ms;
+  --whisker-menu-transition-easing: cubic-bezier(0.4, 0, 0.2, 1);
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;


### PR DESCRIPTION
## Summary
- centralize Whisker menu animation timing via new motion design tokens and a reusable utility class
- update the menu components to consume the shared motion class and read the CSS duration for hide timers
- add documentation covering the motion constants for future consumers

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da1bff478883289a5ac685bea06ee2