### PR TITLE
[ui] align quick settings borders with token

### DIFF
--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -23,7 +23,7 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border border-card ${
         open ? '' : 'hidden'
       }`}
     >
@@ -36,22 +36,33 @@ const QuickSettings = ({ open }: Props) => {
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
+      <label className="px-4 pb-2 flex cursor-pointer items-center justify-between">
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
+        <input
+          aria-label="Toggle sound"
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+        />
+      </label>
+      <label className="px-4 pb-2 flex cursor-pointer items-center justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
+        <input
+          aria-label="Toggle network availability"
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+        />
+      </label>
+      <label className="px-4 flex cursor-pointer items-center justify-between">
         <span>Reduced motion</span>
         <input
+          aria-label="Toggle reduced motion"
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
         />
-      </div>
+      </label>
     </div>
   );
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,6 +15,7 @@
   --color-surface: #1a1f26; /* panel surfaces */
   --color-inverse: #000000; /* inverse of text */
   --color-border: #2a2e36; /* subtle borders */
+  --border-card: color-mix(in srgb, var(--color-border) 65%, transparent);
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
   --color-focus-ring: var(--color-accent);
@@ -40,6 +41,7 @@ html[data-theme='dark'] {
   --color-surface: #121212;
   --color-inverse: #ffffff;
   --color-border: #333333;
+  --border-card: color-mix(in srgb, var(--color-border) 65%, transparent);
   --color-terminal: #00ff00;
   --color-dark: #0a0a0a;
 }
@@ -55,6 +57,7 @@ html[data-theme='neon'] {
   --color-surface: #111111;
   --color-inverse: #ffffff;
   --color-border: #333333;
+  --border-card: color-mix(in srgb, var(--color-border) 65%, transparent);
   --color-terminal: #39ff14;
   --color-dark: #000000;
 }
@@ -70,6 +73,7 @@ html[data-theme='matrix'] {
   --color-surface: #001100;
   --color-inverse: #ffffff;
   --color-border: #003300;
+  --border-card: color-mix(in srgb, var(--color-border) 65%, transparent);
   --color-terminal: #00ff00;
   --color-dark: #000000;
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -93,6 +93,7 @@
   --color-ub-orange: #ffff00;
   --color-ub-lite-abrgn: #00ffff;
   --color-ub-border-orange: #ffff00;
+  --border-card: var(--color-ub-border-orange);
   --game-color-secondary: #ffff00;
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
@@ -136,5 +137,6 @@
     --color-ub-orange: #ffff00;
     --color-ub-lite-abrgn: #00ffff;
     --color-ub-border-orange: #ffff00;
+    --border-card: var(--color-ub-border-orange);
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,6 +36,7 @@ module.exports = {
         'ubt-gedit-dark': 'var(--color-ubt-gedit-dark)',
         'ub-border-orange': 'var(--color-ub-border-orange)',
         'ub-dark-grey': 'var(--color-ub-dark-grey)',
+        card: 'var(--border-card)',
         kali: {
           background: 'var(--color-bg)',
           text: 'var(--color-text)',


### PR DESCRIPTION
## Summary
- replace the literal QuickSettings separator color with the border-card design token and improve toggle labelling
- expose the new border-card token across themes and Tailwind so separators stay consistent in light, dark, neon, and matrix modes

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da1c08255c8328b955d92d4daff1cd