### PR TITLE
[games] Add shared title bar navigation

### DIFF
--- a/apps/tower-defense/index.tsx
+++ b/apps/tower-defense/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/router";
 import GameLayout from "../../components/apps/GameLayout";
 import DpsCharts from "../games/tower-defense/components/DpsCharts";
 import RangeUpgradeTree from "../games/tower-defense/components/RangeUpgradeTree";
@@ -87,6 +88,7 @@ interface EnemyInstance extends Enemy {
 }
 
 const TowerDefense = () => {
+  const router = useRouter();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [editing, setEditing] = useState(true);
   const [path, setPath] = useState<{ x: number; y: number }[]>([]);
@@ -417,8 +419,29 @@ const TowerDefense = () => {
     });
   };
 
+  const goToGames = useCallback(() => {
+    void router.push("/apps?category=games");
+  }, [router]);
+
+  const handleBack = useCallback(() => {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+    } else {
+      goToGames();
+    }
+  }, [goToGames, router]);
+
   return (
-    <GameLayout gameId="tower-defense">
+    <GameLayout
+      gameId="tower-defense"
+      title="Tower Defense"
+      breadcrumbs={[
+        { label: "Games", onSelect: goToGames },
+        { label: "Tower Defense" },
+      ]}
+      onBack={handleBack}
+      contextLabel="Games collection. Tower Defense strategy builder."
+    >
       <div className="p-2 space-y-2">
         {waveCountdownRef.current !== null && (
           <div className="text-center bg-gray-700 text-white py-1 rounded">
@@ -469,6 +492,7 @@ const TowerDefense = () => {
             className="w-full bg-black text-white p-1 rounded h-24"
             value={waveJson}
             onChange={(e) => setWaveJson(e.target.value)}
+            aria-label="Wave configuration JSON"
           />
           <div className="space-x-2">
             <button
@@ -494,6 +518,7 @@ const TowerDefense = () => {
             onClick={handleCanvasClick}
             onMouseMove={handleCanvasMove}
             onMouseLeave={handleCanvasLeave}
+            aria-label="Tower defense map editor grid"
           />
           {selected !== null && (
             <div className="ml-2 flex flex-col space-y-1 items-center">

--- a/components/ui/AppTitleBar.tsx
+++ b/components/ui/AppTitleBar.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import React, { useId } from "react";
+
+export interface AppBreadcrumb {
+  label: string;
+  onSelect?: () => void;
+}
+
+export interface AppTitleBarAction {
+  id: string;
+  label: string;
+  onSelect: () => void;
+  icon?: React.ReactNode;
+  ariaLabel?: string;
+  disabled?: boolean;
+  tooltip?: string;
+  pressed?: boolean;
+  ariaExpanded?: boolean;
+}
+
+interface AppTitleBarProps {
+  title: string;
+  breadcrumbs?: AppBreadcrumb[];
+  onBack?: () => void;
+  backLabel?: string;
+  contextLabel?: string;
+  actions?: AppTitleBarAction[];
+  actionsLabel?: string;
+}
+
+const AppTitleBar: React.FC<AppTitleBarProps> = ({
+  title,
+  breadcrumbs,
+  onBack,
+  backLabel = "Go back",
+  contextLabel,
+  actions,
+  actionsLabel = "App actions",
+}) => {
+  const headingId = useId();
+  const contextId = useId();
+  const describedBy = contextLabel ? contextId : undefined;
+
+  return (
+    <header
+      className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-700 bg-gray-900 px-3 py-2 text-white"
+      aria-labelledby={headingId}
+      {...(describedBy ? { "aria-describedby": describedBy } : {})}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        {onBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-sm font-medium hover:bg-gray-700 focus:outline-none focus:ring focus:ring-cyan-400"
+          >
+            {backLabel}
+          </button>
+        )}
+        {breadcrumbs?.length ? (
+          <nav
+            className="flex min-w-0 items-center"
+            aria-label={contextLabel ? `${contextLabel} navigation` : "App navigation"}
+          >
+            <ol className="flex flex-wrap items-center gap-1 text-sm text-gray-200">
+              {breadcrumbs.map((crumb, index) => {
+                const isCurrent = index === breadcrumbs.length - 1;
+                const separator = index < breadcrumbs.length - 1;
+                return (
+                  <li key={`${crumb.label}-${index}`} className="flex items-center gap-1">
+                    {crumb.onSelect && !isCurrent ? (
+                      <button
+                        type="button"
+                        onClick={crumb.onSelect}
+                        className="rounded px-1 py-0.5 text-left hover:underline focus:outline-none focus:ring focus:ring-cyan-400"
+                      >
+                        {crumb.label}
+                      </button>
+                    ) : (
+                      <span
+                        className="truncate"
+                        {...(isCurrent ? { "aria-current": "page" } : {})}
+                      >
+                        {crumb.label}
+                      </span>
+                    )}
+                    {separator && <span aria-hidden="true" className="text-gray-500">/</span>}
+                  </li>
+                );
+              })}
+            </ol>
+          </nav>
+        ) : null}
+        <h1
+          id={headingId}
+          className="truncate text-base font-semibold"
+        >
+          {title}
+        </h1>
+      </div>
+      {contextLabel ? (
+        <p id={contextId} className="sr-only">
+          {contextLabel}
+        </p>
+      ) : null}
+      {actions?.length ? (
+        <div
+          className="flex flex-wrap items-center gap-2"
+          role="group"
+          aria-label={actionsLabel}
+        >
+          {actions.map((action) => (
+            <button
+              key={action.id}
+              type="button"
+              onClick={action.onSelect}
+              className="rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-sm font-medium hover:bg-gray-700 focus:outline-none focus:ring focus:ring-cyan-400 disabled:cursor-not-allowed disabled:opacity-60"
+              aria-label={action.ariaLabel ?? action.label}
+              title={action.tooltip ?? action.label}
+              disabled={action.disabled}
+              {...(typeof action.pressed === "boolean" ? { "aria-pressed": action.pressed } : {})}
+              {...(typeof action.ariaExpanded === "boolean"
+                ? { "aria-expanded": action.ariaExpanded }
+                : {})}
+            >
+              {action.icon ? (
+                <span className="flex items-center gap-1">
+                  <span aria-hidden="true">{action.icon}</span>
+                  <span className="sr-only">{action.label}</span>
+                </span>
+              ) : (
+                action.label
+              )}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </header>
+  );
+};
+
+export default AppTitleBar;


### PR DESCRIPTION
## Summary
- add a reusable `AppTitleBar` component that renders breadcrumbs, back navigation, and grouped actions
- integrate the title bar into `GameLayout` so game overlays inherit consistent navigation and context labelling
- update the Word Search and Tower Defense apps to provide breadcrumbs/back actions and improve control labelling for accessibility

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da482e128083289794db143e689f44