### PR TITLE
[a11y] Label desktop landmarks for rotor

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1743,7 +1743,7 @@ export class Desktop extends Component {
         return (
             <main
                 id="desktop"
-                role="main"
+                aria-label="Desktop workspace"
                 ref={this.desktopRef}
                 className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse bg-transparent relative overflow-hidden overscroll-none window-parent"}
                 style={{ paddingTop: DESKTOP_TOP_PADDING }}
@@ -1752,7 +1752,9 @@ export class Desktop extends Component {
                 {/* Window Area */}
                 <div
                     id="window-area"
-                    role="main"
+                    role="region"
+                    aria-label="Open windows"
+                    tabIndex={-1}
                     className="absolute h-full w-full bg-transparent"
                     data-context="desktop-area"
                 >

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -78,8 +78,9 @@ export default class Navbar extends PureComponent {
                 render() {
                         const { workspaces, activeWorkspace } = this.state;
                         return (
-                                <div
+                                <nav
                                         className="main-navbar-vp fixed inset-x-0 top-0 z-50 flex h-14 w-full items-center justify-between bg-slate-950/80 px-3 text-ubt-grey shadow-lg backdrop-blur-md"
+                                        aria-label="Desktop controls"
                                         style={{ minHeight: NAVBAR_HEIGHT }}
                                 >
                                         <div className="flex items-center gap-2 text-xs md:text-sm">
@@ -112,9 +113,9 @@ export default class Navbar extends PureComponent {
                                                 <Status />
                                                 <QuickSettings open={this.state.status_card} />
                                         </button>
-				</div>
-			);
-		}
+                                </nav>
+                        );
+                }
 
 
 }

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -20,6 +20,7 @@ export default function Taskbar(props) {
         <div
             className="absolute bottom-0 left-0 w-full bg-black bg-opacity-50 flex items-center justify-start z-40 backdrop-blur-sm"
             role="toolbar"
+            aria-label="Running applications"
             style={{
                 height: 'var(--shell-taskbar-height, 2.5rem)',
                 paddingInline: 'var(--shell-taskbar-padding-x, 0.75rem)',

--- a/docs/accessibility-checklist.md
+++ b/docs/accessibility-checklist.md
@@ -1,0 +1,8 @@
+# Accessibility Checklist
+
+## Landmark Audit (2025-09-29)
+- [x] Confirmed the desktop workspace uses a single `<main>` landmark with an `aria-label` for rotor discovery.
+- [x] Labeled the desktop navigation bar for assistive technologies.
+- [x] Labeled the taskbar toolbar to clarify its purpose when navigating landmarks or rotor listings.
+- [x] Converted the window area into a named region so skip links and rotor navigation land on an announced target without duplicate `main` landmarks.
+


### PR DESCRIPTION
## Summary
- label the desktop main area, navigation bar, and taskbar to improve rotor landmark discovery
- convert the desktop window area into a named region and log the audit in the accessibility checklist

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da51ab0d1c8328ae1963a59c1001bd