### PR TITLE
[desktop] scaffold command palette registry

### DIFF
--- a/__tests__/commandPalette.integration.test.tsx
+++ b/__tests__/commandPalette.integration.test.tsx
@@ -1,0 +1,108 @@
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
+import {
+  CommandPaletteProvider,
+  useCommandPalette,
+  COMMAND_PALETTE_RECENTS_KEY,
+  type CommandPaletteAction,
+} from '../components/desktop/CommandPalette';
+import { useCommandPaletteActions } from '../hooks/useCommandPaletteActions';
+
+describe('CommandPalette integration', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <CommandPaletteProvider>{children}</CommandPaletteProvider>
+  );
+
+  it('ranks actions by recent usage with alphabetical fallback', async () => {
+    const actions: CommandPaletteAction[] = [
+      { id: 'action-terminal', label: 'Terminal', handler: jest.fn(), appId: 'terminal' },
+      { id: 'action-browser', label: 'Browser', handler: jest.fn(), appId: 'firefox' },
+      { id: 'action-settings', label: 'Settings', handler: jest.fn(), appId: 'settings' },
+    ];
+
+    const { result } = renderHook(() => {
+      useCommandPaletteActions(actions);
+      return useCommandPalette();
+    }, { wrapper });
+
+    expect(result.current.actions.map((item) => item.id)).toEqual([
+      'action-browser',
+      'action-settings',
+      'action-terminal',
+    ]);
+
+    await act(async () => {
+      await result.current.invokeAction('action-terminal');
+    });
+
+    expect(actions[0].handler).toHaveBeenCalledTimes(1);
+    expect(result.current.actions[0]?.id).toBe('action-terminal');
+
+    const stored = window.localStorage.getItem(COMMAND_PALETTE_RECENTS_KEY);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored as string) as Record<string, number>;
+    expect(parsed['action-terminal']).toEqual(expect.any(Number));
+  });
+
+  it('cleans up recents for actions that are unregistered', async () => {
+    const primary: CommandPaletteAction = {
+      id: 'primary-action',
+      label: 'Primary',
+      handler: jest.fn(),
+      appId: 'terminal',
+    };
+    const secondary: CommandPaletteAction = {
+      id: 'secondary-action',
+      label: 'Secondary',
+      handler: jest.fn(),
+      appId: 'logs',
+    };
+
+    const { result, rerender, unmount } = renderHook(
+      ({ registered }: { registered: CommandPaletteAction[] }) => {
+        useCommandPaletteActions(registered, [registered]);
+        return useCommandPalette();
+      },
+      {
+        initialProps: { registered: [primary, secondary] },
+        wrapper,
+      },
+    );
+
+    await act(async () => {
+      await result.current.invokeAction('primary-action');
+    });
+
+    expect(primary.handler).toHaveBeenCalled();
+    let stored = window.localStorage.getItem(COMMAND_PALETTE_RECENTS_KEY);
+    expect(stored).not.toBeNull();
+    let parsed = JSON.parse(stored as string) as Record<string, number>;
+    expect(parsed['primary-action']).toBeDefined();
+
+    rerender({ registered: [secondary] });
+
+    stored = window.localStorage.getItem(COMMAND_PALETTE_RECENTS_KEY);
+    if (stored) {
+      parsed = JSON.parse(stored) as Record<string, number>;
+      expect(parsed['primary-action']).toBeUndefined();
+    }
+
+    await act(async () => {
+      await result.current.invokeAction('secondary-action');
+    });
+
+    stored = window.localStorage.getItem(COMMAND_PALETTE_RECENTS_KEY);
+    expect(stored).not.toBeNull();
+    parsed = JSON.parse(stored as string) as Record<string, number>;
+    expect(parsed['secondary-action']).toBeDefined();
+    expect(parsed['primary-action']).toBeUndefined();
+
+    unmount();
+
+    expect(window.localStorage.getItem(COMMAND_PALETTE_RECENTS_KEY)).toBeNull();
+  });
+});

--- a/components/desktop/CommandPalette/context.tsx
+++ b/components/desktop/CommandPalette/context.tsx
@@ -1,0 +1,212 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { hasStorage } from '../../../utils/env';
+import type {
+  CommandPaletteAction,
+  CommandPaletteStoredAction,
+} from './types';
+
+export const COMMAND_PALETTE_RECENTS_KEY = 'desktop:commandPalette:recents';
+
+type CommandPaletteContextValue = {
+  actions: CommandPaletteStoredAction[];
+  registerActions: (actions: CommandPaletteAction[]) => void;
+  unregisterActions: (ids: string[]) => void;
+  invokeAction: (id: string) => Promise<void>;
+};
+
+type RecentsMap = Record<string, number>;
+
+const CommandPaletteContext = createContext<CommandPaletteContextValue | undefined>(
+  undefined,
+);
+
+const loadRecents = (): RecentsMap => {
+  if (typeof window === 'undefined' || !hasStorage) return {};
+  try {
+    const raw = window.localStorage.getItem(COMMAND_PALETTE_RECENTS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== 'object' || parsed === null) return {};
+    return Object.entries(parsed as Record<string, unknown>).reduce<RecentsMap>(
+      (acc, [id, value]) => {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          acc[id] = value;
+        }
+        return acc;
+      },
+      {},
+    );
+  } catch (err) {
+    console.warn('[CommandPalette] Failed to parse recents from storage', err);
+    return {};
+  }
+};
+
+const persistRecents = (recents: RecentsMap) => {
+  if (typeof window === 'undefined' || !hasStorage) return;
+  const keys = Object.keys(recents);
+  if (!keys.length) {
+    window.localStorage.removeItem(COMMAND_PALETTE_RECENTS_KEY);
+    return;
+  }
+  try {
+    window.localStorage.setItem(
+      COMMAND_PALETTE_RECENTS_KEY,
+      JSON.stringify(recents),
+    );
+  } catch (err) {
+    console.warn('[CommandPalette] Failed to persist recents', err);
+  }
+};
+
+export const CommandPaletteProvider = ({ children }: { children: ReactNode }) => {
+  const [registry, setRegistryState] = useState<Map<string, CommandPaletteStoredAction>>(
+    () => new Map(),
+  );
+  const registryRef = useRef(registry);
+  const recentsRef = useRef<RecentsMap>(loadRecents());
+
+  const setRegistry = useCallback(
+    (updater: (prev: Map<string, CommandPaletteStoredAction>) => Map<string, CommandPaletteStoredAction>) => {
+      setRegistryState((prev) => {
+        const next = updater(prev);
+        registryRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
+
+  const updateRecents = useCallback((updater: (prev: RecentsMap) => RecentsMap) => {
+    const next = updater(recentsRef.current);
+    if (next === recentsRef.current) return;
+    recentsRef.current = next;
+    persistRecents(next);
+  }, []);
+
+  const registerActions = useCallback(
+    (actions: CommandPaletteAction[]) => {
+      if (!actions.length) return;
+      setRegistry((prev) => {
+        let changed = false;
+        const next = new Map(prev);
+        const now = Date.now();
+        actions.forEach((action) => {
+          const lastInvoked = recentsRef.current[action.id];
+          const existing = next.get(action.id);
+          if (
+            existing &&
+            existing.label === action.label &&
+            existing.handler === action.handler &&
+            existing.appId === action.appId &&
+            existing.lastInvoked === lastInvoked
+          ) {
+            return;
+          }
+          changed = true;
+          next.set(action.id, {
+            ...action,
+            lastInvoked,
+            registeredAt: existing?.registeredAt ?? now,
+          });
+        });
+        return changed ? next : prev;
+      });
+    },
+    [setRegistry],
+  );
+
+  const unregisterActions = useCallback(
+    (ids: string[]) => {
+      if (!ids.length) return;
+      setRegistry((prev) => {
+        let changed = false;
+        const next = new Map(prev);
+        ids.forEach((id) => {
+          if (next.delete(id)) changed = true;
+        });
+        return changed ? next : prev;
+      });
+      updateRecents((prev) => {
+        let changed = false;
+        const next = { ...prev };
+        ids.forEach((id) => {
+          if (id in next) {
+            changed = true;
+            delete next[id];
+          }
+        });
+        return changed ? next : prev;
+      });
+    },
+    [setRegistry, updateRecents],
+  );
+
+  const invokeAction = useCallback(
+    async (id: string) => {
+      const action = registryRef.current.get(id);
+      if (!action) return;
+      await action.handler();
+      const timestamp = Date.now();
+      updateRecents((prev) => ({
+        ...prev,
+        [id]: timestamp,
+      }));
+      setRegistry((prev) => {
+        const current = prev.get(id);
+        if (!current || current.lastInvoked === timestamp) {
+          return prev;
+        }
+        const next = new Map(prev);
+        next.set(id, {
+          ...current,
+          lastInvoked: timestamp,
+        });
+        return next;
+      });
+    },
+    [setRegistry, updateRecents],
+  );
+
+  const actions = useMemo(() => {
+    const list = Array.from(registry.values());
+    list.sort((a, b) => {
+      const aTime = a.lastInvoked ?? 0;
+      const bTime = b.lastInvoked ?? 0;
+      if (aTime && bTime) {
+        return bTime - aTime;
+      }
+      if (aTime) return -1;
+      if (bTime) return 1;
+      return a.label.localeCompare(b.label);
+    });
+    return list;
+  }, [registry]);
+
+  const value = useMemo<CommandPaletteContextValue>(
+    () => ({ actions, registerActions, unregisterActions, invokeAction }),
+    [actions, registerActions, unregisterActions, invokeAction],
+  );
+
+  return (
+    <CommandPaletteContext.Provider value={value}>
+      {children}
+    </CommandPaletteContext.Provider>
+  );
+};
+
+export const useCommandPalette = () => {
+  const context = useContext(CommandPaletteContext);
+  if (!context) {
+    throw new Error('useCommandPalette must be used within a CommandPaletteProvider');
+  }
+  return context;
+};

--- a/components/desktop/CommandPalette/index.ts
+++ b/components/desktop/CommandPalette/index.ts
@@ -1,0 +1,2 @@
+export * from './context';
+export * from './types';

--- a/components/desktop/CommandPalette/types.ts
+++ b/components/desktop/CommandPalette/types.ts
@@ -1,0 +1,27 @@
+export type CommandPaletteActionHandler = () => void | Promise<void>;
+
+export interface CommandPaletteAction {
+  /**
+   * Unique identifier for the action. Used for deduping and persistence keys.
+   */
+  id: string;
+  /**
+   * Display label that appears in the palette search results.
+   */
+  label: string;
+  /**
+   * Handler invoked when the action is selected.
+   */
+  handler: CommandPaletteActionHandler;
+  /**
+   * Optional application scope so palette consumers can filter actions.
+   */
+  appId?: string;
+}
+
+export interface CommandPaletteStoredAction extends CommandPaletteAction {
+  /** Timestamp representing when the action was registered. */
+  registeredAt: number;
+  /** Timestamp of the most recent invocation for ranking. */
+  lastInvoked?: number;
+}

--- a/hooks/useCommandPaletteActions.ts
+++ b/hooks/useCommandPaletteActions.ts
@@ -1,0 +1,23 @@
+import { useEffect, type DependencyList } from 'react';
+import {
+  useCommandPalette,
+  type CommandPaletteAction,
+} from '../components/desktop/CommandPalette';
+
+/**
+ * Register a set of command palette actions for the lifecycle of a component.
+ * The optional dependency list controls when the actions should be refreshed.
+ */
+export const useCommandPaletteActions = (
+  actions: CommandPaletteAction[],
+  deps?: DependencyList,
+) => {
+  const { registerActions, unregisterActions } = useCommandPalette();
+  const effectDeps: DependencyList = deps ? [...deps] : [actions];
+
+  useEffect(() => {
+    if (!actions.length) return;
+    registerActions(actions);
+    return () => unregisterActions(actions.map((action) => action.id));
+  }, [registerActions, unregisterActions, ...effectDeps]);
+};


### PR DESCRIPTION
## Summary
- add a command palette provider that tracks actions with persistent recency metadata
- define shared command palette action types and a hook for component registration
- cover ranking behaviour and cleanup persistence with integration tests

## Testing
- yarn test commandPalette

------
https://chatgpt.com/codex/tasks/task_e_68da519b46f08328b0399f1212257941