### PR TITLE
[ui] Align interactive state styling

### DIFF
--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -86,13 +86,8 @@ export default function AppGrid({ openApp }) {
         {({ ref, onMouseEnter, onMouseLeave, onFocus, onBlur }) => (
           <div
             ref={ref}
-            style={{
-              ...style,
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              padding: 12,
-            }}
+            style={style}
+            className="flex h-full w-full items-center justify-center p-3"
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
             onFocus={onFocus}
@@ -114,7 +109,8 @@ export default function AppGrid({ openApp }) {
   return (
     <div className="flex flex-col items-center h-full">
       <input
-        className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+        className="mb-6 mt-4 w-2/3 rounded-md border border-interactive-border bg-interactive-surface px-4 py-2 text-white shadow-interactive transition-colors focus-visible:border-interactive-border-hover focus-visible:bg-interactive-hover focus-visible:shadow-interactive-hover md:w-1/3"
+        aria-label="Search apps"
         placeholder="Search"
         value={query}
         onChange={(e) => setQuery(e.target.value)}

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -70,7 +70,7 @@ export class UbuntuApp extends Component {
                 onPointerCancel={onPointerCancel}
                 style={combinedStyle}
                 className={(this.state.launching ? " app-icon-launch " : "") + (dragging ? " opacity-70 " : "") +
-                    " m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none flex flex-col justify-start items-center text-center font-normal text-white transition-hover transition-active "}
+                    " m-px z-10 flex select-none flex-col justify-start items-center text-center font-normal text-white rounded-lg border border-transparent bg-transparent transition-hover transition-active hover:border-interactive-border-hover hover:bg-interactive-hover hover:shadow-interactive-hover focus-visible:border-interactive-border-hover focus-visible:bg-interactive-hover focus-visible:shadow-interactive-hover active:border-interactive-border-active active:bg-interactive-active active:shadow-interactive-active "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -17,7 +17,7 @@ const Breadcrumbs: React.FC<Props> = ({ path, onNavigate }) => {
           <button
             type="button"
             onClick={() => onNavigate(idx)}
-            className="hover:underline focus:outline-none"
+            className="rounded-md px-2 py-1 text-sm font-medium text-white/90 transition-colors hover:bg-interactive-hover hover:text-white focus-visible:bg-interactive-hover focus-visible:text-white active:bg-interactive-active"
           >
             {seg.name || '/'}
           </button>

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -243,7 +243,7 @@ const NotificationBell: React.FC = () => {
         aria-expanded={isOpen}
         aria-controls={panelId}
         onClick={togglePanel}
-        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey transition focus:border-ubb-orange focus:outline-none focus:ring-0 hover:bg-white hover:bg-opacity-10"
+        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey shadow-none transition-colors hover:border-interactive-border-hover hover:bg-interactive-hover hover:text-white hover:shadow-interactive-hover focus-visible:border-interactive-border-hover focus-visible:bg-interactive-hover focus-visible:text-white focus-visible:shadow-interactive-hover active:border-interactive-border-active active:bg-interactive-active active:shadow-interactive-active"
       >
         <svg
           aria-hidden="true"
@@ -269,9 +269,9 @@ const NotificationBell: React.FC = () => {
           aria-modal="false"
           aria-labelledby={headingId}
           tabIndex={-1}
-          className="absolute right-0 z-50 mt-2 w-72 max-h-96 overflow-hidden rounded-md border border-white/10 bg-ub-grey/95 text-ubt-grey shadow-xl backdrop-blur"
+          className="absolute right-0 z-50 mt-2 max-h-96 w-72 overflow-hidden rounded-lg border border-interactive-border bg-interactive-surface text-white shadow-interactive backdrop-blur"
         >
-          <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
+          <div className="flex items-center justify-between border-b border-interactive-border px-4 py-2">
             <h2 id={headingId} className="text-sm font-semibold text-white">
               Notifications
             </h2>
@@ -279,7 +279,7 @@ const NotificationBell: React.FC = () => {
               type="button"
               onClick={handleDismissAll}
               disabled={notifications.length === 0}
-              className="text-xs font-medium text-ubb-orange transition disabled:cursor-not-allowed disabled:text-ubt-grey disabled:text-opacity-50"
+              className="rounded-md px-2 py-1 text-xs font-medium text-ubb-orange transition-colors hover:bg-interactive-hover focus-visible:bg-interactive-hover active:bg-interactive-active disabled:cursor-not-allowed disabled:text-white/40"
             >
               Dismiss all
             </button>
@@ -302,7 +302,7 @@ const NotificationBell: React.FC = () => {
                         onClick={() => toggleGroup(group.priority)}
                         aria-expanded={!collapsed}
                         aria-controls={contentId}
-                        className="flex w-full items-center justify-between px-4 py-2 text-left text-sm font-semibold text-white transition hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-ubb-orange"
+                        className="flex w-full items-center justify-between px-4 py-2 text-left text-sm font-semibold text-white transition-colors hover:bg-interactive-hover focus-visible:bg-interactive-hover active:bg-interactive-active"
                       >
                         <span className="flex items-center gap-2">
                           {group.metadata.label}

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import clsx from 'clsx';
 
 interface Props {
   open: boolean;
@@ -12,6 +13,9 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const soundId = 'quick-settings-sound';
+  const networkId = 'quick-settings-network';
+  const motionId = 'quick-settings-motion';
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -21,36 +25,56 @@ const QuickSettings = ({ open }: Props) => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
 
+  const rowClass =
+    'flex items-center justify-between px-4 py-2 text-sm text-white/90 transition-colors';
+
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
-        open ? '' : 'hidden'
-      }`}
+      className={clsx(
+        'absolute top-9 right-3 z-40 w-64 rounded-lg border border-interactive-border bg-interactive-surface shadow-interactive backdrop-blur-sm transition-all duration-150',
+        open ? 'block' : 'hidden',
+      )}
+      role="dialog"
+      aria-label="Quick settings"
     >
-      <div className="px-4 pb-2">
+      <div className="space-y-1 py-2">
         <button
-          className="w-full flex justify-between"
+          className={`${rowClass} w-full rounded-md text-left hover:bg-interactive-hover focus-visible:bg-interactive-hover active:bg-interactive-active`}
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
         >
           <span>Theme</span>
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
-        <input
-          type="checkbox"
-          checked={reduceMotion}
-          onChange={() => setReduceMotion(!reduceMotion)}
-        />
+        <label htmlFor={soundId} className={`${rowClass} cursor-pointer`}>
+          <span className="font-medium text-white">Sound</span>
+          <input
+            id={soundId}
+            type="checkbox"
+            checked={sound}
+            aria-label="Toggle sound"
+            onChange={() => setSound(!sound)}
+          />
+        </label>
+        <label htmlFor={networkId} className={`${rowClass} cursor-pointer`}>
+          <span className="font-medium text-white">Network</span>
+          <input
+            id={networkId}
+            type="checkbox"
+            checked={online}
+            aria-label="Toggle network"
+            onChange={() => setOnline(!online)}
+          />
+        </label>
+        <label htmlFor={motionId} className={`${rowClass} cursor-pointer`}>
+          <span className="font-medium text-white">Reduced motion</span>
+          <input
+            id={motionId}
+            type="checkbox"
+            checked={reduceMotion}
+            aria-label="Toggle reduced motion"
+            onChange={() => setReduceMotion(!reduceMotion)}
+          />
+        </label>
       </div>
     </div>
   );

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState, createContext, useContext } from 'react';
+import clsx from 'clsx';
 
 function middleEllipsis(text: string, max = 30) {
   if (text.length <= max) return text;
@@ -168,13 +169,16 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
       tabIndex={0}
       onKeyDown={onKeyDown}
     >
-      <div className="flex flex-shrink-0 bg-gray-800 text-white text-sm overflow-x-auto">
+      <div className="flex flex-shrink-0 overflow-x-auto border-b border-interactive-border bg-interactive-surface text-sm text-white">
         {tabs.map((t, i) => (
           <div
             key={t.id}
-            className={`flex items-center gap-1.5 px-3 py-1 cursor-pointer select-none ${
-              t.id === activeId ? 'bg-gray-700' : 'bg-gray-800'
-            }`}
+            className={clsx(
+              'flex cursor-pointer select-none items-center gap-1.5 rounded-t-md border border-transparent px-3 py-1 transition-colors',
+              t.id === activeId
+                ? 'border-interactive-border-hover bg-interactive-hover text-white shadow-interactive-hover'
+                : 'text-white/80 hover:border-interactive-border-hover hover:bg-interactive-hover hover:text-white',
+            )}
             draggable
             onDragStart={handleDragStart(i)}
             onDragOver={handleDragOver(i)}
@@ -184,7 +188,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
             <span className="max-w-[150px]">{middleEllipsis(t.title)}</span>
             {t.closable !== false && tabs.length > 1 && (
               <button
-                className="p-0.5"
+                className="rounded p-0.5 text-white/70 transition-colors hover:bg-interactive-hover hover:text-white focus-visible:bg-interactive-hover focus-visible:text-white active:bg-interactive-active"
                 onClick={(e) => {
                   e.stopPropagation();
                   closeTab(t.id);
@@ -198,7 +202,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
         ))}
         {onNewTab && (
           <button
-            className="px-2 py-1 bg-gray-800 hover:bg-gray-700"
+            className="ml-1 rounded-md border border-transparent px-2 py-1 text-white/80 transition-colors hover:border-interactive-border-hover hover:bg-interactive-hover hover:text-white focus-visible:border-interactive-border-hover focus-visible:bg-interactive-hover focus-visible:text-white active:border-interactive-border-active active:bg-interactive-active"
             onClick={addTab}
             aria-label="New Tab"
           >

--- a/docs/shared-interactive-components.md
+++ b/docs/shared-interactive-components.md
@@ -1,0 +1,14 @@
+# Shared interactive component inventory
+
+This inventory captures the reusable interactive elements (buttons, cards, tiles) that live under `components/ui`, `components/apps`, and `components/desktop`.
+
+| Directory | Component | Interaction type | Notes |
+| --- | --- | --- | --- |
+| `components/ui` | `NotificationBell.tsx` | Icon button with dropdown | Opens a notification panel with grouped items, dismissal controls, and keyboard trapping. |
+| `components/ui` | `QuickSettings.tsx` | Settings surface | Toggleable panel for theme, sound, network, and motion preferences. |
+| `components/ui` | `TabbedWindow.tsx` | Tab strip | Provides draggable tabs, close buttons, and a "new tab" action for apps that need multiple documents. |
+| `components/ui` | `Breadcrumbs.tsx` | Navigation buttons | Renders breadcrumb buttons for hierarchical navigation within apps. |
+| `components/apps` | `app-grid.js` | App tiles | Virtualized grid of launcher tiles that delegates individual tile rendering to `UbuntuApp`. |
+| `components/desktop` | `Layout.tsx` | Desktop shell container | Establishes desktop layout variables; no direct interactive targets but defines environment for shared controls. |
+
+> **Note:** The launcher tile itself is implemented in `components/base/ubuntu_app.js`, but it is consumed by `components/apps/app-grid.js` and receives the same interaction tokens defined for the shared inventory above.

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -39,6 +39,41 @@
   --kali-terminal-green: #00ff00;
   --kali-terminal-text: #f5f5f5;
 
+  /* Interactive surfaces */
+  --interactive-surface: color-mix(in srgb, var(--color-surface) 85%, var(--color-text) 15%);
+  --interactive-surface-hover: color-mix(
+    in srgb,
+    var(--color-surface) 70%,
+    var(--color-primary) 30%
+  );
+  --interactive-surface-active: color-mix(
+    in srgb,
+    var(--color-surface) 65%,
+    var(--color-primary) 35%
+  );
+  --interactive-border: color-mix(in srgb, var(--color-border) 70%, transparent 30%);
+  --interactive-border-hover: color-mix(
+    in srgb,
+    var(--color-primary) 35%,
+    var(--color-border) 65%
+  );
+  --interactive-border-active: color-mix(
+    in srgb,
+    var(--color-primary) 55%,
+    var(--color-border) 45%
+  );
+  --interactive-shadow: 0 2px 8px color-mix(in srgb, var(--color-inverse), transparent 85%);
+  --interactive-shadow-hover: 0 4px 14px color-mix(
+    in srgb,
+    var(--color-inverse),
+    transparent 75%
+  );
+  --interactive-shadow-active: inset 0 2px 6px color-mix(
+    in srgb,
+    var(--color-inverse),
+    transparent 70%
+  );
+
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
   --game-color-success: #15803d;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -53,9 +53,20 @@ module.exports = {
           control: 'var(--color-control-accent)',
           backdrop: 'var(--kali-bg)',
         },
+        interactive: {
+          surface: 'var(--interactive-surface)',
+          hover: 'var(--interactive-surface-hover)',
+          active: 'var(--interactive-surface-active)',
+          border: 'var(--interactive-border)',
+          'border-hover': 'var(--interactive-border-hover)',
+          'border-active': 'var(--interactive-border-active)',
+        },
       },
       boxShadow: {
         'kali-panel': '0 6px 20px rgba(0,0,0,.35)',
+        interactive: 'var(--interactive-shadow)',
+        'interactive-hover': 'var(--interactive-shadow-hover)',
+        'interactive-active': 'var(--interactive-shadow-active)',
       },
       fontFamily: {
         ubuntu: ['Ubuntu', 'sans-serif'],


### PR DESCRIPTION
## Summary
- document the shared interactive components under components/ui, components/apps, and components/desktop
- add reusable interactive background, border, and shadow tokens and surface them through Tailwind utilities
- refresh QuickSettings, NotificationBell, TabbedWindow, Breadcrumbs, and launcher tiles to consume the new interaction styles

## Testing
- [x] yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da51933f688328a9da81b40a56205a