### PR TITLE
[components] add confirm dialog to route abort guard

### DIFF
--- a/components/UseRouteAbortGuard.tsx
+++ b/components/UseRouteAbortGuard.tsx
@@ -1,28 +1,207 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
+import ConfirmDialog from './base/ConfirmDialog';
+
+type NavigationBlockerConfig = {
+  title?: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+};
+
+type NavigationBlockState = Required<Pick<NavigationBlockerConfig, 'title' | 'description' | 'confirmLabel' | 'cancelLabel'>> &
+  Pick<NavigationBlockerConfig, 'onConfirm' | 'onCancel'>;
+
+type RouteChangeStartOptions = {
+  shallow?: boolean;
+  locale?: string | false;
+  scroll?: boolean;
+  [key: string]: unknown;
+};
+
+type PendingNavigation = {
+  url: string;
+  as?: string;
+  options?: RouteChangeStartOptions;
+};
+
+type RouteAbortController = AbortController & {
+  blockNavigation: (config?: NavigationBlockerConfig) => void;
+  releaseNavigation: () => void;
+  isNavigationBlocked: () => boolean;
+};
+
+const DEFAULT_DIALOG: NavigationBlockState = {
+  title: 'Leave this page?',
+  description: 'You have unsaved changes. If you leave now, your progress may be lost.',
+  confirmLabel: 'Leave page',
+  cancelLabel: 'Stay here',
+};
 
 declare global {
   interface Window {
-    routeAbortController?: AbortController;
+    routeAbortController?: RouteAbortController;
   }
 }
 
 export default function UseRouteAbortGuard() {
   const router = useRouter();
+  const [isDialogOpen, setDialogOpen] = useState(false);
+  const [dialogContent, setDialogContent] = useState<NavigationBlockState>({ ...DEFAULT_DIALOG });
+  const blockStateRef = useRef<NavigationBlockState | null>(null);
+  const pendingNavigationRef = useRef<PendingNavigation | null>(null);
+  const allowNavigationRef = useRef(false);
+
+  const blockNavigation = useCallback((config?: NavigationBlockerConfig) => {
+    const merged: NavigationBlockState = {
+      ...DEFAULT_DIALOG,
+      ...config,
+    };
+    blockStateRef.current = merged;
+    setDialogContent({
+      title: merged.title,
+      description: merged.description,
+      confirmLabel: merged.confirmLabel,
+      cancelLabel: merged.cancelLabel,
+    });
+  }, []);
+
+  const releaseNavigation = useCallback(() => {
+    blockStateRef.current = null;
+    setDialogOpen(false);
+    setDialogContent({ ...DEFAULT_DIALOG });
+  }, []);
+
+  const createRouteAbortController = useCallback((): RouteAbortController => {
+    const controller = new AbortController() as RouteAbortController;
+    controller.blockNavigation = blockNavigation;
+    controller.releaseNavigation = releaseNavigation;
+    controller.isNavigationBlocked = () => blockStateRef.current !== null;
+    return controller;
+  }, [blockNavigation, releaseNavigation]);
+
+  const handleNavigationBlocked = useCallback((url: string, options: RouteChangeStartOptions) => {
+      const blockedState = blockStateRef.current;
+      if (!blockedState) return null;
+      pendingNavigationRef.current = {
+        url,
+        options,
+      };
+      setDialogOpen(true);
+      const error = new Error('Route change aborted by UseRouteAbortGuard');
+      (error as Error & { cancelled?: boolean }).cancelled = true;
+      router.events.emit('routeChangeError', error, url, options);
+      return error;
+    },
+    [router.events],
+  );
+
+  const handleRouteChangeStart = useCallback(
+    (url: string, options: RouteChangeStartOptions) => {
+      const controller = window.routeAbortController;
+      controller?.abort();
+      window.routeAbortController = createRouteAbortController();
+      if (allowNavigationRef.current) {
+        allowNavigationRef.current = false;
+        return;
+      }
+      const navigationError = handleNavigationBlocked(url, options);
+      if (navigationError) {
+        throw navigationError;
+      }
+    },
+    [createRouteAbortController, handleNavigationBlocked],
+  );
+
+  const handlePopState = useCallback(
+    (state: { url?: string; as?: string; options?: RouteChangeStartOptions }) => {
+      const controller = window.routeAbortController;
+      controller?.abort();
+      window.routeAbortController = createRouteAbortController();
+      if (allowNavigationRef.current) {
+        allowNavigationRef.current = false;
+        return true;
+      }
+      if (!blockStateRef.current) {
+        return true;
+      }
+      const url = state?.as ?? state?.url;
+      if (!url) {
+        return true;
+      }
+      pendingNavigationRef.current = {
+        url,
+        as: state?.as,
+        options: state?.options ?? {},
+      };
+      setDialogOpen(true);
+      return false;
+    },
+    [createRouteAbortController],
+  );
+
+  const handleConfirm = useCallback(() => {
+    const pending = pendingNavigationRef.current;
+    pendingNavigationRef.current = null;
+    const blockedState = blockStateRef.current;
+    blockedState?.onConfirm?.();
+    blockStateRef.current = null;
+    setDialogContent({ ...DEFAULT_DIALOG });
+    setDialogOpen(false);
+    allowNavigationRef.current = true;
+    if (pending) {
+      router.push(pending.url, pending.as, pending.options);
+    }
+  }, [router]);
+
+  const handleCancel = useCallback(() => {
+    pendingNavigationRef.current = null;
+    const blockedState = blockStateRef.current;
+    blockedState?.onCancel?.();
+    setDialogOpen(false);
+  }, []);
 
   useEffect(() => {
-    window.routeAbortController = new AbortController();
-    const handleRouteChange = () => {
-      window.routeAbortController?.abort();
-      window.routeAbortController = new AbortController();
-    };
-    router.events.on('routeChangeStart', handleRouteChange);
+    window.routeAbortController = createRouteAbortController();
     return () => {
-      router.events.off('routeChangeStart', handleRouteChange);
       window.routeAbortController?.abort();
       delete window.routeAbortController;
     };
-  }, [router.events]);
+  }, [createRouteAbortController]);
 
-  return null;
+  useEffect(() => {
+    router.events.on('routeChangeStart', handleRouteChangeStart);
+    const handleComplete = () => {
+      allowNavigationRef.current = false;
+      pendingNavigationRef.current = null;
+    };
+    router.events.on('routeChangeComplete', handleComplete);
+    router.events.on('routeChangeError', handleComplete);
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChangeStart);
+      router.events.off('routeChangeComplete', handleComplete);
+      router.events.off('routeChangeError', handleComplete);
+    };
+  }, [handleRouteChangeStart, router.events]);
+
+  useEffect(() => {
+    router.beforePopState(handlePopState);
+    return () => {
+      router.beforePopState(() => true);
+    };
+  }, [handlePopState, router]);
+
+  return (
+    <ConfirmDialog
+      isOpen={isDialogOpen}
+      title={dialogContent.title}
+      description={dialogContent.description}
+      confirmLabel={dialogContent.confirmLabel}
+      cancelLabel={dialogContent.cancelLabel}
+      onConfirm={handleConfirm}
+      onCancel={handleCancel}
+    />
+  );
 }

--- a/components/base/ConfirmDialog.tsx
+++ b/components/base/ConfirmDialog.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useId, useRef } from 'react';
+import Modal from './Modal';
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  description?: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmDialog({
+  isOpen,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+  const titleId = useId();
+  const descriptionId = useId();
+
+  useEffect(() => {
+    if (!isOpen) return;
+    confirmButtonRef.current?.focus();
+  }, [isOpen]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onCancel}>
+      <div className="fixed inset-0 z-[2000] flex items-center justify-center bg-slate-900/70 p-4">
+        <div
+          role="document"
+          aria-labelledby={titleId}
+          aria-describedby={description ? descriptionId : undefined}
+          className="w-full max-w-md rounded-lg bg-slate-900 text-slate-100 shadow-2xl"
+        >
+          <div className="border-b border-slate-700 px-6 py-4">
+            <h2 id={titleId} className="text-lg font-semibold">
+              {title}
+            </h2>
+          </div>
+          {description && (
+            <div className="px-6 py-4">
+              <p id={descriptionId} className="text-sm text-slate-300">
+                {description}
+              </p>
+            </div>
+          )}
+          <div className="flex justify-end gap-3 border-t border-slate-700 px-6 py-4">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded border border-slate-600 px-4 py-2 text-sm font-medium text-slate-200 transition hover:bg-slate-800 focus:outline-none focus-visible:ring focus-visible:ring-slate-300"
+            >
+              {cancelLabel}
+            </button>
+            <button
+              type="button"
+              ref={confirmButtonRef}
+              onClick={onConfirm}
+              className="rounded bg-blue-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-600 focus:outline-none focus-visible:ring focus-visible:ring-blue-300"
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared `ConfirmDialog` modal with automatic focus management
- refactor `UseRouteAbortGuard` to use the dialog when navigation is blocked and expose helper methods on the controller

## Testing
- yarn lint components/UseRouteAbortGuard.tsx components/base/ConfirmDialog.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da1c24e2f88328aa11d81108fbc969