### PR TITLE
[ui] Improve beta badge accessibility

### DIFF
--- a/components/BetaBadge.jsx
+++ b/components/BetaBadge.jsx
@@ -3,7 +3,14 @@ export default function BetaBadge() {
   return (
     <button
       type="button"
-      className="fixed bottom-4 right-4 rounded bg-yellow-500/90 px-2 py-1 text-xs font-semibold text-black"
+      aria-label="Beta"
+      className="fixed bottom-4 right-4 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide shadow-lg backdrop-blur-sm"
+      style={{
+        backgroundColor: 'var(--color-surface)',
+        color: 'var(--color-text)',
+        borderColor: 'var(--color-border)',
+        boxShadow: '0 6px 18px color-mix(in srgb, var(--color-inverse), transparent 82%)',
+      }}
     >
       Beta
     </button>


### PR DESCRIPTION
## Summary
- switch the floating beta badge to design-token colors so it respects theme contrast requirements
- add an aria-label so screen readers always announce the beta badge
- add subtle blur and shadow styling so the badge stays legible on busy wallpapers

## Testing
- ⚠️ `yarn lint` *(fails: ESLint reports "File ignored because no matching configuration was supplied" for components/BetaBadge.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68da1c16565883288386abec0cf2d421