### PR TITLE
[pwa] improve install button install prompt handling

### DIFF
--- a/__tests__/installButton.test.tsx
+++ b/__tests__/installButton.test.tsx
@@ -1,13 +1,13 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import InstallButton from '../components/InstallButton';
-import { initA2HS } from '@/src/pwa/a2hs';
 
 describe('InstallButton', () => {
   test('shows install prompt when beforeinstallprompt fires', async () => {
     render(<InstallButton />);
-    initA2HS();
-    expect(screen.queryByText(/install/i)).toBeNull();
+    const idleButton = screen.getByRole('button', { name: /install/i });
+    expect(idleButton).toBeDisabled();
+    expect(idleButton).toHaveAttribute('title');
 
     let resolveChoice: (value: any) => void = () => {};
     const userChoice = new Promise((resolve) => {
@@ -36,12 +36,13 @@ describe('InstallButton', () => {
       await userChoice;
     });
 
-    await waitFor(() => expect(screen.queryByText(/install/i)).toBeNull());
+    await waitFor(() => expect(screen.getByRole('button', { name: /install/i })).toBeDisabled());
   });
 
   test('can be focused via keyboard', async () => {
     render(<InstallButton />);
-    initA2HS();
+    const idleButton = screen.getByRole('button', { name: /install/i });
+    expect(idleButton).toBeDisabled();
     const event: any = new Event('beforeinstallprompt');
     event.preventDefault = jest.fn();
     event.prompt = jest.fn();
@@ -50,7 +51,35 @@ describe('InstallButton', () => {
       window.dispatchEvent(event);
     });
     const button = await screen.findByRole('button', { name: /install/i });
+    expect(button).not.toBeDisabled();
     await userEvent.tab();
     expect(button).toHaveFocus();
+  });
+
+  test('resets state when prompt is dismissed', async () => {
+    render(<InstallButton />);
+    const event: any = new Event('beforeinstallprompt');
+    event.preventDefault = jest.fn();
+    event.prompt = jest.fn().mockResolvedValue(undefined);
+
+    let resolveChoice: (value: any) => void = () => {};
+    const userChoice = new Promise((resolve) => {
+      resolveChoice = resolve;
+    });
+    event.userChoice = userChoice;
+
+    await act(async () => {
+      window.dispatchEvent(event);
+    });
+
+    const button = await screen.findByRole('button', { name: /install/i });
+    await userEvent.click(button);
+
+    await act(async () => {
+      resolveChoice({ outcome: 'dismissed', platform: 'test' });
+      await userChoice;
+    });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /install/i })).toBeDisabled());
   });
 });


### PR DESCRIPTION
## Summary
- listen for the `beforeinstallprompt` event inside the install button and store the deferred prompt
- disable the CTA with helpful messaging until install is available, then prompt and track the user outcome
- extend the install button test suite to cover acceptance, focus, and dismissal flows

## Testing
- yarn test installButton

------
https://chatgpt.com/codex/tasks/task_e_68da1c1ada58832887d177aa15956a31