### PR TITLE
[ui] add video player keyboard shortcuts

### DIFF
--- a/pages/keyboard-reference.tsx
+++ b/pages/keyboard-reference.tsx
@@ -32,6 +32,18 @@ const KeyboardReference = () => (
           <td className="p-2 border border-ubt-grey">Alt + F4</td>
           <td className="p-2 border border-ubt-grey">Close current window</td>
         </tr>
+        <tr>
+          <td className="p-2 border border-ubt-grey">Space</td>
+          <td className="p-2 border border-ubt-grey">Play or pause focused video player</td>
+        </tr>
+        <tr>
+          <td className="p-2 border border-ubt-grey">Arrow Left / Arrow Right</td>
+          <td className="p-2 border border-ubt-grey">Seek video backward or forward 5 seconds</td>
+        </tr>
+        <tr>
+          <td className="p-2 border border-ubt-grey">M</td>
+          <td className="p-2 border border-ubt-grey">Toggle mute on focused video player</td>
+        </tr>
       </tbody>
     </table>
   </main>


### PR DESCRIPTION
## Summary
- add keyboard handlers and focus styles to the reusable video player for play, seek, and mute shortcuts
- skip shortcut handling when typing in text inputs and provide aria labels for controls
- document the new video shortcuts on the keyboard reference page

## Testing
- yarn lint


------
https://chatgpt.com/codex/tasks/task_e_68da1c0c1dd48328a65eef964380adab