### PR TITLE
[pwa] Improve offline shell caching and status UI

### DIFF
--- a/__tests__/installButton.test.tsx
+++ b/__tests__/installButton.test.tsx
@@ -7,7 +7,7 @@ describe('InstallButton', () => {
   test('shows install prompt when beforeinstallprompt fires', async () => {
     render(<InstallButton />);
     initA2HS();
-    expect(screen.queryByText(/install/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /install/i })).toBeNull();
 
     let resolveChoice: (value: any) => void = () => {};
     const userChoice = new Promise((resolve) => {
@@ -27,7 +27,7 @@ describe('InstallButton', () => {
     // The install prompt shouldn't trigger automatically.
     expect(prompt).not.toHaveBeenCalled();
 
-    const button = await screen.findByText(/install/i);
+    const button = await screen.findByRole('button', { name: /install/i });
     await userEvent.click(button);
     expect(prompt).toHaveBeenCalledTimes(1);
 
@@ -36,7 +36,9 @@ describe('InstallButton', () => {
       await userChoice;
     });
 
-    await waitFor(() => expect(screen.queryByText(/install/i)).toBeNull());
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /install/i })).toBeNull(),
+    );
   });
 
   test('can be focused via keyboard', async () => {

--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -1,35 +1,100 @@
 "use client";
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { trackEvent } from '@/lib/analytics-client';
 import { showA2HS } from '@/src/pwa/a2hs';
+import {
+  readStoredStatus,
+  subscribeToStatus,
+  STATUS_DEFAULT_MESSAGES,
+  type PwaStatus,
+} from '@/src/pwa/status';
 
 const InstallButton: React.FC = () => {
-  const [visible, setVisible] = useState(false);
+  const initialStatus = useMemo<PwaStatus | null>(() => readStoredStatus(), []);
+  const [message, setMessage] = useState<string>(
+    initialStatus ? initialStatus.message || STATUS_DEFAULT_MESSAGES[initialStatus.type] : '',
+  );
+  const [installVisible, setInstallVisible] = useState<boolean>(initialStatus?.action === 'install');
+  const [updateVisible, setUpdateVisible] = useState<boolean>(initialStatus?.action === 'reload');
 
   useEffect(() => {
-    const handler = () => setVisible(true);
+    const applyStatus = (incoming: PwaStatus) => {
+      const nextMessage = incoming.message || STATUS_DEFAULT_MESSAGES[incoming.type] || '';
+      setMessage(nextMessage);
+      setInstallVisible(incoming.action === 'install');
+      setUpdateVisible(incoming.action === 'reload');
+    };
+
+    const unsubscribe = subscribeToStatus(applyStatus);
+
+    const handler = () =>
+      applyStatus({
+        type: 'install-ready',
+        action: 'install',
+        message: STATUS_DEFAULT_MESSAGES['install-ready'],
+      });
+
     (window as any).addEventListener('a2hs:available', handler);
-    return () => (window as any).removeEventListener('a2hs:available', handler);
+
+    return () => {
+      if (typeof unsubscribe === 'function') {
+        unsubscribe();
+      }
+      (window as any).removeEventListener('a2hs:available', handler);
+    };
   }, []);
 
   const handleInstall = async () => {
     const shown = await showA2HS();
     if (shown) {
       trackEvent('cta_click', { location: 'install_button' });
-      setVisible(false);
+      setInstallVisible(false);
+      setMessage('Follow the browser prompt to finish installing.');
     }
   };
 
-  if (!visible) return null;
+  const handleReload = () => {
+    if (typeof window === 'undefined') return;
+    if (typeof (window as any).manualRefresh === 'function') {
+      (window as any).manualRefresh();
+    } else {
+      window.location.reload();
+    }
+  };
+
+  if (!installVisible && !updateVisible && !message) return null;
 
   return (
-    <button
-      onClick={handleInstall}
-      className="fixed bottom-4 right-4 bg-ubt-blue text-white px-3 py-1 rounded"
-    >
-      Install
-    </button>
+    <div className="fixed bottom-4 right-4 z-50 flex max-w-xs flex-col gap-2 text-sm text-white">
+      {message && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="rounded border border-white/10 bg-slate-900/90 px-3 py-2 shadow-lg backdrop-blur"
+        >
+          {message}
+        </div>
+      )}
+      {installVisible && (
+        <button
+          onClick={handleInstall}
+          className="rounded bg-ubt-blue px-3 py-1 font-medium text-white shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          type="button"
+        >
+          Install
+        </button>
+      )}
+      {updateVisible && (
+        <button
+          onClick={handleReload}
+          className="rounded bg-ubb-orange px-3 py-1 font-medium text-slate-950 shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          type="button"
+        >
+          Reload to update
+        </button>
+      )}
+    </div>
   );
 };
 

--- a/next.config.js
+++ b/next.config.js
@@ -147,20 +147,41 @@ const withPWA = withPWAInit({
   disable: process.env.NODE_ENV === 'development',
   buildExcludes: [/dynamic-css-manifest\.json$/],
   workboxOptions: {
-    navigateFallback: '/offline.html',
-    additionalManifestEntries: [
-      { url: '/', revision: null },
-      { url: '/feeds', revision: null },
-      { url: '/about', revision: null },
-      { url: '/projects', revision: null },
-      { url: '/projects.json', revision: null },
-      { url: '/apps', revision: null },
-      { url: '/apps/weather', revision: null },
-      { url: '/apps/terminal', revision: null },
-      { url: '/apps/checkers', revision: null },
-      { url: '/offline.html', revision: null },
-      { url: '/manifest.webmanifest', revision: null },
-    ],
+    navigateFallback: (() => {
+      if (normalizedBasePath === '/') return '/offline.html';
+      return `${normalizedBasePath}/offline.html`;
+    })(),
+    additionalManifestEntries: (() => {
+      const applyBasePath = (path) => {
+        if (!path) return path;
+        if (normalizedBasePath === '/' || path.startsWith('http')) return path;
+        if (path === '/') return normalizedBasePath;
+        return `${normalizedBasePath}${path.startsWith('/') ? path : `/${path}`}`;
+      };
+
+      const essentialPaths = [
+        '/',
+        '/feeds',
+        '/about',
+        '/projects',
+        '/projects.json',
+        '/apps',
+        '/apps/weather',
+        '/apps/terminal',
+        '/apps/checkers',
+        '/offline.html',
+        '/offline.css',
+        '/offline.js',
+        '/manifest.webmanifest',
+        '/favicon.ico',
+        '/favicon.svg',
+        '/images/logos/fevicon.png',
+        '/images/logos/logo_1024.png',
+      ];
+
+      const unique = Array.from(new Set(essentialPaths));
+      return unique.map((path) => ({ url: applyBasePath(path), revision: null }));
+    })(),
     runtimeCaching,
     ...(workboxCacheId && { cacheId: workboxCacheId }),
   },

--- a/public/offline.css
+++ b/public/offline.css
@@ -1,2 +1,112 @@
-body { font-family: sans-serif; padding: 2rem; text-align: center; }
-ul { list-style: none; padding: 0; }
+body {
+  font-family: 'Ubuntu', sans-serif;
+  background: radial-gradient(circle at top, #1f2933, #0b0f14);
+  color: #f8fafc;
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+main {
+  max-width: 480px;
+  width: 100%;
+  background: rgba(15, 19, 23, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.5);
+  text-align: left;
+}
+
+h1 {
+  margin-top: 0;
+  font-size: 1.75rem;
+}
+
+p {
+  line-height: 1.5;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  border-radius: 9999px;
+  padding: 0.75rem 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:focus-visible {
+  outline: 2px solid #e2e8f0;
+  outline-offset: 2px;
+}
+
+button:active {
+  transform: scale(0.97);
+}
+
+button.primary {
+  background: #2563eb;
+  color: #f8fafc;
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.35);
+}
+
+button.accent {
+  background: #f97316;
+  color: #0b0f14;
+  box-shadow: 0 10px 30px rgba(249, 115, 22, 0.35);
+}
+
+button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.status-card {
+  margin: 1.5rem 0;
+  padding: 1.25rem;
+  border-radius: 12px;
+  background: rgba(51, 65, 85, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.status-title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.1rem;
+}
+
+.status-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+section h2 {
+  margin-top: 2rem;
+  font-size: 1.25rem;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+li {
+  margin-bottom: 0.5rem;
+}
+
+a {
+  color: #93c5fd;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}

--- a/public/offline.html
+++ b/public/offline.html
@@ -10,7 +10,19 @@
   <main>
     <h1>Offline</h1>
     <p>You appear to be offline. Please check your connection.</p>
-    <button id="retry">Retry</button>
+    <section id="pwa-status" class="status-card" hidden aria-live="polite">
+      <h2 class="status-title">Install &amp; Update Status</h2>
+      <p id="pwa-status-message"></p>
+      <div class="status-actions">
+        <button id="pwa-install" type="button" class="primary" hidden disabled>
+          Install when back online
+        </button>
+        <button id="pwa-reload" type="button" class="accent" hidden>
+          Reload to update
+        </button>
+      </div>
+    </section>
+    <button id="retry" class="primary">Retry</button>
     <section>
       <h2>Cached Apps</h2>
       <ul id="apps"></ul>

--- a/public/offline.js
+++ b/public/offline.js
@@ -1,6 +1,106 @@
 /* eslint-disable no-top-level-window/no-top-level-window-or-document */
-document.getElementById('retry').addEventListener('click', () => {
+const STATUS_STORAGE_KEY = 'pwa:lastStatus';
+const STATUS_CHANNEL = 'pwa-status';
+
+const retryButton = document.getElementById('retry');
+const statusCard = document.getElementById('pwa-status');
+const statusMessage = document.getElementById('pwa-status-message');
+const installButton = document.getElementById('pwa-install');
+const reloadButton = document.getElementById('pwa-reload');
+
+const DEFAULT_MESSAGES = {
+  'install-ready': 'Install this app to unlock offline access.',
+  installed: 'App installed. You can launch it from your home screen.',
+  'update-ready': 'An update is ready. Reload to apply it.',
+  updated: 'You are running the latest version.',
+};
+
+const parseStatus = (value) => {
+  if (!value) return null;
+  try {
+    const parsed = typeof value === 'string' ? JSON.parse(value) : value;
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (typeof parsed.type !== 'string') return null;
+    if (!(parsed.type in DEFAULT_MESSAGES)) return null;
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to parse stored status', error);
+    return null;
+  }
+};
+
+const updateStatusUI = (status) => {
+  const message = status?.message || DEFAULT_MESSAGES[status?.type];
+  if (message) {
+    statusCard.hidden = false;
+    statusMessage.textContent = message;
+  } else {
+    statusCard.hidden = true;
+    statusMessage.textContent = '';
+  }
+
+  const action = status?.action;
+  const shouldShowInstall = action === 'install';
+  const shouldShowReload = action === 'reload';
+
+  installButton.hidden = !shouldShowInstall;
+  installButton.disabled = !navigator.onLine;
+  reloadButton.hidden = !shouldShowReload;
+
+  retryButton.hidden = shouldShowReload;
+};
+
+const readStatus = () => {
+  try {
+    const stored = window.localStorage?.getItem(STATUS_STORAGE_KEY);
+    return parseStatus(stored);
+  } catch (error) {
+    console.warn('Unable to read stored PWA status', error);
+    return null;
+  }
+};
+
+const applyStoredStatus = () => {
+  const status = readStatus();
+  updateStatusUI(status);
+};
+
+retryButton.addEventListener('click', () => {
   window.location.reload();
+});
+
+installButton.addEventListener('click', () => {
+  window.location.href = '/';
+});
+
+reloadButton.addEventListener('click', () => {
+  window.location.reload();
+});
+
+applyStoredStatus();
+
+try {
+  if ('BroadcastChannel' in window) {
+    const channel = new BroadcastChannel(STATUS_CHANNEL);
+    const listener = (event) => {
+      const status = parseStatus(event?.data);
+      if (status) updateStatusUI(status);
+    };
+    channel.addEventListener('message', listener);
+    window.addEventListener('pagehide', () => {
+      channel.removeEventListener('message', listener);
+      channel.close();
+    });
+  }
+} catch (error) {
+  console.warn('Broadcast channel unavailable for offline status sync', error);
+}
+
+window.addEventListener('storage', (event) => {
+  if (event.key === STATUS_STORAGE_KEY) {
+    const status = parseStatus(event.newValue);
+    if (status) updateStatusUI(status);
+  }
 });
 
 (async () => {

--- a/src/pwa/a2hs.ts
+++ b/src/pwa/a2hs.ts
@@ -6,6 +6,19 @@ interface BeforeInstallPromptEvent extends Event {
 
 let deferredPrompt: BeforeInstallPromptEvent | null = null;
 
+async function announceInstallReady() {
+  try {
+    const { broadcastStatus, STATUS_DEFAULT_MESSAGES } = await import('./status');
+    broadcastStatus({
+      type: 'install-ready',
+      action: 'install',
+      message: STATUS_DEFAULT_MESSAGES['install-ready'],
+    });
+  } catch (error) {
+    console.warn('Failed to announce install availability', error);
+  }
+}
+
 export function initA2HS() {
   if (typeof window === 'undefined') return;
   window.addEventListener('beforeinstallprompt', (e: Event) => {
@@ -13,6 +26,7 @@ export function initA2HS() {
     event.preventDefault();
     deferredPrompt = event;
     window.dispatchEvent(new Event('a2hs:available'));
+    announceInstallReady();
   });
 }
 

--- a/src/pwa/status.ts
+++ b/src/pwa/status.ts
@@ -1,0 +1,119 @@
+export type PwaAction = 'install' | 'reload';
+
+export type PwaStatus = {
+  type: 'install-ready' | 'installed' | 'update-ready' | 'updated';
+  message?: string;
+  action?: PwaAction;
+  timestamp?: number;
+};
+
+const STATUS_EVENT = 'pwa:status';
+const STATUS_STORAGE_KEY = 'pwa:lastStatus';
+const STATUS_CHANNEL = 'pwa-status';
+
+function isPwaStatus(value: unknown): value is PwaStatus {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.type !== 'string') return false;
+  return (
+    candidate.type === 'install-ready' ||
+    candidate.type === 'installed' ||
+    candidate.type === 'update-ready' ||
+    candidate.type === 'updated'
+  );
+}
+
+function withTimestamp(status: PwaStatus): PwaStatus {
+  return { ...status, timestamp: Date.now() };
+}
+
+export function broadcastStatus(status: PwaStatus) {
+  if (typeof window === 'undefined') return;
+  const payload = withTimestamp(status);
+  try {
+    window.dispatchEvent(new CustomEvent(STATUS_EVENT, { detail: payload }));
+  } catch (err) {
+    console.warn('Failed to dispatch PWA status event', err);
+  }
+
+  try {
+    window.localStorage?.setItem(STATUS_STORAGE_KEY, JSON.stringify(payload));
+  } catch (err) {
+    console.warn('Failed to persist PWA status', err);
+  }
+
+  try {
+    if ('BroadcastChannel' in window) {
+      const channel = new BroadcastChannel(STATUS_CHANNEL);
+      channel.postMessage(payload);
+      channel.close();
+    }
+  } catch (err) {
+    console.warn('Failed to broadcast PWA status', err);
+  }
+}
+
+export function readStoredStatus(): PwaStatus | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage?.getItem(STATUS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return isPwaStatus(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function subscribeToStatus(callback: (status: PwaStatus) => void) {
+  if (typeof window === 'undefined') return () => {};
+
+  const handler = (event: Event) => {
+    const detail = (event as CustomEvent)?.detail;
+    if (isPwaStatus(detail)) {
+      callback(detail);
+    }
+  };
+
+  window.addEventListener(STATUS_EVENT, handler);
+
+  let channel: BroadcastChannel | null = null;
+  let channelHandler: ((event: MessageEvent) => void) | null = null;
+
+  if ('BroadcastChannel' in window) {
+    try {
+      channel = new BroadcastChannel(STATUS_CHANNEL);
+      channelHandler = (event: MessageEvent) => {
+        if (isPwaStatus(event.data)) {
+          callback(event.data);
+        }
+      };
+      channel.addEventListener('message', channelHandler);
+    } catch (err) {
+      console.warn('Failed to subscribe to PWA status channel', err);
+      channel = null;
+      channelHandler = null;
+    }
+  }
+
+  return () => {
+    window.removeEventListener(STATUS_EVENT, handler);
+    if (channel && channelHandler) {
+      channel.removeEventListener('message', channelHandler);
+      channel.close();
+    } else if (channel) {
+      channel.close();
+    }
+  };
+}
+
+export const STATUS_DEFAULT_MESSAGES: Record<PwaStatus['type'], string> = {
+  'install-ready': 'Install this app to unlock offline access.',
+  installed: 'App installed. You can launch it from your home screen.',
+  'update-ready': 'An update is ready. Reload to apply the latest changes.',
+  updated: 'You are now running the latest version of the desktop.',
+};
+
+export const STATUS_STORAGE_KEY_NAME = STATUS_STORAGE_KEY;
+export const STATUS_CHANNEL_NAME = STATUS_CHANNEL;
+export const STATUS_EVENT_NAME = STATUS_EVENT;

--- a/tests/offline.spec.ts
+++ b/tests/offline.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect, Page } from '@playwright/test';
+
+const waitForServiceWorker = async (page: Page) => {
+  await page.waitForFunction(() => {
+    if (!('serviceWorker' in navigator)) {
+      return true;
+    }
+    return navigator.serviceWorker.ready.then(() => true);
+  });
+};
+
+test.describe('offline desktop shell', () => {
+  test('boots the desktop UI when offline', async ({ page, context }) => {
+    await page.goto('/');
+    await page.waitForSelector('#status-bar', { timeout: 60000 });
+    await expect(page.locator('#status-bar')).toBeVisible();
+
+    await waitForServiceWorker(page);
+    await page.waitForTimeout(1000);
+
+    await context.setOffline(true);
+
+    try {
+      await page.reload();
+      await page.waitForSelector('#status-bar', { timeout: 60000 });
+      await expect(page.locator('#status-bar')).toBeVisible();
+      await expect(page.locator('text=Offline')).toHaveCount(0);
+    } finally {
+      await context.setOffline(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- expand the Workbox configuration to precache core routes, offline assets, and icons while broadcasting install/update status events
- surface install and update messaging in the InstallButton component and the offline fallback page via a shared status channel
- add a Playwright offline integration test to ensure the desktop shell still boots without network access

## Testing
- yarn test installButton
- yarn lint *(fails: ESLint ignores pages/_app.jsx because no matching configuration was supplied)*
- npx playwright test tests/offline.spec.ts *(fails: Playwright browsers not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da4840f4b083288be18ef3052b252b