### PR TITLE
[sprite] Add zoom slider to sprite preview

### DIFF
--- a/__tests__/spriteStrip.test.tsx
+++ b/__tests__/spriteStrip.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { act } from 'react';
 import SpriteStripPreview from '../components/SpriteStripPreview';
 import { importSpriteStrip, clearSpriteStripCache } from '../utils/spriteStrip';
@@ -24,5 +24,21 @@ describe('sprite strip utilities', () => {
       jest.advanceTimersByTime(100);
     });
     expect(el).toHaveStyle('background-position: -10px 0px');
+  });
+
+  test('zoom slider scales the preview', () => {
+    const { getByTestId, getByLabelText } = render(
+      <SpriteStripPreview src="foo.png" frameWidth={10} frameHeight={10} frames={3} fps={10} />,
+    );
+    const el = getByTestId('sprite-strip-preview');
+    const slider = getByLabelText('Zoom') as HTMLInputElement;
+
+    expect(slider.value).toBe('100');
+    expect(el).toHaveStyle('transform: scale(1)');
+
+    fireEvent.change(slider, { target: { value: '150' } });
+
+    expect(slider.value).toBe('150');
+    expect(el).toHaveStyle('transform: scale(1.5)');
   });
 });

--- a/components/SpriteStripPreview.tsx
+++ b/components/SpriteStripPreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useId, useState } from 'react';
 import { importSpriteStrip } from '../utils/spriteStrip';
 
 interface SpriteStripPreviewProps {
@@ -27,6 +27,12 @@ const SpriteStripPreview: React.FC<SpriteStripPreviewProps> = ({
   fps = 12,
 }) => {
   const [frame, setFrame] = useState(0);
+  const [zoom, setZoom] = useState(100);
+  const sliderId = useId();
+
+  const minZoom = 50;
+  const maxZoom = 200;
+  const scale = zoom / 100;
 
   // Preload and cache the sprite strip
   useEffect(() => {
@@ -42,16 +48,60 @@ const SpriteStripPreview: React.FC<SpriteStripPreviewProps> = ({
     return () => window.clearInterval(id);
   }, [frames, fps]);
 
-  const style: React.CSSProperties = {
+  const containerStyle: React.CSSProperties = {
+    width: frameWidth * (maxZoom / 100),
+    height: frameHeight * (maxZoom / 100),
+    maxWidth: '100%',
+    aspectRatio: `${frameWidth} / ${frameHeight}`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  };
+
+  const previewStyle: React.CSSProperties = {
     width: frameWidth,
     height: frameHeight,
     backgroundImage: `url(${src})`,
     backgroundPosition: `-${frame * frameWidth}px 0px`,
     backgroundRepeat: 'no-repeat',
     imageRendering: 'pixelated',
+    transform: `scale(${scale})`,
+    transformOrigin: 'center',
   };
 
-  return <div style={style} data-testid="sprite-strip-preview" />;
+  const sliderWrapperStyle: React.CSSProperties = {
+    marginTop: '0.5rem',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+  };
+
+  const sliderStyle: React.CSSProperties = {
+    flex: 1,
+  };
+
+  return (
+    <div>
+      <div style={containerStyle}>
+        <div style={previewStyle} data-testid="sprite-strip-preview" />
+      </div>
+      <div style={sliderWrapperStyle}>
+        <label htmlFor={sliderId}>Zoom</label>
+        <input
+          id={sliderId}
+          type="range"
+          min={minZoom}
+          max={maxZoom}
+          step={10}
+          value={zoom}
+          onChange={(event) => setZoom(Number(event.target.value))}
+          aria-valuetext={`${zoom}%`}
+          style={sliderStyle}
+        />
+        <span>{zoom}%</span>
+      </div>
+    </div>
+  );
 };
 
 export default SpriteStripPreview;


### PR DESCRIPTION
## Summary
- wrap the sprite preview with a fixed-aspect container so frames never stretch
- add an accessible zoom slider that scales frames with CSS transforms without affecting layout

## Testing
- yarn test spriteStrip

## Flags
- none

------
https://chatgpt.com/codex/tasks/task_e_68da1c2151488328810e4767ff0b099a