### PR TITLE
[core] Improve error boundary accessibility

### DIFF
--- a/__tests__/ErrorBoundary.test.tsx
+++ b/__tests__/ErrorBoundary.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import ErrorBoundary from '../components/core/ErrorBoundary';
+import { logEvent } from '../utils/analytics';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+jest.mock('../utils/analytics', () => ({ logEvent: jest.fn() }));
+
+const mockedLogEvent = logEvent as jest.MockedFunction<typeof logEvent>;
 
 interface ProblemChildProps {
   shouldThrow?: boolean;
@@ -21,6 +25,7 @@ describe('ErrorBoundary', () => {
 
   beforeEach(() => {
     jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockedLogEvent.mockClear();
   });
 
   afterEach(() => {
@@ -28,15 +33,28 @@ describe('ErrorBoundary', () => {
     jest.restoreAllMocks();
   });
 
-  it('renders fallback UI when an error is thrown', () => {
+  it('renders fallback UI when an error is thrown', async () => {
+    const focusSpy = jest.spyOn(HTMLElement.prototype, 'focus');
+
     render(
       <ErrorBoundary>
         <ProblemChild shouldThrow />
       </ErrorBoundary>
     );
 
-    expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong.');
-    expect(screen.getByText(/please refresh/i)).toBeInTheDocument();
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Something went wrong.');
+    expect(alert).toHaveTextContent('Try the action again or review the logs for more details.');
+    await waitFor(() => {
+      expect(focusSpy).toHaveBeenCalled();
+    });
+    expect(focusSpy.mock.instances).toContain(alert);
+    focusSpy.mockRestore();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /view logs/i })).toHaveAttribute(
+      'href',
+      'https://unnippillil.com/test-log'
+    );
   });
 
   it('recovers and renders children again when they change after an error', async () => {
@@ -59,6 +77,44 @@ describe('ErrorBoundary', () => {
     });
 
     expect(screen.getByText('All good')).toBeInTheDocument();
+  });
+
+  it('allows retrying after an error is shown', async () => {
+    const { rerender } = render(
+      <ErrorBoundary>
+        <ProblemChild shouldThrow />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    rerender(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('All good')).toBeInTheDocument();
+  });
+
+  it('logs analytics when the log link is activated', () => {
+    render(
+      <ErrorBoundary>
+        <ProblemChild shouldThrow />
+      </ErrorBoundary>
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: /view logs/i }));
+
+    expect(mockedLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'error_boundary', action: 'view_logs' })
+    );
   });
 });
 

--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -1,8 +1,11 @@
-import { Component, ErrorInfo, ReactNode } from 'react';
+import { Component, ErrorInfo, ReactNode, createRef } from 'react';
 import { createLogger } from '../../lib/logger';
+import { logEvent } from '../../utils/analytics';
 
 interface Props {
   children: ReactNode;
+  logHref?: string;
+  onRetry?: () => void;
 }
 
 interface State {
@@ -12,6 +15,8 @@ interface State {
 const log = createLogger();
 
 class ErrorBoundary extends Component<Props, State> {
+  private alertRef = createRef<HTMLDivElement>();
+
   constructor(props: Props) {
     super(props);
     this.state = { hasError: false };
@@ -23,20 +28,76 @@ class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
     log.error('ErrorBoundary caught an error', { error, errorInfo });
+    this.focusAlert();
   }
 
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    if (!prevState.hasError && this.state.hasError) {
+      this.focusAlert();
+    }
+
     if (this.state.hasError && prevProps.children !== this.props.children) {
       this.setState({ hasError: false });
     }
   }
 
+  private focusAlert() {
+    this.alertRef.current?.focus({ preventScroll: true });
+  }
+
+  private handleRetry = () => {
+    this.setState({ hasError: false }, () => {
+      this.props.onRetry?.();
+    });
+  };
+
+  private handleViewLogs = () => {
+    logEvent({
+      category: 'error_boundary',
+      action: 'view_logs',
+      label: typeof window !== 'undefined' ? window.location.href : undefined,
+    });
+  };
+
   render() {
     if (this.state.hasError) {
+      const logHref = this.props.logHref ?? 'https://unnippillil.com/test-log';
+
       return (
-        <div role="alert" className="p-4 text-center">
-          <h1 className="text-xl font-bold">Something went wrong.</h1>
-          <p>Please refresh the page or try again.</p>
+        <div className="p-4 text-center">
+          <div aria-live="polite" aria-atomic="true" className="sr-only">
+            An error occurred. Retry the action or view the logs for details.
+          </div>
+          <div
+            role="alert"
+            aria-live="polite"
+            tabIndex={-1}
+            ref={this.alertRef}
+            className="mx-auto flex max-w-md flex-col gap-3 rounded-md border border-red-200 bg-red-50 p-6 text-left shadow-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+          >
+            <h1 className="text-xl font-bold text-red-900">Something went wrong.</h1>
+            <p className="text-sm text-red-800">
+              Try the action again or review the logs for more details.
+            </p>
+            <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:justify-start">
+              <button
+                type="button"
+                onClick={this.handleRetry}
+                className="rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+              >
+                Retry
+              </button>
+              <a
+                href={logHref}
+                target="_blank"
+                rel="noreferrer"
+                onClick={this.handleViewLogs}
+                className="rounded-md border border-red-500 px-4 py-2 text-sm font-semibold text-red-700 transition hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+              >
+                View logs
+              </a>
+            </div>
+          </div>
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- add an accessible fallback with retry and log actions plus polite screen reader announcements
- focus the alert when errors surface and send analytics when logs are viewed
- expand the ErrorBoundary unit tests to cover retry recovery and log link tracking

## Testing
- yarn lint
- yarn test __tests__/ErrorBoundary.test.tsx --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68da5199220c83288bff719ffd2b7df8