### PR TITLE
Add permission dialogs and device controls for screen recorder and QR scanner

### DIFF
--- a/components/apps/qr/index.tsx
+++ b/components/apps/qr/index.tsx
@@ -1,51 +1,174 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import QRCode from 'qrcode';
+
+type ScannerStatus = 'idle' | 'awaiting-permission' | 'scanning' | 'error';
+
+const StatusIndicator: React.FC<{ status: ScannerStatus; message: string }> = ({ status, message }) => {
+  const color = useMemo(() => {
+    switch (status) {
+      case 'scanning':
+        return 'bg-green-500';
+      case 'awaiting-permission':
+        return 'bg-yellow-400';
+      case 'error':
+        return 'bg-red-500';
+      default:
+        return 'bg-gray-400';
+    }
+  }, [status]);
+
+  return (
+    <div className="flex items-center gap-2 text-sm text-white/80">
+      <span className={`inline-block h-3 w-3 rounded-full ${color}`} aria-hidden />
+      <span className="font-medium">{message}</span>
+    </div>
+  );
+};
 
 const QRScanner: React.FC = () => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const controlsRef = useRef<{ stop: () => void } | null>(null);
   const trackRef = useRef<MediaStreamTrack | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
+  const [selectedCamera, setSelectedCamera] = useState<string>('environment');
+  const [startRequested, setStartRequested] = useState(false);
+  const [status, setStatus] = useState<ScannerStatus>('idle');
+  const [statusMessage, setStatusMessage] = useState('Ready to scan a QR code.');
   const [result, setResult] = useState('');
-  const [error, setError] = useState('');
-  const [facing, setFacing] = useState<'environment' | 'user'>('environment');
+  const [error, setError] = useState<string | null>(null);
   const [torch, setTorch] = useState(false);
+  const [torchSupported, setTorchSupported] = useState(false);
   const [preview, setPreview] = useState('');
+  const [showPermissionModal, setShowPermissionModal] = useState(true);
+  const [isEnumerating, setIsEnumerating] = useState(false);
+
+  const shutdownStream = useCallback(() => {
+    controlsRef.current?.stop?.();
+    controlsRef.current = null;
+    streamRef.current?.getTracks().forEach((track) => {
+      try {
+        track.stop();
+      } catch {
+        /* ignore */
+      }
+    });
+    streamRef.current = null;
+    trackRef.current = null;
+    setTorch(false);
+    setTorchSupported(false);
+    const video = videoRef.current;
+    if (video) {
+      video.pause();
+      video.srcObject = null;
+    }
+  }, []);
+
+  const loadDevices = useCallback(async () => {
+    if (!navigator.mediaDevices?.enumerateDevices) {
+      setDevices([]);
+      setError('Camera enumeration is not supported in this browser. Switch to a modern browser like Chrome or Edge.');
+      return;
+    }
+    setIsEnumerating(true);
+    try {
+      const all = await navigator.mediaDevices.enumerateDevices();
+      const videoInputs = all.filter((device) => device.kind === 'videoinput');
+      setDevices(videoInputs);
+      if (videoInputs.length === 0) {
+        setStatus('error');
+        setStatusMessage('No cameras detected.');
+        setError('No camera inputs were found. Connect a webcam or enable camera access in your browser, then refresh the list.');
+        setStartRequested(false);
+        shutdownStream();
+      } else {
+        setError((previous) => (previous && previous.startsWith('No camera') ? null : previous));
+      }
+    } catch {
+      setError('The browser blocked the device list. Allow camera access in the address bar, then try again.');
+    } finally {
+      setIsEnumerating(false);
+    }
+  }, [shutdownStream]);
 
   useEffect(() => {
-    let active = true;
-    const video = videoRef.current;
+    loadDevices();
+    if (!navigator.mediaDevices?.addEventListener) return;
+    const handler = () => loadDevices();
+    navigator.mediaDevices.addEventListener('devicechange', handler);
+    return () => {
+      navigator.mediaDevices.removeEventListener('devicechange', handler);
+    };
+  }, [loadDevices]);
+
+  useEffect(() => {
+    if (!startRequested) {
+      shutdownStream();
+      return;
+    }
+
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setStatus('error');
+      setStatusMessage('Camera access not supported.');
+      setError('Your browser does not support the camera APIs required for scanning. Try using Chrome, Edge, or Firefox.');
+      setStartRequested(false);
+      return;
+    }
+
+    let cancelled = false;
+
     const start = async () => {
-      if (!navigator.mediaDevices?.getUserMedia) {
-        setError('Camera API not supported');
-        return;
-      }
+      setStatus('awaiting-permission');
+      setStatusMessage('Waiting for camera permission…');
+      setError(null);
+      setResult('');
+      setPreview('');
+
       try {
         controlsRef.current?.stop?.();
+        const videoConstraint: MediaTrackConstraints =
+          selectedCamera === 'environment' || selectedCamera === 'user'
+            ? { facingMode: selectedCamera }
+            : { deviceId: { exact: selectedCamera } };
         const stream = await navigator.mediaDevices.getUserMedia({
-          video: { facingMode: facing },
+          video: videoConstraint,
         });
+
+        if (cancelled) {
+          stream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+
+        shutdownStream();
         streamRef.current = stream;
         trackRef.current = stream.getVideoTracks()[0] || null;
-        if (!active) return;
+        setTorch(false);
+        setTorchSupported(Boolean(trackRef.current?.getCapabilities?.().torch));
+
         const videoEl = videoRef.current;
         if (videoEl) {
           videoEl.srcObject = stream;
           await videoEl.play();
         }
+
+        setStatus('scanning');
+        setStatusMessage('Point a QR code at the camera.');
+
         if ('BarcodeDetector' in window) {
           const detector = new (window as any).BarcodeDetector({ formats: ['qr_code'] });
           const scan = async () => {
-            if (!active) return;
+            if (cancelled) return;
             try {
-              const codes = await detector.detect(videoRef.current!);
-              if (codes[0]) setResult(codes[0].rawValue);
+              if (videoRef.current) {
+                const codes = await detector.detect(videoRef.current);
+                if (codes[0]) setResult(codes[0].rawValue);
+              }
             } catch {
-              /* ignore */
+              /* ignore detection blips */
             }
-            requestAnimationFrame(scan);
+            if (!cancelled) requestAnimationFrame(scan);
           };
           scan();
         } else {
@@ -53,6 +176,7 @@ const QRScanner: React.FC = () => {
             import('@zxing/browser'),
             import('@zxing/library'),
           ]);
+          if (cancelled) return;
           const codeReader = new BrowserQRCodeReader();
           controlsRef.current = await codeReader.decodeFromVideoDevice(
             undefined,
@@ -60,35 +184,52 @@ const QRScanner: React.FC = () => {
             (res, err) => {
               if (res) setResult(res.getText());
               if (err && !(err instanceof NotFoundException)) {
-                setError('Failed to read QR code');
+                setError('We could not read the QR code. Adjust the lighting or move the code closer, then try again.');
               }
             },
           );
         }
       } catch (err) {
+        shutdownStream();
+        setStartRequested(false);
+        setStatus('error');
         if (err instanceof DOMException && err.name === 'NotAllowedError') {
-          setError('Camera access was denied');
+          setStatusMessage('Camera permission denied.');
+          setError('Camera access was blocked. Use the camera icon in the browser’s address bar to allow access, then press “Start scanning” again.');
+        } else if (err instanceof DOMException && err.name === 'NotFoundError') {
+          setStatusMessage('No camera available.');
+          setError('No camera was found. Connect a webcam or ensure your device camera is enabled, then retry.');
+        } else if (err instanceof DOMException && err.name === 'NotReadableError') {
+          setStatusMessage('Camera is in use by another app.');
+          setError('Another application is using the camera. Close that app or tab, then start scanning again.');
         } else {
-          setError('Could not start camera');
+          setStatusMessage('Could not start the scanner.');
+          setError('The scanner failed to start. Refresh the page and try again, or switch to a different browser.');
         }
       }
     };
+
     start();
+
     return () => {
-      active = false;
-      controlsRef.current?.stop?.();
-      streamRef.current?.getTracks().forEach((t) => t.stop());
-      if (video) video.srcObject = null;
-      trackRef.current = null;
+      cancelled = true;
+      shutdownStream();
     };
-  }, [facing]);
+  }, [selectedCamera, shutdownStream, startRequested]);
 
   useEffect(() => {
     const track = trackRef.current as any;
     if (!track) return;
     const capabilities = track.getCapabilities?.();
-    if (!capabilities?.torch) return;
-    track.applyConstraints({ advanced: [{ torch }] }).catch(() => {});
+    const supportsTorch = Boolean(capabilities?.torch);
+    setTorchSupported(supportsTorch);
+    if (!supportsTorch) return;
+    track
+      .applyConstraints({ advanced: [{ torch }] })
+      .catch(() => {
+        setTorch(false);
+        setError('Torch control is not available on this device. Try increasing ambient light instead.');
+      });
   }, [torch]);
 
   useEffect(() => {
@@ -101,62 +242,186 @@ const QRScanner: React.FC = () => {
     }
   }, [result]);
 
+  useEffect(() => {
+    return () => {
+      shutdownStream();
+    };
+  }, [shutdownStream]);
+
   const copyResult = () => {
     if (result) navigator.clipboard?.writeText(result).catch(() => {});
   };
 
   const toggleTorch = () => {
+    if (!torchSupported) return;
     setTorch((t) => !t);
   };
 
   const switchCamera = () => {
-    setFacing((f) => (f === 'environment' ? 'user' : 'environment'));
+    setSelectedCamera((current) => (current === 'environment' ? 'user' : 'environment'));
+  };
+
+  const cameraOptions = useMemo(() => {
+    const baseOptions = [
+      { label: 'Rear camera (if available)', value: 'environment' },
+      { label: 'Front camera', value: 'user' },
+    ];
+    const deviceOptions = devices.map((device, index) => ({
+      label: device.label || `Camera ${index + 1}`,
+      value: device.deviceId,
+    }));
+    return [...baseOptions, ...deviceOptions];
+  }, [devices]);
+
+  const handleStop = useCallback(() => {
+    setStartRequested(false);
+    setStatus('idle');
+    setStatusMessage('Camera stopped. Press “Start scanning” to try again.');
+    shutdownStream();
+  }, [shutdownStream]);
+
+  const openScanner = () => {
+    setShowPermissionModal(true);
+  };
+
+  const beginScanning = () => {
+    setShowPermissionModal(false);
+    setStartRequested(true);
   };
 
   return (
-    <div className="p-4 space-y-4 text-white bg-ub-cool-grey h-full flex flex-col items-center">
-      <div className="relative w-full max-w-sm">
-        <video ref={videoRef} className="w-full rounded-md border-2 border-white bg-black" />
-        <div className="absolute top-2 right-2 flex gap-2">
+    <div className="relative flex h-full flex-col items-center gap-4 bg-ub-cool-grey p-4 text-white">
+      <div className="w-full max-w-xl space-y-4 rounded-lg bg-black/30 p-4">
+        <StatusIndicator status={status} message={statusMessage} />
+        {error && (
+          <div className="rounded border border-red-500/60 bg-red-500/10 p-3 text-sm text-red-200">
+            <p className="font-semibold">Need help?</p>
+            <p>{error}</p>
+          </div>
+        )}
+        <div className="flex flex-col gap-2">
+          <label htmlFor="qr-camera-select" className="text-sm font-semibold text-white/80">
+            Camera source
+          </label>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <select
+              id="qr-camera-select"
+              value={selectedCamera}
+              onChange={(event) => setSelectedCamera(event.target.value)}
+              className="w-full rounded border border-white/20 bg-black/40 p-2 text-white"
+            >
+              {cameraOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={loadDevices}
+              className="rounded bg-ub-dracula px-3 py-2 text-sm font-medium hover:bg-ub-dracula-dark disabled:opacity-60"
+              disabled={isEnumerating}
+            >
+              {isEnumerating ? 'Refreshing…' : 'Refresh devices'}
+            </button>
+          </div>
+          <p className="text-xs text-white/60">
+            If cameras appear without labels, grant camera access in your browser so names become visible. Plug in new devices
+            and click “Refresh devices” to update the list.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
           <button
             type="button"
-            onClick={toggleTorch}
-            aria-label="Toggle flashlight"
-            className="p-1 bg-black/50 rounded"
+            onClick={openScanner}
+            className="rounded bg-ub-dracula px-4 py-2 font-semibold hover:bg-ub-dracula-dark"
+            disabled={startRequested && status !== 'error'}
           >
-            <FlashIcon className="w-6 h-6" />
+            {startRequested && status !== 'error' ? 'Scanning…' : 'Start scanning'}
           </button>
           <button
             type="button"
-            onClick={switchCamera}
-            aria-label="Switch camera"
-            className="p-1 bg-black/50 rounded"
+            onClick={handleStop}
+            className="rounded bg-red-600 px-4 py-2 font-semibold hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={!startRequested}
           >
-            <SwitchCameraIcon className="w-6 h-6" />
+            Stop camera
           </button>
         </div>
-      </div>
-      {error && <p className="text-sm text-red-500">{error}</p>}
-      {result && (
-        <div className="flex items-center gap-2 p-2 bg-white text-black rounded-md w-full max-w-sm">
-          {preview && (
-            <img
-              src={preview}
-              alt="QR preview"
-              className="w-32 h-32 rounded-md border"
-            />
-          )}
-          <div className="flex-1 min-w-0">
-            <p className="break-all text-sm">{result}</p>
+        <div className="relative w-full max-w-sm">
+          <video
+            ref={videoRef}
+            className="w-full rounded-md border-2 border-white bg-black"
+            aria-label="Camera preview"
+          />
+          <div className="absolute top-2 right-2 flex gap-2">
+            <button
+              type="button"
+              onClick={toggleTorch}
+              aria-label="Toggle flashlight"
+              className="rounded bg-black/50 p-1 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={!torchSupported}
+            >
+              <FlashIcon className="h-6 w-6" />
+            </button>
+            <button
+              type="button"
+              onClick={switchCamera}
+              aria-label="Switch camera"
+              className="rounded bg-black/50 p-1"
+            >
+              <SwitchCameraIcon className="h-6 w-6" />
+            </button>
           </div>
-          <button
-            type="button"
-            onClick={copyResult}
-            aria-label="Copy result"
-            className="p-1"
-          >
-            <CopyIcon className="w-6 h-6" />
-          </button>
+        </div>
+        {result && (
+          <div className="flex items-center gap-2 rounded-md bg-white p-2 text-black">
+            {preview && (
+              <img src={preview} alt="QR preview" className="h-32 w-32 rounded-md border" />
+            )}
+            <div className="min-w-0 flex-1">
+              <p className="break-all text-sm">{result}</p>
+            </div>
+            <button
+              type="button"
+              onClick={copyResult}
+              aria-label="Copy result"
+              className="p-1"
+            >
+              <CopyIcon className="h-6 w-6" />
+            </button>
+          </div>
+        )}
+      </div>
+      {showPermissionModal && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/80 p-4">
+          <div className="max-w-lg rounded-lg bg-ub-dark p-6 text-left text-white shadow-xl">
+            <h2 className="text-lg font-semibold">Prepare to scan</h2>
+            <ol className="mt-3 list-decimal space-y-2 pl-5 text-sm text-white/80">
+              <li>When prompted, allow the browser to use your camera.</li>
+              <li>Point the camera steadily at the QR code so the full square is visible.</li>
+              <li>If nothing happens, adjust lighting or choose a different camera above.</li>
+            </ol>
+            <p className="mt-3 text-xs text-white/60">
+              Blocked the camera earlier? Use the camera icon in the address bar to re-enable it, then press “Start scanning”.
+            </p>
+            <div className="mt-4 flex flex-wrap justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setShowPermissionModal(false)}
+                className="rounded bg-white/10 px-4 py-2 text-sm font-medium hover:bg-white/20"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={beginScanning}
+                className="rounded bg-ub-dracula px-4 py-2 text-sm font-semibold hover:bg-ub-dracula-dark"
+              >
+                Start scanning
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/components/apps/screen-recorder.tsx
+++ b/components/apps/screen-recorder.tsx
@@ -1,44 +1,191 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+type RecorderStatus =
+    | 'idle'
+    | 'awaiting-permission'
+    | 'recording'
+    | 'processing'
+    | 'ready'
+    | 'error';
+
+const StatusIndicator: React.FC<{ status: RecorderStatus; message: string }> = ({ status, message }) => {
+    const color = useMemo(() => {
+        switch (status) {
+            case 'recording':
+                return 'bg-red-500';
+            case 'awaiting-permission':
+                return 'bg-yellow-400';
+            case 'processing':
+                return 'bg-blue-400';
+            case 'ready':
+                return 'bg-green-500';
+            case 'error':
+                return 'bg-red-600';
+            default:
+                return 'bg-gray-400';
+        }
+    }, [status]);
+
+    return (
+        <div className="flex items-center gap-2 text-sm text-white/80">
+            <span className={`inline-block h-3 w-3 rounded-full ${color}`} aria-hidden />
+            <span className="font-medium">{message}</span>
+        </div>
+    );
+};
 
 function ScreenRecorder() {
-    const [recording, setRecording] = useState(false);
+    const [status, setStatus] = useState<RecorderStatus>('idle');
+    const [statusMessage, setStatusMessage] = useState('Ready to start a new recording.');
+    const [error, setError] = useState<string | null>(null);
     const [videoUrl, setVideoUrl] = useState<string | null>(null);
+    const [showPermissionModal, setShowPermissionModal] = useState(false);
+    const [audioDevices, setAudioDevices] = useState<MediaDeviceInfo[]>([]);
+    const [selectedMic, setSelectedMic] = useState<string>('none');
+    const [isEnumerating, setIsEnumerating] = useState(false);
     const recorderRef = useRef<MediaRecorder | null>(null);
     const chunksRef = useRef<Blob[]>([]);
-    const streamRef = useRef<MediaStream | null>(null);
+    const displayStreamRef = useRef<MediaStream | null>(null);
+    const micStreamRef = useRef<MediaStream | null>(null);
 
-    const startRecording = async () => {
+    const stopTracks = useCallback(() => {
+        displayStreamRef.current?.getTracks().forEach((t) => {
+            try {
+                t.stop();
+            } catch {
+                /* ignore */
+            }
+        });
+        micStreamRef.current?.getTracks().forEach((t) => {
+            try {
+                t.stop();
+            } catch {
+                /* ignore */
+            }
+        });
+        displayStreamRef.current = null;
+        micStreamRef.current = null;
+    }, []);
+
+    const loadAudioDevices = useCallback(async () => {
+        if (!navigator.mediaDevices?.enumerateDevices) {
+            setAudioDevices([]);
+            return;
+        }
+        setIsEnumerating(true);
         try {
-            const stream = await navigator.mediaDevices.getDisplayMedia({
-                video: true,
-                audio: true,
+            const devices = await navigator.mediaDevices.enumerateDevices();
+            const inputs = devices.filter((device) => device.kind === 'audioinput');
+            setAudioDevices(inputs);
+            if (inputs.length === 0) {
+                setError(
+                    'No recording devices were reported by the browser. Connect a microphone and press “Refresh devices”, or continue with “No microphone”.',
+                );
+                if (selectedMic !== 'none') {
+                    setSelectedMic('none');
+                }
+            } else {
+                setError((previous) =>
+                    previous && previous.startsWith('No recording devices') ? null : previous,
+                );
+            }
+        } catch {
+            setError('The browser blocked access to the device list. Allow microphone access in the address bar, then retry.');
+        } finally {
+            setIsEnumerating(false);
+        }
+    }, [selectedMic]);
+
+    const startRecording = useCallback(async () => {
+        if (!navigator.mediaDevices?.getDisplayMedia) {
+            setStatus('error');
+            setStatusMessage('Screen capture is not supported.');
+            setError('Screen capture APIs are unavailable in this browser. Try Chrome, Edge, or another Chromium-based browser.');
+            return;
+        }
+
+        setShowPermissionModal(false);
+        setError(null);
+        setStatus('awaiting-permission');
+        setStatusMessage('Waiting for you to pick what to share…');
+
+        try {
+            const displayStream = await navigator.mediaDevices.getDisplayMedia({
+                video: { frameRate: 30 },
+                audio: selectedMic !== 'none',
             });
-            streamRef.current = stream;
-            const recorder = new MediaRecorder(stream);
+
+            displayStreamRef.current = displayStream;
             chunksRef.current = [];
-            recorder.ondataavailable = (e: BlobEvent) => {
-                if (e.data.size > 0) chunksRef.current.push(e.data);
+
+            if (selectedMic !== 'none') {
+                try {
+                    const audioConstraints: MediaTrackConstraints =
+                        selectedMic === 'default'
+                            ? { noiseSuppression: true }
+                            : { deviceId: { exact: selectedMic }, noiseSuppression: true };
+                    const micStream = await navigator.mediaDevices.getUserMedia({ audio: audioConstraints });
+                    micStreamRef.current = micStream;
+                    micStream.getAudioTracks().forEach((track) => displayStream.addTrack(track));
+                } catch {
+                    setError(
+                        'The selected microphone could not be started. The recording will continue with system audio only. Check that no other tab or application is locking the mic.',
+                    );
+                }
+            }
+
+            const recorder = new MediaRecorder(displayStream);
+            recorderRef.current = recorder;
+
+            recorder.ondataavailable = (event: BlobEvent) => {
+                if (event.data.size > 0) {
+                    chunksRef.current.push(event.data);
+                }
             };
+
             recorder.onstop = () => {
+                setStatus('processing');
+                setStatusMessage('Finalising your recording…');
                 const blob = new Blob(chunksRef.current, { type: 'video/webm' });
                 const url = URL.createObjectURL(blob);
                 setVideoUrl(url);
-                stream.getTracks().forEach((t) => t.stop());
+                stopTracks();
+                setStatus('ready');
+                setStatusMessage('Recording ready — you can preview or save it below.');
             };
+
             recorder.start();
-            recorderRef.current = recorder;
-            setRecording(true);
-        } catch {
-            // ignore
+            setStatus('recording');
+            setStatusMessage('Recording in progress. Use “Stop sharing” when finished.');
+        } catch (err) {
+            stopTracks();
+            setStatus('error');
+            if (err instanceof DOMException && err.name === 'NotAllowedError') {
+                setStatusMessage('Screen capture permission denied.');
+                setError(
+                    'Screen sharing was blocked. Click the screen icon in the address bar, allow access, then press “Start recording” again.',
+                );
+            } else if (err instanceof DOMException && err.name === 'NotFoundError') {
+                setStatusMessage('No shareable screens were found.');
+                setError('The browser could not find a display to capture. If you cancelled the prompt, try again and select a screen.');
+            } else {
+                setStatusMessage('Something went wrong while starting the recording.');
+                setError('The recording could not start. Refresh the page and try again, or check another browser.');
+            }
         }
-    };
+    }, [selectedMic, stopTracks]);
 
-    const stopRecording = () => {
-        recorderRef.current?.stop();
-        setRecording(false);
-    };
+    const stopRecording = useCallback(() => {
+        if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+            recorderRef.current.stop();
+        } else {
+            stopTracks();
+            setStatus('idle');
+            setStatusMessage('Recording stopped.');
+        }
+    }, [stopTracks]);
 
-    const saveRecording = async () => {
+    const saveRecording = useCallback(async () => {
         if (!videoUrl) return;
         const blob = new Blob(chunksRef.current, { type: 'video/webm' });
         if ('showSaveFilePicker' in window) {
@@ -55,8 +202,11 @@ function ScreenRecorder() {
                 const writable = await handle.createWritable();
                 await writable.write(blob);
                 await writable.close();
-            } catch {
-                // ignore
+                setStatusMessage('Recording saved to your device.');
+            } catch (err) {
+                if (err instanceof DOMException && err.name === 'AbortError') {
+                    setStatusMessage('Save cancelled. The recording is still available below.');
+                }
             }
         } else {
             const a = document.createElement('a');
@@ -65,47 +215,163 @@ function ScreenRecorder() {
             document.body.appendChild(a);
             a.click();
             a.remove();
+            setStatusMessage('Recording download started.');
         }
-    };
+    }, [videoUrl]);
+
+    useEffect(() => {
+        loadAudioDevices();
+        if (!navigator.mediaDevices?.addEventListener) return;
+        const handler = () => loadAudioDevices();
+        navigator.mediaDevices.addEventListener('devicechange', handler);
+        return () => {
+            navigator.mediaDevices.removeEventListener('devicechange', handler);
+        };
+    }, [loadAudioDevices]);
 
     useEffect(() => {
         return () => {
-            streamRef.current?.getTracks().forEach((t) => t.stop());
-            recorderRef.current?.stop();
+            stopTracks();
+            if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+                recorderRef.current.stop();
+            }
         };
-    }, []);
+    }, [stopTracks]);
+
+    const micOptions = useMemo(() => {
+        const options = [
+            { label: 'No microphone (screen only)', value: 'none' },
+            { label: 'Browser default microphone', value: 'default' },
+            ...audioDevices.map((device, index) => ({
+                label: device.label || `Microphone ${index + 1}`,
+                value: device.deviceId,
+            })),
+        ];
+        return options;
+    }, [audioDevices]);
 
     return (
-        <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white space-y-4 p-4">
-            {!recording && (
-                <button
-                    type="button"
-                    onClick={startRecording}
-                    className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
-                >
-                    Start Recording
-                </button>
-            )}
-            {recording && (
-                <button
-                    type="button"
-                    onClick={stopRecording}
-                    className="px-4 py-2 rounded bg-red-600 hover:bg-red-700"
-                >
-                    Stop Recording
-                </button>
-            )}
-            {videoUrl && !recording && (
-                <>
-                    <video src={videoUrl} controls className="max-w-full" />
+        <div className="relative flex h-full w-full flex-col items-center justify-start gap-6 bg-ub-cool-grey p-6 text-white">
+            <div className="flex w-full max-w-xl flex-col gap-4 rounded-lg bg-black/30 p-4">
+                <StatusIndicator status={status} message={statusMessage} />
+                {error && (
+                    <div className="rounded border border-red-500/60 bg-red-500/10 p-3 text-sm text-red-200">
+                        <p className="font-semibold">Having trouble?</p>
+                        <p>{error}</p>
+                    </div>
+                )}
+                <div className="flex flex-col gap-2">
+                    <label htmlFor="screen-mic-select" className="text-sm font-semibold text-white/80">
+                        Microphone source
+                    </label>
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                        <select
+                            id="screen-mic-select"
+                            value={selectedMic}
+                            onChange={(event) => setSelectedMic(event.target.value)}
+                            className="w-full rounded border border-white/20 bg-black/40 p-2 text-white"
+                        >
+                            {micOptions.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </select>
+                        <button
+                            type="button"
+                            onClick={loadAudioDevices}
+                            className="rounded bg-ub-dracula px-3 py-2 text-sm font-medium hover:bg-ub-dracula-dark"
+                            disabled={isEnumerating}
+                        >
+                            {isEnumerating ? 'Refreshing…' : 'Refresh devices'}
+                        </button>
+                    </div>
+                    <p className="text-xs text-white/60">
+                        Choose “No microphone” if you only want to capture the screen. Selecting a specific input may require that
+                        you grant microphone permission.
+                    </p>
+                </div>
+                <div className="flex flex-wrap gap-3">
                     <button
                         type="button"
-                        onClick={saveRecording}
-                        className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
+                        onClick={() => setShowPermissionModal(true)}
+                        className="rounded bg-ub-dracula px-4 py-2 font-semibold hover:bg-ub-dracula-dark"
+                        disabled={status === 'recording' || status === 'awaiting-permission'}
                     >
-                        Save Recording
+                        {status === 'recording' ? 'Recording…' : 'Start recording'}
                     </button>
-                </>
+                    <button
+                        type="button"
+                        onClick={stopRecording}
+                        className="rounded bg-red-600 px-4 py-2 font-semibold hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60"
+                        disabled={status !== 'recording' && status !== 'awaiting-permission'}
+                    >
+                        Stop sharing
+                    </button>
+                </div>
+                {videoUrl && (
+                    <div className="flex flex-col gap-3">
+                        <video
+                            src={videoUrl}
+                            controls
+                            className="max-h-64 w-full rounded border border-white/10"
+                            aria-label="Screen recording playback"
+                        />
+                        <div className="flex flex-wrap gap-3">
+                            <button
+                                type="button"
+                                onClick={saveRecording}
+                                className="rounded bg-ub-dracula px-4 py-2 font-semibold hover:bg-ub-dracula-dark"
+                            >
+                                Save recording
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    setVideoUrl(null);
+                                    chunksRef.current = [];
+                                    setStatus('idle');
+                                    setStatusMessage('Ready to start a new recording.');
+                                }}
+                                className="rounded bg-white/10 px-4 py-2 text-sm font-semibold hover:bg-white/20"
+                            >
+                                Discard &amp; start again
+                            </button>
+                        </div>
+                    </div>
+                )}
+            </div>
+            {showPermissionModal && (
+                <div className="absolute inset-0 flex items-center justify-center bg-black/80 p-4">
+                    <div className="max-w-lg rounded-lg bg-ub-dark p-6 text-left text-white shadow-xl">
+                        <h2 className="text-lg font-semibold">Grant screen sharing permission</h2>
+                        <ol className="mt-3 list-decimal space-y-2 pl-5 text-sm text-white/80">
+                            <li>When your browser prompt appears, choose the screen, window, or tab you want to share.</li>
+                            <li>Ensure the “Share system audio” checkbox is ticked if you want to capture computer sound.</li>
+                            <li>Click <strong>Share</strong> to begin recording.</li>
+                        </ol>
+                        <p className="mt-3 text-xs text-white/60">
+                            If the prompt does not show, make sure screen capture is allowed for this site in your browser’s address
+                            bar controls.
+                        </p>
+                        <div className="mt-4 flex flex-wrap justify-end gap-3">
+                            <button
+                                type="button"
+                                onClick={() => setShowPermissionModal(false)}
+                                className="rounded bg-white/10 px-4 py-2 text-sm font-medium hover:bg-white/20"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                onClick={startRecording}
+                                className="rounded bg-ub-dracula px-4 py-2 text-sm font-semibold hover:bg-ub-dracula-dark"
+                            >
+                                Share my screen
+                            </button>
+                        </div>
+                    </div>
+                </div>
             )}
         </div>
     );


### PR DESCRIPTION
## Summary
- add permission modal, device enumeration, and friendly error handling to the screen recorder
- surface camera selection, permission guidance, and persistent stop controls in the QR scanner
- update both apps with status indicators and accessibility tweaks for media previews

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da484e29cc8328ac26f003a7a070d4