### PR TITLE
[apps] Add suspense skeletons for heavy tools

### DIFF
--- a/components/ui/AppWindowSkeleton.tsx
+++ b/components/ui/AppWindowSkeleton.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from 'react';
+
+type AppWindowSkeletonProps = {
+  /**
+   * Title of the app that is currently loading. Shown to assistive tech users
+   * inside the live region and to help tailor messaging.
+   */
+  title?: string;
+  /**
+   * Optional short description that clarifies what is being prepared.
+   */
+  description?: ReactNode;
+  /**
+   * Number of placeholder content rows to render below the header region.
+   */
+  lines?: number;
+};
+
+const buildLineWidths = (count: number) =>
+  Array.from({ length: count }, (_, index) => 100 - index * 12).map((width) =>
+    Math.max(width, 34),
+  );
+
+export default function AppWindowSkeleton({
+  title = 'Loading app',
+  description,
+  lines = 4,
+}: AppWindowSkeletonProps) {
+  const widths = buildLineWidths(lines);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex h-full w-full flex-col gap-6 rounded-xl border border-slate-800/60 bg-slate-950/80 p-6 text-slate-200 shadow-inner"
+    >
+      <div className="flex items-center gap-4">
+        <div className="h-12 w-12 rounded-lg bg-slate-800/70 animate-pulse" />
+        <div className="flex flex-1 flex-col gap-2">
+          <div className="h-4 w-40 rounded bg-slate-800/70 animate-pulse" />
+          <div className="h-3 w-28 rounded bg-slate-900/70 animate-pulse" />
+        </div>
+      </div>
+      <div className="space-y-3">
+        {widths.map((width, index) => (
+          <div
+            key={`skeleton-line-${index}`}
+            className="h-3 rounded bg-slate-900/70 animate-pulse"
+            style={{ width: `${width}%` }}
+          />
+        ))}
+      </div>
+      <span className="sr-only">
+        {`${title} is loading.`}
+        {description ? ` ${description}` : ''}
+      </span>
+    </div>
+  );
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,9 @@ const compat = new FlatCompat();
 const config = [
   { ignores: ['components/apps/Chrome/index.tsx'] },
   {
+    files: ['**/*.{js,jsx,ts,tsx}'],
+  },
+  {
     plugins: {
       'no-top-level-window': noTopLevelWindow,
     },

--- a/pages/apps/autopsy.jsx
+++ b/pages/apps/autopsy.jsx
@@ -1,10 +1,23 @@
+import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
+import AppWindowSkeleton from '../../components/ui/AppWindowSkeleton';
 
 const Autopsy = dynamic(() => import('../../apps/autopsy'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  suspense: true,
 });
 
 export default function AutopsyPage() {
-  return <Autopsy />;
+  return (
+    <Suspense
+      fallback={
+        <AppWindowSkeleton
+          title="Autopsy"
+          description="Mounting evidence timeline"
+        />
+      }
+    >
+      <Autopsy />
+    </Suspense>
+  );
 }

--- a/pages/apps/ghidra.jsx
+++ b/pages/apps/ghidra.jsx
@@ -2,22 +2,22 @@ import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import AppWindowSkeleton from '../../components/ui/AppWindowSkeleton';
 
-const Wireshark = dynamic(() => import('../../apps/wireshark'), {
+const Ghidra = dynamic(() => import('../../apps/ghidra'), {
   ssr: false,
   suspense: true,
 });
 
-export default function WiresharkPage() {
+export default function GhidraPage() {
   return (
     <Suspense
       fallback={
         <AppWindowSkeleton
-          title="Wireshark"
-          description="Preparing packet capture fixtures"
+          title="Ghidra"
+          description="Bootstrapping reverse engineering workspace"
         />
       }
     >
-      <Wireshark />
+      <Ghidra />
     </Suspense>
   );
 }

--- a/pages/apps/metasploit-post.jsx
+++ b/pages/apps/metasploit-post.jsx
@@ -1,10 +1,23 @@
+import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
+import AppWindowSkeleton from '../../components/ui/AppWindowSkeleton';
 
 const MetasploitPost = dynamic(() => import('../../apps/metasploit-post'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  suspense: true,
 });
 
 export default function MetasploitPostPage() {
-  return <MetasploitPost />;
+  return (
+    <Suspense
+      fallback={
+        <AppWindowSkeleton
+          title="Metasploit Post"
+          description="Replaying post-exploitation scripts"
+        />
+      }
+    >
+      <MetasploitPost />
+    </Suspense>
+  );
 }

--- a/pages/apps/metasploit.jsx
+++ b/pages/apps/metasploit.jsx
@@ -1,10 +1,23 @@
+import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
+import AppWindowSkeleton from '../../components/ui/AppWindowSkeleton';
 
 const Metasploit = dynamic(() => import('../../apps/metasploit'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  suspense: true,
 });
 
 export default function MetasploitPage() {
-  return <Metasploit />;
+  return (
+    <Suspense
+      fallback={
+        <AppWindowSkeleton
+          title="Metasploit"
+          description="Loading module catalog"
+        />
+      }
+    >
+      <Metasploit />
+    </Suspense>
+  );
 }

--- a/pages/apps/volatility.jsx
+++ b/pages/apps/volatility.jsx
@@ -1,10 +1,23 @@
+import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
+import AppWindowSkeleton from '../../components/ui/AppWindowSkeleton';
 
 const Volatility = dynamic(() => import('../../apps/volatility'), {
   ssr: false,
-  loading: () => <p>Loading...</p>,
+  suspense: true,
 });
 
 export default function VolatilityPage() {
-  return <Volatility />;
+  return (
+    <Suspense
+      fallback={
+        <AppWindowSkeleton
+          title="Volatility"
+          description="Analyzing memory snapshot"
+        />
+      }
+    >
+      <Volatility />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary
- add a reusable AppWindowSkeleton component and suspense fallbacks for heavy security tool pages
- expose the ghidra page through a dynamic import with the new skeleton loader
- update the flat ESLint config so the new JSX pages are linted

## Testing
- yarn lint
- CI=1 yarn analyze

------
https://chatgpt.com/codex/tasks/task_e_68da4839631c8328b28e68c8e30fd432