### PR TITLE
[ui] Add responsive typography ramp

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import Image from 'next/image';
+import { typography, typeClassName } from '@/styles/theme';
 import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 
@@ -399,7 +400,9 @@ const WhiskerMenu: React.FC = () => {
           }}
         >
           <div className="flex w-full max-h-[36vh] flex-col overflow-y-auto bg-gradient-to-b from-[#111c2b] via-[#101a27] to-[#0d1622] sm:max-h-[420px] sm:w-[260px] sm:overflow-visible">
-            <div className="flex items-center gap-2 border-b border-[#1d2a3c] px-4 py-3 text-xs uppercase tracking-[0.2em] text-[#4aa8ff]">
+            <div
+              className={`flex items-center gap-2 border-b border-[#1d2a3c] px-4 py-3 uppercase tracking-[0.2em] text-[#4aa8ff] ${typography.label}`}
+            >
               <span className="inline-flex h-2 w-2 rounded-full bg-[#4aa8ff]" aria-hidden />
               Categories
             </div>
@@ -418,7 +421,7 @@ const WhiskerMenu: React.FC = () => {
                     categoryButtonRefs.current[index] = el;
                   }}
                   type="button"
-                  className={`group flex items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1724] ${
+                  className={`group flex items-center gap-3 rounded-md px-3 py-2 text-left ${typography.bodySm} transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1724] ${
                     category === cat.id
                       ? 'bg-[#162236] text-white shadow-[inset_2px_0_0_#53b9ff]'
                       : 'text-gray-300 hover:bg-[#152133] hover:text-white'
@@ -430,7 +433,11 @@ const WhiskerMenu: React.FC = () => {
                     setCategoryHighlight(index);
                   }}
                 >
-                  <span className="w-8 font-mono text-[11px] uppercase tracking-[0.2em] text-[#4aa8ff]">{String(index + 1).padStart(2, '0')}</span>
+                  <span
+                    className={`w-8 font-mono uppercase tracking-[0.2em] text-[#4aa8ff] ${typeClassName('2xs')}`}
+                  >
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
                   <span className="flex items-center gap-2">
                     <Image
                       src={cat.icon}
@@ -445,12 +452,16 @@ const WhiskerMenu: React.FC = () => {
                 </button>
               ))}
             </div>
-            <div className="border-t border-[#1d2a3c] px-4 py-3 text-sm text-gray-400">
+            <div className={`border-t border-[#1d2a3c] px-4 py-3 text-gray-400 ${typography.bodySm}`}>
               <div className="flex items-center gap-2">
-                <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#142132] text-sm font-semibold uppercase text-[#53b9ff]">k</span>
+                <span
+                  className={`inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#142132] font-semibold uppercase text-[#53b9ff] ${typography.bodySm}`}
+                >
+                  k
+                </span>
                 <div>
-                  <p className="text-sm font-semibold text-white">kali</p>
-                  <p className="text-xs uppercase tracking-[0.3em] text-gray-500">User Session</p>
+                  <p className={`font-semibold text-white ${typography.bodySm}`}>kali</p>
+                  <p className={`uppercase tracking-[0.3em] text-gray-500 ${typography.label}`}>User Session</p>
                 </div>
               </div>
             </div>
@@ -485,7 +496,7 @@ const WhiskerMenu: React.FC = () => {
                   </svg>
                 </span>
                 <input
-                  className="h-10 w-full rounded-lg border border-transparent bg-[#101c2d] pl-9 pr-3 text-sm text-gray-100 shadow-inner focus:border-[#53b9ff] focus:outline-none focus:ring-0"
+                  className={`h-10 w-full rounded-lg border border-transparent bg-[#101c2d] pl-9 pr-3 text-gray-100 shadow-inner focus:border-[#53b9ff] focus:outline-none focus:ring-0 ${typography.bodySm}`}
                   placeholder="Search applications"
                   aria-label="Search applications"
                   value={query}
@@ -496,7 +507,7 @@ const WhiskerMenu: React.FC = () => {
             </div>
             <div className="flex-1 overflow-y-auto px-3 py-3 sm:px-2">
               {currentApps.length === 0 ? (
-                <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-gray-500">
+                <div className={`flex h-full flex-col items-center justify-center gap-3 text-gray-500 ${typography.bodySm}`}>
                   <span className="flex h-12 w-12 items-center justify-center rounded-full bg-[#121f33] text-[#4aa8ff]">
                     <svg
                       width="24"
@@ -522,11 +533,11 @@ const WhiskerMenu: React.FC = () => {
                     <li key={app.id}>
                       <button
                         type="button"
-                        className={`flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1a29] ${
-                          idx === highlight
-                            ? 'bg-[#162438] text-white shadow-[0_0_0_1px_rgba(83,185,255,0.35)]'
-                            : 'text-gray-200 hover:bg-[#142132]'
-                        } ${app.disabled ? 'cursor-not-allowed opacity-60' : ''}`}
+                      className={`flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left ${typography.bodySm} transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1a29] ${
+                        idx === highlight
+                          ? 'bg-[#162438] text-white shadow-[0_0_0_1px_rgba(83,185,255,0.35)]'
+                          : 'text-gray-200 hover:bg-[#142132]'
+                      } ${app.disabled ? 'cursor-not-allowed opacity-60' : ''}`}
                         aria-label={app.title}
                         disabled={app.disabled}
                         onClick={() => {
@@ -548,8 +559,8 @@ const WhiskerMenu: React.FC = () => {
                             />
                           </div>
                           <div>
-                            <p className="font-medium text-[15px]">{app.title}</p>
-                            <p className="text-xs uppercase tracking-[0.25em] text-[#4aa8ff]">Application</p>
+                            <p className={`font-medium ${typography.body}`}>{app.title}</p>
+                            <p className={`uppercase tracking-[0.25em] text-[#4aa8ff] ${typography.label}`}>Application</p>
                           </div>
                         </div>
                         <svg

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import UbuntuApp from '../base/ubuntu_app';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { typography, typeClassName } from '@/styles/theme';
 
 const FAVORITES_KEY = 'launcherFavorites';
 const RECENTS_KEY = 'recentApps';
@@ -134,7 +135,7 @@ class AllApplications extends React.Component {
                             : `Add ${app.title} to favorites`
                     }
                     onClick={(event) => this.handleToggleFavorite(event, app.id)}
-                    className={`absolute right-2 top-2 text-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
+                    className={`absolute right-2 top-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${typeClassName('lg')} ${
                         isFavorite ? 'text-yellow-300' : 'text-white/60 hover:text-white'
                     }`}
                 >
@@ -156,7 +157,7 @@ class AllApplications extends React.Component {
         if (!apps.length) return null;
         return (
             <section key={title} aria-label={`${title} apps`} className="mb-8 w-full">
-                <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-white/70">
+                <h2 className={`mb-3 font-semibold uppercase tracking-wider text-white/70 ${typography.bodySm}`}>
                     {title}
                 </h2>
                 <div className="grid grid-cols-3 gap-6 place-items-center pb-6 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8">
@@ -198,7 +199,7 @@ class AllApplications extends React.Component {
                         group.length ? this.renderSection(`Group ${index + 1}`, group) : null
                     )}
                     {!hasResults && (
-                        <p className="mt-6 text-center text-sm text-white/70">
+                        <p className={`mt-6 text-center text-white/70 ${typography.bodySm}`}>
                             No applications match your search.
                         </p>
                     )}

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { typography, typeClassName } from '@/styles/theme'
 
 const bootMessages = [
     'Securing environment',
@@ -29,7 +30,7 @@ function BootingScreen(props) {
                 </div>
 
                 <div className="relative flex flex-col items-center gap-6 px-6 text-center">
-                    <span className="text-xs uppercase tracking-[0.5em] text-slate-400">Initializing workspace</span>
+                    <span className={`uppercase tracking-[0.5em] text-slate-400 ${typography.label}`}>Initializing workspace</span>
                     <div className="relative">
                         <div className="absolute -inset-6 rounded-full bg-sky-500/20 blur-3xl" aria-hidden />
                         <Image
@@ -42,7 +43,7 @@ function BootingScreen(props) {
                             priority
                         />
                     </div>
-                    <span className="text-4xl font-semibold tracking-[0.35em] text-sky-200 md:text-5xl">KALI</span>
+                    <span className={`font-semibold tracking-[0.35em] text-sky-200 ${typeClassName('2xl')} md:${typeClassName('3xl')}`}>KALI</span>
                 </div>
 
                 <div className="relative flex flex-col items-center gap-6 px-6">
@@ -66,7 +67,7 @@ function BootingScreen(props) {
                         )}
                     </button>
 
-                    <ul className="flex flex-col gap-2 text-sm text-slate-300">
+                    <ul className={`flex flex-col gap-2 text-slate-300 ${typography.bodySm}`}>
                         {bootMessages.map((message) => (
                             <li key={message} className="flex items-center gap-3">
                                 <span className="inline-flex h-2 w-2 rounded-full bg-sky-400/70 shadow-[0_0_12px_rgba(56,189,248,0.7)] animate-[pulse_2s_ease-in-out_infinite]" aria-hidden />
@@ -76,7 +77,7 @@ function BootingScreen(props) {
                     </ul>
                 </div>
 
-                <div className="relative mb-6 flex gap-4 text-xs uppercase tracking-[0.4em] text-slate-500">
+                <div className={`relative mb-6 flex gap-4 uppercase tracking-[0.4em] text-slate-500 ${typography.label}`}>
                     <a className="transition hover:text-slate-200" href="https://www.linkedin.com/in/unnippillil/" rel="noopener noreferrer" target="_blank">
                         LinkedIn
                     </a>

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -2,6 +2,7 @@
 
 import React, { Component } from 'react';
 import dynamic from 'next/dynamic';
+import { typography } from '@/styles/theme';
 
 const BackgroundImage = dynamic(
     () => import('../util-components/background-image'),
@@ -1704,7 +1705,7 @@ export class Desktop extends Component {
         };
 
         return (
-            <div className="absolute rounded-md top-1/2 left-1/2 text-center text-white font-light text-sm bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50">
+            <div className={`absolute rounded-md top-1/2 left-1/2 text-center text-white font-light bg-ub-cool-grey transform -translate-y-1/2 -translate-x-1/2 sm:w-96 w-3/4 z-50 ${typography.bodySm}`}>
                 <div className="w-full flex flex-col justify-around items-start pl-6 pb-8 pt-6">
                     <span>New folder name</span>
                     <input

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
 import KaliWallpaper from '../util-components/kali-wallpaper';
+import { typography, typeClassName } from '@/styles/theme';
 
 export default function LockScreen(props) {
 
@@ -30,13 +31,13 @@ export default function LockScreen(props) {
                 />
             )}
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
-                <div className=" text-7xl">
+                <div className={` ${typography.display}`}>
                     <Clock onlyTime={true} />
                 </div>
-                <div className="mt-4 text-xl font-medium">
+                <div className={`mt-4 font-medium ${typeClassName('xl')}`}>
                     <Clock onlyDay={true} />
                 </div>
-                <div className=" mt-16 text-base">
+                <div className={` mt-16 ${typography.body}`}>
                     Click or Press a key to unlock
                 </div>
             </div>

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -6,6 +6,7 @@ import WhiskerMenu from '../menu/WhiskerMenu';
 import PerformanceGraph from '../ui/PerformanceGraph';
 import WorkspaceSwitcher from '../panel/WorkspaceSwitcher';
 import { NAVBAR_HEIGHT } from '../../utils/uiConstants';
+import { typography, typeClassName } from '@/styles/theme';
 
 const areWorkspacesEqual = (next, prev) => {
         if (next.length !== prev.length) return false;
@@ -82,7 +83,7 @@ export default class Navbar extends PureComponent {
                                         className="main-navbar-vp fixed inset-x-0 top-0 z-50 flex h-14 w-full items-center justify-between bg-slate-950/80 px-3 text-ubt-grey shadow-lg backdrop-blur-md"
                                         style={{ minHeight: NAVBAR_HEIGHT }}
                                 >
-                                        <div className="flex items-center gap-2 text-xs md:text-sm">
+                                        <div className={`flex items-center gap-2 ${typography.bodySm} md:${typeClassName('md')}`}>
                                                 <WhiskerMenu />
                                                 {workspaces.length > 0 && (
                                                         <WorkspaceSwitcher
@@ -94,9 +95,7 @@ export default class Navbar extends PureComponent {
                                                 <PerformanceGraph />
                                         </div>
                                         <div
-                                                className={
-                                                        'rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/90 shadow-sm backdrop-blur transition duration-150 ease-in-out hover:border-white/30 hover:bg-white/10'
-                                                }
+                                                className={`rounded-full border border-white/10 bg-white/5 px-3 py-1 font-medium text-white/90 shadow-sm backdrop-blur transition duration-150 ease-in-out hover:border-white/30 hover:bg-white/10 ${typography.caption}`}
                                         >
                                                 <Clock onlyTime={true} showCalendar={true} hour12={false} />
                                         </div>
@@ -105,9 +104,7 @@ export default class Navbar extends PureComponent {
                                                 id="status-bar"
                                                 aria-label="System status"
                                                 onClick={this.handleStatusToggle}
-                                                className={
-                                                        'relative rounded-full border border-transparent px-3 py-1 text-xs font-medium text-white/80 transition duration-150 ease-in-out hover:border-white/20 hover:bg-white/10 focus:border-ubb-orange focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300'
-                                                }
+                                                className={`relative rounded-full border border-transparent px-3 py-1 font-medium text-white/80 transition duration-150 ease-in-out hover:border-white/20 hover:bg-white/10 focus:border-ubb-orange focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 ${typography.caption}`}
                                         >
                                                 <Status />
                                                 <QuickSettings open={this.state.status_card} />

--- a/components/ui/AppTooltipContent.tsx
+++ b/components/ui/AppTooltipContent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { typography, typographyMono } from '@/styles/theme';
 
 type AppTooltipContentProps = {
   meta?: {
@@ -11,27 +12,27 @@ type AppTooltipContentProps = {
 
 const AppTooltipContent: React.FC<AppTooltipContentProps> = ({ meta }) => {
   if (!meta) {
-    return <span className="text-xs text-gray-200">Metadata unavailable.</span>;
+    return <span className={`${typography.caption} text-gray-200`}>Metadata unavailable.</span>;
   }
 
   return (
     <div className="space-y-2">
       {meta.title ? (
-        <p className="text-sm font-semibold text-white">{meta.title}</p>
+        <p className={`font-semibold text-white ${typography.body}`}>{meta.title}</p>
       ) : null}
       {meta.description ? (
-        <p className="text-xs leading-relaxed text-gray-200">{meta.description}</p>
+        <p className={`${typography.bodySm} leading-relaxed text-gray-200`}>{meta.description}</p>
       ) : null}
       {meta.path ? (
-        <p className="text-[11px] text-gray-300">
-          <span className="font-semibold text-gray-100">Path:</span>{' '}
-          <code className="rounded bg-black/40 px-1 py-0.5 text-[11px] text-ubt-grey">
+        <p className={`${typography.caption} text-gray-300`}>
+          <span className={`font-semibold text-gray-100 ${typography.bodySm}`}>Path:</span>{' '}
+          <code className={`rounded bg-black/40 px-1 py-0.5 text-ubt-grey ${typographyMono.xs}`}>
             {meta.path}
           </code>
         </p>
       ) : null}
       {meta.keyboard?.length ? (
-        <ul className="list-disc space-y-1 pl-4 text-[11px] text-gray-200">
+        <ul className={`list-disc space-y-1 pl-4 text-gray-200 ${typography.caption}`}>
           {meta.keyboard.map((hint) => (
             <li key={hint}>{hint}</li>
           ))}

--- a/components/ui/BatteryIndicator.tsx
+++ b/components/ui/BatteryIndicator.tsx
@@ -3,6 +3,8 @@
 import type { ChangeEvent, FC, MouseEvent } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { typography } from "@/styles/theme";
+
 import usePersistentState from "../../hooks/usePersistentState";
 
 export const clampLevel = (value: number) => Math.min(1, Math.max(0, value));
@@ -193,21 +195,25 @@ const BatteryIndicator: FC<BatteryIndicatorProps> = ({ className = "" }) => {
       </button>
       {open && (
         <div
-          className="absolute bottom-full right-0 z-50 mb-2 min-w-[14rem] rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-3 text-xs text-white shadow-lg"
+          className={`absolute bottom-full right-0 z-50 mb-2 min-w-[14rem] rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-3 text-white shadow-lg ${typography.caption}`}
           role="menu"
           aria-label="Battery menu"
           onClick={(event) => event.stopPropagation()}
           onPointerDown={(event) => event.stopPropagation()}
         >
-          <div className="mb-3 text-[11px] uppercase tracking-wide text-gray-200">Battery</div>
-          <div className="mb-3 rounded bg-black bg-opacity-20 p-3 text-[11px] text-gray-200">
+          <div className={`mb-3 uppercase tracking-wide text-gray-200 ${typography.label}`}>
+            Battery
+          </div>
+          <div className={`mb-3 rounded bg-black bg-opacity-20 p-3 text-gray-200 ${typography.label}`}>
             <div className="flex items-center justify-between text-white">
-              <span className="text-base font-semibold">{formattedLevel}</span>
-              <span className="uppercase">{charging ? "Charging" : "On battery"}</span>
+              <span className={`font-semibold ${typography.body}`}>{formattedLevel}</span>
+              <span className={`uppercase ${typography.label}`}>{charging ? "Charging" : "On battery"}</span>
             </div>
             <p className="mt-1 text-gray-300">{estimateBatteryTime(level, charging)}</p>
           </div>
-          <div className="mb-3 text-[11px] uppercase tracking-wide text-gray-200">Adjust level</div>
+          <div className={`mb-3 uppercase tracking-wide text-gray-200 ${typography.label}`}>
+            Adjust level
+          </div>
           <input
             ref={sliderRef}
             type="range"
@@ -221,8 +227,10 @@ const BatteryIndicator: FC<BatteryIndicatorProps> = ({ className = "" }) => {
               setLevel(clampLevel(Number(event.target.value) / 100))
             }
           />
-          <label className="mb-3 flex items-center justify-between text-[11px] uppercase tracking-wide text-gray-200">
-            <span className="text-white normal-case">Charging</span>
+          <label
+            className={`mb-3 flex items-center justify-between uppercase tracking-wide text-gray-200 ${typography.label}`}
+          >
+            <span className={`text-white normal-case ${typography.bodySm}`}>Charging</span>
             <input
               type="checkbox"
               checked={charging}
@@ -230,8 +238,10 @@ const BatteryIndicator: FC<BatteryIndicatorProps> = ({ className = "" }) => {
               aria-label={charging ? "Stop charging" : "Start charging"}
             />
           </label>
-          <label className="mb-3 flex items-center justify-between text-[11px] uppercase tracking-wide text-gray-200">
-            <span className="text-white normal-case">Battery saver</span>
+          <label
+            className={`mb-3 flex items-center justify-between uppercase tracking-wide text-gray-200 ${typography.label}`}
+          >
+            <span className={`text-white normal-case ${typography.bodySm}`}>Battery saver</span>
             <input
               type="checkbox"
               checked={batterySaver}
@@ -239,14 +249,18 @@ const BatteryIndicator: FC<BatteryIndicatorProps> = ({ className = "" }) => {
               aria-label="Toggle battery saver"
             />
           </label>
-          <div className="mb-2 text-[11px] uppercase tracking-wide text-gray-200">Power mode</div>
+          <div className={`mb-2 uppercase tracking-wide text-gray-200 ${typography.label}`}>
+            Power mode
+          </div>
           <div className="space-y-1" role="group" aria-label="Power mode">
             {(Object.keys(POWER_MODE_LABEL) as PowerMode[]).map((mode) => (
               <label
                 key={mode}
-                className="flex items-center justify-between rounded px-2 py-2 text-sm transition hover:bg-white hover:bg-opacity-10"
+                className={`flex items-center justify-between rounded px-2 py-2 transition hover:bg-white hover:bg-opacity-10 ${typography.bodySm}`}
               >
-                <span className="font-medium text-white">{POWER_MODE_LABEL[mode]}</span>
+                <span className={`font-medium text-white ${typography.bodySm}`}>
+                  {POWER_MODE_LABEL[mode]}
+                </span>
                 <input
                   type="radio"
                   name="power-mode"

--- a/components/ui/DelayedTooltip.tsx
+++ b/components/ui/DelayedTooltip.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { typography } from '@/styles/theme';
 
 type TriggerProps = {
   ref: (node: HTMLElement | null) => void;
@@ -23,7 +24,9 @@ type DelayedTooltipProps = {
 };
 
 const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+  typeof globalThis !== 'undefined' && 'document' in globalThis
+    ? useLayoutEffect
+    : useEffect;
 
 const DEFAULT_OFFSET = 8;
 
@@ -53,14 +56,14 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
 
   const clearTimer = useCallback(() => {
     if (timerRef.current !== null) {
-      window.clearTimeout(timerRef.current);
+      clearTimeout(timerRef.current);
       timerRef.current = null;
     }
   }, []);
 
   const show = useCallback(() => {
     clearTimer();
-    timerRef.current = window.setTimeout(() => {
+    timerRef.current = setTimeout(() => {
       setVisible(true);
     }, delay);
   }, [clearTimer, delay]);
@@ -136,7 +139,7 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
                 left: position.left,
                 zIndex: 1000,
               }}
-              className="pointer-events-none max-w-xs rounded-md border border-gray-500/60 bg-ub-grey/95 px-3 py-2 text-xs text-white shadow-xl backdrop-blur"
+              className={`pointer-events-none max-w-xs rounded-md border border-gray-500/60 bg-ub-grey/95 px-3 py-2 text-white shadow-xl backdrop-blur ${typography.caption}`}
             >
               {content}
             </div>,

--- a/components/ui/FormError.tsx
+++ b/components/ui/FormError.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { typography } from '@/styles/theme';
 
 interface FormErrorProps {
   id?: string;
@@ -11,7 +12,7 @@ const FormError = ({ id, className = '', children }: FormErrorProps) => (
     id={id}
     role="status"
     aria-live="polite"
-    className={`text-red-600 text-sm mt-2 ${className}`.trim()}
+    className={`mt-2 text-red-600 ${typography.bodySm} ${className}`.trim()}
   >
     {children}
   </p>

--- a/components/ui/NetworkIndicator.tsx
+++ b/components/ui/NetworkIndicator.tsx
@@ -4,6 +4,7 @@ import QRCode from "qrcode";
 import type { FC, MouseEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { typography, typographyMono, typeClassName } from "@/styles/theme";
 import usePersistentState from "../../hooks/usePersistentState";
 
 type NetworkType = "wired" | "wifi";
@@ -576,28 +577,34 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
       </button>
       {open && (
         <div
-          className="absolute bottom-full right-0 z-50 mb-2 min-w-[14rem] rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-3 text-xs text-white shadow-lg"
+          className={`absolute bottom-full right-0 z-50 mb-2 min-w-[14rem] rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-3 text-white shadow-lg ${typography.caption}`}
           role="menu"
           aria-label="Network menu"
           onClick={(event) => event.stopPropagation()}
           onPointerDown={(event) => event.stopPropagation()}
         >
-          <div className="mb-3 text-[11px] uppercase tracking-wide text-gray-200">Network</div>
+          <div className={`mb-3 uppercase tracking-wide text-gray-200 ${typography.label}`}>
+            Network
+          </div>
           <div className="mb-3 rounded bg-black bg-opacity-20 p-3">
-            <div className="flex items-center justify-between text-[11px] text-gray-200">
+            <div className={`flex items-center justify-between text-gray-200 ${typography.label}`}>
               <span className="uppercase">Status</span>
-              <span className="font-semibold text-white">{summary.label}</span>
+              <span className={`font-semibold text-white ${typography.bodySm}`}>{summary.label}</span>
             </div>
-            <p className="mt-1 text-[11px] text-gray-300">{summary.description}</p>
-            {summary.meta && <p className="mt-1 text-[11px] text-gray-400">{summary.meta}</p>}
+            <p className={`mt-1 text-gray-300 ${typography.label}`}>{summary.description}</p>
+            {summary.meta && (
+              <p className={`mt-1 text-gray-400 ${typography.label}`}>{summary.meta}</p>
+            )}
           </div>
           {summary.notice && (
-            <div className="mb-3 rounded border border-red-500/50 bg-red-900/30 p-2 text-[11px] text-red-200">
+            <div className={`mb-3 rounded border border-red-500/50 bg-red-900/30 p-2 text-red-200 ${typography.label}`}>
               {summary.notice}
             </div>
           )}
-          <label className="mb-3 flex items-center justify-between text-[11px] uppercase tracking-wide text-gray-200">
-            <span className="text-white normal-case">Wi-Fi</span>
+          <label
+            className={`mb-3 flex items-center justify-between uppercase tracking-wide text-gray-200 ${typography.label}`}
+          >
+            <span className={`text-white normal-case ${typography.bodySm}`}>Wi-Fi</span>
             <input
               type="checkbox"
               checked={wifiEnabled}
@@ -605,7 +612,9 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
               aria-label={wifiEnabled ? "Disable Wi-Fi" : "Enable Wi-Fi"}
             />
           </label>
-          <div className="mb-2 text-[11px] uppercase tracking-wide text-gray-200">Available networks</div>
+          <div className={`mb-2 uppercase tracking-wide text-gray-200 ${typography.label}`}>
+            Available networks
+          </div>
           <ul className="space-y-2" role="group" aria-label="Available networks">
             {NETWORKS.map((network) => {
               const connected = connectedId === network.id;
@@ -624,13 +633,15 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
                       disabled={disabled}
                       aria-pressed={connected}
                     >
-                      <div className="flex items-center justify-between text-sm">
-                        <span className="font-medium text-white">{network.name}</span>
+                      <div className={`flex items-center justify-between ${typography.bodySm}`}>
+                        <span className={`font-medium text-white ${typography.bodySm}`}>{network.name}</span>
                         {network.type === "wifi" && network.strength && (
-                          <span className="text-[11px] text-gray-200">{SIGNAL_LABEL[network.strength]}</span>
+                          <span className={`text-gray-200 ${typography.label}`}>
+                            {SIGNAL_LABEL[network.strength]}
+                          </span>
                         )}
                       </div>
-                      <div className="text-[11px] text-gray-300">
+                      <div className={`text-gray-300 ${typography.label}`}>
                         {connected
                           ? network.details
                           : network.type === "wifi"
@@ -643,7 +654,7 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
                     {network.type === "wifi" && (
                       <button
                         type="button"
-                        className="h-full min-h-[2.75rem] rounded border border-white/20 px-2 text-[11px] uppercase tracking-wide text-gray-200 transition hover:border-white/40 hover:text-white"
+                        className={`h-full min-h-[2.75rem] rounded border border-white/20 px-2 uppercase tracking-wide text-gray-200 transition hover:border-white/40 hover:text-white ${typography.label}`}
                         onClick={() => handleShare(network)}
                         aria-label={`Share ${network.name}`}
                       >
@@ -657,14 +668,14 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
           </ul>
           <button
             type="button"
-            className="mt-3 w-full rounded border border-white/10 bg-black/20 px-2 py-1 text-[11px] uppercase tracking-wide text-gray-300 transition hover:border-white/40 hover:text-white"
+            className={`mt-3 w-full rounded border border-white/10 bg-black/20 px-2 py-1 uppercase tracking-wide text-gray-300 transition hover:border-white/40 hover:text-white ${typography.label}`}
             onClick={() => setShowLogs((prev) => !prev)}
             aria-expanded={showLogs}
           >
             {showLogs ? "Hide share activity" : "Show share activity"}
           </button>
           {showLogs && (
-            <div className="mt-2 max-h-32 overflow-y-auto rounded border border-white/10 bg-black/30 p-2 text-[11px] text-gray-200">
+            <div className={`mt-2 max-h-32 overflow-y-auto rounded border border-white/10 bg-black/30 p-2 text-gray-200 ${typography.label}`}>
               {shareLogs.length === 0 ? (
                 <p>No share activity recorded yet.</p>
               ) : (
@@ -696,37 +707,41 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
             role="dialog"
             aria-modal="true"
             aria-label={`Share ${shareTarget.name}`}
-            className="w-full max-w-md rounded-lg border border-white/20 bg-ub-cool-grey p-5 text-sm text-white shadow-xl"
+            className={`w-full max-w-md rounded-lg border border-white/20 bg-ub-cool-grey p-5 text-white shadow-xl ${typography.bodySm}`}
             onClick={(event) => event.stopPropagation()}
           >
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h2 className="text-base font-semibold">Share {shareTarget.name}</h2>
-                <p className="mt-1 text-[11px] uppercase tracking-wide text-red-200">
+                <h2 className={`font-semibold ${typography.titleSm}`}>Share {shareTarget.name}</h2>
+                <p className={`mt-1 uppercase tracking-wide text-red-200 ${typography.label}`}>
                   Privacy warning: credentials stay hidden until you confirm. All share actions are logged locally for review.
                 </p>
               </div>
               <button
                 type="button"
-                className="rounded border border-white/20 px-2 py-1 text-[11px] uppercase tracking-wide text-gray-200 transition hover:border-white/40 hover:text-white"
+                className={`rounded border border-white/20 px-2 py-1 uppercase tracking-wide text-gray-200 transition hover:border-white/40 hover:text-white ${typography.label}`}
                 onClick={closeShare}
                 aria-label="Close share dialog"
               >
                 Close
               </button>
             </div>
-            <div className="mt-4 space-y-2 rounded border border-white/15 bg-black/30 p-3 text-[13px]">
+            <div className={`mt-4 space-y-2 rounded border border-white/15 bg-black/30 p-3 ${typography.bodySm}`}>
               <div className="flex items-center justify-between">
                 <span className="text-gray-300">SSID</span>
-                <span className="font-medium text-white">{shareTarget.credentials?.ssid ?? shareTarget.name}</span>
+                <span className={`font-medium text-white ${typography.bodySm}`}>
+                  {shareTarget.credentials?.ssid ?? shareTarget.name}
+                </span>
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-gray-300">Security</span>
-                <span className="text-white">{shareTarget.credentials?.security ?? "Unknown"}</span>
+                <span className={`text-white ${typography.bodySm}`}>
+                  {shareTarget.credentials?.security ?? "Unknown"}
+                </span>
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-gray-300">Password</span>
-                <span className="font-mono text-white">
+                <span className={`font-mono text-white ${typographyMono.body}`}>
                   {shareConfirmed
                     ? shareTarget.credentials?.password ?? "Not required"
                     : maskSecret(shareTarget.credentials?.password)}
@@ -737,14 +752,14 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
               {!shareConfirmed && (
                 <button
                   type="button"
-                  className="w-full rounded bg-ub-blue px-3 py-2 text-sm font-semibold text-white transition hover:bg-ub-blue/80"
+                  className={`w-full rounded bg-ub-blue px-3 py-2 font-semibold text-white transition hover:bg-ub-blue/80 ${typography.bodySm}`}
                   onClick={handleConfirmShare}
                 >
                   Reveal &amp; Generate QR
                 </button>
               )}
               {shareConfirmed && shareStatus.state === "pending" && (
-                <div className="rounded border border-white/10 bg-black/40 px-3 py-2 text-center text-[13px] text-gray-200">
+                <div className={`rounded border border-white/10 bg-black/40 px-3 py-2 text-center text-gray-200 ${typography.bodySm}`}>
                   Generating secure QR code…
                 </div>
               )}
@@ -755,12 +770,12 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
                     alt={`Wi-Fi share code for ${shareTarget.name}`}
                     className="mx-auto h-40 w-40 rounded bg-white p-2"
                   />
-                  <p className="text-[11px] text-gray-300">Payload: {shareStatus.payload}</p>
-                  {nfcStatus && <p className="text-[11px] text-gray-200">{nfcStatus}</p>}
+                  <p className={`text-gray-300 ${typography.label}`}>Payload: {shareStatus.payload}</p>
+                  {nfcStatus && <p className={`text-gray-200 ${typography.label}`}>{nfcStatus}</p>}
                 </div>
               )}
               {shareStatus.state === "error" && (
-                <div className="rounded border border-red-500/60 bg-red-900/40 px-3 py-2 text-[13px] text-red-100">
+                <div className={`rounded border border-red-500/60 bg-red-900/40 px-3 py-2 text-red-100 ${typography.bodySm}`}>
                   {shareStatus.message}
                 </div>
               )}

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -14,6 +14,7 @@ import {
   NotificationPriority,
 } from '../../hooks/useNotifications';
 import { PRIORITY_ORDER } from '../../utils/notifications/ruleEngine';
+import { typography, typeClassName } from '@/styles/theme';
 
 const focusableSelector =
   'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
@@ -256,7 +257,9 @@ const NotificationBell: React.FC = () => {
           <path d="M7 12a3 3 0 006 0H7z" />
         </svg>
         {unreadCount > 0 && (
-          <span className="absolute -top-1.5 -right-1.5 min-w-[1.5rem] rounded-full bg-ubb-orange px-1 text-center text-[0.65rem] font-semibold leading-5 text-white">
+          <span
+            className={`absolute -top-1.5 -right-1.5 min-w-[1.5rem] rounded-full bg-ubb-orange px-1 text-center font-semibold leading-5 text-white ${typeClassName('2xs')}`}
+          >
             {unreadCount > 99 ? '99+' : unreadCount}
           </span>
         )}
@@ -272,21 +275,21 @@ const NotificationBell: React.FC = () => {
           className="absolute right-0 z-50 mt-2 w-72 max-h-96 overflow-hidden rounded-md border border-white/10 bg-ub-grey/95 text-ubt-grey shadow-xl backdrop-blur"
         >
           <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
-            <h2 id={headingId} className="text-sm font-semibold text-white">
+            <h2 id={headingId} className={`font-semibold text-white ${typography.body}`}>
               Notifications
             </h2>
             <button
               type="button"
               onClick={handleDismissAll}
               disabled={notifications.length === 0}
-              className="text-xs font-medium text-ubb-orange transition disabled:cursor-not-allowed disabled:text-ubt-grey disabled:text-opacity-50"
+              className={`font-medium text-ubb-orange transition disabled:cursor-not-allowed disabled:text-ubt-grey disabled:text-opacity-50 ${typography.caption}`}
             >
               Dismiss all
             </button>
           </div>
           <div className="max-h-80 overflow-y-auto">
             {notifications.length === 0 ? (
-              <p className="px-4 py-6 text-center text-sm text-ubt-grey text-opacity-80">
+              <p className={`px-4 py-6 text-center text-ubt-grey text-opacity-80 ${typography.bodySm}`}>
                 You&apos;re all caught up.
               </p>
             ) : (
@@ -302,12 +305,12 @@ const NotificationBell: React.FC = () => {
                         onClick={() => toggleGroup(group.priority)}
                         aria-expanded={!collapsed}
                         aria-controls={contentId}
-                        className="flex w-full items-center justify-between px-4 py-2 text-left text-sm font-semibold text-white transition hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-ubb-orange"
+                        className={`flex w-full items-center justify-between px-4 py-2 text-left font-semibold text-white transition hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-ubb-orange ${typography.bodySm}`}
                       >
                         <span className="flex items-center gap-2">
                           {group.metadata.label}
                           <span
-                            className={`rounded-full px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide ${group.metadata.badgeClass}`}
+                            className={`rounded-full px-2 py-0.5 font-semibold uppercase tracking-wide ${group.metadata.badgeClass} ${typeClassName('2xs')}`}
                             title={group.metadata.description}
                           >
                             {group.notifications.length}
@@ -334,12 +337,12 @@ const NotificationBell: React.FC = () => {
                           {group.notifications.map(notification => (
                             <li
                               key={notification.id}
-                              className={`border-l-2 px-4 py-3 text-sm text-white ${notification.metadata.accentClass}`}
+                              className={`border-l-2 px-4 py-3 text-white ${notification.metadata.accentClass} ${typography.bodySm}`}
                             >
                               <div className="flex items-start justify-between gap-2">
                                 <p className="font-medium">{notification.title}</p>
                                 <span
-                                  className={`shrink-0 rounded-full px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-wide ${notification.metadata.badgeClass}`}
+                                  className={`shrink-0 rounded-full px-2 py-0.5 font-semibold uppercase tracking-wide ${notification.metadata.badgeClass} ${typeClassName('2xs')}`}
                                   title={
                                     notification.classification.matchedRuleId
                                       ? `Priority ${notification.metadata.label} (${notification.classification.source}: ${notification.classification.matchedRuleId})`
@@ -350,11 +353,13 @@ const NotificationBell: React.FC = () => {
                                 </span>
                               </div>
                               {notification.body && (
-                                <p className="mt-1 whitespace-pre-line text-xs text-ubt-grey text-opacity-80">
+                                <p className={`mt-1 whitespace-pre-line text-ubt-grey text-opacity-80 ${typography.caption}`}>
                                   {notification.body}
                                 </p>
                               )}
-                              <div className="mt-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-[0.65rem] uppercase tracking-wide text-ubt-grey text-opacity-70">
+                              <div
+                                className={`mt-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 uppercase tracking-wide text-ubt-grey text-opacity-70 ${typeClassName('2xs')}`}
+                              >
                                 <span>{notification.appId}</span>
                                 <time dateTime={notification.formattedTime}>{notification.readableTime}</time>
                               </div>

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState, createContext, useContext } from 'react';
+import { typography } from '@/styles/theme';
 
 function middleEllipsis(text: string, max = 30) {
   if (text.length <= max) return text;
@@ -168,7 +169,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
       tabIndex={0}
       onKeyDown={onKeyDown}
     >
-      <div className="flex flex-shrink-0 bg-gray-800 text-white text-sm overflow-x-auto">
+      <div className={`flex flex-shrink-0 bg-gray-800 text-white overflow-x-auto ${typography.bodySm}`}>
         {tabs.map((t, i) => (
           <div
             key={t.id}

--- a/components/ui/VideoPlayer.tsx
+++ b/components/ui/VideoPlayer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
+import { typography } from "@/styles/theme";
 import PipPortalProvider, { usePipPortal } from "../common/PipPortal";
 
 interface VideoPlayerProps {
@@ -105,15 +106,34 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
             alignItems: "center",
           }}
         >
-          <button onClick={() => send({ type: "toggle" })}>Play/Pause</button>
-          <button onClick={() => send({ type: "seek", delta: -5 })}>-5s</button>
-          <button onClick={() => send({ type: "seek", delta: 5 })}>+5s</button>
+          <button
+            type="button"
+            onClick={() => send({ type: "toggle" })}
+            aria-label="Toggle playback"
+          >
+            Play/Pause
+          </button>
+          <button
+            type="button"
+            onClick={() => send({ type: "seek", delta: -5 })}
+            aria-label="Seek backward five seconds"
+          >
+            -5s
+          </button>
+          <button
+            type="button"
+            onClick={() => send({ type: "seek", delta: 5 })}
+            aria-label="Seek forward five seconds"
+          >
+            +5s
+          </button>
           <input
             type="range"
             min={0}
             max={1}
             step={0.05}
             value={vol}
+            aria-label="Volume"
             onChange={(e) => {
               const v = parseFloat(e.target.value);
               setVol(v);
@@ -129,12 +149,20 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
 
   return (
     <div className={`relative ${className}`.trim()}>
-      <video ref={videoRef} src={src} poster={poster} controls className="w-full h-auto" />
+      <video
+        ref={videoRef}
+        src={src}
+        poster={poster}
+        controls
+        aria-label="Video player"
+        className="w-full h-auto"
+      />
       {pipSupported && (
         <button
           type="button"
           onClick={togglePiP}
-          className="absolute bottom-2 right-2 rounded bg-black bg-opacity-50 px-2 py-1 text-xs text-white"
+          aria-label={isPip ? "Exit picture-in-picture" : "Enter picture-in-picture"}
+          className={`absolute bottom-2 right-2 rounded bg-black bg-opacity-50 px-2 py-1 text-white ${typography.caption}`}
         >
           {isPip ? "Exit PiP" : "PiP"}
         </button>
@@ -143,7 +171,8 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
         <button
           type="button"
           onClick={openDocPip}
-          className="absolute bottom-2 right-16 rounded bg-black bg-opacity-50 px-2 py-1 text-xs text-white"
+          aria-label="Open document picture-in-picture controls"
+          className={`absolute bottom-2 right-16 rounded bg-black bg-opacity-50 px-2 py-1 text-white ${typography.caption}`}
         >
           Doc-PiP
         </button>

--- a/components/ui/VolumeControl.tsx
+++ b/components/ui/VolumeControl.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { typography } from "@/styles/theme";
 import usePersistentState from "../../hooks/usePersistentState";
 
 const ICONS = {
@@ -128,14 +129,18 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
       </button>
       {open && (
         <div
-          className="absolute bottom-full right-0 z-50 mb-2 min-w-[9rem] rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-2 text-xs text-white shadow-lg"
+          className={`absolute bottom-full right-0 z-50 mb-2 min-w-[9rem] rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-2 text-white shadow-lg ${typography.caption}`}
           onClick={(event) => event.stopPropagation()}
           onPointerDown={(event) => event.stopPropagation()}
           onWheel={handleWheel}
         >
-          <div className="mb-2 flex items-center justify-between text-[11px] uppercase tracking-wide text-gray-200">
+          <div
+            className={`mb-2 flex items-center justify-between uppercase tracking-wide text-gray-200 ${typography.label}`}
+          >
             <span>Volume</span>
-            <span className="font-semibold text-white">{formatPercent(volume)}</span>
+            <span className={`font-semibold text-white ${typography.bodySm}`}>
+              {formatPercent(volume)}
+            </span>
           </div>
           <input
             ref={sliderRef}

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,0 +1,30 @@
+import { typeRamp, typeRampVars } from './type-scale';
+
+export type TypeRampToken = keyof typeof typeRamp;
+
+export const typeClassName = (token: TypeRampToken): string => `text-ramp-${token}`;
+
+export const typography = {
+  caption: typeClassName('xs'),
+  label: typeClassName('2xs'),
+  labelTight: typeClassName('xs'),
+  bodySm: typeClassName('sm'),
+  body: typeClassName('md'),
+  bodyStrong: `${typeClassName('md')} font-medium`,
+  bodyBold: `${typeClassName('md')} font-semibold`,
+  bodyLg: typeClassName('lg'),
+  titleSm: `${typeClassName('lg')} font-semibold`,
+  title: `${typeClassName('xl')} font-semibold`,
+  titleLg: `${typeClassName('2xl')} font-semibold`,
+  display: `${typeClassName('3xl')} font-bold`,
+};
+
+export const typographyMono = {
+  xs: `${typeClassName('2xs')} font-mono`,
+  sm: `${typeClassName('xs')} font-mono`,
+  body: `${typeClassName('sm')} font-mono`,
+};
+
+export const typeRampVariables = typeRampVars;
+
+export { typeRamp };

--- a/styles/type-scale.js
+++ b/styles/type-scale.js
@@ -1,0 +1,43 @@
+const typeRamp = {
+  '2xs': {
+    fontSize: 'clamp(0.625rem, 0.58rem + 0.2vw, 0.72rem)',
+    lineHeight: '1.35',
+  },
+  xs: {
+    fontSize: 'clamp(0.7rem, 0.66rem + 0.22vw, 0.82rem)',
+    lineHeight: '1.4',
+  },
+  sm: {
+    fontSize: 'clamp(0.82rem, 0.78rem + 0.26vw, 0.94rem)',
+    lineHeight: '1.45',
+  },
+  md: {
+    fontSize: 'clamp(0.95rem, 0.9rem + 0.32vw, 1.08rem)',
+    lineHeight: '1.5',
+  },
+  lg: {
+    fontSize: 'clamp(1.12rem, 1.04rem + 0.42vw, 1.35rem)',
+    lineHeight: '1.45',
+  },
+  xl: {
+    fontSize: 'clamp(1.35rem, 1.24rem + 0.6vw, 1.75rem)',
+    lineHeight: '1.35',
+  },
+  '2xl': {
+    fontSize: 'clamp(1.7rem, 1.5rem + 0.75vw, 2.25rem)',
+    lineHeight: '1.25',
+  },
+  '3xl': {
+    fontSize: 'clamp(2.1rem, 1.82rem + 0.95vw, 2.8rem)',
+    lineHeight: '1.2',
+  },
+};
+
+const typeRampVars = Object.fromEntries(
+  Object.entries(typeRamp).flatMap(([token, values]) => [
+    [`--font-size-${token}`, values.fontSize],
+    [`--line-height-${token}`, values.lineHeight],
+  ]),
+);
+
+module.exports = { typeRamp, typeRampVars };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 const plugin = require('tailwindcss/plugin');
+const { typeRamp, typeRampVars } = require('./styles/type-scale');
 
 module.exports = {
   darkMode: 'class',
@@ -60,6 +61,15 @@ module.exports = {
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],
       },
+      fontSize: Object.fromEntries(
+        Object.entries(typeRamp).map(([token]) => [
+          `ramp-${token}`,
+          [
+            `var(--font-size-${token})`,
+            { lineHeight: `var(--line-height-${token})` },
+          ],
+        ]),
+      ),
       minWidth: {
         '0': '0',
         '1/4': '25%',
@@ -116,7 +126,10 @@ module.exports = {
     },
   },
   plugins: [
-    plugin(function ({ addUtilities }) {
+    plugin(function ({ addUtilities, addBase }) {
+      addBase({
+        ':root': typeRampVars,
+      });
       const cols = {};
       for (let i = 1; i <= 12; i++) {
         const width = `${(i / 12) * 100}%`;


### PR DESCRIPTION
## Summary
- introduce a shared responsive type ramp via new theme utilities and Tailwind config
- migrate menu, UI widgets, and shell components to use the shared typography helpers
- ensure picture-in-picture controls and tooltips remain accessible with labeled buttons

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da4822aac08328bd52064967c03c71