### PR TITLE
[ui] add shared menu surface with keyboard support

### DIFF
--- a/__tests__/MenuSurface.test.tsx
+++ b/__tests__/MenuSurface.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import MenuSurface from '../components/context-menus/MenuSurface';
+
+test('menu surface roves focus with arrow, home, and end keys', async () => {
+  const user = userEvent.setup();
+  render(
+    <MenuSurface id="menu" active onClose={jest.fn()} aria-label="Test menu" className="test">
+      <button role="menuitem" aria-label="Alpha">Alpha</button>
+      <button role="menuitem" aria-label="Beta">Beta</button>
+      <button role="menuitem" aria-label="Gamma">Gamma</button>
+    </MenuSurface>
+  );
+
+  const alpha = screen.getByRole('menuitem', { name: 'Alpha' });
+  const beta = screen.getByRole('menuitem', { name: 'Beta' });
+  const gamma = screen.getByRole('menuitem', { name: 'Gamma' });
+
+  await waitFor(() => expect(alpha).toHaveFocus());
+  await user.keyboard('{ArrowDown}');
+  expect(beta).toHaveFocus();
+  await user.keyboard('{End}');
+  expect(gamma).toHaveFocus();
+  await user.keyboard('{Home}');
+  expect(alpha).toHaveFocus();
+  await user.keyboard('{ArrowUp}');
+  expect(gamma).toHaveFocus();
+});
+
+test('menu surface supports typeahead and escape closes menu', async () => {
+  const user = userEvent.setup();
+  const onClose = jest.fn();
+  render(
+    <MenuSurface id="menu" active onClose={onClose} aria-label="Test menu" className="test">
+      <button role="menuitem" aria-label="Alpha">Alpha</button>
+      <button role="menuitem" aria-label="Beta">Beta</button>
+      <button role="menuitem" aria-label="Gamma">Gamma</button>
+    </MenuSurface>
+  );
+
+  const alpha = screen.getByRole('menuitem', { name: 'Alpha' });
+  const gamma = screen.getByRole('menuitem', { name: 'Gamma' });
+
+  await waitFor(() => expect(alpha).toHaveFocus());
+  await user.keyboard('g');
+  expect(gamma).toHaveFocus();
+  await user.keyboard('{Escape}');
+  expect(onClose).toHaveBeenCalled();
+});
+
+test('menu surface restores focus to opener when closed', async () => {
+  const user = userEvent.setup();
+  const Wrapper: React.FC = () => {
+    const [open, setOpen] = React.useState(false);
+    return (
+      <>
+        <button onClick={() => setOpen(true)}>open</button>
+        <button onClick={() => setOpen(false)}>close menu</button>
+        <MenuSurface
+          id="menu"
+          active={open}
+          onClose={() => setOpen(false)}
+          aria-label="Test menu"
+          className="test"
+        >
+          <button role="menuitem" aria-label="Alpha">Alpha</button>
+        </MenuSurface>
+      </>
+    );
+  };
+
+  render(<Wrapper />);
+
+  const openButton = screen.getByText('open');
+  const closeButton = screen.getByText('close menu');
+
+  openButton.focus();
+  await user.click(openButton);
+  const alpha = await screen.findByRole('menuitem', { name: 'Alpha' });
+  await waitFor(() => expect(alpha).toHaveFocus());
+
+  await user.click(closeButton);
+  await waitFor(() => expect(openButton).toHaveFocus());
+});

--- a/components/context-menus/MenuSurface.tsx
+++ b/components/context-menus/MenuSurface.tsx
@@ -1,0 +1,317 @@
+import React, {
+  ForwardedRef,
+  HTMLAttributes,
+  KeyboardEvent as ReactKeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+
+type MenuSurfaceProps = Omit<HTMLAttributes<HTMLDivElement>, 'role'> & {
+  /** Controls visibility of the menu surface. */
+  active: boolean;
+  /** Called when the surface requests to close, e.g. via Escape. */
+  onClose?: () => void;
+  /** Orientation for keyboard navigation. */
+  orientation?: 'horizontal' | 'vertical';
+  /** Whether focus should be restored to the opener when the menu closes. */
+  restoreFocus?: boolean;
+};
+
+const TYPEAHEAD_TIMEOUT = 500;
+
+function setTabStops(items: HTMLElement[], focusIndex: number) {
+  items.forEach((item, index) => {
+    item.tabIndex = index === focusIndex ? 0 : -1;
+  });
+}
+
+function getItemLabel(item: HTMLElement): string {
+  const data = item.getAttribute('data-menu-label');
+  if (data) return data.trim().toLowerCase();
+  const aria = item.getAttribute('aria-label');
+  if (aria) return aria.trim().toLowerCase();
+  return (item.textContent ?? '').trim().toLowerCase();
+}
+
+function mergeRefs<T>(
+  target: React.MutableRefObject<T | null>,
+  forwarded?: ForwardedRef<T>
+) {
+  return (node: T | null) => {
+    target.current = node;
+    if (typeof forwarded === 'function') {
+      forwarded(node);
+    } else if (forwarded && typeof forwarded === 'object') {
+      (forwarded as React.MutableRefObject<T | null>).current = node;
+    }
+  };
+}
+
+const MenuSurface = React.forwardRef<HTMLDivElement, MenuSurfaceProps>(
+  (
+    {
+      active,
+      children,
+      className = '',
+      onClose,
+      orientation = 'vertical',
+      restoreFocus = true,
+      ...rest
+    },
+    forwardedRef
+  ) => {
+    const nodeRef = useRef<HTMLDivElement | null>(null);
+    const previousFocusRef = useRef<HTMLElement | null>(null);
+    const itemsRef = useRef<HTMLElement[]>([]);
+    const focusIndexRef = useRef(0);
+    const typeaheadRef = useRef('');
+    const typeaheadTimerRef = useRef<number | null>(null);
+
+    useFocusTrap(nodeRef, active);
+
+    const updateItems = useCallback(() => {
+      const node = nodeRef.current;
+      if (!node) {
+        itemsRef.current = [];
+        return itemsRef.current;
+      }
+      const selector = [
+        '[role="menuitem"]',
+        '[role="menuitemcheckbox"]',
+        '[role="menuitemradio"]',
+        '[role="option"]',
+        '[role="tab"]'
+      ]
+        .map((value) => `${value}:not([aria-disabled="true"])`)
+        .join(', ');
+      const items = Array.from(
+        node.querySelectorAll<HTMLElement>(selector)
+      ).filter((item) => !item.hasAttribute('disabled'));
+      itemsRef.current = items;
+      return items;
+    }, []);
+
+    const focusItem = useCallback(
+      (index: number) => {
+        const items = itemsRef.current;
+        if (!items.length) return;
+        const normalized = (index + items.length) % items.length;
+        focusIndexRef.current = normalized;
+        setTabStops(items, normalized);
+        const target = items[normalized];
+        target.focus();
+      },
+      []
+    );
+
+    const findMatch = useCallback(
+      (search: string) => {
+        const items = itemsRef.current;
+        if (!items.length) return -1;
+        const current = focusIndexRef.current ?? 0;
+        const total = items.length;
+        for (let offset = 0; offset < total; offset += 1) {
+          const index = (current + offset) % total;
+          const label = getItemLabel(items[index]);
+          if (label && label.startsWith(search)) {
+            return index;
+          }
+        }
+        return -1;
+      },
+      []
+    );
+
+    const clearTypeahead = useCallback(() => {
+      if (typeaheadTimerRef.current) {
+        window.clearTimeout(typeaheadTimerRef.current);
+        typeaheadTimerRef.current = null;
+      }
+      typeaheadRef.current = '';
+    }, []);
+
+    const handleTypeahead = useCallback(
+      (key: string) => {
+        const items = itemsRef.current;
+        if (!items.length) return;
+
+        const lower = key.toLowerCase();
+        const nextBuffer = `${typeaheadRef.current}${lower}`;
+        let match = findMatch(nextBuffer);
+        let bufferToUse = nextBuffer;
+        if (match === -1) {
+          match = findMatch(lower);
+          bufferToUse = lower;
+        }
+        if (match === -1) return;
+
+        typeaheadRef.current = bufferToUse;
+        if (typeaheadTimerRef.current) {
+          window.clearTimeout(typeaheadTimerRef.current);
+        }
+        typeaheadTimerRef.current = window.setTimeout(() => {
+          typeaheadRef.current = '';
+          typeaheadTimerRef.current = null;
+        }, TYPEAHEAD_TIMEOUT);
+        focusItem(match);
+      },
+      [findMatch, focusItem]
+    );
+
+    const handleKeyDown = useCallback(
+      (event: KeyboardEvent) => {
+        const items = updateItems();
+        if (!items.length) return;
+
+        const key = event.key;
+        const isHorizontal = orientation === 'horizontal';
+        const forwardKeys = isHorizontal
+          ? ['ArrowRight', 'ArrowDown']
+          : ['ArrowDown'];
+        const backwardKeys = isHorizontal
+          ? ['ArrowLeft', 'ArrowUp']
+          : ['ArrowUp'];
+
+        if (forwardKeys.includes(key)) {
+          event.preventDefault();
+          focusItem(focusIndexRef.current + 1);
+          clearTypeahead();
+          return;
+        }
+        if (backwardKeys.includes(key)) {
+          event.preventDefault();
+          focusItem(focusIndexRef.current - 1);
+          clearTypeahead();
+          return;
+        }
+        if (key === 'Home') {
+          event.preventDefault();
+          focusItem(0);
+          clearTypeahead();
+          return;
+        }
+        if (key === 'End') {
+          event.preventDefault();
+          focusItem(items.length - 1);
+          clearTypeahead();
+          return;
+        }
+        if (key === 'Escape') {
+          event.preventDefault();
+          onClose?.();
+          return;
+        }
+
+        if (
+          key.length === 1 &&
+          !event.altKey &&
+          !event.ctrlKey &&
+          !event.metaKey
+        ) {
+          handleTypeahead(key);
+        }
+      },
+      [clearTypeahead, focusItem, handleTypeahead, onClose, orientation, updateItems]
+    );
+
+    useEffect(() => {
+      const node = nodeRef.current;
+      if (!node || !active) return undefined;
+
+      const items = updateItems();
+      if (!items.length) return undefined;
+      focusIndexRef.current = 0;
+      setTabStops(items, 0);
+      const first = items[0];
+
+      let frame: number | undefined;
+      let timeout: number | undefined;
+
+      const focusFirst = () => {
+        first.focus();
+      };
+
+      if (typeof window.requestAnimationFrame === 'function') {
+        frame = window.requestAnimationFrame(focusFirst);
+      } else {
+        timeout = window.setTimeout(focusFirst, 0);
+      }
+
+      return () => {
+        if (typeof window.cancelAnimationFrame === 'function' && frame !== undefined) {
+          window.cancelAnimationFrame(frame);
+        }
+        if (timeout !== undefined) {
+          window.clearTimeout(timeout);
+        }
+      };
+    }, [active, updateItems]);
+
+    useEffect(() => {
+      const node = nodeRef.current;
+      if (!node || !active) return undefined;
+      const keyHandler = (event: KeyboardEvent) => handleKeyDown(event);
+      node.addEventListener('keydown', keyHandler);
+      return () => {
+        node.removeEventListener('keydown', keyHandler);
+      };
+    }, [active, handleKeyDown]);
+
+    useEffect(() => {
+      if (active) {
+        const activeElement = document.activeElement as HTMLElement | null;
+        previousFocusRef.current = activeElement;
+      } else {
+        clearTypeahead();
+        if (!restoreFocus) return;
+        const previous = previousFocusRef.current;
+        previousFocusRef.current = null;
+        if (
+          previous &&
+          typeof previous.focus === 'function' &&
+          previous !== document.body &&
+          !nodeRef.current?.contains(previous)
+        ) {
+          previous.focus();
+        }
+      }
+      return undefined;
+    }, [active, clearTypeahead, restoreFocus]);
+
+    useEffect(
+      () => () => {
+        if (typeaheadTimerRef.current) {
+          window.clearTimeout(typeaheadTimerRef.current);
+        }
+      },
+      []
+    );
+
+    const visibilityClass = active ? 'block' : 'hidden';
+    const combinedClassName = `${visibilityClass} ${className}`.trim();
+
+    return (
+      <div
+        {...rest}
+        ref={mergeRefs(nodeRef, forwardedRef)}
+        role="menu"
+        aria-hidden={!active}
+        className={combinedClassName}
+        onKeyDown={(event: ReactKeyboardEvent<HTMLDivElement>) => {
+          // Allow consumer-level handlers to run after internal logic.
+          if (rest.onKeyDown) {
+            rest.onKeyDown(event);
+          }
+        }}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+MenuSurface.displayName = 'MenuSurface';
+
+export default MenuSurface;

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -1,18 +1,7 @@
-import React, { useRef } from 'react'
-import useFocusTrap from '../../hooks/useFocusTrap'
-import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import React from 'react'
+import MenuSurface from './MenuSurface'
 
 function AppMenu(props) {
-    const menuRef = useRef(null)
-    useFocusTrap(menuRef, props.active)
-    useRovingTabIndex(menuRef, props.active, 'vertical')
-
-    const handleKeyDown = (e) => {
-        if (e.key === 'Escape') {
-            props.onClose && props.onClose()
-        }
-    }
-
     const handlePin = () => {
         if (props.pinned) {
             props.unpinApp && props.unpinApp()
@@ -22,13 +11,11 @@ function AppMenu(props) {
     }
 
     return (
-        <div
+        <MenuSurface
             id="app-menu"
-            role="menu"
-            aria-hidden={!props.active}
-            ref={menuRef}
-            onKeyDown={handleKeyDown}
-            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
+            active={props.active}
+            onClose={props.onClose}
+            className="cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"
         >
             <button
                 type="button"
@@ -39,7 +26,7 @@ function AppMenu(props) {
             >
                 <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
             </button>
-        </div>
+        </MenuSurface>
     )
 }
 

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -1,28 +1,14 @@
-import React, { useRef } from 'react'
-import useFocusTrap from '../../hooks/useFocusTrap'
-import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import React from 'react'
+import MenuSurface from './MenuSurface'
 
 function DefaultMenu(props) {
-    const menuRef = useRef(null)
-    useFocusTrap(menuRef, props.active)
-    useRovingTabIndex(menuRef, props.active, 'vertical')
-
-    const handleKeyDown = (e) => {
-        if (e.key === 'Escape') {
-            props.onClose && props.onClose()
-        }
-    }
-
     return (
-        <div
+        <MenuSurface
             id="default-menu"
-            role="menu"
-            aria-hidden={!props.active}
-            ref={menuRef}
-            onKeyDown={handleKeyDown}
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            active={props.active}
+            onClose={props.onClose}
+            className="cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm"
         >
-
             <Devider />
             <a
                 rel="noopener noreferrer"
@@ -64,7 +50,7 @@ function DefaultMenu(props) {
             >
                 <span className="ml-5">🧹</span> <span className="ml-2">Reset Kali Linux</span>
             </button>
-        </div>
+        </MenuSurface>
     )
 }
 

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,9 +1,18 @@
 import React, { useState, useEffect } from 'react'
 import logger from '../../utils/logger'
+import MenuSurface from './MenuSurface'
 
 function DesktopMenu(props) {
 
     const [isFullScreen, setIsFullScreen] = useState(false)
+
+    const checkFullScreen = () => {
+        if (document.fullscreenElement) {
+            setIsFullScreen(true)
+        } else {
+            setIsFullScreen(false)
+        }
+    }
 
     useEffect(() => {
         document.addEventListener('fullscreenchange', checkFullScreen);
@@ -12,21 +21,12 @@ function DesktopMenu(props) {
         };
     }, [])
 
-
     const openTerminal = () => {
         props.openApp("terminal");
     }
 
     const openSettings = () => {
         props.openApp("settings");
-    }
-
-    const checkFullScreen = () => {
-        if (document.fullscreenElement) {
-            setIsFullScreen(true)
-        } else {
-            setIsFullScreen(false)
-        }
     }
 
     const goFullScreen = () => {
@@ -44,11 +44,12 @@ function DesktopMenu(props) {
     }
 
     return (
-        <div
+        <MenuSurface
             id="desktop-menu"
-            role="menu"
+            active={props.active}
+            onClose={props.onClose}
             aria-label="Desktop context menu"
-            className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
+            className="cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"
         >
             <button
                 onClick={props.addNewFolder}
@@ -128,7 +129,7 @@ function DesktopMenu(props) {
             >
                 <span className="ml-5">Clear Session</span>
             </button>
-        </div>
+        </MenuSurface>
     )
 }
 
@@ -139,6 +140,5 @@ function Devider() {
         </div>
     );
 }
-
 
 export default DesktopMenu

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -1,18 +1,7 @@
-import React, { useRef } from 'react';
-import useFocusTrap from '../../hooks/useFocusTrap';
-import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+import React from 'react';
+import MenuSurface from './MenuSurface';
 
 function TaskbarMenu(props) {
-    const menuRef = useRef(null);
-    useFocusTrap(menuRef, props.active);
-    useRovingTabIndex(menuRef, props.active, 'vertical');
-
-    const handleKeyDown = (e) => {
-        if (e.key === 'Escape') {
-            props.onCloseMenu && props.onCloseMenu();
-        }
-    };
-
     const handleMinimize = () => {
         props.onMinimize && props.onMinimize();
         props.onCloseMenu && props.onCloseMenu();
@@ -24,13 +13,11 @@ function TaskbarMenu(props) {
     };
 
     return (
-        <div
+        <MenuSurface
             id="taskbar-menu"
-            role="menu"
-            aria-hidden={!props.active}
-            ref={menuRef}
-            onKeyDown={handleKeyDown}
-            className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
+            active={props.active}
+            onClose={props.onCloseMenu}
+            className="cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm"
         >
             <button
                 type="button"
@@ -50,7 +37,7 @@ function TaskbarMenu(props) {
             >
                 <span className="ml-5">Close</span>
             </button>
-        </div>
+        </MenuSurface>
     );
 }
 

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1781,6 +1781,7 @@ export class Desktop extends Component {
                     openApp={this.openApp}
                     addNewFolder={this.addNewFolder}
                     openShortcutSelector={this.openShortcutSelector}
+                    onClose={this.hideAllContextMenu}
                     clearSession={() => { this.props.clearSession(); window.location.reload(); }}
                 />
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />


### PR DESCRIPTION
## Summary
- add a shared MenuSurface component that manages roving focus, typeahead search, escape handling, and focus restoration
- refactor desktop, default, app, and taskbar context menus to consume the shared surface
- add unit tests covering keyboard navigation, escape handling, and focus restore logic

## Testing
- yarn lint
- yarn test MenuSurface

------
https://chatgpt.com/codex/tasks/task_e_68da482f540c83289b374aad24aa8f3f