### PR TITLE
[openvas] cache template data and add loading states

### DIFF
--- a/components/apps/openvas/data-loader.js
+++ b/components/apps/openvas/data-loader.js
@@ -1,0 +1,106 @@
+import { createStore, get, set } from 'idb-keyval';
+import { hasIndexedDB, isBrowser } from '../../../utils/isBrowser';
+
+const STORE_NAME = 'openvas-cache';
+const STORE_KEY = 'json';
+const LOCAL_PREFIX = 'openvas-cache:';
+
+const loaders = {
+  'template:PCI': () => import('./templates/pci.json'),
+  'template:HIPAA': () => import('./templates/hipaa.json'),
+  'history:runs': () => import('./task-history.json'),
+};
+
+let store = null;
+if (hasIndexedDB) {
+  try {
+    store = createStore(STORE_NAME, STORE_KEY);
+  } catch (err) {
+    console.warn('openvas cache store failed', err);
+  }
+}
+
+const schedule = (fn) => {
+  if (!isBrowser) {
+    fn();
+    return;
+  }
+  if (typeof window.requestIdleCallback === 'function') {
+    window.requestIdleCallback(() => fn());
+  } else {
+    setTimeout(fn, 0);
+  }
+};
+
+async function readFromCache(key) {
+  const namespaced = `${LOCAL_PREFIX}${key}`;
+  if (store) {
+    try {
+      const cached = await get(namespaced, store);
+      if (cached) return cached;
+    } catch (err) {
+      console.warn('openvas cache read failed', err);
+    }
+  }
+  if (isBrowser) {
+    try {
+      const raw = window.localStorage.getItem(namespaced);
+      if (raw) return JSON.parse(raw);
+    } catch (err) {
+      console.warn('openvas localStorage read failed', err);
+    }
+  }
+  return null;
+}
+
+function writeToCache(key, value) {
+  const namespaced = `${LOCAL_PREFIX}${key}`;
+  schedule(() => {
+    if (store) {
+      set(namespaced, value, store).catch((err) => {
+        console.warn('openvas cache write failed', err);
+      });
+      return;
+    }
+    if (isBrowser) {
+      try {
+        window.localStorage.setItem(namespaced, JSON.stringify(value));
+      } catch (err) {
+        console.warn('openvas localStorage write failed', err);
+      }
+    }
+  });
+}
+
+async function loadData(key) {
+  const loader = loaders[key];
+  if (!loader) throw new Error(`No loader registered for ${key}`);
+
+  if (!isBrowser) {
+    const mod = await loader();
+    return mod.default ?? null;
+  }
+
+  const cached = await readFromCache(key);
+  if (cached) return cached;
+
+  const mod = await loader();
+  const data = mod.default ?? null;
+  if (data) writeToCache(key, data);
+  return data;
+}
+
+export function loadTemplate(profile) {
+  return loadData(`template:${profile}`);
+}
+
+export function loadTaskHistory() {
+  return loadData('history:runs');
+}
+
+export function preloadTemplates(ids = []) {
+  if (!isBrowser) return;
+  ids.forEach((id) => {
+    loadTemplate(id).catch(() => {});
+  });
+}

--- a/components/apps/openvas/policy-settings.js
+++ b/components/apps/openvas/policy-settings.js
@@ -1,13 +1,22 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-const PolicySettings = ({ policy }) => {
-  const defaultConfig = {
-    name: 'Full and Fast',
-    portList: 'OpenVAS Default',
-    maxHosts: '10 concurrent hosts',
-    qod: '70% minimum',
-  };
-  const [config, setConfig] = useState(policy || defaultConfig);
+const DEFAULT_CONFIG = {
+  name: 'Full and Fast',
+  portList: 'OpenVAS Default',
+  maxHosts: '10 concurrent hosts',
+  qod: '70% minimum',
+};
+
+const PolicySettings = ({ policy, loading = false, error = null }) => {
+  const [config, setConfig] = useState(policy || DEFAULT_CONFIG);
+
+  useEffect(() => {
+    if (policy) {
+      setConfig(policy);
+    } else if (!loading) {
+      setConfig(DEFAULT_CONFIG);
+    }
+  }, [policy, loading]);
 
   const handleChange = (field) => (e) =>
     setConfig({ ...config, [field]: e.target.value });
@@ -24,8 +33,30 @@ const PolicySettings = ({ policy }) => {
     }
   };
 
+  if (loading && !policy) {
+    return (
+      <div className="p-4 bg-gray-800 rounded mb-4 animate-pulse" aria-busy="true">
+        <div className="h-4 bg-gray-700 rounded w-32 mb-3" />
+        <div className="space-y-2">
+          {[0, 1, 2, 3].map((idx) => (
+            <div key={idx} className="h-3 bg-gray-700 rounded" />
+          ))}
+        </div>
+        <div className="mt-4 space-y-2">
+          {[0, 1, 2, 3].map((idx) => (
+            <div key={idx} className="h-8 bg-gray-700 rounded" />
+          ))}
+        </div>
+        <span className="sr-only">Loading policy settings…</span>
+      </div>
+    );
+  }
+
   return (
-    <div className="p-4 bg-gray-800 rounded mb-4">
+    <div
+      className={`p-4 bg-gray-800 rounded mb-4 ${loading ? 'opacity-90' : ''}`}
+      aria-busy={loading}
+    >
       <h3 className="text-md font-bold mb-2">Policy Settings</h3>
       <ul className="text-sm space-y-1">
         <li>
@@ -98,6 +129,11 @@ const PolicySettings = ({ policy }) => {
       <p className="text-xs text-gray-400 mt-2">
         Sample configuration shown for demo purposes.
       </p>
+      {error && (
+        <p className="text-xs text-red-400 mt-2" role="status">
+          Failed to load profile: {error.message || 'Unknown error'}
+        </p>
+      )}
     </div>
   );
 };

--- a/components/apps/openvas/task-run-chart.js
+++ b/components/apps/openvas/task-run-chart.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import history from './task-history.json';
+import React, { useEffect, useMemo, useState } from 'react';
+import { loadTaskHistory } from './data-loader';
 
 const statuses = ['Queued', 'Running', 'Completed'];
 const colors = {
@@ -9,50 +9,98 @@ const colors = {
 };
 
 const TaskRunChart = () => {
-  const height = 40;
-  const width = history.length * 20 + 20;
-  const points = history
-    .map((d, i) => {
-      const x = i * 20 + 10;
-      const y =
-        height - (statuses.indexOf(d.status) / (statuses.length - 1)) * height;
-      return `${x},${y}`;
-    })
-    .join(' ');
+  const [history, setHistory] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    loadTaskHistory()
+      .then((data) => {
+        if (cancelled) return;
+        setHistory(Array.isArray(data) ? data : []);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setHistory([]);
+        setError(err);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const chart = useMemo(() => {
+    const height = 40;
+    const width = history.length * 20 + 20;
+    const points = history
+      .map((d, i) => {
+        const x = i * 20 + 10;
+        const y =
+          height - (statuses.indexOf(d.status) / (statuses.length - 1)) * height;
+        return `${x},${y}`;
+      })
+      .join(' ');
+    return { height, width, points };
+  }, [history]);
+
+  if (loading && history.length === 0) {
+    return (
+      <div className="w-full h-24 mb-2">
+        <div className="w-full h-full rounded bg-gray-700/70 animate-pulse" />
+        <span className="sr-only">Loading task run history…</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="text-xs text-red-400" role="status">
+        Failed to load task run history.
+      </p>
+    );
+  }
+
   return (
     <svg
-      viewBox={`0 0 ${width} ${height + 10}`}
+      viewBox={`0 0 ${chart.width || 100} ${(chart.height || 40) + 10}`}
       className="w-full h-24 mb-2"
       role="img"
       aria-label="Task runs and status changes over time"
     >
       {statuses.map((s, idx) => {
-        const y = height - (idx / (statuses.length - 1)) * height;
+        const y = (chart.height || 40) - (idx / (statuses.length - 1)) * (chart.height || 40);
         return (
           <g key={s}>
             <line
               x1="0"
               y1={y}
-              x2={width}
+              x2={chart.width || 100}
               y2={y}
               className="stroke-gray-600"
               strokeWidth="0.5"
             />
-            <text
-              x="0"
-              y={y - 1}
-              className="fill-white text-[8px]"
-            >
+            <text x="0" y={y - 1} className="fill-white text-[8px]">
               {s}
             </text>
           </g>
         );
       })}
-      <polyline points={points} fill="none" stroke="white" strokeWidth="1" />
+      <polyline
+        points={chart.points}
+        fill="none"
+        stroke="white"
+        strokeWidth="1"
+      />
       {history.map((d, i) => {
         const x = i * 20 + 10;
         const y =
-          height - (statuses.indexOf(d.status) / (statuses.length - 1)) * height;
+          (chart.height || 40) -
+          (statuses.indexOf(d.status) / (statuses.length - 1)) * (chart.height || 40);
         return <circle key={d.time} cx={x} cy={y} r="2" className={colors[d.status]} />;
       })}
     </svg>


### PR DESCRIPTION
## Summary
- add a shared OpenVAS data loader that dynamically imports JSON and caches it via IndexedDB/localStorage
- load scan policy templates on demand with skeleton/error states and prefetch profiles
- async-load task history for the dashboard with loading and failure fallbacks

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da483cc14483288a306609fbedf15c