### PR TITLE
[input] adopt pointer events for drag interactions

### DIFF
--- a/__tests__/pointer.test.ts
+++ b/__tests__/pointer.test.ts
@@ -1,19 +1,34 @@
 import { pointerHandlers } from '../utils/pointer';
 
 describe('pointerHandlers', () => {
-  it('calls handler on click', () => {
+  it('captures the pointer and calls the handler on pointer down', () => {
     const handler = jest.fn();
+    const preventDefault = jest.fn();
+    const setPointerCapture = jest.fn();
     const handlers = pointerHandlers(handler);
-    handlers.onClick();
+
+    handlers.onPointerDown({
+      preventDefault,
+      currentTarget: { setPointerCapture } as any,
+      pointerId: 5,
+    } as any);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(setPointerCapture).toHaveBeenCalledWith(5);
     expect(handler).toHaveBeenCalled();
   });
 
-  it('calls handler and prevents default on touchstart', () => {
+  it('releases pointer capture on pointer up', () => {
     const handler = jest.fn();
-    const preventDefault = jest.fn();
+    const releasePointerCapture = jest.fn();
+    const hasPointerCapture = jest.fn().mockReturnValue(true);
     const handlers = pointerHandlers(handler);
-    handlers.onTouchStart({ preventDefault } as any);
-    expect(preventDefault).toHaveBeenCalled();
-    expect(handler).toHaveBeenCalled();
+
+    handlers.onPointerUp({
+      currentTarget: { releasePointerCapture, hasPointerCapture } as any,
+      pointerId: 2,
+    } as any);
+
+    expect(releasePointerCapture).toHaveBeenCalledWith(2);
   });
 });

--- a/utils/pointer.ts
+++ b/utils/pointer.ts
@@ -1,14 +1,65 @@
 import React from 'react';
 
-// Helper to normalize pointer events for both mouse and touch
-// Returns props that can be spread onto an element to handle both
-// mouse and touch interactions consistently.
-export const pointerHandlers = (handler: () => void) => ({
-  onClick: () => handler(),
-  onTouchStart: (e: React.TouchEvent) => {
-    e.preventDefault();
-    handler();
-  },
-});
+type PointerHandlerOptions = {
+  /** Prevent default browser behaviour such as text selection */
+  preventDefault?: boolean;
+  /** Use pointer capture so move events keep firing while dragging */
+  capture?: boolean;
+};
+
+/**
+ * Normalise pointer interactions across mouse, touch and pen input.
+ *
+ * Returns handlers that can be spread on an element to trigger the provided
+ * callback on pointer down. Pointer capture is enabled by default so dragging
+ * continues even if the pointer leaves the element.
+ */
+export const pointerHandlers = <T extends HTMLElement>(
+  handler: React.PointerEventHandler<T>,
+  options: PointerHandlerOptions = {},
+) => {
+  const { preventDefault = true, capture = true } = options;
+
+  const onPointerDown: React.PointerEventHandler<T> = (event) => {
+    if (preventDefault) {
+      event.preventDefault();
+    }
+
+    if (capture) {
+      const target = event.currentTarget as HTMLElement;
+      if (typeof target.setPointerCapture === 'function') {
+        try {
+          target.setPointerCapture(event.pointerId);
+        } catch {
+          // Older browsers may throw if the element is not connected yet.
+        }
+      }
+    }
+
+    handler(event);
+  };
+
+  const onPointerUp: React.PointerEventHandler<T> = (event) => {
+    if (!capture) return;
+    const target = event.currentTarget as HTMLElement;
+    if (typeof target.releasePointerCapture === 'function') {
+      try {
+        if (target.hasPointerCapture?.(event.pointerId)) {
+          target.releasePointerCapture(event.pointerId);
+        }
+      } catch {
+        // Ignore if the capture was already released.
+      }
+    }
+  };
+
+  const onPointerCancel = onPointerUp;
+
+  return {
+    onPointerDown,
+    onPointerUp,
+    onPointerCancel,
+  };
+};
 
 export default pointerHandlers;


### PR DESCRIPTION
## Summary
- add a pointerHandlers helper that uses Pointer Events with capture by default
- migrate the tower defense canvas and terminal pane splitter to pointer interactions
- update sticky notes dragging to use pointer events across mouse, touch, and pen

## Testing
- yarn test __tests__/pointer.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68da4849279483289a1c2b730e9306a1