### PR TITLE
[apps] add simulation notices to security tool apps

### DIFF
--- a/apps/hashcat/index.tsx
+++ b/apps/hashcat/index.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
 import RulesSandbox from './components/RulesSandbox';
 import StatsChart from '../../components/StatsChart';
+import SimulationNotice from '../../components/apps/common/SimulationNotice';
 
 interface Preset {
   value: string;
@@ -170,6 +171,16 @@ const Hashcat: React.FC = () => {
 
   return (
     <div className="p-4 bg-gray-900 text-white min-h-screen space-y-4">
+      <SimulationNotice
+        baseI18nKey="apps.hashcat.notice"
+        messages={{
+          title: 'Hashcat Simulation',
+          description:
+            'This Hashcat dashboard is an educational simulation intended to explore cracking concepts without processing live credentials.',
+          sandbox:
+            'Hashes, rules, and results stay inside sandboxed demo data so no external systems or personal data are touched.',
+        }}
+      />
       <h1 className="text-2xl">Hashcat Simulator</h1>
 
       <div>

--- a/apps/john/index.tsx
+++ b/apps/john/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import SimulationNotice from '../../components/apps/common/SimulationNotice';
 import AuditSimulator from './components/AuditSimulator';
 
 interface HashItem {
@@ -155,7 +156,16 @@ const JohnApp: React.FC = () => {
 
   return (
     <div className="h-full w-full p-4 bg-gray-900 text-white flex flex-col gap-4">
-      <p className="text-xs text-yellow-300">Demo only – simulated cracking.</p>
+      <SimulationNotice
+        baseI18nKey="apps.john.notice"
+        messages={{
+          title: "John the Ripper Simulation",
+          description:
+            'This John the Ripper lab is a controlled simulation to teach auditing techniques without attacking actual credentials.',
+          sandbox:
+            'Password lists, hashes, and cracking results are generated from sandboxed demo content and never leave this environment.',
+        }}
+      />
       <div className="flex flex-wrap gap-4 items-center">
         <div className="flex gap-2">
           {modes.map((m) => (

--- a/apps/metasploit-post/index.tsx
+++ b/apps/metasploit-post/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useMemo, useState } from 'react';
+import SimulationNotice from '../../components/apps/common/SimulationNotice';
 import modules from './modules.json';
 import privTree from './priv-esc.json';
 import RemediationTable from './components/RemediationTable';
@@ -280,6 +281,17 @@ const MetasploitPost: React.FC = () => {
 
   return (
     <div className="p-4 bg-gray-900 text-white min-h-screen">
+      <SimulationNotice
+        baseI18nKey="apps.metasploitPost.notice"
+        className="mb-4"
+        messages={{
+          title: 'Metasploit Post-Exploitation Simulation',
+          description:
+            'Post-exploitation modules shown here are simulated to demonstrate analysis and reporting workflows only.',
+          sandbox:
+            'Evidence, credentials, and host details are fictional and remain within this sandboxed environment.',
+        }}
+      />
       <h1 className="text-xl mb-4">Metasploit Post Modules</h1>
       <div className="flex space-x-4 mb-4">
         {tabs.map((t) => (

--- a/apps/metasploit/index.tsx
+++ b/apps/metasploit/index.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import modulesData from '../../components/apps/metasploit/modules.json';
 import MetasploitApp from '../../components/apps/metasploit';
+import SimulationNotice from '../../components/apps/common/SimulationNotice';
 import Toast from '../../components/ui/Toast';
 
 interface Module {
@@ -132,7 +133,19 @@ const MetasploitPage: React.FC = () => {
   );
 
   return (
-    <div className="flex h-full">
+    <div className="flex h-full flex-col">
+      <SimulationNotice
+        baseI18nKey="apps.metasploit.notice"
+        className="mb-4"
+        messages={{
+          title: 'Metasploit Simulation',
+          description:
+            'This Metasploit workspace is a guided simulation for practicing workflows only. Modules and payloads do not target live systems.',
+          sandbox:
+            'Generated payloads and console output are based on sandboxed datasets with no outbound network activity.',
+        }}
+      />
+      <div className="flex flex-1 overflow-hidden">
         <div className="w-1/3 border-r overflow-auto p-2">
           <label htmlFor="metasploit-search" className="sr-only" id="metasploit-search-label">
             Search modules
@@ -146,55 +159,55 @@ const MetasploitPage: React.FC = () => {
             className="w-full p-1 mb-2 border rounded"
             aria-labelledby="metasploit-search-label"
           />
-        <div className="flex flex-wrap gap-1 mb-2">
-          <button
-            onClick={() => setTag('')}
-            className={`px-2 py-0.5 text-xs rounded ${
-              tag === '' ? 'bg-blue-600 text-white' : 'bg-gray-200'
-            }`}
-          >
-            All
-          </button>
-          {allTags.map((t) => (
+          <div className="flex flex-wrap gap-1 mb-2">
             <button
-              key={t}
-              onClick={() => setTag(t)}
+              onClick={() => setTag('')}
               className={`px-2 py-0.5 text-xs rounded ${
-                tag === t ? 'bg-blue-600 text-white' : 'bg-gray-200'
+                tag === '' ? 'bg-blue-600 text-white' : 'bg-gray-200'
               }`}
             >
-              {t}
+              All
             </button>
-          ))}
-        </div>
-        {renderTree(tree)}
-      </div>
-      <div className="flex-1 flex flex-col">
-        <div className="flex-1 overflow-auto p-4">
-          {selected ? (
-            <div>
-              <h2 className="font-bold mb-2 flex items-center">
-                {selected.name}
-                <span
-                  className={`ml-2 text-xs text-white px-2 py-0.5 rounded ${typeColors[selected.type] || 'bg-gray-500'}`}
-                >
-                  {selected.type}
-                </span>
-              </h2>
-              <p className="whitespace-pre-wrap">{selected.description}</p>
-            </div>
-          ) : (
-            <p>Select a module to view details</p>
-          )}
-        </div>
-        <div ref={splitRef} className="h-96 border-t flex flex-col">
-          <div style={{ height: `calc(${split}% - 2px)` }} className="overflow-auto">
-            <MetasploitApp />
+            {allTags.map((t) => (
+              <button
+                key={t}
+                onClick={() => setTag(t)}
+                className={`px-2 py-0.5 text-xs rounded ${
+                  tag === t ? 'bg-blue-600 text-white' : 'bg-gray-200'
+                }`}
+              >
+                {t}
+              </button>
+            ))}
           </div>
-          <div
-            className="h-1 bg-gray-400 cursor-row-resize"
-            onMouseDown={() => (dragging.current = true)}
-          />
+          {renderTree(tree)}
+        </div>
+        <div className="flex-1 flex flex-col">
+          <div className="flex-1 overflow-auto p-4">
+            {selected ? (
+              <div>
+                <h2 className="font-bold mb-2 flex items-center">
+                  {selected.name}
+                  <span
+                    className={`ml-2 text-xs text-white px-2 py-0.5 rounded ${typeColors[selected.type] || 'bg-gray-500'}`}
+                  >
+                    {selected.type}
+                  </span>
+                </h2>
+                <p className="whitespace-pre-wrap">{selected.description}</p>
+              </div>
+            ) : (
+              <p>Select a module to view details</p>
+            )}
+          </div>
+          <div ref={splitRef} className="h-96 border-t flex flex-col">
+            <div style={{ height: `calc(${split}% - 2px)` }} className="overflow-auto">
+              <MetasploitApp />
+            </div>
+            <div
+              className="h-1 bg-gray-400 cursor-row-resize"
+              onMouseDown={() => (dragging.current = true)}
+            />
             <div
               style={{ height: `calc(${100 - split}% - 2px)` }}
               className="overflow-auto p-2 space-y-2"
@@ -214,12 +227,13 @@ const MetasploitPage: React.FC = () => {
                 className="border p-1 w-full"
                 aria-labelledby="metasploit-payload-options-label"
               />
-            <button
-              onClick={handleGenerate}
-              className="px-2 py-1 bg-blue-500 text-white rounded"
-            >
-              Generate
-            </button>
+              <button
+                onClick={handleGenerate}
+                className="px-2 py-1 bg-blue-500 text-white rounded"
+              >
+                Generate
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/components/apps/common/SimulationNotice.tsx
+++ b/components/apps/common/SimulationNotice.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+
+interface ResourceLink {
+  href: string;
+  label: string;
+  i18nKey?: string;
+}
+
+export interface SimulationNoticeMessages {
+  title: string;
+  description: string;
+  sandbox: string;
+  resourcesHeading: string;
+  resources: ResourceLink[];
+}
+
+export const defaultSimulationNoticeMessages: SimulationNoticeMessages = {
+  title: 'Training Simulation',
+  description:
+    'This interface reproduces security tooling for learning and awareness. It does not execute actions against real systems.',
+  sandbox: 'All scenarios use sandboxed, fictitious data and remain isolated from your environment.',
+  resourcesHeading: 'Learn about responsible security research',
+  resources: [
+    {
+      href: 'https://www.kali.org/docs/policy/training-labs/',
+      label: 'Kali Linux: responsible use of training labs',
+      i18nKey: 'resourceGuidelines',
+    },
+    {
+      href: 'https://owasp.org/www-community/Vulnerability_Disclosure',
+      label: 'OWASP: vulnerability disclosure best practices',
+      i18nKey: 'resourceDisclosure',
+    },
+  ],
+};
+
+interface SimulationNoticeProps {
+  messages?: Partial<SimulationNoticeMessages> & {
+    resources?: ResourceLink[];
+  };
+  baseI18nKey?: string;
+  className?: string;
+}
+
+const SimulationNotice: React.FC<SimulationNoticeProps> = ({
+  messages,
+  baseI18nKey = 'simulationNotice',
+  className = '',
+}) => {
+  const merged: SimulationNoticeMessages = {
+    ...defaultSimulationNoticeMessages,
+    ...messages,
+    resources: messages?.resources ?? defaultSimulationNoticeMessages.resources,
+  };
+
+  const titleId = `${baseI18nKey}-title`;
+  const descriptionId = `${baseI18nKey}-description`;
+
+  return (
+    <section
+      className={`rounded-md border-l-4 border-yellow-500 bg-yellow-50 p-4 text-sm text-gray-900 shadow-sm dark:border-yellow-400 dark:bg-yellow-900/30 dark:text-yellow-50 ${className}`}
+      role="note"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      data-i18n-key={`${baseI18nKey}.container`}
+    >
+      <h2
+        id={titleId}
+        className="text-base font-semibold"
+        data-i18n-key={`${baseI18nKey}.title`}
+      >
+        {merged.title}
+      </h2>
+      <p
+        id={descriptionId}
+        className="mt-1"
+        data-i18n-key={`${baseI18nKey}.description`}
+      >
+        {merged.description}
+      </p>
+      <p className="mt-1" data-i18n-key={`${baseI18nKey}.sandbox`}>
+        {merged.sandbox}
+      </p>
+      <p
+        className="mt-3 font-medium"
+        data-i18n-key={`${baseI18nKey}.resourcesHeading`}
+      >
+        {merged.resourcesHeading}
+      </p>
+      <ul className="mt-1 list-disc space-y-1 pl-5">
+        {merged.resources.map((resource, index) => (
+          <li key={resource.href}>
+            <a
+              href={resource.href}
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-2 hover:text-yellow-700 focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-500 dark:hover:text-yellow-200"
+              data-i18n-key={`${baseI18nKey}.resources.${resource.i18nKey ?? index}`}
+            >
+              {resource.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default SimulationNotice;


### PR DESCRIPTION
## Summary
- add a reusable simulation notice component with accessibility and i18n hooks
- display persistent sandboxed-use messaging in Metasploit, Metasploit Post, Hashcat, and John simulators

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da4855607883289e8e9dd5cd8568e8