### PR TITLE
[settings] Add configurable keyboard shortcut remapping

### DIFF
--- a/__tests__/keymapRegistry.test.ts
+++ b/__tests__/keymapRegistry.test.ts
@@ -1,0 +1,67 @@
+import {
+  applyShortcutUpdate,
+  computeShortcutBindings,
+  getDefaultShortcut,
+  keyboardEventToCombo,
+  KeymapConfig,
+  KEYMAP_SCHEMA_VERSION,
+  normalizeCombo,
+  resolveKeymap,
+  ShortcutId,
+  ShortcutUpdateOutcome,
+} from '../apps/settings/keymapRegistry';
+
+const createConfig = (overrides: Partial<Record<ShortcutId, string>> = {}): KeymapConfig => ({
+  version: KEYMAP_SCHEMA_VERSION,
+  overrides,
+});
+
+describe('keymapRegistry', () => {
+  it('normalizes modifier ordering', () => {
+    expect(normalizeCombo('shift+ctrl+a')).toBe('Ctrl+Shift+A');
+    expect(normalizeCombo('Alt + Meta + b')).toBe('Alt+Meta+B');
+    expect(normalizeCombo('Shift+?')).toBe('?');
+  });
+
+  it('computes bindings with defaults when no overrides exist', () => {
+    const config = createConfig();
+    const bindings = computeShortcutBindings(config);
+    bindings.forEach((binding) => {
+      expect(binding.keys).toBe(binding.default);
+      expect(binding.isDefault).toBe(true);
+      expect(binding.conflicts).toHaveLength(0);
+    });
+  });
+
+  it('updates bindings and reverts conflicts to defaults', () => {
+    let config = createConfig();
+
+    [config] = applyShortcutUpdate(config, 'open-settings', 'Ctrl+K');
+    expect(resolveKeymap(config)['open-settings']).toBe('Ctrl+K');
+
+    let outcome: ShortcutUpdateOutcome;
+    [config, outcome] = applyShortcutUpdate(config, 'show-shortcuts', 'Ctrl+K');
+
+    expect(outcome.reverted).toContain('open-settings');
+    const resolved = resolveKeymap(config);
+    expect(resolved['show-shortcuts']).toBe('Ctrl+K');
+    expect(resolved['open-settings']).toBe(
+      getDefaultShortcut('open-settings'),
+    );
+  });
+
+  it('derives combos from keyboard events', () => {
+    const questionMark = new KeyboardEvent('keydown', {
+      key: '?',
+      shiftKey: true,
+    });
+    expect(keyboardEventToCombo(questionMark)).toBe('?');
+
+    const clipboard = new KeyboardEvent('keydown', {
+      key: 'v',
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    expect(keyboardEventToCombo(clipboard)).toBe('Ctrl+Shift+V');
+  });
+});

--- a/apps/settings/components/KeymapOverlay.tsx
+++ b/apps/settings/components/KeymapOverlay.tsx
@@ -1,51 +1,52 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import useKeymap from '../keymapRegistry';
+import { useEffect, useMemo, useState } from 'react';
+import useKeymap, {
+  keyboardEventToCombo,
+  ShortcutId,
+  getShortcutDescription,
+} from '../keymapRegistry';
 
 interface KeymapOverlayProps {
   open: boolean;
   onClose: () => void;
 }
 
-const formatEvent = (e: KeyboardEvent) => {
-  const parts = [
-    e.ctrlKey ? 'Ctrl' : '',
-    e.altKey ? 'Alt' : '',
-    e.shiftKey ? 'Shift' : '',
-    e.metaKey ? 'Meta' : '',
-    e.key.length === 1 ? e.key.toUpperCase() : e.key,
-  ];
-  return parts.filter(Boolean).join('+');
-};
-
 export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
-  const { shortcuts, updateShortcut } = useKeymap();
-  const [rebinding, setRebinding] = useState<string | null>(null);
+  const { shortcuts, updateShortcut, resetShortcut } = useKeymap();
+  const [rebinding, setRebinding] = useState<ShortcutId | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const descriptions = useMemo(() => {
+    return shortcuts.reduce<Record<ShortcutId, string>>((acc, shortcut) => {
+      acc[shortcut.id] = shortcut.description;
+      return acc;
+    }, {} as Record<ShortcutId, string>);
+  }, [shortcuts]);
 
   useEffect(() => {
     if (!rebinding) return;
     const handler = (e: KeyboardEvent) => {
       e.preventDefault();
-      const combo = formatEvent(e);
-      updateShortcut(rebinding, combo);
+      const combo = keyboardEventToCombo(e);
+      const result = updateShortcut(rebinding, combo);
+      if (result.reverted.length > 0) {
+        const names = result.reverted
+          .map((id) => descriptions[id] || getShortcutDescription(id))
+          .join(', ');
+        setMessage(
+          `Restored default for ${names} to resolve a shortcut conflict.`,
+        );
+      } else {
+        setMessage(null);
+      }
       setRebinding(null);
     };
     window.addEventListener('keydown', handler, { once: true });
     return () => window.removeEventListener('keydown', handler);
-  }, [rebinding, updateShortcut]);
+  }, [rebinding, updateShortcut, descriptions]);
 
   if (!open) return null;
-
-  const keyCounts = shortcuts.reduce<Map<string, number>>((map, s) => {
-    map.set(s.keys, (map.get(s.keys) || 0) + 1);
-    return map;
-  }, new Map());
-  const conflicts = new Set(
-    Array.from(keyCounts.entries())
-      .filter(([, count]) => count > 1)
-      .map(([key]) => key)
-  );
 
   return (
     <div
@@ -60,6 +61,7 @@ export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
             type="button"
             onClick={() => {
               setRebinding(null);
+              setMessage(null);
               onClose();
             }}
             className="text-sm underline"
@@ -67,26 +69,58 @@ export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
             Close
           </button>
         </div>
+        {message && (
+          <p className="text-sm text-ub-orange" role="status" aria-live="polite">
+            {message}
+          </p>
+        )}
         <ul className="space-y-1">
           {shortcuts.map((s) => (
             <li
-              key={s.description}
-              data-conflict={conflicts.has(s.keys) ? 'true' : 'false'}
+              key={s.id}
+              data-conflict={s.conflicts.length > 0 ? 'true' : 'false'}
               className={
-                conflicts.has(s.keys)
+                s.conflicts.length > 0
                   ? 'flex justify-between bg-red-600/70 px-2 py-1 rounded'
-                  : 'flex justify-between px-2 py-1'
+                  : 'flex flex-col gap-1 md:flex-row md:items-center md:justify-between px-2 py-1'
               }
             >
-              <span className="flex-1">{s.description}</span>
-              <span className="font-mono mr-2">{s.keys}</span>
-              <button
-                type="button"
-                onClick={() => setRebinding(s.description)}
-                className="px-2 py-1 bg-ub-orange text-white rounded text-sm"
-              >
-                {rebinding === s.description ? 'Press keys...' : 'Rebind'}
-              </button>
+              <div className="flex-1">
+                <span className="block">{s.description}</span>
+                <span className="text-xs text-gray-300">
+                  Default: {s.default}
+                </span>
+                {s.conflicts.length > 0 && (
+                  <span className="block text-xs text-red-200">
+                    Conflicts with{' '}
+                    {s.conflicts
+                      .map((id) => descriptions[id] || getShortcutDescription(id))
+                      .join(', ')}
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="font-mono mr-2 whitespace-nowrap">{s.keys}</span>
+                <button
+                  type="button"
+                  onClick={() => setRebinding(s.id)}
+                  className="px-2 py-1 bg-ub-orange text-white rounded text-sm"
+                >
+                  {rebinding === s.id ? 'Press keys...' : 'Rebind'}
+                </button>
+                {!s.isDefault && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      resetShortcut(s.id);
+                      setMessage(null);
+                    }}
+                    className="px-2 py-1 bg-gray-700 rounded text-sm"
+                  >
+                    Reset
+                  </button>
+                )}
+              </div>
             </li>
           ))}
         </ul>

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -1,50 +1,321 @@
+import { useCallback, useEffect, useMemo } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
 
-export interface Shortcut {
+export type ShortcutId =
+  | 'show-shortcuts'
+  | 'open-settings'
+  | 'open-clipboard-manager';
+
+export interface ShortcutDefinition {
+  id: ShortcutId;
   description: string;
-  keys: string;
+  default: string;
 }
 
-const DEFAULT_SHORTCUTS: Shortcut[] = [
-  { description: 'Show keyboard shortcuts', keys: '?' },
-  { description: 'Open settings', keys: 'Ctrl+,' },
+export interface ShortcutBinding extends ShortcutDefinition {
+  keys: string;
+  isDefault: boolean;
+  conflicts: ShortcutId[];
+}
+
+export interface KeymapConfig {
+  version: number;
+  overrides: Partial<Record<ShortcutId, string>>;
+}
+
+export interface ShortcutUpdateOutcome {
+  keys: string;
+  reverted: ShortcutId[];
+}
+
+export const KEYMAP_STORAGE_KEY = 'keymap';
+export const KEYMAP_SCHEMA_VERSION = 1;
+
+const MODIFIER_ORDER: ReadonlyArray<string> = ['Ctrl', 'Alt', 'Shift', 'Meta'];
+
+const canonicalModifier = (value: string) => {
+  const lower = value.toLowerCase();
+  switch (lower) {
+    case 'ctrl':
+    case 'control':
+      return 'Ctrl';
+    case 'alt':
+    case 'option':
+      return 'Alt';
+    case 'shift':
+      return 'Shift';
+    case 'meta':
+    case 'cmd':
+    case 'command':
+      return 'Meta';
+    default:
+      return null;
+  }
+};
+
+export const normalizeCombo = (combo: string): string => {
+  const parts = combo
+    .split('+')
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  const modifiers = new Set<string>();
+  let key: string | null = null;
+
+  parts.forEach((part) => {
+    const modifier = canonicalModifier(part);
+    if (modifier) {
+      modifiers.add(modifier);
+      return;
+    }
+    if (part.length === 1) {
+      key = part.toUpperCase();
+    } else if (part.length > 1) {
+      key = part[0].toUpperCase() + part.slice(1);
+    }
+  });
+
+  const orderedModifiers = MODIFIER_ORDER.filter((modifier) =>
+    modifiers.has(modifier)
+  );
+
+  if (key === '?' && orderedModifiers.includes('Shift')) {
+    return [
+      ...orderedModifiers.filter((modifier) => modifier !== 'Shift'),
+      key,
+    ]
+      .filter(Boolean)
+      .join('+');
+  }
+
+  return [...orderedModifiers, key].filter(Boolean).join('+');
+};
+
+export const keyboardEventToCombo = (event: KeyboardEvent): string => {
+  const parts: string[] = [];
+  if (event.ctrlKey) parts.push('Ctrl');
+  if (event.altKey) parts.push('Alt');
+  if (event.shiftKey) parts.push('Shift');
+  if (event.metaKey) parts.push('Meta');
+
+  let key = event.key;
+  if (key.length === 1) {
+    key = key.toUpperCase();
+  }
+
+  if (key === '?' && parts.includes('Shift')) {
+    parts.splice(parts.indexOf('Shift'), 1);
+  }
+
+  parts.push(key);
+  return normalizeCombo(parts.join('+'));
+};
+
+const createDefinition = (
+  id: ShortcutId,
+  description: string,
+  combo: string,
+): ShortcutDefinition => ({
+  id,
+  description,
+  default: normalizeCombo(combo),
+});
+
+export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
+  createDefinition('show-shortcuts', 'Show keyboard shortcuts', '?'),
+  createDefinition('open-settings', 'Open settings', 'Ctrl+,'),
+  createDefinition(
+    'open-clipboard-manager',
+    'Open clipboard manager',
+    'Ctrl+Shift+V',
+  ),
 ];
 
-const validator = (value: unknown): value is Record<string, string> => {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    !Array.isArray(value) &&
-    Object.values(value as Record<string, unknown>).every(
-      (v) => typeof v === 'string'
-    )
+const DEFINITIONS_BY_ID = new Map(
+  SHORTCUT_DEFINITIONS.map((definition) => [definition.id, definition]),
+);
+
+export const getDefaultShortcut = (id: ShortcutId): string =>
+  DEFINITIONS_BY_ID.get(id)?.default ?? '';
+
+export const getShortcutDescription = (id: ShortcutId): string =>
+  DEFINITIONS_BY_ID.get(id)?.description ?? id;
+
+const createInitialConfig = (): KeymapConfig => ({
+  version: KEYMAP_SCHEMA_VERSION,
+  overrides: {},
+});
+
+const isKeymapConfig = (value: unknown): value is KeymapConfig => {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    Array.isArray(value)
+  ) {
+    return false;
+  }
+
+  const candidate = value as Partial<KeymapConfig>;
+  if (candidate.version !== KEYMAP_SCHEMA_VERSION) return false;
+  if (typeof candidate.overrides !== 'object' || candidate.overrides === null) {
+    return false;
+  }
+
+  return Object.entries(candidate.overrides).every(([key, val]) => {
+    return (
+      DEFINITIONS_BY_ID.has(key as ShortcutId) && typeof val === 'string'
+    );
+  });
+};
+
+export const resolveKeymap = (
+  config: KeymapConfig = createInitialConfig(),
+): Record<ShortcutId, string> => {
+  const overrides = config.overrides ?? {};
+  return SHORTCUT_DEFINITIONS.reduce<Record<ShortcutId, string>>(
+    (accumulator, definition) => {
+      const override = overrides[definition.id];
+      accumulator[definition.id] = override
+        ? normalizeCombo(override)
+        : definition.default;
+      return accumulator;
+    },
+    {} as Record<ShortcutId, string>,
   );
 };
 
-export function useKeymap() {
-  const initial = DEFAULT_SHORTCUTS.reduce<Record<string, string>>(
-    (acc, s) => {
-      acc[s.description] = s.keys;
-      return acc;
+export const getResolvedShortcutMap = (): Record<ShortcutId, string> => {
+  if (typeof window === 'undefined') {
+    return resolveKeymap(createInitialConfig());
+  }
+
+  try {
+    const stored = window.localStorage.getItem(KEYMAP_STORAGE_KEY);
+    if (!stored) return resolveKeymap(createInitialConfig());
+    const parsed = JSON.parse(stored);
+    if (!isKeymapConfig(parsed)) return resolveKeymap(createInitialConfig());
+    return resolveKeymap(parsed);
+  } catch {
+    return resolveKeymap(createInitialConfig());
+  }
+};
+
+export const computeShortcutBindings = (
+  config: KeymapConfig,
+): ShortcutBinding[] => {
+  const resolved = resolveKeymap(config);
+  const byCombo = new Map<string, ShortcutId[]>();
+
+  SHORTCUT_DEFINITIONS.forEach((definition) => {
+    const combo = resolved[definition.id];
+    const list = byCombo.get(combo) ?? [];
+    list.push(definition.id);
+    byCombo.set(combo, list);
+  });
+
+  return SHORTCUT_DEFINITIONS.map((definition) => {
+    const combo = resolved[definition.id];
+    const conflicts = (byCombo.get(combo) ?? []).filter(
+      (otherId) => otherId !== definition.id,
+    );
+
+    return {
+      ...definition,
+      keys: combo,
+      isDefault: combo === definition.default,
+      conflicts,
+    };
+  });
+};
+
+export const removeShortcutOverride = (
+  config: KeymapConfig,
+  id: ShortcutId,
+): KeymapConfig => {
+  if (!config.overrides[id]) return config;
+  const overrides = { ...config.overrides };
+  delete overrides[id];
+  return { ...config, overrides };
+};
+
+export const applyShortcutUpdate = (
+  config: KeymapConfig,
+  id: ShortcutId,
+  combo: string,
+): [KeymapConfig, ShortcutUpdateOutcome] => {
+  const normalized = normalizeCombo(combo);
+  const overrides = { ...config.overrides };
+  const resolved = resolveKeymap(config);
+
+  const conflicts = (Object.entries(resolved) as [ShortcutId, string][]).filter(
+    ([otherId, keys]) => otherId !== id && keys === normalized,
+  );
+
+  const reverted: ShortcutId[] = [];
+  conflicts.forEach(([otherId]) => {
+    if (overrides[otherId]) {
+      delete overrides[otherId];
+      reverted.push(otherId);
+    }
+  });
+
+  if (normalized === getDefaultShortcut(id)) {
+    delete overrides[id];
+  } else {
+    overrides[id] = normalized;
+  }
+
+  return [
+    { ...config, overrides },
+    {
+      keys: normalized,
+      reverted,
     },
-    {}
+  ];
+};
+
+export function useKeymap() {
+  const [config, setConfig, resetConfig] = usePersistentState<KeymapConfig>(
+    KEYMAP_STORAGE_KEY,
+    createInitialConfig,
+    isKeymapConfig,
   );
 
-  const [map, setMap] = usePersistentState<Record<string, string>>(
-    'keymap',
-    initial,
-    validator
+  const shortcuts = useMemo(() => computeShortcutBindings(config), [config]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const detail = {
+      map: resolveKeymap(config),
+    };
+    window.dispatchEvent(new CustomEvent('keymap-changed', { detail }));
+  }, [config]);
+
+  const updateShortcut = useCallback(
+    (id: ShortcutId, combo: string) => {
+      let outcome: ShortcutUpdateOutcome | null = null;
+      setConfig((current) => {
+        const [nextConfig, result] = applyShortcutUpdate(current, id, combo);
+        outcome = result;
+        return nextConfig;
+      });
+      return outcome ?? { keys: getDefaultShortcut(id), reverted: [] };
+    },
+    [setConfig],
   );
 
-  const shortcuts = DEFAULT_SHORTCUTS.map(({ description, keys }) => ({
-    description,
-    keys: map[description] || keys,
-  }));
+  const resetShortcut = useCallback(
+    (id: ShortcutId) => {
+      setConfig((current) => removeShortcutOverride(current, id));
+    },
+    [setConfig],
+  );
 
-  const updateShortcut = (description: string, keys: string) =>
-    setMap({ ...map, [description]: keys });
+  const resetAll = useCallback(() => {
+    resetConfig();
+  }, [resetConfig]);
 
-  return { shortcuts, updateShortcut };
+  return { shortcuts, updateShortcut, resetShortcut, resetAll };
 }
 
 export default useKeymap;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -28,6 +28,10 @@ import {
     clampWindowTopPosition,
     measureWindowTopOffset,
 } from '../../utils/windowLayout';
+import {
+    getResolvedShortcutMap,
+    keyboardEventToCombo,
+} from '../../apps/settings/keymapRegistry';
 
 
 export class Desktop extends Component {
@@ -952,24 +956,49 @@ export class Desktop extends Component {
     }
 
     handleGlobalShortcut = (e) => {
+        const target = e.target;
+        const tagName = typeof target?.tagName === 'string'
+            ? target.tagName.toUpperCase()
+            : null;
+        const isEditable = Boolean(
+            tagName &&
+            (tagName === 'INPUT' || tagName === 'TEXTAREA' || target?.isContentEditable)
+        );
+
+        const shortcutMap = getResolvedShortcutMap();
+        const combo = keyboardEventToCombo(e);
+
+        if (combo === shortcutMap['open-settings']) {
+            if (isEditable) return;
+            e.preventDefault();
+            this.openApp('settings');
+            return;
+        }
+
+        if (combo === shortcutMap['open-clipboard-manager']) {
+            if (isEditable) return;
+            e.preventDefault();
+            this.openApp('clipboard-manager');
+            return;
+        }
+
         if (e.altKey && e.key === 'Tab') {
             e.preventDefault();
             if (!this.state.showWindowSwitcher) {
                 this.openWindowSwitcher();
+            } else {
+                this.cycleApps(e.shiftKey ? -1 : 1);
             }
-        } else if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'v') {
-            e.preventDefault();
-            this.openApp('clipboard-manager');
+            return;
         }
-        else if (e.altKey && e.key === 'Tab') {
-            e.preventDefault();
-            this.cycleApps(e.shiftKey ? -1 : 1);
-        }
-        else if (e.altKey && (e.key === '`' || e.key === '~')) {
+
+        if (e.altKey && (e.key === '`' || e.key === '~')) {
             e.preventDefault();
             this.cycleAppWindows(e.shiftKey ? -1 : 1);
+            return;
         }
-        else if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+
+        if (e.metaKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
             e.preventDefault();
             const id = this.getFocusedWindowId();
             if (id) {


### PR DESCRIPTION
## Summary
- replace the keymap registry with a schema-driven configuration that normalizes combos, persists overrides, and broadcasts updates
- enhance the settings overlay to capture new key combinations, surface conflicts, and allow resets while syncing the global hotkey listener
- refresh the shared shortcut overlay to honor remapped bindings and surface conflict details

## Testing
- yarn test keymapRegistry

------
https://chatgpt.com/codex/tasks/task_e_68da51a42bd083288b120a72971a0767