### PR TITLE
[ui] Add toast pause controls

### DIFF
--- a/__tests__/toastTimers.test.tsx
+++ b/__tests__/toastTimers.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Toast from '../components/ui/Toast';
+
+describe('Toast timer controls', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('pauses auto-dismiss when the toast receives focus', () => {
+    const onClose = jest.fn();
+    render(<Toast message="Saved" onClose={onClose} duration={3000} />);
+
+    const toast = screen.getByRole('status');
+
+    act(() => {
+      (toast as HTMLElement).focus();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.blur(toast);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops the timer when paused manually and resumes on demand', async () => {
+    const onClose = jest.fn();
+    render(<Toast message="Saved" onClose={onClose} duration={5000} />);
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const pauseButton = screen.getByRole('button', { name: /pause/i });
+    const resumeButton = screen.getByRole('button', { name: /resume/i });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await user.click(pauseButton);
+
+    act(() => {
+      jest.advanceTimersByTime(6000);
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    await user.click(resumeButton);
+
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -5,7 +5,14 @@ interface ToastProps {
   actionLabel?: string;
   onAction?: () => void;
   onClose?: () => void;
+  onPause?: () => void;
+  onResume?: () => void;
+  onExtend?: (remainingMs: number) => void;
   duration?: number;
+  extendBy?: number;
+  pauseLabel?: string;
+  resumeLabel?: string;
+  extendLabel?: string;
 }
 
 const Toast: React.FC<ToastProps> = ({
@@ -13,36 +20,166 @@ const Toast: React.FC<ToastProps> = ({
   actionLabel,
   onAction,
   onClose,
+  onPause,
+  onResume,
+  onExtend,
   duration = 6000,
+  extendBy = 4000,
+  pauseLabel = 'Pause',
+  resumeLabel = 'Resume',
+  extendLabel = 'Extend',
 }) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const startTimeRef = useRef<number | null>(null);
+  const remainingRef = useRef(duration);
+  const focusPauseRef = useRef(false);
+  const isPausedRef = useRef(false);
   const [visible, setVisible] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+  const [remaining, setRemaining] = useState(duration);
+
+  const clearTimer = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  };
+
+  const updateRemaining = (value: number) => {
+    remainingRef.current = value;
+    setRemaining(value);
+  };
+
+  const scheduleClose = (delay: number) => {
+    clearTimer();
+    if (delay <= 0) {
+      onClose && onClose();
+      return;
+    }
+    startTimeRef.current = Date.now();
+    timeoutRef.current = setTimeout(() => {
+      onClose && onClose();
+    }, delay);
+  };
+
+  const pauseToast = (source: 'focus' | 'manual' = 'manual') => {
+    if (isPausedRef.current) {
+      if (source === 'focus') {
+        focusPauseRef.current = true;
+      }
+      return;
+    }
+
+    if (startTimeRef.current) {
+      const elapsed = Date.now() - startTimeRef.current;
+      const nextRemaining = Math.max(remainingRef.current - elapsed, 0);
+      updateRemaining(nextRemaining);
+    }
+
+    clearTimer();
+    startTimeRef.current = null;
+    isPausedRef.current = true;
+    setIsPaused(true);
+    focusPauseRef.current = source === 'focus';
+    onPause && onPause();
+  };
+
+  const resumeToast = () => {
+    if (!isPausedRef.current || remainingRef.current <= 0) {
+      return;
+    }
+
+    isPausedRef.current = false;
+    setIsPaused(false);
+    focusPauseRef.current = false;
+    scheduleClose(remainingRef.current);
+    onResume && onResume();
+  };
+
+  const extendToast = () => {
+    const nextRemaining = remainingRef.current + extendBy;
+    updateRemaining(nextRemaining);
+    onExtend && onExtend(nextRemaining);
+
+    if (!isPausedRef.current) {
+      scheduleClose(nextRemaining);
+    }
+  };
 
   useEffect(() => {
     setVisible(true);
-    timeoutRef.current = setTimeout(() => {
-      onClose && onClose();
-    }, duration);
+    isPausedRef.current = false;
+    focusPauseRef.current = false;
+    remainingRef.current = duration;
+    setRemaining(duration);
+    setIsPaused(false);
+    scheduleClose(duration);
+
     return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      clearTimer();
     };
   }, [duration, onClose]);
+
+  const handleFocus = () => {
+    pauseToast('focus');
+  };
+
+  const handleBlur = () => {
+    if (focusPauseRef.current) {
+      focusPauseRef.current = false;
+      resumeToast();
+    }
+  };
 
   return (
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      tabIndex={-1}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
-      <span>{message}</span>
-      {onAction && actionLabel && (
-        <button
-          onClick={onAction}
-          className="ml-4 underline focus:outline-none"
-        >
-          {actionLabel}
-        </button>
-      )}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <span className="text-sm leading-snug sm:text-base">{message}</span>
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          {onAction && actionLabel && (
+            <button
+              type="button"
+              onClick={onAction}
+              className="rounded border border-transparent bg-indigo-600 px-3 py-1 text-white transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400"
+            >
+              {actionLabel}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => pauseToast('manual')}
+            disabled={isPaused}
+            className="rounded border border-gray-600 px-3 py-1 transition hover:border-indigo-400 hover:text-indigo-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {pauseLabel}
+          </button>
+          <button
+            type="button"
+            onClick={resumeToast}
+            disabled={!isPaused}
+            className="rounded border border-gray-600 px-3 py-1 transition hover:border-indigo-400 hover:text-indigo-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {resumeLabel}
+          </button>
+          <button
+            type="button"
+            onClick={extendToast}
+            className="rounded border border-gray-600 px-3 py-1 transition hover:border-indigo-400 hover:text-indigo-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400"
+          >
+            {extendLabel}
+          </button>
+        </div>
+      </div>
+      <p className="mt-2 text-xs text-gray-300" aria-hidden="true">
+        {isPaused ? 'Paused' : `Closing in ${(remaining / 1000).toFixed(1)}s`}
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add pause, resume, and extend controls to the toast component
- expose the controls with updated styling and countdown messaging
- cover focus and manual pause scenarios with new Jest tests

## Testing
- [x] yarn test toastTimers --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68da4836dc84832882c83aacf77ed003