### PR TITLE
[ui] Improve module card focus and hover states

### DIFF
--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -33,7 +33,7 @@ export default function ModuleCard({
   return (
     <button
       onClick={() => onSelect(module)}
-      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
+      className={`w-full text-left border rounded p-3 flex items-start justify-between transition-[background-color,transform,box-shadow] duration-[var(--motion-fast)] ease-out motion-reduce:transition-none motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-[var(--shadow-2)] hover:bg-gray-50 focus-visible:outline focus-visible:outline-[var(--focus-outline-width)] focus-visible:outline-offset-2 focus-visible:outline-[color:var(--focus-outline-color)] ${
         selected ? 'bg-gray-100' : ''
       }`}
     >


### PR DESCRIPTION
## Summary
- add a visible keyboard focus outline to module cards using shared design tokens
- animate hover elevation with motion-safe translate and shared card shadow
- align transition timing with design motion tokens and respect reduced motion settings

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da1c1c9db483289ae26a1a8c631bd1