### PR TITLE
[ui] Improve breadcrumb overflow handling

### DIFF
--- a/__tests__/Breadcrumbs.test.tsx
+++ b/__tests__/Breadcrumbs.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Breadcrumbs from '../components/ui/Breadcrumbs';
+
+type HTMLElementPrototypeWithOverrides = typeof HTMLElement.prototype & {
+  clientWidth?: number;
+  scrollWidth?: number;
+};
+
+const elementPrototype = HTMLElement.prototype as HTMLElementPrototypeWithOverrides;
+
+const originalClientWidth = Object.getOwnPropertyDescriptor(elementPrototype, 'clientWidth');
+const originalScrollWidth = Object.getOwnPropertyDescriptor(elementPrototype, 'scrollWidth');
+
+const mockLayout = (clientWidth: number, scrollWidth: number) => {
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get() {
+      return clientWidth;
+    },
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+    configurable: true,
+    get() {
+      return scrollWidth;
+    },
+  });
+};
+
+const restoreLayout = () => {
+  if (originalClientWidth) {
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+  } else {
+    delete elementPrototype.clientWidth;
+  }
+
+  if (originalScrollWidth) {
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalScrollWidth);
+  } else {
+    delete elementPrototype.scrollWidth;
+  }
+};
+
+const noop = () => {};
+
+describe('Breadcrumbs', () => {
+  afterEach(() => {
+    restoreLayout();
+  });
+
+  it('renders full crumb labels when space is sufficient', () => {
+    mockLayout(600, 400);
+
+    render(
+      <Breadcrumbs
+        path={[
+          { name: 'root' },
+          { name: 'Projects' },
+          { name: 'Case Files' },
+        ]}
+        onNavigate={noop}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Projects' })).toHaveTextContent('Projects');
+    expect(screen.getByRole('button', { name: 'Case Files' })).toHaveTextContent('Case Files');
+  });
+
+  it('middle-truncates intermediate crumbs when the path overflows', async () => {
+    const intermediate = 'Extremely long folder name used for breadcrumb overflow testing';
+    const secondary = 'Second folder with a very long name to demonstrate truncation';
+
+    mockLayout(220, 640);
+
+    render(
+      <Breadcrumbs
+        path={[
+          { name: 'root' },
+          { name: intermediate },
+          { name: secondary },
+          { name: 'final-report.txt' },
+        ]}
+        onNavigate={noop}
+      />,
+    );
+
+    const firstIntermediate = await screen.findByRole('button', { name: intermediate });
+    const secondIntermediate = screen.getByRole('button', { name: secondary });
+
+    const truncate = (label: string) => {
+      if (label.length <= 24) {
+        return label;
+      }
+
+      const ellipsis = '…';
+      const keep = 24 - ellipsis.length;
+      const start = Math.ceil(keep / 2);
+      const end = Math.floor(keep / 2);
+
+      return `${label.slice(0, start)}${ellipsis}${label.slice(label.length - end)}`;
+    };
+
+    expect(firstIntermediate).toHaveTextContent(truncate(intermediate));
+    expect(secondIntermediate).toHaveTextContent(truncate(secondary));
+
+    [firstIntermediate, secondIntermediate].forEach((element, index) => {
+      const label = index === 0 ? intermediate : secondary;
+
+      expect(element).toHaveAttribute('title', label);
+      expect(element).toHaveAttribute('aria-label', label);
+    });
+
+    expect(screen.getByRole('navigation', { name: /breadcrumb/i })).toHaveClass('overflow-hidden');
+  });
+});

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 interface Segment {
   name: string;
@@ -9,21 +9,114 @@ interface Props {
   onNavigate: (index: number) => void;
 }
 
+const MAX_TRUNCATED_LENGTH = 24;
+
 const Breadcrumbs: React.FC<Props> = ({ path, onNavigate }) => {
+  const navRef = useRef<HTMLElement | null>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  const checkOverflow = useCallback(() => {
+    const node = navRef.current;
+
+    if (!node) {
+      return;
+    }
+
+    const { clientWidth, scrollWidth } = node;
+    const shouldTruncate = scrollWidth > clientWidth + 1;
+
+    setIsOverflowing((prev) => (prev !== shouldTruncate ? shouldTruncate : prev));
+  }, []);
+
+  useEffect(() => {
+    checkOverflow();
+  }, [checkOverflow, path]);
+
+  useEffect(() => {
+    const node = navRef.current;
+
+    if (!node || typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+
+    const observer = new ResizeObserver(() => {
+      checkOverflow();
+    });
+
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [checkOverflow]);
+
+  useEffect(() => {
+    if (!isOverflowing || typeof window === 'undefined') {
+      return undefined;
+    }
+
+    // Re-evaluate after the truncated labels have rendered to avoid stale overflow state.
+    const timeout = window.setTimeout(() => {
+      checkOverflow();
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [checkOverflow, isOverflowing]);
+
+  const visiblePath = useMemo(
+    () =>
+      path.map((seg, idx) => {
+        const label = seg.name || '/';
+
+        if (!isOverflowing || idx === 0 || idx === path.length - 1) {
+          return label;
+        }
+
+        if (label.length <= MAX_TRUNCATED_LENGTH) {
+          return label;
+        }
+
+        const ellipsis = '…';
+        const keep = MAX_TRUNCATED_LENGTH - ellipsis.length;
+        const start = Math.ceil(keep / 2);
+        const end = Math.floor(keep / 2);
+
+        return `${label.slice(0, start)}${ellipsis}${label.slice(label.length - end)}`;
+      }),
+    [isOverflowing, path],
+  );
+
   return (
-    <nav className="flex items-center space-x-1 text-white" aria-label="Breadcrumb">
-      {path.map((seg, idx) => (
-        <React.Fragment key={idx}>
-          <button
-            type="button"
-            onClick={() => onNavigate(idx)}
-            className="hover:underline focus:outline-none"
-          >
-            {seg.name || '/'}
-          </button>
-          {idx < path.length - 1 && <span>/</span>}
-        </React.Fragment>
-      ))}
+    <nav
+      ref={navRef}
+      className="flex items-center space-x-1 overflow-hidden text-white"
+      aria-label="Breadcrumb"
+    >
+      {path.map((seg, idx) => {
+        const displayLabel = visiblePath[idx];
+        const originalLabel = seg.name || '/';
+
+        return (
+          <React.Fragment key={idx}>
+            <button
+              type="button"
+              onClick={() => onNavigate(idx)}
+              className="min-w-0 max-w-[12rem] truncate whitespace-nowrap text-left hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/70"
+              title={originalLabel}
+              aria-label={originalLabel}
+            >
+              {displayLabel}
+            </button>
+            {idx < path.length - 1 && (
+              <span className="text-white/70" aria-hidden="true">
+                /
+              </span>
+            )}
+          </React.Fragment>
+        );
+      })}
     </nav>
   );
 };


### PR DESCRIPTION
## Summary
- detect breadcrumb overflow and truncate intermediate segments with a middle ellipsis
- add accessible tooltips for breadcrumb buttons including keyboard focus support
- add unit tests to cover overflow handling and tooltip attributes

## Testing
- [x] yarn test --runTestsByPath __tests__/Breadcrumbs.test.tsx

## Flags
- No feature flags were toggled

------
https://chatgpt.com/codex/tasks/task_e_68da1c02ebf08328b9797aab0fa71903