### PR TITLE
[desktop] persist window sessions and add restore fallback

### DIFF
--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -1,0 +1,79 @@
+import { sanitizeDesktopSession, sanitizeSessionWindow, SESSION_VERSION } from '../hooks/useSession';
+import { defaults } from '../utils/settingsStore';
+
+describe('session persistence sanitizers', () => {
+  it('fills defaults for legacy window entries', () => {
+    const legacy = {
+      windows: [
+        { id: 'terminal', x: 42 },
+        { id: 'files', y: 120, minimized: true },
+      ],
+    };
+
+    const session = sanitizeDesktopSession(legacy);
+
+    expect(session.version).toBe(SESSION_VERSION);
+    expect(session.wallpaper).toBe(defaults.wallpaper);
+    expect(session.dock).toEqual([]);
+    expect(session.windows).toHaveLength(2);
+    expect(session.windows[0]).toMatchObject({
+      id: 'terminal',
+      x: 42,
+      y: expect.any(Number),
+      width: expect.any(Number),
+      height: expect.any(Number),
+      minimized: false,
+      order: 0,
+    });
+    expect(session.windows[1]).toMatchObject({
+      id: 'files',
+      minimized: true,
+      order: 1,
+    });
+  });
+
+  it('drops invalid windows and preserves explicit ordering', () => {
+    const dirty = {
+      wallpaper: 'custom.png',
+      dock: ['about-alex', 123],
+      windows: [
+        { id: 12, x: 10, y: 10 },
+        { id: 'valid', x: 1, y: 2, order: 5, workspace: 3 },
+        { id: 'another', x: 3, y: 4, order: 2 },
+      ],
+    };
+
+    const session = sanitizeDesktopSession(dirty);
+
+    expect(session.windows).toHaveLength(2);
+    expect(session.windows[0]).toMatchObject({ id: 'another', order: 0, workspace: 0 });
+    expect(session.windows[1]).toMatchObject({ id: 'valid', order: 1, workspace: 3 });
+    expect(session.dock).toEqual(['about-alex']);
+    expect(session.wallpaper).toBe('custom.png');
+  });
+
+  it('sanitizes individual windows independently', () => {
+    const windowState = sanitizeSessionWindow({
+      id: 'viewer',
+      x: '12',
+      y: 200,
+      width: 75,
+      height: 60,
+      snapped: 'invalid',
+      minimized: 'yes',
+      context: { path: '/tmp' },
+    });
+
+    expect(windowState).toMatchObject({
+      id: 'viewer',
+      x: 60,
+      y: 200,
+      width: 75,
+      height: 60,
+      minimized: false,
+      snapped: null,
+      context: { path: '/tmp' },
+    });
+  });
+});
+

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -1,44 +1,181 @@
+import { useCallback, useMemo } from 'react';
+import type { SetStateAction } from 'react';
 import usePersistentState from './usePersistentState';
 import { defaults } from '../utils/settingsStore';
+
+export type SnapPosition = 'left' | 'right' | 'top' | null;
 
 export interface SessionWindow {
   id: string;
   x: number;
   y: number;
+  width: number;
+  height: number;
+  workspace: number;
+  minimized: boolean;
+  maximized: boolean;
+  snapped: SnapPosition;
+  order: number;
+  context?: Record<string, unknown>;
 }
 
 export interface DesktopSession {
+  version: number;
   windows: SessionWindow[];
   wallpaper: string;
   dock: string[];
 }
 
+export const SESSION_VERSION = 2;
+
+const STORAGE_KEY = 'desktop-session';
+
+const DEFAULT_WINDOW_WIDTH = 60;
+const DEFAULT_WINDOW_HEIGHT = 85;
+const DEFAULT_WORKSPACE = 0;
+
 const initialSession: DesktopSession = {
+  version: SESSION_VERSION,
   windows: [],
   wallpaper: defaults.wallpaper,
   dock: [],
 };
 
-function isSession(value: unknown): value is DesktopSession {
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const isValidContext = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+const isPersistedSession = (value: unknown): value is Partial<DesktopSession> => {
   if (!value || typeof value !== 'object') return false;
-  const s = value as DesktopSession;
-  return (
-    Array.isArray(s.windows) &&
-    typeof s.wallpaper === 'string' &&
-    Array.isArray(s.dock)
-  );
+  const session = value as Partial<DesktopSession>;
+  return Array.isArray(session.windows);
+};
+
+export function sanitizeSessionWindow(value: unknown, fallbackOrder = 0): SessionWindow | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const windowValue = value as Partial<SessionWindow> & { id?: unknown };
+  if (typeof windowValue.id !== 'string' || windowValue.id.trim().length === 0) {
+    return null;
+  }
+
+  const x = isFiniteNumber(windowValue.x) ? windowValue.x : 60;
+  const y = isFiniteNumber(windowValue.y) ? windowValue.y : 60;
+  const width = isFiniteNumber(windowValue.width)
+    ? windowValue.width
+    : DEFAULT_WINDOW_WIDTH;
+  const height = isFiniteNumber(windowValue.height)
+    ? windowValue.height
+    : DEFAULT_WINDOW_HEIGHT;
+  const workspace = isFiniteNumber(windowValue.workspace)
+    ? Math.max(0, Math.floor(windowValue.workspace))
+    : DEFAULT_WORKSPACE;
+  const minimized = typeof windowValue.minimized === 'boolean'
+    ? windowValue.minimized
+    : false;
+  const maximized = typeof windowValue.maximized === 'boolean'
+    ? windowValue.maximized
+    : false;
+  const snapped =
+    windowValue.snapped === 'left' ||
+    windowValue.snapped === 'right' ||
+    windowValue.snapped === 'top'
+      ? windowValue.snapped
+      : null;
+  const order = isFiniteNumber(windowValue.order)
+    ? windowValue.order
+    : fallbackOrder;
+
+  const context = isValidContext(windowValue.context)
+    ? { ...windowValue.context }
+    : undefined;
+
+  return {
+    id: windowValue.id,
+    x,
+    y,
+    width,
+    height,
+    workspace,
+    minimized,
+    maximized,
+    snapped,
+    order,
+    context,
+  };
+}
+
+export function sanitizeDesktopSession(value: unknown): DesktopSession {
+  if (!isPersistedSession(value)) {
+    return { ...initialSession };
+  }
+
+  const raw = value as Partial<DesktopSession>;
+  const windows = Array.isArray(raw.windows)
+    ? raw.windows
+        .map((windowValue, index) => sanitizeSessionWindow(windowValue, index))
+        .filter((windowValue): windowValue is SessionWindow => windowValue !== null)
+        .sort((a, b) => a.order - b.order)
+    : [];
+
+  windows.forEach((windowValue, index) => {
+    windowValue.order = index;
+  });
+
+  const wallpaper = typeof raw.wallpaper === 'string'
+    ? raw.wallpaper
+    : defaults.wallpaper;
+
+  const dock = Array.isArray(raw.dock)
+    ? raw.dock.filter((item): item is string => typeof item === 'string')
+    : [];
+
+  return {
+    version: SESSION_VERSION,
+    windows,
+    wallpaper,
+    dock,
+  };
 }
 
 export default function useSession() {
-  const [session, setSession, _reset, clear] = usePersistentState<DesktopSession>(
-    'desktop-session',
+  const [rawSession, setRawSession, _reset, clear] = usePersistentState<DesktopSession>(
+    STORAGE_KEY,
     initialSession,
-    isSession,
+    isPersistedSession,
   );
 
-  const resetSession = () => {
+  const session = useMemo(() => sanitizeDesktopSession(rawSession), [rawSession]);
+
+  const setSession = useCallback(
+    (value: SetStateAction<DesktopSession>) => {
+      setRawSession((prev) => {
+        const base = sanitizeDesktopSession(prev);
+        const next = typeof value === 'function' ? value(base) : value;
+        const sanitized = sanitizeDesktopSession(next);
+        try {
+          window.localStorage.setItem(STORAGE_KEY, JSON.stringify(sanitized));
+        } catch {
+          // ignore storage errors
+        }
+        return sanitized;
+      });
+    },
+    [setRawSession],
+  );
+
+  const resetSession = useCallback(() => {
     clear();
-  };
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+  }, [clear]);
 
   return { session, setSession, resetSession };
 }


### PR DESCRIPTION
## Summary
- capture window metrics and publish them through the session layer so restored apps reopen with their saved size and position
- rebuild desktop session hydration to respect saved z-order/minimized state and show a discard banner when loading fails
- add unit coverage for the session sanitizers to guard serialization/deserialization edge cases

## Testing
- yarn lint
- yarn test __tests__/session.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68da51a5e03c8328b5053664eba39c7c