### PR TITLE
[ui] align toast styling with shared tokens

### DIFF
--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -32,7 +32,7 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-[var(--color-surface)] text-[var(--color-text)] border-card px-4 py-3 rounded-md shadow-card flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
       <span>{message}</span>
       {onAction && actionLabel && (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,6 +21,8 @@
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   --kali-text: #f5f5f5;
+  --border-card: color-mix(in srgb, var(--color-border) 70%, var(--color-text) 30%);
+  --shadow-card: var(--shadow-2);
   accent-color: var(--color-control-accent);
 }
 

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -18,6 +18,12 @@
   .accent-border {
     border-color: color-mix(in srgb, var(--color-accent), transparent 45%);
   }
+  .border-card {
+    border: 1px solid var(--border-card);
+  }
+  .shadow-card {
+    box-shadow: var(--shadow-card);
+  }
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- add shared border-card and shadow-card utilities backed by theme tokens
- restyle the toast component to consume the shared tokens and theme surface/text colors

## Testing
- yarn lint
- Manual: toggled theme dataset between default, dark, neon, and matrix while triggering toast

------
https://chatgpt.com/codex/tasks/task_e_68da1c066ef08328a468e0d6511fe3d3