### PR TITLE
[ui] add reusable onboarding overlay

### DIFF
--- a/__tests__/HelpOverlay.test.tsx
+++ b/__tests__/HelpOverlay.test.tsx
@@ -4,12 +4,14 @@ import HelpOverlay from '../components/apps/HelpOverlay';
 
 describe('HelpOverlay', () => {
   it('returns null when no instructions exist for the game', () => {
-    const { container } = render(<HelpOverlay gameId="unknown" onClose={() => {}} />);
+    const { container } = render(
+      <HelpOverlay gameId="unknown" open onOpenChange={() => {}} />,
+    );
     expect(container.firstChild).toBeNull();
   });
 
   it('renders instructions when available', () => {
-    render(<HelpOverlay gameId="2048" onClose={() => {}} />);
+    render(<HelpOverlay gameId="2048" open onOpenChange={() => {}} />);
     expect(screen.getByText('2048 Help')).toBeInTheDocument();
     expect(
       screen.getByText('Reach the 2048 tile by merging numbers.')

--- a/components/ExplainerPane.tsx
+++ b/components/ExplainerPane.tsx
@@ -1,3 +1,5 @@
+import OnboardingOverlay from "./ui/OnboardingOverlay";
+
 interface Resource {
   label: string;
   url: string;
@@ -6,36 +8,66 @@ interface Resource {
 interface Props {
   lines: string[];
   resources: Resource[];
+  storageKey?: string;
+  title?: string;
+  defaultOpen?: boolean;
 }
 
-export default function ExplainerPane({ lines, resources }: Props) {
+export default function ExplainerPane({
+  lines,
+  resources,
+  storageKey = "explainer:lab",
+  title = "Key lab takeaways",
+  defaultOpen = true,
+}: Props) {
   return (
-    <aside
-      className="text-xs p-2 border-l border-ub-cool-grey overflow-auto h-full"
-      aria-label="explainer pane"
+    <OnboardingOverlay
+      storageKey={storageKey}
+      title={title}
+      description="Keep this quick reference handy while you explore the lab workspace."
+      defaultOpen={defaultOpen}
+      align="end"
+      dismissLabel="Let's build"
+      footer="This note only auto-opens on your first visit."
+      trigger={(controls) => (
+        <button
+          type="button"
+          aria-label="Show lab explainer"
+          onClick={controls.toggle}
+          className="fixed bottom-4 right-4 z-40 rounded-full bg-ub-orange px-3 py-2 text-xs font-semibold text-black shadow focus:outline-none focus:ring"
+        >
+          Lab guide
+        </button>
+      )}
     >
-      <h3 className="font-bold mb-2">Key Points</h3>
-      <ul className="list-disc list-inside mb-4">
-        {lines.map((line, i) => (
-          <li key={i}>{line}</li>
-        ))}
-      </ul>
-      <h3 className="font-bold mb-2">Learn More</h3>
-      <ul className="list-disc list-inside">
-        {resources.map((r, i) => (
-          <li key={i}>
-            <a
-              href={r.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline"
-            >
-              {r.label}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </aside>
+      <section className="space-y-4 text-sm text-gray-200">
+        <div>
+          <h3 className="text-base font-semibold text-white">Key Points</h3>
+          <ul className="mt-2 list-disc list-inside space-y-1">
+            {lines.map((line, i) => (
+              <li key={`${line}-${i}`}>{line}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="text-base font-semibold text-white">Learn More</h3>
+          <ul className="mt-2 list-disc list-inside space-y-1">
+            {resources.map((resource) => (
+              <li key={resource.url}>
+                <a
+                  href={resource.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-ub-orange hover:underline"
+                >
+                  {resource.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+    </OnboardingOverlay>
   );
 }
 

--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -1,33 +1,150 @@
 "use client";
 
-import { useEffect, useState } from 'react';
-import DOMPurify from 'dompurify';
-import { marked } from 'marked';
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import DOMPurify from "dompurify";
+import { marked } from "marked";
+import OnboardingOverlay, {
+  useOnboardingProgress,
+} from "./ui/OnboardingOverlay";
 
 interface HelpPanelProps {
   appId: string;
   docPath?: string;
 }
 
+interface TipConfig {
+  title: string;
+  tips: string[];
+  resources?: { label: string; url: string }[];
+}
+
+const TIP_MAP: Record<string, TipConfig> = {
+  wireshark: {
+    title: "Packet sleuth tips",
+    tips: [
+      "Drop the bundled PCAPs from the Samples menu to explore finished captures.",
+      "The Filter Helper suggests display filters as you type — use it to learn syntax.",
+      "Load a TLS key log to watch encrypted handshakes decode in real time.",
+    ],
+    resources: [
+      {
+        label: "Wireshark display filter reference",
+        url: "https://www.wireshark.org/docs/dfref/",
+      },
+      {
+        label: "Practical capture workflow",
+        url: "https://wiki.wireshark.org/CaptureSetup",
+      },
+    ],
+  },
+  ghidra: {
+    title: "Reverse engineering primer",
+    tips: [
+      "Try the sample binaries first — they are small and annotated for the lab.",
+      "Switch engines if WebAssembly is blocked; the Capstone fallback still disassembles.",
+      "Use the notes tabs to track findings; they persist between sessions.",
+    ],
+    resources: [
+      {
+        label: "Ghidra script hub",
+        url: "https://ghidra.re/courses/",
+      },
+      {
+        label: "Capstone quickstart",
+        url: "http://www.capstone-engine.org/lang_python.html",
+      },
+    ],
+  },
+  "nmap-nse": {
+    title: "Script lab pointers",
+    tips: [
+      "Start from the presets to see typical NSE script scaffolding.",
+      "Simulated output highlights which arguments change behaviour.",
+      "Use the notes panel to capture post-scan actions for blue team drills.",
+    ],
+    resources: [
+      {
+        label: "Nmap NSE reference",
+        url: "https://nmap.org/book/nse.html",
+      },
+    ],
+  },
+  metasploit: {
+    title: "Operator shortcuts",
+    tips: [
+      "Saved sessions are stored locally so you can resume your lab workflow.",
+      "Toggle payload previews to understand what each module is simulating.",
+      "Use the MITRE notes to map simulated findings to ATT&CK tactics.",
+    ],
+    resources: [
+      {
+        label: "Metasploit module docs",
+        url: "https://docs.metasploit.com/",
+      },
+    ],
+  },
+  radare2: {
+    title: "Radare2 workflow",
+    tips: [
+      "Load the sample analysis bundles to compare r2 and Ghidra perspectives.",
+      "Use the graph view toggle to understand function relationships before decompiling.",
+      "Export notes to share investigations between the simulated tools.",
+    ],
+    resources: [
+      {
+        label: "Radare2 book",
+        url: "https://radare.gitbooks.io/radare2book/content/",
+      },
+    ],
+  },
+  volatility: {
+    title: "Memory triage flow",
+    tips: [
+      "Start with the Profile Wizard to choose the correct image preset.",
+      "Bookmark commands to build a repeatable hunt checklist.",
+      "Use timeline mode to spot persistence or injection activity quickly.",
+    ],
+    resources: [
+      {
+        label: "Volatility Foundation",
+        url: "https://www.volatilityfoundation.org/",
+      },
+    ],
+  },
+};
+
 export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
-  const [open, setOpen] = useState(false);
-  const [html, setHtml] = useState("<p>Loading...</p>");
+  const path = docPath || `/docs/apps/${appId}.md`;
+  const [html, setHtml] = useState<string>("<p>Loading…</p>");
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const toggleRef = useRef<() => void>(() => {});
+  const { dismissed } = useOnboardingProgress(`help:${appId}`);
 
   useEffect(() => {
-    if (!open) return;
-    const path = docPath || `/docs/apps/${appId}.md`;
-    fetch(path)
-      .then((res) => (res.ok ? res.text() : ""))
-      .then((md) => {
-        if (!md) {
-          setHtml("<p>No help available.</p>");
-          return;
-        }
-        const rendered = DOMPurify.sanitize(marked.parse(md) as string);
-        setHtml(rendered);
-      })
-      .catch(() => setHtml("<p>No help available.</p>"));
-  }, [open, appId, docPath]);
+    if (!dismissed) {
+      setIsOpen(true);
+    }
+  }, [dismissed]);
+
+  const loadDoc = useCallback(async () => {
+    try {
+      const res = await fetch(path);
+      if (!res.ok) throw new Error("not found");
+      const md = await res.text();
+      if (!md) throw new Error("empty");
+      const rendered = DOMPurify.sanitize(marked.parse(md) as string);
+      setHtml(rendered);
+    } catch {
+      setHtml("<p>No help available.</p>");
+    }
+  }, [path]);
+
+  useEffect(() => {
+    if (isOpen && !hasLoaded) {
+      loadDoc().finally(() => setHasLoaded(true));
+    }
+  }, [isOpen, hasLoaded, loadDoc]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -39,40 +156,72 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
       if (isInput) return;
       if (e.key === "?" || (e.key === "/" && e.shiftKey)) {
         e.preventDefault();
-        setOpen((o) => !o);
+        toggleRef.current();
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, []);
 
-  const toggle = () => setOpen((o) => !o);
+  const tips = useMemo(() => TIP_MAP[appId], [appId]);
 
-  return (
-    <>
-      <button
-        type="button"
-        aria-label="Help"
-        aria-expanded={open}
-        onClick={toggle}
-        className="fixed top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
-      >
-        ?
-      </button>
-      {open && (
-        <div
-          className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-start justify-end p-4"
-          onClick={toggle}
-        >
-          <div
-            className="bg-white text-black p-4 rounded max-w-md w-full h-full overflow-auto"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div dangerouslySetInnerHTML={{ __html: html }} />
-          </div>
+  const aside = tips ? (
+    <div>
+      <h3 className="text-sm font-semibold text-white">{tips.title}</h3>
+      <ul className="mt-2 list-disc list-inside space-y-1 text-xs text-gray-200">
+        {tips.tips.map((tip) => (
+          <li key={tip}>{tip}</li>
+        ))}
+      </ul>
+      {tips.resources && (
+        <div className="mt-3 space-y-1">
+          {tips.resources.map((resource) => (
+            <a
+              key={resource.url}
+              href={resource.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block text-xs font-medium text-ub-orange hover:underline"
+            >
+              {resource.label}
+            </a>
+          ))}
         </div>
       )}
-    </>
+    </div>
+  ) : undefined;
+
+  return (
+    <OnboardingOverlay
+      storageKey={`help:${appId}`}
+      title="Help & onboarding"
+      description="Lab docs, shortcuts, and the latest pro tips for this tool."
+      defaultOpen
+      align="end"
+      dismissLabel="Close help"
+      trigger={(controls) => {
+        toggleRef.current = controls.toggle;
+        return (
+          <button
+            type="button"
+            aria-label="Help"
+            aria-expanded={controls.isOpen}
+            onClick={controls.toggle}
+            className="fixed top-2 right-2 z-40 flex h-8 w-8 items-center justify-center rounded-full bg-gray-700 text-white shadow focus:outline-none focus:ring"
+          >
+            ?
+          </button>
+        );
+      }}
+      aside={aside}
+      footer="Press ? to toggle this guide at any time."
+      onOpenChange={setIsOpen}
+    >
+      <div
+        className="prose prose-invert max-w-none text-sm"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </OnboardingOverlay>
   );
 }
 

--- a/components/ui/OnboardingOverlay.tsx
+++ b/components/ui/OnboardingOverlay.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import {
+  PropsWithChildren,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { MouseEvent } from "react";
+import usePersistentState from "../../hooks/usePersistentState";
+
+const STORAGE_PREFIX = "onboarding:";
+
+const isBoolean = (value: unknown): value is boolean => typeof value === "boolean";
+
+export interface OnboardingOverlayControls {
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  reset: () => void;
+  dismissed: boolean;
+  isOpen: boolean;
+}
+
+interface OnboardingOverlayProps {
+  storageKey: string;
+  title: ReactNode;
+  description?: ReactNode;
+  children: ReactNode;
+  aside?: ReactNode;
+  footer?: ReactNode;
+  trigger?: (controls: OnboardingOverlayControls) => ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  dismissLabel?: string;
+  align?: "center" | "end";
+  disableBackdropClose?: boolean;
+}
+
+interface UseOnboardingProgress {
+  dismissed: boolean;
+  markComplete: () => void;
+  reset: () => void;
+}
+
+export const useOnboardingProgress = (storageKey: string): UseOnboardingProgress => {
+  const [dismissed, setDismissed] = usePersistentState<boolean>(
+    `${STORAGE_PREFIX}${storageKey}`,
+    false,
+    isBoolean,
+  );
+
+  const markComplete = useCallback(() => {
+    setDismissed(true);
+  }, [setDismissed]);
+
+  const reset = useCallback(() => {
+    setDismissed(false);
+  }, [setDismissed]);
+
+  return { dismissed, markComplete, reset };
+};
+
+const alignmentClasses: Record<NonNullable<OnboardingOverlayProps["align"]>, string> = {
+  center: "items-center justify-center",
+  end: "items-start justify-end",
+};
+
+const focusSelectors =
+  'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+const OnboardingOverlay = ({
+  storageKey,
+  title,
+  description,
+  children,
+  aside,
+  footer,
+  trigger,
+  open: controlledOpen,
+  defaultOpen = true,
+  onOpenChange,
+  dismissLabel = "Got it",
+  align = "center",
+  disableBackdropClose = false,
+}: PropsWithChildren<OnboardingOverlayProps>) => {
+  const { dismissed, markComplete, reset } = useOnboardingProgress(storageKey);
+  const isControlled = typeof controlledOpen === "boolean";
+  const [internalOpen, setInternalOpen] = useState<boolean>(
+    () => !dismissed && defaultOpen,
+  );
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const previousActive = useRef<HTMLElement | null>(null);
+  const prevControlledOpen = useRef<boolean | undefined>(controlledOpen);
+
+  useEffect(() => {
+    if (isControlled) return;
+    if (!dismissed && defaultOpen) {
+      setInternalOpen(true);
+    }
+  }, [dismissed, defaultOpen, isControlled]);
+
+  const setOpen = useCallback(
+    (next: boolean, persistDismissal: boolean) => {
+      if (!isControlled) {
+        setInternalOpen(next);
+      }
+      onOpenChange?.(next);
+      if (!next && persistDismissal) {
+        markComplete();
+      }
+    },
+    [isControlled, markComplete, onOpenChange],
+  );
+
+  const openOverlay = useCallback(() => {
+    setOpen(true, false);
+  }, [setOpen]);
+
+  const closeOverlay = useCallback(() => {
+    setOpen(false, true);
+  }, [setOpen]);
+
+  const resetAndShow = useCallback(() => {
+    reset();
+    setOpen(true, false);
+  }, [reset, setOpen]);
+
+  const isOpen = isControlled ? Boolean(controlledOpen) : internalOpen;
+
+  useEffect(() => {
+    if (!isControlled) return;
+    if (prevControlledOpen.current && !controlledOpen) {
+      markComplete();
+    }
+    prevControlledOpen.current = controlledOpen;
+  }, [controlledOpen, isControlled, markComplete]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const node = overlayRef.current;
+    if (!node) return;
+    previousActive.current = document.activeElement as HTMLElement | null;
+    const focusables = Array.from(node.querySelectorAll<HTMLElement>(focusSelectors));
+    focusables[0]?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeOverlay();
+        return;
+      }
+      if (event.key !== "Tab" || focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    node.addEventListener("keydown", handleKeyDown);
+    return () => {
+      node.removeEventListener("keydown", handleKeyDown);
+      previousActive.current?.focus();
+    };
+  }, [closeOverlay, isOpen]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (!isOpen || disableBackdropClose) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeOverlay();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [closeOverlay, disableBackdropClose, isOpen]);
+
+  const handleBackdropClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (disableBackdropClose) return;
+      if (event.target === event.currentTarget) {
+        closeOverlay();
+      }
+    },
+    [closeOverlay, disableBackdropClose],
+  );
+
+  const controls = useMemo<OnboardingOverlayControls>(
+    () => ({
+      open: openOverlay,
+      close: closeOverlay,
+      toggle: () => {
+        if (isOpen) {
+          closeOverlay();
+        } else {
+          openOverlay();
+        }
+      },
+      reset: resetAndShow,
+      dismissed,
+      isOpen,
+    }),
+    [closeOverlay, dismissed, isOpen, openOverlay, resetAndShow],
+  );
+
+  const alignment = alignmentClasses[align] ?? alignmentClasses.center;
+
+  return (
+    <>
+      {trigger?.(controls)}
+      {isOpen && (
+        <div
+          className={`fixed inset-0 z-50 flex ${alignment} p-4 bg-black/70 backdrop-blur-sm`}
+          onClick={handleBackdropClick}
+        >
+          <div
+            ref={overlayRef}
+            className="relative w-full max-w-3xl rounded-lg border border-gray-700 bg-gray-900 text-gray-100 shadow-xl focus:outline-none"
+            role="dialog"
+            aria-modal="true"
+          >
+            <button
+              type="button"
+              onClick={closeOverlay}
+              className="absolute right-3 top-3 rounded-full bg-gray-800 px-3 py-1 text-sm font-medium text-gray-200 shadow focus:outline-none focus:ring"
+            >
+              ✕
+            </button>
+            <div className="flex flex-col gap-6 p-6 md:flex-row">
+              <div className="flex-1">
+                <h2 className="text-xl font-semibold text-white">{title}</h2>
+                {description && (
+                  <p className="mt-2 text-sm text-gray-300">{description}</p>
+                )}
+                <div className="mt-4 space-y-4 text-sm text-gray-200">{children}</div>
+              </div>
+              {aside && (
+                <aside className="w-full max-w-xs rounded-md border border-gray-700 bg-gray-800 p-4 text-sm text-gray-200">
+                  {aside}
+                </aside>
+              )}
+            </div>
+            <div className="flex flex-col gap-3 border-t border-gray-800 bg-gray-900 px-6 py-4 text-sm md:flex-row md:items-center md:justify-between">
+              <div className="text-gray-400">{footer}</div>
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={resetAndShow}
+                  className="rounded border border-gray-600 px-3 py-1 text-gray-200 transition hover:border-gray-400 hover:text-white"
+                >
+                  Revisit intro
+                </button>
+                <button
+                  type="button"
+                  onClick={closeOverlay}
+                  className="rounded bg-ub-orange px-4 py-1 font-semibold text-black transition hover:bg-orange-400 focus:outline-none focus:ring"
+                >
+                  {dismissLabel}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default OnboardingOverlay;


### PR DESCRIPTION
## Summary
- add a reusable onboarding overlay component with persistent dismissal controls
- migrate app help surfaces to the shared overlay and add advanced lab tips
- integrate first-run persistence for game help and refresh related tests

## Testing
- yarn test HelpOverlay
- yarn lint --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68da482fd5848328b484a5822bc5eb34