### PR TITLE
desktop: add session history drawer

### DIFF
--- a/__tests__/desktopHistoryState.test.ts
+++ b/__tests__/desktopHistoryState.test.ts
@@ -1,0 +1,101 @@
+import { Desktop } from '../components/screen/desktop';
+import {
+  DesktopHistoryEntry,
+  insertHistoryEntry,
+  MAX_HISTORY_ENTRIES,
+} from '../components/desktop/history';
+
+jest.mock('react-ga4', () => ({ event: jest.fn(), send: jest.fn() }));
+
+describe('Desktop session history', () => {
+  it('persists history entries when saving the session', () => {
+    const session = { windows: [], wallpaper: 'wall-2', dock: [], history: [] };
+    const setSession = jest.fn();
+    const desktop = new Desktop({ session, setSession });
+
+    desktop.state = {
+      ...desktop.state,
+      closed_windows: { terminal: false },
+      minimized_windows: {},
+      window_positions: { terminal: { x: 120, y: 120 } },
+      session_history: [
+        {
+          id: 'open-terminal-1',
+          appId: 'terminal',
+          title: 'Terminal',
+          action: 'open',
+          timestamp: 1700000000000,
+          workspace: 0,
+        },
+      ],
+    };
+
+    desktop.saveSession();
+
+    expect(setSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        history: desktop.state.session_history,
+        windows: [expect.objectContaining({ id: 'terminal' })],
+      }),
+    );
+  });
+
+  it('caps the history length when inserting new entries', () => {
+    const baseEntries: DesktopHistoryEntry[] = Array.from({ length: MAX_HISTORY_ENTRIES }, (_, index) => ({
+      id: `open-app-${index}`,
+      appId: 'terminal',
+      title: 'Terminal',
+      action: 'open',
+      timestamp: index,
+      workspace: 0,
+    }));
+
+    const newest: DesktopHistoryEntry = {
+      id: 'open-app-new',
+      appId: 'terminal',
+      title: 'Terminal',
+      action: 'open',
+      timestamp: 9999,
+      workspace: 1,
+    };
+
+    const next = insertHistoryEntry(baseEntries, newest);
+
+    expect(next).toHaveLength(MAX_HISTORY_ENTRIES);
+    expect(next[0]).toEqual(newest);
+    expect(next[next.length - 1].id).toBe(baseEntries[MAX_HISTORY_ENTRIES - 2].id);
+  });
+
+  it('switches workspace and reopens windows when jumping to history entries', () => {
+    const desktop = new Desktop({ session: { windows: [], wallpaper: 'wall-2', dock: [], history: [] } });
+
+    desktop.state = {
+      ...desktop.state,
+      activeWorkspace: 0,
+      showHistoryDrawer: true,
+    };
+
+    const closeDrawer = jest
+      .spyOn(desktop, 'closeHistoryDrawer')
+      .mockImplementation((callback: (() => void) | undefined) => {
+        callback?.();
+      });
+    const switchWorkspace = jest.spyOn(desktop, 'switchWorkspace').mockImplementation(() => {});
+    const openApp = jest.spyOn(desktop, 'openApp').mockImplementation(() => {});
+
+    const entry: DesktopHistoryEntry = {
+      id: 'close-terminal',
+      appId: 'terminal',
+      title: 'Terminal',
+      action: 'close',
+      timestamp: 1700000005000,
+      workspace: 2,
+    };
+
+    desktop.handleHistoryJump(entry);
+
+    expect(closeDrawer).toHaveBeenCalledWith(expect.any(Function), { restoreFocus: false });
+    expect(switchWorkspace).toHaveBeenCalledWith(2);
+    expect(openApp).toHaveBeenCalledWith('terminal', undefined, { skipHistory: true });
+  });
+});

--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -18,6 +18,8 @@ describe('Taskbar', () => {
         focused_windows={{ app1: true }}
         openApp={openApp}
         minimize={minimize}
+        historyOpen={false}
+        onHistoryToggle={() => {}}
       />
     );
     const button = screen.getByRole('button', { name: /app one/i });
@@ -40,6 +42,8 @@ describe('Taskbar', () => {
         focused_windows={{ app1: false }}
         openApp={openApp}
         minimize={minimize}
+        historyOpen={false}
+        onHistoryToggle={() => {}}
       />
     );
     const button = screen.getByRole('button', { name: /app one/i });

--- a/components/desktop/SessionHistoryDrawer.tsx
+++ b/components/desktop/SessionHistoryDrawer.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import {
+  DesktopHistoryEntry,
+  groupHistoryEntries,
+  formatHistoryTimestamp,
+} from "./history";
+
+interface SessionHistoryDrawerProps {
+  open: boolean;
+  entries: DesktopHistoryEntry[];
+  onClose: () => void;
+  onJump: (entry: DesktopHistoryEntry) => void;
+  autoFocus?: boolean;
+}
+
+export default function SessionHistoryDrawer({
+  open,
+  entries,
+  onClose,
+  onJump,
+  autoFocus = false,
+}: SessionHistoryDrawerProps) {
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const groups = useMemo(() => groupHistoryEntries(entries), [entries]);
+
+  useEffect(() => {
+    if (open && autoFocus) {
+      closeButtonRef.current?.focus();
+    }
+  }, [open, autoFocus]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      role="presentation"
+      aria-hidden={!open}
+      className="fixed inset-0 z-[70] flex items-end justify-end bg-black/30 backdrop-blur"
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-label="Session history"
+        className="m-4 w-full max-w-md rounded-xl bg-slate-900/95 text-white shadow-2xl ring-1 ring-white/10"
+      >
+        <header className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+          <div>
+            <h2 className="text-lg font-semibold">Session history</h2>
+            <p className="text-xs text-slate-300">Review recently opened and closed windows.</p>
+          </div>
+          <button
+            type="button"
+            ref={closeButtonRef}
+            onClick={onClose}
+            className="rounded-md px-2 py-1 text-sm font-medium text-white/80 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+          >
+            Close
+          </button>
+        </header>
+        <div className="max-h-[60vh] overflow-y-auto px-4 py-3 text-sm">
+          {groups.length === 0 ? (
+            <p className="py-6 text-center text-slate-300">No session activity yet.</p>
+          ) : (
+            <ul className="space-y-4">
+              {groups.map((group) => (
+                <li key={group.label} className="space-y-2">
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    {group.label}
+                  </h3>
+                  <ul className="space-y-1.5">
+                    {group.entries.map((entry) => (
+                      <li
+                        key={entry.id}
+                        className="flex items-center justify-between rounded-lg border border-white/5 bg-white/5 px-3 py-2"
+                      >
+                        <div>
+                          <p className="font-medium">
+                            {entry.action === "open" ? "Opened" : "Closed"} {entry.title}
+                          </p>
+                          <p className="text-xs text-slate-300">
+                            {formatHistoryTimestamp(entry.timestamp)} · Workspace {entry.workspace + 1}
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => onJump(entry)}
+                          className="rounded-md px-2 py-1 text-xs font-semibold uppercase tracking-wide text-cyan-200 transition hover:bg-cyan-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+                        >
+                          Jump back
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/desktop/history.ts
+++ b/components/desktop/history.ts
@@ -1,0 +1,107 @@
+export type DesktopHistoryAction = "open" | "close";
+
+export interface DesktopHistoryEntry {
+  id: string;
+  appId: string;
+  title: string;
+  action: DesktopHistoryAction;
+  timestamp: number;
+  workspace: number;
+}
+
+export interface DesktopHistoryGroup {
+  label: string;
+  entries: DesktopHistoryEntry[];
+}
+
+export const MAX_HISTORY_ENTRIES = 50;
+
+export function isDesktopHistoryEntry(value: unknown): value is DesktopHistoryEntry {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Partial<DesktopHistoryEntry>;
+  return (
+    typeof entry.id === "string" &&
+    typeof entry.appId === "string" &&
+    typeof entry.title === "string" &&
+    (entry.action === "open" || entry.action === "close") &&
+    typeof entry.timestamp === "number" &&
+    Number.isFinite(entry.timestamp) &&
+    typeof entry.workspace === "number"
+  );
+}
+
+export function insertHistoryEntry(
+  entries: DesktopHistoryEntry[] | undefined,
+  next: DesktopHistoryEntry,
+  max: number = MAX_HISTORY_ENTRIES,
+): DesktopHistoryEntry[] {
+  const safeEntries = Array.isArray(entries) ? entries : [];
+  const merged = [next, ...safeEntries];
+  if (merged.length <= max) {
+    return merged;
+  }
+  return merged.slice(0, max);
+}
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+const ONE_HOUR = 60 * 60 * 1000;
+
+function isSameDay(a: number, b: number) {
+  const dateA = new Date(a);
+  const dateB = new Date(b);
+  return (
+    dateA.getFullYear() === dateB.getFullYear() &&
+    dateA.getMonth() === dateB.getMonth() &&
+    dateA.getDate() === dateB.getDate()
+  );
+}
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+});
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+export function formatHistoryTimestamp(timestamp: number): string {
+  return timeFormatter.format(new Date(timestamp));
+}
+
+export function groupHistoryEntries(
+  entries: DesktopHistoryEntry[] | undefined,
+  now: number = Date.now(),
+): DesktopHistoryGroup[] {
+  if (!entries || entries.length === 0) {
+    return [];
+  }
+
+  const buckets = new Map<string, DesktopHistoryEntry[]>();
+  const order: string[] = [];
+
+  const register = (label: string, entry: DesktopHistoryEntry) => {
+    if (!buckets.has(label)) {
+      buckets.set(label, []);
+      order.push(label);
+    }
+    buckets.get(label)!.push(entry);
+  };
+
+  entries.forEach((entry) => {
+    const diff = now - entry.timestamp;
+    if (diff < FIVE_MINUTES) {
+      register("Last 5 minutes", entry);
+    } else if (diff < ONE_HOUR) {
+      register("Last hour", entry);
+    } else if (isSameDay(entry.timestamp, now)) {
+      register("Earlier today", entry);
+    } else {
+      register(dateFormatter.format(new Date(entry.timestamp)), entry);
+    }
+  });
+
+  return order.map((label) => ({ label, entries: buckets.get(label)! }));
+}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Image from 'next/image';
 
 export default function Taskbar(props) {
+    const { historyOpen = false, onHistoryToggle, historyButtonRef } = props;
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
 
     const handleClick = (app) => {
@@ -13,6 +14,12 @@ export default function Taskbar(props) {
         } else {
             props.openApp(id);
         }
+    };
+
+    const handleHistoryClick = (event) => {
+        if (typeof onHistoryToggle !== 'function') return;
+        const trigger = event?.detail === 0 ? 'keyboard' : 'pointer';
+        onHistoryToggle(trigger);
     };
 
     return (
@@ -29,6 +36,33 @@ export default function Taskbar(props) {
                 className="flex items-center overflow-x-auto"
                 style={{ gap: 'var(--shell-taskbar-gap, 0.5rem)' }}
             >
+                <button
+                    type="button"
+                    ref={historyButtonRef ?? null}
+                    onClick={handleHistoryClick}
+                    aria-label={historyOpen ? 'Hide session history' : 'Show session history'}
+                    aria-pressed={historyOpen}
+                    data-active={historyOpen ? 'true' : 'false'}
+                    className={`${historyOpen ? 'bg-white bg-opacity-20 ' : ''}relative flex items-center justify-center rounded-lg transition-colors hover:bg-white hover:bg-opacity-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70`}
+                    style={{
+                        minHeight: 'var(--shell-hit-target, 2.5rem)',
+                        minWidth: 'var(--shell-hit-target, 2.5rem)',
+                        paddingInline: 'calc(var(--shell-taskbar-padding-x, 0.75rem) * 0.55)',
+                    }}
+                >
+                    <svg
+                        width="20"
+                        height="20"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="text-white/90"
+                    >
+                        <circle cx="12" cy="12" r="8.5" stroke="currentColor" strokeWidth="1.5" opacity="0.85" />
+                        <path d="M12 7.5V12l3 1.75" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                        <path d="M8.5 5.5l-2 2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity="0.65" />
+                    </svg>
+                </button>
                 {runningApps.map(app => {
                     const isMinimized = Boolean(props.minimized_windows[app.id]);
                     const isFocused = Boolean(props.focused_windows[app.id]);

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -1,5 +1,9 @@
 import usePersistentState from './usePersistentState';
 import { defaults } from '../utils/settingsStore';
+import {
+  DesktopHistoryEntry,
+  isDesktopHistoryEntry,
+} from '../components/desktop/history';
 
 export interface SessionWindow {
   id: string;
@@ -11,12 +15,14 @@ export interface DesktopSession {
   windows: SessionWindow[];
   wallpaper: string;
   dock: string[];
+  history: DesktopHistoryEntry[];
 }
 
 const initialSession: DesktopSession = {
   windows: [],
   wallpaper: defaults.wallpaper,
   dock: [],
+  history: [],
 };
 
 function isSession(value: unknown): value is DesktopSession {
@@ -25,7 +31,9 @@ function isSession(value: unknown): value is DesktopSession {
   return (
     Array.isArray(s.windows) &&
     typeof s.wallpaper === 'string' &&
-    Array.isArray(s.dock)
+    Array.isArray(s.dock) &&
+    Array.isArray((s as DesktopSession).history) &&
+    (s.history as unknown[]).every((entry) => isDesktopHistoryEntry(entry))
   );
 }
 


### PR DESCRIPTION
## Summary
- persist desktop window history with timestamps and load it through the session hook
- expose a session history drawer with grouped events and jump-back actions wired to the taskbar toggle and shortcut
- cover history persistence, list limits, and jump-back logic with new Jest tests

## Testing
- yarn test desktopHistoryState


------
https://chatgpt.com/codex/tasks/task_e_68da519bd5f883289d10bcf089bba3e4