### PR TITLE
[components] Add loading skeleton to explainer pane

### DIFF
--- a/components/ExplainerPane.tsx
+++ b/components/ExplainerPane.tsx
@@ -4,11 +4,65 @@ interface Resource {
 }
 
 interface Props {
-  lines: string[];
-  resources: Resource[];
+  lines?: string[];
+  resources?: Resource[];
+  isLoading?: boolean;
 }
 
-export default function ExplainerPane({ lines, resources }: Props) {
+const skeletonBaseStyles =
+  'bg-ub-grey/40 rounded motion-safe:animate-pulse motion-reduce:animate-none';
+
+function SkeletonLine({ width }: { width: string }) {
+  return <div className={`${skeletonBaseStyles} h-3 ${width}`} aria-hidden="true" />;
+}
+
+function SkeletonHeader({ width }: { width: string }) {
+  return <div className={`${skeletonBaseStyles} h-4 ${width}`} aria-hidden="true" />;
+}
+
+export default function ExplainerPane({
+  lines = [],
+  resources = [],
+  isLoading = false,
+}: Props) {
+  if (isLoading) {
+    return (
+      <aside
+        className="text-xs p-2 border-l border-ub-cool-grey overflow-auto h-full"
+        aria-label="explainer pane loading"
+        aria-busy="true"
+      >
+        <div className="space-y-4" role="status" aria-live="polite">
+          <section className="space-y-2">
+            <SkeletonHeader width="w-24" />
+            <ul className="list-none space-y-2">
+              <li>
+                <SkeletonLine width="w-5/6" />
+              </li>
+              <li>
+                <SkeletonLine width="w-4/5" />
+              </li>
+              <li>
+                <SkeletonLine width="w-3/4" />
+              </li>
+            </ul>
+          </section>
+          <section className="space-y-2">
+            <SkeletonHeader width="w-20" />
+            <ul className="list-none space-y-2">
+              <li>
+                <SkeletonLine width="w-2/3" />
+              </li>
+              <li>
+                <SkeletonLine width="w-1/2" />
+              </li>
+            </ul>
+          </section>
+        </div>
+      </aside>
+    );
+  }
+
   return (
     <aside
       className="text-xs p-2 border-l border-ub-cool-grey overflow-auto h-full"


### PR DESCRIPTION
## Summary
- add lightweight skeleton placeholders for the explainer pane header, body, and resource call-to-action
- respect reduced motion preferences while animating the loading state and keep layout dimensions stable when data loads

## Testing
- [x] yarn lint

## Flags
- [ ] Feature flags toggled


------
https://chatgpt.com/codex/tasks/task_e_68da1c16e4108328a8f4a4560d7c9f68