### PR TITLE
[ui] Improve viewer accessibility and shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ See `.env.local.example` for the full list.
 - Run `yarn lint` and `yarn test` before committing changes.
 - For manual smoke tests, start `yarn dev` and in another terminal run `yarn smoke` to visit every `/apps/*` route.
 
+## Keyboard Shortcuts
+
+The document viewer and media player surface inline help text and respond to the following shortcuts:
+
+- **PDF Viewer** – `Alt` + `ArrowLeft` moves to the previous page, `Alt` + `ArrowRight` advances to the next page, and `Alt` + `Enter` runs a document search.
+- **Video Player** – `Space` toggles play/pause, `ArrowLeft`/`ArrowRight` seek by five seconds, and `C` toggles captions when tracks are available.
+
 ---
 
 ## Speed Insights

--- a/__tests__/videoplayer.test.tsx
+++ b/__tests__/videoplayer.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import VideoPlayer from '../components/ui/VideoPlayer';
+
+describe('VideoPlayer', () => {
+  let playSpy: jest.SpyInstance;
+  let pauseSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    playSpy = jest
+      .spyOn(HTMLMediaElement.prototype, 'play')
+      .mockImplementation(async function play(this: HTMLMediaElement) {
+        return undefined;
+      });
+    pauseSpy = jest
+      .spyOn(HTMLMediaElement.prototype, 'pause')
+      .mockImplementation(function pause(this: HTMLMediaElement) {
+        return undefined;
+      });
+  });
+
+  afterEach(() => {
+    playSpy.mockClear();
+    pauseSpy.mockClear();
+  });
+
+  afterAll(() => {
+    playSpy.mockRestore();
+    pauseSpy.mockRestore();
+  });
+
+  it('exposes custom controls, shortcuts, and caption toggles', async () => {
+    const user = userEvent.setup();
+    render(<VideoPlayer src="/video.mp4" />);
+
+    const player = screen.getByRole('group', { name: /video player/i });
+    const video = screen.getByLabelText('Video') as HTMLVideoElement;
+
+    Object.defineProperty(video, 'duration', { value: 120, configurable: true });
+    const track = { mode: 'hidden' } as TextTrack;
+    const trackList = {
+      length: 1,
+      0: track,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    } as unknown as TextTrackList;
+    Object.defineProperty(video, 'textTracks', { value: trackList, configurable: true });
+
+    await act(async () => {
+      video.dispatchEvent(new Event('loadedmetadata'));
+    });
+
+    const playButton = screen.getByRole('button', { name: /play video/i });
+    await user.click(playButton);
+    expect(playSpy).toHaveBeenCalled();
+
+    await act(async () => {
+      Object.defineProperty(video, 'paused', { value: false, configurable: true });
+      video.dispatchEvent(new Event('play'));
+    });
+
+    expect(screen.getByRole('button', { name: /pause video/i })).toBeInTheDocument();
+
+    player.focus();
+    await user.keyboard(' ');
+    expect(pauseSpy).toHaveBeenCalled();
+
+    await act(async () => {
+      Object.defineProperty(video, 'paused', { value: true, configurable: true });
+      video.dispatchEvent(new Event('pause'));
+      video.currentTime = 10;
+      video.dispatchEvent(new Event('timeupdate'));
+    });
+
+    const seekForward = screen.getByRole('button', { name: /forward 5 seconds/i });
+    await user.click(seekForward);
+    expect(video.currentTime).toBeCloseTo(15, 5);
+
+    const ccButton = await screen.findByRole('button', { name: /show captions/i });
+    await user.click(ccButton);
+    expect(ccButton).toHaveAttribute('aria-pressed', 'true');
+    expect(track.mode).toBe('showing');
+
+    const timeline = screen.getByLabelText(/seek timeline/i) as HTMLInputElement;
+    expect(Number(timeline.value)).toBeGreaterThanOrEqual(0);
+    fireEvent.change(timeline, { target: { value: '20' } });
+    expect(video.currentTime).toBeCloseTo(20, 5);
+
+    expect(
+      screen.getByText(
+        /shortcuts: space toggles play, arrowleft\/arrowright seek 5 seconds, c toggles captions\./i,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/components/ui/VideoPlayer.tsx
+++ b/components/ui/VideoPlayer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import PipPortalProvider, { usePipPortal } from "../common/PipPortal";
 
 interface VideoPlayerProps {
@@ -15,10 +15,16 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
   className = "",
 }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const { open, close } = usePipPortal();
   const [pipSupported, setPipSupported] = useState(false);
   const [docPipSupported, setDocPipSupported] = useState(false);
   const [isPip, setIsPip] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [captionsAvailable, setCaptionsAvailable] = useState(false);
+  const [captionsEnabled, setCaptionsEnabled] = useState(false);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -43,6 +49,153 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
       video?.removeEventListener("ended", handleEnd);
     };
   }, [close]);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const updatePlayState = () => setIsPlaying(!video.paused);
+    const updateTime = () => setCurrentTime(video.currentTime || 0);
+    const updateDuration = () =>
+      setDuration(Number.isFinite(video.duration) ? video.duration : 0);
+    const updateCaptions = () => {
+      const tracks = video.textTracks;
+      const list = tracks
+        ? Array.from({ length: tracks.length }, (_, idx) => tracks[idx])
+        : [];
+      setCaptionsAvailable(list.length > 0);
+      setCaptionsEnabled(list.some((track) => track.mode === "showing"));
+    };
+
+    updatePlayState();
+    updateTime();
+    updateDuration();
+    updateCaptions();
+
+    const handleLoadedMetadata = () => {
+      updateDuration();
+      updateCaptions();
+    };
+
+    video.addEventListener("play", updatePlayState);
+    video.addEventListener("pause", updatePlayState);
+    video.addEventListener("timeupdate", updateTime);
+    video.addEventListener("loadedmetadata", handleLoadedMetadata);
+    video.addEventListener("durationchange", updateDuration);
+
+    const tracks = video.textTracks;
+    const handleTrackChange = () => updateCaptions();
+    if (tracks && typeof tracks.addEventListener === "function") {
+      tracks.addEventListener("change", handleTrackChange);
+    }
+
+    return () => {
+      video.removeEventListener("play", updatePlayState);
+      video.removeEventListener("pause", updatePlayState);
+      video.removeEventListener("timeupdate", updateTime);
+      video.removeEventListener("loadedmetadata", handleLoadedMetadata);
+      video.removeEventListener("durationchange", updateDuration);
+      if (tracks && typeof tracks.removeEventListener === "function") {
+        tracks.removeEventListener("change", handleTrackChange);
+      }
+    };
+  }, []);
+
+  const safeDuration = useMemo(() => {
+    if (Number.isFinite(duration) && duration > 0) return duration;
+    const video = videoRef.current;
+    if (video && Number.isFinite(video.duration) && video.duration > 0) {
+      return video.duration;
+    }
+    return currentTime > 0 ? currentTime : 0;
+  }, [currentTime, duration]);
+
+  const sliderMax = useMemo(
+    () => Math.max(safeDuration, currentTime, 1),
+    [currentTime, safeDuration],
+  );
+
+  const clampTime = useCallback(
+    (time: number) => {
+      const video = videoRef.current;
+      const fallbackMax = Math.max(safeDuration, currentTime, time, 0);
+      const max =
+        video && Number.isFinite(video.duration) && video.duration > 0
+          ? video.duration
+          : fallbackMax;
+      return Math.min(Math.max(time, 0), max);
+    },
+    [currentTime, safeDuration],
+  );
+
+  const togglePlay = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    if (video.paused) {
+      void video.play();
+    } else {
+      video.pause();
+    }
+  }, []);
+
+  const handleSeekRelative = useCallback(
+    (delta: number) => {
+      const video = videoRef.current;
+      if (!video) return;
+      const next = clampTime(video.currentTime + delta);
+      video.currentTime = next;
+      setCurrentTime(next);
+    },
+    [clampTime],
+  );
+
+  const handleSeekTo = useCallback(
+    (time: number) => {
+      const video = videoRef.current;
+      if (!video) return;
+      const next = clampTime(time);
+      video.currentTime = next;
+      setCurrentTime(next);
+    },
+    [clampTime],
+  );
+
+  const toggleCaptions = useCallback(() => {
+    const video = videoRef.current;
+    if (!video || !video.textTracks) return;
+    const shouldEnable = !captionsEnabled;
+    for (let i = 0; i < video.textTracks.length; i += 1) {
+      video.textTracks[i].mode = shouldEnable ? "showing" : "hidden";
+    }
+    setCaptionsEnabled(shouldEnable);
+  }, [captionsEnabled]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === " " || event.key === "Spacebar") {
+        event.preventDefault();
+        togglePlay();
+      } else if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        handleSeekRelative(-5);
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        handleSeekRelative(5);
+      } else if (event.key.toLowerCase() === "c") {
+        event.preventDefault();
+        toggleCaptions();
+      }
+    },
+    [handleSeekRelative, toggleCaptions, togglePlay],
+  );
+
+  const formatTime = useCallback((value: number) => {
+    if (!Number.isFinite(value) || value < 0) return "0:00";
+    const totalSeconds = Math.floor(value);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  }, []);
 
   const togglePiP = async () => {
     const video = videoRef.current;
@@ -79,18 +232,26 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
         case "volume":
           video.volume = Math.max(0, Math.min(1, Number(e.data.value)));
           break;
+        case "captions":
+          toggleCaptions();
+          break;
         default:
       }
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, []);
+  }, [toggleCaptions]);
 
   const openDocPip = async () => {
     if (!docPipSupported) return;
     const initialVolume = videoRef.current?.volume ?? 1;
-    const DocPipControls: React.FC<{ initialVolume: number }> = ({ initialVolume }) => {
+    const DocPipControls: React.FC<{
+      initialVolume: number;
+      initialCaptions: boolean;
+      captionsAvailable: boolean;
+    }> = ({ initialVolume, initialCaptions, captionsAvailable }) => {
       const [vol, setVol] = useState(initialVolume);
+      const [cc, setCc] = useState(initialCaptions);
       const send = (msg: any) =>
         window.opener?.postMessage({ source: "doc-pip", ...msg }, "*");
       return (
@@ -108,6 +269,16 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
           <button onClick={() => send({ type: "toggle" })}>Play/Pause</button>
           <button onClick={() => send({ type: "seek", delta: -5 })}>-5s</button>
           <button onClick={() => send({ type: "seek", delta: 5 })}>+5s</button>
+          {captionsAvailable ? (
+            <button
+              onClick={() => {
+                send({ type: "captions" });
+                setCc((prev) => !prev);
+              }}
+            >
+              {cc ? "Hide CC" : "Show CC"}
+            </button>
+          ) : null}
           <input
             type="range"
             min={0}
@@ -119,35 +290,120 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
               setVol(v);
               send({ type: "volume", value: v });
             }}
+            aria-label="Volume"
           />
         </div>
       );
     };
 
-    await open(<DocPipControls initialVolume={initialVolume} />);
+    await open(
+      <DocPipControls
+        initialVolume={initialVolume}
+        initialCaptions={captionsEnabled}
+        captionsAvailable={captionsAvailable}
+      />,
+    );
   };
 
   return (
-    <div className={`relative ${className}`.trim()}>
-      <video ref={videoRef} src={src} poster={poster} controls className="w-full h-auto" />
-      {pipSupported && (
-        <button
-          type="button"
-          onClick={togglePiP}
-          className="absolute bottom-2 right-2 rounded bg-black bg-opacity-50 px-2 py-1 text-xs text-white"
-        >
-          {isPip ? "Exit PiP" : "PiP"}
-        </button>
-      )}
-      {docPipSupported && (
-        <button
-          type="button"
-          onClick={openDocPip}
-          className="absolute bottom-2 right-16 rounded bg-black bg-opacity-50 px-2 py-1 text-xs text-white"
-        >
-          Doc-PiP
-        </button>
-      )}
+    <div
+      ref={containerRef}
+      className={`relative ${className}`.trim()}
+      tabIndex={0}
+      role="group"
+      aria-label="Video player"
+      onKeyDown={handleKeyDown}
+    >
+      <video
+        ref={videoRef}
+        src={src}
+        poster={poster}
+        className="w-full h-auto"
+        aria-label="Video"
+      />
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex flex-col gap-2 bg-gradient-to-t from-black/70 via-black/50 to-transparent p-3 text-xs text-white sm:text-sm">
+        <div className="pointer-events-auto flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={togglePlay}
+            className="rounded bg-white/20 px-2 py-1"
+            aria-label={isPlaying ? "Pause video (Space)" : "Play video (Space)"}
+            title="Space"
+          >
+            {isPlaying ? "Pause" : "Play"}
+          </button>
+          <button
+            type="button"
+            onClick={() => handleSeekRelative(-5)}
+            className="rounded bg-white/10 px-2 py-1"
+            aria-label="Rewind 5 seconds (ArrowLeft)"
+            title="ArrowLeft"
+          >
+            -5s
+          </button>
+          <button
+            type="button"
+            onClick={() => handleSeekRelative(5)}
+            className="rounded bg-white/10 px-2 py-1"
+            aria-label="Forward 5 seconds (ArrowRight)"
+            title="ArrowRight"
+          >
+            +5s
+          </button>
+          <div className="flex min-w-[140px] flex-1 items-center gap-2">
+            <input
+              type="range"
+              min={0}
+              max={sliderMax}
+              step={0.1}
+              value={Math.min(currentTime, sliderMax)}
+              onChange={(event) => handleSeekTo(Number(event.target.value))}
+              aria-label="Seek timeline"
+              aria-valuetext={`${formatTime(currentTime)} of ${formatTime(safeDuration)}`}
+              className="h-1 flex-1 accent-sky-400"
+            />
+            <span className="whitespace-nowrap">
+              {formatTime(currentTime)} / {formatTime(safeDuration)}
+            </span>
+          </div>
+          {captionsAvailable && (
+            <button
+              type="button"
+              onClick={toggleCaptions}
+              className="rounded bg-white/10 px-2 py-1"
+              aria-label={captionsEnabled ? "Hide captions (C)" : "Show captions (C)"}
+              aria-pressed={captionsEnabled}
+              title="C"
+            >
+              {captionsEnabled ? "Hide CC" : "Show CC"}
+            </button>
+          )}
+          {docPipSupported && (
+            <button
+              type="button"
+              onClick={openDocPip}
+              className="rounded bg-white/20 px-2 py-1"
+              aria-label="Open Doc Picture-in-Picture controls"
+              title="Open Doc-PiP"
+            >
+              Doc-PiP
+            </button>
+          )}
+          {pipSupported && (
+            <button
+              type="button"
+              onClick={togglePiP}
+              className="rounded bg-white/20 px-2 py-1"
+              aria-label={isPip ? "Exit Picture-in-Picture" : "Enter Picture-in-Picture"}
+            >
+              {isPip ? "Exit PiP" : "PiP"}
+            </button>
+          )}
+        </div>
+        <p className="pointer-events-auto text-[11px] text-white/70">
+          Shortcuts: Space toggles play, ArrowLeft/ArrowRight seek 5 seconds, C toggles captions.
+        </p>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add keyboard-accessible navigation, search status messaging, and shortcut hints to the PDF viewer
- replace the native video controls with custom keyboard-friendly transport controls, caption toggles, and Doc-PiP integration
- document the viewer shortcuts in the README and cover them with focused Jest tests

## Testing
- yarn lint
- yarn test --runTestsByPath __tests__/pdfviewer.test.tsx __tests__/videoplayer.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68da48378df48328834e2dda1c732e4a