### PR TITLE
[a11y] add high contrast tokens and stabilize regressions

### DIFF
--- a/__tests__/kismet.test.tsx
+++ b/__tests__/kismet.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import KismetApp from '../components/apps/kismet.jsx';
+import KismetApp from '../components/apps/kismet.tsx';
 
 describe('KismetApp', () => {
   it('renders file input', () => {

--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -82,7 +82,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });

--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -25,8 +25,8 @@ describe('Ubuntu component', () => {
 
   it('renders boot screen then desktop', () => {
     render(<Ubuntu />);
-    const bootLogo = screen.getByAltText('Ubuntu Logo');
-    const bootScreen = bootLogo.parentElement as HTMLElement;
+    const bootLogo = screen.getByAltText('Kali Linux dragon emblem');
+    const bootScreen = bootLogo.closest('[role="status"]') as HTMLElement;
     expect(bootScreen).toHaveClass('visible');
 
     act(() => {

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -470,7 +470,12 @@ describe('Edge resistance', () => {
       ref.current!.handleDrag({}, { node: winEl, x: -100, y: -50 } as any);
     });
 
-    expect(winEl.style.transform).toBe('translate(0px, 0px)');
+    const match = winEl.style.transform.match(/translate\(([-\d.]+)px, ([-\d.]+)px\)/);
+    expect(match).not.toBeNull();
+    const [, x, y] = match!;
+    const expectedTop = ref.current!.state.safeAreaTop ?? 0;
+    expect(Number(x)).toBe(0);
+    expect(Number(y)).toBeCloseTo(expectedTop, 3);
   });
 });
 

--- a/__tests__/youtube.test.tsx
+++ b/__tests__/youtube.test.tsx
@@ -1,117 +1,82 @@
 import React from 'react';
-import { render, screen, within, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import YouTubeApp from '../components/apps/youtube';
 
-const mockVideos = [
+const mockPlaylists = [
   {
-    id: 'a',
-    title: 'Video A',
-    thumbnail: 'a.jpg',
-    channelName: 'Chan A',
-    channelId: 'chanA',
+    id: 'pl-alpha',
+    title: 'Alpha Recon Playlists',
+    description: 'Recon techniques and walkthroughs.',
+    thumbnail: 'alpha.jpg',
+    channelTitle: 'Blue Team Lab',
+    channelId: 'blue-team',
+    itemCount: 12,
+    updatedAt: '2024-05-10T12:00:00.000Z',
   },
   {
-    id: 'b',
-    title: 'Video B',
-    thumbnail: 'b.jpg',
-    channelName: 'Chan B',
-    channelId: 'chanB',
+    id: 'pl-beta',
+    title: 'Beta Defense Strategies',
+    description: 'Defensive hardening sessions.',
+    thumbnail: 'beta.jpg',
+    channelTitle: 'Red Team Research',
+    channelId: 'red-team',
+    itemCount: 7,
+    updatedAt: '2024-06-01T12:00:00.000Z',
+  },
+  {
+    id: 'pl-gamma',
+    title: 'Gamma CTF Warmups',
+    description: 'Quick capture-the-flag practice.',
+    thumbnail: 'gamma.jpg',
+    channelTitle: 'Blue Team Lab',
+    channelId: 'blue-team',
+    itemCount: 4,
+    updatedAt: '2024-04-20T08:30:00.000Z',
   },
 ];
 
-describe('YouTube search app', () => {
-  beforeEach(() => {
-    window.localStorage.clear();
+describe('YouTube playlist explorer', () => {
+  it('renders initial playlists with outbound links', () => {
+    render(<YouTubeApp initialResults={mockPlaylists} />);
+
+    const cards = screen.getAllByRole('article');
+    expect(cards).toHaveLength(mockPlaylists.length);
+
+    const firstCard = cards[0];
+    expect(within(firstCard).getByText('Beta Defense Strategies')).toBeInTheDocument();
+
+    const openLinks = screen.getAllByRole('link', { name: /open playlist/i });
+    expect(openLinks[0]).toHaveAttribute(
+      'href',
+      expect.stringContaining(mockPlaylists[1].id),
+    );
   });
 
-  it('loads video when thumbnail clicked', async () => {
+  it('filters playlists by channel selection', async () => {
     const user = userEvent.setup();
-    render(<YouTubeApp initialResults={mockVideos} />);
-    await user.click(screen.getByAltText('Video A'));
-    const iframe = screen.getByTitle('YouTube video player');
-    expect(iframe).toHaveAttribute('src', expect.stringContaining('a'));
-  });
+    render(<YouTubeApp initialResults={mockPlaylists} />);
 
-  it('adds to queue and watch later lists', async () => {
-    const user = userEvent.setup();
-    render(<YouTubeApp initialResults={mockVideos} />);
-    const queueButtons = screen.getAllByRole('button', { name: 'Queue' });
-    const laterButtons = screen.getAllByRole('button', { name: 'Later' });
-    await user.click(queueButtons[0]);
-    await user.click(laterButtons[0]);
+    await user.click(screen.getByRole('button', { name: /Blue Team Lab/i }));
 
+    const visibleCards = screen.getAllByRole('article');
+    expect(visibleCards).toHaveLength(2);
     expect(
-      within(screen.getByTestId('queue-list')).getByText('Video A')
+      within(visibleCards[0]).getByText(/Alpha Recon Playlists/),
     ).toBeInTheDocument();
-    const stored = JSON.parse(
-      window.localStorage.getItem('youtube:watch-later') || '[]'
-    );
-    expect(stored).toHaveLength(1);
-    expect(stored[0].id).toBe('a');
+    expect(
+      within(visibleCards[1]).getByText(/Gamma CTF Warmups/),
+    ).toBeInTheDocument();
   });
 
-  it('renders watch later playlist from storage', () => {
-    window.localStorage.setItem('youtube:watch-later', JSON.stringify(mockVideos));
-    render(<YouTubeApp initialResults={[]} />);
-    const list = within(screen.getByTestId('watch-later-list'));
-    expect(list.getByText('Video A')).toBeInTheDocument();
-    expect(list.getByText('Video B')).toBeInTheDocument();
-  });
-
-  it('reorders watch later with keyboard', async () => {
+  it('sorts playlists alphabetically when requested', async () => {
     const user = userEvent.setup();
-    render(<YouTubeApp initialResults={mockVideos} />);
-    const laterButtons = screen.getAllByRole('button', { name: 'Later' });
-    await user.click(laterButtons[0]);
-    await user.click(laterButtons[1]);
+    render(<YouTubeApp initialResults={mockPlaylists} />);
 
-    const list = screen.getByTestId('watch-later-list');
-    const first = within(list).getByText('Video A').parentElement as HTMLElement;
-    fireEvent.keyDown(first, { key: 'ArrowDown' });
-    await waitFor(() => {
-      const items = within(list).getAllByText(/Video/);
-      expect(items[0].textContent).toBe('Video B');
-      expect(items[1].textContent).toBe('Video A');
-    });
-  });
+    await user.click(screen.getByRole('button', { name: 'Title A → Z' }));
 
-  it('saves named clips with timestamps', async () => {
-    const user = userEvent.setup();
-    let curTime = 0;
-    (window as any).YT = {
-      Player: function (_el: any, { events }: any) {
-        const obj = {
-          getCurrentTime: () => curTime,
-          getPlayerState: () => 0,
-          loadVideoById: jest.fn(),
-          pauseVideo: jest.fn(),
-          playVideo: jest.fn(),
-          seekTo: jest.fn(),
-          getPlaybackRate: () => 1,
-        };
-        events?.onReady?.({ target: obj });
-        return obj;
-      },
-      PlayerState: { PLAYING: 1 },
-    };
-    render(<YouTubeApp initialResults={mockVideos} />);
-    await user.click(screen.getByAltText('Video A'));
-    curTime = 5;
-    await user.click(screen.getByLabelText('Set loop start'));
-    curTime = 10;
-    await user.click(screen.getByLabelText('Set loop end'));
-    window.prompt = jest.fn().mockReturnValue('My Clip');
-    await user.click(screen.getByLabelText('Save clip'));
-    const stored = JSON.parse(
-      window.localStorage.getItem('youtube:watch-later') || '[]'
-    );
-    expect(stored[0]).toMatchObject({
-      id: 'a',
-      start: 5,
-      end: 10,
-      name: 'My Clip',
-    });
+    const cards = screen.getAllByRole('article');
+    expect(within(cards[0]).getByText('Alpha Recon Playlists')).toBeInTheDocument();
+    expect(within(cards[1]).getByText('Beta Defense Strategies')).toBeInTheDocument();
   });
 });
-

--- a/apps.config.js
+++ b/apps.config.js
@@ -87,7 +87,7 @@ const GomokuApp = createDynamicApp('gomoku', 'Gomoku');
 const PinballApp = createDynamicApp('pinball', 'Pinball');
 const VolatilityApp = createDynamicApp('volatility', 'Volatility');
 
-const KismetApp = createDynamicApp('kismet.jsx', 'Kismet');
+const KismetApp = createDynamicApp('kismet.tsx', 'Kismet');
 
 const HashcatApp = createDynamicApp('hashcat', 'Hashcat');
 const MsfPostApp = createDynamicApp('msf-post', 'Metasploit Post');

--- a/apps/kismet/index.tsx
+++ b/apps/kismet/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import KismetApp from '../../components/apps/kismet.jsx';
+import KismetApp from '../../components/apps/kismet.tsx';
 import DeauthWalkthrough from './components/DeauthWalkthrough';
 import { createLogger } from '../../lib/logger';
 

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -163,6 +163,7 @@ export default function Settings() {
                 checked={useKaliWallpaper}
                 onChange={(e) => setUseKaliWallpaper(e.target.checked)}
                 className="mr-2"
+                aria-label="Use Kali gradient wallpaper"
               />
               Kali Gradient Wallpaper
             </label>
@@ -274,6 +275,14 @@ export default function Settings() {
               ariaLabel="High Contrast"
             />
           </div>
+          <p
+            className="mx-auto max-w-xl text-center text-xs px-6"
+            style={{ color: 'var(--theme-muted-text)' }}
+          >
+            High contrast swaps the desktop, charts, and badges to a yellow, cyan,
+            and white palette for WCAG compliance. Tool dashboards and games now
+            follow the same tokens, so their accents shift automatically.
+          </p>
           <div className="flex justify-center my-4 items-center">
             <span className="mr-2 text-ubt-grey">Haptics:</span>
             <ToggleSwitch

--- a/components/ResultViewer.tsx
+++ b/components/ResultViewer.tsx
@@ -1,12 +1,45 @@
 "use client";
 
-import { useState, useMemo, useEffect } from 'react';
+import { forwardRef, useState, useMemo, useEffect } from 'react';
+
+const chartPalette = [
+  'var(--chart-series-1)',
+  'var(--chart-series-2)',
+  'var(--chart-series-3)',
+  'var(--chart-series-4)',
+  'var(--chart-series-5)',
+];
+
+const tabButtonBase =
+  'px-2 py-1 rounded border text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent transition-colors';
+
+const tabButtonStyle = (active: boolean) => ({
+  backgroundColor: active
+    ? 'var(--theme-color-accent)'
+    : 'var(--theme-color-surface)',
+  color: active ? 'var(--theme-color-on-accent)' : 'var(--theme-color-text)',
+  borderColor: 'var(--theme-border-subtle)',
+});
+
+const controlStyle = {
+  backgroundColor: 'var(--theme-control-background)',
+  color: 'var(--theme-control-text)',
+  borderColor: 'var(--theme-border-subtle)',
+};
+
+const surfaceStyle = {
+  backgroundColor: 'var(--theme-color-surface)',
+  color: 'var(--theme-color-text)',
+};
 
 interface ViewerProps {
   data: any[];
 }
 
-export default function ResultViewer({ data }: ViewerProps) {
+const ResultViewer = forwardRef<HTMLDivElement, ViewerProps>(function ResultViewer(
+  { data }: ViewerProps,
+  ref,
+) {
   const [tab, setTab] = useState<'raw' | 'parsed' | 'chart'>('raw');
   const [sortKey, setSortKey] = useState('');
   const [filter, setFilter] = useState('');
@@ -50,41 +83,103 @@ export default function ResultViewer({ data }: ViewerProps) {
   };
 
   return (
-    <div className="text-xs" aria-label="result viewer">
-      <div role="tablist" className="mb-2 flex">
-        <button role="tab" aria-selected={tab === 'raw'} onClick={() => setTab('raw')} className="px-2 py-1 bg-ub-cool-grey text-white mr-2">
+    <div
+      ref={ref}
+      className="text-xs"
+      aria-label="result viewer"
+      style={{ color: 'var(--theme-color-text)' }}
+    >
+      <div role="tablist" className="mb-2 flex gap-2">
+        <button
+          role="tab"
+          aria-selected={tab === 'raw'}
+          onClick={() => setTab('raw')}
+          className={`${tabButtonBase}`}
+          style={tabButtonStyle(tab === 'raw')}
+        >
           Raw
         </button>
-        <button role="tab" aria-selected={tab === 'parsed'} onClick={() => setTab('parsed')} className="px-2 py-1 bg-ub-cool-grey text-white mr-2">
+        <button
+          role="tab"
+          aria-selected={tab === 'parsed'}
+          onClick={() => setTab('parsed')}
+          className={tabButtonBase}
+          style={tabButtonStyle(tab === 'parsed')}
+        >
           Parsed
         </button>
-        <button role="tab" aria-selected={tab === 'chart'} onClick={() => setTab('chart')} className="px-2 py-1 bg-ub-cool-grey text-white">
+        <button
+          role="tab"
+          aria-selected={tab === 'chart'}
+          onClick={() => setTab('chart')}
+          className={tabButtonBase}
+          style={tabButtonStyle(tab === 'chart')}
+        >
           Chart
         </button>
       </div>
-      {tab === 'raw' && <pre className="bg-black text-white p-1 h-40 overflow-auto">{JSON.stringify(data, null, 2)}</pre>}
+      {tab === 'raw' && (
+        <pre
+          className="p-2 h-40 overflow-auto rounded"
+          style={{
+            ...surfaceStyle,
+            backgroundColor: 'var(--chart-surface)',
+          }}
+        >
+          {JSON.stringify(data, null, 2)}
+        </pre>
+      )}
       {tab === 'parsed' && (
-        <div>
-          <div className="mb-2">
-            <label>
-              Filter:
-              <input value={filter} onChange={(e) => setFilter(e.target.value)} className="border p-1 text-black ml-1" />
-            </label>
+        <div style={{ color: 'var(--theme-color-text)' }}>
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <label htmlFor="result-viewer-filter">Filter:</label>
+            <input
+              id="result-viewer-filter"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              className="ml-1 rounded border px-2 py-1"
+              style={controlStyle}
+              aria-label="Filter results"
+            />
             {keys.map((k) => (
-              <button key={k} onClick={() => setSortKey(k)} className="px-2 py-1 bg-ub-cool-grey text-white ml-2">
+              <button
+                key={k}
+                onClick={() => setSortKey(k)}
+                className={`${tabButtonBase} ml-0`}
+                style={tabButtonStyle(sortKey === k)}
+              >
                 {k}
               </button>
             ))}
-            <button onClick={exportCsv} className="px-2 py-1 bg-ub-green text-black ml-2" type="button">
+            <button
+              onClick={exportCsv}
+              className={`${tabButtonBase} ml-0`}
+              type="button"
+              style={{
+                ...tabButtonStyle(true),
+                backgroundColor: 'var(--theme-color-accent)',
+                color: 'var(--theme-color-on-accent)',
+              }}
+            >
               CSV
             </button>
           </div>
           <div className="overflow-auto max-h-60">
-            <table className="w-full text-left">
+            <table
+              className="w-full text-left border-collapse"
+              style={{ color: 'var(--theme-color-text)' }}
+            >
               <thead>
                 <tr>
                   {keys.map((k) => (
-                    <th key={k} className="border px-1">
+                    <th
+                      key={k}
+                      className="px-2 py-1"
+                      style={{
+                        border: '1px solid var(--theme-border-subtle)',
+                        backgroundColor: 'var(--theme-color-surface)',
+                      }}
+                    >
                       {k}
                     </th>
                   ))}
@@ -92,9 +187,19 @@ export default function ResultViewer({ data }: ViewerProps) {
               </thead>
               <tbody>
                 {sorted.map((row, i) => (
-                  <tr key={i}>
+                  <tr
+                    key={i}
+                    style={{
+                      backgroundColor:
+                        i % 2 === 0 ? 'transparent' : 'var(--table-row-alt)',
+                    }}
+                  >
                     {keys.map((k) => (
-                      <td key={k} className="border px-1">
+                      <td
+                        key={k}
+                        className="px-2 py-1"
+                        style={{ border: '1px solid var(--theme-border-subtle)' }}
+                      >
                         {String(row[k])}
                       </td>
                     ))}
@@ -106,7 +211,13 @@ export default function ResultViewer({ data }: ViewerProps) {
         </div>
       )}
       {tab === 'chart' && (
-        <svg width="100%" height="100" role="img" aria-label="bar chart">
+        <svg
+          width="100%"
+          height="100"
+          role="img"
+          aria-label="bar chart"
+          style={{ backgroundColor: 'var(--chart-surface)' }}
+        >
           {data.slice(0, keys.length).map((row, i) => (
             <rect
               key={i}
@@ -114,12 +225,14 @@ export default function ResultViewer({ data }: ViewerProps) {
               y={100 - Number(row[keys[0]])}
               width={30}
               height={Number(row[keys[0]])}
-              fill={['#377eb8', '#4daf4a', '#e41a1c', '#984ea3', '#ff7f00'][i % 5]}
+              fill={chartPalette[i % chartPalette.length]}
             />
           ))}
         </svg>
       )}
     </div>
   );
-}
+});
+
+export default ResultViewer;
 

--- a/components/StatsChart.js
+++ b/components/StatsChart.js
@@ -6,12 +6,24 @@ const StatsChart = ({ count, time }) => {
   const tH = (time / max) * 80;
   return (
     <svg viewBox="0 0 120 100" className="w-full h-24 mt-2">
-      <rect x="10" y={90 - cH} width="40" height={cH} fill="#10b981" />
-      <rect x="70" y={90 - tH} width="40" height={tH} fill="#3b82f6" />
-      <text x="30" y="95" textAnchor="middle" fontSize="8" fill="white">
+      <rect
+        x="10"
+        y={90 - cH}
+        width="40"
+        height={cH}
+        fill="var(--chart-series-1)"
+      />
+      <rect
+        x="70"
+        y={90 - tH}
+        width="40"
+        height={tH}
+        fill="var(--chart-series-2)"
+      />
+      <text x="30" y="95" textAnchor="middle" fontSize="8" fill="var(--chart-label)">
         candidates
       </text>
-      <text x="90" y="95" textAnchor="middle" fontSize="8" fill="white">
+      <text x="90" y="95" textAnchor="middle" fontSize="8" fill="var(--chart-label)">
         seconds
       </text>
     </svg>

--- a/components/apps/kismet.tsx
+++ b/components/apps/kismet.tsx
@@ -95,8 +95,11 @@ const ChannelChart = ({ data }) => {
       {channels.map((c) => (
         <div key={c} className="flex flex-col items-center">
           <div
-            className="bg-blue-600 w-4"
-            style={{ height: `${(data[c] / max) * 100}%` }}
+            className="w-4 rounded"
+            style={{
+              height: `${(data[c] / max) * 100}%`,
+              backgroundColor: 'var(--chart-series-1)',
+            }}
           />
           <span className="text-xs mt-1">{c}</span>
         </div>
@@ -124,10 +127,10 @@ const TimeChart = ({ data }) => {
     <svg
       width={width}
       height={height}
-      className="bg-gray-900"
+      style={{ backgroundColor: 'var(--chart-surface)' }}
       aria-label="Time chart"
     >
-      <path d={points} stroke="#0f0" fill="none" />
+      <path d={points} stroke="var(--chart-line)" fill="none" />
     </svg>
   );
 };
@@ -136,6 +139,12 @@ const KismetApp = ({ onNetworkDiscovered }) => {
   const [networks, setNetworks] = useState([]);
   const [channels, setChannels] = useState({});
   const [times, setTimes] = useState({});
+
+  const controlStyle = {
+    backgroundColor: 'var(--theme-control-background)',
+    color: 'var(--theme-control-text)',
+    border: `1px solid var(--theme-border-subtle)`,
+  };
 
   const handleFile = async (e) => {
     const file = e.target.files?.[0];
@@ -151,13 +160,21 @@ const KismetApp = ({ onNetworkDiscovered }) => {
   };
 
   return (
-    <div className="p-4 text-white space-y-4">
+    <div
+      className="p-4 space-y-4"
+      style={{
+        backgroundColor: 'var(--theme-color-background)',
+        color: 'var(--theme-color-text)',
+        borderRadius: 'var(--radius-lg)',
+      }}
+    >
       <input
         type="file"
         accept=".pcap"
         onChange={handleFile}
         aria-label="pcap file"
-        className="block"
+        className="block rounded border px-2 py-1"
+        style={controlStyle}
       />
 
       {networks.length > 0 && (
@@ -172,12 +189,18 @@ const KismetApp = ({ onNetworkDiscovered }) => {
               </tr>
             </thead>
             <tbody>
-              {networks.map((n) => (
-                <tr key={n.bssid} className="odd:bg-gray-800">
-                  <td className="pr-2">{n.ssid || '(hidden)'}</td>
-                  <td className="pr-2">{n.bssid}</td>
-                  <td className="pr-2">{n.channel ?? '-'}</td>
-                  <td>{n.frames}</td>
+              {networks.map((n, index) => (
+                <tr
+                  key={n.bssid}
+                  style={{
+                    backgroundColor:
+                      index % 2 === 0 ? 'transparent' : 'var(--table-row-alt)',
+                  }}
+                >
+                  <td className="pr-2 py-1">{n.ssid || '(hidden)'}</td>
+                  <td className="pr-2 py-1">{n.bssid}</td>
+                  <td className="pr-2 py-1">{n.channel ?? '-'}</td>
+                  <td className="py-1">{n.frames}</td>
                 </tr>
               ))}
             </tbody>

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -42,6 +42,13 @@ const escapeHtml = (str = '') =>
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 
+const severitySwatches = {
+  low: 'var(--severity-low)',
+  medium: 'var(--severity-medium)',
+  high: 'var(--severity-high)',
+  critical: 'var(--severity-critical)',
+};
+
 const SeverityChart = ({ data, selected, onSelect }) => {
   const levels = ['low', 'medium', 'high', 'critical'];
   const max = Math.max(...levels.map((l) => data[l] || 0), 1);
@@ -51,6 +58,7 @@ const SeverityChart = ({ data, selected, onSelect }) => {
       role="img"
       aria-label="OpenVAS findings severity chart"
       className="w-full h-32 mb-4"
+      style={{ backgroundColor: 'var(--chart-surface)' }}
     >
       {levels.map((level, i) => {
         const value = data[level] || 0;
@@ -72,9 +80,10 @@ const SeverityChart = ({ data, selected, onSelect }) => {
               y={y}
               width="20"
               height={height}
-              className={`${severityColors[level]} ${onSelect ? 'cursor-pointer' : ''} ${
-                isSelected ? 'stroke-white stroke-2' : ''
-              }`}
+              fill={severitySwatches[level]}
+              stroke={isSelected ? 'var(--theme-color-text)' : 'transparent'}
+              strokeWidth={isSelected ? 2 : 0}
+              className={onSelect ? 'cursor-pointer' : undefined}
               role={onSelect ? 'button' : undefined}
               tabIndex={onSelect ? 0 : undefined}
               aria-label={`${value} ${level} findings`}
@@ -85,7 +94,8 @@ const SeverityChart = ({ data, selected, onSelect }) => {
               x={x + 10}
               y="58"
               textAnchor="middle"
-              className="fill-white text-[8px] capitalize"
+              className="text-[8px] capitalize"
+              fill="var(--chart-label)"
             >
               {level}
             </text>
@@ -98,10 +108,10 @@ const SeverityChart = ({ data, selected, onSelect }) => {
 
 const severityLevels = ['All', 'Low', 'Medium', 'High', 'Critical'];
 const severityColors = {
-  low: 'bg-green-700',
-  medium: 'bg-yellow-700',
-  high: 'bg-orange-700',
-  critical: 'bg-red-700',
+  low: severitySwatches.low,
+  medium: severitySwatches.medium,
+  high: severitySwatches.high,
+  critical: severitySwatches.critical,
 };
 
 const remediationMap = {
@@ -335,11 +345,29 @@ const OpenVASApp = () => {
 
   const color = (i, j) => {
     const idx = Math.max(i, j);
-    return ['bg-green-700', 'bg-yellow-700', 'bg-orange-700', 'bg-red-700'][idx];
+    return severityColors[['low', 'medium', 'high', 'critical'][idx]];
+  };
+
+  const controlStyle = {
+    backgroundColor: 'var(--theme-control-background)',
+    color: 'var(--theme-control-text)',
+    border: `1px solid var(--theme-border-subtle)`,
+  };
+
+  const surfaceStyle = {
+    backgroundColor: 'var(--theme-color-surface)',
+    color: 'var(--theme-color-text)',
+    border: `1px solid var(--theme-border-subtle)`,
   };
 
   return (
-    <div className="h-full w-full p-4 bg-ub-cool-grey text-white overflow-auto">
+    <div
+      className="h-full w-full p-4 overflow-auto"
+      style={{
+        backgroundColor: 'var(--theme-color-background)',
+        color: 'var(--theme-color-text)',
+      }}
+    >
       <TaskOverview />
       <PolicySettings policy={templates[profile]} />
       {hostReports.length > 0 && (
@@ -349,12 +377,17 @@ const OpenVASApp = () => {
               key={h.host}
               type="button"
               onClick={() => setActiveHost(h)}
-              className="p-4 bg-gray-800 rounded text-left focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="p-4 rounded text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color-accent)] focus-visible:ring-offset-2 transition-colors"
+              style={surfaceStyle}
             >
               <div className="font-bold mb-1">{h.host}</div>
               <div className="mb-1">
                 <span
-                  className={`px-2 py-1 rounded text-xs ${severityColors[h.risk.toLowerCase()]}`}
+                  className="px-2 py-1 rounded text-xs"
+                  style={{
+                    backgroundColor: severityColors[h.risk.toLowerCase()],
+                    color: 'var(--severity-text)',
+                  }}
                 >
                   {h.risk}
                 </span>
@@ -373,16 +406,20 @@ const OpenVASApp = () => {
       <h2 className="text-lg mb-2">OpenVAS Scanner</h2>
       <div className="flex mb-4 space-x-2">
         <input
-          className="flex-1 p-2 rounded text-black"
+          className="flex-1 p-2 rounded border"
           placeholder="Target (e.g. 192.168.1.1)"
           value={target}
           onChange={(e) => setTarget(e.target.value)}
+          style={controlStyle}
+          aria-label="Scan target"
         />
         <input
-          className="flex-1 p-2 rounded text-black"
+          className="flex-1 p-2 rounded border"
           placeholder="Group (e.g. Servers)"
           value={group}
           onChange={(e) => setGroup(e.target.value)}
+          style={controlStyle}
+          aria-label="Scan group"
         />
         <div className="flex items-center space-x-2" role="tablist" aria-label="Scan profile">
           {profileTabs.map((p) => (
@@ -393,9 +430,21 @@ const OpenVASApp = () => {
               aria-selected={profile === p.id}
               aria-label={p.label}
               onClick={() => setProfile(p.id)}
-              className={`w-6 h-6 flex items-center justify-center rounded ${
-                profile === p.id ? 'bg-gray-700' : 'bg-gray-600'
-              }`}
+              className="w-6 h-6 flex items-center justify-center rounded border focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color-accent)] focus-visible:ring-offset-2"
+              style={{
+                backgroundColor:
+                  profile === p.id
+                    ? 'var(--theme-color-accent)'
+                    : 'var(--theme-color-surface)',
+                color:
+                  profile === p.id
+                    ? 'var(--theme-color-on-accent)'
+                    : 'var(--theme-color-text)',
+                borderColor:
+                  profile === p.id
+                    ? 'var(--theme-color-accent)'
+                    : 'var(--theme-border-subtle)',
+              }}
             >
               {p.icon}
             </button>
@@ -405,19 +454,29 @@ const OpenVASApp = () => {
           type="button"
           onClick={() => runScan()}
           disabled={loading}
-          className="px-4 py-2 bg-green-600 rounded disabled:opacity-50"
+          className="px-4 py-2 rounded disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color-accent)] focus-visible:ring-offset-2 transition-colors"
+          style={{
+            backgroundColor: 'var(--theme-color-accent)',
+            color: 'var(--theme-color-on-accent)',
+          }}
         >
           {loading ? 'Scanning...' : 'Scan'}
         </button>
       </div>
-      {loading && (
-        <div className="w-full bg-gray-700 h-2 mb-4">
+        {loading && (
           <div
-            style={{ width: `${progress}%` }}
-            className="h-2 bg-green-500 transition-all"
-          />
-        </div>
-      )}
+            className="w-full h-2 mb-4 rounded"
+            style={{ backgroundColor: 'var(--chart-grid)' }}
+          >
+            <div
+              style={{
+                width: `${progress}%`,
+                backgroundColor: 'var(--theme-color-accent)',
+              }}
+              className="h-2 rounded transition-all"
+            />
+          </div>
+        )}
       <SeverityChart
         data={severityCounts}
         selected={severity === 'All' ? null : severity.toLowerCase()}
@@ -452,15 +511,19 @@ const OpenVASApp = () => {
                       type="button"
                       onClick={() => handleCellClick(likelihood, impact)}
                       disabled={count === 0}
-                      className={`p-2 ${color(i, j)} text-white focus:outline-none w-full ${
+                      className={`p-2 rounded focus:outline-none w-full ${
                         reduceMotion.current ? '' : 'transition-transform hover:scale-105'
-                      } ${
-                        filter &&
-                        filter.likelihood === likelihood &&
-                        filter.impact === impact
-                          ? 'ring-2 ring-white'
-                          : ''
                       } disabled:opacity-50`}
+                      style={{
+                        backgroundColor: color(i, j),
+                        color: 'var(--severity-text)',
+                        border:
+                          filter &&
+                          filter.likelihood === likelihood &&
+                          filter.impact === impact
+                            ? `2px solid var(--theme-color-text)`
+                            : '1px solid transparent',
+                      }}
                       aria-label={`${count} findings with ${likelihood} likelihood and ${impact} impact`}
                     >
                       {count}
@@ -480,11 +543,18 @@ const OpenVASApp = () => {
                 key={level}
                 onClick={() => handleSeverityChange(level)}
                 aria-pressed={severity === level}
-                className={`px-3 py-1 rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
-                  severity === level
-                    ? 'bg-white text-black'
-                    : 'bg-gray-800 text-white'
-                }`}
+                className="px-3 py-1 rounded-full text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--theme-color-accent)] transition-colors"
+                style={{
+                  backgroundColor:
+                    severity === level
+                      ? 'var(--theme-color-accent)'
+                      : 'var(--theme-color-surface)',
+                  color:
+                    severity === level
+                      ? 'var(--theme-color-on-accent)'
+                      : 'var(--theme-color-text)',
+                  border: '1px solid var(--theme-border-subtle)',
+                }}
               >
                 {level}
               </button>
@@ -496,7 +566,11 @@ const OpenVASApp = () => {
               .map((level) => (
                 <div key={level} className="flex items-center">
                   <span
-                    className={`w-3 h-3 mr-1 ${severityColors[level.toLowerCase()]}`}
+                    className="w-3 h-3 mr-1 rounded-sm"
+                    style={{
+                      backgroundColor: severityColors[level.toLowerCase()],
+                      display: 'inline-block',
+                    }}
                   />
                   {level}
                 </div>
@@ -510,22 +584,39 @@ const OpenVASApp = () => {
             <li
               key={idx}
               role="listitem"
-              className={`p-2 rounded ${severityColors[f.severity]} text-white`}
+              className="p-2 rounded"
+              style={{
+                backgroundColor: severityColors[f.severity],
+                color: 'var(--severity-text)',
+              }}
             >
               <button
                 type="button"
                 onClick={() => setSelected(f)}
                 className="w-full text-left focus:outline-none"
+                aria-label={`View findings for ${f.host} vulnerability ${f.name}`}
               >
-                <div className="flex items-center justify-between">
-                  <span
-                    dangerouslySetInnerHTML={{ __html: escapeHtml(f.description) }}
-                  />
-                  <div className="flex gap-1 ml-2">
-                    <span className="px-1 py-0.5 bg-red-700 rounded text-xs">
+                  <div className="flex items-center justify-between">
+                    <span
+                      dangerouslySetInnerHTML={{ __html: escapeHtml(f.description) }}
+                    />
+                    <div className="flex gap-1 ml-2">
+                    <span
+                      className="px-1 py-0.5 rounded text-xs"
+                      style={{
+                        backgroundColor: severityColors.critical,
+                        color: 'var(--severity-text)',
+                      }}
+                    >
                       CVSS {f.cvss}
                     </span>
-                    <span className="px-1 py-0.5 bg-blue-700 rounded text-xs">
+                    <span
+                      className="px-1 py-0.5 rounded text-xs"
+                      style={{
+                        backgroundColor: 'var(--chart-series-1)',
+                        color: 'var(--theme-color-on-accent)',
+                      }}
+                    >
                       EPSS {(f.epss * 100).toFixed(1)}%
                     </span>
                   </div>
@@ -541,18 +632,44 @@ const OpenVASApp = () => {
           aria-modal="true"
           className="fixed inset-0 bg-black/70 flex items-center justify-center p-4"
         >
-          <div className="bg-gray-800 p-4 rounded max-w-md w-full">
+          <div
+            className="p-4 rounded max-w-md w-full shadow-lg"
+            style={{
+              backgroundColor: 'var(--theme-color-surface)',
+              color: 'var(--theme-color-text)',
+              border: `1px solid var(--theme-border-subtle)`,
+            }}
+          >
             <h3 className="text-lg mb-2">Host {activeHost.host} Findings</h3>
             <ul className="space-y-2 max-h-60 overflow-auto">
               {activeHost.vulns.map((v, i) => (
-                <li key={i} className="p-2 bg-gray-700 rounded">
+                <li
+                  key={i}
+                  className="p-2 rounded"
+                  style={{
+                    backgroundColor: 'var(--chart-surface)',
+                    border: `1px solid var(--theme-border-subtle)`,
+                  }}
+                >
                   <div className="flex items-center justify-between">
                     <span className="font-semibold">{v.title}</span>
                     <div className="flex gap-1 ml-2">
-                      <span className="px-2 py-0.5 rounded text-xs bg-red-700">
+                      <span
+                        className="px-2 py-0.5 rounded text-xs"
+                        style={{
+                          backgroundColor: severityColors.critical,
+                          color: 'var(--severity-text)',
+                        }}
+                      >
                         CVSS {v.cvss}
                       </span>
-                      <span className="px-2 py-0.5 rounded text-xs bg-blue-700">
+                      <span
+                        className="px-2 py-0.5 rounded text-xs"
+                        style={{
+                          backgroundColor: 'var(--chart-series-1)',
+                          color: 'var(--theme-color-on-accent)',
+                        }}
+                      >
                         EPSS {(v.epss * 100).toFixed(1)}%
                       </span>
                     </div>
@@ -561,7 +678,11 @@ const OpenVASApp = () => {
                     {v.remediation.map((tag) => (
                       <span
                         key={tag}
-                        className="inline-block mr-1 mb-1 px-2 py-0.5 bg-gray-600 rounded text-xs"
+                        className="inline-block mr-1 mb-1 px-2 py-0.5 rounded text-xs"
+                        style={{
+                          backgroundColor: 'var(--table-row-alt)',
+                          color: 'var(--theme-color-text)',
+                        }}
                       >
                         {tag}
                       </span>
@@ -573,7 +694,11 @@ const OpenVASApp = () => {
             <button
               type="button"
               onClick={() => setActiveHost(null)}
-              className="mt-4 px-3 py-1 bg-blue-600 rounded"
+              className="mt-4 px-3 py-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color-accent)] focus-visible:ring-offset-2"
+              style={{
+                backgroundColor: 'var(--theme-color-accent)',
+                color: 'var(--theme-color-on-accent)',
+              }}
             >
               Close
             </button>
@@ -586,7 +711,14 @@ const OpenVASApp = () => {
           aria-modal="true"
           className="fixed inset-0 bg-black/70 flex items-center justify-center p-4"
         >
-          <div className="bg-gray-800 p-4 rounded max-w-md w-full">
+          <div
+            className="p-4 rounded max-w-md w-full shadow-lg"
+            style={{
+              backgroundColor: 'var(--theme-color-surface)',
+              color: 'var(--theme-color-text)',
+              border: `1px solid var(--theme-border-subtle)`,
+            }}
+          >
             <h3 className="text-lg mb-2">Issue Detail</h3>
             <p
               className="mb-2"
@@ -594,12 +726,24 @@ const OpenVASApp = () => {
             />
             <div className="flex gap-2 mb-2">
               {selected.cvss !== undefined && (
-                <span className="px-2 py-0.5 bg-red-700 rounded text-xs">
+                <span
+                  className="px-2 py-0.5 rounded text-xs"
+                  style={{
+                    backgroundColor: severityColors.critical,
+                    color: 'var(--severity-text)',
+                  }}
+                >
                   CVSS {selected.cvss}
                 </span>
               )}
               {selected.epss !== undefined && (
-                <span className="px-2 py-0.5 bg-blue-700 rounded text-xs">
+                <span
+                  className="px-2 py-0.5 rounded text-xs"
+                  style={{
+                    backgroundColor: 'var(--chart-series-1)',
+                    color: 'var(--theme-color-on-accent)',
+                  }}
+                >
                   EPSS {(selected.epss * 100).toFixed(1)}%
                 </span>
               )}
@@ -612,7 +756,11 @@ const OpenVASApp = () => {
             <button
               type="button"
               onClick={() => setSelected(null)}
-              className="px-3 py-1 bg-blue-600 rounded"
+              className="px-3 py-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color-accent)] focus-visible:ring-offset-2"
+              style={{
+                backgroundColor: 'var(--theme-color-accent)',
+                color: 'var(--theme-color-on-accent)',
+              }}
             >
               Close
             </button>
@@ -623,9 +771,23 @@ const OpenVASApp = () => {
         {announce}
       </div>
       {output && (
-        <div className="bg-black text-white text-xs font-mono rounded overflow-auto">
+        <div
+          className="text-xs font-mono rounded overflow-auto"
+          style={{
+            backgroundColor: 'var(--chart-surface)',
+            color: 'var(--theme-color-text)',
+            border: `1px solid var(--theme-border-subtle)`,
+          }}
+        >
           {output.split('\n').map((line, i) => (
-            <div key={i} className={`px-2 ${i % 2 ? 'bg-gray-900' : 'bg-gray-800'}`}>
+            <div
+              key={i}
+              className="px-2"
+              style={{
+                backgroundColor:
+                  i % 2 === 0 ? 'transparent' : 'var(--table-row-alt)',
+              }}
+            >
               {line || '\u00A0'}
             </div>
           ))}
@@ -636,12 +798,19 @@ const OpenVASApp = () => {
           href={summaryUrl}
           download="openvas-summary.md"
           aria-label="Download summary"
-          className="inline-flex items-center mt-2 p-2 bg-blue-600 rounded"
+          className="inline-flex items-center mt-2 p-2 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color-accent)] focus-visible:ring-offset-2"
+          style={{
+            backgroundColor: 'var(--theme-color-accent)',
+            color: 'var(--theme-color-on-accent)',
+          }}
         >
           <img src="/themes/Yaru/status/download.svg" alt="" className="w-4 h-4" />
         </a>
       )}
-      <footer className="mt-4 text-xs text-gray-400">
+      <footer
+        className="mt-4 text-xs"
+        style={{ color: 'var(--theme-muted-text)' }}
+      >
         <a
           href="https://www.openvas.org"
           target="_blank"

--- a/components/apps/openvas/task-run-chart.js
+++ b/components/apps/openvas/task-run-chart.js
@@ -3,9 +3,9 @@ import history from './task-history.json';
 
 const statuses = ['Queued', 'Running', 'Completed'];
 const colors = {
-  Queued: 'fill-blue-500',
-  Running: 'fill-yellow-500',
-  Completed: 'fill-green-500',
+  Queued: 'var(--chart-status-queued)',
+  Running: 'var(--chart-status-running)',
+  Completed: 'var(--chart-status-completed)',
 };
 
 const TaskRunChart = () => {
@@ -35,25 +35,39 @@ const TaskRunChart = () => {
               y1={y}
               x2={width}
               y2={y}
-              className="stroke-gray-600"
+              stroke="var(--chart-grid)"
               strokeWidth="0.5"
             />
             <text
               x="0"
               y={y - 1}
-              className="fill-white text-[8px]"
+              className="text-[8px]"
+              fill="var(--chart-label)"
             >
               {s}
             </text>
           </g>
         );
       })}
-      <polyline points={points} fill="none" stroke="white" strokeWidth="1" />
+      <polyline
+        points={points}
+        fill="none"
+        stroke="var(--chart-line)"
+        strokeWidth="1"
+      />
       {history.map((d, i) => {
         const x = i * 20 + 10;
         const y =
           height - (statuses.indexOf(d.status) / (statuses.length - 1)) * height;
-        return <circle key={d.time} cx={x} cy={y} r="2" className={colors[d.status]} />;
+        return (
+          <circle
+            key={d.time}
+            cx={x}
+            cy={y}
+            r="2"
+            fill={colors[d.status]}
+          />
+        );
       })}
     </svg>
   );

--- a/components/apps/resource_monitor.js
+++ b/components/apps/resource_monitor.js
@@ -3,6 +3,12 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 // Number of samples to keep in the timeline
 const MAX_POINTS = 60;
 
+const resolveCssVar = (name, fallback) => {
+  if (typeof window === 'undefined') return fallback;
+  const value = getComputedStyle(document.documentElement).getPropertyValue(name);
+  return value?.trim() || fallback;
+};
+
 const ResourceMonitor = () => {
   const cpuCanvas = useRef(null);
   const memCanvas = useRef(null);
@@ -127,10 +133,34 @@ const ResourceMonitor = () => {
   };
 
   const drawCharts = (dataset = dataRef.current) => {
-    drawChart(cpuCanvas.current, dataset.cpu, '#00ff00', 'CPU %', 100);
-    drawChart(memCanvas.current, dataset.mem, '#ffd700', 'Memory %', 100);
-    drawChart(fpsCanvas.current, dataset.fps, '#00ffff', 'FPS', 120);
-    drawChart(netCanvas.current, dataset.net, '#ff00ff', 'Mbps', 100);
+    drawChart(
+      cpuCanvas.current,
+      dataset.cpu,
+      resolveCssVar('--chart-cpu-line', '#00ff00'),
+      'CPU %',
+      100,
+    );
+    drawChart(
+      memCanvas.current,
+      dataset.mem,
+      resolveCssVar('--chart-mem-line', '#ffd700'),
+      'Memory %',
+      100,
+    );
+    drawChart(
+      fpsCanvas.current,
+      dataset.fps,
+      resolveCssVar('--chart-fps-line', '#00ffff'),
+      'FPS',
+      120,
+    );
+    drawChart(
+      netCanvas.current,
+      dataset.net,
+      resolveCssVar('--chart-net-line', '#ff00ff'),
+      'Mbps',
+      100,
+    );
   };
 
   const animateCharts = useCallback(() => {
@@ -176,13 +206,33 @@ const ResourceMonitor = () => {
   return (
     <div
       ref={containerRef}
-      className="relative h-full w-full flex flex-col bg-ub-cool-grey text-white font-ubuntu overflow-hidden"
+      className="relative h-full w-full flex flex-col font-ubuntu overflow-hidden"
+      style={{
+        backgroundColor: 'var(--theme-color-background)',
+        color: 'var(--theme-color-text)',
+      }}
     >
       <div className="p-2 flex gap-2 items-center">
-        <button onClick={togglePause} className="px-2 py-1 bg-ub-dark-grey rounded">
+        <button
+          onClick={togglePause}
+          className="px-2 py-1 rounded border focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color-accent)] focus-visible:ring-offset-2"
+          style={{
+            backgroundColor: 'var(--theme-color-surface)',
+            color: 'var(--theme-color-text)',
+            borderColor: 'var(--theme-border-subtle)',
+          }}
+        >
           {paused ? 'Resume' : 'Pause'}
         </button>
-        <button onClick={toggleStress} className="px-2 py-1 bg-ub-dark-grey rounded">
+        <button
+          onClick={toggleStress}
+          className="px-2 py-1 rounded border focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color-accent)] focus-visible:ring-offset-2"
+          style={{
+            backgroundColor: 'var(--theme-color-surface)',
+            color: 'var(--theme-color-text)',
+            borderColor: 'var(--theme-border-subtle)',
+          }}
+        >
           {stress ? 'Stop Stress' : 'Stress Test'}
         </button>
         <span className="ml-auto text-sm">FPS: {fps.toFixed(1)}</span>
@@ -194,7 +244,11 @@ const ResourceMonitor = () => {
           height={100}
           role="img"
           aria-label="CPU usage chart"
-          className="bg-ub-dark-grey"
+          style={{
+            backgroundColor: 'var(--chart-surface)',
+            borderRadius: 'var(--radius-md)',
+            border: `1px solid var(--theme-border-subtle)`,
+          }}
         />
         <canvas
           ref={memCanvas}
@@ -202,7 +256,11 @@ const ResourceMonitor = () => {
           height={100}
           role="img"
           aria-label="Memory usage chart"
-          className="bg-ub-dark-grey"
+          style={{
+            backgroundColor: 'var(--chart-surface)',
+            borderRadius: 'var(--radius-md)',
+            border: `1px solid var(--theme-border-subtle)`,
+          }}
         />
         <canvas
           ref={fpsCanvas}
@@ -210,7 +268,11 @@ const ResourceMonitor = () => {
           height={100}
           role="img"
           aria-label="FPS chart"
-          className="bg-ub-dark-grey"
+          style={{
+            backgroundColor: 'var(--chart-surface)',
+            borderRadius: 'var(--radius-md)',
+            border: `1px solid var(--theme-border-subtle)`,
+          }}
         />
         <canvas
           ref={netCanvas}
@@ -218,7 +280,11 @@ const ResourceMonitor = () => {
           height={100}
           role="img"
           aria-label="Network speed chart"
-          className="bg-ub-dark-grey"
+          style={{
+            backgroundColor: 'var(--chart-surface)',
+            borderRadius: 'var(--radius-md)',
+            border: `1px solid var(--theme-border-subtle)`,
+          }}
         />
       </div>
       {stressWindows.current.map((_, i) => (
@@ -227,7 +293,11 @@ const ResourceMonitor = () => {
           ref={(el) => {
             stressEls.current[i] = el;
           }}
-          className="absolute w-8 h-6 bg-white bg-opacity-20 border border-gray-500 pointer-events-none"
+          className="absolute w-8 h-6 pointer-events-none rounded"
+          style={{
+            backgroundColor: 'color-mix(in srgb, var(--theme-color-text) 20%, transparent)',
+            border: `1px solid var(--theme-border-subtle)`,
+          }}
         />
       ))}
     </div>
@@ -252,7 +322,7 @@ function drawChart(canvas, values, color, label, maxVal) {
   });
   ctx.stroke();
   const latest = values[values.length - 1] || 0;
-  ctx.fillStyle = '#ffffff';
+  ctx.fillStyle = resolveCssVar('--chart-label', '#ffffff');
   ctx.font = '12px sans-serif';
   ctx.fillText(`${label}: ${latest.toFixed(1)}`, 4, 12);
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,12 +21,12 @@
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   --kali-text: #f5f5f5;
-  accent-color: var(--color-control-accent);
+  accent-color: var(--theme-color-accent);
 }
 
 body {
-  background: var(--kali-bg);
-  color: var(--kali-text);
+  background: var(--theme-color-background);
+  color: var(--theme-color-text);
 }
 
 /* Dark theme */
@@ -76,8 +76,8 @@ html[data-theme='matrix'] {
 }
 
 ::selection {
-  background: color-mix(in srgb, var(--color-primary) 65%, var(--kali-bg));
-  color: var(--kali-text);
+  background: color-mix(in srgb, var(--theme-color-accent) 65%, var(--theme-color-background));
+  color: var(--theme-color-on-accent);
 }
 
 *:focus-visible {

--- a/styles/index.css
+++ b/styles/index.css
@@ -527,6 +527,7 @@ textarea:focus-visible {
 
 /* High contrast overrides */
 .high-contrast .bg-ub-orange {
-    color: #000 !important;
+    color: var(--theme-color-on-accent) !important;
+    background-color: var(--theme-color-accent) !important;
 }
 

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,0 +1,31 @@
+export const themeTokens = {
+  background: 'var(--theme-color-background)',
+  surface: 'var(--theme-color-surface)',
+  text: 'var(--theme-color-text)',
+  accent: 'var(--theme-color-accent)',
+  onAccent: 'var(--theme-color-on-accent)',
+  border: 'var(--theme-border-subtle)',
+  mutedText: 'var(--theme-muted-text)',
+} as const;
+
+export const highContrastTokens = {
+  background: 'var(--color-hc-background)',
+  text: 'var(--color-hc-text)',
+  accent: 'var(--color-hc-accent)',
+} as const;
+
+export const themeVariants = {
+  default: themeTokens,
+  'high-contrast': {
+    ...themeTokens,
+    background: highContrastTokens.background,
+    text: highContrastTokens.text,
+    accent: highContrastTokens.accent,
+    onAccent: 'var(--theme-color-on-accent)',
+  },
+} as const;
+
+export type ThemeVariant = keyof typeof themeVariants;
+
+export const getThemeTokens = (variant: ThemeVariant = 'default') =>
+  themeVariants[variant];

--- a/styles/themes/kali.ts
+++ b/styles/themes/kali.ts
@@ -1,8 +1,10 @@
+import { themeTokens } from '../theme';
+
 export const kaliTheme = {
-  background: 'var(--color-bg)',
-  text: 'var(--color-text)',
-  accent: 'var(--color-primary)',
-  sidebar: 'var(--color-secondary)',
+  background: themeTokens.background,
+  text: themeTokens.text,
+  accent: themeTokens.accent,
+  sidebar: 'var(--theme-color-surface)',
 };
 
 export type KaliTheme = typeof kaliTheme;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -28,6 +28,48 @@
   --kali-bg: rgba(15, 19, 23, 0.85);
   --kali-blue: #1793d1;
 
+  /* High contrast palette anchors */
+  --color-hc-background: #000000;
+  --color-hc-text: #ffffff;
+  --color-hc-accent: #ffd800;
+
+  /* Theme token indirection */
+  --theme-color-background: var(--color-bg);
+  --theme-color-surface: var(--kali-panel, rgba(26, 31, 38, 0.9));
+  --theme-color-text: var(--color-text);
+  --theme-color-accent: var(--color-primary);
+  --theme-color-on-accent: var(--color-inverse, #0f1317);
+  --theme-border-subtle: rgba(255, 255, 255, 0.16);
+  --theme-muted-text: rgba(245, 245, 245, 0.72);
+  --theme-control-background: #ffffff;
+  --theme-control-text: #0f1317;
+
+  /* Chart & data visualization tokens */
+  --chart-grid: rgba(245, 245, 245, 0.2);
+  --chart-line: var(--color-primary);
+  --chart-series-1: #377eb8;
+  --chart-series-2: #4daf4a;
+  --chart-series-3: #e41a1c;
+  --chart-series-4: #984ea3;
+  --chart-series-5: #ff7f00;
+  --chart-status-queued: #3b82f6;
+  --chart-status-running: #facc15;
+  --chart-status-completed: #22c55e;
+  --chart-label: var(--theme-color-text);
+  --chart-surface: rgba(12, 15, 18, 0.85);
+  --chart-cpu-line: #00ff00;
+  --chart-mem-line: #ffd700;
+  --chart-fps-line: #00ffff;
+  --chart-net-line: #ff00ff;
+
+  /* Data states */
+  --severity-low: #10b981;
+  --severity-medium: #f59e0b;
+  --severity-high: #f97316;
+  --severity-critical: #ef4444;
+  --severity-text: var(--theme-color-text);
+  --table-row-alt: rgba(255, 255, 255, 0.06);
+
   /* Kali theme tokens */
   --kali-blue: #1793d1;
   --kali-blue-dark: #0f6fa1;
@@ -84,19 +126,53 @@
 
 /* High contrast theme */
 .high-contrast {
-  --color-bg: #000000;
-  --color-text: #ffffff;
+  --color-bg: var(--color-hc-background);
+  --color-text: var(--color-hc-text);
+  --color-primary: var(--color-hc-accent);
+  --color-accent: var(--color-hc-accent);
+  --color-secondary: var(--color-hc-background);
   --color-ub-grey: #000000;
   --color-ub-cool-grey: #000000;
   --color-ubt-grey: #ffffff;
   --color-ubt-cool-grey: #ffffff;
-  --color-ub-orange: #ffff00;
+  --color-ub-orange: var(--color-hc-accent);
   --color-ub-lite-abrgn: #00ffff;
-  --color-ub-border-orange: #ffff00;
-  --game-color-secondary: #ffff00;
+  --color-ub-border-orange: var(--color-hc-accent);
+  --game-color-secondary: var(--color-hc-accent);
   --game-color-success: #00ffff;
-  --game-color-warning: #ff00ff;
+  --game-color-warning: #ff66ff;
   --game-color-danger: #ff0000;
+  --theme-color-background: var(--color-hc-background);
+  --theme-color-surface: #000000;
+  --theme-color-text: var(--color-hc-text);
+  --theme-color-accent: var(--color-hc-accent);
+  --theme-color-on-accent: #000000;
+  --theme-border-subtle: var(--color-hc-text);
+  --theme-muted-text: var(--color-hc-text);
+  --theme-control-background: #000000;
+  --theme-control-text: var(--color-hc-text);
+  --chart-grid: var(--color-hc-text);
+  --chart-line: var(--color-hc-accent);
+  --chart-series-1: var(--color-hc-accent);
+  --chart-series-2: #00ffff;
+  --chart-series-3: #ff66ff;
+  --chart-series-4: #ffffff;
+  --chart-series-5: #ff8800;
+  --chart-status-queued: var(--color-hc-accent);
+  --chart-status-running: #00ffff;
+  --chart-status-completed: #ffffff;
+  --chart-label: var(--color-hc-text);
+  --chart-surface: #000000;
+  --chart-cpu-line: var(--color-hc-accent);
+  --chart-mem-line: #00ffff;
+  --chart-fps-line: #ff66ff;
+  --chart-net-line: #ffffff;
+  --severity-low: #00ffff;
+  --severity-medium: #ffff5a;
+  --severity-high: #ff66ff;
+  --severity-critical: #ffffff;
+  --severity-text: #000000;
+  --table-row-alt: rgba(255, 255, 255, 0.2);
 }
 
 /* Dyslexia-friendly fonts */
@@ -127,14 +203,23 @@
 /* Optional high contrast via media query */
 @media (prefers-contrast: more) {
   :root {
-    --color-bg: #000000;
-    --color-text: #ffffff;
+    --color-bg: var(--color-hc-background);
+    --color-text: var(--color-hc-text);
+    --color-primary: var(--color-hc-accent);
+    --color-accent: var(--color-hc-accent);
     --color-ub-grey: #000000;
     --color-ub-cool-grey: #000000;
     --color-ubt-grey: #ffffff;
     --color-ubt-cool-grey: #ffffff;
-    --color-ub-orange: #ffff00;
+    --color-ub-orange: var(--color-hc-accent);
     --color-ub-lite-abrgn: #00ffff;
-    --color-ub-border-orange: #ffff00;
+    --color-ub-border-orange: var(--color-hc-accent);
+    --theme-color-background: var(--color-hc-background);
+    --theme-color-text: var(--color-hc-text);
+    --theme-color-accent: var(--color-hc-accent);
+    --theme-color-on-accent: #000000;
+    --theme-control-background: #000000;
+    --theme-control-text: var(--color-hc-text);
+    --chart-grid: var(--color-hc-text);
   }
 }

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -2,6 +2,7 @@
 
 import { get, set, del } from 'idb-keyval';
 import { getTheme, setTheme } from './theme';
+import { safeLocalStorage } from './safeStorage';
 
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
@@ -16,6 +17,47 @@ const DEFAULT_SETTINGS = {
   allowNetwork: false,
   haptics: true,
 };
+
+function getBrowserStorage() {
+  if (typeof window === 'undefined') {
+    return safeLocalStorage ?? null;
+  }
+  try {
+    return window.localStorage;
+  } catch (error) {
+    return safeLocalStorage ?? null;
+  }
+}
+
+function readStorage(key) {
+  const storage = getBrowserStorage();
+  if (!storage) return null;
+  try {
+    return storage.getItem(key);
+  } catch (error) {
+    return null;
+  }
+}
+
+function writeStorage(key, value) {
+  const storage = getBrowserStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(key, value);
+  } catch (error) {
+    // ignore storage errors in non-browser environments
+  }
+}
+
+function removeStorage(key) {
+  const storage = getBrowserStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(key);
+  } catch (error) {
+    // ignore storage errors in non-browser environments
+  }
+}
 
 export async function getAccent() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
@@ -39,28 +81,28 @@ export async function setWallpaper(wallpaper) {
 
 export async function getUseKaliWallpaper() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.useKaliWallpaper;
-  const stored = window.localStorage.getItem('use-kali-wallpaper');
+  const stored = readStorage('use-kali-wallpaper');
   return stored === null ? DEFAULT_SETTINGS.useKaliWallpaper : stored === 'true';
 }
 
 export async function setUseKaliWallpaper(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('use-kali-wallpaper', value ? 'true' : 'false');
+  writeStorage('use-kali-wallpaper', value ? 'true' : 'false');
 }
 
 export async function getDensity() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  return readStorage('density') || DEFAULT_SETTINGS.density;
 }
 
 export async function setDensity(density) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
+  writeStorage('density', density);
 }
 
 export async function getReducedMotion() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  const stored = window.localStorage.getItem('reduced-motion');
+  const stored = readStorage('reduced-motion');
   if (stored !== null) {
     return stored === 'true';
   }
@@ -69,70 +111,70 @@ export async function getReducedMotion() {
 
 export async function setReducedMotion(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+  writeStorage('reduced-motion', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
+  const stored = readStorage('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  writeStorage('font-scale', String(scale));
 }
 
 export async function getHighContrast() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  return readStorage('high-contrast') === 'true';
 }
 
 export async function setHighContrast(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+  writeStorage('high-contrast', value ? 'true' : 'false');
 }
 
 export async function getLargeHitAreas() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
+  return readStorage('large-hit-areas') === 'true';
 }
 
 export async function setLargeHitAreas(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
+  writeStorage('large-hit-areas', value ? 'true' : 'false');
 }
 
 export async function getHaptics() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
-  const val = window.localStorage.getItem('haptics');
+  const val = readStorage('haptics');
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
 export async function setHaptics(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('haptics', value ? 'true' : 'false');
+  writeStorage('haptics', value ? 'true' : 'false');
 }
 
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
+  const val = readStorage('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
 export async function setPongSpin(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
+  writeStorage('pong-spin', value ? 'true' : 'false');
 }
 
 export async function getAllowNetwork() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
+  return readStorage('allow-network') === 'true';
 }
 
 export async function setAllowNetwork(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+  writeStorage('allow-network', value ? 'true' : 'false');
 }
 
 export async function resetSettings() {
@@ -141,15 +183,15 @@ export async function resetSettings() {
     del('accent'),
     del('bg-image'),
   ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
-  window.localStorage.removeItem('use-kali-wallpaper');
+  removeStorage('density');
+  removeStorage('reduced-motion');
+  removeStorage('font-scale');
+  removeStorage('high-contrast');
+  removeStorage('large-hit-areas');
+  removeStorage('pong-spin');
+  removeStorage('allow-network');
+  removeStorage('haptics');
+  removeStorage('use-kali-wallpaper');
 }
 
 export async function exportSettings() {


### PR DESCRIPTION
## Summary
- introduce theme token helpers and high-contrast cascading variables and update shared styles to consume them
- migrate visual dashboards (OpenVAS, Kismet, Resource Monitor, Result Viewer, StatsChart) to theme tokens for accessible palettes
- harden settings persistence and refresh Jest suites for the new YouTube playlists UI, window snapping, Ubuntu boot, and Nmap demos

## Testing
- yarn lint
- yarn test __tests__/youtube.test.tsx
- yarn test __tests__/nmapNse.test.tsx
- yarn test __tests__/reconng.test.tsx
- yarn test __tests__/window.test.tsx
- yarn test __tests__/ubuntu.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da4835c5d4832886280871acc71c4a