### PR TITLE
[ui] unify button variants

### DIFF
--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import clsx from 'clsx';
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import Image from 'next/image';
 import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import Button from '../ui/Button';
 
 type AppMeta = {
   id: string;
@@ -369,11 +371,12 @@ const WhiskerMenu: React.FC = () => {
 
   return (
     <div className="relative inline-flex">
-      <button
+      <Button
         ref={buttonRef}
         type="button"
+        variant="ghost"
         onClick={toggleMenu}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className="border-0 border-b-2 border-transparent rounded-none py-1 pl-3 pr-3 text-ubt-grey transition duration-100 ease-in-out hover:bg-transparent hover:text-white focus-visible:ring-offset-transparent"
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"
@@ -383,7 +386,7 @@ const WhiskerMenu: React.FC = () => {
           className="inline mr-1"
         />
         Applications
-      </button>
+      </Button>
       {isVisible && (
         <div
           ref={menuRef}
@@ -412,17 +415,19 @@ const WhiskerMenu: React.FC = () => {
               onKeyDown={handleCategoryKeyDown}
             >
               {categoryConfigs.map((cat, index) => (
-                <button
+                <Button
                   key={cat.id}
                   ref={(el) => {
                     categoryButtonRefs.current[index] = el;
                   }}
                   type="button"
-                  className={`group flex items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1724] ${
+                  variant="ghost"
+                  className={clsx(
+                    'group flex w-full items-center gap-3 rounded-md border-0 px-3 py-2 text-left text-sm transition focus-visible:ring-offset-[#0f1724]',
                     category === cat.id
                       ? 'bg-[#162236] text-white shadow-[inset_2px_0_0_#53b9ff]'
-                      : 'text-gray-300 hover:bg-[#152133] hover:text-white'
-                  }`}
+                      : 'text-gray-300 hover:bg-[#152133] hover:text-white',
+                  )}
                   role="option"
                   aria-selected={category === cat.id}
                   onClick={() => {
@@ -442,7 +447,7 @@ const WhiskerMenu: React.FC = () => {
                     />
                     <span>{cat.label}</span>
                   </span>
-                </button>
+                </Button>
               ))}
             </div>
             <div className="border-t border-[#1d2a3c] px-4 py-3 text-sm text-gray-400">
@@ -459,11 +464,12 @@ const WhiskerMenu: React.FC = () => {
             <div className="border-b border-[#1d2a3c] px-4 py-4 sm:px-5">
               <div className="mb-4 flex flex-wrap items-center gap-3">
                 {favoriteApps.slice(0, 6).map((app) => (
-                  <button
+                  <Button
                     key={app.id}
                     type="button"
+                    variant="ghost"
                     onClick={() => openSelectedApp(app.id)}
-                    className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#122136] text-white transition hover:-translate-y-0.5 hover:bg-[#1b2d46] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1a29]"
+                    className="flex h-10 w-10 items-center justify-center rounded-lg border-0 bg-[#122136] p-0 text-white transition hover:-translate-y-0.5 hover:bg-[#1b2d46] focus-visible:ring-offset-[#0f1a29]"
                     aria-label={`Open ${app.title}`}
                   >
                     <Image
@@ -474,7 +480,7 @@ const WhiskerMenu: React.FC = () => {
                       className="h-6 w-6"
                       sizes="24px"
                     />
-                  </button>
+                  </Button>
                 ))}
               </div>
               <div className="relative">
@@ -520,13 +526,16 @@ const WhiskerMenu: React.FC = () => {
                 <ul className="space-y-1">
                   {currentApps.map((app, idx) => (
                     <li key={app.id}>
-                      <button
+                      <Button
                         type="button"
-                        className={`flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1a29] ${
+                        variant="ghost"
+                        className={clsx(
+                          'flex w-full items-center justify-between gap-3 rounded-lg border-0 px-3 py-2 text-left text-sm transition focus-visible:ring-offset-[#0f1a29] disabled:cursor-not-allowed',
                           idx === highlight
                             ? 'bg-[#162438] text-white shadow-[0_0_0_1px_rgba(83,185,255,0.35)]'
-                            : 'text-gray-200 hover:bg-[#142132]'
-                        } ${app.disabled ? 'cursor-not-allowed opacity-60' : ''}`}
+                            : 'text-gray-200 hover:bg-[#142132]',
+                          app.disabled && 'opacity-60',
+                        )}
                         aria-label={app.title}
                         disabled={app.disabled}
                         onClick={() => {
@@ -564,7 +573,7 @@ const WhiskerMenu: React.FC = () => {
                         >
                           <polyline points="9 18 15 12 9 6" />
                         </svg>
-                      </button>
+                      </Button>
                     </li>
                   ))}
                 </ul>

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import Button from './Button';
+
 interface Segment {
   name: string;
 }
@@ -14,13 +16,14 @@ const Breadcrumbs: React.FC<Props> = ({ path, onNavigate }) => {
     <nav className="flex items-center space-x-1 text-white" aria-label="Breadcrumb">
       {path.map((seg, idx) => (
         <React.Fragment key={idx}>
-          <button
+          <Button
             type="button"
+            variant="link"
+            className="px-0 py-0 text-white hover:text-ubt-grey"
             onClick={() => onNavigate(idx)}
-            className="hover:underline focus:outline-none"
           >
             {seg.name || '/'}
-          </button>
+          </Button>
           {idx < path.length - 1 && <span>/</span>}
         </React.Fragment>
       ))}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,38 @@
+import clsx from 'clsx';
+import React from 'react';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive' | 'link';
+
+const baseClasses =
+  'inline-flex items-center justify-center gap-2 rounded-md border text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-focus focus-visible:ring-offset-2 focus-visible:ring-offset-kali-dark disabled:pointer-events-none disabled:opacity-60 px-3 py-2';
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    'bg-ub-orange text-black border-transparent shadow-sm hover:bg-[#ffb347] focus-visible:ring-offset-ub-dark-grey disabled:bg-ub-orange/70 disabled:text-black/70',
+  secondary:
+    'bg-ub-cool-grey text-white border border-white/10 hover:bg-ub-grey focus-visible:ring-offset-ub-dark-grey disabled:bg-ub-cool-grey/70 disabled:text-white/80',
+  ghost:
+    'bg-transparent text-inherit border-transparent hover:bg-white/10 focus-visible:ring-offset-transparent disabled:text-ubt-grey/70',
+  destructive:
+    'bg-red-600 text-white border-transparent shadow-sm hover:bg-red-500 focus-visible:ring-offset-ub-dark-grey disabled:bg-red-700/60 disabled:text-white/80',
+  link:
+    'bg-transparent border-transparent px-0 py-0 text-ubb-orange underline underline-offset-4 hover:text-orange-200 hover:underline focus-visible:ring-offset-0 focus-visible:ring-offset-transparent disabled:no-underline disabled:text-ubt-grey disabled:hover:text-ubt-grey',
+};
+
+export const buttonClasses = (variant: ButtonVariant, className?: string) =>
+  clsx(baseClasses, variantClasses[variant], className);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = 'primary', type = 'button', className, ...props }, ref) => (
+    <button ref={ref} type={type} className={buttonClasses(variant, className)} {...props} />
+  ),
+);
+
+Button.displayName = 'Button';
+
+export default Button;

--- a/components/ui/LinkButton.tsx
+++ b/components/ui/LinkButton.tsx
@@ -1,0 +1,22 @@
+import Link, { LinkProps } from 'next/link';
+import React from 'react';
+
+import { ButtonVariant, buttonClasses } from './Button';
+
+export interface LinkButtonProps
+  extends LinkProps,
+    Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+  variant?: ButtonVariant;
+}
+
+const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
+  ({ variant = 'primary', className, children, ...props }, ref) => (
+    <Link ref={ref} className={buttonClasses(variant, className)} {...props}>
+      {children}
+    </Link>
+  ),
+);
+
+LinkButton.displayName = 'LinkButton';
+
+export default LinkButton;

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -14,6 +14,7 @@ import {
   NotificationPriority,
 } from '../../hooks/useNotifications';
 import { PRIORITY_ORDER } from '../../utils/notifications/ruleEngine';
+import Button from './Button';
 
 const focusableSelector =
   'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
@@ -235,15 +236,16 @@ const NotificationBell: React.FC = () => {
 
   return (
     <div className="relative">
-      <button
+      <Button
         type="button"
         ref={buttonRef}
+        variant="ghost"
         aria-label="Open notifications"
         aria-haspopup="dialog"
         aria-expanded={isOpen}
         aria-controls={panelId}
         onClick={togglePanel}
-        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey transition focus:border-ubb-orange focus:outline-none focus:ring-0 hover:bg-white hover:bg-opacity-10"
+        className="relative mx-1 flex h-9 w-9 items-center justify-center border-0 bg-transparent text-ubt-grey transition hover:bg-white hover:bg-opacity-10 focus-visible:ring-offset-0 focus-visible:ring-offset-transparent"
       >
         <svg
           aria-hidden="true"
@@ -260,7 +262,7 @@ const NotificationBell: React.FC = () => {
             {unreadCount > 99 ? '99+' : unreadCount}
           </span>
         )}
-      </button>
+      </Button>
       {isOpen && (
         <div
           ref={panelRef}
@@ -275,14 +277,15 @@ const NotificationBell: React.FC = () => {
             <h2 id={headingId} className="text-sm font-semibold text-white">
               Notifications
             </h2>
-            <button
+            <Button
               type="button"
+              variant="link"
               onClick={handleDismissAll}
               disabled={notifications.length === 0}
-              className="text-xs font-medium text-ubb-orange transition disabled:cursor-not-allowed disabled:text-ubt-grey disabled:text-opacity-50"
+              className="text-xs font-medium"
             >
               Dismiss all
-            </button>
+            </Button>
           </div>
           <div className="max-h-80 overflow-y-auto">
             {notifications.length === 0 ? (
@@ -297,12 +300,13 @@ const NotificationBell: React.FC = () => {
                   const contentId = `${panelId}-${group.priority}-group`;
                   return (
                     <section key={group.priority} className="border-b border-white/10 last:border-b-0">
-                      <button
+                      <Button
                         type="button"
+                        variant="ghost"
                         onClick={() => toggleGroup(group.priority)}
                         aria-expanded={!collapsed}
                         aria-controls={contentId}
-                        className="flex w-full items-center justify-between px-4 py-2 text-left text-sm font-semibold text-white transition hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-ubb-orange"
+                        className="flex w-full items-center justify-between border-0 px-4 py-2 text-left text-sm font-semibold text-white transition hover:bg-white/5 focus-visible:ring-offset-ub-dark-grey"
                       >
                         <span className="flex items-center gap-2">
                           {group.metadata.label}
@@ -322,7 +326,7 @@ const NotificationBell: React.FC = () => {
                         >
                           <path d="M7 5l6 5-6 5V5z" />
                         </svg>
-                      </button>
+                      </Button>
                       <div
                         id={contentId}
                         role="region"

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useEffect, useId } from 'react';
+
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import Button from './Button';
 
 interface Props {
   open: boolean;
@@ -12,6 +14,9 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const soundId = useId();
+  const networkId = useId();
+  const reducedMotionId = useId();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -28,28 +33,43 @@ const QuickSettings = ({ open }: Props) => {
       }`}
     >
       <div className="px-4 pb-2">
-        <button
-          className="w-full flex justify-between"
+        <Button
+          variant="ghost"
+          className="flex w-full justify-between text-left text-white hover:bg-white/10"
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
         >
           <span>Theme</span>
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
-        </button>
+        </Button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
+      <div className="flex items-center justify-between gap-4 px-4 pb-2">
+        <label htmlFor={soundId}>Sound</label>
         <input
+          id={soundId}
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+          aria-label="Toggle sound"
+        />
+      </div>
+      <div className="flex items-center justify-between gap-4 px-4 pb-2">
+        <label htmlFor={networkId}>Network</label>
+        <input
+          id={networkId}
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+          aria-label="Toggle network"
+        />
+      </div>
+      <div className="flex items-center justify-between gap-4 px-4">
+        <label htmlFor={reducedMotionId}>Reduced motion</label>
+        <input
+          id={reducedMotionId}
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
+          aria-label="Toggle reduced motion"
         />
       </div>
     </div>

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 
+import Button from './Button';
+
 interface ToastProps {
   message: string;
   actionLabel?: string;
@@ -36,12 +38,13 @@ const Toast: React.FC<ToastProps> = ({
     >
       <span>{message}</span>
       {onAction && actionLabel && (
-        <button
+        <Button
           onClick={onAction}
-          className="ml-4 underline focus:outline-none"
+          variant="link"
+          className="ml-4"
         >
           {actionLabel}
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/docs/ui-button-variants.md
+++ b/docs/ui-button-variants.md
@@ -1,0 +1,37 @@
+# Button Variant System
+
+The shared UI buttons now live under `components/ui` and centralize hover, focus, and disabled states across the desktop shell. Use these React components instead of hand-rolled `<button>` or `<a>` styles:
+
+- `Button` — semantic button element with theme-aware variants.
+- `LinkButton` — Next.js `Link` wrapper that reuses the same visual system for navigation links.
+
+## Variants
+
+All variants include a consistent focus ring (`focus-visible:ring-kali-focus`) and offset so keyboard users receive the same affordance anywhere.
+
+| Variant | Purpose | Notes |
+| --- | --- | --- |
+| `primary` | High-emphasis actions like confirmations or primary CTA buttons. | Orange Ubuntu tone with dark text. |
+| `secondary` | Neutral controls in panels or dialogs. | Muted cool-grey background, works on dark shells. |
+| `ghost` | Low-emphasis triggers that sit on colored backdrops. | Transparent by default; add layout classes per context. |
+| `destructive` | Destructive operations. | Red background, used sparingly. |
+| `link` | Inline textual actions. | Zero padding, underline hover state. |
+
+## Usage
+
+Import from `components/ui` and pass extra layout classes as needed. Variants already cover hover and disabled states; only append custom classes for positioning or color overrides.
+
+```tsx
+import Button from '@/components/ui/Button';
+import LinkButton from '@/components/ui/LinkButton';
+
+<Button variant="primary" onClick={handleSubmit}>
+  Save changes
+</Button>
+
+<LinkButton href="/docs" variant="link">
+  View docs
+</LinkButton>
+```
+
+Avoid reintroducing ad-hoc `className` strings for focus or disabled states—extend the shared variants instead.


### PR DESCRIPTION
## Summary
- add shared Button and LinkButton components with consistent variant styling
- refactor QuickSettings, WhiskerMenu, NotificationBell, Breadcrumbs, and Toast to consume the shared buttons
- document the button taxonomy for contributors

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da4826072c8328914a75520364c532