### PR TITLE
[components] Add loading skeleton and empty state to workflow card

### DIFF
--- a/__tests__/WorkflowCard.test.tsx
+++ b/__tests__/WorkflowCard.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import WorkflowCard from '../components/WorkflowCard';
+
+const mockSteps = [
+  {
+    title: 'Planning',
+    link: 'https://example.com/planning',
+    description: 'Draft the scope and objectives.'
+  },
+  {
+    title: 'Execution',
+    link: 'https://example.com/execution',
+    description: 'Carry out the agreed workflow.'
+  }
+];
+
+describe('WorkflowCard', () => {
+  it('renders workflow steps when provided', () => {
+    render(<WorkflowCard steps={mockSteps} />);
+
+    expect(screen.getByText('Planning')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Planning' })).toHaveAttribute(
+      'href',
+      'https://example.com/planning'
+    );
+    expect(screen.getByText('Draft the scope and objectives.')).toBeInTheDocument();
+  });
+
+  it('shows skeleton placeholders when loading', () => {
+    render(<WorkflowCard isLoading steps={[]} />);
+
+    const placeholders = screen.getAllByTestId('workflow-skeleton');
+    expect(placeholders).toHaveLength(3);
+  });
+
+  it('transitions through loading, empty, and populated states', () => {
+    const { rerender } = render(<WorkflowCard isLoading steps={[]} />);
+    expect(screen.getAllByTestId('workflow-skeleton')).toHaveLength(3);
+
+    rerender(
+      <WorkflowCard
+        steps={[]}
+        emptyMessage="No items here."
+        emptyCtaLabel="Add your first step"
+        emptyCtaHref="https://example.com/add"
+      />
+    );
+
+    expect(screen.queryAllByTestId('workflow-skeleton')).toHaveLength(0);
+    expect(screen.getByText('No items here.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Add your first step' })).toHaveAttribute(
+      'href',
+      'https://example.com/add'
+    );
+
+    rerender(<WorkflowCard steps={mockSteps} />);
+    expect(screen.queryByText('No items here.')).not.toBeInTheDocument();
+    expect(screen.getByText('Execution')).toBeInTheDocument();
+  });
+});
+

--- a/components/WorkflowCard.tsx
+++ b/components/WorkflowCard.tsx
@@ -6,7 +6,15 @@ interface Step {
   description: string;
 }
 
-const steps: Step[] = [
+interface WorkflowCardProps {
+  steps?: Step[];
+  isLoading?: boolean;
+  emptyMessage?: string;
+  emptyCtaLabel?: string;
+  emptyCtaHref?: string;
+}
+
+const defaultSteps: Step[] = [
   {
     title: 'Reconnaissance',
     link: 'https://www.kali.org/tools/nmap/',
@@ -24,26 +32,65 @@ const steps: Step[] = [
   }
 ];
 
-const WorkflowCard: React.FC = () => (
-  <section className="p-4 rounded bg-ub-grey text-white">
-    <h2 className="text-xl font-bold mb-2">Workflow</h2>
-    <ul>
-      {steps.map((s) => (
-        <li key={s.title} className="mb-2">
-          <a
-            href={s.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-ub-orange underline"
-          >
-            {s.title}
-          </a>
-          <p className="text-sm">{s.description}</p>
-        </li>
-      ))}
-    </ul>
-  </section>
-);
+const WorkflowCard: React.FC<WorkflowCardProps> = ({
+  steps = defaultSteps,
+  isLoading = false,
+  emptyMessage = 'No workflow steps are available right now.',
+  emptyCtaLabel = 'Browse sample workflows',
+  emptyCtaHref = 'https://www.kali.org/docs/'
+}) => {
+  const hasSteps = steps.length > 0;
+  const placeholderCount = Math.max(steps.length || 0, defaultSteps.length);
+
+  return (
+    <section className="p-4 rounded bg-ub-grey text-white">
+      <h2 className="text-xl font-bold mb-2">Workflow</h2>
+      <ul className="space-y-3" aria-live="polite">
+        {isLoading &&
+          Array.from({ length: placeholderCount }).map((_, index) => (
+            <li
+              key={`workflow-skeleton-${index}`}
+              className="rounded border border-white/10 p-3"
+              data-testid="workflow-skeleton"
+              aria-busy="true"
+            >
+              <div className="h-4 w-32 animate-pulse rounded bg-white/30" />
+              <div className="mt-3 h-3 w-full animate-pulse rounded bg-white/10" />
+            </li>
+          ))}
+
+        {!isLoading && hasSteps &&
+          steps.map((step) => (
+            <li key={step.title} className="rounded border border-white/10 p-3">
+              <a
+                href={step.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-ub-orange underline"
+              >
+                {step.title}
+              </a>
+              <p className="mt-2 text-sm text-white/80">{step.description}</p>
+            </li>
+          ))}
+
+        {!isLoading && !hasSteps && (
+          <li className="rounded border border-dashed border-white/20 p-6 text-center">
+            <p className="text-base font-medium text-white/80">{emptyMessage}</p>
+            <a
+              href={emptyCtaHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 inline-flex items-center justify-center rounded bg-ub-orange px-4 py-2 text-sm font-semibold text-black transition hover:bg-ub-orange/90"
+            >
+              {emptyCtaLabel}
+            </a>
+          </li>
+        )}
+      </ul>
+    </section>
+  );
+};
 
 export default WorkflowCard;
 


### PR DESCRIPTION
## Summary
- add loading and empty state support to the workflow card while keeping default steps
- introduce CTA-driven empty experience and skeleton placeholders to minimize layout shift
- cover loading, empty, and populated transitions with new unit tests

## Testing
- yarn test __tests__/WorkflowCard.test.tsx --runTestsByPath

------
https://chatgpt.com/codex/tasks/task_e_68da1c261e5c8328b6a1ef4cd36aa1b8