### PR TITLE
[launcher] improve search and navigation experience

### DIFF
--- a/__tests__/useAppSearch.test.tsx
+++ b/__tests__/useAppSearch.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useAppSearch, getHighlightedSegments } from '../hooks/useAppSearch';
+
+const APPS = [
+  { id: 'hydra', title: 'Hydra' },
+  { id: 'metasploit', title: 'Metasploit' },
+  { id: 'nmap', title: 'Nmap NSE' },
+];
+
+const SearchHarness: React.FC = () => {
+  const { query, setQuery, results } = useAppSearch(APPS, { debounceMs: 0 });
+  return (
+    <div>
+      <input
+        aria-label="search"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+      />
+      <div data-testid="result-count">{results.length}</div>
+      <ul>
+        {results.map(({ item }) => (
+          <li key={item.id}>{item.title}</li>
+        ))}
+      </ul>
+      <output data-testid="matches">
+        {JSON.stringify(results[0]?.matches ?? null)}
+      </output>
+    </div>
+  );
+};
+
+describe('useAppSearch', () => {
+  it('returns all apps when the query is empty and filters case-insensitively', () => {
+    render(<SearchHarness />);
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+
+    const input = screen.getByLabelText('search');
+    fireEvent.change(input, { target: { value: 'meta' } });
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByText('Metasploit')).toBeInTheDocument();
+  });
+
+  it('highlights the matched characters in the title', () => {
+    render(<SearchHarness />);
+
+    const input = screen.getByLabelText('search');
+    fireEvent.change(input, { target: { value: 'hyd' } });
+
+    const matchesRaw = screen.getByTestId('matches').textContent ?? 'null';
+    const matches = JSON.parse(matchesRaw);
+    const segments = getHighlightedSegments('Hydra', matches, 'title');
+    const highlighted = segments
+      .filter((segment) => segment.match)
+      .map((segment) => segment.text)
+      .join('')
+      .toLowerCase();
+
+    expect(highlighted).toBe('hyd');
+  });
+});

--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -1,4 +1,10 @@
-import React, { useState, useMemo, useRef, useCallback, useEffect } from 'react';
+import React, {
+  useState,
+  useMemo,
+  useRef,
+  useCallback,
+  useEffect,
+} from 'react';
 import UbuntuApp from '../base/ubuntu_app';
 import apps from '../../apps.config';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -6,81 +12,203 @@ import { Grid } from 'react-window';
 import DelayedTooltip from '../ui/DelayedTooltip';
 import AppTooltipContent from '../ui/AppTooltipContent';
 import { createRegistryMap, buildAppMetadata } from '../../lib/appRegistry';
+import {
+  FAVORITES_KEY,
+  RECENTS_KEY,
+  arraysEqual,
+  persistIds,
+  readStoredIds,
+  sanitizeIds,
+  updateRecentIds,
+} from '../../utils/appPreferences';
+import { useAppSearch, getHighlightedSegments } from '../../hooks/useAppSearch';
+import { buildCategoryConfigs } from '../../lib/appCategories';
+import useRovingTabIndex from '../../hooks/useRovingTabIndex';
 
 const registryMetadata = createRegistryMap(apps);
 
-function fuzzyHighlight(text, query) {
-  const q = query.toLowerCase();
-  let qi = 0;
-  const result = [];
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i];
-    if (qi < q.length && ch.toLowerCase() === q[qi]) {
-      result.push(<mark key={i}>{ch}</mark>);
-      qi++;
-    } else {
-      result.push(ch);
-    }
-  }
-  return { matched: qi === q.length, nodes: result };
-}
+const getColumnCount = (width) => {
+  if (width >= 1024) return 8;
+  if (width >= 768) return 6;
+  if (width >= 640) return 4;
+  return 3;
+};
 
 export default function AppGrid({ openApp }) {
-  const [query, setQuery] = useState('');
-  const gridRef = useRef(null);
-  const columnCountRef = useRef(1);
   const [focusedIndex, setFocusedIndex] = useState(0);
+  const [activeCategory, setActiveCategory] = useState('all');
+  const columnCountRef = useRef(1);
+  const gridRef = useRef(null);
+  const categoryListRef = useRef(null);
 
-  const filtered = useMemo(() => {
-    if (!query) return apps.map((app) => ({ ...app, nodes: app.title }));
-    return apps
-      .map((app) => {
-        const { matched, nodes } = fuzzyHighlight(app.title, query);
-        return matched ? { ...app, nodes } : null;
-      })
-      .filter(Boolean);
-  }, [query]);
+  const availableIds = useMemo(() => new Set(apps.map((app) => app.id)), []);
+
+  const [favoriteIds, setFavoriteIds] = useState(() =>
+    sanitizeIds(readStoredIds(FAVORITES_KEY), availableIds),
+  );
+  const [recentIds, setRecentIds] = useState(() =>
+    sanitizeIds(readStoredIds(RECENTS_KEY), availableIds, 10),
+  );
+
+  useRovingTabIndex(categoryListRef, true, 'horizontal');
 
   useEffect(() => {
-    if (focusedIndex >= filtered.length) {
+    setFavoriteIds((current) => {
+      const sanitized = sanitizeIds(current, availableIds);
+      if (!arraysEqual(sanitized, current)) {
+        persistIds(FAVORITES_KEY, sanitized);
+        return sanitized;
+      }
+      return current;
+    });
+    setRecentIds((current) => {
+      const sanitized = sanitizeIds(current, availableIds, 10);
+      if (!arraysEqual(sanitized, current)) {
+        persistIds(RECENTS_KEY, sanitized);
+        return sanitized;
+      }
+      return current;
+    });
+  }, [availableIds]);
+
+  const { query, setQuery, results, filtered } = useAppSearch(apps, {
+    fuseOptions: { keys: ['title', 'id'] },
+  });
+
+  const matchMap = useMemo(() => {
+    const map = new Map();
+    results.forEach(({ item, matches }) => {
+      map.set(item.id, matches);
+    });
+    return map;
+  }, [results]);
+
+  const favoritesForCategories = useMemo(() => {
+    const stored = favoriteIds;
+    if (stored.length > 0) return stored;
+    return apps.filter((app) => app.favourite).map((app) => app.id);
+  }, [favoriteIds]);
+
+  const categories = useMemo(
+    () =>
+      buildCategoryConfigs(filtered, {
+        favoriteIds: favoritesForCategories,
+        recentIds,
+      }),
+    [filtered, favoritesForCategories, recentIds],
+  );
+
+  useEffect(() => {
+    if (!categories.some((category) => category.id === activeCategory)) {
+      setActiveCategory(categories[0]?.id ?? 'all');
+    }
+  }, [categories, activeCategory]);
+
+  const activeCategoryConfig = useMemo(
+    () => categories.find((category) => category.id === activeCategory) ?? categories[0],
+    [categories, activeCategory],
+  );
+
+  const filteredMap = useMemo(
+    () => new Map(filtered.map((app) => [app.id, app])),
+    [filtered],
+  );
+
+  const recentApps = useMemo(
+    () =>
+      recentIds
+        .map((id) => filteredMap.get(id))
+        .filter(Boolean),
+    [recentIds, filteredMap],
+  );
+
+  const recentSet = useMemo(
+    () => new Set(recentApps.map((app) => app.id)),
+    [recentApps],
+  );
+
+  const visibleApps = useMemo(() => {
+    if (!activeCategoryConfig) return [];
+    if (activeCategoryConfig.type === 'favorites' || activeCategoryConfig.type === 'recent') {
+      return activeCategoryConfig.apps;
+    }
+    const base =
+      activeCategoryConfig.type === 'all'
+        ? filtered
+        : activeCategoryConfig.apps;
+    return base.filter((app) => !recentSet.has(app.id));
+  }, [activeCategoryConfig, filtered, recentSet]);
+
+  useEffect(() => {
+    if (visibleApps.length === 0) {
+      setFocusedIndex(0);
+    } else if (focusedIndex >= visibleApps.length) {
       setFocusedIndex(0);
     }
-  }, [filtered, focusedIndex]);
+  }, [visibleApps, focusedIndex]);
 
-  const getColumnCount = (width) => {
-    if (width >= 1024) return 8;
-    if (width >= 768) return 6;
-    if (width >= 640) return 4;
-    return 3;
-  };
+  useEffect(() => {
+    if (visibleApps.length > 0) {
+      setFocusedIndex(0);
+    }
+  }, [query, activeCategory, visibleApps.length]);
+
+  const handleLaunch = useCallback(
+    (id) => {
+      setRecentIds((current) => {
+        const next = updateRecentIds(current, id, 10);
+        persistIds(RECENTS_KEY, next);
+        return next;
+      });
+      if (openApp) {
+        openApp(id);
+      }
+    },
+    [openApp],
+  );
 
   const handleKeyDown = useCallback(
     (e) => {
       if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+      if (visibleApps.length === 0) return;
       e.preventDefault();
       const colCount = columnCountRef.current;
       let idx = focusedIndex;
-      if (e.key === 'ArrowRight') idx = Math.min(idx + 1, filtered.length - 1);
+      if (e.key === 'ArrowRight') idx = Math.min(idx + 1, visibleApps.length - 1);
       if (e.key === 'ArrowLeft') idx = Math.max(idx - 1, 0);
-      if (e.key === 'ArrowDown') idx = Math.min(idx + colCount, filtered.length - 1);
+      if (e.key === 'ArrowDown') idx = Math.min(idx + colCount, visibleApps.length - 1);
       if (e.key === 'ArrowUp') idx = Math.max(idx - colCount, 0);
       setFocusedIndex(idx);
       const row = Math.floor(idx / colCount);
       const col = idx % colCount;
-      gridRef.current?.scrollToCell({ rowIndex: row, columnIndex: col, rowAlign: 'smart', columnAlign: 'smart' });
-      setTimeout(() => {
-        const el = document.getElementById('app-' + filtered[idx].id);
-        el?.focus();
-      }, 0);
+      gridRef.current?.scrollToItem?.({ rowIndex: row, columnIndex: col, align: 'smart' });
+      const target = visibleApps[idx];
+      if (target) {
+        setTimeout(() => {
+          const el = document.getElementById('app-' + target.id);
+          el?.focus();
+        }, 0);
+      }
     },
-    [filtered, focusedIndex]
+    [focusedIndex, visibleApps],
   );
+
+  const rowCount = useMemo(() => {
+    const columns = Math.max(columnCountRef.current, 1);
+    return Math.ceil(visibleApps.length / columns);
+  }, [visibleApps.length]);
 
   const Cell = ({ columnIndex, rowIndex, style, data }) => {
     const index = rowIndex * data.columnCount + columnIndex;
     if (index >= data.items.length) return null;
     const app = data.items[index];
     const meta = data.metadata[app.id] ?? buildAppMetadata(app);
+    const matches = data.matches.get(app.id);
+    const segments = getHighlightedSegments(app.title, matches, 'title');
+    const displayName = segments.map((segment, segmentIndex) =>
+      segment.match ? <mark key={segmentIndex}>{segment.text}</mark> : segment.text,
+    );
+    const tabIndex = index === focusedIndex ? 0 : -1;
     return (
       <DelayedTooltip content={<AppTooltipContent meta={meta} />}>
         {({ ref, onMouseEnter, onMouseLeave, onFocus, onBlur }) => (
@@ -102,8 +230,10 @@ export default function AppGrid({ openApp }) {
               id={app.id}
               icon={app.icon}
               name={app.title}
-              displayName={<>{app.nodes}</>}
-              openApp={() => openApp && openApp(app.id)}
+              displayName={<>{displayName}</>}
+              openApp={() => handleLaunch(app.id)}
+              tabIndex={tabIndex}
+              onFocus={() => setFocusedIndex(index)}
             />
           </div>
         )}
@@ -112,40 +242,117 @@ export default function AppGrid({ openApp }) {
   };
 
   return (
-    <div className="flex flex-col items-center h-full">
+    <div className="flex h-full flex-col items-center">
+      <label htmlFor="app-grid-search" className="sr-only">
+        Search applications
+      </label>
       <input
-        className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
-        placeholder="Search"
+        id="app-grid-search"
+        className="mb-4 mt-4 w-11/12 max-w-xl rounded bg-black bg-opacity-20 px-4 py-2 text-white focus:outline-none"
+        placeholder="Search applications"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
+        type="search"
       />
-      <div className="w-full flex-1 h-[70vh] outline-none" onKeyDown={handleKeyDown}>
+      <nav className="mb-4 w-full px-4" aria-label="Filter apps by category">
+        <div
+          ref={categoryListRef}
+          className="flex flex-wrap justify-center gap-2"
+          role="tablist"
+          aria-label="Application categories"
+        >
+          {categories.map((category) => {
+            const isActive = category.id === activeCategory;
+            return (
+              <button
+                key={category.id}
+                type="button"
+                role="tab"
+                tabIndex={isActive ? 0 : -1}
+                aria-selected={isActive}
+                onClick={() => {
+                  setActiveCategory(category.id);
+                  setFocusedIndex(0);
+                }}
+                className={`flex items-center gap-2 rounded-full px-4 py-2 text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
+                  isActive
+                    ? 'bg-white/20 text-white'
+                    : 'bg-white/10 text-white/80 hover:bg-white/20'
+                }`}
+              >
+                <span>{category.label}</span>
+                <span className="rounded-full bg-black/30 px-2 text-xs text-white/70">
+                  {category.apps.length}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </nav>
+      {recentApps.length > 0 && (
+        <section className="mb-4 w-full px-4" aria-label="Recently opened apps">
+          <h2 className="mb-2 text-sm font-semibold uppercase tracking-wider text-white/70">Recent</h2>
+          <div className="flex flex-wrap justify-center gap-4">
+            {recentApps.map((app) => (
+              <UbuntuApp
+                key={app.id}
+                id={app.id}
+                icon={app.icon}
+                name={app.title}
+                openApp={() => handleLaunch(app.id)}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+      <div
+        className="h-[70vh] w-full flex-1 outline-none"
+        onKeyDown={handleKeyDown}
+        tabIndex={0}
+        role="grid"
+        aria-label="Application grid"
+      >
         <AutoSizer>
           {({ height, width }) => {
             const columnCount = getColumnCount(width);
             columnCountRef.current = columnCount;
-            const rowCount = Math.ceil(filtered.length / columnCount);
+            const rowCountValue = Math.ceil(visibleApps.length / columnCount) || 0;
             return (
               <Grid
-                gridRef={gridRef}
+                ref={gridRef}
                 columnCount={columnCount}
                 columnWidth={width / columnCount}
                 height={height}
-                rowCount={rowCount}
+                rowCount={rowCountValue}
                 rowHeight={112}
                 width={width}
                 className="scroll-smooth"
+                itemData={{
+                  items: visibleApps,
+                  columnCount,
+                  metadata: registryMetadata,
+                  matches: matchMap,
+                }}
               >
                 {(props) => (
                   <Cell
                     {...props}
-                    data={{ items: filtered, columnCount, metadata: registryMetadata }}
+                    data={{
+                      ...props.data,
+                      metadata: registryMetadata,
+                      matches: matchMap,
+                    }}
                   />
                 )}
               </Grid>
             );
           }}
         </AutoSizer>
+        {visibleApps.length === 0 && (
+          <p className="mt-6 text-center text-sm text-white/70">
+            No applications match your filters.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -39,6 +39,8 @@ export class UbuntuApp extends Component {
             onPointerUp,
             onPointerCancel,
             style,
+            tabIndex,
+            onFocus,
         } = this.props;
 
         const dragging = this.state.dragging || isBeingDragged;
@@ -53,6 +55,13 @@ export class UbuntuApp extends Component {
             gap: 'var(--desktop-icon-gap, 0.375rem)',
             ...style,
         };
+
+        const computedTabIndex =
+            typeof tabIndex === 'number'
+                ? tabIndex
+                : this.props.disabled
+                ? -1
+                : 0;
 
         return (
             <div
@@ -74,9 +83,14 @@ export class UbuntuApp extends Component {
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
-                tabIndex={this.props.disabled ? -1 : 0}
+                tabIndex={computedTabIndex}
                 onMouseEnter={this.handlePrefetch}
-                onFocus={this.handlePrefetch}
+                onFocus={(event) => {
+                    this.handlePrefetch();
+                    if (typeof onFocus === 'function') {
+                        onFocus(event);
+                    }
+                }}
             >
                 <Image
                     width={48}

--- a/hooks/useAppSearch.ts
+++ b/hooks/useAppSearch.ts
@@ -1,0 +1,112 @@
+import { useEffect, useMemo, useState } from 'react';
+import Fuse from 'fuse.js';
+
+const DEFAULT_FUSE_OPTIONS: Fuse.IFuseOptions<any> = {
+  includeMatches: true,
+  threshold: 0.3,
+  ignoreLocation: true,
+  minMatchCharLength: 2,
+  keys: ['title', 'description', 'tags', 'keywords', 'id'],
+};
+
+type UseAppSearchOptions<T> = {
+  fuseOptions?: Fuse.IFuseOptions<T>;
+  debounceMs?: number;
+};
+
+type SearchResult<T> = {
+  item: T;
+  matches?: readonly Fuse.FuseResultMatch[];
+};
+
+const useDebouncedValue = <T,>(value: T, delay: number): T => {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    if (delay <= 0) {
+      setDebounced(value);
+      return;
+    }
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+};
+
+const buildOptionsKey = (options: Fuse.IFuseOptions<any> | undefined) =>
+  JSON.stringify(options ?? {});
+
+export const getHighlightedSegments = (
+  text: string,
+  matches: readonly Fuse.FuseResultMatch[] | undefined,
+  key: string,
+): Array<{ text: string; match: boolean }> => {
+  if (!matches || matches.length === 0) {
+    return [{ text, match: false }];
+  }
+  const matchForKey = matches.find((match) => match.key === key);
+  if (!matchForKey || !matchForKey.indices || matchForKey.indices.length === 0) {
+    return [{ text, match: false }];
+  }
+
+  const segments: Array<{ text: string; match: boolean }> = [];
+  let lastIndex = 0;
+  matchForKey.indices.forEach(([start, end]) => {
+    if (start > lastIndex) {
+      segments.push({ text: text.slice(lastIndex, start), match: false });
+    }
+    segments.push({ text: text.slice(start, end + 1), match: true });
+    lastIndex = end + 1;
+  });
+  if (lastIndex < text.length) {
+    segments.push({ text: text.slice(lastIndex), match: false });
+  }
+  return segments;
+};
+
+export const useAppSearch = <T extends { id: string }>(
+  items: readonly T[],
+  options: UseAppSearchOptions<T> = {},
+) => {
+  const { fuseOptions, debounceMs = 150 } = options;
+  const optionsKey = useMemo(() => buildOptionsKey(fuseOptions), [fuseOptions]);
+  const fuse = useMemo(() => {
+    if (!items || items.length === 0) {
+      return null;
+    }
+    const resolvedOptions = {
+      ...DEFAULT_FUSE_OPTIONS,
+      ...fuseOptions,
+    } satisfies Fuse.IFuseOptions<T>;
+    return new Fuse(items, resolvedOptions);
+  }, [items, optionsKey]);
+
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebouncedValue(query, debounceMs);
+
+  const results: SearchResult<T>[] = useMemo(() => {
+    if (!debouncedQuery.trim()) {
+      return items.map((item) => ({ item }));
+    }
+    if (!fuse) {
+      return [];
+    }
+    return fuse.search(debouncedQuery.trim()).map(({ item, matches }) => ({
+      item,
+      matches,
+    }));
+  }, [debouncedQuery, fuse, items]);
+
+  const filtered = useMemo(() => results.map((result) => result.item), [results]);
+
+  return {
+    query,
+    setQuery,
+    results,
+    filtered,
+    isFiltering: Boolean(debouncedQuery.trim()),
+  };
+};
+
+export type { SearchResult };

--- a/lib/appCategories.ts
+++ b/lib/appCategories.ts
@@ -1,0 +1,150 @@
+export type CategorySource =
+  | { type: 'all' }
+  | { type: 'favorites' }
+  | { type: 'recent' }
+  | { type: 'ids'; appIds: readonly string[] };
+
+export type CategoryDefinition = {
+  id: string;
+  label: string;
+  icon: string;
+} & CategorySource;
+
+export type CategoryConfig<T> = CategoryDefinition & { apps: T[] };
+
+export const CATEGORY_DEFINITIONS = [
+  {
+    id: 'all',
+    label: 'All Applications',
+    icon: '/themes/Yaru/system/view-app-grid-symbolic.svg',
+    type: 'all',
+  },
+  {
+    id: 'favorites',
+    label: 'Favorites',
+    icon: '/themes/Yaru/status/projects.svg',
+    type: 'favorites',
+  },
+  {
+    id: 'recent',
+    label: 'Recent',
+    icon: '/themes/Yaru/status/process-working-symbolic.svg',
+    type: 'recent',
+  },
+  {
+    id: 'information-gathering',
+    label: 'Information Gathering',
+    icon: '/themes/Yaru/apps/radar-symbolic.svg',
+    type: 'ids',
+    appIds: ['nmap-nse', 'reconng', 'kismet', 'wireshark'],
+  },
+  {
+    id: 'vulnerability-analysis',
+    label: 'Vulnerability Analysis',
+    icon: '/themes/Yaru/apps/nessus.svg',
+    type: 'ids',
+    appIds: ['nessus', 'openvas', 'nikto'],
+  },
+  {
+    id: 'web-app-analysis',
+    label: 'Web App Analysis',
+    icon: '/themes/Yaru/apps/http.svg',
+    type: 'ids',
+    appIds: ['http', 'beef', 'metasploit'],
+  },
+  {
+    id: 'password-attacks',
+    label: 'Password Attacks',
+    icon: '/themes/Yaru/apps/john.svg',
+    type: 'ids',
+    appIds: ['john', 'hashcat', 'hydra'],
+  },
+  {
+    id: 'wireless-attacks',
+    label: 'Wireless Attacks',
+    icon: '/themes/Yaru/status/network-wireless-signal-good-symbolic.svg',
+    type: 'ids',
+    appIds: ['kismet', 'reaver', 'wireshark'],
+  },
+  {
+    id: 'exploitation-tools',
+    label: 'Exploitation Tools',
+    icon: '/themes/Yaru/apps/metasploit.svg',
+    type: 'ids',
+    appIds: ['metasploit', 'security-tools', 'beef'],
+  },
+  {
+    id: 'sniffing-spoofing',
+    label: 'Sniffing & Spoofing',
+    icon: '/themes/Yaru/apps/ettercap.svg',
+    type: 'ids',
+    appIds: ['dsniff', 'ettercap', 'wireshark'],
+  },
+  {
+    id: 'post-exploitation',
+    label: 'Post Exploitation',
+    icon: '/themes/Yaru/apps/msf-post.svg',
+    type: 'ids',
+    appIds: ['msf-post', 'mimikatz', 'volatility'],
+  },
+  {
+    id: 'forensics-reporting',
+    label: 'Forensics & Reporting',
+    icon: '/themes/Yaru/apps/autopsy.svg',
+    type: 'ids',
+    appIds: ['autopsy', 'evidence-vault', 'project-gallery'],
+  },
+] as const satisfies readonly CategoryDefinition[];
+
+const CATEGORY_ID_SET = new Set(CATEGORY_DEFINITIONS.map((category) => category.id));
+
+export const isCategoryId = (
+  value: string,
+): value is CategoryDefinition['id'] => CATEGORY_ID_SET.has(value);
+
+export const buildCategoryConfigs = <T extends { id: string; favourite?: boolean; disabled?: boolean }>(
+  apps: readonly T[],
+  options: {
+    favoriteIds?: readonly string[];
+    recentIds?: readonly string[];
+  } = {},
+): CategoryConfig<T>[] => {
+  const mapById = new Map(apps.map((app) => [app.id, app] as const));
+  const fallbackFavorites = apps
+    .filter((app) => Boolean(app.favourite))
+    .map((app) => app.id);
+  const favoriteIds =
+    options.favoriteIds && options.favoriteIds.length > 0
+      ? Array.from(options.favoriteIds)
+      : fallbackFavorites;
+  const favoritesSet = new Set(favoriteIds);
+  const recentIds = options.recentIds ? Array.from(options.recentIds) : [];
+
+  return CATEGORY_DEFINITIONS.map((definition) => {
+    let appsForCategory: T[] = [];
+    switch (definition.type) {
+      case 'all':
+        appsForCategory = apps.filter((app) => !app.disabled);
+        break;
+      case 'favorites':
+        appsForCategory = apps.filter((app) => favoritesSet.has(app.id));
+        break;
+      case 'recent':
+        appsForCategory = recentIds
+          .map((appId) => mapById.get(appId))
+          .filter((app): app is T => Boolean(app));
+        break;
+      case 'ids':
+        appsForCategory = (definition.appIds ?? [])
+          .map((appId) => mapById.get(appId))
+          .filter((app): app is T => Boolean(app));
+        break;
+      default:
+        appsForCategory = apps;
+    }
+    return {
+      ...definition,
+      apps: appsForCategory,
+    };
+  });
+};

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "dompurify": "^3.2.6",
     "fast-xml-parser": "^4.3.5",
     "figlet": "^1.8.2",
+    "fuse.js": "^6.6.2",
     "hash-wasm": "^4.12.0",
     "howler": "^2.2.4",
     "html-to-image": "^1.11.13",

--- a/utils/appPreferences.js
+++ b/utils/appPreferences.js
@@ -1,0 +1,56 @@
+import { safeLocalStorage } from './safeStorage';
+
+export const FAVORITES_KEY = 'launcherFavorites';
+export const RECENTS_KEY = 'recentApps';
+
+export const readStoredIds = (key) => {
+    if (!safeLocalStorage) return [];
+    try {
+        const raw = JSON.parse(safeLocalStorage.getItem(key) || '[]');
+        if (Array.isArray(raw)) {
+            return raw.filter((id) => typeof id === 'string');
+        }
+    } catch (error) {
+        // ignore malformed entries
+    }
+    return [];
+};
+
+export const persistIds = (key, ids) => {
+    if (!safeLocalStorage) return;
+    try {
+        safeLocalStorage.setItem(key, JSON.stringify(ids));
+    } catch (error) {
+        // ignore quota errors
+    }
+};
+
+export const sanitizeIds = (ids, availableIds, limit) => {
+    const unique = [];
+    const seen = new Set();
+    ids.forEach((id) => {
+        if (!availableIds.has(id) || seen.has(id)) return;
+        seen.add(id);
+        unique.push(id);
+    });
+    if (typeof limit === 'number') {
+        return unique.slice(0, limit);
+    }
+    return unique;
+};
+
+export const updateRecentIds = (current, id, limit = 10) => {
+    const filtered = current.filter((existing) => existing !== id);
+    const next = [id, ...filtered];
+    return typeof limit === 'number' ? next.slice(0, limit) : next;
+};
+
+export const arraysEqual = (a, b) => {
+    if (a === b) return true;
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+        if (a[i] !== b[i]) return false;
+    }
+    return true;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7640,6 +7640,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fuse.js@npm:^6.6.2":
+  version: 6.6.2
+  resolution: "fuse.js@npm:6.6.2"
+  checksum: 10c0/c2fe4f234f516e9ea83b06f06f8f3c8b7117f51aa75bbccd052eed0c0423364bf1e360ffbf29cadae8ef6aa39476b7961eaf9d07bed779cea5c83d62b34e2df9
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -13911,6 +13918,7 @@ __metadata:
     fast-glob: "npm:^3.3.3"
     fast-xml-parser: "npm:^4.3.5"
     figlet: "npm:^1.8.2"
+    fuse.js: "npm:^6.6.2"
     hash-wasm: "npm:^4.12.0"
     howler: "npm:^2.2.4"
     html-to-image: "npm:^1.11.13"


### PR DESCRIPTION
## Summary
- add a shared Fuse-powered `useAppSearch` hook plus storage helpers for favorites and recent apps
- refactor the all applications overlay to use the shared search, expose category filters, and support roving tabindex navigation
- update the AppGrid to consume the shared search, surface recent apps, improve keyboard focus, and cover the hook with unit tests

## Testing
- yarn test --runInBand *(fails: existing Nmap NSE clipboard and YouTube playlist tests)*

------
https://chatgpt.com/codex/tasks/task_e_68da482b8aac832897c3f82758b0f783