### PR TITLE
[pip-portal] add copy confirmation toast

### DIFF
--- a/components/PipPortal.tsx
+++ b/components/PipPortal.tsx
@@ -1,7 +1,15 @@
 "use client";
 
-import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
+import Toast from './ui/Toast';
 
 // The Document Picture-in-Picture API is still experimental and the
 // TypeScript definitions do not ship with the DOM lib yet.
@@ -22,6 +30,9 @@ const PipPortalProvider: React.FC<{ children: React.ReactNode }> = ({ children }
   const pipWindowRef = useRef<Window | null>(null);
   const [container, setContainer] = useState<HTMLElement | null>(null);
   const [content, setContent] = useState<React.ReactNode>(null);
+  const [copyShortcut, setCopyShortcut] = useState('Ctrl+C');
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const toastActiveRef = useRef(false);
 
   const close = useCallback(() => {
     const win = pipWindowRef.current;
@@ -71,10 +82,72 @@ const PipPortalProvider: React.FC<{ children: React.ReactNode }> = ({ children }
     };
   }, [container]);
 
+  useEffect(() => {
+    if (typeof navigator === 'undefined') return;
+    const platform =
+      (navigator as any).userAgentData?.platform ?? navigator.platform ?? '';
+    const ua = navigator.userAgent ?? '';
+    const isApple = /mac|iphone|ipad|ipod/i.test(platform) || /mac|iphone|ipad|ipod/i.test(ua);
+    setCopyShortcut(isApple ? 'Cmd+C' : 'Ctrl+C');
+  }, []);
+
+  const handleToastClose = useCallback(() => {
+    toastActiveRef.current = false;
+    setToastMessage(null);
+  }, []);
+
+  const showCopyToast = useCallback(() => {
+    if (toastActiveRef.current) return;
+    toastActiveRef.current = true;
+    setToastMessage(`Copied to clipboard. Tip: Use ${copyShortcut}.`);
+  }, [copyShortcut]);
+
+  useEffect(() => {
+    return () => {
+      toastActiveRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleCopy = () => {
+      showCopyToast();
+    };
+
+    window.addEventListener('copy', handleCopy);
+    return () => {
+      window.removeEventListener('copy', handleCopy);
+    };
+  }, [showCopyToast]);
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined') return;
+    const clipboard = navigator.clipboard as Clipboard & { writeText?: (text: string) => Promise<void> };
+    if (!clipboard || typeof clipboard.writeText !== 'function') return;
+
+    const originalWrite = clipboard.writeText.bind(clipboard);
+
+    const wrappedWrite = async (text: string) => {
+      const result = await originalWrite(text);
+      showCopyToast();
+      return result;
+    };
+
+    clipboard.writeText = wrappedWrite;
+
+    return () => {
+      clipboard.writeText = originalWrite;
+    };
+  }, [showCopyToast]);
+
   return (
     <PipPortalContext.Provider value={{ open, close }}>
       {children}
       {container && content ? createPortal(content, container) : null}
+      {toastMessage ? (
+        <Toast message={toastMessage} onClose={handleToastClose} duration={3000} />
+      ) : null}
     </PipPortalContext.Provider>
   );
 };

--- a/components/common/PipPortal.tsx
+++ b/components/common/PipPortal.tsx
@@ -1,7 +1,15 @@
 "use client";
 
-import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
+import Toast from '../ui/Toast';
 
 // The Document Picture-in-Picture API is still experimental and the
 // TypeScript definitions do not ship with the DOM lib yet.
@@ -29,6 +37,9 @@ const PipPortalProvider: React.FC<{ children: React.ReactNode }> = ({ children }
   const [container, setContainer] = useState<HTMLElement | null>(null);
   const [content, setContent] = useState<React.ReactNode>(null);
   const [isOpen, setIsOpen] = useState(false);
+  const [copyShortcut, setCopyShortcut] = useState('Ctrl+C');
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const toastActiveRef = useRef(false);
 
   const close = useCallback(() => {
     const win = pipWindowRef.current;
@@ -84,10 +95,72 @@ const PipPortalProvider: React.FC<{ children: React.ReactNode }> = ({ children }
     };
   }, [container]);
 
+  useEffect(() => {
+    if (typeof navigator === 'undefined') return;
+    const platform =
+      (navigator as any).userAgentData?.platform ?? navigator.platform ?? '';
+    const ua = navigator.userAgent ?? '';
+    const isApple = /mac|iphone|ipad|ipod/i.test(platform) || /mac|iphone|ipad|ipod/i.test(ua);
+    setCopyShortcut(isApple ? 'Cmd+C' : 'Ctrl+C');
+  }, []);
+
+  const handleToastClose = useCallback(() => {
+    toastActiveRef.current = false;
+    setToastMessage(null);
+  }, []);
+
+  const showCopyToast = useCallback(() => {
+    if (toastActiveRef.current) return;
+    toastActiveRef.current = true;
+    setToastMessage(`Copied to clipboard. Tip: Use ${copyShortcut}.`);
+  }, [copyShortcut]);
+
+  useEffect(() => {
+    return () => {
+      toastActiveRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleCopy = () => {
+      showCopyToast();
+    };
+
+    window.addEventListener('copy', handleCopy);
+    return () => {
+      window.removeEventListener('copy', handleCopy);
+    };
+  }, [showCopyToast]);
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined') return;
+    const clipboard = navigator.clipboard as Clipboard & { writeText?: (text: string) => Promise<void> };
+    if (!clipboard || typeof clipboard.writeText !== 'function') return;
+
+    const originalWrite = clipboard.writeText.bind(clipboard);
+
+    const wrappedWrite = async (text: string) => {
+      const result = await originalWrite(text);
+      showCopyToast();
+      return result;
+    };
+
+    clipboard.writeText = wrappedWrite;
+
+    return () => {
+      clipboard.writeText = originalWrite;
+    };
+  }, [showCopyToast]);
+
   return (
     <PipPortalContext.Provider value={{ open, close, isOpen }}>
       {children}
       {container && content ? createPortal(content, container) : null}
+      {toastMessage ? (
+        <Toast message={toastMessage} onClose={handleToastClose} duration={3000} />
+      ) : null}
     </PipPortalContext.Provider>
   );
 };


### PR DESCRIPTION
## Summary
- show an accessible toast from the PipPortal provider whenever copy actions succeed, including keyboard shortcut guidance
- wrap clipboard interactions and copy events to avoid duplicate toasts during rapid copy operations

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da1c1db0148328a5449461c107aa9e