### PR TITLE
[ui] centralize window chrome theme

### DIFF
--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,12 +1,34 @@
 'use client';
 
+import clsx from 'clsx';
 import Image from 'next/image';
 import ExternalFrame from '../../components/ExternalFrame';
-import { CloseIcon, MaximizeIcon, MinimizeIcon } from '../../components/ToolbarIcons';
+import {
+  CloseIcon,
+  MaximizeIcon,
+  MinimizeIcon,
+  WINDOW_CONTROL_TOOLTIPS,
+} from '../../components/ToolbarIcons';
 import { kaliTheme } from '../../styles/themes/kali';
+import {
+  WINDOW_CONTROL_CLASSES,
+  WINDOW_CONTROL_ICON_CLASS,
+  WINDOW_CONTROL_SIZE,
+} from '../../styles/theme';
 import { SIDEBAR_WIDTH, ICON_SIZE } from './utils';
 
 export default function VsCode() {
+  const buttonDimensions = {
+    width: WINDOW_CONTROL_SIZE,
+    height: WINDOW_CONTROL_SIZE,
+    minWidth: WINDOW_CONTROL_SIZE,
+    minHeight: WINDOW_CONTROL_SIZE,
+  } as const;
+
+  const baseButtonClass = WINDOW_CONTROL_CLASSES.base;
+  const defaultButtonClass = clsx(baseButtonClass, WINDOW_CONTROL_CLASSES.defaultState);
+  const destructiveButtonClass = clsx(baseButtonClass, WINDOW_CONTROL_CLASSES.destructiveState);
+
   return (
     <div
       className="flex flex-col min-[1366px]:flex-row h-full w-full max-w-full"
@@ -35,17 +57,35 @@ export default function VsCode() {
       </aside>
       <div className="flex-1 flex flex-col border border-black/20 rounded-md overflow-hidden">
         <div
-          className="flex items-center justify-end gap-2 px-2 py-1 border-b border-black/20"
-          style={{ backgroundColor: kaliTheme.background }}
+          className="flex items-center justify-end gap-2 px-2 border-b border-black/20"
+          style={{ backgroundColor: kaliTheme.background, minHeight: WINDOW_CONTROL_SIZE }}
         >
-          <button aria-label="Minimize">
-            <MinimizeIcon />
+          <button
+            type="button"
+            aria-label={WINDOW_CONTROL_TOOLTIPS.minimize}
+            title={WINDOW_CONTROL_TOOLTIPS.minimize}
+            className={defaultButtonClass}
+            style={buttonDimensions}
+          >
+            <MinimizeIcon className={WINDOW_CONTROL_ICON_CLASS} />
           </button>
-          <button aria-label="Maximize">
-            <MaximizeIcon />
+          <button
+            type="button"
+            aria-label={WINDOW_CONTROL_TOOLTIPS.maximize}
+            title={WINDOW_CONTROL_TOOLTIPS.maximize}
+            className={defaultButtonClass}
+            style={buttonDimensions}
+          >
+            <MaximizeIcon className={WINDOW_CONTROL_ICON_CLASS} />
           </button>
-          <button aria-label="Close">
-            <CloseIcon />
+          <button
+            type="button"
+            aria-label={WINDOW_CONTROL_TOOLTIPS.close}
+            title={WINDOW_CONTROL_TOOLTIPS.close}
+            className={destructiveButtonClass}
+            style={buttonDimensions}
+          >
+            <CloseIcon className={WINDOW_CONTROL_ICON_CLASS} />
           </button>
         </div>
         <div className="relative flex-1" style={{ backgroundColor: kaliTheme.background }}>

--- a/components/ToolbarIcons.tsx
+++ b/components/ToolbarIcons.tsx
@@ -1,56 +1,84 @@
 import Image from 'next/image';
 
-export function CloseIcon() {
+import {
+  WINDOW_CONTROL_ICON_CLASS,
+  WINDOW_CONTROL_ICON_SIZE,
+  WINDOW_CONTROL_SIZE,
+} from '../styles/theme';
+
+type ToolbarIconProps = {
+  className?: string;
+};
+
+export const WINDOW_CONTROL_TOOLTIPS = {
+  minimize: 'Minimize window',
+  maximize: 'Maximize window',
+  restore: 'Restore window',
+  close: 'Close window',
+  pin: 'Pin window',
+} as const;
+
+export const WINDOW_CONTROL_HIT_TARGET = WINDOW_CONTROL_SIZE;
+
+function ToolbarIcon({ src, alt, className }: { src: string; alt: string; className?: string }) {
   return (
     <Image
+      src={src}
+      alt={alt}
+      width={WINDOW_CONTROL_ICON_SIZE}
+      height={WINDOW_CONTROL_ICON_SIZE}
+      sizes={`${WINDOW_CONTROL_ICON_SIZE}px`}
+      className={className ?? WINDOW_CONTROL_ICON_CLASS}
+    />
+  );
+}
+
+export function CloseIcon({ className }: ToolbarIconProps) {
+  return (
+    <ToolbarIcon
       src="/themes/Yaru/window/window-close-symbolic.svg"
-      alt="Close"
-      width={16}
-      height={16}
+      alt={WINDOW_CONTROL_TOOLTIPS.close}
+      className={className}
     />
   );
 }
 
-export function MinimizeIcon() {
+export function MinimizeIcon({ className }: ToolbarIconProps) {
   return (
-    <Image
+    <ToolbarIcon
       src="/themes/Yaru/window/window-minimize-symbolic.svg"
-      alt="Minimize"
-      width={16}
-      height={16}
+      alt={WINDOW_CONTROL_TOOLTIPS.minimize}
+      className={className}
     />
   );
 }
 
-export function MaximizeIcon() {
+export function MaximizeIcon({ className }: ToolbarIconProps) {
   return (
-    <Image
+    <ToolbarIcon
       src="/themes/Yaru/window/window-maximize-symbolic.svg"
-      alt="Maximize"
-      width={16}
-      height={16}
+      alt={WINDOW_CONTROL_TOOLTIPS.maximize}
+      className={className}
     />
   );
 }
 
-export function RestoreIcon() {
+export function RestoreIcon({ className }: ToolbarIconProps) {
   return (
-    <Image
+    <ToolbarIcon
       src="/themes/Yaru/window/window-restore-symbolic.svg"
-      alt="Restore"
-      width={16}
-      height={16}
+      alt={WINDOW_CONTROL_TOOLTIPS.restore}
+      className={className}
     />
   );
 }
 
-export function PinIcon() {
+export function PinIcon({ className }: ToolbarIconProps) {
   return (
-    <Image
+    <ToolbarIcon
       src="/themes/Yaru/window/window-pin-symbolic.svg"
-      alt="Pin"
-      width={16}
-      height={16}
+      alt={WINDOW_CONTROL_TOOLTIPS.pin}
+      className={className}
     />
   );
 }

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -1,11 +1,9 @@
 "use client";
 
 import React, { Component } from 'react';
-import NextImage from 'next/image';
 import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
-import useDocPiP from '../../hooks/useDocPiP';
 import {
     clampWindowTopPosition,
     DEFAULT_WINDOW_TOP_OFFSET,
@@ -13,6 +11,7 @@ import {
 } from '../../utils/windowLayout';
 import styles from './window.module.css';
 import { DESKTOP_TOP_PADDING, SNAP_BOTTOM_INSET, WINDOW_TOP_INSET } from '../../utils/uiConstants';
+import { WindowChrome, WINDOW_CHROME_HANDLE_CLASS } from '../ui/WindowChrome';
 
 const EDGE_THRESHOLD_MIN = 48;
 const EDGE_THRESHOLD_MAX = 160;
@@ -628,7 +627,7 @@ export class Window extends Component {
                 <Draggable
                     nodeRef={this.windowRef}
                     axis="both"
-                    handle=".bg-ub-window-title"
+                    handle={`.${WINDOW_CHROME_HANDLE_CLASS}`}
                     grid={this.props.snapEnabled ? [8, 8] : [1, 1]}
                     scale={1}
                     onStart={this.changeCursorToMove}
@@ -669,21 +668,25 @@ export class Window extends Component {
                     >
                         {this.props.resizable !== false && <WindowYBorder resize={this.handleHorizontalResize} />}
                         {this.props.resizable !== false && <WindowXBorder resize={this.handleVerticleResize} />}
-                        <WindowTopBar
+                        <WindowChrome
+                            windowId={this.id}
                             title={this.props.title}
-                            onKeyDown={this.handleTitleBarKeyDown}
-                            onBlur={this.releaseGrab}
                             grabbed={this.state.grabbed}
-                            onPointerDown={this.focusWindow}
-                        />
-                        <WindowEditButtons
-                            minimize={this.minimizeWindow}
-                            maximize={this.maximizeWindow}
-                            isMaximised={this.state.maximized}
-                            close={this.closeWindow}
-                            id={this.id}
+                            isMaximized={this.state.maximized}
                             allowMaximize={this.props.allowMaximize !== false}
-                            pip={() => this.props.screen(this.props.addFolder, this.props.openApp, this.props.context)}
+                            onMinimize={this.minimizeWindow}
+                            onMaximize={this.maximizeWindow}
+                            onClose={this.closeWindow}
+                            pipRenderer={() =>
+                                this.props.screen(
+                                    this.props.addFolder,
+                                    this.props.openApp,
+                                    this.props.context,
+                                )
+                            }
+                            onTitleKeyDown={this.handleTitleBarKeyDown}
+                            onTitleBlur={this.releaseGrab}
+                            onTitlePointerDown={this.focusWindow}
                         />
                         {(this.id === "settings"
                             ? <Settings />
@@ -699,23 +702,6 @@ export class Window extends Component {
 }
 
 export default Window
-
-// Window's title bar
-export function WindowTopBar({ title, onKeyDown, onBlur, grabbed, onPointerDown }) {
-    return (
-        <div
-            className={`${styles.windowTitlebar} relative bg-ub-window-title px-3 text-white w-full select-none flex items-center`}
-            tabIndex={0}
-            role="button"
-            aria-grabbed={grabbed}
-            onKeyDown={onKeyDown}
-            onBlur={onBlur}
-            onPointerDown={onPointerDown}
-        >
-            <div className="flex justify-center w-full text-sm font-bold">{title}</div>
-        </div>
-    )
-}
 
 // Window's Borders
 export class WindowYBorder extends Component {
@@ -755,100 +741,6 @@ export class WindowXBorder extends Component {
                 ></div>
             )
         }
-    }
-
-// Window's Edit Buttons
-export function WindowEditButtons(props) {
-    const { togglePin } = useDocPiP(props.pip || (() => null));
-    const pipSupported = typeof window !== 'undefined' && !!window.documentPictureInPicture;
-    return (
-        <div className={`${styles.windowControls} absolute select-none right-0 top-0 mr-1 flex justify-center items-center min-w-[8.25rem]`}>
-            {pipSupported && props.pip && (
-                <button
-                    type="button"
-                    aria-label="Window pin"
-                    className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                    onClick={togglePin}
-                >
-                    <NextImage
-                        src="/themes/Yaru/window/window-pin-symbolic.svg"
-                        alt="Kali window pin"
-                        className="h-4 w-4 inline"
-                        width={16}
-                        height={16}
-                        sizes="16px"
-                    />
-                </button>
-            )}
-            <button
-                type="button"
-                aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                onClick={props.minimize}
-            >
-                <NextImage
-                    src="/themes/Yaru/window/window-minimize-symbolic.svg"
-                    alt="Kali window minimize"
-                    className="h-4 w-4 inline"
-                    width={16}
-                    height={16}
-                    sizes="16px"
-                />
-            </button>
-            {props.allowMaximize && (
-                props.isMaximised
-                    ? (
-                        <button
-                            type="button"
-                            aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                            onClick={props.maximize}
-                        >
-                            <NextImage
-                                src="/themes/Yaru/window/window-restore-symbolic.svg"
-                                alt="Kali window restore"
-                                className="h-4 w-4 inline"
-                                width={16}
-                                height={16}
-                                sizes="16px"
-                            />
-                        </button>
-                    ) : (
-                        <button
-                            type="button"
-                            aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
-                            onClick={props.maximize}
-                        >
-                            <NextImage
-                                src="/themes/Yaru/window/window-maximize-symbolic.svg"
-                                alt="Kali window maximize"
-                                className="h-4 w-4 inline"
-                                width={16}
-                                height={16}
-                                sizes="16px"
-                            />
-                        </button>
-                    )
-            )}
-            <button
-                type="button"
-                id={`close-${props.id}`}
-                aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
-                onClick={props.close}
-            >
-                <NextImage
-                    src="/themes/Yaru/window/window-close-symbolic.svg"
-                    alt="Kali window close"
-                    className="h-4 w-4 inline"
-                    width={16}
-                    height={16}
-                    sizes="16px"
-                />
-            </button>
-        </div>
-    )
 }
 
 // Window's Main Screen

--- a/components/ui/WindowChrome.tsx
+++ b/components/ui/WindowChrome.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import clsx from 'clsx';
+import type {
+  FocusEventHandler,
+  KeyboardEventHandler,
+  PointerEventHandler,
+  ReactNode,
+} from 'react';
+
+import useDocPiP from '../../hooks/useDocPiP';
+import {
+  WINDOW_CHROME_HEIGHT,
+  WINDOW_CONTROL_CLASSES,
+  WINDOW_CONTROL_ICON_CLASS,
+  WINDOW_CONTROL_SIZE,
+} from '../../styles/theme';
+import {
+  CloseIcon,
+  MaximizeIcon,
+  MinimizeIcon,
+  PinIcon,
+  RestoreIcon,
+  WINDOW_CONTROL_TOOLTIPS,
+} from '../ToolbarIcons';
+import windowStyles from '../base/window.module.css';
+
+export const WINDOW_CHROME_HANDLE_CLASS = 'window-chrome-handle';
+
+export type WindowChromeProps = {
+  windowId: string;
+  title: string;
+  grabbed?: boolean;
+  isMaximized: boolean;
+  allowMaximize?: boolean;
+  onMinimize: () => void;
+  onMaximize: () => void;
+  onClose: () => void;
+  pipRenderer?: () => ReactNode;
+  onTitleKeyDown?: KeyboardEventHandler<HTMLDivElement>;
+  onTitleBlur?: FocusEventHandler<HTMLDivElement>;
+  onTitlePointerDown?: PointerEventHandler<HTMLDivElement>;
+};
+
+const buttonDimensions = {
+  width: WINDOW_CONTROL_SIZE,
+  height: WINDOW_CONTROL_SIZE,
+  minWidth: WINDOW_CONTROL_SIZE,
+  minHeight: WINDOW_CONTROL_SIZE,
+} as const;
+
+export function WindowChrome({
+  windowId,
+  title,
+  grabbed,
+  isMaximized,
+  allowMaximize = true,
+  onMinimize,
+  onMaximize,
+  onClose,
+  pipRenderer,
+  onTitleKeyDown,
+  onTitleBlur,
+  onTitlePointerDown,
+}: WindowChromeProps) {
+  const { togglePin, isPinned } = useDocPiP(pipRenderer ?? (() => null));
+  const pipSupported =
+    typeof window !== 'undefined' && 'documentPictureInPicture' in window;
+  const showPin = pipSupported && Boolean(pipRenderer);
+
+  const baseButtonClass = WINDOW_CONTROL_CLASSES.base;
+  const destructiveButtonClass = clsx(baseButtonClass, WINDOW_CONTROL_CLASSES.destructiveState);
+  const defaultButtonClass = clsx(baseButtonClass, WINDOW_CONTROL_CLASSES.defaultState);
+  const pinnedButtonClass = clsx(
+    baseButtonClass,
+    isPinned ? WINDOW_CONTROL_CLASSES.pinnedState : WINDOW_CONTROL_CLASSES.defaultState,
+  );
+
+  const maximizeLabel = isMaximized
+    ? WINDOW_CONTROL_TOOLTIPS.restore
+    : WINDOW_CONTROL_TOOLTIPS.maximize;
+
+  return (
+    <div
+      className={clsx(
+        windowStyles.windowTitlebar,
+        'flex items-center justify-between bg-ub-window-title px-3 text-white',
+      )}
+      style={{ height: WINDOW_CHROME_HEIGHT }}
+    >
+      <div
+        className={clsx(
+          WINDOW_CHROME_HANDLE_CLASS,
+          'flex flex-1 select-none items-center justify-center text-sm font-bold',
+        )}
+        role="button"
+        aria-grabbed={grabbed}
+        tabIndex={0}
+        onKeyDown={onTitleKeyDown}
+        onBlur={onTitleBlur}
+        onPointerDown={onTitlePointerDown}
+      >
+        <span className="pointer-events-none text-center" title={title}>
+          {title}
+        </span>
+      </div>
+      <div className="flex items-center gap-2 pl-3">
+        {showPin && (
+          <button
+            type="button"
+            aria-label={WINDOW_CONTROL_TOOLTIPS.pin}
+            title={WINDOW_CONTROL_TOOLTIPS.pin}
+            aria-pressed={isPinned}
+            className={pinnedButtonClass}
+            style={buttonDimensions}
+            onClick={togglePin}
+          >
+            <PinIcon className={WINDOW_CONTROL_ICON_CLASS} />
+          </button>
+        )}
+        <button
+          type="button"
+          aria-label={WINDOW_CONTROL_TOOLTIPS.minimize}
+          title={WINDOW_CONTROL_TOOLTIPS.minimize}
+          className={defaultButtonClass}
+          style={buttonDimensions}
+          onClick={onMinimize}
+        >
+          <MinimizeIcon className={WINDOW_CONTROL_ICON_CLASS} />
+        </button>
+        {allowMaximize && (
+          <button
+            type="button"
+            aria-label={maximizeLabel}
+            title={maximizeLabel}
+            className={defaultButtonClass}
+            style={buttonDimensions}
+            onClick={onMaximize}
+          >
+            {isMaximized ? (
+              <RestoreIcon className={WINDOW_CONTROL_ICON_CLASS} />
+            ) : (
+              <MaximizeIcon className={WINDOW_CONTROL_ICON_CLASS} />
+            )}
+          </button>
+        )}
+        <button
+          type="button"
+          aria-label={WINDOW_CONTROL_TOOLTIPS.close}
+          title={WINDOW_CONTROL_TOOLTIPS.close}
+          className={destructiveButtonClass}
+          style={buttonDimensions}
+          onClick={onClose}
+          id={`close-${windowId}`}
+        >
+          <CloseIcon className={WINDOW_CONTROL_ICON_CLASS} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,0 +1,13 @@
+export const WINDOW_CONTROL_SIZE = 44;
+export const WINDOW_CONTROL_ICON_SIZE = 16;
+
+export const WINDOW_CHROME_HEIGHT = WINDOW_CONTROL_SIZE;
+
+export const WINDOW_CONTROL_CLASSES = {
+  base: 'inline-flex items-center justify-center rounded-full text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-ub-window-title disabled:opacity-50 disabled:pointer-events-none',
+  defaultState: 'bg-white/10 hover:bg-white/20 active:bg-white/30',
+  pinnedState: 'bg-white/20 hover:bg-white/30 active:bg-white/40',
+  destructiveState: 'bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 active:bg-opacity-100',
+};
+
+export const WINDOW_CONTROL_ICON_CLASS = 'pointer-events-none h-4 w-4';


### PR DESCRIPTION
## Summary
- move window control sizing and state styles into a shared theme and chrome component
- update the base window to consume the shared chrome for consistent drag handle, tooltips, and PiP pinning
- align VS Code app toolbar buttons with the shared hit target and tooltips

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da482966a48328bb782481392aa175