### PR TITLE
[desktop] enable dock reordering persistence

### DIFF
--- a/__tests__/taskbar.test.tsx
+++ b/__tests__/taskbar.test.tsx
@@ -1,10 +1,27 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Taskbar from '../components/screen/taskbar';
 
 jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
 
-const apps = [{ id: 'app1', title: 'App One', icon: '/icon.png' }];
+const apps = [
+  { id: 'app1', title: 'App One', icon: '/icon1.png' },
+  { id: 'app2', title: 'App Two', icon: '/icon2.png' },
+];
+
+const createDataTransfer = () => {
+  const data: Record<string, string> = {};
+  return {
+    data,
+    setData: (key: string, value: string) => {
+      data[key] = value;
+    },
+    getData: (key: string) => data[key],
+    dropEffect: 'move',
+    effectAllowed: 'move',
+    setDragImage: jest.fn(),
+  } as unknown as DataTransfer;
+};
 
 describe('Taskbar', () => {
   it('minimizes focused window on click', () => {
@@ -13,14 +30,16 @@ describe('Taskbar', () => {
     render(
       <Taskbar
         apps={apps}
+        pinnedAppIds={['app1']}
         closed_windows={{ app1: false }}
         minimized_windows={{ app1: false }}
         focused_windows={{ app1: true }}
         openApp={openApp}
         minimize={minimize}
+        onReorderPinnedApps={jest.fn()}
       />
     );
-    const button = screen.getByRole('button', { name: /app one/i });
+    const button = screen.getByRole('button', { name: /^app one$/i });
     fireEvent.click(button);
     expect(minimize).toHaveBeenCalledWith('app1');
     expect(button).toHaveAttribute('data-context', 'taskbar');
@@ -35,18 +54,68 @@ describe('Taskbar', () => {
     render(
       <Taskbar
         apps={apps}
+        pinnedAppIds={['app1']}
         closed_windows={{ app1: false }}
         minimized_windows={{ app1: true }}
         focused_windows={{ app1: false }}
         openApp={openApp}
         minimize={minimize}
+        onReorderPinnedApps={jest.fn()}
       />
     );
-    const button = screen.getByRole('button', { name: /app one/i });
+    const button = screen.getByRole('button', { name: /^app one$/i });
     fireEvent.click(button);
     expect(openApp).toHaveBeenCalledWith('app1');
     expect(button).toHaveAttribute('aria-pressed', 'false');
     expect(button).toHaveAttribute('data-active', 'false');
     expect(button.querySelector('[data-testid="running-indicator"]')).toBeFalsy();
+  });
+
+  it('announces drag reorder changes', async () => {
+    const handleReorder = jest.fn();
+    const dataTransfer = createDataTransfer();
+    render(
+      <Taskbar
+        apps={apps}
+        pinnedAppIds={['app1', 'app2']}
+        closed_windows={{ app1: false, app2: true }}
+        minimized_windows={{ app1: false, app2: false }}
+        focused_windows={{ app1: false, app2: false }}
+        openApp={jest.fn()}
+        minimize={jest.fn()}
+        onReorderPinnedApps={handleReorder}
+      />
+    );
+    const first = screen.getByRole('button', { name: /^app one$/i });
+    const second = screen.getByRole('button', { name: /^app two$/i });
+    fireEvent.dragStart(first, { dataTransfer });
+    fireEvent.dragOver(second, { dataTransfer });
+    fireEvent.drop(second, { dataTransfer });
+    await waitFor(() => {
+      expect(handleReorder).toHaveBeenCalledWith(['app2', 'app1']);
+    });
+    const status = screen.getByRole('status');
+    await waitFor(() => {
+      expect(status).toHaveTextContent(/app one moved to position 2/i);
+    });
+  });
+
+  it('supports keyboard reorder controls', () => {
+    const handleReorder = jest.fn();
+    render(
+      <Taskbar
+        apps={apps}
+        pinnedAppIds={['app1', 'app2']}
+        closed_windows={{ app1: true, app2: true }}
+        minimized_windows={{}}
+        focused_windows={{}}
+        openApp={jest.fn()}
+        minimize={jest.fn()}
+        onReorderPinnedApps={handleReorder}
+      />
+    );
+    const moveRight = screen.getByRole('button', { name: /move app one right/i });
+    fireEvent.click(moveRight);
+    expect(handleReorder).toHaveBeenCalledWith(['app2', 'app1']);
   });
 });

--- a/__tests__/useUserPrefs.test.tsx
+++ b/__tests__/useUserPrefs.test.tsx
@@ -1,0 +1,38 @@
+import { act, renderHook } from '@testing-library/react';
+import useUserPrefs from '../hooks/useUserPrefs';
+
+describe('useUserPrefs', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('initializes from legacy pinnedApps', () => {
+    window.localStorage.setItem('pinnedApps', JSON.stringify(['app1', 'app2']));
+    const { result } = renderHook(() => useUserPrefs());
+    expect(result.current.dockPinnedOrder).toEqual(['app1', 'app2']);
+  });
+
+  it('persists order updates to storage', () => {
+    const { result } = renderHook(() => useUserPrefs());
+    act(() => {
+      result.current.setDockPinnedOrder(['app2', 'app1']);
+    });
+    const storedPrefs = JSON.parse(
+      window.localStorage.getItem('user-preferences') ?? '{}'
+    );
+    expect(storedPrefs.dockPinnedOrder).toEqual(['app2', 'app1']);
+    expect(JSON.parse(window.localStorage.getItem('pinnedApps') ?? '[]')).toEqual([
+      'app2',
+      'app1',
+    ]);
+    expect(result.current.dockPinnedOrder).toEqual(['app2', 'app1']);
+  });
+
+  it('ensures defaults when preferences are empty', () => {
+    const { result } = renderHook(() => useUserPrefs());
+    act(() => {
+      result.current.ensureDockPinnedApps(['app3', 'app4']);
+    });
+    expect(result.current.dockPinnedOrder).toEqual(['app3', 'app4']);
+  });
+});

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,24 +1,209 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import Image from 'next/image';
 
-export default function Taskbar(props) {
-    const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+const noop = () => {};
 
-    const handleClick = (app) => {
-        const id = app.id;
-        if (props.minimized_windows[id]) {
-            props.openApp(id);
-        } else if (props.focused_windows[id]) {
-            props.minimize(id);
-        } else {
-            props.openApp(id);
+const getDataTransferId = (event, fallback) => {
+    const transfer = event?.dataTransfer;
+    if (transfer) {
+        const id = transfer.getData('text/plain');
+        if (id) return id;
+    }
+    return fallback ?? null;
+};
+
+const scheduleUpdate = (callback) => {
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(callback);
+        return;
+    }
+    setTimeout(callback, 0);
+};
+
+export default function Taskbar(props) {
+    const {
+        apps,
+        pinnedAppIds = [],
+        onReorderPinnedApps,
+        closed_windows,
+        minimized_windows,
+        focused_windows,
+        openApp,
+        minimize,
+    } = props;
+
+    const [draggedId, setDraggedId] = useState(null);
+    const [announcement, setAnnouncement] = useState('');
+
+    const pinnedSet = useMemo(() => new Set(pinnedAppIds), [pinnedAppIds]);
+    const pinnedCount = pinnedAppIds.length;
+
+    const pinnedApps = useMemo(
+        () => pinnedAppIds.map((id) => apps.find((app) => app.id === id)).filter(Boolean),
+        [apps, pinnedAppIds],
+    );
+
+    const runningApps = useMemo(
+        () => apps.filter((app) => closed_windows[app.id] === false),
+        [apps, closed_windows],
+    );
+
+    const extraRunningApps = useMemo(
+        () => runningApps.filter((app) => !pinnedSet.has(app.id)),
+        [runningApps, pinnedSet],
+    );
+
+    const announce = useCallback((message) => {
+        setAnnouncement('');
+        if (!message) return;
+        scheduleUpdate(() => setAnnouncement(message));
+    }, []);
+
+    const movePinned = useCallback((sourceId, targetIndex) => {
+        if (!pinnedSet.has(sourceId)) return;
+        if (typeof targetIndex !== 'number' || Number.isNaN(targetIndex)) return;
+        const current = [...pinnedAppIds];
+        if (!current.includes(sourceId)) return;
+        const withoutSource = current.filter((id) => id !== sourceId);
+        const clampedIndex = Math.max(0, Math.min(targetIndex, withoutSource.length));
+        withoutSource.splice(clampedIndex, 0, sourceId);
+        const hasChanged =
+            withoutSource.length !== current.length ||
+            withoutSource.some((id, index) => id !== current[index]);
+        if (!hasChanged) return;
+        (onReorderPinnedApps || noop)(withoutSource);
+        const app = apps.find((item) => item.id === sourceId);
+        if (app) {
+            announce(`${app.title} moved to position ${clampedIndex + 1} in dock`);
         }
-    };
+    }, [announce, apps, onReorderPinnedApps, pinnedAppIds, pinnedSet]);
+
+    const handleClick = useCallback((app) => {
+        const id = app.id;
+        const isClosed = closed_windows[id] !== false;
+        const isMinimized = Boolean(minimized_windows[id]);
+        const isFocused = Boolean(focused_windows[id]);
+        if (isClosed) {
+            openApp(id);
+            return;
+        }
+        if (isMinimized) {
+            openApp(id);
+        } else if (isFocused) {
+            minimize(id);
+        } else {
+            openApp(id);
+        }
+    }, [closed_windows, focused_windows, minimized_windows, minimize, openApp]);
+
+    const handleDragStart = useCallback((event, appId) => {
+        if (event?.dataTransfer) {
+            event.dataTransfer.effectAllowed = 'move';
+            event.dataTransfer.setData('text/plain', appId);
+        }
+        setDraggedId(appId);
+    }, []);
+
+    const handleDragEnd = useCallback(() => {
+        setDraggedId(null);
+    }, []);
+
+    const handleDragOver = useCallback((event) => {
+        event.preventDefault();
+        if (event?.dataTransfer) {
+            event.dataTransfer.dropEffect = 'move';
+        }
+    }, []);
+
+    const handleDropOnItem = useCallback((event, targetId, targetIndex) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const sourceId = getDataTransferId(event, draggedId);
+        if (!sourceId || sourceId === targetId) {
+            setDraggedId(null);
+            return;
+        }
+        movePinned(sourceId, targetIndex);
+        setDraggedId(null);
+    }, [draggedId, movePinned]);
+
+    const handleDropOnContainer = useCallback((event) => {
+        if (event.target !== event.currentTarget) return;
+        event.preventDefault();
+        const sourceId = getDataTransferId(event, draggedId);
+        if (!sourceId) {
+            setDraggedId(null);
+            return;
+        }
+        movePinned(sourceId, pinnedCount);
+        setDraggedId(null);
+    }, [draggedId, movePinned, pinnedCount]);
+
+    const renderTaskbarButton = useCallback((app, pinned) => {
+        const isRunning = closed_windows[app.id] === false;
+        const isMinimized = Boolean(minimized_windows[app.id]);
+        const isFocused = Boolean(focused_windows[app.id]);
+        const isActive = isRunning && !isMinimized;
+
+        return (
+            <button
+                type="button"
+                aria-label={app.title}
+                data-context="taskbar"
+                data-app-id={app.id}
+                data-active={isActive ? 'true' : 'false'}
+                aria-pressed={isActive}
+                aria-grabbed={pinned ? (draggedId === app.id ? 'true' : 'false') : undefined}
+                onClick={() => handleClick(app)}
+                className={`${isFocused && isActive ? 'bg-white bg-opacity-20 ' : ''}relative flex items-center justify-center rounded-lg transition-colors hover:bg-white hover:bg-opacity-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70`}
+                style={{
+                    minHeight: 'var(--shell-hit-target, 2.5rem)',
+                    minWidth: 'var(--shell-hit-target, 2.5rem)',
+                    paddingInline: 'calc(var(--shell-taskbar-padding-x, 0.75rem) * 0.75)',
+                    fontSize: 'var(--shell-taskbar-font-size, 0.875rem)',
+                    gap: '0.5rem',
+                    cursor: pinned ? 'grab' : 'pointer',
+                }}
+                draggable={pinned}
+                onDragStart={pinned ? (event) => handleDragStart(event, app.id) : undefined}
+                onDragEnd={pinned ? handleDragEnd : undefined}
+            >
+                <Image
+                    width={32}
+                    height={32}
+                    style={{
+                        width: 'var(--shell-taskbar-icon, 1.5rem)',
+                        height: 'var(--shell-taskbar-icon, 1.5rem)',
+                    }}
+                    src={app.icon.replace('./', '/')}
+                    alt=""
+                    sizes="(max-width: 768px) 32px, 40px"
+                />
+                <span
+                    className="text-white whitespace-nowrap"
+                    style={{ fontSize: 'var(--shell-taskbar-font-size, 0.875rem)' }}
+                >
+                    {app.title}
+                </span>
+                {isActive && (
+                    <span
+                        aria-hidden="true"
+                        data-testid="running-indicator"
+                        className="absolute bottom-1 left-1/2 -translate-x-1/2 rounded"
+                        style={{
+                            width: '0.5rem',
+                            height: '0.25rem',
+                            background: 'currentColor',
+                        }}
+                    />
+                )}
+            </button>
+        );
+    }, [closed_windows, draggedId, focused_windows, handleClick, handleDragEnd, handleDragStart, minimized_windows]);
 
     return (
-
         <div
-            className="absolute bottom-0 left-0 w-full bg-black bg-opacity-50 flex items-center justify-start z-40 backdrop-blur-sm"
+            className="absolute bottom-0 left-0 z-40 flex w-full items-center justify-start bg-black bg-opacity-50 backdrop-blur-sm"
             role="toolbar"
             style={{
                 height: 'var(--shell-taskbar-height, 2.5rem)',
@@ -28,63 +213,47 @@ export default function Taskbar(props) {
             <div
                 className="flex items-center overflow-x-auto"
                 style={{ gap: 'var(--shell-taskbar-gap, 0.5rem)' }}
+                onDragOver={handleDragOver}
+                onDrop={handleDropOnContainer}
             >
-                {runningApps.map(app => {
-                    const isMinimized = Boolean(props.minimized_windows[app.id]);
-                    const isFocused = Boolean(props.focused_windows[app.id]);
-                    const isActive = !isMinimized;
-
-                    return (
-                        <button
-                            key={app.id}
-                            type="button"
-                            aria-label={app.title}
-                            data-context="taskbar"
-                            data-app-id={app.id}
-                            data-active={isActive ? 'true' : 'false'}
-                            aria-pressed={isActive}
-                            onClick={() => handleClick(app)}
-                            className={`${isFocused && isActive ? 'bg-white bg-opacity-20 ' : ''}relative flex items-center justify-center rounded-lg transition-colors hover:bg-white hover:bg-opacity-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70`}
-                            style={{
-                                minHeight: 'var(--shell-hit-target, 2.5rem)',
-                                minWidth: 'var(--shell-hit-target, 2.5rem)',
-                                paddingInline: 'calc(var(--shell-taskbar-padding-x, 0.75rem) * 0.75)',
-                                fontSize: 'var(--shell-taskbar-font-size, 0.875rem)',
-                                gap: '0.5rem',
-                            }}
-                        >
-                            <Image
-                                width={32}
-                                height={32}
-                                style={{
-                                    width: 'var(--shell-taskbar-icon, 1.5rem)',
-                                    height: 'var(--shell-taskbar-icon, 1.5rem)',
-                                }}
-                                src={app.icon.replace('./', '/')}
-                                alt=""
-                                sizes="(max-width: 768px) 32px, 40px"
-                            />
-                            <span
-                                className="text-white whitespace-nowrap"
-                                style={{ fontSize: 'var(--shell-taskbar-font-size, 0.875rem)' }}
+                {pinnedApps.map((app, index) => (
+                    <div
+                        key={app.id}
+                        className="group relative flex flex-col items-center"
+                        onDragOver={handleDragOver}
+                        onDrop={(event) => handleDropOnItem(event, app.id, index)}
+                    >
+                        <div className="pointer-events-auto absolute -top-10 flex gap-1 rounded-md bg-black/80 px-1 py-0.5 text-[0.65rem] text-white opacity-0 shadow-lg transition group-focus-within:opacity-100 group-hover:opacity-100">
+                            <button
+                                type="button"
+                                className="rounded px-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:opacity-50"
+                                onClick={() => movePinned(app.id, index - 1)}
+                                aria-label={`Move ${app.title} left`}
+                                disabled={index === 0}
                             >
-                                {app.title}
-                            </span>
-                            {isActive && (
-                                <span
-                                    aria-hidden="true"
-                                    data-testid="running-indicator"
-                                    className="absolute bottom-1 left-1/2 -translate-x-1/2 rounded"
-                                    style={{
-                                        width: '0.5rem',
-                                        height: '0.25rem',
-                                        background: 'currentColor',
-                                    }}
-                                />
-                            )}
-                        </button>
-                    );
-                })}
+                                ◀
+                            </button>
+                            <button
+                                type="button"
+                                className="rounded px-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:opacity-50"
+                                onClick={() => movePinned(app.id, index + 1)}
+                                aria-label={`Move ${app.title} right`}
+                                disabled={index === pinnedApps.length - 1}
+                            >
+                                ▶
+                            </button>
+                        </div>
+                        {renderTaskbarButton(app, true)}
+                    </div>
+                ))}
+                {extraRunningApps.map((app) => (
+                    <React.Fragment key={app.id}>
+                        {renderTaskbarButton(app, false)}
+                    </React.Fragment>
+                ))}
+            </div>
+            <div role="status" aria-live="polite" className="sr-only">
+                {announcement}
             </div>
         </div>
     );

--- a/hooks/useUserPrefs.ts
+++ b/hooks/useUserPrefs.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback, useMemo } from 'react';
+import usePersistentState from './usePersistentState';
+
+export interface UserPrefs {
+  dockPinnedOrder: string[];
+}
+
+const USER_PREFS_KEY = 'user-preferences';
+
+const defaultPrefs: UserPrefs = {
+  dockPinnedOrder: [],
+};
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+const isUserPrefs = (value: unknown): value is UserPrefs => {
+  if (!value || typeof value !== 'object') return false;
+  const prefs = value as Partial<UserPrefs>;
+  return isStringArray(prefs.dockPinnedOrder);
+};
+
+const readLegacyPinnedApps = (): string[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const stored = window.localStorage.getItem('pinnedApps');
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    if (isStringArray(parsed)) {
+      return parsed;
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return [];
+};
+
+const uniqueOrder = (order: string[]) => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  order.forEach((id) => {
+    if (typeof id !== 'string') return;
+    if (seen.has(id)) return;
+    seen.add(id);
+    result.push(id);
+  });
+  return result;
+};
+
+const persistLegacyPinnedApps = (order: string[]) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem('pinnedApps', JSON.stringify(order));
+  } catch {
+    // ignore write errors
+  }
+};
+
+export default function useUserPrefs() {
+  const [prefs, setPrefs] = usePersistentState<UserPrefs>(
+    USER_PREFS_KEY,
+    () => {
+      const legacy = uniqueOrder(readLegacyPinnedApps());
+      if (legacy.length > 0) {
+        return { dockPinnedOrder: legacy };
+      }
+      return defaultPrefs;
+    },
+    isUserPrefs,
+  );
+
+  const dockPinnedOrder = prefs.dockPinnedOrder;
+
+  const setDockPinnedOrder = useCallback(
+    (next: string[] | ((current: string[]) => string[])) => {
+      setPrefs((previous) => {
+        const currentOrder = previous.dockPinnedOrder ?? [];
+        const proposed =
+          typeof next === 'function' ? next(currentOrder) : next;
+        const normalized = uniqueOrder(proposed ?? []);
+        const isSame =
+          normalized.length === currentOrder.length &&
+          normalized.every((id, index) => id === currentOrder[index]);
+        if (isSame) {
+          return previous;
+        }
+        persistLegacyPinnedApps(normalized);
+        return {
+          ...previous,
+          dockPinnedOrder: normalized,
+        };
+      });
+    },
+    [setPrefs],
+  );
+
+  const ensureDockPinnedApps = useCallback(
+    (appIds: string[]) => {
+      if (!Array.isArray(appIds) || appIds.length === 0) return;
+      setDockPinnedOrder((current) => {
+        if (!current || current.length === 0) {
+          return uniqueOrder(appIds);
+        }
+        const merged = uniqueOrder([...current, ...appIds]);
+        return merged;
+      });
+    },
+    [setDockPinnedOrder],
+  );
+
+  const value = useMemo(
+    () => ({
+      prefs,
+      dockPinnedOrder,
+      setDockPinnedOrder,
+      ensureDockPinnedApps,
+    }),
+    [prefs, dockPinnedOrder, setDockPinnedOrder, ensureDockPinnedApps],
+  );
+
+  return value;
+}


### PR DESCRIPTION
## Summary
- add a user preferences hook to persist the dock pinned order while seeding from legacy storage
- enable drag-and-drop plus keyboard move controls on the taskbar with aria-live announcements for reorders
- sync desktop pin/unpin flows with the stored order and add unit tests for dock reordering and persistence

## Testing
- yarn test --runTestsByPath __tests__/taskbar.test.tsx __tests__/useUserPrefs.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da51a26638832897d8c8bfdaee08da