### PR TITLE
[ui] Add focus-triggered form hints

### DIFF
--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useId } from "react";
 import FormError from "../../components/ui/FormError";
 import Toast from "../../components/ui/Toast";
 import { processContactForm } from "../../components/apps/contact";
@@ -8,6 +8,7 @@ import { contactSchema } from "../../utils/contactSchema";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openMailto } from "../../utils/mailto";
 import { trackEvent } from "@/lib/analytics-client";
+import FormHint from "../../components/ui/FormHint";
 
 const DRAFT_KEY = "contact-draft";
 const EMAIL = "alex.unnippillil@hotmail.com";
@@ -34,6 +35,18 @@ const ContactApp: React.FC = () => {
   const [submitting, setSubmitting] = useState(false);
   const [emailError, setEmailError] = useState("");
   const [messageError, setMessageError] = useState("");
+  const [activeHint, setActiveHint] = useState<string | null>(null);
+  const hintBaseId = useId();
+  const nameHintId = `${hintBaseId}-contact-name`;
+  const emailHintId = `${hintBaseId}-contact-email`;
+  const messageHintId = `${hintBaseId}-contact-message`;
+
+  const describe = (
+    ...ids: Array<string | undefined | false>
+  ): string | undefined => {
+    const filtered = ids.filter(Boolean) as string[];
+    return filtered.length ? filtered.join(" ") : undefined;
+  };
 
   useEffect(() => {
     const saved = localStorage.getItem(DRAFT_KEY);
@@ -155,6 +168,15 @@ const ContactApp: React.FC = () => {
               value={name}
               onChange={(e) => setName(e.target.value)}
               required
+              onFocus={() => setActiveHint(nameHintId)}
+              onBlur={() =>
+                setActiveHint((current) =>
+                  current === nameHintId ? null : current,
+                )
+              }
+              aria-describedby={describe(
+                activeHint === nameHintId ? nameHintId : undefined,
+              )}
               aria-labelledby="contact-name-label"
             />
             <svg
@@ -171,6 +193,15 @@ const ContactApp: React.FC = () => {
                 d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.25v-1.5A4.5 4.5 0 0 1 9 14.25h6a4.5 4.5 0 0 1 4.5 4.5v1.5"
               />
             </svg>
+            <FormHint
+              id={nameHintId}
+              visible={activeHint === nameHintId}
+              placement="right"
+              className="md:z-20"
+              panelClassName="bg-gray-900/95 text-gray-100 border border-gray-700 shadow-xl"
+            >
+              Let us know who&apos;s reaching out so we can personalise our response.
+            </FormHint>
           </div>
         </div>
         <div>
@@ -190,7 +221,16 @@ const ContactApp: React.FC = () => {
               onChange={(e) => setEmail(e.target.value)}
               required
               aria-invalid={!!emailError}
-              aria-describedby={emailError ? "contact-email-error" : undefined}
+              onFocus={() => setActiveHint(emailHintId)}
+              onBlur={() =>
+                setActiveHint((current) =>
+                  current === emailHintId ? null : current,
+                )
+              }
+              aria-describedby={describe(
+                activeHint === emailHintId ? emailHintId : undefined,
+                emailError ? "contact-email-error" : undefined,
+              )}
               aria-labelledby="contact-email-label"
             />
             <svg
@@ -207,6 +247,16 @@ const ContactApp: React.FC = () => {
                 d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15A2.25 2.25 0 0 1 2.25 17.25V6.75A2.25 2.25 0 0 1 4.5 4.5h15a2.25 2.25 0 0 1 2.25 2.25ZM3 6l9 6 9-6"
               />
             </svg>
+            <FormHint
+              id={emailHintId}
+              visible={activeHint === emailHintId}
+              placement="right"
+              className="md:z-20"
+              panelClassName="bg-gray-900/95 text-gray-100 border border-gray-700 shadow-xl"
+            >
+              Use the address that we should reply to. We never share contact
+              details.
+            </FormHint>
           </div>
           {emailError && (
             <FormError id="contact-email-error" className="mt-2">
@@ -231,7 +281,16 @@ const ContactApp: React.FC = () => {
               onChange={(e) => setMessage(e.target.value)}
               required
               aria-invalid={!!messageError}
-              aria-describedby={messageError ? "contact-message-error" : undefined}
+              onFocus={() => setActiveHint(messageHintId)}
+              onBlur={() =>
+                setActiveHint((current) =>
+                  current === messageHintId ? null : current,
+                )
+              }
+              aria-describedby={describe(
+                activeHint === messageHintId ? messageHintId : undefined,
+                messageError ? "contact-message-error" : undefined,
+              )}
               aria-labelledby="contact-message-label"
             />
             <svg
@@ -248,6 +307,16 @@ const ContactApp: React.FC = () => {
                 d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286a2.25 2.25 0 0 1-1.98 2.193c-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.1 2.1 0 0 1-.825-.242M3.75 7.5c0-1.621 1.152-3.026 2.76-3.235A48.455 48.455 0 0 1 12 3c2.115 0 4.198.137 6.24.402 1.608.209 2.76 1.614 2.76 3.235v6.226c0 1.621-1.152 3.026-2.76 3.235-.577.075-1.157.14-1.74.194V21L12.345 16.845"
               />
             </svg>
+            <FormHint
+              id={messageHintId}
+              visible={activeHint === messageHintId}
+              placement="right"
+              className="md:z-20"
+              panelClassName="bg-gray-900/95 text-gray-100 border border-gray-700 shadow-xl"
+            >
+              Share the context for your question, including timelines or links,
+              so the right teammate can follow up.
+            </FormHint>
           </div>
           {messageError && (
             <FormError id="contact-message-error" className="mt-2">

--- a/components/ui/FormHint.tsx
+++ b/components/ui/FormHint.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import clsx from "clsx";
+
+export type FormHintPlacement = "bottom" | "right";
+
+interface FormHintProps {
+  id: string;
+  visible: boolean;
+  children: React.ReactNode;
+  placement?: FormHintPlacement;
+  className?: string;
+  panelClassName?: string;
+}
+
+const basePanelClass =
+  "rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs leading-snug shadow-sm transition-all duration-150";
+
+const hiddenPanelClass = "pointer-events-none opacity-0 scale-95";
+const visiblePanelClass = "opacity-100 scale-100";
+
+const FormHint: React.FC<FormHintProps> = ({
+  id,
+  visible,
+  children,
+  placement = "bottom",
+  className,
+  panelClassName,
+}) => {
+  if (placement === "right") {
+    return (
+      <div
+        className={clsx(
+          "relative mt-2 min-h-[1.5rem] md:mt-0 md:min-h-0",
+          className,
+        )}
+      >
+        <div
+          id={id}
+          role="note"
+          aria-hidden={!visible}
+          className={clsx(
+            basePanelClass,
+            "origin-top md:absolute md:left-full md:top-1/2 md:ml-3 md:w-64 md:-translate-y-1/2 md:origin-left",
+            visible ? visiblePanelClass : hiddenPanelClass,
+            panelClassName,
+          )}
+        >
+          {children}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={clsx("mt-2 min-h-[1.75rem]", className)}>
+      <div
+        id={id}
+        role="note"
+        aria-hidden={!visible}
+        className={clsx(
+          basePanelClass,
+          "origin-top",
+          visible ? visiblePanelClass : hiddenPanelClass,
+          panelClassName,
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default FormHint;

--- a/pages/dummy-form.tsx
+++ b/pages/dummy-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useId } from 'react';
 import FormError from '../components/ui/FormError';
+import FormHint from '../components/ui/FormHint';
 
 const STORAGE_KEY = 'dummy-form-draft';
 
@@ -12,6 +13,14 @@ const DummyForm: React.FC = () => {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
   const [recovered, setRecovered] = useState(false);
+  const [activeHint, setActiveHint] = useState<string | null>(null);
+  const hintBaseId = useId();
+  const nameHintId = `${hintBaseId}-name`;
+  const emailHintId = `${hintBaseId}-email`;
+  const messageHintId = `${hintBaseId}-message`;
+  const nameLabelId = `${hintBaseId}-name-label`;
+  const emailLabelId = `${hintBaseId}-email-label`;
+  const messageLabelId = `${hintBaseId}-message-label`;
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -92,29 +101,95 @@ const DummyForm: React.FC = () => {
         {recovered && <p className="mb-4 text-sm text-blue-600">Recovered draft</p>}
         {error && <FormError className="mb-4 mt-0">{error}</FormError>}
         {success && <p className="mb-4 text-sm text-green-600">Form submitted successfully!</p>}
-        <label className="mb-2 block text-sm font-medium" htmlFor="name">Name</label>
-        <input
-          id="name"
-          className="mb-4 w-full rounded border p-2"
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <label className="mb-2 block text-sm font-medium" htmlFor="email">Email</label>
-        <input
-          id="email"
-          className="mb-4 w-full rounded border p-2"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <label className="mb-2 block text-sm font-medium" htmlFor="message">Message</label>
-        <textarea
-          id="message"
-          className="mb-4 w-full rounded border p-2"
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-        />
+        <div className="mb-4">
+          <label
+            className="mb-2 block text-sm font-medium"
+            htmlFor="name"
+            id={nameLabelId}
+          >
+            Name
+          </label>
+          <div className="relative">
+            <input
+              id="name"
+              className="w-full rounded border p-2"
+              type="text"
+              value={name}
+              onFocus={() => setActiveHint(nameHintId)}
+              onBlur={() => setActiveHint((current) => (current === nameHintId ? null : current))}
+              aria-describedby={activeHint === nameHintId ? nameHintId : undefined}
+              aria-labelledby={nameLabelId}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <FormHint
+              id={nameHintId}
+              visible={activeHint === nameHintId}
+              placement="right"
+              panelClassName="bg-white text-gray-700 border-gray-200 shadow-lg"
+            >
+              Share your full name so we know how to address you when we reply.
+            </FormHint>
+          </div>
+        </div>
+        <div className="mb-4">
+          <label
+            className="mb-2 block text-sm font-medium"
+            htmlFor="email"
+            id={emailLabelId}
+          >
+            Email
+          </label>
+          <div className="relative">
+            <input
+              id="email"
+              className="w-full rounded border p-2"
+              type="email"
+              value={email}
+              onFocus={() => setActiveHint(emailHintId)}
+              onBlur={() => setActiveHint((current) => (current === emailHintId ? null : current))}
+              aria-describedby={activeHint === emailHintId ? emailHintId : undefined}
+              aria-labelledby={emailLabelId}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <FormHint
+              id={emailHintId}
+              visible={activeHint === emailHintId}
+              placement="right"
+              panelClassName="bg-white text-gray-700 border-gray-200 shadow-lg"
+            >
+              Use the email where you&apos;d like to receive a confirmation.
+            </FormHint>
+          </div>
+        </div>
+        <div className="mb-4">
+          <label
+            className="mb-2 block text-sm font-medium"
+            htmlFor="message"
+            id={messageLabelId}
+          >
+            Message
+          </label>
+          <div className="relative">
+            <textarea
+              id="message"
+              className="w-full rounded border p-2"
+              value={message}
+              onFocus={() => setActiveHint(messageHintId)}
+              onBlur={() => setActiveHint((current) => (current === messageHintId ? null : current))}
+              aria-describedby={activeHint === messageHintId ? messageHintId : undefined}
+              aria-labelledby={messageLabelId}
+              onChange={(e) => setMessage(e.target.value)}
+            />
+            <FormHint
+              id={messageHintId}
+              visible={activeHint === messageHintId}
+              placement="right"
+              panelClassName="bg-white text-gray-700 border-gray-200 shadow-lg"
+            >
+              Include context, links, or questions so we can respond accurately.
+            </FormHint>
+          </div>
+        </div>
         <button type="submit" className="w-full rounded bg-blue-600 p-2 text-white">Submit</button>
         <p className="mt-4 text-xs text-gray-500">
           This form posts to a dummy endpoint. No data is stored. By submitting, you consent to this temporary processing of your information.


### PR DESCRIPTION
## Summary
- add a reusable FormHint component to surface focus-based helper text without causing layout shifts
- integrate contextual hints and aria-describedby wiring into the dummy contact form and the desktop contact app

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da51ad5eac83289c52d4fa0c0a34f6