### PR TITLE
[a11y] Adopt focus-visible focus outlines

### DIFF
--- a/apps/calculator/components/FormulaEditor.tsx
+++ b/apps/calculator/components/FormulaEditor.tsx
@@ -45,19 +45,19 @@ export default function FormulaEditor() {
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Name"
-            className="rounded-lg border border-white/10 bg-[#0f1117] px-3 py-2 text-sm font-semibold text-slate-100 placeholder:text-slate-500 focus:border-[#f97316] focus:outline-none focus:ring-2 focus:ring-[#f97316]"
+            className="rounded-lg border border-white/10 bg-[#0f1117] px-3 py-2 text-sm font-semibold text-slate-100 placeholder:text-slate-500 focus-visible:border-[#f97316] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316]"
           />
           <input
             value={expr}
             onChange={(e) => setExpr(e.target.value)}
             placeholder="Expression"
-            className="rounded-lg border border-white/10 bg-[#0f1117] px-3 py-2 text-sm font-mono text-slate-100 placeholder:text-slate-500 focus:border-[#f97316] focus:outline-none focus:ring-2 focus:ring-[#f97316]"
+            className="rounded-lg border border-white/10 bg-[#0f1117] px-3 py-2 text-sm font-mono text-slate-100 placeholder:text-slate-500 focus-visible:border-[#f97316] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316]"
           />
         </div>
         <button
           type="button"
           onClick={save}
-          className="inline-flex w-full items-center justify-center rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-slate-200 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#15171d]"
+          className="inline-flex w-full items-center justify-center rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-slate-200 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#15171d]"
         >
           Save formula
         </button>

--- a/apps/calculator/components/MemorySlots.tsx
+++ b/apps/calculator/components/MemorySlots.tsx
@@ -53,7 +53,7 @@ export default function MemorySlots() {
           onChange={(e) => setName(e.target.value)}
           placeholder="var"
           aria-label="variable name"
-          className="w-20 flex-1 rounded-lg border border-white/10 bg-[#0f1117] px-3 py-2 text-sm font-semibold uppercase tracking-wide text-slate-100 placeholder:text-slate-500 focus:border-[#f97316] focus:outline-none focus:ring-2 focus:ring-[#f97316]"
+          className="w-20 flex-1 rounded-lg border border-white/10 bg-[#0f1117] px-3 py-2 text-sm font-semibold uppercase tracking-wide text-slate-100 placeholder:text-slate-500 focus-visible:border-[#f97316] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316]"
         />
         <button
           type="button"
@@ -61,7 +61,7 @@ export default function MemorySlots() {
             handleStore(name.trim());
             setName('');
           }}
-          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-200 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#15171d]"
+          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-200 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#15171d]"
         >
           Store
         </button>

--- a/apps/calculator/components/ModeSwitcher.tsx
+++ b/apps/calculator/components/ModeSwitcher.tsx
@@ -31,7 +31,7 @@ export default function ModeSwitcher({ onChange }: Props) {
         id="mode-select"
         value={mode}
         onChange={(event) => setMode(event.target.value as Mode)}
-        className="appearance-none rounded-xl border border-white/10 bg-[#2a2d35] py-2 pl-3 pr-10 text-sm font-semibold capitalize text-slate-100 shadow-inner focus:border-[#f97316] focus:outline-none focus:ring-2 focus:ring-[#f97316]"
+        className="appearance-none rounded-xl border border-white/10 bg-[#2a2d35] py-2 pl-3 pr-10 text-sm font-semibold capitalize text-slate-100 shadow-inner focus-visible:border-[#f97316] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316]"
       >
         {MODES.map((m) => (
           <option key={m} value={m} className="bg-[#1f212a] capitalize">

--- a/apps/calculator/index.tsx
+++ b/apps/calculator/index.tsx
@@ -23,7 +23,7 @@ export default function Calculator() {
   );
 
   const baseBtnCls =
-    'btn flex items-center justify-center font-semibold transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]';
+    'btn flex items-center justify-center font-semibold transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]';
   const keypadBtnCls =
     `${baseBtnCls} h-14 rounded-xl border border-white/5 bg-[#2a2d35] text-lg text-slate-100 shadow-sm hover:-translate-y-0.5 hover:bg-[#343842]`;
   const pillUtilityBtnCls =
@@ -247,7 +247,7 @@ export default function Calculator() {
             const display = document.getElementById('display') as HTMLInputElement | null;
             if (display) display.value = display.value.slice(0, -1);
           }}
-          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-slate-200 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
+          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-slate-200 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
         >
           <svg
             className="h-4 w-4"
@@ -272,7 +272,7 @@ export default function Calculator() {
           <div className="flex items-center gap-1 text-slate-500">
             <button
               id="toggle-history"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-transparent text-slate-400 transition hover:border-white/10 hover:text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-transparent text-slate-400 transition hover:border-white/10 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
               aria-pressed="false"
               aria-label="toggle history"
             >
@@ -295,7 +295,7 @@ export default function Calculator() {
             </button>
             <button
               id="toggle-formulas"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-transparent text-slate-400 transition hover:border-white/10 hover:text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-transparent text-slate-400 transition hover:border-white/10 hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
               aria-pressed="false"
               aria-label="toggle formulas"
             >
@@ -329,7 +329,7 @@ export default function Calculator() {
         </label>
         <input
           id="display"
-          className="display w-full bg-transparent text-right text-3xl font-semibold tracking-wide text-white placeholder:text-slate-600 focus:outline-none"
+          className="display w-full bg-transparent text-right text-3xl font-semibold tracking-wide text-white placeholder:text-slate-600 focus-visible:outline-none"
           placeholder="0"
           aria-labelledby="calculator-display-label"
         />
@@ -338,7 +338,7 @@ export default function Calculator() {
       <div className="flex flex-wrap gap-2 text-xs font-medium uppercase tracking-wide text-slate-300">
         <button
           id="toggle-precise"
-          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
+          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
           aria-pressed="false"
           aria-label="toggle precise mode"
         >
@@ -346,7 +346,7 @@ export default function Calculator() {
         </button>
         <button
           id="toggle-scientific"
-          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
+          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
           aria-pressed="false"
           aria-label="toggle scientific mode"
         >
@@ -354,7 +354,7 @@ export default function Calculator() {
         </button>
         <button
           id="toggle-programmer"
-          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
+          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1f212a]"
           aria-pressed="false"
           aria-label="toggle programmer mode"
         >
@@ -435,7 +435,7 @@ export default function Calculator() {
         <select
           id="base-select"
           defaultValue="10"
-          className="h-11 rounded-xl border border-white/10 bg-[#12151b] px-3 text-sm font-medium text-slate-100 focus:border-[#f97316] focus:outline-none focus:ring-2 focus:ring-[#f97316]"
+          className="h-11 rounded-xl border border-white/10 bg-[#12151b] px-3 text-sm font-medium text-slate-100 focus-visible:border-[#f97316] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f97316]"
         >
           <option value="2">Binary</option>
           <option value="8">Octal</option>

--- a/apps/project-gallery/components/FilterChip.tsx
+++ b/apps/project-gallery/components/FilterChip.tsx
@@ -11,7 +11,7 @@ export default function FilterChip({ label, active, onClick, icon }: FilterChipP
   return (
     <button
       onClick={onClick}
-      className={`flex items-center gap-1 px-3 py-1 rounded-full border focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 ${
+      className={`flex items-center gap-1 px-3 py-1 rounded-full border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-400 ${
         active ? 'bg-blue-600 text-white' : 'bg-gray-200 text-black'
       }`}
     >

--- a/apps/project-gallery/pages/index.tsx
+++ b/apps/project-gallery/pages/index.tsx
@@ -286,7 +286,7 @@ export default function ProjectGalleryPage() {
               <div
                 key={p.id}
                 tabIndex={0}
-                className="group relative h-72 flex flex-col border rounded overflow-hidden transition-transform transition-opacity duration-300 hover:scale-105 hover:opacity-90 focus:scale-105 focus:opacity-90 focus:outline-none"
+                className="group relative h-72 flex flex-col border rounded overflow-hidden transition-transform transition-opacity duration-300 hover:scale-105 hover:opacity-90 focus-visible:scale-105 focus-visible:opacity-90 focus-visible:outline-none"
                 aria-label={`${p.title}: ${p.description}`}
               >
                 <div className="w-full aspect-video overflow-hidden">

--- a/apps/spotify/index.tsx
+++ b/apps/spotify/index.tsx
@@ -261,7 +261,7 @@ const SpotifyApp = () => {
               {queue.map((t, i) => (
                 <li key={t.url} className={i === current ? "bg-gray-700" : ""}>
                   <button
-                    className="w-full text-left px-2 py-1 hover:bg-gray-600 focus:outline-none"
+                    className="w-full text-left px-2 py-1 hover:bg-gray-600 focus-visible:outline-none"
                     onClick={() => setCurrent(i)}
                   >
                     {t.title || t.url}

--- a/apps/subnet-calculator/index.tsx
+++ b/apps/subnet-calculator/index.tsx
@@ -80,7 +80,7 @@ const SubnetCalculator = () => {
             <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">IPv4 address</span>
             <input
               id="subnet-calculator-ipv4-address"
-              className="rounded-md border border-slate-600 bg-black/40 px-3 py-2 font-mono text-white focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500"
+              className="rounded-md border border-slate-600 bg-black/40 px-3 py-2 font-mono text-white focus-visible:border-sky-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
               aria-label="IPv4 address"
               inputMode="numeric"
               placeholder="e.g. 10.0.0.42"
@@ -96,7 +96,7 @@ const SubnetCalculator = () => {
             <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">CIDR prefix</span>
             <input
               id="subnet-calculator-cidr-prefix"
-              className="rounded-md border border-slate-600 bg-black/40 px-3 py-2 font-mono text-white focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500"
+              className="rounded-md border border-slate-600 bg-black/40 px-3 py-2 font-mono text-white focus-visible:border-sky-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
               aria-label="CIDR prefix"
               type="number"
               min={0}

--- a/apps/trash/components/HistoryList.tsx
+++ b/apps/trash/components/HistoryList.tsx
@@ -19,7 +19,7 @@ export default function HistoryList({ history, onRestore, onRestoreAll }: Props)
           onClick={() => {
             if (window.confirm('Restore all windows?')) onRestoreAll();
           }}
-          className="border border-black bg-black bg-opacity-50 px-2 py-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange"
+          className="border border-black bg-black bg-opacity-50 px-2 py-1 rounded hover:bg-opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange"
         >
           Restore All
         </button>

--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -145,21 +145,21 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
             <button
               onClick={restore}
               disabled={selected === null}
-              className="px-3 py-1 my-1 rounded bg-blue-600 text-white hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50"
+              className="px-3 py-1 my-1 rounded bg-blue-600 text-white hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-50"
             >
               Restore
             </button>
             <button
               onClick={remove}
               disabled={selected === null}
-              className="px-3 py-1 my-1 ml-3 rounded bg-red-600 text-white hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-400 disabled:opacity-50"
+              className="px-3 py-1 my-1 ml-3 rounded bg-red-600 text-white hover:bg-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 disabled:opacity-50"
             >
               Delete
             </button>
             <button
               onClick={purge}
               disabled={selected === null}
-              className="px-3 py-1 my-1 ml-3 rounded bg-yellow-600 text-white hover:bg-yellow-500 focus:outline-none focus:ring-2 focus:ring-yellow-400 disabled:opacity-50"
+              className="px-3 py-1 my-1 ml-3 rounded bg-yellow-600 text-white hover:bg-yellow-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 disabled:opacity-50"
             >
               Purge
             </button>
@@ -167,14 +167,14 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
           <button
             onClick={restoreAll}
             disabled={items.length === 0}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange disabled:opacity-50"
           >
             Restore All
           </button>
           <button
             onClick={empty}
             disabled={items.length === 0 || emptyCountdown !== null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange disabled:opacity-50"
           >
             {emptyCountdown !== null ? `Emptying in ${emptyCountdown}` : 'Empty'}
           </button>

--- a/apps/youtube/components/ClipMaker.tsx
+++ b/apps/youtube/components/ClipMaker.tsx
@@ -75,7 +75,7 @@ export default function ClipMaker() {
         value={videoId}
         onChange={(e) => setVideoId(extractVideoId(e.target.value))}
         placeholder="YouTube URL or ID"
-        className="w-full rounded bg-gray-800 p-2 text-black focus:text-white"
+        className="w-full rounded bg-gray-800 p-2 text-black focus-visible:text-white"
       />
       <div ref={containerRef} className="aspect-video w-full bg-black" />
       <div className="flex gap-2">

--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -55,7 +55,7 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
         aria-label="Help"
         aria-expanded={open}
         onClick={toggle}
-        className="fixed top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+        className="fixed top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus-visible:outline-none focus-visible:ring"
       >
         ?
       </button>

--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -33,7 +33,7 @@ export default function ModuleCard({
   return (
     <button
       onClick={() => onSelect(module)}
-      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
+      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus-visible:outline-none ${
         selected ? 'bg-gray-100' : ''
       }`}
     >

--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -188,7 +188,7 @@ const PopularModules: React.FC = () => {
       <div className="flex items-center gap-2">
         <button
           onClick={handleUpdate}
-          className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          className="px-2 py-1 text-sm rounded bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         >
           Update Modules
         </button>
@@ -208,7 +208,7 @@ const PopularModules: React.FC = () => {
       <div className="flex flex-wrap gap-2">
         <button
           onClick={() => setFilter('')}
-          className={`px-2 py-1 text-sm rounded focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+          className={`px-2 py-1 text-sm rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
             filter === '' ? 'bg-blue-600' : 'bg-gray-700'
           }`}
         >
@@ -218,7 +218,7 @@ const PopularModules: React.FC = () => {
           <button
             key={t}
             onClick={() => setFilter(t)}
-            className={`px-2 py-1 text-sm rounded focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+            className={`px-2 py-1 text-sm rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
               filter === t ? 'bg-blue-600' : 'bg-gray-700'
             }`}
           >
@@ -231,7 +231,7 @@ const PopularModules: React.FC = () => {
           <button
             key={m.id}
             onClick={() => handleSelect(m)}
-            className="p-3 text-left bg-ub-grey rounded border border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            className="p-3 text-left bg-ub-grey rounded border border-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
           >
             <h3 className="font-semibold">{m.name}</h3>
             <p className="text-sm text-gray-300">{m.description}</p>
@@ -276,7 +276,7 @@ const PopularModules: React.FC = () => {
             <button
               type="button"
               onClick={copyCommand}
-              className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className="px-2 py-1 text-sm rounded bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
             >
               Copy
             </button>
@@ -295,7 +295,7 @@ const PopularModules: React.FC = () => {
             <button
               type="button"
               onClick={copyLogs}
-              className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className="px-2 py-1 text-sm rounded bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
             >
               Copy Logs
             </button>

--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -98,7 +98,7 @@ const ScrollableTimeline: React.FC = () => {
       </div>
       <div
         ref={containerRef}
-        className="overflow-x-auto snap-x snap-mandatory focus:outline-none"
+        className="overflow-x-auto snap-x snap-mandatory focus-visible:outline-none"
         aria-labelledby="timeline-heading"
       >
         <h3 id="timeline-heading" className="sr-only">
@@ -115,7 +115,7 @@ const ScrollableTimeline: React.FC = () => {
                       itemRefs.current[index] = el;
                     }}
                     tabIndex={-1}
-                    className="snap-center flex-shrink-0 w-64 p-4 bg-gray-800 rounded-lg focus:outline-none"
+                    className="snap-center flex-shrink-0 w-64 p-4 bg-gray-800 rounded-lg focus-visible:outline-none"
                   >
                     <button
                       type="button"
@@ -123,7 +123,7 @@ const ScrollableTimeline: React.FC = () => {
                         setView('month');
                         setSelectedYear(year);
                       }}
-                      className="text-left w-full focus:outline-none"
+                      className="text-left w-full focus-visible:outline-none"
                     >
                       <div className="text-ubt-blue font-bold text-lg mb-2">{year}</div>
                       <img
@@ -144,7 +144,7 @@ const ScrollableTimeline: React.FC = () => {
                     itemRefs.current[index] = el;
                   }}
                   tabIndex={-1}
-                  className="snap-center flex-shrink-0 w-64 p-4 bg-gray-800 rounded-lg focus:outline-none"
+                  className="snap-center flex-shrink-0 w-64 p-4 bg-gray-800 rounded-lg focus-visible:outline-none"
                 >
                   <div className="text-ubt-blue font-bold text-lg mb-2">
                     {selectedYear}-{m.month}

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -28,7 +28,7 @@ export default function Tabs<T extends string>({
           aria-selected={active === t.id}
           tabIndex={active === t.id ? 0 : -1}
           onClick={() => onChange(t.id)}
-          className={`px-4 py-2 focus:outline-none ${
+          className={`px-4 py-2 focus-visible:outline-none ${
             active === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
           }`}
         >

--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -20,7 +20,7 @@ export default function ToggleSwitch({
       aria-checked={checked}
       aria-label={ariaLabel}
       onClick={() => onChange(!checked)}
-      className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
+      className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus-visible:outline-none ${
         checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
       } ${className}`.trim()}
     >

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -65,7 +65,7 @@ class AboutAlex extends Component<unknown, { screen: React.ReactNode; active_scr
             (this.state.active_screen === section.id
               ? ' bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95'
               : ' hover:bg-gray-50 hover:bg-opacity-5 ') +
-            ' w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5'
+            ' w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus-visible:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5'
           }
         >
           <Image

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -222,7 +222,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           <button
             type="button"
             onClick={resume}
-            className="px-4 py-2 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className="px-4 py-2 bg-gray-700 text-white rounded focus-visible:outline-none focus-visible:ring"
             autoFocus
           >
             Resume
@@ -233,28 +233,28 @@ const GameLayout: React.FC<GameLayoutProps> = ({
         <button
           type="button"
           onClick={() => setPaused((p) => !p)}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className="px-2 py-1 bg-gray-700 text-white rounded focus-visible:outline-none focus-visible:ring"
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
         <button
           type="button"
           onClick={snapshot}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className="px-2 py-1 bg-gray-700 text-white rounded focus-visible:outline-none focus-visible:ring"
         >
           Snapshot
         </button>
         <button
           type="button"
           onClick={replay}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className="px-2 py-1 bg-gray-700 text-white rounded focus-visible:outline-none focus-visible:ring"
         >
           Replay
         </button>
         <button
           type="button"
           onClick={shareApp}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className="px-2 py-1 bg-gray-700 text-white rounded focus-visible:outline-none focus-visible:ring"
         >
           Share
         </button>
@@ -262,7 +262,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           <button
             type="button"
             onClick={shareScore}
-            className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className="px-2 py-1 bg-gray-700 text-white rounded focus-visible:outline-none focus-visible:ring"
           >
             Share Score
           </button>
@@ -272,7 +272,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           aria-label="Help"
           aria-expanded={showHelp}
           onClick={toggle}
-          className="bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+          className="bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus-visible:outline-none focus-visible:ring"
         >
           ?
         </button>

--- a/components/apps/Games/common/input-remap/InputRemap.tsx
+++ b/components/apps/Games/common/input-remap/InputRemap.tsx
@@ -32,7 +32,7 @@ const InputRemap: React.FC<Props> = ({ mapping, setKey, actions }) => {
           <button
             type="button"
             onClick={() => capture(action)}
-            className="px-2 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+            className="px-2 py-1 bg-gray-700 rounded focus-visible:outline-none focus-visible:ring"
           >
             {waiting === action ? 'Press key...' : mapping[action]}
           </button>

--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -244,7 +244,7 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
         )}
         <button
           onClick={onClose}
-          className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          className="mt-4 px-3 py-1 bg-gray-700 rounded focus-visible:outline-none focus-visible:ring"
         >
           Close
         </button>

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -67,7 +67,7 @@ export class AboutAlex extends Component {
                         id={section.id}
                         tabIndex="0"
                         onFocus={this.changeScreen}
-                        className={(this.state.active_screen === section.id ? " bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95" : " hover:bg-gray-50 hover:bg-opacity-5 ") + " w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5"}
+                        className={(this.state.active_screen === section.id ? " bg-ub-gedit-light bg-opacity-100 hover:bg-opacity-95" : " hover:bg-gray-50 hover:bg-opacity-5 ") + " w-28 md:w-full md:rounded-none rounded-sm cursor-default outline-none py-1.5 focus-visible:outline-none duration-100 my-0.5 flex justify-start items-center pl-2 md:pl-2.5"}
                     >
                         <Image
                             className=" w-3 md:w-4"

--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -114,7 +114,7 @@ export default function AppGrid({ openApp }) {
   return (
     <div className="flex flex-col items-center h-full">
       <input
-        className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+        className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus-visible:outline-none"
         placeholder="Search"
         value={query}
         onChange={(e) => setQuery(e.target.value)}

--- a/components/apps/beef/GuideOverlay.js
+++ b/components/apps/beef/GuideOverlay.js
@@ -62,7 +62,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={prev}
             disabled={step === 0}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus-visible:outline-none focus-visible:ring"
           >
             Prev
           </button>
@@ -71,7 +71,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={next}
             disabled={step === STEPS.length - 1}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus-visible:outline-none focus-visible:ring"
           >
             Next
           </button>
@@ -86,7 +86,7 @@ export default function GuideOverlay({ onClose }) {
         </label>
         <button
           onClick={handleClose}
-          className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          className="mt-4 px-3 py-1 bg-gray-700 rounded focus-visible:outline-none focus-visible:ring"
         >
           Close
         </button>

--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -601,31 +601,31 @@ const CarRacer = () => {
       </div>
       <div className="absolute bottom-2 left-2 space-x-2 z-10 text-sm">
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
           onClick={openCustomization}
         >
           Reset
         </button>
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
           onClick={togglePause}
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
           onClick={toggleSound}
         >
           {sound ? 'Sound: on' : 'Sound: off'}
         </button>
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
           onClick={toggleLaneAssist}
         >
           {laneAssist ? 'Lane Assist: on' : 'Lane Assist: off'}
         </button>
         <button
-          className="bg-gray-700 px-2 focus:outline-none focus:ring-2 focus:ring-white"
+          className="bg-gray-700 px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
           onClick={triggerBoost}
         >
           Boost

--- a/components/apps/checkers/index.tsx
+++ b/components/apps/checkers/index.tsx
@@ -458,7 +458,7 @@ const Checkers = () => {
                 {...pointerHandlers(() =>
                   selected ? tryMove(r, c) : selectPiece(r, c)
                 )}
-                className={`w-12 h-12 md:w-14 md:h-14 flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-white ${
+                className={`w-12 h-12 md:w-14 md:h-14 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white ${
                   isDark ? 'bg-gray-700' : 'bg-gray-400'
                 } ${
                   showMove

--- a/components/apps/connect-four.js
+++ b/components/apps/connect-four.js
@@ -308,7 +308,7 @@ export default function ConnectFour() {
                 <button
                   key={`${rIdx}-${cIdx}`}
                   aria-label={`cell-${rIdx}-${cIdx}`}
-                  className="w-10 h-10 rounded-full flex items-center justify-center focus:outline-none bg-gray-700"
+                  className="w-10 h-10 rounded-full flex items-center justify-center focus-visible:outline-none bg-gray-700"
                   style={
                     hoverCol === cIdx && !winner
                       ? { backgroundColor: getColor(scores[cIdx]) }

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -302,7 +302,7 @@ const ContactApp: React.FC = () => {
         <div className="relative">
           <input
             id="contact-name"
-            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
             value={name}
             onChange={(e) => setName(e.target.value)}
             required
@@ -310,7 +310,7 @@ const ContactApp: React.FC = () => {
           />
           <label
             htmlFor="contact-name"
-            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-blue-400"
+            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus-visible:-top-2 peer-focus-visible:text-xs peer-focus-visible:text-blue-400"
           >
             Name
           </label>
@@ -319,7 +319,7 @@ const ContactApp: React.FC = () => {
           <input
             id="contact-email"
             type="email"
-            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
@@ -329,7 +329,7 @@ const ContactApp: React.FC = () => {
           />
           <label
             htmlFor="contact-email"
-            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-blue-400"
+            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus-visible:-top-2 peer-focus-visible:text-xs peer-focus-visible:text-blue-400"
           >
             Email
           </label>
@@ -342,7 +342,7 @@ const ContactApp: React.FC = () => {
         <div className="relative">
           <textarea
             id="contact-message"
-            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
             rows={4}
             value={message}
             onChange={(e) => setMessage(e.target.value)}
@@ -353,7 +353,7 @@ const ContactApp: React.FC = () => {
           />
           <label
             htmlFor="contact-message"
-            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-blue-400"
+            className="absolute left-3 -top-2 bg-gray-800 px-1 text-xs text-gray-400 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus-visible:-top-2 peer-focus-visible:text-xs peer-focus-visible:text-blue-400"
           >
             Message
           </label>

--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -354,7 +354,7 @@ const Dsniff = () => {
         <h1 className="text-lg">dsniff</h1>
         <button
           onClick={exportSummary}
-          className="px-2 py-1 bg-ub-grey rounded text-xs focus:outline-none focus:ring-2 focus:ring-yellow-400"
+          className="px-2 py-1 bg-ub-grey rounded text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400"
         >
           Export summary
         </button>
@@ -435,7 +435,7 @@ const Dsniff = () => {
             <span className="font-bold text-sm">Sample command</span>
             <button
               onClick={copySampleCommand}
-              className="px-2 py-1 bg-ub-grey rounded text-xs focus:outline-none focus:ring-2 focus:ring-yellow-400"
+              className="px-2 py-1 bg-ub-grey rounded text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400"
             >
               Copy sample command
             </button>
@@ -490,7 +490,7 @@ const Dsniff = () => {
         <button
           onClick={copySelectedPacket}
           disabled={selectedPacket === null}
-          className="mb-2 px-2 py-1 bg-ub-grey rounded text-xs focus:outline-none focus:ring-2 focus:ring-yellow-400 disabled:opacity-50"
+          className="mb-2 px-2 py-1 bg-ub-grey rounded text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 disabled:opacity-50"
         >
           Copy selected row
         </button>

--- a/components/apps/evidence-vault/index.js
+++ b/components/apps/evidence-vault/index.js
@@ -47,7 +47,7 @@ const TagTreeNode = ({ name, node, onSelect }) => {
       ) : (
         <button
           onClick={() => onSelect(node)}
-          className="text-left hover:underline focus:outline-none"
+          className="text-left hover:underline focus-visible:outline-none"
         >
           {name}
         </button>

--- a/components/apps/firefox/index.tsx
+++ b/components/apps/firefox/index.tsx
@@ -100,11 +100,11 @@ const Firefox: React.FC = () => {
           value={inputValue}
           onChange={(event) => setInputValue(event.target.value)}
           placeholder="Enter a URL"
-          className="flex-1 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-400 focus:border-blue-500 focus:outline-none"
+          className="flex-1 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-400 focus-visible:border-blue-500 focus-visible:outline-none"
         />
         <button
           type="submit"
-          className="rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
+          className="rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
         >
           Go
         </button>
@@ -115,7 +115,7 @@ const Firefox: React.FC = () => {
             key={bookmark.url}
             type="button"
             onClick={() => updateAddress(bookmark.url)}
-            className="rounded bg-gray-800 px-3 py-1 font-medium text-gray-200 transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            className="rounded bg-gray-800 px-3 py-1 font-medium text-gray-200 transition hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
           >
             {bookmark.label}
           </button>

--- a/components/apps/firefox/simulations.tsx
+++ b/components/apps/firefox/simulations.tsx
@@ -537,7 +537,7 @@ export const FirefoxSimulationView: React.FC<{ simulation: FirefoxSimulation }> 
         href={simulation.externalUrl}
         target="_blank"
         rel="noreferrer"
-        className="mt-4 inline-flex items-center gap-2 rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
+        className="mt-4 inline-flex items-center gap-2 rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
       >
         {simulation.ctaLabel ?? 'Open official site'}
         <span aria-hidden="true" className="text-xs">↗</span>
@@ -557,7 +557,7 @@ export const FirefoxSimulationView: React.FC<{ simulation: FirefoxSimulation }> 
                       href={link.href}
                       target="_blank"
                       rel="noreferrer"
-                      className="font-medium text-blue-300 hover:text-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
+                      className="font-medium text-blue-300 hover:text-blue-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
                     >
                       {link.label}
                     </a>

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -153,14 +153,14 @@ export class Gedit extends Component {
                 <div className="relative flex-grow flex flex-col bg-ub-gedit-dark font-normal windowMainScreen">
                     <div className="absolute left-0 top-0 h-full px-2 bg-ub-gedit-darker"></div>
                     <div className="relative">
-                        <input id="sender-name" value={this.state.name} onChange={this.handleChange('name')} onBlur={this.handleBlur('name')} aria-invalid={nameInvalid} aria-describedby="name-status" className={`w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent ${nameInvalid ? 'border border-red-500' : nameValid ? 'border border-emerald-500' : ''}`} placeholder="Your Email / Name :" spellCheck="false" autoComplete="off" type="text" />
+                        <input id="sender-name" value={this.state.name} onChange={this.handleChange('name')} onBlur={this.handleBlur('name')} aria-invalid={nameInvalid} aria-describedby="name-status" className={`w-full text-ubt-gedit-orange focus-visible:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent ${nameInvalid ? 'border border-red-500' : nameValid ? 'border border-emerald-500' : ''}`} placeholder="Your Email / Name :" spellCheck="false" autoComplete="off" type="text" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold light text-sm text-ubt-gedit-blue">1</span>
                         <p id="name-status" className={`text-xs mt-1 ${nameInvalid ? 'text-red-400' : nameValid ? 'text-emerald-400' : 'sr-only'}`} aria-live="polite">
                             {nameInvalid ? 'Name must not be empty' : nameValid ? 'Looks good' : ''}
                         </p>
                     </div>
                     <div className="relative">
-                        <input id="sender-subject" value={this.state.subject} onChange={this.handleChange('subject')} className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" />
+                        <input id="sender-subject" value={this.state.subject} onChange={this.handleChange('subject')} className=" w-full my-1 text-ubt-gedit-blue focus-visible:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold  text-sm text-ubt-gedit-blue">2</span>
                     </div>
                     <div className="relative flex-grow">

--- a/components/apps/hangman.js
+++ b/components/apps/hangman.js
@@ -553,7 +553,7 @@ const Hangman = () => {
                 type="button"
                 onClick={() => handleGuess(l)}
                 style={{ backgroundColor: color }}
-                className={`w-6 h-6 flex items-center justify-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange ${guessedAlready ? 'opacity-50' : ''}`}
+                className={`w-6 h-6 flex items-center justify-center rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange ${guessedAlready ? 'opacity-50' : ''}`}
                 aria-pressed={guessedAlready}
                 disabled={guessedAlready || wrong >= maxWrong || won || paused}
               >

--- a/components/apps/metasploit/metasploit.jsx
+++ b/components/apps/metasploit/metasploit.jsx
@@ -409,7 +409,7 @@ const MetasploitApp = ({
                   key={s}
                   onClick={() => setSelectedSeverity(s)}
                   aria-pressed={selectedSeverity === s}
-                  className={`px-2 py-1 rounded-full text-xs font-bold mr-2 mb-2 focus:outline-none ${severityStyles[s]} ${
+                  className={`px-2 py-1 rounded-full text-xs font-bold mr-2 mb-2 focus-visible:outline-none ${severityStyles[s]} ${
                     selectedSeverity === s
                       ? 'ring-2 ring-white motion-safe:transition-transform motion-safe:duration-300 motion-safe:scale-110 motion-reduce:transition-none motion-reduce:scale-100'
                       : ''

--- a/components/apps/msf-post/index.js
+++ b/components/apps/msf-post/index.js
@@ -76,7 +76,7 @@ const TreeNode = ({ name, node, onSelect, depth }) => {
       <li>
         <button
           onClick={() => onSelect(node.module)}
-          className="text-left hover:underline focus:outline-none h-8 flex items-center w-full"
+          className="text-left hover:underline focus-visible:outline-none h-8 flex items-center w-full"
           style={{ paddingLeft: indent }}
         >
           {name}

--- a/components/apps/nessus/HostBubbleChart.js
+++ b/components/apps/nessus/HostBubbleChart.js
@@ -65,7 +65,7 @@ const HostBubbleChart = ({ hosts = sampleHosts }) => {
             key={level}
             onClick={() => setFilter(level)}
             aria-pressed={filter === level}
-            className={`px-3 py-1 rounded-full text-sm border focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+            className={`px-3 py-1 rounded-full text-sm border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 ${
               filter === level
                 ? 'bg-white text-black border-gray-300'
                 : 'bg-gray-800 text-white border-gray-600'

--- a/components/apps/nessus/PluginFeedViewer.js
+++ b/components/apps/nessus/PluginFeedViewer.js
@@ -25,7 +25,7 @@ const PluginFeedViewer = ({ plugins = sampleReport }) => {
             key={level}
             onClick={() => setFilter(level)}
             aria-pressed={filter === level}
-            className={`px-3 py-1 rounded-full text-sm border focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+            className={`px-3 py-1 rounded-full text-sm border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 ${
               filter === level
                 ? 'bg-white text-black border-gray-300'
                 : 'bg-gray-800 text-white border-gray-600'

--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -265,7 +265,7 @@ const NmapNSEApp = () => {
                 key={p.label}
                 type="button"
                 onClick={() => setPortFlag(p.flag)}
-                className={`px-2 py-1 rounded text-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow ${
+                className={`px-2 py-1 rounded text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ub-yellow ${
                   portFlag === p.flag ? 'bg-ub-yellow' : 'bg-ub-grey'
                 }`}
               >
@@ -281,7 +281,7 @@ const NmapNSEApp = () => {
           <button
             type="button"
             onClick={copyCommand}
-            className="ml-2 px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+            className="ml-2 px-2 py-1 bg-ub-grey text-black rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ub-yellow"
           >
             Copy Command
           </button>
@@ -329,14 +329,14 @@ const NmapNSEApp = () => {
                     )
                   )
                 }
-                className="px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+                className="px-2 py-1 bg-ub-grey text-black rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ub-yellow"
               >
                 Step
               </button>
               <button
                 type="button"
                 onClick={() => setPhaseStep(0)}
-                className="px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+                className="px-2 py-1 bg-ub-grey text-black rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ub-yellow"
               >
                 Reset
               </button>
@@ -422,14 +422,14 @@ const NmapNSEApp = () => {
           <button
             type="button"
             onClick={copyOutput}
-            className="px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+            className="px-2 py-1 bg-ub-grey text-black rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ub-yellow"
           >
             Copy Output
           </button>
           <button
             type="button"
             onClick={selectOutput}
-            className="px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+            className="px-2 py-1 bg-ub-grey text-black rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ub-yellow"
           >
             Select All
           </button>

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -349,7 +349,7 @@ const OpenVASApp = () => {
               key={h.host}
               type="button"
               onClick={() => setActiveHost(h)}
-              className="p-4 bg-gray-800 rounded text-left focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="p-4 bg-gray-800 rounded text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             >
               <div className="font-bold mb-1">{h.host}</div>
               <div className="mb-1">
@@ -452,7 +452,7 @@ const OpenVASApp = () => {
                       type="button"
                       onClick={() => handleCellClick(likelihood, impact)}
                       disabled={count === 0}
-                      className={`p-2 ${color(i, j)} text-white focus:outline-none w-full ${
+                      className={`p-2 ${color(i, j)} text-white focus-visible:outline-none w-full ${
                         reduceMotion.current ? '' : 'transition-transform hover:scale-105'
                       } ${
                         filter &&
@@ -480,7 +480,7 @@ const OpenVASApp = () => {
                 key={level}
                 onClick={() => handleSeverityChange(level)}
                 aria-pressed={severity === level}
-                className={`px-3 py-1 rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+                className={`px-3 py-1 rounded-full text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 ${
                   severity === level
                     ? 'bg-white text-black'
                     : 'bg-gray-800 text-white'
@@ -515,7 +515,7 @@ const OpenVASApp = () => {
               <button
                 type="button"
                 onClick={() => setSelected(f)}
-                className="w-full text-left focus:outline-none"
+                className="w-full text-left focus-visible:outline-none"
               >
                 <div className="flex items-center justify-between">
                   <span

--- a/components/apps/radare2/GuideOverlay.js
+++ b/components/apps/radare2/GuideOverlay.js
@@ -56,7 +56,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={prev}
             disabled={step === 0}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus-visible:outline-none focus-visible:ring"
           >
             Prev
           </button>
@@ -65,7 +65,7 @@ export default function GuideOverlay({ onClose }) {
             type="button"
             onClick={next}
             disabled={step === STEPS.length - 1}
-            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50 focus-visible:outline-none focus-visible:ring"
           >
             Next
           </button>
@@ -89,7 +89,7 @@ export default function GuideOverlay({ onClose }) {
           </a>
           <button
             onClick={handleClose}
-            className="px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+            className="px-3 py-1 bg-gray-700 rounded focus-visible:outline-none focus-visible:ring"
           >
             Close
           </button>

--- a/components/apps/radare2/HexEditor.js
+++ b/components/apps/radare2/HexEditor.js
@@ -181,7 +181,7 @@ const HexEditor = ({ hex, theme }) => {
                       onMouseDown={() => handleMouseDown(idx)}
                       onMouseEnter={() => handleMouseEnter(idx)}
                       onDoubleClick={() => handleEdit(idx, b)}
-                      className="w-6 h-6 flex items-center justify-center rounded focus:outline-none focus-visible:ring-2"
+                      className="w-6 h-6 flex items-center justify-center rounded focus-visible:outline-none focus-visible:ring-2"
                       style={{
                         backgroundColor: selected
                           ? 'var(--r2-accent)'

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -671,7 +671,7 @@ const Solitaire = () => {
           <button
             type="button"
             onClick={resume}
-            className="px-4 py-2 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className="px-4 py-2 bg-gray-700 text-white rounded focus-visible:outline-none focus-visible:ring"
             autoFocus
           >
             Resume

--- a/components/apps/sudoku.js
+++ b/components/apps/sudoku.js
@@ -269,7 +269,7 @@ const Sudoku = () => {
                 } ${isHint ? 'ring-2 ring-yellow-400' : ''}`}
               >
                 <input
-                  className={`w-full h-full text-center bg-transparent outline-none focus:outline-none ${
+                  className={`w-full h-full text-center bg-transparent outline-none focus-visible:outline-none ${
                     conflict || wrong ? 'text-white' : 'text-black'
                   }`}
                   ref={(el) => (inputRefs.current[r][c] = el)}

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -587,7 +587,7 @@ export default function Todoist() {
           draggable
           onDragStart={handleDragStart(group, task)}
           onKeyDown={handleKeyDown(group, task)}
-          className="rounded shadow bg-white text-black flex items-center px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="rounded shadow bg-white text-black flex items-center px-2 py-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           role="listitem"
         >
           <label className="mr-2 inline-flex items-center">
@@ -596,7 +596,7 @@ export default function Todoist() {
               aria-label="Toggle completion"
               checked={!!task.completed}
               onChange={() => toggleCompleted(group, task.id)}
-              className="w-6 h-6 focus:ring-2 focus:ring-blue-500"
+              className="w-6 h-6 focus-visible:ring-2 focus-visible:ring-blue-500"
             />
           </label>
           <div className="flex-1">
@@ -831,7 +831,7 @@ export default function Todoist() {
           />
           <button
             type="submit"
-            className="px-2 py-1 bg-blue-600 text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="px-2 py-1 bg-blue-600 text-white rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           >
             Add
           </button>
@@ -886,7 +886,7 @@ export default function Todoist() {
           </select>
           <button
             type="submit"
-            className="px-2 py-1 bg-blue-600 text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="px-2 py-1 bg-blue-600 text-white rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           >
             Add
           </button>

--- a/components/apps/trash/index.tsx
+++ b/components/apps/trash/index.tsx
@@ -106,28 +106,28 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
           <button
             onClick={restore}
             disabled={selected === null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange disabled:opacity-50"
           >
             Restore
           </button>
           <button
             onClick={restoreAll}
             disabled={items.length === 0}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange disabled:opacity-50"
           >
             Restore All
           </button>
           <button
             onClick={remove}
             disabled={selected === null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange disabled:opacity-50"
           >
             Delete
           </button>
           <button
             onClick={empty}
             disabled={items.length === 0}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange disabled:opacity-50"
           >
             Empty
           </button>

--- a/components/apps/volatility/MemoryHeatmap.js
+++ b/components/apps/volatility/MemoryHeatmap.js
@@ -109,10 +109,10 @@ const MemoryHeatmap = ({ data }) => {
             key={key}
             onClick={() => toggle(key)}
             aria-pressed={filters[key]}
-            className={`px-3 py-1 rounded-full text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+            className={`px-3 py-1 rounded-full text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${
               filters[key]
-                ? `${chipColors[key]} text-white focus:ring-white`
-                : 'bg-gray-200 text-gray-800 focus:ring-black'
+                ? `${chipColors[key]} text-white focus-visible:ring-white`
+                : 'bg-gray-200 text-gray-800 focus-visible:ring-black'
             }`}
           >
             {categories[key]}
@@ -126,7 +126,7 @@ const MemoryHeatmap = ({ data }) => {
         tabIndex={0}
         role="img"
         aria-label="Heatmap of memory regions. Use arrow keys to pan."
-        className="border border-gray-500 w-full h-40 focus:outline-none"
+        className="border border-gray-500 w-full h-40 focus-visible:outline-none"
       />
       <div className="sr-only" aria-live="polite">
         {announcement}

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -416,7 +416,7 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
                 if (error) setError(null);
               }}
               placeholder="Search for playlists by topic, creator, or mood…"
-              className="w-full rounded-md border border-white/10 bg-black/40 px-4 py-3 text-sm text-white placeholder:text-ubt-grey focus:border-ubt-green focus:outline-none focus:ring-2 focus:ring-ubt-green/40"
+              className="w-full rounded-md border border-white/10 bg-black/40 px-4 py-3 text-sm text-white placeholder:text-ubt-grey focus-visible:border-ubt-green focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ubt-green/40"
             />
           </div>
           <button

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -70,7 +70,7 @@ export class UbuntuApp extends Component {
                 onPointerCancel={onPointerCancel}
                 style={combinedStyle}
                 className={(this.state.launching ? " app-icon-launch " : "") + (dragging ? " opacity-70 " : "") +
-                    " m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none flex flex-col justify-start items-center text-center font-normal text-white transition-hover transition-active "}
+                    " m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus-visible:bg-white focus-visible:bg-opacity-50 focus-visible:border-yellow-700 focus-visible:border-opacity-100 border border-transparent outline-none rounded select-none flex flex-col justify-start items-center text-center font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -835,7 +835,7 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                className="mx-1 focus-visible:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
                 onClick={props.close}
             >
                 <NextImage

--- a/components/menu/ApplicationsMenu.tsx
+++ b/components/menu/ApplicationsMenu.tsx
@@ -97,7 +97,7 @@ const ApplicationsMenu: React.FC<ApplicationsMenuProps> = ({ activeCategory, onS
               <button
                 type="button"
                 onClick={() => onSelect(category.id)}
-                className={`flex w-full items-center gap-3 rounded px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
+                className={`flex w-full items-center gap-3 rounded px-3 py-2 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 ${
                   isActive ? 'bg-gray-700 text-white' : 'bg-transparent hover:bg-gray-700/60'
                 }`}
                 aria-pressed={isActive}

--- a/components/menu/PlacesMenu.tsx
+++ b/components/menu/PlacesMenu.tsx
@@ -63,7 +63,7 @@ const PlacesMenu: React.FC<PlacesMenuProps> = ({ heading = 'Places', items }) =>
               <button
                 type="button"
                 onClick={handleClick}
-                className="flex w-full items-center gap-3 rounded px-3 py-2 text-left transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-ubb-orange"
+                className="flex w-full items-center gap-3 rounded px-3 py-2 text-left transition hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ubb-orange"
               >
                 <img
                   src={src}

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -418,7 +418,7 @@ const WhiskerMenu: React.FC = () => {
                     categoryButtonRefs.current[index] = el;
                   }}
                   type="button"
-                  className={`group flex items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1724] ${
+                  className={`group flex items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1724] ${
                     category === cat.id
                       ? 'bg-[#162236] text-white shadow-[inset_2px_0_0_#53b9ff]'
                       : 'text-gray-300 hover:bg-[#152133] hover:text-white'
@@ -485,7 +485,7 @@ const WhiskerMenu: React.FC = () => {
                   </svg>
                 </span>
                 <input
-                  className="h-10 w-full rounded-lg border border-transparent bg-[#101c2d] pl-9 pr-3 text-sm text-gray-100 shadow-inner focus:border-[#53b9ff] focus:outline-none focus:ring-0"
+                  className="h-10 w-full rounded-lg border border-transparent bg-[#101c2d] pl-9 pr-3 text-sm text-gray-100 shadow-inner focus-visible:border-[#53b9ff] focus-visible:outline-none focus-visible:ring-0"
                   placeholder="Search applications"
                   aria-label="Search applications"
                   value={query}

--- a/components/panel/WorkspaceSwitcher.tsx
+++ b/components/panel/WorkspaceSwitcher.tsx
@@ -48,7 +48,7 @@ export default function WorkspaceSwitcher({
             aria-pressed={isActive}
             aria-label={formatAriaLabel(workspace)}
             onClick={() => onSelect(workspace.id)}
-            className={`relative flex h-8 min-w-[2.25rem] items-center justify-center px-3 text-xs font-medium text-white/70 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kali-blue)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#161b25] ${
+            className={`relative flex h-8 min-w-[2.25rem] items-center justify-center px-3 text-xs font-medium text-white/70 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kali-blue)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#161b25] ${
               index > 0 ? "border-l border-white/10" : ""
             } ${isActive ? "text-white" : "hover:text-white"}`}
           >

--- a/components/screen/all-applications.js
+++ b/components/screen/all-applications.js
@@ -134,7 +134,7 @@ class AllApplications extends React.Component {
                             : `Add ${app.title} to favorites`
                     }
                     onClick={(event) => this.handleToggleFavorite(event, app.id)}
-                    className={`absolute right-2 top-2 text-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
+                    className={`absolute right-2 top-2 text-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
                         isFavorite ? 'text-yellow-300' : 'text-white/60 hover:text-white'
                     }`}
                 >
@@ -185,7 +185,7 @@ class AllApplications extends React.Component {
         return (
             <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
                 <input
-                    className="mt-10 mb-8 w-2/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none md:w-1/3"
+                    className="mt-10 mb-8 w-2/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus-visible:outline-none md:w-1/3"
                     placeholder="Search"
                     value={this.state.query}
                     onChange={this.handleChange}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -106,7 +106,7 @@ export default class Navbar extends PureComponent {
                                                 aria-label="System status"
                                                 onClick={this.handleStatusToggle}
                                                 className={
-                                                        'relative rounded-full border border-transparent px-3 py-1 text-xs font-medium text-white/80 transition duration-150 ease-in-out hover:border-white/20 hover:bg-white/10 focus:border-ubb-orange focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300'
+                                                        'relative rounded-full border border-transparent px-3 py-1 text-xs font-medium text-white/80 transition duration-150 ease-in-out hover:border-white/20 hover:bg-white/10 focus-visible:border-ubb-orange focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300'
                                                 }
                                         >
                                                 <Status />

--- a/components/screen/shortcut-selector.js
+++ b/components/screen/shortcut-selector.js
@@ -57,7 +57,7 @@ class ShortcutSelector extends React.Component {
         return (
             <div className="fixed inset-0 z-50 flex flex-col items-center overflow-y-auto bg-ub-grey bg-opacity-95 all-apps-anim">
                 <input
-                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+                    className="mt-10 mb-8 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus-visible:outline-none"
                     placeholder="Search"
                     value={this.state.query}
                     onChange={this.handleChange}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -44,7 +44,7 @@ export default function Taskbar(props) {
                             data-active={isActive ? 'true' : 'false'}
                             aria-pressed={isActive}
                             onClick={() => handleClick(app)}
-                            className={`${isFocused && isActive ? 'bg-white bg-opacity-20 ' : ''}relative flex items-center justify-center rounded-lg transition-colors hover:bg-white hover:bg-opacity-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70`}
+                            className={`${isFocused && isActive ? 'bg-white bg-opacity-20 ' : ''}relative flex items-center justify-center rounded-lg transition-colors hover:bg-white hover:bg-opacity-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70`}
                             style={{
                                 minHeight: 'var(--shell-hit-target, 2.5rem)',
                                 minWidth: 'var(--shell-hit-target, 2.5rem)',

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -64,7 +64,7 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
           value={query}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+          className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus-visible:outline-none"
           placeholder="Search windows"
         />
         <ul>

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -17,7 +17,7 @@ const Breadcrumbs: React.FC<Props> = ({ path, onNavigate }) => {
           <button
             type="button"
             onClick={() => onNavigate(idx)}
-            className="hover:underline focus:outline-none"
+            className="hover:underline focus-visible:outline-none"
           >
             {seg.name || '/'}
           </button>

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -243,7 +243,7 @@ const NotificationBell: React.FC = () => {
         aria-expanded={isOpen}
         aria-controls={panelId}
         onClick={togglePanel}
-        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey transition focus:border-ubb-orange focus:outline-none focus:ring-0 hover:bg-white hover:bg-opacity-10"
+        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey transition focus-visible:border-ubb-orange focus-visible:outline-none focus-visible:ring-0 hover:bg-white hover:bg-opacity-10"
       >
         <svg
           aria-hidden="true"
@@ -302,7 +302,7 @@ const NotificationBell: React.FC = () => {
                         onClick={() => toggleGroup(group.priority)}
                         aria-expanded={!collapsed}
                         aria-controls={contentId}
-                        className="flex w-full items-center justify-between px-4 py-2 text-left text-sm font-semibold text-white transition hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-ubb-orange"
+                        className="flex w-full items-center justify-between px-4 py-2 text-left text-sm font-semibold text-white transition hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ubb-orange"
                       >
                         <span className="flex items-center gap-2">
                           {group.metadata.label}

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -38,7 +38,7 @@ const Toast: React.FC<ToastProps> = ({
       {onAction && actionLabel && (
         <button
           onClick={onAction}
-          className="ml-4 underline focus:outline-none"
+          className="ml-4 underline focus-visible:outline-none"
         >
           {actionLabel}
         </button>

--- a/components/util-components/clock.js
+++ b/components/util-components/clock.js
@@ -423,7 +423,7 @@ const Clock = ({ onlyDay = false, onlyTime = false, showCalendar = false, hour12
                     <button
                         type="button"
                         onClick={() => handleMonthChange(-1)}
-                        className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/10 bg-slate-900/60 text-lg text-white/80 transition-colors hover:border-white/30 hover:bg-slate-800 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/10 bg-slate-900/60 text-lg text-white/80 transition-colors hover:border-white/30 hover:bg-slate-800 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
                         aria-label="Previous month"
                     >
                         ‹
@@ -431,7 +431,7 @@ const Clock = ({ onlyDay = false, onlyTime = false, showCalendar = false, hour12
                     <button
                         type="button"
                         onClick={() => handleMonthChange(1)}
-                        className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/10 bg-slate-900/60 text-lg text-white/80 transition-colors hover:border-white/30 hover:bg-slate-800 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/10 bg-slate-900/60 text-lg text-white/80 transition-colors hover:border-white/30 hover:bg-slate-800 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
                         aria-label="Next month"
                     >
                         ›
@@ -475,7 +475,7 @@ const Clock = ({ onlyDay = false, onlyTime = false, showCalendar = false, hour12
                                             type="button"
                                             onClick={handleDayClick}
                                             onKeyDown={(event) => handleDayKeyDown(event, date)}
-                                            className={`flex h-9 w-9 items-center justify-center rounded-2xl text-sm font-medium transition duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
+                                            className={`flex h-9 w-9 items-center justify-center rounded-2xl text-sm font-medium transition duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
                                                 inCurrentMonth ? 'text-white' : 'text-white/35'
                                             } ${
                                                 isToday
@@ -500,14 +500,14 @@ const Clock = ({ onlyDay = false, onlyTime = false, showCalendar = false, hour12
                 <button
                     type="button"
                     onClick={handleToday}
-                    className="rounded-full bg-gradient-to-r from-cyan-400 via-sky-500 to-blue-600 px-4 py-1.5 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-slate-950 shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+                    className="rounded-full bg-gradient-to-r from-cyan-400 via-sky-500 to-blue-600 px-4 py-1.5 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-slate-950 shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
                 >
                     Today
                 </button>
                 <button
                     type="button"
                     onClick={handleClose}
-                    className="rounded-full border border-white/20 px-3 py-1.5 text-[0.65rem] font-medium uppercase tracking-[0.3em] text-white/70 transition hover:border-white/40 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+                    className="rounded-full border border-white/20 px-3 py-1.5 text-[0.65rem] font-medium uppercase tracking-[0.3em] text-white/70 transition hover:border-white/40 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
                 >
                     Close
                 </button>
@@ -531,7 +531,7 @@ const Clock = ({ onlyDay = false, onlyTime = false, showCalendar = false, hour12
                 type="button"
                 ref={buttonRef}
                 onClick={handleToggle}
-                className="group flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-left text-sm font-medium text-white shadow-sm transition-colors duration-200 hover:border-white/20 hover:bg-white/15 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+                className="group flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-left text-sm font-medium text-white shadow-sm transition-colors duration-200 hover:border-white/20 hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                 aria-haspopup="dialog"
                 aria-expanded={isOpen}
                 aria-controls={popoverId}

--- a/docs/TASKS_UI_POLISH.md
+++ b/docs/TASKS_UI_POLISH.md
@@ -177,6 +177,7 @@ This document tracks UI polish tasks for the Kali/Ubuntu inspired desktop experi
 41. **Keyboard-first navigation**
     - **Accept:** Full desktop and app grid operable by keyboard (Tab, Arrow, Enter, Escape), with visible focus.
     - **Where:** focus management in desktop and window components.
+    - **Dev note:** Use `:focus-visible` (or the `.focus-visible` polyfill class) for custom focus treatments so pointer clicks do not suppress keyboard-visible rings.
 
 42. **ARIA for window chrome**
     - **Accept:** Titlebar buttons have `aria-label`s, window has `role="dialog"` or `region"` with descriptive `aria-labelledby`.

--- a/docs/keyboard-only-test-plan.md
+++ b/docs/keyboard-only-test-plan.md
@@ -21,3 +21,8 @@
 1. After resizing or snapping, press **Tab** to move focus inside the window.
 2. Continue pressing **Tab** to confirm focus can leave the window and is not trapped.
 3. Shift+Tab moves focus backward as expected.
+
+## Focus indicators across UI surfaces
+1. Open the applications menu and press **Tab** to move through launchers. Each item should display the Tailwind focus-visible ring.
+2. Trigger a modal (settings, dialog, or confirmation). Use **Tab** and **Shift+Tab** to cycle through controls and confirm the ring remains visible on each element.
+3. Navigate to a form (contact app or terminal command input). Use the keyboard to focus fields and ensure focus-visible tokens remain active, then click with the pointer to confirm focus outlines are suppressed for pointer-only interactions.

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -153,7 +153,7 @@ function MyApp(props) {
       <div className={ubuntu.className}>
         <a
           href="#app-grid"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+          className="sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:top-0 focus-visible:left-0 focus-visible:z-50 focus-visible:p-2 focus-visible:bg-white focus-visible:text-black"
         >
           Skip to app grid
         </a>

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -70,7 +70,7 @@ const AppsPage = () => {
                 >
                   <Link
                     href={`/apps/${app.id}`}
-                    className="flex h-full w-full flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
+                    className="flex h-full w-full flex-col items-center rounded border p-4 text-center focus-visible:outline-none focus-visible:ring"
                     aria-label={app.title}
                     onFocus={onFocus}
                     onBlur={onBlur}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -30,7 +30,7 @@ const InstallButton = dynamic(
  */
 const App = () => (
   <>
-    <a href="#window-area" className="sr-only focus:not-sr-only">
+    <a href="#window-area" className="sr-only focus-visible:not-sr-only">
       Skip to content
     </a>
     <Meta />

--- a/pages/network-topology.tsx
+++ b/pages/network-topology.tsx
@@ -10,7 +10,7 @@ const NetworkTopology: React.FC = () => {
       <main className="bg-ub-cool-grey text-white min-h-screen p-4 space-y-4">
         <button
           onClick={() => setMitigated((m) => !m)}
-          className="px-4 py-2 bg-blue-600 rounded focus:outline-none focus:ring-2 focus:ring-blue-400"
+          className="px-4 py-2 bg-blue-600 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         >
           {mitigated ? 'Disable Mitigation' : 'Enable Mitigation'}
         </button>

--- a/pages/spoofing.tsx
+++ b/pages/spoofing.tsx
@@ -12,7 +12,7 @@ const ToolTile = ({ title, link, children }: TileProps) => (
     href={link}
     target="_blank"
     rel="noopener noreferrer"
-    className="block p-4 bg-ub-grey text-white rounded shadow hover:bg-black focus:outline-none focus:ring"
+    className="block p-4 bg-ub-grey text-white rounded shadow hover:bg-black focus-visible:outline-none focus-visible:ring"
   >
     <h2 className="text-xl mb-2">{title}</h2>
     {children}

--- a/pages/ui/settings/theme.tsx
+++ b/pages/ui/settings/theme.tsx
@@ -26,7 +26,7 @@ function Toggle({
       aria-checked={checked}
       aria-label={label}
       onClick={() => onChange(!checked)}
-      className={`relative w-12 h-6 rounded-full transition-colors duration-200 focus:outline-none ${
+      className={`relative w-12 h-6 rounded-full transition-colors duration-200 focus-visible:outline-none ${
         checked ? 'bg-ubt-blue' : 'bg-ubt-grey'
       }`}
     >

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -85,6 +85,21 @@ html[data-theme='matrix'] {
   outline-offset: 2px;
 }
 
+*:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.js-focus-visible :focus:not(.focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.js-focus-visible :focus.focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 html {
   scrollbar-color: var(--kali-border, var(--color-border)) transparent;
 }


### PR DESCRIPTION
## Summary
- replace Tailwind `focus:` overrides with `focus-visible:` across interactive components so pointer taps do not hide keyboard rings
- hide outlines for pointer-only focus in global CSS while keeping the `.focus-visible` polyfill hook available
- update accessibility documentation with the new focus-visible guidance and keyboard QA steps

## Testing
- yarn test __tests__/Modal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da51a993f483288d87c9e0b50801ed