### PR TITLE
[desktop] Improve keyboard drag accessibility

### DIFF
--- a/__tests__/desktop-drag-accessibility.test.tsx
+++ b/__tests__/desktop-drag-accessibility.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { Desktop } from '../components/screen/desktop';
+
+jest.mock('react-ga4', () => ({ event: jest.fn(), send: jest.fn() }));
+jest.mock('html-to-image', () => ({ toPng: jest.fn().mockResolvedValue('data:image/png;base64,') }));
+jest.mock('../components/util-components/background-image', () => () => <div data-testid="background" />);
+jest.mock('../components/base/window', () => ({
+  __esModule: true,
+  default: ({ id }: { id: string }) => <div data-testid={`window-${id}`} />,
+}));
+
+const noop = () => {};
+
+describe('Desktop keyboard drag accessibility', () => {
+  let liveRegion: HTMLDivElement;
+  let handleAnnounce: (event: Event) => void;
+  let timers: Set<ReturnType<typeof setTimeout>>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    timers = new Set();
+    liveRegion = document.createElement('div');
+    liveRegion.id = 'live-region';
+    liveRegion.setAttribute('aria-live', 'polite');
+    document.body.appendChild(liveRegion);
+
+    handleAnnounce = (event: Event) => {
+      const detail: any = (event as CustomEvent).detail ?? {};
+      const message = typeof detail === 'string' ? detail : detail.message;
+      const politeness = typeof detail?.politeness === 'string' ? detail.politeness : 'polite';
+      liveRegion.setAttribute('aria-live', politeness === 'assertive' ? 'assertive' : 'polite');
+      liveRegion.textContent = '';
+      const timer = setTimeout(() => {
+        liveRegion.textContent = message || '';
+        timers.delete(timer);
+      }, 100);
+      timers.add(timer);
+    };
+
+    window.addEventListener('sr-announce', handleAnnounce);
+  });
+
+  afterEach(() => {
+    window.removeEventListener('sr-announce', handleAnnounce);
+    timers.forEach((timer) => clearTimeout(timer));
+    timers.clear();
+    if (liveRegion.parentNode) {
+      liveRegion.parentNode.removeChild(liveRegion);
+    }
+    jest.useRealTimers();
+  });
+
+  const renderDesktop = () =>
+    render(
+      <Desktop
+        clearSession={noop}
+        session={{}}
+        setSession={noop}
+        snapEnabled={false}
+      />,
+    );
+
+  it('announces keyboard drag lifecycle via the live region', async () => {
+    renderDesktop();
+
+    const firefoxIcon = await screen.findByRole('button', { name: /firefox/i });
+
+    fireEvent.keyDown(firefoxIcon, { key: ' ', code: 'Space' });
+    await act(async () => {
+      jest.advanceTimersByTime(120);
+    });
+
+    expect(firefoxIcon).toHaveAttribute('aria-grabbed', 'true');
+    expect(liveRegion.textContent).toMatch(/picked up firefox/i);
+
+    fireEvent.keyDown(firefoxIcon, { key: 'ArrowRight', code: 'ArrowRight' });
+    await act(async () => {
+      jest.advanceTimersByTime(120);
+    });
+
+    expect(liveRegion.textContent).toMatch(/moved/i);
+
+    fireEvent.keyDown(firefoxIcon, { key: ' ', code: 'Space' });
+    await act(async () => {
+      jest.advanceTimersByTime(120);
+    });
+
+    expect(firefoxIcon).toHaveAttribute('aria-grabbed', 'false');
+    expect(liveRegion.textContent).toMatch(/dropped firefox/i);
+  });
+
+  it('marks desktop and dock as drop targets during a drag', async () => {
+    renderDesktop();
+
+    const firefoxIcon = await screen.findByRole('button', { name: /firefox/i });
+    const grid = await screen.findByRole('grid', { name: /desktop icons/i });
+    const dock = await screen.findByRole('toolbar', { name: /dock/i });
+
+    fireEvent.keyDown(firefoxIcon, { key: ' ', code: 'Space' });
+    await act(async () => {
+      jest.advanceTimersByTime(120);
+    });
+
+    expect(grid).toHaveAttribute('aria-dropeffect', 'move');
+    expect(dock).toHaveAttribute('aria-dropeffect', 'move');
+
+    fireEvent.keyDown(firefoxIcon, { key: ' ', code: 'Space' });
+    await act(async () => {
+      jest.advanceTimersByTime(120);
+    });
+
+    expect(grid).not.toHaveAttribute('aria-dropeffect');
+    expect(dock).not.toHaveAttribute('aria-dropeffect');
+  });
+});

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -38,7 +38,10 @@ export class UbuntuApp extends Component {
             onPointerMove,
             onPointerUp,
             onPointerCancel,
+            onKeyDown,
             style,
+            ariaGrabbed,
+            ariaDescribedBy,
         } = this.props;
 
         const dragging = this.state.dragging || isBeingDragged;
@@ -59,6 +62,8 @@ export class UbuntuApp extends Component {
                 role="button"
                 aria-label={this.props.name}
                 aria-disabled={this.props.disabled}
+                aria-grabbed={typeof ariaGrabbed === 'boolean' ? ariaGrabbed : undefined}
+                aria-describedby={ariaDescribedBy}
                 data-context="app"
                 data-app-id={this.props.id}
                 draggable={draggable}
@@ -68,12 +73,21 @@ export class UbuntuApp extends Component {
                 onPointerMove={onPointerMove}
                 onPointerUp={onPointerUp}
                 onPointerCancel={onPointerCancel}
+                onKeyDown={(event) => {
+                    if (typeof onKeyDown === 'function') {
+                        onKeyDown(event);
+                    }
+                    if (event.defaultPrevented) return;
+                    if ((event.key === 'Enter' || event.key === ' ') && !this.props.disabled) {
+                        event.preventDefault();
+                        this.openApp();
+                    }
+                }}
                 style={combinedStyle}
                 className={(this.state.launching ? " app-icon-launch " : "") + (dragging ? " opacity-70 " : "") +
                     " m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none flex flex-col justify-start items-center text-center font-normal text-white transition-hover transition-active "}
                 id={"app-" + this.props.id}
                 onDoubleClick={this.openApp}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
                 tabIndex={this.props.disabled ? -1 : 0}
                 onMouseEnter={this.handlePrefetch}
                 onFocus={this.handlePrefetch}

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Image from 'next/image';
 
 export default function Taskbar(props) {
+    const { dragActive = false } = props;
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
 
     const handleClick = (app) => {
@@ -20,6 +21,8 @@ export default function Taskbar(props) {
         <div
             className="absolute bottom-0 left-0 w-full bg-black bg-opacity-50 flex items-center justify-start z-40 backdrop-blur-sm"
             role="toolbar"
+            aria-label="Dock"
+            aria-dropeffect={dragActive ? 'move' : undefined}
             style={{
                 height: 'var(--shell-taskbar-height, 2.5rem)',
                 paddingInline: 'var(--shell-taskbar-padding-x, 0.75rem)',


### PR DESCRIPTION
## Summary
- add keyboard-accessible drag and drop handling for desktop icons with live announcements
- expose drop targets on the dock and desktop grid via ARIA attributes for assistive tech
- introduce tests covering screen reader feedback during keyboard drag operations

## Testing
- yarn test desktop-drag-accessibility

------
https://chatgpt.com/codex/tasks/task_e_68da51aba940832881ab4407803e0c86