### PR TITLE
[apps] improve bluetooth and usb onboarding dialogs

### DIFF
--- a/components/apps/ble-sensor.tsx
+++ b/components/apps/ble-sensor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import FormError from '../ui/FormError';
 import {
   loadProfiles,
@@ -15,6 +15,7 @@ type BluetoothDevice = any;
 type BluetoothRemoteGATTServer = any;
 
 const MAX_RETRIES = 3;
+const CONNECT_TIMEOUT = 10000;
 
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
@@ -24,10 +25,25 @@ const BleSensor: React.FC = () => {
   const [services, setServices] = useState<ServiceData[]>([]);
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<
+    'idle' | 'prompt' | 'scanning' | 'connecting' | 'connected' | 'error'
+  >('idle');
+  const [showPreflight, setShowPreflight] = useState(false);
+  const [acknowledgedPreflight, setAcknowledgedPreflight] = useState(false);
+  const [logEntries, setLogEntries] = useState<string[]>([]);
   const [profiles, setProfiles] = useState<SavedProfile[]>([]);
   const bcRef = useRef<BroadcastChannel | null>(null);
 
-  const refreshProfiles = async () => setProfiles(await loadProfiles());
+  const appendLog = useCallback((entry: string) => {
+    setLogEntries((prev) => {
+      const next = [...prev, entry];
+      return next.slice(-40);
+    });
+  }, []);
+
+  const refreshProfiles = useCallback(async () => {
+    setProfiles(await loadProfiles());
+  }, []);
 
   useEffect(() => {
     refreshProfiles();
@@ -37,39 +53,58 @@ const BleSensor: React.FC = () => {
       bcRef.current = bc;
       return () => bc.close();
     }
-  }, []);
+  }, [refreshProfiles]);
 
-  const connectWithRetry = async (
-    device: BluetoothDevice,
-    retries = MAX_RETRIES
-  ): Promise<BluetoothRemoteGATTServer> => {
-    let lastError: unknown = new Error('Unable to connect');
-    for (let attempt = 1; attempt <= retries; attempt++) {
-      try {
-        return await device.gatt!.connect();
-      } catch (err) {
-        lastError = err;
-        if (attempt < retries) {
-          await delay(1000 * attempt);
-        }
+  useEffect(() => {
+    if (!supported) {
+      const ua = typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown';
+      const message = `Web Bluetooth unsupported. UA: ${ua}`;
+      appendLog(message);
+      if (typeof console !== 'undefined') {
+        console.info(message);
       }
     }
-    throw lastError;
-  };
+  }, [appendLog, supported]);
 
-  const handleScan = async () => {
-    if (!supported || busy) return;
-    setError('');
+  const connectWithRetry = useCallback(
+    async (
+      device: BluetoothDevice,
+      retries = MAX_RETRIES
+    ): Promise<BluetoothRemoteGATTServer> => {
+      let lastError: unknown = new Error('Unable to connect');
+      for (let attempt = 1; attempt <= retries; attempt++) {
+        try {
+          appendLog(`Connecting (attempt ${attempt}/${retries})...`);
+          const server = (await Promise.race([
+            device.gatt!.connect(),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error('Connection timed out')), CONNECT_TIMEOUT)
+            ),
+          ])) as BluetoothRemoteGATTServer;
+          appendLog('Connection established.');
+          return server;
+        } catch (err) {
+          lastError = err;
+          appendLog(
+            `Attempt ${attempt} failed: ${(err as Error).message || 'Unknown error'}`
+          );
+          if (attempt < retries) {
+            appendLog('Retrying...');
+            await delay(1000 * attempt);
+          }
+        }
+      }
+      throw lastError;
+    },
+    [appendLog]
+  );
+
+  const startScan = useCallback(async () => {
+    if (!supported) return;
     setBusy(true);
-
-    const consent = window.confirm(
-      'This application will request access to nearby Bluetooth devices. Continue?'
-    );
-    if (!consent) {
-      setBusy(false);
-      return;
-    }
-
+    setStatus('scanning');
+    setError('');
+    appendLog('Starting Bluetooth scan. Waiting for device selection.');
     try {
       const device = await (navigator as any).bluetooth.requestDevice({
         acceptAllDevices: true,
@@ -80,16 +115,22 @@ const BleSensor: React.FC = () => {
       if (saved) {
         setDeviceName(saved.name);
         setServices(saved.services);
+        setStatus('connected');
+        appendLog(`Loaded saved profile for ${saved.name}.`);
         return;
       }
 
       setDeviceName(device.name || 'Unknown device');
 
+      setStatus('connecting');
+      appendLog('Connecting to selected device.');
       const server = await connectWithRetry(device);
 
-      device.addEventListener('gattserverdisconnected', () =>
-        setError('Device disconnected.')
-      );
+      device.addEventListener('gattserverdisconnected', () => {
+        setError('Device disconnected.');
+        setStatus('error');
+        appendLog('Device disconnected unexpectedly.');
+      });
 
       const primServices = await server.getPrimaryServices();
       const serviceData: ServiceData[] = [];
@@ -116,6 +157,8 @@ const BleSensor: React.FC = () => {
       });
       bcRef.current?.postMessage('update');
       await refreshProfiles();
+      setStatus('connected');
+      appendLog('Services read and cached locally.');
     } catch (err) {
       const e = err as DOMException;
       if (e.name === 'NotAllowedError') {
@@ -125,26 +168,117 @@ const BleSensor: React.FC = () => {
       } else {
         setError(e.message || 'An unknown error occurred.');
       }
+      setStatus('error');
+      appendLog(`Scan failed: ${e.message || e.name || 'Unknown error'}`);
     } finally {
       setBusy(false);
     }
+  }, [appendLog, connectWithRetry, refreshProfiles, supported]);
+
+  const handleScan = useCallback(() => {
+    if (!supported || busy) return;
+    if (!acknowledgedPreflight) {
+      setShowPreflight(true);
+      setStatus('prompt');
+      return;
+    }
+    void startScan();
+  }, [acknowledgedPreflight, busy, startScan, supported]);
+
+  const handleConfirmPreflight = useCallback(() => {
+    setAcknowledgedPreflight(true);
+    setShowPreflight(false);
+    void startScan();
+  }, [startScan]);
+
+  const handleCancelPreflight = useCallback(() => {
+    setShowPreflight(false);
+    setStatus('idle');
+    appendLog('Scan cancelled at preflight dialog.');
+  }, [appendLog]);
+
+  const statusLabels: Record<
+    'idle' | 'prompt' | 'scanning' | 'connecting' | 'connected' | 'error',
+    string
+  > = {
+    idle: 'Idle',
+    prompt: 'Awaiting confirmation',
+    scanning: 'Scanning for devices',
+    connecting: 'Connecting',
+    connected: 'Connected',
+    error: 'Needs attention',
   };
 
   return (
-    <div className="h-full w-full bg-black p-4 text-white">
+    <div className="relative flex h-full w-full flex-col bg-black p-4 text-white">
+      {showPreflight && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/80 p-4">
+          <div className="w-full max-w-md rounded bg-gray-900 p-4 shadow-lg">
+            <h2 className="mb-2 text-lg font-bold" data-locale-key="connections.preflight.title">
+              Before we scan
+            </h2>
+            <p className="text-sm text-gray-200" data-locale-key="connections.preflight.bleSummary">
+              This tool will request permission to read your nearby Bluetooth device name, service identifiers, and characteristic values so it can display them within this simulator.
+            </p>
+            <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-gray-200">
+              <li data-locale-key="connections.preflight.localOnly">
+                Data stays on this page and remains only in your browser; nothing is sent to external services.
+              </li>
+              <li data-locale-key="connections.preflight.fallback">
+                If Bluetooth access is denied or unsupported, load a saved profile or switch to a Chromium-based browser on desktop.
+              </li>
+              <li data-locale-key="connections.preflight.retry">
+                You can retry the scan at any time if the device is asleep or out of range.
+              </li>
+            </ul>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                onClick={handleCancelPreflight}
+                className="rounded bg-gray-700 px-3 py-1 text-sm"
+                data-locale-key="connections.preflight.cancel"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmPreflight}
+                className="rounded bg-blue-600 px-3 py-1 text-sm"
+                data-locale-key="connections.preflight.continue"
+              >
+                Continue
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       {!supported && (
         <p className="mb-4 text-sm text-yellow-400">
           Web Bluetooth is not supported in this browser.
         </p>
       )}
 
-      <button
-        onClick={handleScan}
-        disabled={!supported || busy}
-        className="mb-4 rounded bg-blue-600 px-3 py-1 disabled:opacity-50"
-      >
-        Scan for Devices
-      </button>
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <button
+          onClick={handleScan}
+          disabled={!supported || busy}
+          className="rounded bg-blue-600 px-3 py-1 disabled:opacity-50"
+          data-locale-key="connections.actions.scan"
+        >
+          Scan for Devices
+        </button>
+        <p className="text-xs text-gray-300" data-locale-key="connections.status" aria-live="polite">
+          Status: {statusLabels[status]}
+        </p>
+      </div>
+
+      {status === 'error' && !busy && (
+        <button
+          onClick={handleScan}
+          className="mb-2 self-start rounded border border-blue-400 px-3 py-1 text-sm"
+          data-locale-key="connections.actions.retryScan"
+        >
+          Retry Scan
+        </button>
+      )}
 
       {error && <FormError className="mt-0 mb-4">{error}</FormError>}
 
@@ -162,6 +296,8 @@ const BleSensor: React.FC = () => {
                     await refreshProfiles();
                   }}
                   className="w-40 bg-gray-800 px-1"
+                  aria-label="Rename saved profile"
+                  data-locale-key="connections.savedProfiles.renameLabel"
                 />
                 <button
                   onClick={async () => {
@@ -179,7 +315,11 @@ const BleSensor: React.FC = () => {
         </div>
       )}
 
-      {deviceName && <p className="mb-2">Connected to: {deviceName}</p>}
+      {deviceName && (
+        <p className="mb-2" data-locale-key="connections.connectedLabel">
+          Connected to: {deviceName}
+        </p>
+      )}
 
       <ul className="space-y-2 overflow-auto">
         {services.map((service) => (
@@ -195,6 +335,16 @@ const BleSensor: React.FC = () => {
           </li>
         ))}
       </ul>
+
+      <div className="mt-4 h-28 overflow-auto rounded bg-gray-900 p-2 text-xs">
+        {logEntries.length === 0 ? (
+          <p className="text-gray-400" data-locale-key="connections.log.empty">
+            Activity log will appear here.
+          </p>
+        ) : (
+          logEntries.map((entry, idx) => <p key={`${entry}-${idx}`}>{entry}</p>)
+        )}
+      </div>
     </div>
   );
 };

--- a/components/apps/webusb.tsx
+++ b/components/apps/webusb.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import FormError from '../ui/FormError';
 
 interface USBEndpoint {
@@ -44,18 +44,52 @@ const WebUSBApp: React.FC = () => {
   const [outEndpoint, setOutEndpoint] = useState<number | null>(null);
   const [connected, setConnected] = useState(false);
   const [message, setMessage] = useState('');
-  const [log, setLog] = useState<string[]>([]);
+  const [logs, setLogs] = useState<string[]>([]);
   const [error, setError] = useState('');
+  const [status, setStatus] = useState<'idle' | 'prompt' | 'connecting' | 'connected' | 'error'>(
+    'idle'
+  );
+  const [showPreflight, setShowPreflight] = useState(false);
+  const [acknowledgedPreflight, setAcknowledgedPreflight] = useState(false);
+  const [busy, setBusy] = useState(false);
 
-  const handleConnect = async () => {
+  const appendLog = useCallback((entry: string) => {
+    setLogs((prev) => {
+      const next = [...prev, entry];
+      return next.slice(-40);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!supported) {
+      const ua = typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown';
+      const message = `WebUSB unsupported. UA: ${ua}`;
+      appendLog(message);
+      if (typeof console !== 'undefined') {
+        console.info(message);
+      }
+    }
+  }, [appendLog, supported]);
+
+  const startConnection = useCallback(async () => {
     if (useMock || !supported) {
       setConnected(true);
-      setLog((l) => [...l, 'Connected to mock device']);
+      setStatus('connected');
+      appendLog('Connected to mock USB device.');
       return;
     }
+
+    setBusy(true);
+    setStatus('connecting');
+    setError('');
+    appendLog('Requesting USB device selection.');
     try {
       const d = await (navigator as NavigatorUSB).usb.requestDevice({ filters: [] });
-      await d.open();
+      const openPromise = d.open();
+      const timeout = new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('Connection timed out')), 10000)
+      );
+      await Promise.race([openPromise, timeout]);
       if (d.configuration === null) {
         await d.selectConfiguration(1);
       }
@@ -68,12 +102,14 @@ const WebUSBApp: React.FC = () => {
       d.addEventListener('disconnect', () => {
         setConnected(false);
         setDevice(null);
-        setLog((l) => [...l, 'Device disconnected']);
+        setStatus('error');
+        appendLog('USB device disconnected.');
       });
       setDevice(d);
       setConnected(true);
+      setStatus('connected');
       setError('');
-      setLog((l) => [...l, `Connected to ${d.productName ?? 'device'}`]);
+      appendLog(`Connected to ${d.productName ?? 'device'}.`);
     } catch (err) {
       const e = err as DOMException;
       if (e.name === 'NotFoundError') {
@@ -81,15 +117,31 @@ const WebUSBApp: React.FC = () => {
       } else if (e.name === 'NotAllowedError') {
         setError('Permission to access USB was denied.');
       } else {
-        setError(e.message || 'An unknown error occurred.');
+        setError((err as Error).message || 'An unknown error occurred.');
       }
+      setStatus('error');
+      appendLog(`USB connection failed: ${(err as Error).message || e.name || 'Unknown error'}`);
+    } finally {
+      setBusy(false);
     }
-  };
+  }, [appendLog, supported, useMock]);
 
-  const handleDisconnect = async () => {
+  const handleConnect = useCallback(() => {
+    if (busy) return;
+    if (!acknowledgedPreflight) {
+      setShowPreflight(true);
+      setStatus('prompt');
+      return;
+    }
+    void startConnection();
+  }, [acknowledgedPreflight, busy, startConnection]);
+
+  const handleDisconnect = useCallback(async () => {
+    if (busy) return;
     if (useMock) {
       setConnected(false);
-      setLog((l) => [...l, 'Disconnected']);
+      setStatus('idle');
+      appendLog('Disconnected from mock device.');
       return;
     }
     if (device) {
@@ -97,13 +149,34 @@ const WebUSBApp: React.FC = () => {
     }
     setConnected(false);
     setDevice(null);
-    setLog((l) => [...l, 'Disconnected']);
+    setStatus('idle');
+    appendLog('Disconnected from device.');
+  }, [busy, device, useMock, appendLog]);
+
+  const confirmPreflight = useCallback(() => {
+    setAcknowledgedPreflight(true);
+    setShowPreflight(false);
+    void startConnection();
+  }, [startConnection]);
+
+  const cancelPreflight = useCallback(() => {
+    setShowPreflight(false);
+    setStatus('idle');
+    appendLog('USB connect cancelled at preflight dialog.');
+  }, [appendLog]);
+
+  const statusLabels: Record<'idle' | 'prompt' | 'connecting' | 'connected' | 'error', string> = {
+    idle: 'Idle',
+    prompt: 'Awaiting confirmation',
+    connecting: 'Connecting',
+    connected: 'Connected',
+    error: 'Needs attention',
   };
 
   const sendMessage = async () => {
     if (!connected) return;
     if (useMock) {
-      setLog((l) => [...l, `> ${message}`, `< ${message}`]);
+      setLogs((l) => [...l, `> ${message}`, `< ${message}`]);
       setMessage('');
       return;
     }
@@ -117,7 +190,7 @@ const WebUSBApp: React.FC = () => {
       await device.transferOut(outEndpoint, encoder.encode(message + '\n'));
       const result = await device.transferIn(inEndpoint, 64);
       const text = decoder.decode(result.data);
-      setLog((l) => [...l, `> ${message}`, `< ${text.trim()}`]);
+      setLogs((l) => [...l, `> ${message}`, `< ${text.trim()}`]);
       setMessage('');
     } catch (err) {
       setError((err as Error).message);
@@ -126,43 +199,106 @@ const WebUSBApp: React.FC = () => {
 
   const toggleMock = () => {
     setUseMock((v) => !v);
-    setLog([]);
+    setLogs([]);
     setError('');
     setConnected(false);
+    setStatus('idle');
+    appendLog('Toggled mock mode.');
   };
 
   return (
-    <div className="relative h-full w-full bg-black p-4 text-white">
-      <div className="mb-4 flex items-center gap-4">
+    <div className="relative flex h-full w-full flex-col bg-black p-4 text-white">
+      {showPreflight && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/80 p-4">
+          <div className="w-full max-w-md rounded bg-gray-900 p-4 shadow-lg">
+            <h2 className="mb-2 text-lg font-bold" data-locale-key="connections.preflight.title">
+              Before we connect
+            </h2>
+            <p className="text-sm text-gray-200" data-locale-key="connections.preflight.usbSummary">
+              This tool will ask for permission to access a USB device so it can list endpoints and echo test messages inside this simulator.
+            </p>
+            <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-gray-200">
+              <li data-locale-key="connections.preflight.localOnly">
+                Data stays on this page and remains only in your browser; nothing is sent to external services.
+              </li>
+              <li data-locale-key="connections.preflight.usbFallback">
+                If USB access is unavailable, enable mock mode or connect through a Chromium-based browser on desktop.
+              </li>
+              <li data-locale-key="connections.preflight.retry">
+                You can retry the connection if the device was busy or locked.
+              </li>
+            </ul>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                onClick={cancelPreflight}
+                className="rounded bg-gray-700 px-3 py-1 text-sm"
+                data-locale-key="connections.preflight.cancel"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmPreflight}
+                className="rounded bg-blue-600 px-3 py-1 text-sm"
+                data-locale-key="connections.preflight.continue"
+              >
+                Continue
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <button
           onClick={connected ? handleDisconnect : handleConnect}
           className="rounded bg-blue-600 px-3 py-1 disabled:opacity-50"
+          disabled={busy}
+          data-locale-key={
+            connected ? 'connections.actions.disconnect' : 'connections.actions.connect'
+          }
         >
           {connected ? 'Disconnect' : 'Connect'}
         </button>
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={useMock}
-            onChange={toggleMock}
-            disabled={!supported}
-          />
-          Use Mock
-        </label>
-        {!supported && (
-          <span className="text-sm text-yellow-400">WebUSB not supported</span>
-        )}
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={useMock}
+              onChange={toggleMock}
+              disabled={!supported}
+              aria-label="Toggle mock USB device"
+              data-locale-key="connections.mockToggleAria"
+            />
+            <span data-locale-key="connections.mockToggle">Use Mock</span>
+          </label>
+        <p className="text-xs text-gray-300" data-locale-key="connections.status" aria-live="polite">
+          Status: {statusLabels[status]}
+        </p>
       </div>
+      {!supported && (
+        <span className="mb-2 text-sm text-yellow-400" data-locale-key="connections.usbUnsupported">
+          WebUSB is not supported in this browser.
+        </span>
+      )}
+      {status === 'error' && !busy && !connected && (
+        <button
+          onClick={handleConnect}
+          className="mb-2 self-start rounded border border-blue-400 px-3 py-1 text-sm"
+          data-locale-key="connections.actions.retryConnect"
+        >
+          Retry Connection
+        </button>
+      )}
       {error && <FormError className="mb-4 mt-0">{error}</FormError>}
       <div className="mb-4 flex gap-2">
-        <input
-          type="text"
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          placeholder="Message"
-          disabled={!connected}
-          className="flex-1 rounded bg-gray-800 p-2 text-white disabled:opacity-50"
-        />
+          <input
+            type="text"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Message"
+            disabled={!connected}
+            className="flex-1 rounded bg-gray-800 p-2 text-white disabled:opacity-50"
+            aria-label="USB message"
+            data-locale-key="connections.usbMessageLabel"
+          />
         <button
           onClick={sendMessage}
           disabled={!connected || !message}
@@ -172,9 +308,13 @@ const WebUSBApp: React.FC = () => {
         </button>
       </div>
       <div className="h-[calc(100%-8rem)] overflow-auto rounded bg-gray-800 p-2 text-sm">
-        {log.map((line, idx) => (
-          <p key={idx}>{line}</p>
-        ))}
+        {logs.length === 0 ? (
+          <p className="text-gray-400" data-locale-key="connections.log.empty">
+            Activity log will appear here.
+          </p>
+        ) : (
+          logs.map((line, idx) => <p key={`${line}-${idx}`}>{line}</p>)
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add pre-flight guidance, status tracking, and activity logs for the BLE Sensor simulator
- implement timeout-aware USB connection flow with shared pre-flight copy and localization hooks
- surface retry affordances and accessibility labels while logging unsupported browser diagnostics

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da484b3124832887b127307c42c52e