### PR TITLE
[components] Improve ResultViewer raw output UX

### DIFF
--- a/components/ResultViewer.tsx
+++ b/components/ResultViewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 
 interface ViewerProps {
   data: any[];
@@ -10,6 +10,8 @@ export default function ResultViewer({ data }: ViewerProps) {
   const [tab, setTab] = useState<'raw' | 'parsed' | 'chart'>('raw');
   const [sortKey, setSortKey] = useState('');
   const [filter, setFilter] = useState('');
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const copyResetTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     try {
@@ -37,6 +39,58 @@ export default function ResultViewer({ data }: ViewerProps) {
     if (!sortKey) return filtered;
     return [...filtered].sort((a, b) => (a[sortKey] > b[sortKey] ? 1 : -1));
   }, [filtered, sortKey]);
+  const rawContent = useMemo(() => JSON.stringify(data, null, 2), [data]);
+
+  useEffect(() => {
+    if (copyStatus === 'idle') return;
+
+    if (copyResetTimeout.current) {
+      clearTimeout(copyResetTimeout.current);
+    }
+
+    copyResetTimeout.current = setTimeout(() => {
+      setCopyStatus('idle');
+      copyResetTimeout.current = null;
+    }, 2000);
+
+    return () => {
+      if (copyResetTimeout.current) {
+        clearTimeout(copyResetTimeout.current);
+        copyResetTimeout.current = null;
+      }
+    };
+  }, [copyStatus]);
+
+  useEffect(() => {
+    return () => {
+      if (copyResetTimeout.current) {
+        clearTimeout(copyResetTimeout.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(rawContent);
+      } else if (typeof document !== 'undefined') {
+        const textarea = document.createElement('textarea');
+        textarea.value = rawContent;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'absolute';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      } else {
+        throw new Error('Clipboard unavailable');
+      }
+      setCopyStatus('success');
+    } catch {
+      setCopyStatus('error');
+    }
+  };
 
   const exportCsv = () => {
     const csv = [keys.join(','), ...data.map((row) => keys.map((k) => JSON.stringify(row[k] ?? '')).join(','))].join('\n');
@@ -62,7 +116,30 @@ export default function ResultViewer({ data }: ViewerProps) {
           Chart
         </button>
       </div>
-      {tab === 'raw' && <pre className="bg-black text-white p-1 h-40 overflow-auto">{JSON.stringify(data, null, 2)}</pre>}
+      {tab === 'raw' && (
+        <div>
+          <div className="mb-2 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="px-2 py-1 bg-ub-green text-black font-semibold"
+              aria-label="Copy raw results"
+            >
+              Copy
+            </button>
+            <span role="status" aria-live="polite" className="text-ubt-grey">
+              {copyStatus === 'success' && 'Copied!'}
+              {copyStatus === 'error' && 'Copy failed'}
+            </span>
+          </div>
+          <pre
+            className="bg-black text-white p-1 h-40 overflow-auto font-mono"
+            style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+          >
+            {rawContent}
+          </pre>
+        </div>
+      )}
       {tab === 'parsed' && (
         <div>
           <div className="mb-2">


### PR DESCRIPTION
## Summary
- preserve raw output formatting with pre-wrapped, monospace styling to prevent horizontal scrolling
- add an accessible copy button with clipboard fallback and status feedback for the raw results

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68da1c1f44e48328a0eabb68e66f659f