### PR TITLE
feat: add SmartImage helper and enforce blur placeholders

### DIFF
--- a/apps/About/index.tsx
+++ b/apps/About/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import Image from 'next/image';
 import AboutApp from '../../components/apps/About';
+import SmartImage from '../../components/util-components/SmartImage';
 
 function GitHubIcon({ className }: { className?: string }) {
   return (
@@ -34,7 +34,7 @@ export default function AboutPage() {
     <div className="min-h-screen w-full bg-[var(--kali-bg)] text-sm">
       <div className="max-w-screen-md mx-auto my-4 sm:my-8 p-4 sm:p-6">
         <section className="flex items-center mb-8">
-          <Image
+          <SmartImage
             src="/images/logos/bitmoji.png"
             alt="Alex Unnippillil"
             width={128}

--- a/apps/beef/index.tsx
+++ b/apps/beef/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import React, { useState } from 'react';
-import Image from 'next/image';
 import BeefApp from '../../components/apps/beef';
+import SmartImage from '../../components/util-components/SmartImage';
 
 type Severity = 'Low' | 'Medium' | 'High';
 
@@ -29,7 +29,7 @@ const BeefPage: React.FC = () => {
     <div className="bg-ub-cool-grey text-white h-full w-full flex flex-col">
       <header className="flex items-center justify-between p-4">
         <div className="flex items-center gap-2">
-          <Image
+          <SmartImage
             src="/themes/Yaru/apps/beef.svg"
             alt="BeEF badge"
             width={48}

--- a/apps/ghidra/components/DemoRunner.tsx
+++ b/apps/ghidra/components/DemoRunner.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Image from 'next/image';
 import GhidraApp from '../../../components/apps/ghidra';
+import SmartImage from '../../../components/util-components/SmartImage';
 
 export default function DemoRunner() {
   const wasmUrl = process.env.NEXT_PUBLIC_GHIDRA_WASM;
@@ -32,13 +32,13 @@ export default function DemoRunner() {
   if (!enabled) {
     return (
       <div className="flex flex-col items-center space-y-4">
-        <Image
+        <SmartImage
           src="/themes/Yaru/apps/ghidra.svg"
           width={256}
           height={256}
           alt="Ghidra screenshot 1"
         />
-        <Image
+        <SmartImage
           src="/themes/Yaru/apps/ghidra.svg"
           width={256}
           height={256}

--- a/apps/settings/components/BackgroundSlideshow.tsx
+++ b/apps/settings/components/BackgroundSlideshow.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import { useSettings } from '../../../hooks/useSettings';
+import SmartImage from '../../../components/util-components/SmartImage';
 
 export default function BackgroundSlideshow() {
   const { setWallpaper } = useSettings();
@@ -57,8 +57,8 @@ export default function BackgroundSlideshow() {
     <div className="p-4 space-y-4 text-ubt-grey">
       <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
         {available.map((file) => (
-          <label key={file} className="flex flex-col items-center cursor-pointer">
-            <Image
+          <label key={file} className="flex flex-col items-center cursor-pointer" aria-label={`Toggle ${file} wallpaper`}>
+            <SmartImage
               src={`/images/wallpapers/${file}`}
               alt={file}
               width={96}
@@ -70,6 +70,7 @@ export default function BackgroundSlideshow() {
               type="checkbox"
               checked={selected.includes(file)}
               onChange={() => toggle(file)}
+              aria-label={`Include ${file} in slideshow`}
             />
           </label>
         ))}
@@ -83,6 +84,7 @@ export default function BackgroundSlideshow() {
           value={Math.round(intervalMs / 1000)}
           onChange={(e) => setIntervalMs(Number(e.target.value) * 1000)}
           className="w-20 bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+          aria-label="Slideshow interval in seconds"
         />
       </div>
       <button

--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import Image from 'next/image';
 import ExternalFrame from '../../components/ExternalFrame';
 import { CloseIcon, MaximizeIcon, MinimizeIcon } from '../../components/ToolbarIcons';
 import { kaliTheme } from '../../styles/themes/kali';
 import { SIDEBAR_WIDTH, ICON_SIZE } from './utils';
+import SmartImage from '../../components/util-components/SmartImage';
 
 export default function VsCode() {
   return (
@@ -56,7 +56,7 @@ export default function VsCode() {
             onLoad={() => {}}
           />
           <div className="absolute top-4 left-4 flex items-center gap-4 bg-black/50 p-4 rounded">
-            <Image
+            <SmartImage
               src="/themes/Yaru/system/view-app-grid-symbolic.svg"
               alt="Open Folder"
               width={64}

--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -1,5 +1,6 @@
-import Image from 'next/image';
 import { ModuleMetadata } from '../modules/metadata';
+
+import SmartImage from './util-components/SmartImage';
 
 interface ModuleCardProps {
   module: ModuleMetadata;
@@ -42,13 +43,13 @@ export default function ModuleCard({
         <p className="text-sm">{highlight(module.description, query)}</p>
       </div>
       <div className="flex flex-col gap-2 items-center">
-        <Image
+        <SmartImage
           src="/themes/Yaru/status/about.svg"
           alt="Details"
           width={24}
           height={24}
         />
-        <Image
+        <SmartImage
           src="/themes/Yaru/status/download.svg"
           alt="Run"
           width={24}

--- a/components/ToolbarIcons.tsx
+++ b/components/ToolbarIcons.tsx
@@ -1,8 +1,8 @@
-import Image from 'next/image';
+import SmartImage from './util-components/SmartImage';
 
 export function CloseIcon() {
   return (
-    <Image
+    <SmartImage
       src="/themes/Yaru/window/window-close-symbolic.svg"
       alt="Close"
       width={16}
@@ -13,7 +13,7 @@ export function CloseIcon() {
 
 export function MinimizeIcon() {
   return (
-    <Image
+    <SmartImage
       src="/themes/Yaru/window/window-minimize-symbolic.svg"
       alt="Minimize"
       width={16}
@@ -24,7 +24,7 @@ export function MinimizeIcon() {
 
 export function MaximizeIcon() {
   return (
-    <Image
+    <SmartImage
       src="/themes/Yaru/window/window-maximize-symbolic.svg"
       alt="Maximize"
       width={16}
@@ -35,7 +35,7 @@ export function MaximizeIcon() {
 
 export function RestoreIcon() {
   return (
-    <Image
+    <SmartImage
       src="/themes/Yaru/window/window-restore-symbolic.svg"
       alt="Restore"
       width={16}
@@ -46,7 +46,7 @@ export function RestoreIcon() {
 
 export function PinIcon() {
   return (
-    <Image
+    <SmartImage
       src="/themes/Yaru/window/window-pin-symbolic.svg"
       alt="Pin"
       width={16}

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import Image from 'next/image';
 import Head from 'next/head';
 import ReactGA from 'react-ga4';
 import GitHubStars from '../../GitHubStars';
@@ -9,6 +8,7 @@ import SafetyNote from './SafetyNote';
 import { getCspNonce } from '../../../utils/csp';
 import AboutSlides from './slides';
 import ScrollableTimeline from '../../ScrollableTimeline';
+import SmartImage from '../../util-components/SmartImage';
 
 class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_screen: string; navbar: boolean }> {
   screens: Record<string, React.ReactNode> = {};
@@ -68,7 +68,7 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
             ' w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5'
           }
         >
-          <Image
+          <SmartImage
             className="w-3 md:w-4 rounded border border-gray-600"
             alt={section.alt}
             src={section.icon}
@@ -169,7 +169,7 @@ function About() {
   return (
     <>
       <div className="w-20 md:w-28 my-4 full">
-        <Image
+        <SmartImage
           className="w-full rounded border border-gray-600"
           src="/images/logos/bitmoji.png"
           alt="Alex Unnippillil Logo"
@@ -355,6 +355,7 @@ const SkillSection = ({ title, badges }: { title: string; badges: { src: string;
         className="mt-2 w-full px-2 py-1 rounded text-black"
         value={filter}
         onChange={(e) => setFilter(e.target.value)}
+        aria-label={`Filter ${title} badges`}
       />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
         {filteredBadges.map((badge) => (

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
-import Image from 'next/image';
 import ReactGA from 'react-ga4';
 import GitHubStars from '../GitHubStars';
 import Certs from './certs';
 import data from './alex/data.json';
 import resumeData from './alex/resume.json';
 import ActivityCalendar from 'react-activity-calendar';
+import SmartImage from '../util-components/SmartImage';
 
 export class AboutAlex extends Component {
 
@@ -69,7 +69,7 @@ export class AboutAlex extends Component {
                         onFocus={this.changeScreen}
                         className={(this.state.active_screen === section.id ? " bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95" : " hover:bg-gray-50 hover:bg-opacity-5 ") + " w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5"}
                     >
-                        <Image
+                        <SmartImage
                             className=" w-3 md:w-4"
                             alt={section.alt}
                             src={section.icon}
@@ -117,7 +117,7 @@ function About() {
     return (
         <>
             <div className="w-20 md:w-28 my-4 full">
-                <Image
+                <SmartImage
                     className="w-full"
                     src="/images/logos/bitmoji.png"
                     alt="Alex Unnippillil Logo"
@@ -307,6 +307,7 @@ const SkillSection = ({ title, badges }) => {
         className="mt-2 w-full px-2 py-1 rounded text-black"
         value={filter}
         onChange={(e) => setFilter(e.target.value)}
+        aria-label={`Filter ${title} badges`}
       />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
         {filteredBadges.map(badge => (

--- a/components/apps/certs.js
+++ b/components/apps/certs.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import Image from 'next/image';
+
+import SmartImage from '../util-components/SmartImage';
 
 const certBadges = [
   {
@@ -262,7 +263,7 @@ const Certs = () => {
         {filtered.map((badge) => (
           <div key={badge.href} className="m-2 text-center w-28">
             <a href={badge.href} target="_blank" rel="noopener noreferrer">
-              <Image
+              <SmartImage
                 src={badge.src}
                 alt={badge.alt}
                 className="mx-auto"

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
-import Image from 'next/image';
 import ReactGA from 'react-ga4';
 import emailjs from '@emailjs/browser';
 import ProgressBar from '../ui/ProgressBar';
 import { createDisplay } from '../../utils/createDynamicApp';
+import SmartImage from '../util-components/SmartImage';
 
 export class Gedit extends Component {
 
@@ -153,18 +153,27 @@ export class Gedit extends Component {
                 <div className="relative flex-grow flex flex-col bg-ub-gedit-dark font-normal windowMainScreen">
                     <div className="absolute left-0 top-0 h-full px-2 bg-ub-gedit-darker"></div>
                     <div className="relative">
-                        <input id="sender-name" value={this.state.name} onChange={this.handleChange('name')} onBlur={this.handleBlur('name')} aria-invalid={nameInvalid} aria-describedby="name-status" className={`w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent ${nameInvalid ? 'border border-red-500' : nameValid ? 'border border-emerald-500' : ''}`} placeholder="Your Email / Name :" spellCheck="false" autoComplete="off" type="text" />
+                        <label htmlFor="sender-name" className="sr-only">
+                            Your email or name
+                        </label>
+                        <input id="sender-name" value={this.state.name} onChange={this.handleChange('name')} onBlur={this.handleBlur('name')} aria-invalid={nameInvalid} aria-describedby="name-status" className={`w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent ${nameInvalid ? 'border border-red-500' : nameValid ? 'border border-emerald-500' : ''}`} placeholder="Your Email / Name :" spellCheck="false" autoComplete="off" type="text" aria-label="Your email or name" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold light text-sm text-ubt-gedit-blue">1</span>
                         <p id="name-status" className={`text-xs mt-1 ${nameInvalid ? 'text-red-400' : nameValid ? 'text-emerald-400' : 'sr-only'}`} aria-live="polite">
                             {nameInvalid ? 'Name must not be empty' : nameValid ? 'Looks good' : ''}
                         </p>
                     </div>
                     <div className="relative">
-                        <input id="sender-subject" value={this.state.subject} onChange={this.handleChange('subject')} className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" />
+                        <label htmlFor="sender-subject" className="sr-only">
+                            Subject
+                        </label>
+                        <input id="sender-subject" value={this.state.subject} onChange={this.handleChange('subject')} className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" aria-label="Subject" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold  text-sm text-ubt-gedit-blue">2</span>
                     </div>
                     <div className="relative flex-grow">
-                        <textarea id="sender-message" value={this.state.message} onChange={this.handleChange('message')} onBlur={this.handleBlur('message')} aria-invalid={messageInvalid} aria-describedby="message-status" className={`w-full gedit-message font-light text-sm resize-none h-full windowMainScreen outline-none tracking-wider pl-6 py-1 bg-transparent ${messageInvalid ? 'border border-red-500' : messageValid ? 'border border-emerald-500' : ''}`} placeholder="Message" spellCheck="false" autoComplete="none" type="text" />
+                        <label htmlFor="sender-message" className="sr-only">
+                            Message
+                        </label>
+                        <textarea id="sender-message" value={this.state.message} onChange={this.handleChange('message')} onBlur={this.handleBlur('message')} aria-invalid={messageInvalid} aria-describedby="message-status" className={`w-full gedit-message font-light text-sm resize-none h-full windowMainScreen outline-none tracking-wider pl-6 py-1 bg-transparent ${messageInvalid ? 'border border-red-500' : messageValid ? 'border border-emerald-500' : ''}`} placeholder="Message" spellCheck="false" autoComplete="none" type="text" aria-label="Message" />
                         <span className="absolute left-1 top-1 font-bold  text-sm text-ubt-gedit-blue">3</span>
                         <p id="message-status" className={`text-xs mt-1 ${messageInvalid ? 'text-red-400' : messageValid ? 'text-emerald-400' : 'sr-only'}`} aria-live="polite">
                             {messageInvalid ? 'Message must not be empty' : messageValid ? 'Looks good' : ''}
@@ -175,7 +184,7 @@ export class Gedit extends Component {
                     this.state.location &&
                     <div className="bg-ub-gedit-dark border-t border-b border-ubt-gedit-blue p-2">
                         <h2 className="font-bold text-sm mb-1">Your Local Time</h2>
-                        <Image
+                        <SmartImage
                             src={`https://staticmap.openstreetmap.de/staticmap.php?center=${this.state.location.latitude},${this.state.location.longitude}&zoom=3&size=300x150&markers=${this.state.location.latitude},${this.state.location.longitude},red-dot`}
                             alt="Map showing your approximate location"
                             className="w-full rounded"
@@ -192,7 +201,7 @@ export class Gedit extends Component {
                             {this.state.showProgress ? (
                                 <ProgressBar progress={this.state.progress} />
                             ) : (
-                                <Image
+                                <SmartImage
                                     className="w-8 motion-safe:animate-spin"
                                     src="/themes/Yaru/status/process-working-symbolic.svg"
                                     alt="Ubuntu Process Symbol"

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import Image from 'next/image';
+import SmartImage from '../../util-components/SmartImage';
 import Waterfall from './Waterfall';
 import BurstChart from './BurstChart';
 import { protocolName, getRowColor, matchesDisplayFilter } from './utils';
@@ -225,7 +225,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
             className="flex items-center justify-between bg-gray-800 rounded p-2"
           >
             <div className="flex items-center space-x-2">
-              <Image
+              <SmartImage
                 src={
                   iface.type === 'wired'
                     ? '/themes/Yaru/status/network-wireless-signal-good-symbolic.svg'
@@ -302,11 +302,11 @@ const WiresharkApp = ({ initialPackets = [] }) => {
           className="px-2 py-1 bg-gray-800 rounded text-white"
         />
         <datalist id="bpf-suggestions">
-          <option value="tcp" />
-          <option value="udp" />
-          <option value="icmp" />
-          <option value="port 80" />
-          <option value="host 10.0.0.1" />
+          <option value="tcp">tcp</option>
+          <option value="udp">udp</option>
+          <option value="icmp">icmp</option>
+          <option value="port 80">port 80</option>
+          <option value="host 10.0.0.1">host 10.0.0.1</option>
         </datalist>
         <a
           href="https://www.wireshark.org/docs/dfref/"

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
-import Image from 'next/image'
+
+import SmartImage from '../util-components/SmartImage'
 
 export class UbuntuApp extends Component {
     constructor() {
@@ -78,7 +79,7 @@ export class UbuntuApp extends Component {
                 onMouseEnter={this.handlePrefetch}
                 onFocus={this.handlePrefetch}
             >
-                <Image
+                <SmartImage
                     width={48}
                     height={48}
                     className="mb-1"

--- a/components/menu/ApplicationsMenu.tsx
+++ b/components/menu/ApplicationsMenu.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import Image from 'next/image';
+
+import SmartImage from '../util-components/SmartImage';
 
 export type KaliCategory = {
   id: string;
@@ -66,7 +67,7 @@ const CategoryIcon: React.FC<CategoryIconProps> = ({ categoryId, label }) => {
   }, [categoryId]);
 
   return (
-    <Image
+    <SmartImage
       src={src}
       alt={`${label} category icon`}
       width={20}

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
-import Image from 'next/image';
+
+import SmartImage from '../util-components/SmartImage';
 import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 
@@ -375,7 +376,7 @@ const WhiskerMenu: React.FC = () => {
         onClick={toggleMenu}
         className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
       >
-        <Image
+        <SmartImage
           src="/themes/Yaru/status/decompiler-symbolic.svg"
           alt="Menu"
           width={16}
@@ -432,7 +433,7 @@ const WhiskerMenu: React.FC = () => {
                 >
                   <span className="w-8 font-mono text-[11px] uppercase tracking-[0.2em] text-[#4aa8ff]">{String(index + 1).padStart(2, '0')}</span>
                   <span className="flex items-center gap-2">
-                    <Image
+                    <SmartImage
                       src={cat.icon}
                       alt=""
                       width={20}
@@ -466,7 +467,7 @@ const WhiskerMenu: React.FC = () => {
                     className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#122136] text-white transition hover:-translate-y-0.5 hover:bg-[#1b2d46] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1a29]"
                     aria-label={`Open ${app.title}`}
                   >
-                    <Image
+                    <SmartImage
                       src={app.icon}
                       alt=""
                       width={24}
@@ -538,7 +539,7 @@ const WhiskerMenu: React.FC = () => {
                       >
                         <div className="flex items-center gap-3">
                           <div className="flex h-10 w-10 items-center justify-center rounded-md bg-[#121f33]">
-                            <Image
+                            <SmartImage
                               src={app.icon}
                               alt=""
                               width={28}

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import Image from 'next/image'
+
+import SmartImage from '../util-components/SmartImage'
 
 const bootMessages = [
     'Securing environment',
@@ -32,7 +33,7 @@ function BootingScreen(props) {
                     <span className="text-xs uppercase tracking-[0.5em] text-slate-400">Initializing workspace</span>
                     <div className="relative">
                         <div className="absolute -inset-6 rounded-full bg-sky-500/20 blur-3xl" aria-hidden />
-                        <Image
+                        <SmartImage
                             width={360}
                             height={360}
                             className="w-48 md:w-64"
@@ -55,7 +56,7 @@ function BootingScreen(props) {
                     >
                         {props.isShutDown ? (
                             <div className="flex h-16 w-16 items-center justify-center rounded-full bg-slate-100 text-slate-900 transition group-hover:bg-white">
-                                <Image width={32} height={32} src="/themes/Yaru/status/power-button.svg" alt="Power button" sizes="32px" priority />
+                                <SmartImage width={32} height={32} src="/themes/Yaru/status/power-button.svg" alt="Power button" sizes="32px" priority />
                             </div>
                         ) : (
                             <div className="relative flex h-14 w-14 items-center justify-center">

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import Image from 'next/image';
+
+import SmartImage from '../util-components/SmartImage';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
@@ -53,7 +54,7 @@ export default function Taskbar(props) {
                                 gap: '0.5rem',
                             }}
                         >
-                            <Image
+                            <SmartImage
                                 width={32}
                                 height={32}
                                 style={{

--- a/components/ui/VolumeControl.tsx
+++ b/components/ui/VolumeControl.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import usePersistentState from "../../hooks/usePersistentState";
+import SmartImage from "../util-components/SmartImage";
 
 const ICONS = {
   muted: "/themes/Yaru/status/audio-volume-muted-symbolic.svg",
@@ -116,7 +116,7 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
         onClick={handleToggle}
         onPointerDown={(event) => event.stopPropagation()}
       >
-        <Image
+        <SmartImage
           width={16}
           height={16}
           src={ICONS[level]}

--- a/components/util-components/SmartImage.tsx
+++ b/components/util-components/SmartImage.tsx
@@ -1,0 +1,52 @@
+import { useCallback, useMemo, useState } from "react";
+import Image, { ImageProps } from "next/image";
+import clsx from "clsx";
+
+type SmartImageProps = Omit<ImageProps, "placeholder" | "onLoadingComplete" | "blurDataURL"> & {
+  alt: ImageProps["alt"];
+  blurDataURL?: string;
+  loadingClassName?: string;
+  loadedClassName?: string;
+  onLoadingComplete?: ImageProps["onLoadingComplete"];
+};
+
+const DEFAULT_BLUR_DATA_URL =
+  "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nMScgaGVpZ2h0PScxJyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnPjxyZWN0IHdpZHRoPScxJyBoZWlnaHQ9JzEnIGZpbGw9JyNFQkVCRUInIC8+PC9zdmc+";
+
+const SmartImage = ({
+  alt,
+  blurDataURL,
+  className,
+  loadingClassName = "opacity-60",
+  loadedClassName = "opacity-100",
+  onLoadingComplete,
+  ...props
+}: SmartImageProps) => {
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  const handleLoadingComplete = useCallback<NonNullable<ImageProps["onLoadingComplete"]>>(
+    (result) => {
+      setIsLoaded(true);
+      onLoadingComplete?.(result);
+    },
+    [onLoadingComplete]
+  );
+
+  const transitionClassName = useMemo(
+    () => clsx("transition-opacity duration-500 ease-out", className, isLoaded ? loadedClassName : loadingClassName),
+    [className, isLoaded, loadedClassName, loadingClassName]
+  );
+
+  return (
+    <Image
+      {...props}
+      alt={alt}
+      className={transitionClassName}
+      placeholder="blur"
+      blurDataURL={blurDataURL ?? DEFAULT_BLUR_DATA_URL}
+      onLoadingComplete={handleLoadingComplete}
+    />
+  );
+};
+
+export default SmartImage;

--- a/lib/appRegistry.ts
+++ b/lib/appRegistry.ts
@@ -6,10 +6,12 @@ export type AppMetadata = {
   icon?: string;
 };
 
-type AppEntry = {
+export type AppEntry = {
   id: string;
   title: string;
   icon?: string;
+  disabled?: boolean;
+  favourite?: boolean;
 };
 
 const DEFAULT_KEYBOARD_HINTS = [

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,8 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-
-import "./.next/types/routes.d.ts";
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/pages/apps/index.tsx
+++ b/pages/apps/index.tsx
@@ -1,5 +1,4 @@
-import Image from 'next/image';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ChangeEvent } from 'react';
 import Link from 'next/link';
 import DelayedTooltip from '../../components/ui/DelayedTooltip';
 import AppTooltipContent from '../../components/ui/AppTooltipContent';
@@ -7,11 +6,13 @@ import {
   buildAppMetadata,
   loadAppRegistry,
 } from '../../lib/appRegistry';
+import type { AppEntry, AppMetadata } from '../../lib/appRegistry';
+import SmartImage from '../../components/util-components/SmartImage';
 
 const AppsPage = () => {
-  const [apps, setApps] = useState([]);
+  const [apps, setApps] = useState<AppEntry[]>([]);
   const [query, setQuery] = useState('');
-  const [metadata, setMetadata] = useState({});
+  const [metadata, setMetadata] = useState<Record<string, AppMetadata>>({});
 
   useEffect(() => {
     let isMounted = true;
@@ -45,9 +46,10 @@ const AppsPage = () => {
         id="app-search"
         type="search"
         value={query}
-        onChange={(e) => setQuery(e.target.value)}
+        onChange={(event: ChangeEvent<HTMLInputElement>) => setQuery(event.target.value)}
         placeholder="Search apps"
         className="mb-4 w-full rounded border p-2"
+        aria-label="Search apps"
       />
       <div
         id="app-grid"
@@ -76,7 +78,7 @@ const AppsPage = () => {
                     onBlur={onBlur}
                   >
                     {app.icon && (
-                      <Image
+                      <SmartImage
                         src={app.icon}
                         alt=""
                         width={64}

--- a/pages/hook-flow.tsx
+++ b/pages/hook-flow.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import Image from 'next/image';
 import React, { useState } from 'react';
+
+import SmartImage from '../components/util-components/SmartImage';
 
 const HookFlow: React.FC = () => {
   const [consented, setConsented] = useState(false);
@@ -24,7 +25,7 @@ const HookFlow: React.FC = () => {
 
   return (
     <main className="p-4 space-y-4">
-      <Image
+      <SmartImage
         src="/hook-flow.svg"
         alt="React hook flow diagram"
         width={420}

--- a/pages/qr/index.tsx
+++ b/pages/qr/index.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import Image from 'next/image';
 import React, { useEffect, useRef, useState } from 'react';
 import QRCode from 'qrcode';
 import { BrowserQRCodeReader, NotFoundException } from '@zxing/library';
 import Tabs from '../../components/Tabs';
 import FormError from '../../components/ui/FormError';
 import { clearScans, loadScans, saveScans } from '../../utils/qrStorage';
+import SmartImage from '../../components/util-components/SmartImage';
 
 const tabs = [
   { id: 'text', label: 'Text' },
@@ -197,17 +197,18 @@ const QRPage: React.FC = () => {
           className="mb-4 justify-center"
         />
         {active === 'text' && (
-          <form onSubmit={generateQr} className="space-y-2">
-            <label className="block text-sm" htmlFor="qr-text">
-              Text
-            </label>
-            <input
-              id="qr-text"
-              type="text"
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              className="w-full rounded border p-2"
-            />
+            <form onSubmit={generateQr} className="space-y-2">
+              <label className="block text-sm" htmlFor="qr-text">
+                Text
+              </label>
+              <input
+                id="qr-text"
+                type="text"
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                className="w-full rounded border p-2"
+                aria-label="Text to encode"
+              />
             <button
               type="submit"
               className="w-full rounded bg-blue-600 p-2 text-white"
@@ -221,13 +222,14 @@ const QRPage: React.FC = () => {
             <label className="block text-sm" htmlFor="qr-url">
               URL
             </label>
-            <input
-              id="qr-url"
-              type="url"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-              className="w-full rounded border p-2"
-            />
+              <input
+                id="qr-url"
+                type="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                className="w-full rounded border p-2"
+                aria-label="URL to encode"
+              />
             <button
               type="submit"
               className="w-full rounded bg-blue-600 p-2 text-white"
@@ -236,38 +238,44 @@ const QRPage: React.FC = () => {
             </button>
           </form>
         )}
-        {active === 'wifi' && (
-          <form onSubmit={generateQr} className="space-y-2">
-            <label className="block text-sm">
-              SSID
+          {active === 'wifi' && (
+            <form onSubmit={generateQr} className="space-y-2">
+              <label className="block text-sm" htmlFor="wifi-ssid">
+                SSID
+              </label>
               <input
+                id="wifi-ssid"
                 type="text"
                 value={ssid}
                 onChange={(e) => setSsid(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Wi-Fi SSID"
               />
-            </label>
-            <label className="block text-sm">
-              Password
+              <label className="block text-sm" htmlFor="wifi-password">
+                Password
+              </label>
               <input
+                id="wifi-password"
                 type="text"
                 value={wifiPassword}
                 onChange={(e) => setWifiPassword(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Wi-Fi password"
               />
-            </label>
-            <label className="block text-sm">
-              Encryption
+              <label className="block text-sm" htmlFor="wifi-encryption">
+                Encryption
+              </label>
               <select
+                id="wifi-encryption"
                 value={wifiType}
                 onChange={(e) => setWifiType(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Wi-Fi encryption type"
               >
                 <option value="WPA">WPA/WPA2</option>
                 <option value="WEP">WEP</option>
                 <option value="nopass">None</option>
               </select>
-            </label>
             <button
               type="submit"
               className="w-full rounded bg-blue-600 p-2 text-white"
@@ -276,44 +284,52 @@ const QRPage: React.FC = () => {
             </button>
           </form>
         )}
-        {active === 'vcard' && (
-          <form onSubmit={generateQr} className="space-y-2">
-            <label className="block text-sm">
-              Full Name
+          {active === 'vcard' && (
+            <form onSubmit={generateQr} className="space-y-2">
+              <label className="block text-sm" htmlFor="vcard-name">
+                Full Name
+              </label>
               <input
+                id="vcard-name"
                 type="text"
                 value={vName}
                 onChange={(e) => setVName(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Full name"
               />
-            </label>
-            <label className="block text-sm">
-              Organization
+              <label className="block text-sm" htmlFor="vcard-org">
+                Organization
+              </label>
               <input
+                id="vcard-org"
                 type="text"
                 value={vOrg}
                 onChange={(e) => setVOrg(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Organization"
               />
-            </label>
-            <label className="block text-sm">
-              Phone
+              <label className="block text-sm" htmlFor="vcard-phone">
+                Phone
+              </label>
               <input
+                id="vcard-phone"
                 type="tel"
                 value={vPhone}
                 onChange={(e) => setVPhone(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Phone number"
               />
-            </label>
-            <label className="block text-sm">
-              Email
+              <label className="block text-sm" htmlFor="vcard-email">
+                Email
+              </label>
               <input
+                id="vcard-email"
                 type="email"
                 value={vEmail}
                 onChange={(e) => setVEmail(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Email address"
               />
-            </label>
             <button
               type="submit"
               className="w-full rounded bg-blue-600 p-2 text-white"
@@ -325,7 +341,7 @@ const QRPage: React.FC = () => {
         {error && <FormError className="mt-2">{error}</FormError>}
         {qrPng && (
           <div className="mt-4 flex flex-col items-center gap-2">
-            <Image
+            <SmartImage
               src={qrPng}
               alt="Generated QR code"
               width={192}
@@ -350,8 +366,12 @@ const QRPage: React.FC = () => {
           </div>
         )}
       </div>
-      <div className="w-full max-w-md">
-        <video ref={videoRef} className="h-48 w-full rounded border" />
+        <div className="w-full max-w-md">
+          <video
+            ref={videoRef}
+            className="h-48 w-full rounded border"
+            aria-label="QR scanner preview"
+          />
         {scanResult && (
           <p className="mt-2 text-center text-sm">Decoded: {scanResult}</p>
         )}

--- a/pages/qr/vcard.tsx
+++ b/pages/qr/vcard.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
 import QRCode from 'qrcode';
+import SmartImage from '../../components/util-components/SmartImage';
 
 const VCardPage: React.FC = () => {
   const [name, setName] = useState('');
@@ -71,48 +71,56 @@ const VCardPage: React.FC = () => {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
       <form className="w-full max-w-md space-y-2">
-        <label className="block text-sm">
+        <label className="block text-sm" htmlFor="vcard-full-name">
           Full Name
-          <input
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className="mt-1 w-full rounded border p-2"
-          />
         </label>
-        <label className="block text-sm">
+        <input
+          id="vcard-full-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="mt-1 w-full rounded border p-2"
+          aria-label="Full name"
+        />
+        <label className="block text-sm" htmlFor="vcard-organization">
           Organization
-          <input
-            type="text"
-            value={org}
-            onChange={(e) => setOrg(e.target.value)}
-            className="mt-1 w-full rounded border p-2"
-          />
         </label>
-        <label className="block text-sm">
+        <input
+          id="vcard-organization"
+          type="text"
+          value={org}
+          onChange={(e) => setOrg(e.target.value)}
+          className="mt-1 w-full rounded border p-2"
+          aria-label="Organization"
+        />
+        <label className="block text-sm" htmlFor="vcard-phone">
           Phone
-          <input
-            type="tel"
-            value={phone}
-            onChange={(e) => setPhone(e.target.value)}
-            className="mt-1 w-full rounded border p-2"
-          />
         </label>
-        <label className="block text-sm">
+        <input
+          id="vcard-phone"
+          type="tel"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          className="mt-1 w-full rounded border p-2"
+          aria-label="Phone number"
+        />
+        <label className="block text-sm" htmlFor="vcard-email">
           Email
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="mt-1 w-full rounded border p-2"
-          />
         </label>
+        <input
+          id="vcard-email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="mt-1 w-full rounded border p-2"
+          aria-label="Email address"
+        />
       </form>
       {vcard && (
         <div className="flex flex-col items-center gap-2">
           <pre className="whitespace-pre-wrap break-all text-xs">{vcard}</pre>
           {png && (
-            <Image
+            <SmartImage
               src={png}
               alt="vCard QR"
               width={192}

--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -1,5 +1,6 @@
-import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
+
+import SmartImage from '../components/util-components/SmartImage';
 
 interface Video {
   id: string;
@@ -39,12 +40,17 @@ const VideoGallery: React.FC = () => {
 
   return (
     <main className="p-4">
+      <label htmlFor="video-search" className="sr-only">
+        Search videos
+      </label>
       <input
+        id="video-search"
         type="text"
         placeholder="Search videos..."
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         className="mb-4 w-full max-w-md px-4 py-2 border rounded"
+        aria-label="Search videos"
       />
       {playing && (
         <div className="mb-4 w-full max-w-2xl aspect-video">
@@ -67,7 +73,7 @@ const VideoGallery: React.FC = () => {
             className="text-left rounded outline outline-2 outline-offset-2 outline-transparent hover:outline-blue-500 focus-visible:outline-blue-500"
             onClick={() => setPlaying(video.id)}
           >
-            <Image
+            <SmartImage
               src={`https://i.ytimg.com/vi/${video.id}/hqdefault.jpg`}
               alt={video.title}
               width={480}


### PR DESCRIPTION
## Summary
- add a SmartImage utility that enforces blur placeholders and a fade-in once images finish loading
- replace direct Next Image usage across menus, apps, and pages to consume the helper while tightening form accessibility
- convert the apps index page to TypeScript and export the registry entry type for reuse

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da519643308328998bc919d6db004c