### PR TITLE
[settings] Centralize keyboard shortcuts metadata

### DIFF
--- a/__tests__/ShortcutOverlay.test.tsx
+++ b/__tests__/ShortcutOverlay.test.tsx
@@ -11,18 +11,23 @@ describe('ShortcutOverlay', () => {
     window.localStorage.setItem(
       'keymap',
       JSON.stringify({
-        'Show keyboard shortcuts': 'A',
-        'Open settings': 'A',
+        'shortcutOverlay.toggle': 'A',
+        'settings.open': 'A',
       })
     );
     render(<ShortcutOverlay />);
     fireEvent.keyDown(window, { key: 'a' });
+    const showRow = screen
+      .getByText('Show keyboard shortcuts')
+      .closest('li');
+    const settingsRow = screen.getByText('Open settings').closest('li');
+    if (!showRow || !settingsRow) {
+      throw new Error('Expected conflict rows to be rendered');
+    }
+    expect(showRow).toHaveAttribute('data-conflict', 'true');
+    expect(settingsRow).toHaveAttribute('data-conflict', 'true');
     expect(
-      screen.getByText('Show keyboard shortcuts')
+      screen.getAllByText(/Conflicts with .*Open settings/)[0]
     ).toBeInTheDocument();
-    expect(screen.getByText('Open settings')).toBeInTheDocument();
-    const items = screen.getAllByRole('listitem');
-    expect(items[0]).toHaveAttribute('data-conflict', 'true');
-    expect(items[1]).toHaveAttribute('data-conflict', 'true');
   });
 });

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -1,50 +1,315 @@
+import { useCallback, useEffect, useMemo } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
 
-export interface Shortcut {
+export type ShortcutScope = 'global' | 'contextual';
+
+export interface ShortcutDefinition {
+  id: string;
   description: string;
-  keys: string;
+  defaultKeys: string;
+  context: string;
+  scope: ShortcutScope;
 }
 
-const DEFAULT_SHORTCUTS: Shortcut[] = [
-  { description: 'Show keyboard shortcuts', keys: '?' },
-  { description: 'Open settings', keys: 'Ctrl+,' },
+export interface ResolvedShortcut extends ShortcutDefinition {
+  keys: string;
+  conflictIds: string[];
+  isOverride: boolean;
+}
+
+export interface ShortcutGroup {
+  context: string;
+  shortcuts: ResolvedShortcut[];
+}
+
+export const SHORTCUT_IDS = {
+  showOverlay: 'shortcutOverlay.toggle',
+  openSettings: 'settings.open',
+  openClipboardManager: 'clipboard.open',
+  openWindowSwitcher: 'window.switcher',
+  cycleAppWindows: 'window.cycle',
+  snapLeft: 'window.snapLeft',
+  snapRight: 'window.snapRight',
+  snapUp: 'window.snapUp',
+  snapDown: 'window.snapDown',
+  terminalNewTab: 'terminal.newTab',
+  terminalCloseTab: 'terminal.closeTab',
+  terminalNextTab: 'terminal.nextTab',
+  terminalPrevTab: 'terminal.prevTab',
+  gameHelpOverlay: 'games.helpOverlay',
+} as const;
+
+export const SHORTCUT_REGISTRY: ShortcutDefinition[] = [
+  {
+    id: SHORTCUT_IDS.showOverlay,
+    description: 'Show keyboard shortcuts',
+    defaultKeys: '?',
+    context: 'Global',
+    scope: 'global',
+  },
+  {
+    id: SHORTCUT_IDS.openSettings,
+    description: 'Open settings',
+    defaultKeys: 'Ctrl+,',
+    context: 'Global',
+    scope: 'global',
+  },
+  {
+    id: SHORTCUT_IDS.openClipboardManager,
+    description: 'Open clipboard manager',
+    defaultKeys: 'Ctrl+Shift+V',
+    context: 'Global',
+    scope: 'global',
+  },
+  {
+    id: SHORTCUT_IDS.openWindowSwitcher,
+    description: 'Open window switcher',
+    defaultKeys: 'Alt+Tab',
+    context: 'Desktop & window management',
+    scope: 'global',
+  },
+  {
+    id: SHORTCUT_IDS.cycleAppWindows,
+    description: 'Cycle windows of focused app',
+    defaultKeys: 'Alt+~',
+    context: 'Desktop & window management',
+    scope: 'contextual',
+  },
+  {
+    id: SHORTCUT_IDS.snapLeft,
+    description: 'Snap window to the left',
+    defaultKeys: 'Meta+ArrowLeft',
+    context: 'Desktop & window management',
+    scope: 'global',
+  },
+  {
+    id: SHORTCUT_IDS.snapRight,
+    description: 'Snap window to the right',
+    defaultKeys: 'Meta+ArrowRight',
+    context: 'Desktop & window management',
+    scope: 'global',
+  },
+  {
+    id: SHORTCUT_IDS.snapUp,
+    description: 'Snap window to the top',
+    defaultKeys: 'Meta+ArrowUp',
+    context: 'Desktop & window management',
+    scope: 'global',
+  },
+  {
+    id: SHORTCUT_IDS.snapDown,
+    description: 'Snap window to the bottom',
+    defaultKeys: 'Meta+ArrowDown',
+    context: 'Desktop & window management',
+    scope: 'global',
+  },
+  {
+    id: SHORTCUT_IDS.terminalNewTab,
+    description: 'Open a new terminal tab',
+    defaultKeys: 'Ctrl+T',
+    context: 'Terminal tabs',
+    scope: 'contextual',
+  },
+  {
+    id: SHORTCUT_IDS.terminalCloseTab,
+    description: 'Close current terminal tab',
+    defaultKeys: 'Ctrl+W',
+    context: 'Terminal tabs',
+    scope: 'contextual',
+  },
+  {
+    id: SHORTCUT_IDS.terminalNextTab,
+    description: 'Switch to next terminal tab',
+    defaultKeys: 'Ctrl+Tab',
+    context: 'Terminal tabs',
+    scope: 'contextual',
+  },
+  {
+    id: SHORTCUT_IDS.terminalPrevTab,
+    description: 'Switch to previous terminal tab',
+    defaultKeys: 'Ctrl+Shift+Tab',
+    context: 'Terminal tabs',
+    scope: 'contextual',
+  },
+  {
+    id: SHORTCUT_IDS.gameHelpOverlay,
+    description: 'Toggle in-game help overlay',
+    defaultKeys: '?',
+    context: 'Games',
+    scope: 'contextual',
+  },
 ];
 
-const validator = (value: unknown): value is Record<string, string> => {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    !Array.isArray(value) &&
-    Object.values(value as Record<string, unknown>).every(
-      (v) => typeof v === 'string'
-    )
+const DEFAULT_MAP = SHORTCUT_REGISTRY.reduce<Record<string, string>>(
+  (acc, shortcut) => {
+    acc[shortcut.id] = shortcut.defaultKeys;
+    return acc;
+  },
+  {}
+);
+
+const DESCRIPTION_TO_ID = new Map(
+  SHORTCUT_REGISTRY.map((shortcut) => [shortcut.description, shortcut.id])
+);
+
+const CONTEXT_ORDER = [
+  'Global',
+  'Desktop & window management',
+  'Terminal tabs',
+  'Games',
+];
+
+const validator = (value: unknown): value is Record<string, string> =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  Object.values(value as Record<string, unknown>).every(
+    (v) => typeof v === 'string'
   );
+
+const sortGroups = (groups: ShortcutGroup[]) =>
+  groups.sort((a, b) => {
+    const aIndex = CONTEXT_ORDER.indexOf(a.context);
+    const bIndex = CONTEXT_ORDER.indexOf(b.context);
+    if (aIndex === -1 && bIndex === -1) {
+      return a.context.localeCompare(b.context);
+    }
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
+
+const buildConflictMap = (shortcuts: ShortcutDefinition[], overrides: Record<string, string>) => {
+  const resolved = shortcuts.map((shortcut) => {
+    const legacyKey = overrides[shortcut.description];
+    const idKey = overrides[shortcut.id];
+    const keys = idKey ?? legacyKey ?? shortcut.defaultKeys;
+    return { ...shortcut, keys };
+  });
+
+  const conflicts = new Map<string, string[]>();
+  const buckets = new Map<string, (ShortcutDefinition & { keys: string })[]>();
+
+  resolved.forEach((shortcut) => {
+    const normalized = shortcut.keys.trim();
+    if (!normalized) return;
+    const list = buckets.get(normalized) ?? [];
+    list.push(shortcut);
+    buckets.set(normalized, list);
+  });
+
+  buckets.forEach((entries) => {
+    if (entries.length < 2) return;
+    entries.forEach((shortcut) => {
+      const conflicting = entries
+        .filter((other) => {
+          if (other.id === shortcut.id) return false;
+          if (shortcut.scope === 'global' || other.scope === 'global') return true;
+          return shortcut.context === other.context;
+        })
+        .map((other) => other.id);
+      if (conflicting.length) {
+        conflicts.set(shortcut.id, conflicting);
+      }
+    });
+  });
+
+  return conflicts;
 };
 
 export function useKeymap() {
-  const initial = DEFAULT_SHORTCUTS.reduce<Record<string, string>>(
-    (acc, s) => {
-      acc[s.description] = s.keys;
-      return acc;
-    },
-    {}
-  );
-
-  const [map, setMap] = usePersistentState<Record<string, string>>(
+  const [stored, setStored, resetStored] = usePersistentState<Record<string, string>>(
     'keymap',
-    initial,
+    DEFAULT_MAP,
     validator
   );
 
-  const shortcuts = DEFAULT_SHORTCUTS.map(({ description, keys }) => ({
-    description,
-    keys: map[description] || keys,
-  }));
+  useEffect(() => {
+    setStored((prev) => {
+      const next: Record<string, string> = { ...prev };
+      let changed = false;
 
-  const updateShortcut = (description: string, keys: string) =>
-    setMap({ ...map, [description]: keys });
+      SHORTCUT_REGISTRY.forEach((shortcut) => {
+        if (!(shortcut.id in next)) {
+          next[shortcut.id] = shortcut.defaultKeys;
+          changed = true;
+        }
+      });
 
-  return { shortcuts, updateShortcut };
+      Object.entries(next).forEach(([key, value]) => {
+        const mappedId = DESCRIPTION_TO_ID.get(key);
+        if (!mappedId) return;
+        next[mappedId] = value;
+        if (key !== mappedId) {
+          delete next[key];
+          changed = true;
+        }
+      });
+
+      return changed ? next : prev;
+    });
+  }, [setStored]);
+
+  const conflicts = useMemo(
+    () => buildConflictMap(SHORTCUT_REGISTRY, stored),
+    [stored]
+  );
+
+  const shortcuts = useMemo<ResolvedShortcut[]>(() => {
+    return SHORTCUT_REGISTRY.map((shortcut) => {
+      const legacyKey = stored[shortcut.description];
+      const override = stored[shortcut.id] ?? legacyKey;
+      const keys = override ?? shortcut.defaultKeys;
+      const isOverride = override !== undefined && override !== shortcut.defaultKeys;
+      return {
+        ...shortcut,
+        keys,
+        conflictIds: conflicts.get(shortcut.id) ?? [],
+        isOverride,
+      };
+    });
+  }, [conflicts, stored]);
+
+  const groups = useMemo<ShortcutGroup[]>(() => {
+    const grouped = new Map<string, ResolvedShortcut[]>();
+    shortcuts.forEach((shortcut) => {
+      const collection = grouped.get(shortcut.context) ?? [];
+      collection.push(shortcut);
+      grouped.set(shortcut.context, collection);
+    });
+
+    const result = Array.from(grouped.entries()).map(([context, items]) => ({
+      context,
+      shortcuts: items.sort((a, b) => a.description.localeCompare(b.description)),
+    }));
+
+    return sortGroups(result);
+  }, [shortcuts]);
+
+  const updateShortcut = useCallback(
+    (id: string, keys: string) => {
+      setStored((prev) => {
+        const next = { ...prev, [id]: keys };
+        const description = SHORTCUT_REGISTRY.find((shortcut) => shortcut.id === id)?.description;
+        if (description && description in next) {
+          delete next[description];
+        }
+        return next;
+      });
+    },
+    [setStored]
+  );
+
+  const resetShortcuts = useCallback(() => {
+    resetStored();
+  }, [resetStored]);
+
+  return {
+    shortcuts,
+    groups,
+    updateShortcut,
+    resetShortcuts,
+  };
 }
 
 export default useKeymap;

--- a/components/common/ShortcutOverlay.tsx
+++ b/components/common/ShortcutOverlay.tsx
@@ -1,7 +1,12 @@
 'use client';
 
-import React, { useEffect, useState, useCallback } from 'react';
-import useKeymap from '../../apps/settings/keymapRegistry';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import Link from 'next/link';
+import jsPDF from 'jspdf';
+import useKeymap, {
+  ResolvedShortcut,
+  SHORTCUT_IDS,
+} from '../../apps/settings/keymapRegistry';
 
 const formatEvent = (e: KeyboardEvent) => {
   const parts = [
@@ -16,9 +21,23 @@ const formatEvent = (e: KeyboardEvent) => {
 
 const ShortcutOverlay: React.FC = () => {
   const [open, setOpen] = useState(false);
-  const { shortcuts } = useKeymap();
+  const { shortcuts, groups } = useKeymap();
 
   const toggle = useCallback(() => setOpen((o) => !o), []);
+
+  const shortcutLookup = useMemo(
+    () => new Map(shortcuts.map((shortcut) => [shortcut.id, shortcut])),
+    [shortcuts]
+  );
+
+  const showKey = useMemo(() => {
+    return shortcutLookup.get(SHORTCUT_IDS.showOverlay)?.keys || '?';
+  }, [shortcutLookup]);
+
+  const conflictedShortcuts = useMemo(
+    () => shortcuts.filter((shortcut) => shortcut.conflictIds.length > 0),
+    [shortcuts]
+  );
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -28,10 +47,7 @@ const ShortcutOverlay: React.FC = () => {
         target.tagName === 'TEXTAREA' ||
         (target as HTMLElement).isContentEditable;
       if (isInput) return;
-      const show =
-        shortcuts.find((s) => s.description === 'Show keyboard shortcuts')?.keys ||
-        '?';
-      if (formatEvent(e) === show) {
+      if (formatEvent(e) === showKey) {
         e.preventDefault();
         toggle();
       } else if (e.key === 'Escape' && open) {
@@ -41,30 +57,105 @@ const ShortcutOverlay: React.FC = () => {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [open, toggle, shortcuts]);
+  }, [open, toggle, showKey]);
 
-  const handleExport = () => {
-    const data = JSON.stringify(shortcuts, null, 2);
-    const blob = new Blob([data], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'shortcuts.json';
-    a.click();
-    URL.revokeObjectURL(url);
-  };
+  const downloadFile = useCallback((content: BlobPart, type: string, filename: string) => {
+    try {
+      const blob = new Blob([content], { type });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = filename;
+      anchor.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      // ignore download errors
+    }
+  }, []);
+
+  const handleExportMarkdown = useCallback(() => {
+    const lines: string[] = ['# Keyboard Shortcuts', ''];
+    groups.forEach((group) => {
+      lines.push(`## ${group.context}`);
+      group.shortcuts.forEach((shortcut) => {
+        const keyLabel = shortcut.keys || 'Unassigned';
+        lines.push(`- **${keyLabel}** — ${shortcut.description}`);
+      });
+      lines.push('');
+    });
+    downloadFile(lines.join('\n'), 'text/markdown', 'keyboard-shortcuts.md');
+  }, [downloadFile, groups]);
+
+  const handleExportPdf = useCallback(() => {
+    try {
+      const doc = new jsPDF();
+      doc.setFontSize(16);
+      doc.text('Keyboard Shortcuts', 10, 15);
+      doc.setFontSize(12);
+
+      let cursorY = 25;
+      const lineHeight = 6;
+
+      groups.forEach((group, groupIndex) => {
+        if (groupIndex > 0 && cursorY + lineHeight * 2 >= 285) {
+          doc.addPage();
+          cursorY = 20;
+        }
+
+        if (cursorY > 270) {
+          doc.addPage();
+          cursorY = 20;
+        }
+
+        doc.setFont(undefined, 'bold');
+        doc.text(group.context, 10, cursorY);
+        cursorY += lineHeight;
+        doc.setFont(undefined, 'normal');
+
+        group.shortcuts.forEach((shortcut) => {
+          const keyLabel = shortcut.keys || 'Unassigned';
+          const text = `${keyLabel} — ${shortcut.description}`;
+          const lines = doc.splitTextToSize(text, 190);
+
+          if (cursorY + lines.length * lineHeight > 285) {
+            doc.addPage();
+            cursorY = 20;
+          }
+
+          doc.text(lines, 10, cursorY);
+          cursorY += lines.length * lineHeight;
+        });
+
+        cursorY += lineHeight / 2;
+      });
+
+      doc.save('keyboard-shortcuts.pdf');
+    } catch {
+      // ignore PDF generation errors
+    }
+  }, [groups]);
 
   if (!open) return null;
 
-  const keyCounts = shortcuts.reduce<Map<string, number>>((map, s) => {
-    map.set(s.keys, (map.get(s.keys) || 0) + 1);
-    return map;
-  }, new Map());
-  const conflicts = new Set(
-    Array.from(keyCounts.entries())
-      .filter(([, count]) => count > 1)
-      .map(([key]) => key)
-  );
+  const renderConflictTargets = (shortcut: ResolvedShortcut) => {
+    const items = shortcut.conflictIds
+      .map((id) => shortcutLookup.get(id))
+      .filter((item): item is ResolvedShortcut => Boolean(item));
+    if (!items.length) return null;
+    const label = items.map((item) => item.description).join(', ');
+    return (
+      <p className="mt-2 text-xs text-red-100">
+        Conflicts with {label}. Resolve via{' '}
+        <Link
+          href="/apps/settings"
+          className="underline focus:outline-none focus:ring focus:ring-ubt-blue"
+        >
+          Settings → Keyboard
+        </Link>
+        .
+      </p>
+    );
+  };
 
   return (
     <div
@@ -72,7 +163,7 @@ const ShortcutOverlay: React.FC = () => {
       role="dialog"
       aria-modal="true"
     >
-      <div className="max-w-lg w-full space-y-4">
+      <div className="max-w-2xl w-full space-y-4">
         <div className="flex justify-between items-center">
           <h2 className="text-xl font-bold">Keyboard Shortcuts</h2>
           <button
@@ -83,29 +174,78 @@ const ShortcutOverlay: React.FC = () => {
             Close
           </button>
         </div>
-        <button
-          type="button"
-          onClick={handleExport}
-          className="px-2 py-1 bg-gray-700 rounded text-sm"
-        >
-          Export JSON
-        </button>
-        <ul className="space-y-1">
-          {shortcuts.map((s, i) => (
-            <li
-              key={i}
-              data-conflict={conflicts.has(s.keys) ? 'true' : 'false'}
-              className={
-                conflicts.has(s.keys)
-                  ? 'flex justify-between bg-red-600/70 px-2 py-1 rounded'
-                  : 'flex justify-between px-2 py-1'
-              }
-            >
-              <span className="font-mono mr-4">{s.keys}</span>
-              <span className="flex-1">{s.description}</span>
-            </li>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={handleExportMarkdown}
+            className="px-3 py-1.5 rounded bg-gray-700 text-sm hover:bg-gray-600 focus:outline-none focus:ring focus:ring-ubt-blue"
+          >
+            Export Markdown
+          </button>
+          <button
+            type="button"
+            onClick={handleExportPdf}
+            className="px-3 py-1.5 rounded bg-gray-700 text-sm hover:bg-gray-600 focus:outline-none focus:ring focus:ring-ubt-blue"
+          >
+            Export PDF
+          </button>
+        </div>
+        {conflictedShortcuts.length > 0 && (
+          <div className="rounded border border-red-500 bg-red-600/40 p-3 text-sm">
+            Some shortcuts conflict with each other. Rebind them in the Settings app to avoid
+            unexpected behaviour.
+          </div>
+        )}
+        <div className="space-y-6">
+          {groups.map((group) => (
+            <section key={group.context} aria-label={`${group.context} shortcuts`}>
+              <h3 className="text-lg font-semibold border-b border-white/20 pb-1">
+                {group.context}
+              </h3>
+              <ul className="mt-3 space-y-2">
+                {group.shortcuts.map((shortcut) => {
+                  const hasConflict = shortcut.conflictIds.length > 0;
+                  const scopeLabel = shortcut.scope === 'global' ? 'Global' : 'Contextual';
+                  const scopeClass =
+                    shortcut.scope === 'global'
+                      ? 'bg-ub-orange text-black'
+                      : 'bg-white/10 text-white';
+                  return (
+                    <li
+                      key={shortcut.id}
+                      data-conflict={hasConflict ? 'true' : 'false'}
+                      className={`rounded border px-3 py-2 transition-colors ${
+                        hasConflict
+                          ? 'border-red-400 bg-red-600/40'
+                          : 'border-white/10 bg-white/5'
+                      }`}
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-semibold">{shortcut.description}</span>
+                          <span
+                            className={`text-[10px] uppercase tracking-wide px-2 py-0.5 rounded ${scopeClass}`}
+                          >
+                            {scopeLabel}
+                          </span>
+                          {shortcut.isOverride && (
+                            <span className="text-[10px] uppercase tracking-wide px-2 py-0.5 rounded bg-blue-500/30">
+                              Custom
+                            </span>
+                          )}
+                        </div>
+                        <span className="font-mono text-sm">
+                          {shortcut.keys || 'Unassigned'}
+                        </span>
+                      </div>
+                      {renderConflictTargets(shortcut)}
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
           ))}
-        </ul>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- centralize the keyboard shortcut registry with scope/context metadata and conflict detection
- reorganize the shortcut overlays to group by context, surface conflicts, and add PDF/Markdown exports
- update the settings keymap UI and tests to align with the new registry and user overrides

## Testing
- yarn test ShortcutOverlay
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da4832da308328998db6113f0d0749