### PR TITLE
[games] Improve mobile control overlays

### DIFF
--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -6,6 +6,7 @@ import React, {
   useCallback,
   createContext,
   useContext,
+  type CSSProperties,
 } from 'react';
 import HelpOverlay from './HelpOverlay';
 import PerfOverlay from './Games/common/perf';
@@ -42,6 +43,13 @@ const RecorderContext = createContext<RecorderContextValue>({
 });
 
 export const useInputRecorder = () => useContext(RecorderContext);
+
+const overlaySafeAreaStyles: CSSProperties = {
+  paddingTop: 'max(env(safe-area-inset-top, 0px), 12px)',
+  paddingRight: 'max(env(safe-area-inset-right, 0px), 12px)',
+  paddingBottom: 'max(env(safe-area-inset-bottom, 0px), 16px)',
+  paddingLeft: 'max(env(safe-area-inset-left, 0px), 12px)',
+};
 
 const GameLayout: React.FC<GameLayoutProps> = ({
   gameId = 'unknown',
@@ -208,6 +216,11 @@ const GameLayout: React.FC<GameLayoutProps> = ({
   const resume = useCallback(() => setPaused(false), []);
 
   const contextValue = { record, registerReplay };
+  const hasHudMetrics =
+    stage !== undefined ||
+    lives !== undefined ||
+    score !== undefined ||
+    highScore !== undefined;
 
   return (
     <RecorderContext.Provider value={contextValue}>
@@ -229,65 +242,82 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           </button>
         </div>
       )}
-      <div className="absolute top-2 right-2 z-40 flex space-x-2">
-        <button
-          type="button"
-          onClick={() => setPaused((p) => !p)}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+        <div
+          className="pointer-events-none absolute inset-0 z-40 flex flex-col"
+          style={overlaySafeAreaStyles}
         >
-          {paused ? 'Resume' : 'Pause'}
-        </button>
-        <button
-          type="button"
-          onClick={snapshot}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
-        >
-          Snapshot
-        </button>
-        <button
-          type="button"
-          onClick={replay}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
-        >
-          Replay
-        </button>
-        <button
-          type="button"
-          onClick={shareApp}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
-        >
-          Share
-        </button>
-        {highScore !== undefined && (
-          <button
-            type="button"
-            onClick={shareScore}
-            className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
-          >
-            Share Score
-          </button>
-        )}
-        <button
-          type="button"
-          aria-label="Help"
-          aria-expanded={showHelp}
-          onClick={toggle}
-          className="bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
-        >
-          ?
-        </button>
-      </div>
-      {children}
-      <div className="absolute top-2 left-2 z-10 text-sm space-y-1">
-        {stage !== undefined && <div>Stage: {stage}</div>}
-        {lives !== undefined && <div>Lives: {lives}</div>}
-        {score !== undefined && <div>Score: {score}</div>}
-        {highScore !== undefined && <div>High: {highScore}</div>}
-      </div>
-      {!prefersReducedMotion && <PerfOverlay />}
-      {editor && (
-        <div className="absolute bottom-2 left-2 z-30">{editor}</div>
-      )}
+          <div className="flex w-full flex-wrap items-start gap-3">
+            {hasHudMetrics && (
+              <div className="pointer-events-auto rounded-md bg-black/50 px-3 py-2 text-xs text-white shadow-lg backdrop-blur">
+                {stage !== undefined && <div className="leading-tight">Stage: {stage}</div>}
+                {lives !== undefined && <div className="leading-tight">Lives: {lives}</div>}
+                {score !== undefined && <div className="leading-tight">Score: {score}</div>}
+                {highScore !== undefined && <div className="leading-tight">High: {highScore}</div>}
+              </div>
+            )}
+            <div
+              className={`pointer-events-auto flex max-w-full flex-wrap gap-2 text-xs sm:text-sm ${
+                hasHudMetrics ? 'ml-auto justify-end' : 'ml-auto'
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => setPaused((p) => !p)}
+                className="rounded-full bg-gray-700 px-3 py-2 text-white shadow focus:outline-none focus:ring"
+              >
+                {paused ? 'Resume' : 'Pause'}
+              </button>
+              <button
+                type="button"
+                onClick={snapshot}
+                className="rounded-full bg-gray-700 px-3 py-2 text-white shadow focus:outline-none focus:ring"
+              >
+                Snapshot
+              </button>
+              <button
+                type="button"
+                onClick={replay}
+                className="rounded-full bg-gray-700 px-3 py-2 text-white shadow focus:outline-none focus:ring"
+              >
+                Replay
+              </button>
+              <button
+                type="button"
+                onClick={shareApp}
+                className="rounded-full bg-gray-700 px-3 py-2 text-white shadow focus:outline-none focus:ring"
+              >
+                Share
+              </button>
+              {highScore !== undefined && (
+                <button
+                  type="button"
+                  onClick={shareScore}
+                  className="rounded-full bg-gray-700 px-3 py-2 text-white shadow focus:outline-none focus:ring"
+                >
+                  Share Score
+                </button>
+              )}
+              <button
+                type="button"
+                aria-label="Help"
+                aria-expanded={showHelp}
+                onClick={toggle}
+                className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-700 text-white shadow focus:outline-none focus:ring"
+              >
+                ?
+              </button>
+            </div>
+          </div>
+          <div className="mt-auto flex w-full justify-between gap-3">
+            {editor && (
+              <div className="pointer-events-auto rounded-md bg-black/50 p-2 text-white shadow-lg backdrop-blur">
+                {editor}
+              </div>
+            )}
+          </div>
+        </div>
+        {children}
+        {!prefersReducedMotion && <PerfOverlay />}
       </div>
     </RecorderContext.Provider>
   );

--- a/components/games/VirtualControls.jsx
+++ b/components/games/VirtualControls.jsx
@@ -1,14 +1,89 @@
 "use client";
 
-import React from 'react';
+import React, { Children, isValidElement, useMemo } from 'react';
 import useGameInput from '../../hooks/useGameInput';
 
+const safeAreaPadding = {
+  paddingTop: 'max(env(safe-area-inset-top, 0px), 12px)',
+  paddingRight: 'max(env(safe-area-inset-right, 0px), 12px)',
+  paddingBottom: 'max(env(safe-area-inset-bottom, 0px), 20px)',
+  paddingLeft: 'max(env(safe-area-inset-left, 0px), 12px)',
+};
+
+const POSITION_PROP_NAMES = ['data-position', 'data-control-position', 'position'];
+
+const resolvePosition = (child) => {
+  if (!isValidElement(child)) return 'center';
+  for (const propName of POSITION_PROP_NAMES) {
+    const value = child.props?.[propName];
+    if (typeof value === 'string') {
+      const normalized = value.toLowerCase();
+      if (['left', 'right', 'center'].includes(normalized)) {
+        return normalized;
+      }
+    }
+  }
+  return 'center';
+};
+
+const groupControls = (children) => {
+  const groups = { left: [], right: [], center: [] };
+  Children.toArray(children)
+    .filter((child) => child !== null && child !== undefined && child !== false)
+    .forEach((child) => {
+      const position = resolvePosition(child);
+      groups[position].push(child);
+    });
+  return groups;
+};
+
 /**
- * Renders a container for virtual on-screen controls. By default it does not
- * render any controls but exposes a slot for custom controls. It registers the
- * game input hook so keyboard users can still interact without touch/gamepad.
+ * Renders a container for virtual on-screen controls. It spaces controls to
+ * the lower corners of the viewport, respects device safe areas and keeps
+ * touch targets within reach on mobile screens. Controls can opt-into the
+ * left, right or center stacks using a `data-position` attribute.
  */
 export default function VirtualControls({ children, game }) {
   useGameInput({ game });
-  return <div className="virtual-controls">{children}</div>;
+
+  const groupedControls = useMemo(() => groupControls(children), [children]);
+
+  return (
+    <div className="virtual-controls pointer-events-none absolute inset-0">
+      <div
+        className="flex h-full w-full flex-col justify-end"
+        style={safeAreaPadding}
+      >
+        <div className="flex w-full flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          {groupedControls.left.length > 0 && (
+            <div className="flex flex-col gap-3 pointer-events-auto sm:max-w-[45%]">
+              {groupedControls.left.map((control, index) => (
+                <div key={index} className="flex justify-start">
+                  {control}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {groupedControls.center.length > 0 && (
+            <div className="mt-4 flex w-full justify-center gap-3 pointer-events-auto sm:mt-0 sm:w-auto">
+              {groupedControls.center.map((control, index) => (
+                <div key={index}>{control}</div>
+              ))}
+            </div>
+          )}
+
+          {groupedControls.right.length > 0 && (
+            <div className="flex flex-col gap-3 pointer-events-auto sm:max-w-[45%]">
+              {groupedControls.right.map((control, index) => (
+                <div key={index} className="flex justify-end">
+                  {control}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add responsive safe-area spacing for virtual touch controls so they stay thumb-friendly across viewports
- update game layout overlays to respect safe areas, wrap on narrow screens, and provide pill-shaped action buttons

## Testing
- [x] yarn test --watch=false *(fails in unrelated suites that access window.localStorage or expect seeded YouTube data)*

------
https://chatgpt.com/codex/tasks/task_e_68da484696f48328b06e9c14423c7b6f