### PR TITLE
[components] Improve toggle switch accessibility

### DIFF
--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -157,15 +157,22 @@ export default function Settings() {
             </div>
           </div>
           <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey flex items-center">
+            <div className="flex items-center">
               <input
+                id="kali-gradient-wallpaper"
                 type="checkbox"
                 checked={useKaliWallpaper}
                 onChange={(e) => setUseKaliWallpaper(e.target.checked)}
                 className="mr-2"
+                aria-label="Kali Gradient Wallpaper"
               />
-              Kali Gradient Wallpaper
-            </label>
+              <label
+                htmlFor="kali-gradient-wallpaper"
+                className="text-ubt-grey cursor-pointer"
+              >
+                Kali Gradient Wallpaper
+              </label>
+            </div>
           </div>
           {useKaliWallpaper && (
             <p className="text-center text-xs text-ubt-grey/70 px-6 -mt-2 mb-4">
@@ -258,30 +265,27 @@ export default function Settings() {
               <option value="compact">Compact</option>
             </select>
           </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">Reduced Motion:</span>
-            <ToggleSwitch
-              checked={reducedMotion}
-              onChange={setReducedMotion}
-              ariaLabel="Reduced Motion"
-            />
-          </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">High Contrast:</span>
-            <ToggleSwitch
-              checked={highContrast}
-              onChange={setHighContrast}
-              ariaLabel="High Contrast"
-            />
-          </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">Haptics:</span>
-            <ToggleSwitch
-              checked={haptics}
-              onChange={setHaptics}
-              ariaLabel="Haptics"
-            />
-          </div>
+          <ToggleSwitch
+            id="settings-reduced-motion"
+            label="Reduced Motion"
+            checked={reducedMotion}
+            onChange={setReducedMotion}
+            className="justify-center w-full my-4"
+          />
+          <ToggleSwitch
+            id="settings-high-contrast"
+            label="High Contrast"
+            checked={highContrast}
+            onChange={setHighContrast}
+            className="justify-center w-full my-4"
+          />
+          <ToggleSwitch
+            id="settings-haptics"
+            label="Haptics"
+            checked={haptics}
+            onChange={setHaptics}
+            className="justify-center w-full my-4"
+          />
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
             <button
               onClick={() => setShowKeymap(true)}

--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -1,34 +1,73 @@
 "use client";
-import React from "react";
+import React, { KeyboardEvent, useId } from "react";
 
 interface ToggleSwitchProps {
+  id?: string;
+  label: string;
   checked: boolean;
   onChange: (checked: boolean) => void;
   className?: string;
-  ariaLabel: string;
+  labelClassName?: string;
 }
 
 export default function ToggleSwitch({
+  id,
+  label,
   checked,
   onChange,
   className = "",
-  ariaLabel,
+  labelClassName = "text-ubt-grey",
 }: ToggleSwitchProps) {
+  const generatedId = useId();
+  const switchId = id ?? `${generatedId}-toggle`;
+  const labelId = `${switchId}-label`;
+
+  const handleToggle = () => {
+    onChange(!checked);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === " " || event.key === "Spacebar" || event.key === "Enter") {
+      event.preventDefault();
+      handleToggle();
+    }
+  };
+
   return (
-    <button
-      role="switch"
-      aria-checked={checked}
-      aria-label={ariaLabel}
-      onClick={() => onChange(!checked)}
-      className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
-        checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
-      } ${className}`.trim()}
-    >
-      <span
-        className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-ub-cool-grey transition-transform duration-200 ${
-          checked ? "translate-x-5" : "translate-x-0"
+    <div className={["flex items-center gap-3", className].filter(Boolean).join(" ")}> 
+      <button
+        id={switchId}
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-labelledby={labelId}
+        onClick={handleToggle}
+        onKeyDown={handleKeyDown}
+        className={`relative inline-flex h-10 w-10 items-center justify-center rounded-full p-2 transition-transform duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange focus-visible:ring-offset-2 focus-visible:ring-offset-black active:scale-95 ${
+          checked ? "bg-white/10" : "bg-white/5"
         }`}
-      />
-    </button>
+      >
+        <span
+          className={`pointer-events-none relative inline-flex h-4 w-8 items-center rounded-full transition-colors duration-200 ${
+            checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
+          }`}
+        >
+          <span
+            className={`absolute left-0.5 top-1/2 h-3 w-3 -translate-y-1/2 rounded-full bg-ub-cool-grey shadow transition-transform duration-200 ${
+              checked ? "translate-x-4" : "translate-x-0"
+            }`}
+          />
+        </span>
+      </button>
+      <label
+        id={labelId}
+        htmlFor={switchId}
+        className={["cursor-pointer select-none", labelClassName]
+          .filter(Boolean)
+          .join(" ")}
+      >
+        {label}
+      </label>
+    </div>
   );
 }

--- a/components/panel/Preferences.tsx
+++ b/components/panel/Preferences.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Tabs from "../Tabs";
 import ToggleSwitch from "../ToggleSwitch";
 
@@ -18,7 +18,7 @@ export default function Preferences() {
 
   const [active, setActive] = useState<TabId>("display");
 
-  const isCoarsePointer = () => {
+  const isCoarsePointer = useCallback(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
       return false;
     }
@@ -27,28 +27,34 @@ export default function Preferences() {
     } catch {
       return false;
     }
-  };
+  }, []);
 
-  const resolveNumberSetting = (key: string, touchDefault: number, desktopDefault: number) => {
-    if (typeof window === "undefined") return desktopDefault;
-    const stored = localStorage.getItem(`${PANEL_PREFIX}${key}`);
-    if (stored !== null) {
-      const parsed = parseInt(stored, 10);
-      return Number.isNaN(parsed) ? desktopDefault : parsed;
-    }
-    return isCoarsePointer() ? touchDefault : desktopDefault;
-  };
+  const resolveNumberSetting = useCallback(
+    (key: string, touchDefault: number, desktopDefault: number) => {
+      if (typeof window === "undefined") return desktopDefault;
+      const stored = localStorage.getItem(`${PANEL_PREFIX}${key}`);
+      if (stored !== null) {
+        const parsed = parseInt(stored, 10);
+        return Number.isNaN(parsed) ? desktopDefault : parsed;
+      }
+      return isCoarsePointer() ? touchDefault : desktopDefault;
+    },
+    [isCoarsePointer],
+  );
 
-  const resolveBooleanSetting = (key: string, touchDefault: boolean, desktopDefault: boolean) => {
-    if (typeof window === "undefined") return desktopDefault;
-    const stored = localStorage.getItem(`${PANEL_PREFIX}${key}`);
-    if (stored !== null) {
-      return stored === "true";
-    }
-    return isCoarsePointer() ? touchDefault : desktopDefault;
-  };
+  const resolveBooleanSetting = useCallback(
+    (key: string, touchDefault: boolean, desktopDefault: boolean) => {
+      if (typeof window === "undefined") return desktopDefault;
+      const stored = localStorage.getItem(`${PANEL_PREFIX}${key}`);
+      if (stored !== null) {
+        return stored === "true";
+      }
+      return isCoarsePointer() ? touchDefault : desktopDefault;
+    },
+    [isCoarsePointer],
+  );
 
-  const resolveOrientationSetting = () => {
+  const resolveOrientationSetting = useCallback(() => {
     if (typeof window === "undefined") {
       return isCoarsePointer() ? "horizontal" : "horizontal";
     }
@@ -57,7 +63,7 @@ export default function Preferences() {
       return stored;
     }
     return isCoarsePointer() ? "horizontal" : "horizontal";
-  };
+  }, [isCoarsePointer]);
 
   const [size, setSize] = useState(() => resolveNumberSetting("size", 40, 24));
   const [length, setLength] = useState(() => resolveNumberSetting("length", 100, 100));
@@ -112,7 +118,7 @@ export default function Preferences() {
         media.removeListener(handleChange);
       }
     };
-  }, []);
+  }, [resolveBooleanSetting, resolveNumberSetting, resolveOrientationSetting]);
 
   return (
     <div>
@@ -136,14 +142,13 @@ export default function Preferences() {
                 <option value="vertical">Vertical</option>
               </select>
             </div>
-            <div className="flex items-center justify-between">
-              <span className="text-ubt-grey">Autohide</span>
-              <ToggleSwitch
-                checked={autohide}
-                onChange={setAutohide}
-                ariaLabel="Autohide panel"
-              />
-            </div>
+            <ToggleSwitch
+              id="panel-autohide"
+              label="Autohide"
+              checked={autohide}
+              onChange={setAutohide}
+              className="justify-between w-full"
+            />
           </div>
         )}
         {active === "measurements" && (


### PR DESCRIPTION
## Summary
- guarantee a 40×40px toggle button with visible focus/active states and keyboard activation support
- update settings and panel preferences to use the new labelled switch API for consistent right-aligned labelling
- memoize panel preference helpers to satisfy lint rules while keeping autohide wired to the new toggle

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da1c231d60832898dbd2bdf0d3be45