### PR TITLE
[a11y] Improve focus visibility utilities

### DIFF
--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { focusRing } from '../styles/theme';
 import { ModuleMetadata } from '../modules/metadata';
 
 interface ModuleCardProps {
@@ -33,7 +34,7 @@ export default function ModuleCard({
   return (
     <button
       onClick={() => onSelect(module)}
-      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
+      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 ${focusRing.default} ${
         selected ? 'bg-gray-100' : ''
       }`}
     >

--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import modulesData from '../data/module-index.json';
 import versionInfo from '../data/module-version.json';
+import { focusRing } from '../styles/theme';
 
 interface Module {
   id: string;
@@ -54,6 +55,8 @@ const PopularModules: React.FC = () => {
         l.message.toLowerCase().includes(logFilter.toLowerCase())
       )
     : [];
+  const searchId = 'popular-modules-search';
+  const logFilterId = 'popular-modules-log-filter';
   const copyLogs = () => {
     const text = filteredLog.map((l) => l.message).join('\n');
     if (typeof navigator !== 'undefined' && navigator.clipboard) {
@@ -188,7 +191,7 @@ const PopularModules: React.FC = () => {
       <div className="flex items-center gap-2">
         <button
           onClick={handleUpdate}
-          className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          className={`px-2 py-1 text-sm rounded bg-gray-700 ${focusRing.default}`}
         >
           Update Modules
         </button>
@@ -199,16 +202,18 @@ const PopularModules: React.FC = () => {
       </div>
       {updateMessage && <p className="text-sm">{updateMessage}</p>}
       <input
+        id={searchId}
         type="text"
         placeholder="Search modules"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         className="w-full p-2 text-black rounded"
+        aria-label="Search modules"
       />
       <div className="flex flex-wrap gap-2">
         <button
           onClick={() => setFilter('')}
-          className={`px-2 py-1 text-sm rounded focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+          className={`px-2 py-1 text-sm rounded ${focusRing.default} ${
             filter === '' ? 'bg-blue-600' : 'bg-gray-700'
           }`}
         >
@@ -218,7 +223,7 @@ const PopularModules: React.FC = () => {
           <button
             key={t}
             onClick={() => setFilter(t)}
-            className={`px-2 py-1 text-sm rounded focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+            className={`px-2 py-1 text-sm rounded ${focusRing.default} ${
               filter === t ? 'bg-blue-600' : 'bg-gray-700'
             }`}
           >
@@ -231,7 +236,7 @@ const PopularModules: React.FC = () => {
           <button
             key={m.id}
             onClick={() => handleSelect(m)}
-            className="p-3 text-left bg-ub-grey rounded border border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            className={`p-3 text-left bg-ub-grey rounded border border-gray-700 ${focusRing.default}`}
           >
             <h3 className="font-semibold">{m.name}</h3>
             <p className="text-sm text-gray-300">{m.description}</p>
@@ -276,26 +281,28 @@ const PopularModules: React.FC = () => {
             <button
               type="button"
               onClick={copyCommand}
-              className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className={`px-2 py-1 text-sm rounded bg-gray-700 ${focusRing.default}`}
             >
               Copy
             </button>
           </div>
           <div className="space-y-1">
-            <label className="block text-sm">
+            <label className="block text-sm" htmlFor={logFilterId}>
               Filter logs
               <input
+                id={logFilterId}
                 placeholder="Filter logs"
                 type="text"
                 value={logFilter}
                 onChange={(e) => setLogFilter(e.target.value)}
                 className="w-full p-1 mt-1 text-black rounded"
+                aria-label="Filter logs"
               />
             </label>
             <button
               type="button"
               onClick={copyLogs}
-              className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className={`px-2 py-1 text-sm rounded bg-gray-700 ${focusRing.default}`}
             >
               Copy Logs
             </button>

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import { focusRing } from "../styles/theme";
 
 type Tab<T extends string> = {
   id: T;
@@ -28,7 +29,7 @@ export default function Tabs<T extends string>({
           aria-selected={active === t.id}
           tabIndex={active === t.id ? 0 : -1}
           onClick={() => onChange(t.id)}
-          className={`px-4 py-2 focus:outline-none ${
+          className={`px-4 py-2 ${focusRing.default} ${
             active === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
           }`}
         >

--- a/components/menu/ApplicationsMenu.tsx
+++ b/components/menu/ApplicationsMenu.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
+import { focusRing } from '../../styles/theme';
 
 export type KaliCategory = {
   id: string;
@@ -97,7 +98,7 @@ const ApplicationsMenu: React.FC<ApplicationsMenuProps> = ({ activeCategory, onS
               <button
                 type="button"
                 onClick={() => onSelect(category.id)}
-                className={`flex w-full items-center gap-3 rounded px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
+                className={`flex w-full items-center gap-3 rounded px-3 py-2 text-left transition ${focusRing.default} ${
                   isActive ? 'bg-gray-700 text-white' : 'bg-transparent hover:bg-gray-700/60'
                 }`}
                 aria-pressed={isActive}

--- a/components/menu/PlacesMenu.tsx
+++ b/components/menu/PlacesMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { focusRing } from '../../styles/theme';
 
 export type PlacesMenuItem = {
   id: string;
@@ -63,7 +64,7 @@ const PlacesMenu: React.FC<PlacesMenuProps> = ({ heading = 'Places', items }) =>
               <button
                 type="button"
                 onClick={handleClick}
-                className="flex w-full items-center gap-3 rounded px-3 py-2 text-left transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-ubb-orange"
+                className={`flex w-full items-center gap-3 rounded px-3 py-2 text-left transition hover:bg-gray-700 ${focusRing.default}`}
               >
                 <img
                   src={src}

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import Image from 'next/image';
 import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { focusRing } from '../../styles/theme';
 
 type AppMeta = {
   id: string;
@@ -373,7 +374,7 @@ const WhiskerMenu: React.FC = () => {
         ref={buttonRef}
         type="button"
         onClick={toggleMenu}
-        className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
+        className={`border-b-2 border-transparent py-1 pl-3 pr-3 transition duration-100 ease-in-out ${focusRing.default}`}
       >
         <Image
           src="/themes/Yaru/status/decompiler-symbolic.svg"
@@ -418,7 +419,7 @@ const WhiskerMenu: React.FC = () => {
                     categoryButtonRefs.current[index] = el;
                   }}
                   type="button"
-                  className={`group flex items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1724] ${
+                  className={`group flex items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition ${focusRing.default} ${
                     category === cat.id
                       ? 'bg-[#162236] text-white shadow-[inset_2px_0_0_#53b9ff]'
                       : 'text-gray-300 hover:bg-[#152133] hover:text-white'
@@ -463,7 +464,7 @@ const WhiskerMenu: React.FC = () => {
                     key={app.id}
                     type="button"
                     onClick={() => openSelectedApp(app.id)}
-                    className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#122136] text-white transition hover:-translate-y-0.5 hover:bg-[#1b2d46] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1a29]"
+                  className={`flex h-10 w-10 items-center justify-center rounded-lg bg-[#122136] text-white transition hover:-translate-y-0.5 hover:bg-[#1b2d46] ${focusRing.tight}`}
                     aria-label={`Open ${app.title}`}
                   >
                     <Image
@@ -485,7 +486,7 @@ const WhiskerMenu: React.FC = () => {
                   </svg>
                 </span>
                 <input
-                  className="h-10 w-full rounded-lg border border-transparent bg-[#101c2d] pl-9 pr-3 text-sm text-gray-100 shadow-inner focus:border-[#53b9ff] focus:outline-none focus:ring-0"
+                  className={`h-10 w-full rounded-lg border border-transparent bg-[#101c2d] pl-9 pr-3 text-sm text-gray-100 shadow-inner focus:border-[#53b9ff] ${focusRing.inset}`}
                   placeholder="Search applications"
                   aria-label="Search applications"
                   value={query}
@@ -522,7 +523,7 @@ const WhiskerMenu: React.FC = () => {
                     <li key={app.id}>
                       <button
                         type="button"
-                        className={`flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1a29] ${
+                        className={`flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm transition ${focusRing.default} ${
                           idx === highlight
                             ? 'bg-[#162438] text-white shadow-[0_0_0_1px_rgba(83,185,255,0.35)]'
                             : 'text-gray-200 hover:bg-[#142132]'

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { focusRing } from '../../styles/theme';
 
 interface Segment {
   name: string;
@@ -17,7 +18,7 @@ const Breadcrumbs: React.FC<Props> = ({ path, onNavigate }) => {
           <button
             type="button"
             onClick={() => onNavigate(idx)}
-            className="hover:underline focus:outline-none"
+            className={`hover:underline ${focusRing.tight}`}
           >
             {seg.name || '/'}
           </button>

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import { focusRing } from '../../styles/theme';
 
 interface Props {
   open: boolean;
@@ -12,6 +13,12 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const soundId = 'quick-settings-sound';
+  const networkId = 'quick-settings-network';
+  const motionId = 'quick-settings-motion';
+  const soundLabelId = 'quick-settings-sound-label';
+  const networkLabelId = 'quick-settings-network-label';
+  const motionLabelId = 'quick-settings-motion-label';
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -29,29 +36,46 @@ const QuickSettings = ({ open }: Props) => {
     >
       <div className="px-4 pb-2">
         <button
-          className="w-full flex justify-between"
+          className={`flex w-full items-center justify-between rounded-md px-2 py-1 text-left transition ${focusRing.default}`}
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
         >
           <span>Theme</span>
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
+      <label className="px-4 pb-2 flex items-center justify-between gap-3" htmlFor={soundId}>
+        <span id={soundLabelId}>Sound</span>
         <input
+          id={soundId}
+          className={`h-5 w-5 rounded ${focusRing.tight}`}
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+          aria-labelledby={soundLabelId}
+        />
+      </label>
+      <label className="px-4 pb-2 flex items-center justify-between gap-3" htmlFor={networkId}>
+        <span id={networkLabelId}>Network</span>
+        <input
+          id={networkId}
+          className={`h-5 w-5 rounded ${focusRing.tight}`}
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+          aria-labelledby={networkLabelId}
+        />
+      </label>
+      <label className="px-4 flex items-center justify-between gap-3" htmlFor={motionId}>
+        <span id={motionLabelId}>Reduced motion</span>
+        <input
+          id={motionId}
+          className={`h-5 w-5 rounded ${focusRing.tight}`}
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
+          aria-labelledby={motionLabelId}
         />
-      </div>
+      </label>
     </div>
   );
 };

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { focusRing } from '../../styles/theme';
 
 interface ToastProps {
   message: string;
@@ -38,7 +39,7 @@ const Toast: React.FC<ToastProps> = ({
       {onAction && actionLabel && (
         <button
           onClick={onAction}
-          className="ml-4 underline focus:outline-none"
+          className={`ml-4 underline ${focusRing.tight}`}
         >
           {actionLabel}
         </button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,7 +17,7 @@
   --color-border: #2a2e36; /* subtle borders */
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
-  --color-focus-ring: var(--color-accent);
+  --color-focus-ring: #4aa8ff; /* WCAG-compliant focus indicator */
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   --kali-text: #f5f5f5;
@@ -42,6 +42,7 @@ html[data-theme='dark'] {
   --color-border: #333333;
   --color-terminal: #00ff00;
   --color-dark: #0a0a0a;
+  --color-focus-ring: #64b5f6;
 }
 
 /* Neon theme */
@@ -57,6 +58,7 @@ html[data-theme='neon'] {
   --color-border: #333333;
   --color-terminal: #39ff14;
   --color-dark: #000000;
+  --color-focus-ring: #ff61f6;
 }
 
 /* Matrix theme */
@@ -72,7 +74,7 @@ html[data-theme='matrix'] {
   --color-border: #003300;
   --color-terminal: #00ff00;
   --color-dark: #000000;
-
+  --color-focus-ring: #00ffaa;
 }
 
 ::selection {

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared design utilities for styling interactive states.
+ * Focus ring helpers meet WCAG 2.4.7 (Focus Visible) by
+ * rendering a 2px outline with sufficient contrast and
+ * offset so it is discernible against surrounding surfaces.
+ */
+export const focusRing = Object.freeze({
+  /**
+   * Default focus treatment for buttons and actionable elements.
+   */
+  default:
+    'focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-focus focus-visible:ring-offset-2 focus-visible:ring-offset-kali-surface',
+  /**
+   * Tight focus indicator for compact controls like icon buttons.
+   */
+  tight:
+    'focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kali-focus focus-visible:ring-offset-1 focus-visible:ring-offset-kali-surface',
+  /**
+   * Inset focus indicator for inputs that already have an outer border.
+   */
+  inset:
+    'focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-kali-focus focus-visible:ring-offset-0',
+});
+
+export type FocusRingVariant = keyof typeof focusRing;
+
+export const getFocusRing = (variant: FocusRingVariant = 'default'): string =>
+  focusRing[variant];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -54,6 +54,16 @@ module.exports = {
           backdrop: 'var(--kali-bg)',
         },
       },
+      ringColor: {
+        'kali-focus': 'var(--color-focus-ring)',
+      },
+      ringOffsetColor: {
+        'kali-surface': 'var(--color-surface)',
+        'kali-backdrop': 'var(--kali-bg)',
+      },
+      ringWidth: {
+        3: '3px',
+      },
       boxShadow: {
         'kali-panel': '0 6px 20px rgba(0,0,0,.35)',
       },

--- a/tests/focus-visibility.spec.ts
+++ b/tests/focus-visibility.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test, Locator } from '@playwright/test';
+
+const getFocusStyles = async (locator: Locator) => {
+  await locator.focus();
+  return locator.evaluate((element) => {
+    const styles = window.getComputedStyle(element);
+    return {
+      boxShadow: styles.boxShadow,
+      outlineStyle: styles.outlineStyle,
+      outlineWidth: styles.outlineWidth,
+    };
+  });
+};
+
+test.describe('Focus visibility', () => {
+  test('Applications toggle shows focus ring in default theme', async ({ page }) => {
+    await page.goto('/');
+    const toggle = page.getByRole('button', { name: 'Applications' });
+    const styles = await getFocusStyles(toggle);
+
+    await expect(toggle).toBeFocused();
+    expect(styles.boxShadow).not.toBe('none');
+    expect(styles.boxShadow).toContain('rgb');
+  });
+
+  test('Applications toggle shows focus ring in dark theme', async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => {
+      document.documentElement.dataset.theme = 'dark';
+      document.documentElement.classList.add('dark');
+    });
+
+    const toggle = page.getByRole('button', { name: 'Applications' });
+    const styles = await getFocusStyles(toggle);
+
+    await expect(toggle).toBeFocused();
+    expect(styles.boxShadow).not.toBe('none');
+    expect(styles.boxShadow).toContain('rgb');
+  });
+
+  test('Category buttons retain focus visibility within the Whisker menu', async ({ page }) => {
+    await page.goto('/');
+    const toggle = page.getByRole('button', { name: 'Applications' });
+    await toggle.click();
+
+    const firstCategory = page.locator('[role="listbox"] button').first();
+    await firstCategory.waitFor({ state: 'visible' });
+    const styles = await getFocusStyles(firstCategory);
+
+    await expect(firstCategory).toBeFocused();
+    expect(styles.boxShadow).not.toBe('none');
+    expect(styles.boxShadow).toContain('rgb');
+  });
+});


### PR DESCRIPTION
## Summary
- add shared focus ring utilities and WCAG-compliant focus colors in the theme and Tailwind config
- refactor QuickSettings, WhiskerMenu, and related UI components to use the new focus ring helpers and proper labels
- add a Playwright focus visibility regression test covering default and dark themes

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da48321074832881b8b3f7c42e9031