### PR TITLE
[ui] Improve delayed tooltip behavior

### DIFF
--- a/__tests__/DelayedTooltip.test.tsx
+++ b/__tests__/DelayedTooltip.test.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DelayedTooltip, {
+  calculateTooltipPosition,
+} from '../components/ui/DelayedTooltip';
+
+type MatchMediaMock = {
+  list: MediaQueryList;
+  listeners: Set<(event: MediaQueryListEvent) => void>;
+};
+
+const originalMatchMedia = window.matchMedia;
+
+const setupMatchMedia = (matches = false): MatchMediaMock => {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  const list: MediaQueryList = {
+    matches,
+    media: '(prefers-reduced-motion: reduce)',
+    onchange: null,
+    addEventListener: jest.fn((_event, listener) => {
+      listeners.add(listener as (event: MediaQueryListEvent) => void);
+    }),
+    removeEventListener: jest.fn((_event, listener) => {
+      listeners.delete(listener as (event: MediaQueryListEvent) => void);
+    }),
+    addListener: jest.fn((listener) => {
+      listeners.add(listener as (event: MediaQueryListEvent) => void);
+    }),
+    removeListener: jest.fn((listener) => {
+      listeners.delete(listener as (event: MediaQueryListEvent) => void);
+    }),
+    dispatchEvent: jest.fn(),
+  };
+
+  window.matchMedia = jest.fn().mockImplementation(() => list);
+
+  return { list, listeners };
+};
+
+describe('DelayedTooltip interactions', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    window.matchMedia = originalMatchMedia;
+  });
+
+  test('opens after a 150ms delay and closes immediately', () => {
+    setupMatchMedia(false);
+    const { getByText, unmount } = render(
+      <DelayedTooltip content="Tooltip text">
+        {(triggerProps) => (
+          <button type="button" {...triggerProps}>
+            Trigger
+          </button>
+        )}
+      </DelayedTooltip>,
+    );
+
+    const trigger = getByText('Trigger');
+
+    act(() => {
+      fireEvent.mouseEnter(trigger);
+      jest.advanceTimersByTime(149);
+    });
+
+    expect(screen.queryByText('Tooltip text')).toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    const tooltip = screen.getByText('Tooltip text').closest('[data-placement]');
+    expect(tooltip).toBeTruthy();
+    const portal = document.querySelector('[data-delayed-tooltip="true"]');
+    expect(portal?.contains(tooltip as Node)).toBe(true);
+
+    act(() => {
+      fireEvent.mouseLeave(trigger);
+    });
+
+    expect(screen.queryByText('Tooltip text')).toBeNull();
+
+    unmount();
+  });
+
+  test('respects reduced motion preference and skips delay', () => {
+    const { list, listeners } = setupMatchMedia(true);
+    const { getByText } = render(
+      <DelayedTooltip content="Reduced">
+        {(triggerProps) => (
+          <button type="button" {...triggerProps}>
+            Trigger
+          </button>
+        )}
+      </DelayedTooltip>,
+    );
+
+    const trigger = getByText('Trigger');
+
+    act(() => {
+      fireEvent.mouseEnter(trigger);
+    });
+
+    expect(screen.getByText('Reduced')).toBeInTheDocument();
+
+    act(() => {
+      (list as { matches: boolean }).matches = false;
+      listeners.forEach((listener) =>
+        listener({ matches: false, media: list.media } as MediaQueryListEvent),
+      );
+    });
+
+    act(() => {
+      fireEvent.mouseLeave(trigger);
+      fireEvent.mouseEnter(trigger);
+      jest.advanceTimersByTime(150);
+    });
+
+    expect(screen.getByText('Reduced')).toBeInTheDocument();
+  });
+});
+
+describe('calculateTooltipPosition', () => {
+  const createRect = ({
+    top,
+    left,
+    width,
+    height,
+  }: {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+  }): DOMRect =>
+    ({
+      top,
+      left,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+  const viewportWidth = 800;
+  const viewportHeight = 600;
+
+  test('prefers bottom placement when space is available', () => {
+    const triggerRect = createRect({ top: 200, left: 200, width: 40, height: 40 });
+    const tooltipRect = createRect({ top: 0, left: 0, width: 120, height: 60 });
+    const result = calculateTooltipPosition({
+      triggerRect,
+      tooltipRect,
+      viewportWidth,
+      viewportHeight,
+    });
+
+    expect(result.placement).toBe('bottom');
+    expect(result.top).toBe(triggerRect.bottom + 8);
+    expect(result.arrowOffset.x).toBeGreaterThanOrEqual(8);
+    expect(result.arrowOffset.x).toBeLessThanOrEqual(112);
+  });
+
+  test('falls back to top placement near viewport bottom', () => {
+    const triggerRect = createRect({ top: 560, left: 300, width: 40, height: 40 });
+    const tooltipRect = createRect({ top: 0, left: 0, width: 120, height: 80 });
+    const result = calculateTooltipPosition({
+      triggerRect,
+      tooltipRect,
+      viewportWidth,
+      viewportHeight,
+    });
+
+    expect(result.placement).toBe('top');
+    expect(result.top + tooltipRect.height + 8).toBe(triggerRect.top);
+    expect(result.arrowOffset.x).toBeGreaterThanOrEqual(8);
+  });
+
+  test('uses horizontal placements when vertical space is limited', () => {
+    const tooltipRect = createRect({ top: 0, left: 0, width: 180, height: 120 });
+    const constrainedHeight = 160;
+
+    const rightTarget = createRect({ top: 60, left: 10, width: 40, height: 40 });
+    const rightResult = calculateTooltipPosition({
+      triggerRect: rightTarget,
+      tooltipRect,
+      viewportWidth,
+      viewportHeight: constrainedHeight,
+    });
+    expect(rightResult.placement).toBe('right');
+    expect(rightResult.left).toBe(rightTarget.right + 8);
+    expect(rightResult.arrowOffset.y).toBeGreaterThanOrEqual(8);
+    expect(rightResult.arrowOffset.y).toBeLessThanOrEqual(tooltipRect.height - 8);
+
+    const leftTarget = createRect({ top: 60, left: 760, width: 40, height: 40 });
+    const leftResult = calculateTooltipPosition({
+      triggerRect: leftTarget,
+      tooltipRect,
+      viewportWidth,
+      viewportHeight: constrainedHeight,
+    });
+    expect(leftResult.placement).toBe('left');
+    expect(leftResult.left + tooltipRect.width + 8).toBe(leftTarget.left);
+    expect(leftResult.arrowOffset.y).toBeGreaterThanOrEqual(8);
+    expect(leftResult.arrowOffset.y).toBeLessThanOrEqual(tooltipRect.height - 8);
+  });
+
+  test('clamps tooltip within viewport and limits arrow offset', () => {
+    const triggerRect = createRect({ top: 50, left: 4, width: 40, height: 40 });
+    const tooltipRect = createRect({ top: 0, left: 0, width: 220, height: 60 });
+    const result = calculateTooltipPosition({
+      triggerRect,
+      tooltipRect,
+      viewportWidth: 240,
+      viewportHeight,
+    });
+
+    expect(result.left).toBe(8);
+    expect(result.arrowOffset.x).toBeGreaterThanOrEqual(8);
+    expect(result.arrowOffset.x).toBeLessThanOrEqual(212);
+  });
+});

--- a/components/ui/DelayedTooltip.module.css
+++ b/components/ui/DelayedTooltip.module.css
@@ -1,0 +1,66 @@
+.tooltip {
+  position: fixed;
+  z-index: 1000;
+  pointer-events: none;
+  --tooltip-arrow-size: 12px;
+  --tooltip-arrow-x: 0px;
+  --tooltip-arrow-y: 0px;
+  --tooltip-arrow-offset: 8px;
+}
+
+.content {
+  position: relative;
+  pointer-events: none;
+  display: inline-block;
+}
+
+.arrow {
+  position: absolute;
+  width: var(--tooltip-arrow-size);
+  height: var(--tooltip-arrow-size);
+  pointer-events: none;
+}
+
+.tooltip[data-placement='bottom'] .arrow {
+  top: calc(var(--tooltip-arrow-size) / -2);
+  left: calc(
+    clamp(
+      var(--tooltip-arrow-offset),
+      var(--tooltip-arrow-x),
+      calc(100% - var(--tooltip-arrow-offset))
+    ) - var(--tooltip-arrow-size) / 2
+  );
+}
+
+.tooltip[data-placement='top'] .arrow {
+  bottom: calc(var(--tooltip-arrow-size) / -2);
+  left: calc(
+    clamp(
+      var(--tooltip-arrow-offset),
+      var(--tooltip-arrow-x),
+      calc(100% - var(--tooltip-arrow-offset))
+    ) - var(--tooltip-arrow-size) / 2
+  );
+}
+
+.tooltip[data-placement='left'] .arrow {
+  right: calc(var(--tooltip-arrow-size) / -2);
+  top: calc(
+    clamp(
+      var(--tooltip-arrow-offset),
+      var(--tooltip-arrow-y),
+      calc(100% - var(--tooltip-arrow-offset))
+    ) - var(--tooltip-arrow-size) / 2
+  );
+}
+
+.tooltip[data-placement='right'] .arrow {
+  left: calc(var(--tooltip-arrow-size) / -2);
+  top: calc(
+    clamp(
+      var(--tooltip-arrow-offset),
+      var(--tooltip-arrow-y),
+      calc(100% - var(--tooltip-arrow-offset))
+    ) - var(--tooltip-arrow-size) / 2
+  );
+}

--- a/components/ui/DelayedTooltip.tsx
+++ b/components/ui/DelayedTooltip.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
 } from 'react';
 import { createPortal } from 'react-dom';
+import styles from './DelayedTooltip.module.css';
 
 type TriggerProps = {
   ref: (node: HTMLElement | null) => void;
@@ -14,6 +15,21 @@ type TriggerProps = {
   onMouseLeave: (event: React.MouseEvent<HTMLElement>) => void;
   onFocus: (event: React.FocusEvent<HTMLElement>) => void;
   onBlur: (event: React.FocusEvent<HTMLElement>) => void;
+};
+
+type Placement = 'top' | 'bottom' | 'left' | 'right';
+
+type TooltipPosition = {
+  top: number;
+  left: number;
+  placement: Placement;
+  arrowOffset: { x: number; y: number };
+};
+
+type TooltipInlineStyle = React.CSSProperties & {
+  '--tooltip-arrow-x'?: string;
+  '--tooltip-arrow-y'?: string;
+  '--tooltip-arrow-offset'?: string;
 };
 
 type DelayedTooltipProps = {
@@ -26,18 +42,148 @@ const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 const DEFAULT_OFFSET = 8;
+const DEFAULT_OPEN_DELAY = 150;
+const ARROW_SAFE_OFFSET = 8;
+
+type CalculatePositionArgs = {
+  triggerRect: DOMRect;
+  tooltipRect: DOMRect;
+  viewportWidth: number;
+  viewportHeight: number;
+  offset?: number;
+  arrowOffset?: number;
+};
+
+export function calculateTooltipPosition({
+  triggerRect,
+  tooltipRect,
+  viewportWidth,
+  viewportHeight,
+  offset = DEFAULT_OFFSET,
+  arrowOffset = ARROW_SAFE_OFFSET,
+}: CalculatePositionArgs): TooltipPosition {
+  const spaces = {
+    top: triggerRect.top,
+    bottom: viewportHeight - triggerRect.bottom,
+    left: triggerRect.left,
+    right: viewportWidth - triggerRect.right,
+  };
+
+  const fitsBottom = spaces.bottom >= tooltipRect.height + offset;
+  const fitsTop = spaces.top >= tooltipRect.height + offset;
+  const fitsRight = spaces.right >= tooltipRect.width + offset;
+  const fitsLeft = spaces.left >= tooltipRect.width + offset;
+
+  let placement: Placement = 'bottom';
+  if (fitsBottom) {
+    placement = 'bottom';
+  } else if (fitsTop) {
+    placement = 'top';
+  } else if (fitsRight) {
+    placement = 'right';
+  } else if (fitsLeft) {
+    placement = 'left';
+  } else {
+    placement = (Object.entries(spaces) as Array<[Placement, number]>).reduce(
+      (prev, current) => (current[1] > prev[1] ? (current as [Placement, number]) : prev),
+    )[0];
+  }
+
+  let top = 0;
+  let left = 0;
+
+  if (placement === 'bottom') {
+    top = triggerRect.bottom + offset;
+    left = triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
+  } else if (placement === 'top') {
+    top = triggerRect.top - tooltipRect.height - offset;
+    left = triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
+  } else if (placement === 'right') {
+    top = triggerRect.top + triggerRect.height / 2 - tooltipRect.height / 2;
+    left = triggerRect.right + offset;
+  } else {
+    top = triggerRect.top + triggerRect.height / 2 - tooltipRect.height / 2;
+    left = triggerRect.left - tooltipRect.width - offset;
+  }
+
+  const minLeft = offset;
+  const maxLeft = viewportWidth - tooltipRect.width - offset;
+  const minTop = offset;
+  const maxTop = viewportHeight - tooltipRect.height - offset;
+
+  const clamp = (value: number, min: number, max: number) => {
+    if (max < min) {
+      return min;
+    }
+    return Math.min(Math.max(value, min), max);
+  };
+
+  left = clamp(left, minLeft, maxLeft);
+  top = clamp(top, minTop, maxTop);
+
+  let arrowX = tooltipRect.width / 2;
+  let arrowY = tooltipRect.height / 2;
+
+  if (placement === 'bottom' || placement === 'top') {
+    const triggerCenterX = triggerRect.left + triggerRect.width / 2;
+    const min = arrowOffset;
+    const max = tooltipRect.width - arrowOffset;
+    arrowX = clamp(triggerCenterX - left, min, max);
+    arrowY = placement === 'bottom' ? 0 : tooltipRect.height;
+  } else {
+    const triggerCenterY = triggerRect.top + triggerRect.height / 2;
+    const min = arrowOffset;
+    const max = tooltipRect.height - arrowOffset;
+    arrowY = clamp(triggerCenterY - top, min, max);
+    arrowX = placement === 'right' ? 0 : tooltipRect.width;
+  }
+
+  return {
+    top,
+    left,
+    placement,
+    arrowOffset: { x: arrowX, y: arrowY },
+  };
+}
 
 const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
   content,
-  delay = 300,
+  delay = DEFAULT_OPEN_DELAY,
   children,
 }) => {
   const triggerRef = useRef<HTMLElement | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const [visible, setVisible] = useState(false);
-  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const [position, setPosition] = useState<TooltipPosition>({
+    top: 0,
+    left: 0,
+    placement: 'bottom',
+    arrowOffset: { x: 0, y: 0 },
+  });
   const timerRef = useRef<number | null>(null);
   const [portalEl, setPortalEl] = useState<HTMLElement | null>(null);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+    if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(handleChange);
+      return () => mediaQuery.removeListener(handleChange);
+    }
+    return undefined;
+  }, []);
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
@@ -60,10 +206,16 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
 
   const show = useCallback(() => {
     clearTimer();
+    const effectiveDelay = prefersReducedMotion ? 0 : delay;
+    if (effectiveDelay <= 0) {
+      setVisible(true);
+      return;
+    }
     timerRef.current = window.setTimeout(() => {
       setVisible(true);
-    }, delay);
-  }, [clearTimer, delay]);
+      timerRef.current = null;
+    }, effectiveDelay);
+  }, [clearTimer, delay, prefersReducedMotion]);
 
   const hide = useCallback(() => {
     clearTimer();
@@ -72,38 +224,44 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
 
   useEffect(() => () => clearTimer(), [clearTimer]);
 
-  useIsomorphicLayoutEffect(() => {
-    if (!visible || !triggerRef.current || !tooltipRef.current) {
+  const updatePosition = useCallback(() => {
+    if (!triggerRef.current || !tooltipRef.current) {
       return;
     }
     const triggerRect = triggerRef.current.getBoundingClientRect();
     const tooltipRect = tooltipRef.current.getBoundingClientRect();
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
+    const nextPosition = calculateTooltipPosition({
+      triggerRect,
+      tooltipRect,
+      viewportWidth,
+      viewportHeight,
+      offset: DEFAULT_OFFSET,
+      arrowOffset: ARROW_SAFE_OFFSET,
+    });
+    setPosition(nextPosition);
+  }, []);
 
-    let top = triggerRect.bottom + DEFAULT_OFFSET;
-    let left =
-      triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
-
-    if (left < DEFAULT_OFFSET) {
-      left = DEFAULT_OFFSET;
+  useIsomorphicLayoutEffect(() => {
+    if (!visible) {
+      return;
     }
-    if (left + tooltipRect.width > viewportWidth - DEFAULT_OFFSET) {
-      left = viewportWidth - tooltipRect.width - DEFAULT_OFFSET;
-    }
+    updatePosition();
+  }, [visible, updatePosition, content]);
 
-    if (top + tooltipRect.height > viewportHeight - DEFAULT_OFFSET) {
-      top = triggerRect.top - tooltipRect.height - DEFAULT_OFFSET;
-      if (top < DEFAULT_OFFSET) {
-        top = Math.max(
-          DEFAULT_OFFSET,
-          viewportHeight - tooltipRect.height - DEFAULT_OFFSET,
-        );
-      }
+  useEffect(() => {
+    if (!visible) {
+      return;
     }
-
-    setPosition({ top, left });
-  }, [visible, content]);
+    const handle = () => updatePosition();
+    window.addEventListener('resize', handle);
+    window.addEventListener('scroll', handle, true);
+    return () => {
+      window.removeEventListener('resize', handle);
+      window.removeEventListener('scroll', handle, true);
+    };
+  }, [visible, updatePosition]);
 
   const triggerProps: TriggerProps = {
     ref: (node) => {
@@ -123,6 +281,14 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
     },
   };
 
+  const tooltipStyle: TooltipInlineStyle = {
+    top: position.top,
+    left: position.left,
+    '--tooltip-arrow-x': `${position.arrowOffset.x}px`,
+    '--tooltip-arrow-y': `${position.arrowOffset.y}px`,
+    '--tooltip-arrow-offset': `${ARROW_SAFE_OFFSET}px`,
+  };
+
   return (
     <>
       {children(triggerProps)}
@@ -130,15 +296,18 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
         ? createPortal(
             <div
               ref={tooltipRef}
-              style={{
-                position: 'fixed',
-                top: position.top,
-                left: position.left,
-                zIndex: 1000,
-              }}
-              className="pointer-events-none max-w-xs rounded-md border border-gray-500/60 bg-ub-grey/95 px-3 py-2 text-xs text-white shadow-xl backdrop-blur"
+              className={styles.tooltip}
+              data-placement={position.placement}
+              style={tooltipStyle}
             >
-              {content}
+              <div className={styles.arrow} aria-hidden="true">
+                <span className="block h-full w-full transform rotate-45 rounded-sm border border-gray-500/60 bg-ub-grey/95" />
+              </div>
+              <div
+                className={`${styles.content} max-w-xs rounded-md border border-gray-500/60 bg-ub-grey/95 px-3 py-2 text-xs text-white shadow-xl backdrop-blur`}
+              >
+                {content}
+              </div>
             </div>,
             portalEl,
           )


### PR DESCRIPTION
## Summary
- add reduced-motion aware timing control and expanded placement logic to `DelayedTooltip`
- style tooltip arrow with CSS variables to maintain an 8px offset in every placement
- cover tooltip behavior with focused Jest tests for delays, portal rendering, and geometry calculations

## Testing
- yarn test DelayedTooltip

------
https://chatgpt.com/codex/tasks/task_e_68da5193dc408328b422c2027d82bdad