### PR TITLE
[ui] enhance progress bar variants

### DIFF
--- a/components/ui/ProgressBar.tsx
+++ b/components/ui/ProgressBar.tsx
@@ -1,24 +1,84 @@
 import React from 'react';
 
 interface ProgressBarProps {
-  progress: number;
+  progress?: number;
   className?: string;
+  wrapperClassName?: string;
+  min?: number;
+  max?: number;
+  showValue?: boolean;
+  variant?: 'determinate' | 'indeterminate';
 }
 
-export default function ProgressBar({ progress, className = '' }: ProgressBarProps) {
-  const clamped = Math.max(0, Math.min(progress, 100));
+export default function ProgressBar({
+  progress = 0,
+  className = '',
+  wrapperClassName = '',
+  min = 0,
+  max = 100,
+  showValue = true,
+  variant = 'determinate',
+}: ProgressBarProps) {
+  const isDeterminate = variant === 'determinate';
+  const rangeMin = Math.min(min, max);
+  const rangeMax = Math.max(min, max);
+  const isZeroRange = rangeMax === rangeMin;
+  const safeRange = isZeroRange ? 1 : rangeMax - rangeMin;
+  const rawProgress = progress ?? rangeMin;
+  const clamped = Math.min(Math.max(rawProgress, rangeMin), rangeMax);
+  const percentComplete = isZeroRange
+    ? 100
+    : ((clamped - rangeMin) / safeRange) * 100;
+  const ariaProps: React.AriaAttributes = isDeterminate
+    ? {
+        'aria-valuenow': Math.round(clamped),
+        'aria-valuemin': rangeMin,
+        'aria-valuemax': rangeMax,
+      }
+    : { 'aria-busy': true };
+
   return (
-    <div
-      className={`w-32 h-2 bg-gray-300 rounded ${className}`}
-      role="progressbar"
-      aria-valuenow={Math.round(clamped)}
-      aria-valuemin={0}
-      aria-valuemax={100}
-    >
+    <div className={`inline-flex items-center gap-2 ${wrapperClassName}`}>
       <div
-        className="h-full bg-blue-500 transition-all duration-200"
-        style={{ width: `${clamped}%` }}
-      />
+        className={`relative w-32 h-2 overflow-hidden rounded bg-gray-300 ${className}`}
+        role="progressbar"
+        {...ariaProps}
+      >
+        {isDeterminate ? (
+          <div
+            className="h-full bg-blue-500 transition-all duration-200"
+            style={{ width: `${percentComplete}%` }}
+          />
+        ) : (
+          <div className="absolute inset-0">
+            <div className="animate-indeterminate absolute inset-y-0 -left-1/2 w-1/2 bg-gradient-to-r from-blue-400 via-blue-500 to-blue-400" />
+          </div>
+        )}
+      </div>
+      {isDeterminate && showValue ? (
+        <span className="text-xs font-medium text-blue-600" aria-live="polite">
+          {Math.round(percentComplete)}%
+        </span>
+      ) : null}
+      <style jsx>{`
+        .animate-indeterminate {
+          animation: progress-indeterminate 1.4s ease-in-out infinite;
+        }
+
+        @keyframes progress-indeterminate {
+          0% {
+            transform: translateX(-100%);
+          }
+
+          50% {
+            transform: translateX(-10%);
+          }
+
+          100% {
+            transform: translateX(200%);
+          }
+        }
+      `}</style>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a variant prop to the progress bar component for determinate and indeterminate modes
- update accessibility attributes, optional value text, and add an animated indeterminate treatment

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da1c088ec4832896e42a7c8deaea11