### PR TITLE
[gamepad] centralize mapping and add remap ui

### DIFF
--- a/__tests__/gamepad.test.ts
+++ b/__tests__/gamepad.test.ts
@@ -55,6 +55,37 @@ describe('GamepadManager', () => {
 
     expect(listener).toHaveBeenCalledWith({ gamepad: pad, index: 0, value: 0.2 });
   });
+
+  test('notifies subscribers with mapped action state', () => {
+    const pad: any = {
+      index: 0,
+      buttons: [{ value: 0, pressed: false }],
+      axes: [0],
+    };
+    (navigator as any).getGamepads = () => [pad];
+
+    gamepad.setActionMap('test', {
+      buttons: { fire: { index: 0, threshold: 0.5 } },
+      axes: { moveX: { index: 0, deadzone: 0.1 } },
+    });
+
+    const listener = jest.fn();
+    gamepad.subscribeToActions('test', listener);
+    gamepad.start();
+
+    pad.buttons[0].value = 0.7;
+    pad.buttons[0].pressed = true;
+    pad.axes[0] = 0.6;
+    rafCallback && rafCallback();
+    gamepad.stop();
+
+    expect(listener).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        buttons: expect.objectContaining({ fire: true }),
+        axes: expect.objectContaining({ moveX: 0.6 }),
+      }),
+    );
+  });
 });
 
 describe('pollTwinStick', () => {

--- a/apps/settings/components/GamepadConfigurator.tsx
+++ b/apps/settings/components/GamepadConfigurator.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import gamepad, {
+  GAMEPAD_PRESETS,
+  loadCalibration,
+  saveCalibration,
+  type AxisRange,
+  type ButtonBinding,
+  type GamepadActionMap,
+  type GamepadActionState,
+  type AxisBinding,
+  type AxisToButtonBinding,
+  type ButtonEvent,
+  type AxisEvent,
+} from "../../../utils/gamepad";
+
+interface GameRegistryEntry {
+  id: string;
+  label: string;
+}
+
+const DEADZONE_DEFAULT = 0.25;
+
+function formatButtonBinding(binding: ButtonBinding | undefined): string {
+  if (!binding) return "Unassigned";
+  const normalize = (value: ButtonBinding): string => {
+    if (typeof value === "number") return `Button ${value}`;
+    if (Array.isArray(value)) return value.map(normalize).join(", ");
+    if ("index" in value) return `Button ${value.index}`;
+    if ("axis" in value) {
+      const dir = value.direction === "positive" ? "+" : "-";
+      return `Axis ${value.axis} ${dir}`;
+    }
+    return "Custom";
+  };
+  return normalize(binding);
+}
+
+function formatAxisBinding(binding: AxisBinding | undefined): string {
+  if (!binding) return "Unassigned";
+  const invert = binding.invert ? " (invert)" : "";
+  return `Axis ${binding.index}${invert}`;
+}
+
+function cloneMap(map: GamepadActionMap | undefined): GamepadActionMap | null {
+  if (!map) return null;
+  return {
+    buttons: map.buttons ? { ...map.buttons } : undefined,
+    axes: map.axes ? { ...map.axes } : undefined,
+  };
+}
+
+function ensureAxisArray(length: number, source?: AxisRange[]): AxisRange[] {
+  const base = source ? source.map((r) => ({ ...r })) : [];
+  while (base.length < length) {
+    base.push({ min: -1, max: 1 });
+  }
+  return base;
+}
+
+const GamepadConfigurator = () => {
+  const [games, setGames] = useState<GameRegistryEntry[]>(() => gamepad.listActionMaps());
+  const [selectedGame, setSelectedGame] = useState<string>(
+    () => gamepad.listActionMaps()[0]?.id ?? "",
+  );
+  const [map, setMap] = useState<GamepadActionMap | null>(() => cloneMap(gamepad.getActionMap(selectedGame)));
+  const [snapshot, setSnapshot] = useState<GamepadActionState | null>(null);
+  const [listening, setListening] = useState<string | null>(null);
+  const [vendor, setVendor] = useState<string>("");
+  const [ranges, setRanges] = useState<AxisRange[]>([]);
+  const padIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const updateGames = () => {
+      setGames(gamepad.listActionMaps());
+    };
+    const listener = () => updateGames();
+    updateGames();
+    gamepad.on("mapchange", listener);
+    return () => {
+      gamepad.off("mapchange", listener);
+    };
+  }, []);
+
+  useEffect(() => {
+    const current = gamepad.getActionMap(selectedGame);
+    setMap(cloneMap(current));
+    const unsubscribe = selectedGame
+      ? gamepad.subscribeToActions(selectedGame, (state) => {
+          setSnapshot(state);
+          const padId = state.raw?.id ?? null;
+          if (padId && padId !== padIdRef.current) {
+            padIdRef.current = padId;
+            const calibration = loadCalibration(padId);
+            if (calibration) {
+              setVendor(calibration.vendor ?? "");
+              setRanges(ensureAxisArray(state.raw?.axes.length ?? calibration.axes.length, calibration.axes));
+            } else if (state.raw) {
+              setVendor(padId.split("(")[0]?.trim() ?? "");
+              setRanges(ensureAxisArray(state.raw.axes.length));
+            }
+          }
+        })
+      : () => {};
+    return () => {
+      unsubscribe();
+    };
+  }, [selectedGame]);
+
+  const actions = useMemo(() => {
+    if (!map) return [] as Array<["buttons" | "axes", string]>;
+    const entries: Array<["buttons" | "axes", string]> = [];
+    if (map.buttons) {
+      Object.keys(map.buttons).forEach((key) => entries.push(["buttons", key]));
+    }
+    if (map.axes) {
+      Object.keys(map.axes).forEach((key) => entries.push(["axes", key]));
+    }
+    return entries;
+  }, [map]);
+
+  useEffect(() => {
+    if (!listening || !map) return;
+    const isAxisAction = Boolean(map.axes?.[listening]);
+    const handleButton = (event: ButtonEvent) => {
+      if (!event.pressed) return;
+      const next = cloneMap(map) ?? { buttons: {}, axes: {} };
+      const nextButtons = { ...(next.buttons ?? {}) };
+      nextButtons[listening] = event.index;
+      const updated: GamepadActionMap = {
+        buttons: nextButtons,
+        axes: next.axes,
+      };
+      setMap(updated);
+      gamepad.updateActionMap(selectedGame, updated);
+      setListening(null);
+    };
+    const handleAxis = (event: AxisEvent) => {
+      const next = cloneMap(map) ?? { buttons: {}, axes: {} };
+      if (isAxisAction) {
+        const existing = map.axes?.[listening] as AxisBinding | undefined;
+        const binding: AxisBinding = {
+          index: event.index,
+          deadzone: existing?.deadzone ?? DEADZONE_DEFAULT,
+          invert: existing?.invert ?? false,
+          scale: existing?.scale,
+        };
+        const nextAxes = { ...(next.axes ?? {}) };
+        nextAxes[listening] = binding;
+        const updated: GamepadActionMap = {
+          buttons: next.buttons,
+          axes: nextAxes,
+        };
+        setMap(updated);
+        gamepad.updateActionMap(selectedGame, updated);
+      } else {
+        const direction = event.value >= 0 ? "positive" : "negative";
+        const binding: AxisToButtonBinding = {
+          axis: event.index,
+          direction,
+          threshold: Math.abs(event.value) || 0.5,
+          deadzone: DEADZONE_DEFAULT,
+        };
+        const nextButtons = { ...(next.buttons ?? {}) };
+        nextButtons[listening] = binding;
+        const updated: GamepadActionMap = {
+          buttons: nextButtons,
+          axes: next.axes,
+        };
+        setMap(updated);
+        gamepad.updateActionMap(selectedGame, updated);
+      }
+      setListening(null);
+    };
+    gamepad.on("button", handleButton);
+    gamepad.on("axis", handleAxis);
+    return () => {
+      gamepad.off("button", handleButton);
+      gamepad.off("axis", handleAxis);
+    };
+  }, [listening, map, selectedGame]);
+
+  const resetAction = (type: "buttons" | "axes", action: string) => {
+    if (!map) return;
+    const defaults = gamepad.getActionDefaults(selectedGame);
+    const next = cloneMap(map) ?? { buttons: {}, axes: {} };
+    if (type === "buttons") {
+      const nextButtons = { ...(next.buttons ?? {}) };
+      if (defaults?.buttons?.[action]) nextButtons[action] = defaults.buttons[action];
+      else delete nextButtons[action];
+      next.buttons = nextButtons;
+    } else {
+      const nextAxes = { ...(next.axes ?? {}) };
+      if (defaults?.axes?.[action]) nextAxes[action] = defaults.axes[action];
+      else delete nextAxes[action];
+      next.axes = nextAxes;
+    }
+    setMap(next);
+    gamepad.updateActionMap(selectedGame, next);
+  };
+
+  const applyPreset = (name: string) => {
+    const preset = GAMEPAD_PRESETS[name];
+    if (!preset || !padIdRef.current) return;
+    setRanges(ensureAxisArray(preset.axes.length, preset.axes));
+    setVendor(preset.vendor ?? name);
+  };
+
+  const captureCurrentAxes = () => {
+    if (!snapshot?.raw) return;
+    setRanges((prev) => {
+      const base = ensureAxisArray(snapshot.raw!.axes.length, prev);
+      snapshot.raw!.axes.forEach((value, index) => {
+        base[index] = {
+          min: Math.min(base[index].min, value),
+          max: Math.max(base[index].max, value),
+        };
+      });
+      return base;
+    });
+  };
+
+  const saveCurrentCalibration = () => {
+    if (!padIdRef.current) return;
+    const data = { axes: ranges, vendor: vendor || undefined };
+    saveCalibration(padIdRef.current, data);
+  };
+
+  const hasGames = games.length > 0;
+
+  return (
+    <div className="space-y-6 p-4">
+      <div>
+        <h2 className="text-lg font-semibold">Gamepad bindings</h2>
+        {!hasGames && <p className="text-sm text-ubt-grey/70">Launch a game to register its bindings.</p>}
+        {hasGames && (
+          <div className="mt-2 flex flex-wrap gap-3 items-center">
+            <label className="text-sm text-ubt-grey" htmlFor="gamepad-game-select">
+              Game
+            </label>
+            <select
+              id="gamepad-game-select"
+              value={selectedGame}
+              onChange={(e) => setSelectedGame(e.target.value)}
+              className="bg-ub-cool-grey border border-ubt-cool-grey rounded px-2 py-1 text-sm"
+            >
+              {games.map((entry) => (
+                <option key={entry.id} value={entry.id}>
+                  {entry.label}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              className="px-3 py-1 text-sm rounded bg-ub-orange text-white"
+              onClick={() => gamepad.resetActionMap(selectedGame)}
+            >
+              Reset All
+            </button>
+          </div>
+        )}
+      </div>
+
+      {map && (
+        <div className="space-y-3">
+          <h3 className="font-medium text-sm uppercase text-ubt-grey">Actions</h3>
+          <div className="space-y-2">
+            {actions.map(([type, action]) => (
+              <div
+                key={`${type}-${action}`}
+                className="flex items-center justify-between gap-4 rounded border border-ubt-cool-grey/60 bg-ub-cool-grey/40 px-3 py-2"
+              >
+                <div>
+                  <div className="text-sm font-medium capitalize">{action}</div>
+                  <div className="text-xs text-ubt-grey/70">
+                    {type === "buttons"
+                      ? formatButtonBinding(map.buttons?.[action])
+                      : formatAxisBinding(map.axes?.[action])}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setListening(action)}
+                    className="text-xs px-3 py-1 rounded border border-ubt-cool-grey text-ubt-grey"
+                  >
+                    {listening === action ? "Listening..." : "Remap"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => resetAction(type, action)}
+                    className="text-xs px-3 py-1 rounded border border-ubt-cool-grey text-ubt-grey"
+                  >
+                    Default
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <h3 className="font-medium text-sm uppercase text-ubt-grey">Calibration</h3>
+        {!snapshot?.raw && <p className="text-sm text-ubt-grey/70">Connect a controller to adjust calibration.</p>}
+        {snapshot?.raw && (
+          <div className="space-y-3">
+            <div className="text-sm">Active controller: {snapshot.raw.id}</div>
+            <div className="flex flex-wrap gap-3 items-center text-sm">
+              <label className="text-sm" htmlFor="gamepad-vendor">
+                Vendor
+              </label>
+              <input
+                id="gamepad-vendor"
+                type="text"
+                value={vendor}
+                onChange={(e) => setVendor(e.target.value)}
+                className="bg-ub-cool-grey border border-ubt-cool-grey rounded px-2 py-1 text-sm"
+                aria-label="Controller vendor"
+              />
+              <label className="flex items-center gap-2">
+                Preset:
+                <select
+                  value=""
+                  onChange={(e) => {
+                    applyPreset(e.target.value);
+                  }}
+                  className="bg-ub-cool-grey border border-ubt-cool-grey rounded px-2 py-1 text-sm"
+                  aria-label="Select calibration preset"
+                >
+                  <option value="">--</option>
+                  {Object.keys(GAMEPAD_PRESETS).map((name) => (
+                    <option key={name} value={name}>
+                      {name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                type="button"
+                className="px-3 py-1 text-xs rounded border border-ubt-cool-grey text-ubt-grey"
+                onClick={captureCurrentAxes}
+              >
+                Capture extremes
+              </button>
+              <button
+                type="button"
+                className="px-3 py-1 text-xs rounded bg-ub-orange text-white"
+                onClick={saveCurrentCalibration}
+              >
+                Save calibration
+              </button>
+            </div>
+            <div className="space-y-2">
+              {snapshot.raw.axes.map((value, index) => (
+                <div key={index} className="text-xs">
+                  <div className="flex justify-between">
+                    <span>Axis {index}</span>
+                    <span>{value.toFixed(2)}</span>
+                  </div>
+                  <div className="h-2 bg-ubt-cool-grey/30 rounded">
+                    <div
+                      className="h-2 bg-ub-orange rounded"
+                      style={{ width: `${((value + 1) / 2) * 100}%` }}
+                    />
+                  </div>
+                  <div className="mt-1 text-[10px] text-ubt-grey/60">
+                    Range: {ranges[index]?.min.toFixed(2) ?? "-"} to {ranges[index]?.max.toFixed(2) ?? "-"}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default GamepadConfigurator;

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -13,6 +13,7 @@ import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
 import KaliWallpaper from "../../components/util-components/kali-wallpaper";
+import GamepadConfigurator from "./components/GamepadConfigurator";
 
 export default function Settings() {
   const {
@@ -40,6 +41,7 @@ export default function Settings() {
   const tabs = [
     { id: "appearance", label: "Appearance" },
     { id: "accessibility", label: "Accessibility" },
+    { id: "controls", label: "Controls" },
     { id: "privacy", label: "Privacy" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
@@ -156,14 +158,16 @@ export default function Settings() {
               ))}
             </div>
           </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey flex items-center">
-              <input
-                type="checkbox"
-                checked={useKaliWallpaper}
-                onChange={(e) => setUseKaliWallpaper(e.target.checked)}
-                className="mr-2"
-              />
+          <div className="flex justify-center my-4 items-center text-ubt-grey">
+            <input
+              id="toggle-kali-wallpaper"
+              type="checkbox"
+              checked={useKaliWallpaper}
+              onChange={(e) => setUseKaliWallpaper(e.target.checked)}
+              className="mr-2"
+              aria-labelledby="toggle-kali-wallpaper-label"
+            />
+            <label id="toggle-kali-wallpaper-label" htmlFor="toggle-kali-wallpaper">
               Kali Gradient Wallpaper
             </label>
           </div>
@@ -310,6 +314,7 @@ export default function Settings() {
           </div>
         </>
       )}
+      {activeTab === "controls" && <GamepadConfigurator />}
         <input
           type="file"
           accept="application/json"

--- a/components/apps/battleship.js
+++ b/components/apps/battleship.js
@@ -339,7 +339,7 @@ const Battleship = () => {
       if (cx < 0 || cy < 0 || cx >= BOARD_SIZE || cy >= BOARD_SIZE) return c;
       return cy * BOARD_SIZE + cx;
     });
-  });
+  }, 'battleship');
 
   useEffect(() => {
     const handleKey = (e) => {

--- a/components/apps/pong.js
+++ b/components/apps/pong.js
@@ -95,7 +95,7 @@ const PongInner = () => {
       [sound],
     );
 
-  const controls = useRef(useGameControls(canvasRef));
+  const controls = useRef(useGameControls(canvasRef, 'pong'));
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -663,11 +663,13 @@ const PongInner = () => {
   }, [offerSDP]);
 
   return (
-    <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white">
-      <canvas
-        ref={canvasRef}
-        className="bg-black w-full h-full touch-none"
-      />
+      <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white">
+        <canvas
+          ref={canvasRef}
+          className="bg-black w-full h-full touch-none"
+          role="img"
+          aria-label="Pong playfield"
+        />
       {mode === 'practice' ? (
         <div className="mt-2 font-mono text-center" aria-live="polite" role="status">
           Rally: {rally} (Best: {highScore})

--- a/components/apps/snake.js
+++ b/components/apps/snake.js
@@ -316,7 +316,7 @@ const Snake = () => {
     const curr = queue.length ? queue[queue.length - 1] : dirRef.current;
     if (curr.x + x === 0 && curr.y + y === 0) return;
     queue.push({ x, y });
-  });
+  }, 'snake');
 
   useEffect(() => {
     if (gameOver && score > highScore) {
@@ -404,6 +404,7 @@ const Snake = () => {
             className="bg-gray-800 border border-gray-700 w-full h-full"
             tabIndex={0}
             aria-label="Snake game board"
+            role="img"
           />
           {gameOver && (
             <div
@@ -449,15 +450,16 @@ const Snake = () => {
         </div>
         <div className="mt-2 flex items-center space-x-2">
           <label htmlFor="speed">Speed</label>
-          <input
-            id="speed"
-            type="range"
-            min="50"
-            max="300"
-            step="10"
-            value={speed}
-            onChange={(e) => setSpeed(Number(e.target.value))}
-          />
+            <input
+              id="speed"
+              type="range"
+              min="50"
+              max="300"
+              step="10"
+              value={speed}
+              onChange={(e) => setSpeed(Number(e.target.value))}
+              aria-label="Snake speed"
+            />
         </div>
         <div className="mt-2 flex items-center space-x-2">
           <label htmlFor="replay">Replay</label>

--- a/components/apps/sokoban.js
+++ b/components/apps/sokoban.js
@@ -202,7 +202,7 @@ const move = ({ x, y }) => {
   }
 };
 
-  useGameControls(move);
+  useGameControls(move, 'sokoban');
 
   useEffect(() => {
     if (!checkWin(state.board)) saveProgress(levelIndex, state);
@@ -314,13 +314,25 @@ const move = ({ x, y }) => {
 
   return (
     <GameLayout stage={levelIndex + 1}>
-      <canvas ref={canvasRef} className="mx-auto bg-gray-700" />
-      <div className="mt-2 flex flex-wrap items-center justify-center space-x-2">
-        <select value={levelIndex} onChange={(e) => setLevelIndex(Number(e.target.value))}>
-          {levels.map((_, i) => (
-            <option key={i} value={i}>{`Level ${i + 1}`}</option>
-          ))}
-        </select>
+        <canvas
+          ref={canvasRef}
+          className="mx-auto bg-gray-700"
+          role="img"
+          aria-label="Sokoban warehouse"
+        />
+        <div className="mt-2 flex flex-wrap items-center justify-center space-x-2">
+          <label htmlFor="sokoban-level-select" className="sr-only">
+            Select level
+          </label>
+          <select
+            id="sokoban-level-select"
+            value={levelIndex}
+            onChange={(e) => setLevelIndex(Number(e.target.value))}
+          >
+            {levels.map((_, i) => (
+              <option key={i} value={i}>{`Level ${i + 1}`}</option>
+            ))}
+          </select>
         <button className="px-2 py-1 bg-gray-700 rounded" onClick={undo}>
           Undo
         </button>
@@ -336,10 +348,15 @@ const move = ({ x, y }) => {
         <button className="px-2 py-1 bg-gray-700 rounded" onClick={() => setSound((s) => !s)}>
           {sound ? 'Sound On' : 'Sound Off'}
         </button>
-        <button className="px-2 py-1 bg-gray-700 rounded" onClick={exportLevels}>
-          Export
-        </button>
-        <input type="file" accept=".txt,.json" onChange={handleFile} />
+          <button className="px-2 py-1 bg-gray-700 rounded" onClick={exportLevels}>
+            Export
+          </button>
+          <input
+            type="file"
+            accept=".txt,.json"
+            onChange={handleFile}
+            aria-label="Import custom Sokoban levels"
+          />
         <input
           type="range"
           min="0"

--- a/components/apps/useGameControls.js
+++ b/components/apps/useGameControls.js
@@ -28,7 +28,11 @@ const useGameControls = (arg, gameId = 'default') => {
     hyperspace: false,
     joystick: { x: 0, y: 0, active: false, startX: 0, startY: 0 },
   });
-  const gamepad = useGamepad();
+  const gamepad = useGamepad(gameId, {
+    deadzone: 0.35,
+    label: `Gamepad: ${gameId}`,
+    persist: true,
+  });
   const padTime = useRef(0);
 
   // keyboard controls for directional games

--- a/hooks/useGamepad.ts
+++ b/hooks/useGamepad.ts
@@ -1,18 +1,98 @@
-import { useEffect, useState } from 'react';
-import { pollTwinStick, TwinStickState } from '../utils/gamepad';
+import { useEffect, useMemo, useState } from 'react';
+import gamepad, {
+  createTwinStickMap,
+  GamepadActionMap,
+  GamepadActionState,
+  TwinStickState,
+  ActionMapOptions,
+} from '../utils/gamepad';
 
-export default function useGamepad(deadzone: number = 0.25): TwinStickState {
-  const [state, setState] = useState<TwinStickState>(() => pollTwinStick(deadzone));
+export interface UseGamepadOptions extends ActionMapOptions {
+  persist?: boolean;
+}
+
+const EMPTY_TWIN_STICK: TwinStickState = {
+  moveX: 0,
+  moveY: 0,
+  aimX: 0,
+  aimY: 0,
+  fire: false,
+};
+
+const EMPTY_STATE: GamepadActionState = {
+  connected: false,
+  buttons: {},
+  axes: {},
+  raw: null,
+};
+
+function toTwinStick(state: GamepadActionState): TwinStickState {
+  return {
+    moveX: state.axes.moveX ?? 0,
+    moveY: state.axes.moveY ?? 0,
+    aimX: state.axes.aimX ?? 0,
+    aimY: state.axes.aimY ?? 0,
+    fire: state.buttons.fire ?? false,
+  };
+}
+
+function ensureMap(
+  gameId: string,
+  map: GamepadActionMap,
+  label: string | undefined,
+  persist: boolean,
+  deadzone: number | undefined,
+) {
+  gamepad.setActionMap(gameId, map, {
+    label,
+    persist,
+    deadzone,
+  });
+}
+
+export function useGamepadActions(
+  gameId: string,
+  map: GamepadActionMap,
+  options: UseGamepadOptions = {},
+): GamepadActionState {
+  const persist = options.persist ?? true;
+  const [state, setState] = useState<GamepadActionState>(() =>
+    gamepad.getActionState(gameId) ?? EMPTY_STATE,
+  );
 
   useEffect(() => {
-    let raf: number;
-    const read = () => {
-      setState(pollTwinStick(deadzone));
-      raf = requestAnimationFrame(read);
+    ensureMap(gameId, map, options.label, persist, options.deadzone);
+    const unsubscribe = gamepad.subscribeToActions(gameId, setState);
+    return () => {
+      unsubscribe();
     };
-    raf = requestAnimationFrame(read);
-    return () => cancelAnimationFrame(raf);
-  }, [deadzone]);
+  }, [gameId, map, options.label, persist, options.deadzone]);
+
+  return state;
+}
+
+export default function useGamepad(
+  gameId: string,
+  options: UseGamepadOptions = {},
+): TwinStickState {
+  const deadzone = options.deadzone ?? 0.25;
+  const persist = options.persist ?? true;
+  const map = useMemo(() => createTwinStickMap(deadzone), [deadzone]);
+
+  const [state, setState] = useState<TwinStickState>(() => {
+    const snapshot = gamepad.getActionState(gameId);
+    return snapshot ? toTwinStick(snapshot) : EMPTY_TWIN_STICK;
+  });
+
+  useEffect(() => {
+    ensureMap(gameId, map, options.label, persist, options.deadzone);
+    const unsubscribe = gamepad.subscribeToActions(gameId, (snapshot) => {
+      setState(toTwinStick(snapshot));
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, [gameId, map, options.label, persist, options.deadzone]);
 
   return state;
 }

--- a/utils/gamepad.ts
+++ b/utils/gamepad.ts
@@ -22,6 +22,7 @@ export interface CalibrationData {
 }
 
 const CAL_PREFIX = 'gamepad-calibration-';
+const MAP_PREFIX = 'gamepad-action-map-';
 
 export const GAMEPAD_PRESETS: Record<string, CalibrationData> = {
   Xbox: {
@@ -61,11 +62,65 @@ function applyCalibration(value: number, range?: AxisRange) {
   return ((clamped - range.min) / span) * 2 - 1;
 }
 
+export type AxisDirection = 'positive' | 'negative';
+
+export interface AxisBinding {
+  index: number;
+  deadzone?: number;
+  invert?: boolean;
+  scale?: number;
+}
+
+export interface AxisToButtonBinding {
+  axis: number;
+  direction: AxisDirection;
+  threshold?: number;
+  deadzone?: number;
+  invert?: boolean;
+}
+
+export interface ButtonBindingObject {
+  index: number;
+  threshold?: number;
+}
+
+export type ButtonBinding =
+  | number
+  | ButtonBindingObject
+  | AxisToButtonBinding
+  | Array<number | ButtonBindingObject | AxisToButtonBinding>;
+
+export interface GamepadActionMap {
+  buttons?: Record<string, ButtonBinding>;
+  axes?: Record<string, AxisBinding>;
+}
+
+export interface GamepadActionState {
+  connected: boolean;
+  buttons: Record<string, boolean>;
+  axes: Record<string, number>;
+  raw: Gamepad | null;
+}
+
+export interface ActionMapOptions {
+  label?: string;
+  persist?: boolean;
+  deadzone?: number;
+}
+
+export interface RegisteredActionMap {
+  defaults: GamepadActionMap;
+  overrides?: GamepadActionMap;
+  map: GamepadActionMap;
+  options: Required<ActionMapOptions>;
+}
+
 export type GamepadEventMap = {
   connected: Gamepad;
   disconnected: Gamepad;
   button: ButtonEvent;
   axis: AxisEvent;
+  mapchange: { gameId: string; map: GamepadActionMap; label?: string };
 };
 
 type Listener<T> = (event: T) => void;
@@ -76,11 +131,15 @@ class GamepadManager {
     disconnected: new Set(),
     button: new Set(),
     axis: new Set(),
+    mapchange: new Set(),
   };
   private prevState = new Map<number, { buttons: number[]; axes: number[] }>();
 
   private raf: number | null = null;
   private deadzone: number;
+  private actionMaps = new Map<string, RegisteredActionMap>();
+  private actionSubscribers = new Map<string, Set<Listener<GamepadActionState>>>();
+  private actionStateCache = new Map<string, GamepadActionState>();
 
   constructor(deadzone = 0.1) {
     this.deadzone = deadzone;
@@ -109,8 +168,10 @@ class GamepadManager {
 
   private poll = () => {
     const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+    let primary: Gamepad | null = null;
     for (const pad of pads) {
       if (!pad) continue;
+      if (!primary) primary = pad;
 
       const prev = this.prevState.get(pad.index) || { buttons: [], axes: [] };
 
@@ -148,8 +209,90 @@ class GamepadManager {
         axes: Array.from(pad.axes),
       });
     }
+
+    this.updateActionStates(primary);
     this.raf = requestAnimationFrame(this.poll);
   };
+
+  private updateActionStates(pad: Gamepad | null) {
+    this.actionMaps.forEach((entry, gameId) => {
+      const next = this.computeActionState(entry, pad);
+      const prev = this.actionStateCache.get(gameId);
+      if (!prev || !this.areStatesEqual(prev, next)) {
+        this.actionStateCache.set(gameId, next);
+        const subs = this.actionSubscribers.get(gameId);
+        subs?.forEach((fn) => fn(next));
+      }
+    });
+  }
+
+  private areStatesEqual(a: GamepadActionState, b: GamepadActionState) {
+    if (a.connected !== b.connected) return false;
+    const aButtons = Object.keys(a.buttons);
+    const bButtons = Object.keys(b.buttons);
+    if (aButtons.length !== bButtons.length) return false;
+    for (const key of aButtons) {
+      if (a.buttons[key] !== b.buttons[key]) return false;
+    }
+    const aAxes = Object.keys(a.axes);
+    const bAxes = Object.keys(b.axes);
+    if (aAxes.length !== bAxes.length) return false;
+    for (const key of aAxes) {
+      if (Math.abs(a.axes[key] - b.axes[key]) > 1e-3) return false;
+    }
+    return true;
+  }
+
+  private computeActionState(entry: RegisteredActionMap, pad: Gamepad | null): GamepadActionState {
+    const ranges = pad ? loadCalibration(pad.id)?.axes || [] : [];
+    const buttons: Record<string, boolean> = {};
+    const axes: Record<string, number> = {};
+
+    const map = entry.map;
+
+    const resolveAxisValue = (binding: AxisBinding | AxisToButtonBinding, axisValue?: number) => {
+      if (!pad) return 0;
+      const idx = 'index' in binding ? binding.index : binding.axis;
+      const raw = typeof axisValue === 'number' ? axisValue : pad.axes[idx] ?? 0;
+      const calibrated = applyCalibration(raw, ranges[idx]);
+      const deadzone = binding.deadzone ?? entry.options.deadzone ?? this.deadzone;
+      const value = Math.abs(calibrated) < deadzone ? 0 : calibrated;
+      const scaled = binding.invert ? -value : value;
+      return binding.scale ? scaled * binding.scale : scaled;
+    };
+
+    if (map.axes) {
+      Object.entries(map.axes).forEach(([action, binding]) => {
+        const value = resolveAxisValue(binding as AxisBinding);
+        axes[action] = value;
+      });
+    }
+
+    if (map.buttons) {
+      Object.entries(map.buttons).forEach(([action, binding]) => {
+        const normalized = Array.isArray(binding) ? binding : [binding];
+        buttons[action] = normalized.some((b) => {
+          if (typeof b === 'number') {
+            return pad ? pad.buttons[b]?.pressed ?? false : false;
+          }
+          if ('index' in b) {
+            const threshold = b.threshold ?? 0.5;
+            return pad ? (pad.buttons[b.index]?.value ?? 0) >= threshold : false;
+          }
+          const value = resolveAxisValue(b);
+          const threshold = b.threshold ?? 0.5;
+          return b.direction === 'positive' ? value >= threshold : value <= -threshold;
+        });
+      });
+    }
+
+    return {
+      connected: Boolean(pad),
+      buttons,
+      axes,
+      raw: pad ?? null,
+    };
+  }
 
   start() {
     if (this.raf !== null) return;
@@ -162,10 +305,168 @@ class GamepadManager {
       this.raf = null;
     }
   }
+
+  private mergeMaps(base: GamepadActionMap, overrides?: GamepadActionMap): GamepadActionMap {
+    if (!overrides) return cloneMap(base);
+    const merged: GamepadActionMap = {
+      buttons: { ...(base.buttons ?? {}) },
+      axes: { ...(base.axes ?? {}) },
+    };
+    if (overrides.buttons) {
+      Object.entries(overrides.buttons).forEach(([key, value]) => {
+        (merged.buttons as Record<string, ButtonBinding>)[key] = value;
+      });
+    }
+    if (overrides.axes) {
+      Object.entries(overrides.axes).forEach(([key, value]) => {
+        (merged.axes as Record<string, AxisBinding>)[key] = value;
+      });
+    }
+    if (!Object.keys(merged.buttons as Record<string, ButtonBinding>).length) {
+      delete merged.buttons;
+    }
+    if (!Object.keys(merged.axes as Record<string, AxisBinding>).length) {
+      delete merged.axes;
+    }
+    return merged;
+  }
+
+  setActionMap(gameId: string, map: GamepadActionMap, options: ActionMapOptions = {}) {
+    const existing = this.actionMaps.get(gameId);
+    const defaults = map;
+    const persist = options.persist ?? existing?.options.persist ?? false;
+    const label = options.label ?? existing?.options.label ?? gameId;
+    const deadzone = options.deadzone ?? existing?.options.deadzone ?? this.deadzone;
+
+    let overrides = existing?.overrides;
+    if (persist && typeof window !== 'undefined') {
+      const stored = loadStoredActionMap(gameId);
+      if (stored) overrides = stored;
+    }
+
+    const resolved = this.mergeMaps(defaults, overrides);
+    const entry: RegisteredActionMap = {
+      defaults: cloneMap(defaults),
+      overrides: overrides ? cloneMap(overrides) : undefined,
+      map: resolved,
+      options: { persist, label, deadzone },
+    };
+    this.actionMaps.set(gameId, entry);
+    this.emit('mapchange', { gameId, map: cloneMap(resolved), label });
+    this.updateActionStates(null);
+    this.start();
+  }
+
+  updateActionMap(gameId: string, overrides: GamepadActionMap, persist = true) {
+    const entry = this.actionMaps.get(gameId);
+    if (!entry) return;
+    entry.overrides = cloneMap(overrides);
+    entry.map = this.mergeMaps(entry.defaults, overrides);
+    if (persist && entry.options.persist && typeof window !== 'undefined') {
+      saveStoredActionMap(gameId, overrides);
+    }
+    this.actionMaps.set(gameId, entry);
+    this.emit('mapchange', { gameId, map: cloneMap(entry.map), label: entry.options.label });
+    this.updateActionStates(null);
+  }
+
+  resetActionMap(gameId: string) {
+    const entry = this.actionMaps.get(gameId);
+    if (!entry) return;
+    entry.overrides = undefined;
+    entry.map = cloneMap(entry.defaults);
+    if (entry.options.persist && typeof window !== 'undefined') {
+      clearStoredActionMap(gameId);
+    }
+    this.actionMaps.set(gameId, entry);
+    this.emit('mapchange', { gameId, map: cloneMap(entry.map), label: entry.options.label });
+    this.updateActionStates(null);
+  }
+
+  getActionMap(gameId: string): GamepadActionMap | undefined {
+    return this.actionMaps.get(gameId)?.map ? cloneMap(this.actionMaps.get(gameId)!.map) : undefined;
+  }
+
+  getActionDefaults(gameId: string): GamepadActionMap | undefined {
+    const entry = this.actionMaps.get(gameId);
+    return entry ? cloneMap(entry.defaults) : undefined;
+  }
+
+  getActionState(gameId: string): GamepadActionState | undefined {
+    const cached = this.actionStateCache.get(gameId);
+    if (cached) return cached;
+    const entry = this.actionMaps.get(gameId);
+    if (!entry) return undefined;
+    const state = this.computeActionState(entry, null);
+    this.actionStateCache.set(gameId, state);
+    return state;
+  }
+
+  subscribeToActions(gameId: string, fn: Listener<GamepadActionState>) {
+    const subs = this.actionSubscribers.get(gameId) ?? new Set();
+    subs.add(fn);
+    this.actionSubscribers.set(gameId, subs);
+    const cached = this.getActionState(gameId);
+    if (cached) fn(cached);
+    this.start();
+    return () => {
+      const current = this.actionSubscribers.get(gameId);
+      current?.delete(fn);
+      if (current && current.size === 0) {
+        this.actionSubscribers.delete(gameId);
+      }
+    };
+  }
+
+  listActionMaps() {
+    return Array.from(this.actionMaps.entries()).map(([id, entry]) => ({
+      id,
+      label: entry.options.label ?? id,
+    }));
+  }
 }
 
 export const gamepad = new GamepadManager();
 export default gamepad;
+
+function cloneMap(map: GamepadActionMap): GamepadActionMap {
+  const clone: GamepadActionMap = {};
+  if (map.buttons) {
+    clone.buttons = { ...map.buttons };
+  }
+  if (map.axes) {
+    clone.axes = { ...map.axes };
+  }
+  return clone;
+}
+
+function loadStoredActionMap(gameId: string): GamepadActionMap | undefined {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    const raw = window.localStorage.getItem(MAP_PREFIX + gameId);
+    return raw ? (JSON.parse(raw) as GamepadActionMap) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function saveStoredActionMap(gameId: string, map: GamepadActionMap) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(MAP_PREFIX + gameId, JSON.stringify(map));
+  } catch {
+    // ignore persistence errors
+  }
+}
+
+function clearStoredActionMap(gameId: string) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(MAP_PREFIX + gameId);
+  } catch {
+    // ignore
+  }
+}
 
 export interface TwinStickState {
   moveX: number;
@@ -200,4 +501,24 @@ export function pollTwinStick(deadzone = 0.25): TwinStickState {
     break; // only use first gamepad
   }
   return state;
+}
+
+export function createTwinStickMap(deadzone = 0.25): GamepadActionMap {
+  return {
+    axes: {
+      moveX: { index: 0, deadzone },
+      moveY: { index: 1, deadzone },
+      aimX: { index: 2, deadzone },
+      aimY: { index: 3, deadzone },
+    },
+    buttons: {
+      fire: [
+        { index: 0, threshold: 0.5 },
+        { index: 1, threshold: 0.5 },
+        { index: 2, threshold: 0.5 },
+        { index: 3, threshold: 0.5 },
+        { index: 5, threshold: 0.5 },
+      ],
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- centralize gamepad action handling with per-game maps, stored overrides, and a subscription API
- update the shared hook and arcade modules to bind through the centralized maps instead of polling
- add a Controls tab in Settings that supports button remapping and calibration management

## Testing
- yarn lint
- yarn test --runTestsByPath __tests__/gamepad.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68da484a6520832886b3a5a1f1e513ba