### PR TITLE
[desktop] add density controls

### DIFF
--- a/components/desktop/Layout.tsx
+++ b/components/desktop/Layout.tsx
@@ -1,107 +1,116 @@
+"use client";
+
 import React from "react";
 import clsx from "clsx";
+import { useSettings } from "../../hooks/useSettings";
 
 type LayoutProps = React.HTMLAttributes<HTMLDivElement>;
 
 const Layout = React.forwardRef<HTMLDivElement, LayoutProps>(
   ({ className, children, ...props }, ref) => {
+    const { density } = useSettings();
+    const densityClass = density ? `density-${density}` : undefined;
     return (
       <div
         ref={ref}
         className={clsx(
           "desktop-shell relative h-screen w-screen overflow-hidden bg-transparent text-white antialiased",
+          densityClass,
           className,
         )}
+        data-density={density}
         {...props}
       >
         {children}
         <style jsx>{`
           .desktop-shell {
-            --shell-taskbar-height: 2.5rem;
-            --shell-taskbar-padding-x: 0.75rem;
-            --shell-taskbar-gap: 0.5rem;
-            --shell-taskbar-font-size: 0.875rem;
-            --shell-taskbar-icon: 1.5rem;
-            --shell-hit-target: 2.5rem;
-            --desktop-icon-width: 6rem;
-            --desktop-icon-height: 5.5rem;
-            --desktop-icon-padding: 0.25rem;
-            --desktop-icon-gap: 0.375rem;
-            --desktop-icon-image: 2.5rem;
-            --desktop-icon-font-size: 0.75rem;
+            --shell-taskbar-height: calc(2.5rem * var(--density-spacing-scale, 1));
+            --shell-taskbar-padding-x: calc(0.75rem * var(--density-spacing-scale, 1));
+            --shell-taskbar-gap: var(--space-2, 0.5rem);
+            --shell-taskbar-font-size: calc(0.875rem * var(--density-font-scale, 1));
+            --shell-taskbar-icon: calc(1.5rem * var(--density-spacing-scale, 1));
+            --shell-hit-target: calc(2.5rem * var(--density-spacing-scale, 1));
+            --desktop-icon-width: calc(6rem * var(--density-spacing-scale, 1));
+            --desktop-icon-height: calc(5.5rem * var(--density-spacing-scale, 1));
+            --desktop-icon-padding: var(--space-1, 0.25rem);
+            --desktop-icon-gap: var(--space-2, 0.5rem);
+            --desktop-icon-image: calc(2.5rem * var(--density-spacing-scale, 1));
+            --desktop-icon-font-size: calc(0.75rem * var(--density-font-scale, 1));
             touch-action: manipulation;
-            font-size: clamp(0.95rem, 0.9rem + 0.2vw, 1rem);
+            font-size: calc(
+              clamp(0.95rem, 0.9rem + 0.2vw, 1rem) * var(--density-font-scale, 1)
+            );
           }
 
           @media (min-width: 640px) {
             .desktop-shell {
-              --shell-taskbar-height: 2.75rem;
-              --shell-taskbar-padding-x: 0.875rem;
-              --shell-taskbar-gap: 0.6rem;
-              --desktop-icon-width: 6.25rem;
-              --desktop-icon-height: 5.75rem;
+              --shell-taskbar-height: calc(2.75rem * var(--density-spacing-scale, 1));
+              --shell-taskbar-padding-x: calc(0.875rem * var(--density-spacing-scale, 1));
+              --shell-taskbar-gap: var(--space-3, 0.75rem);
+              --desktop-icon-width: calc(6.25rem * var(--density-spacing-scale, 1));
+              --desktop-icon-height: calc(5.75rem * var(--density-spacing-scale, 1));
             }
           }
 
           @media (min-width: 768px) {
             .desktop-shell {
-              --shell-taskbar-height: 3rem;
-              --shell-taskbar-padding-x: 1rem;
-              --shell-taskbar-gap: 0.75rem;
-              --shell-taskbar-font-size: 0.925rem;
-              --desktop-icon-width: 6.5rem;
-              --desktop-icon-height: 6rem;
-              --desktop-icon-image: 2.75rem;
-              --desktop-icon-font-size: 0.8rem;
+              --shell-taskbar-height: calc(3rem * var(--density-spacing-scale, 1));
+              --shell-taskbar-padding-x: calc(1rem * var(--density-spacing-scale, 1));
+              --shell-taskbar-gap: var(--space-3, 0.75rem);
+              --shell-taskbar-font-size: calc(0.925rem * var(--density-font-scale, 1));
+              --desktop-icon-width: calc(6.5rem * var(--density-spacing-scale, 1));
+              --desktop-icon-height: calc(6rem * var(--density-spacing-scale, 1));
+              --desktop-icon-image: calc(2.75rem * var(--density-spacing-scale, 1));
+              --desktop-icon-font-size: calc(0.8rem * var(--density-font-scale, 1));
             }
           }
 
           @media (min-width: 1024px) {
             .desktop-shell {
-              --shell-taskbar-height: 3.25rem;
-              --shell-taskbar-font-size: 0.95rem;
-              --desktop-icon-width: 6.75rem;
-              --desktop-icon-height: 6.25rem;
+              --shell-taskbar-height: calc(3.25rem * var(--density-spacing-scale, 1));
+              --shell-taskbar-font-size: calc(0.95rem * var(--density-font-scale, 1));
+              --desktop-icon-width: calc(6.75rem * var(--density-spacing-scale, 1));
+              --desktop-icon-height: calc(6.25rem * var(--density-spacing-scale, 1));
             }
           }
 
           @media (min-width: 1280px) {
             .desktop-shell {
-              --shell-taskbar-height: 3.5rem;
-              --shell-taskbar-font-size: 1rem;
-              --desktop-icon-width: 7rem;
-              --desktop-icon-height: 6.5rem;
-              --desktop-icon-image: 3rem;
-              --desktop-icon-font-size: 0.85rem;
+              --shell-taskbar-height: calc(3.5rem * var(--density-spacing-scale, 1));
+              --shell-taskbar-font-size: calc(1rem * var(--density-font-scale, 1));
+              --desktop-icon-width: calc(7rem * var(--density-spacing-scale, 1));
+              --desktop-icon-height: calc(6.5rem * var(--density-spacing-scale, 1));
+              --desktop-icon-image: calc(3rem * var(--density-spacing-scale, 1));
+              --desktop-icon-font-size: calc(0.85rem * var(--density-font-scale, 1));
             }
           }
 
           @media (pointer: coarse) {
             .desktop-shell {
-              --shell-taskbar-height: 3.5rem;
-              --shell-taskbar-padding-x: 1.1rem;
-              --shell-taskbar-gap: 0.85rem;
-              --shell-taskbar-font-size: 1rem;
-              --shell-taskbar-icon: 2rem;
-              --shell-hit-target: 3.5rem;
-              --desktop-icon-width: 7.25rem;
-              --desktop-icon-height: 6.75rem;
-              --desktop-icon-image: 3rem;
-              --desktop-icon-padding: 0.45rem;
-              --desktop-icon-gap: 0.5rem;
-              --desktop-icon-font-size: 0.85rem;
+              --shell-taskbar-height: calc(3.5rem * var(--density-spacing-scale, 1));
+              --shell-taskbar-padding-x: calc(1.1rem * var(--density-spacing-scale, 1));
+              --shell-taskbar-gap: var(--space-3, 0.75rem);
+              --shell-taskbar-font-size: calc(1rem * var(--density-font-scale, 1));
+              --shell-taskbar-icon: calc(2rem * var(--density-spacing-scale, 1));
+              --shell-hit-target: calc(3.5rem * var(--density-spacing-scale, 1));
+              --desktop-icon-width: calc(7.25rem * var(--density-spacing-scale, 1));
+              --desktop-icon-height: calc(6.75rem * var(--density-spacing-scale, 1));
+              --desktop-icon-image: calc(3rem * var(--density-spacing-scale, 1));
+              --desktop-icon-padding: var(--space-2, 0.5rem);
+              --desktop-icon-gap: var(--space-2, 0.5rem);
+              --desktop-icon-font-size: calc(0.85rem * var(--density-font-scale, 1));
             }
           }
 
           @media (pointer: coarse) and (min-width: 768px) {
             .desktop-shell {
-              --shell-taskbar-height: 3.75rem;
-              --shell-taskbar-padding-x: 1.25rem;
-              --shell-hit-target: 3.75rem;
-              --desktop-icon-width: 7.5rem;
-              --desktop-icon-height: 7rem;
-              --desktop-icon-image: 3.25rem;
-              --desktop-icon-font-size: 0.9rem;
+              --shell-taskbar-height: calc(3.75rem * var(--density-spacing-scale, 1));
+              --shell-taskbar-padding-x: calc(1.25rem * var(--density-spacing-scale, 1));
+              --shell-hit-target: calc(3.75rem * var(--density-spacing-scale, 1));
+              --desktop-icon-width: calc(7.5rem * var(--density-spacing-scale, 1));
+              --desktop-icon-height: calc(7rem * var(--density-spacing-scale, 1));
+              --desktop-icon-image: calc(3.25rem * var(--density-spacing-scale, 1));
+              --desktop-icon-font-size: calc(0.9rem * var(--density-font-scale, 1));
             }
           }
         `}</style>

--- a/components/desktop/SettingsDrawer.tsx
+++ b/components/desktop/SettingsDrawer.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { ChangeEvent } from "react";
+import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
+
+type DensityOption = {
+  value: "regular" | "compact";
+  label: string;
+  description: string;
+};
+
+const DENSITY_OPTIONS: DensityOption[] = [
+  { value: "regular", label: "Comfortable", description: "Balanced spacing for desktop displays." },
+  { value: "compact", label: "Compact", description: "Tighter spacing to fit more information." },
+];
+
+const SettingsDrawer = () => {
+  const {
+    density,
+    setDensity,
+    reducedMotion,
+    setReducedMotion,
+    largeHitAreas,
+    setLargeHitAreas,
+    fontScale,
+    setFontScale,
+    accent,
+    setAccent,
+  } = useSettings();
+
+  const handleDensityChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setDensity(event.target.value as DensityOption["value"]);
+  };
+
+  const handleFontScaleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setFontScale(parseFloat(event.target.value));
+  };
+
+  return (
+    <div
+      className="rounded-xl border border-white/10 bg-black/60 text-sm text-white/90 shadow-lg backdrop-blur"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--space-4, 1rem)",
+        padding: "var(--space-4, 1rem)",
+        minWidth: "18rem",
+      }}
+      role="group"
+      aria-label="desktop settings"
+    >
+      <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-2, 0.5rem)" }}>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-white/60">Density</h3>
+        <div
+          style={{ display: "flex", flexDirection: "column", gap: "var(--space-2, 0.5rem)" }}
+          role="radiogroup"
+          aria-label="density"
+        >
+          {DENSITY_OPTIONS.map((option) => (
+            <label key={option.value} className="flex cursor-pointer flex-col gap-1 rounded-lg border border-white/10 bg-white/5 p-2 hover:border-white/30">
+              <div className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="desktop-density"
+                  value={option.value}
+                  checked={density === option.value}
+                  onChange={handleDensityChange}
+                  aria-label={`${option.label} density`}
+                />
+                <span className="font-medium">{option.label}</span>
+              </div>
+              <p className="text-xs text-white/60">{option.description}</p>
+            </label>
+          ))}
+        </div>
+      </section>
+
+      <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-2, 0.5rem)" }}>
+        <div className="flex items-center justify-between gap-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-white/60">Font scale</h3>
+          <span className="text-xs text-white/60">{fontScale.toFixed(2)}x</span>
+        </div>
+        <input
+          type="range"
+          min="0.85"
+          max="1.35"
+          step="0.05"
+          value={fontScale}
+          onChange={handleFontScaleChange}
+          aria-label="font scale"
+        />
+      </section>
+
+      <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-2, 0.5rem)" }}>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-white/60">Accessibility</h3>
+        <label className="flex items-center justify-between gap-4 rounded-lg border border-white/10 bg-white/5 px-3 py-2">
+          <span>Reduced motion</span>
+          <input
+            type="checkbox"
+            checked={reducedMotion}
+            onChange={(event) => setReducedMotion(event.target.checked)}
+            aria-label="toggle reduced motion"
+          />
+        </label>
+        <label className="flex items-center justify-between gap-4 rounded-lg border border-white/10 bg-white/5 px-3 py-2">
+          <span>Large hit areas</span>
+          <input
+            type="checkbox"
+            checked={largeHitAreas}
+            onChange={(event) => setLargeHitAreas(event.target.checked)}
+            aria-label="toggle large hit areas"
+          />
+        </label>
+      </section>
+
+      <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-2, 0.5rem)" }}>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-white/60">Accent</h3>
+        <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="accent color">
+          {ACCENT_OPTIONS.map((color) => (
+            <button
+              key={color}
+              type="button"
+              aria-label={`select accent ${color}`}
+              role="radio"
+              aria-checked={accent === color}
+              onClick={() => setAccent(color)}
+              className={`h-7 w-7 rounded-full border-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 ${
+                accent === color ? "border-white" : "border-transparent"
+              }`}
+              style={{ backgroundColor: color }}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default SettingsDrawer;

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -27,7 +27,7 @@ export default function Taskbar(props) {
         >
             <div
                 className="flex items-center overflow-x-auto"
-                style={{ gap: 'var(--shell-taskbar-gap, 0.5rem)' }}
+                style={{ gap: 'var(--shell-taskbar-gap, var(--space-2, 0.5rem))' }}
             >
                 {runningApps.map(app => {
                     const isMinimized = Boolean(props.minimized_windows[app.id]);
@@ -50,7 +50,7 @@ export default function Taskbar(props) {
                                 minWidth: 'var(--shell-hit-target, 2.5rem)',
                                 paddingInline: 'calc(var(--shell-taskbar-padding-x, 0.75rem) * 0.75)',
                                 fontSize: 'var(--shell-taskbar-font-size, 0.875rem)',
-                                gap: '0.5rem',
+                                gap: 'var(--space-2, 0.5rem)',
                             }}
                         >
                             <Image

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import SettingsDrawer from '../desktop/SettingsDrawer';
 
 interface Props {
   open: boolean;
@@ -23,9 +24,15 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
-      className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
+      className={`absolute top-9 right-3 rounded-xl border border-black/40 bg-ub-cool-grey/95 p-4 shadow-lg backdrop-blur ${
         open ? '' : 'hidden'
       }`}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--space-4, 1rem)',
+        width: 'min(22rem, 90vw)',
+      }}
     >
       <div className="px-4 pb-2">
         <button
@@ -38,11 +45,21 @@ const QuickSettings = ({ open }: Props) => {
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
+        <input
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+          aria-label="Toggle sound"
+        />
       </div>
       <div className="px-4 pb-2 flex justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
+        <input
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+          aria-label="Toggle network"
+        />
       </div>
       <div className="px-4 flex justify-between">
         <span>Reduced motion</span>
@@ -50,8 +67,10 @@ const QuickSettings = ({ open }: Props) => {
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
+          aria-label="Toggle quick reduced motion"
         />
       </div>
+      <SettingsDrawer />
     </div>
   );
 };

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -171,28 +171,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [useKaliWallpaper]);
 
   useEffect(() => {
-    const spacing: Record<Density, Record<string, string>> = {
-      regular: {
-        '--space-1': '0.25rem',
-        '--space-2': '0.5rem',
-        '--space-3': '0.75rem',
-        '--space-4': '1rem',
-        '--space-5': '1.5rem',
-        '--space-6': '2rem',
-      },
-      compact: {
-        '--space-1': '0.125rem',
-        '--space-2': '0.25rem',
-        '--space-3': '0.5rem',
-        '--space-4': '0.75rem',
-        '--space-5': '1rem',
-        '--space-6': '1.5rem',
-      },
-    };
-    const vars = spacing[density];
-    Object.entries(vars).forEach(([key, value]) => {
-      document.documentElement.style.setProperty(key, value);
-    });
     saveDensity(density);
   }, [density]);
 
@@ -202,7 +180,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [reducedMotion]);
 
   useEffect(() => {
-    document.documentElement.style.setProperty('--font-multiplier', fontScale.toString());
+    document.documentElement.style.setProperty('--user-font-scale', fontScale.toString());
     saveFontScale(fontScale);
   }, [fontScale]);
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -45,13 +45,18 @@
   --game-color-warning: #d97706;
   --game-color-danger: #b91c1c;
 
+  /* Density tokens */
+  --density-spacing-scale: 1;
+  --density-font-scale: 1;
+  --user-font-scale: 1;
+
   /* Spacing scale */
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.5rem;
-  --space-6: 2rem;
+  --space-1: calc(0.25rem * var(--density-spacing-scale));
+  --space-2: calc(0.5rem * var(--density-spacing-scale));
+  --space-3: calc(0.75rem * var(--density-spacing-scale));
+  --space-4: calc(1rem * var(--density-spacing-scale));
+  --space-5: calc(1.5rem * var(--density-spacing-scale));
+  --space-6: calc(2rem * var(--density-spacing-scale));
 
   /* Radius */
   --radius-sm: 2px;
@@ -74,12 +79,24 @@
 
   /* Fonts */
   --font-family-base: 'Ubuntu', sans-serif;
-  --font-multiplier: 1;
+  --font-multiplier: calc(var(--density-font-scale) * var(--user-font-scale, 1));
   /* Minimum interactive target size */
   --hit-area: 32px;
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
+}
+
+.density-regular {
+  --density-spacing-scale: 1;
+  --density-font-scale: 1;
+  --hit-area: 32px;
+}
+
+.density-compact {
+  --density-spacing-scale: 0.85;
+  --density-font-scale: 0.95;
+  --hit-area: 28px;
 }
 
 /* High contrast theme */


### PR DESCRIPTION
## Summary
- add density-aware spacing and font tokens so spacing adjusts with user preferences
- apply density classes to the desktop shell and taskbar to consume the new tokens
- embed a desktop settings drawer with density, font, and accessibility controls inside the quick settings menu

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da519e0ca4832888ed3b00d722cf85