### PR TITLE
[ui] Improve toast live announcements

### DIFF
--- a/__tests__/liveRegion.test.tsx
+++ b/__tests__/liveRegion.test.tsx
@@ -1,13 +1,42 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import Toast from '../components/ui/Toast';
 import FormError from '../components/ui/FormError';
 
 describe('live region components', () => {
-  it('Toast uses polite live region', () => {
-    const { unmount } = render(<Toast message="Saved" />);
-    const region = screen.getByRole('status');
-    expect(region).toHaveAttribute('aria-live', 'polite');
+  it('Toast exposes polite live region updates for new notifications', async () => {
+    const { rerender, unmount } = render(
+      <Toast
+        title="Backup finished"
+        status="Success"
+        message="Archive saved"
+        duration={Infinity}
+      />,
+    );
+
+    const liveRegion = screen.getByTestId('toast-live-region');
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    expect(liveRegion.textContent).toContain('Backup finished');
+    expect(liveRegion.textContent).toContain('Success');
+    expect(liveRegion.textContent).toContain('Archive saved');
+
+    rerender(
+      <Toast
+        title="Backup warning"
+        status="Warning"
+        message="Retry scheduled"
+        duration={Infinity}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('toast-live-region').textContent).toContain(
+        'Backup warning',
+      );
+      expect(screen.getByTestId('toast-live-region').textContent).toContain('Warning');
+      expect(screen.getByTestId('toast-live-region').textContent).toContain('Retry scheduled');
+    });
+
     unmount();
   });
 

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,7 +1,9 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 interface ToastProps {
+  title?: string;
   message: string;
+  status?: string;
   actionLabel?: string;
   onAction?: () => void;
   onClose?: () => void;
@@ -9,40 +11,176 @@ interface ToastProps {
 }
 
 const Toast: React.FC<ToastProps> = ({
+  title,
   message,
+  status,
   actionLabel,
   onAction,
   onClose,
   duration = 6000,
 }) => {
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startTimeRef = useRef<number | null>(null);
+  const remainingRef = useRef(duration);
   const [visible, setVisible] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+  const [remaining, setRemaining] = useState(duration);
+  const [liveMessage, setLiveMessage] = useState('');
+
+  const timedDismissalEnabled = useMemo(
+    () => Boolean(onClose) && Number.isFinite(duration) && duration > 0,
+    [duration, onClose],
+  );
+
+  const announcement = useMemo(
+    () => [status, title, message].filter(Boolean).join('. '),
+    [message, status, title],
+  );
+
+  const startTimer = useCallback(
+    (time: number) => {
+      if (!onClose || !Number.isFinite(time) || time <= 0) {
+        if (time <= 0) onClose?.();
+        return;
+      }
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      remainingRef.current = time;
+      setRemaining(time);
+      setIsPaused(false);
+      startTimeRef.current = Date.now();
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = null;
+        onClose();
+      }, time);
+    },
+    [onClose],
+  );
 
   useEffect(() => {
     setVisible(true);
-    timeoutRef.current = setTimeout(() => {
-      onClose && onClose();
-    }, duration);
+  }, []);
+
+  useEffect(() => {
+    setLiveMessage(announcement);
+  }, [announcement]);
+
+  useEffect(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
+    remainingRef.current = duration;
+    setRemaining(duration);
+    setIsPaused(false);
+
+    if (!timedDismissalEnabled) {
+      return () => {
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+        }
+      };
+    }
+
+    startTimer(duration);
+
     return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
     };
-  }, [duration, onClose]);
+  }, [duration, message, startTimer, timedDismissalEnabled, title, status]);
+
+  const handleTogglePause = useCallback(() => {
+    if (!timedDismissalEnabled) return;
+
+    if (isPaused) {
+      if (remainingRef.current <= 0) {
+        onClose?.();
+        return;
+      }
+      startTimer(remainingRef.current);
+      return;
+    }
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
+    const startedAt = startTimeRef.current;
+    if (startedAt) {
+      const elapsed = Date.now() - startedAt;
+      const nextRemaining = Math.max(remainingRef.current - elapsed, 0);
+      remainingRef.current = nextRemaining;
+      setRemaining(nextRemaining);
+    }
+    setIsPaused(true);
+  }, [isPaused, onClose, startTimer, timedDismissalEnabled]);
+
+  const showPauseControl = timedDismissalEnabled;
+  const formattedCountdown = useMemo(() => {
+    if (!showPauseControl || !Number.isFinite(remaining)) return null;
+    return Math.ceil(remaining / 1000);
+  }, [remaining, showPauseControl]);
 
   return (
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`fixed top-4 left-1/2 z-50 -translate-x-1/2 transform rounded-md border border-gray-700 bg-gray-900 px-4 py-3 text-white shadow-md transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
-      <span>{message}</span>
-      {onAction && actionLabel && (
-        <button
-          onClick={onAction}
-          className="ml-4 underline focus:outline-none"
-        >
-          {actionLabel}
-        </button>
-      )}
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+        data-testid="toast-live-region"
+      >
+        {liveMessage}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-1 text-sm">
+        {title && <span className="font-semibold">{title}</span>}
+        <span className="truncate" title={message}>
+          {message}
+        </span>
+        {status && (
+          <span className="text-xs text-gray-300" data-testid="toast-status">
+            {status}
+          </span>
+        )}
+        {showPauseControl && isPaused && formattedCountdown !== null && (
+          <span className="text-xs text-gray-300" data-testid="toast-paused">
+            Dismissal paused{formattedCountdown !== null ? ` with ${formattedCountdown}s remaining` : ''}
+          </span>
+        )}
+      </div>
+      <div className="ml-4 flex flex-shrink-0 items-center gap-3 text-sm">
+        {onAction && actionLabel && (
+          <button
+            type="button"
+            onClick={onAction}
+            className="rounded border border-white/20 px-2 py-1 text-xs font-medium transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+          >
+            {actionLabel}
+          </button>
+        )}
+        {showPauseControl && (
+          <button
+            type="button"
+            onClick={handleTogglePause}
+            aria-pressed={isPaused}
+            aria-label={
+              isPaused ? 'Resume toast auto-dismissal' : 'Pause toast auto-dismissal'
+            }
+            className="rounded border border-white/20 px-2 py-1 text-xs font-medium transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+          >
+            {isPaused ? 'Resume' : 'Pause'}
+          </button>
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a dedicated polite live region to the shared toast component and support optional title/status text
- implement an accessible pause/resume control for timed toasts so announcements can be read fully
- extend the live region unit test to confirm announcements fire when new toast content arrives

## Testing
- yarn test __tests__/liveRegion.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da48341dac8328aef45bab8ee04ac7