### PR TITLE
[ui] Improve notification bell announcements

### DIFF
--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -80,6 +80,9 @@ const NotificationBell: React.FC = () => {
     markAllRead,
   } = useNotifications();
 
+  const [liveCount, setLiveCount] = useState(unreadCount);
+  const previousUnreadCountRef = useRef(unreadCount);
+
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -113,6 +116,14 @@ const NotificationBell: React.FC = () => {
       return !prev;
     });
   }, []);
+
+  useEffect(() => {
+    if (previousUnreadCountRef.current === unreadCount) {
+      return;
+    }
+    previousUnreadCountRef.current = unreadCount;
+    setLiveCount(unreadCount);
+  }, [unreadCount]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -233,12 +244,34 @@ const NotificationBell: React.FC = () => {
     closePanel();
   }, [clearNotifications, closePanel, notifications.length]);
 
+  const liveAnnouncement = useMemo(() => {
+    if (liveCount === 0) {
+      return 'No unread notifications';
+    }
+    if (liveCount === 1) {
+      return '1 unread notification';
+    }
+    return `${liveCount} unread notifications`;
+  }, [liveCount]);
+
+  const buttonAriaLabel = useMemo(
+    () => `Open notifications. ${liveAnnouncement}`,
+    [liveAnnouncement],
+  );
+
+  const badgeDisplayCount = useMemo(
+    () => (unreadCount > 99 ? '99+' : unreadCount.toString()),
+    [unreadCount],
+  );
+
+  const hasUnread = unreadCount > 0;
+
   return (
     <div className="relative">
       <button
         type="button"
         ref={buttonRef}
-        aria-label="Open notifications"
+        aria-label={buttonAriaLabel}
         aria-haspopup="dialog"
         aria-expanded={isOpen}
         aria-controls={panelId}
@@ -255,11 +288,14 @@ const NotificationBell: React.FC = () => {
           <path d="M10 2a4 4 0 00-4 4v1.09c0 .471-.158.93-.45 1.3L4.3 10.2A1 1 0 005 11.8h10a1 1 0 00.7-1.6l-1.25-1.81a2 2 0 01-.45-1.3V6a4 4 0 00-4-4z" />
           <path d="M7 12a3 3 0 006 0H7z" />
         </svg>
-        {unreadCount > 0 && (
-          <span className="absolute -top-1.5 -right-1.5 min-w-[1.5rem] rounded-full bg-ubb-orange px-1 text-center text-[0.65rem] font-semibold leading-5 text-white">
-            {unreadCount > 99 ? '99+' : unreadCount}
-          </span>
-        )}
+        <span
+          className={`pointer-events-none absolute -top-1.5 -right-1.5 min-w-[1.5rem] rounded-full bg-ubb-orange px-1 text-center text-[0.65rem] font-semibold leading-5 text-white transition-opacity ${hasUnread ? 'opacity-100' : 'opacity-0'}`}
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          <span aria-hidden="true">{badgeDisplayCount}</span>
+          <span className="sr-only">{liveAnnouncement}</span>
+        </span>
       </button>
       {isOpen && (
         <div


### PR DESCRIPTION
## Summary
- add contextual aria-label messaging for the notification bell based on unread counts
- wrap the badge indicator in a polite aria-live region so screen readers announce updates
- track unread count changes to trigger announcements without repeating identical counts

## Testing
- [ ] yarn lint
- [ ] yarn test

------
https://chatgpt.com/codex/tasks/task_e_68da1c04f3d8832897fd2caedf46d81c