### PR TITLE
[contact] add accessible error summary

### DIFF
--- a/__tests__/contact.test.tsx
+++ b/__tests__/contact.test.tsx
@@ -1,4 +1,7 @@
-import { processContactForm } from '../components/apps/contact';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ContactApp, { processContactForm } from '../components/apps/contact';
 
 describe('contact form', () => {
   it('invalid email blocked', async () => {
@@ -39,5 +42,67 @@ describe('contact form', () => {
       })
     );
     expect(result.success).toBe(true);
+  });
+});
+
+describe('ContactApp error summary accessibility', () => {
+  beforeEach(() => {
+    (window as any).grecaptcha = {
+      ready: (cb: () => void) => cb(),
+      execute: jest.fn().mockResolvedValue('token'),
+    };
+    process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    delete (window as any).grecaptcha;
+    delete process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+  });
+
+  it('focuses the error banner and allows tabbing to error links', async () => {
+    const user = userEvent.setup();
+    render(<ContactApp />);
+
+    await user.type(screen.getByLabelText('Name'), 'Test User');
+    await user.type(screen.getByLabelText('Email'), 'invalid');
+    await user.click(screen.getByRole('button', { name: /send/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveFocus();
+
+    await user.tab();
+    const emailLink = screen.getByRole('link', { name: /Email: Invalid email/i });
+    expect(emailLink).toHaveFocus();
+
+    await user.tab();
+    const messageLink = screen.getByRole('link', {
+      name: /Message: 1-1000 chars/i,
+    });
+    expect(messageLink).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByLabelText('Name')).toHaveFocus();
+  });
+
+  it('scrolls and focuses the field when an error link is activated', async () => {
+    const user = userEvent.setup();
+    render(<ContactApp />);
+
+    await user.type(screen.getByLabelText('Name'), 'Test User');
+    await user.type(screen.getByLabelText('Email'), 'invalid');
+    await user.click(screen.getByRole('button', { name: /send/i }));
+
+    const emailInput = screen.getByLabelText('Email');
+    const scrollSpy = jest.fn();
+    (emailInput as any).scrollIntoView = scrollSpy;
+
+    const emailLink = await screen.findByRole('link', {
+      name: /Email: Invalid email/i,
+    });
+
+    await user.click(emailLink);
+
+    expect(emailInput).toHaveFocus();
+    expect(scrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
   });
 });

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -1,7 +1,10 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import FormError from '../../ui/FormError';
+import FormErrorSummary, {
+  FormErrorSummaryItem,
+} from '../../ui/FormErrorSummary';
 import { copyToClipboard } from '../../../utils/clipboard';
 import { openMailto } from '../../../utils/mailto';
 import { contactSchema } from '../../../utils/contactSchema';
@@ -139,6 +142,10 @@ const uploadAttachments = async (files: File[]) => {
   }
 };
 
+type BannerState =
+  | { type: 'success'; message: string }
+  | { type: 'error'; message: string; focusKey: number };
+
 const ContactApp: React.FC = () => {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -146,14 +153,17 @@ const ContactApp: React.FC = () => {
   const [honeypot, setHoneypot] = useState('');
   const [attachments, setAttachments] = useState<File[]>([]);
   const [error, setError] = useState('');
-  const [banner, setBanner] = useState<
-    { type: 'success' | 'error'; message: string } | null
-  >(null);
+  const [banner, setBanner] = useState<BannerState | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [csrfToken, setCsrfToken] = useState('');
   const [fallback, setFallback] = useState(false);
   const [emailError, setEmailError] = useState('');
   const [messageError, setMessageError] = useState('');
+  const [errorSummaryItems, setErrorSummaryItems] = useState<
+    FormErrorSummaryItem[]
+  >([]);
+  const bannerRef = useRef<HTMLDivElement | null>(null);
+  const lastFocusKeyRef = useRef<number | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -176,6 +186,17 @@ const ContactApp: React.FC = () => {
     void writeDraft({ name, email, message });
   }, [name, email, message]);
 
+  useEffect(() => {
+    if (banner?.type === 'error') {
+      if (banner.focusKey !== lastFocusKeyRef.current) {
+        lastFocusKeyRef.current = banner.focusKey;
+        bannerRef.current?.focus();
+      }
+    } else if (!banner) {
+      lastFocusKeyRef.current = null;
+    }
+  }, [banner]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (submitting) return;
@@ -184,31 +205,58 @@ const ContactApp: React.FC = () => {
     setBanner(null);
     setEmailError('');
     setMessageError('');
+    setErrorSummaryItems([]);
 
     const emailResult = contactSchema.shape.email.safeParse(email);
     const messageResult = contactSchema.shape.message.safeParse(message);
+    const summaryItems: FormErrorSummaryItem[] = [];
     let hasValidationError = false;
     if (!emailResult.success) {
       setEmailError('Invalid email');
       hasValidationError = true;
+      summaryItems.push({
+        fieldId: 'contact-email',
+        label: 'Email',
+        message: 'Invalid email',
+      });
     }
     if (!messageResult.success) {
       setMessageError('1-1000 chars');
       hasValidationError = true;
+      summaryItems.push({
+        fieldId: 'contact-message',
+        label: 'Message',
+        message: '1-1000 chars',
+      });
     }
     if (hasValidationError) {
-      setBanner({ type: 'error', message: 'Failed to send' });
+      setErrorSummaryItems(summaryItems);
+      setBanner({
+        type: 'error',
+        message: 'Fix the highlighted fields',
+        focusKey: Date.now(),
+      });
       setSubmitting(false);
       return;
     }
     const totalSize = attachments.reduce((s, f) => s + f.size, 0);
     if (totalSize > MAX_TOTAL_ATTACHMENT_SIZE) {
-      setError(
-        `Attachments exceed the ${
-          MAX_TOTAL_ATTACHMENT_SIZE / (1024 * 1024)
-        }MB total limit.`
-      );
-      setBanner({ type: 'error', message: 'Failed to send' });
+      const limitMessage = `Attachments exceed the ${
+        MAX_TOTAL_ATTACHMENT_SIZE / (1024 * 1024)
+      }MB total limit.`;
+      setError(limitMessage);
+      setErrorSummaryItems([
+        {
+          fieldId: 'contact-attachments',
+          label: 'Attachments',
+          message: limitMessage,
+        },
+      ]);
+      setBanner({
+        type: 'error',
+        message: 'Fix the highlighted fields',
+        focusKey: Date.now(),
+      });
       setSubmitting(false);
       return;
     }
@@ -224,7 +272,11 @@ const ContactApp: React.FC = () => {
     if (shouldFallback) {
       setFallback(true);
       setError('Email service unavailable. Use the options above.');
-      setBanner({ type: 'error', message: 'Failed to send' });
+      setBanner({
+        type: 'error',
+        message: 'Email service unavailable. Use the options above.',
+        focusKey: Date.now(),
+      });
       setSubmitting(false);
       return;
     }
@@ -248,7 +300,11 @@ const ContactApp: React.FC = () => {
     } else {
       const msg = result.error || 'Submission failed';
       setError(msg);
-      setBanner({ type: 'error', message: msg });
+      setBanner({
+        type: 'error',
+        message: msg,
+        focusKey: Date.now(),
+      });
       if (
         result.code === 'server_not_configured' ||
         result.error?.toLowerCase().includes('captcha') ||
@@ -260,17 +316,26 @@ const ContactApp: React.FC = () => {
     setSubmitting(false);
   };
 
+  const summaryDescription = errorSummaryItems.length
+    ? 'Select an error below to jump to the field.'
+    : undefined;
+
   return (
     <div className="min-h-screen bg-gray-900 text-white p-6">
       <h1 className="mb-6 text-2xl">Contact</h1>
-      {banner && (
-        <div
-          className={`mb-6 rounded p-3 text-sm ${
-            banner.type === 'success' ? 'bg-green-600' : 'bg-red-600'
-          }`}
-        >
+      {banner?.type === 'success' && (
+        <div className="mb-6 rounded bg-green-600 p-3 text-sm">
           {banner.message}
         </div>
+      )}
+      {banner?.type === 'error' && (
+        <FormErrorSummary
+          ref={bannerRef}
+          className="mb-6"
+          title={banner.message}
+          description={summaryDescription}
+          errors={errorSummaryItems}
+        />
       )}
       {fallback && (
         <p className="mb-6 text-sm">
@@ -298,7 +363,11 @@ const ContactApp: React.FC = () => {
           </button>
         </p>
       )}
-      <form onSubmit={handleSubmit} className="space-y-6 max-w-md">
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-6 max-w-md"
+        noValidate
+      >
         <div className="relative">
           <input
             id="contact-name"

--- a/components/ui/FormErrorSummary.tsx
+++ b/components/ui/FormErrorSummary.tsx
@@ -1,0 +1,71 @@
+import React, { forwardRef, useCallback } from 'react';
+
+export interface FormErrorSummaryItem {
+  fieldId: string;
+  label: string;
+  message: string;
+}
+
+interface FormErrorSummaryProps {
+  title?: string;
+  description?: string;
+  errors: FormErrorSummaryItem[];
+  className?: string;
+}
+
+const FormErrorSummary = forwardRef<HTMLDivElement, FormErrorSummaryProps>(
+  ({ title = 'There is a problem', description, errors, className = '' }, ref) => {
+    const handleNavigate = useCallback((event: React.MouseEvent<HTMLAnchorElement>, fieldId: string) => {
+      event.preventDefault();
+      const target = document.getElementById(fieldId);
+      if (!target) return;
+      if ('focus' in target && typeof (target as HTMLElement).focus === 'function') {
+        const element = target as HTMLElement;
+        try {
+          element.focus({ preventScroll: true });
+        } catch {
+          element.focus();
+        }
+      }
+      if ('scrollIntoView' in target && typeof target.scrollIntoView === 'function') {
+        try {
+          target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        } catch {
+          target.scrollIntoView();
+        }
+      }
+    }, []);
+
+    return (
+      <div
+        ref={ref}
+        role="alert"
+        aria-live="assertive"
+        tabIndex={-1}
+        className={`rounded border-l-4 border-red-400 bg-red-900/60 p-4 text-sm text-red-100 shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-200 ${className}`.trim()}
+      >
+        <p className="font-semibold">{title}</p>
+        {description && <p className="mt-1 text-red-100/90">{description}</p>}
+        {errors.length > 0 && (
+          <ul className="mt-3 space-y-1 list-disc pl-5">
+            {errors.map(({ fieldId, label, message }) => (
+              <li key={fieldId}>
+                <a
+                  href={`#${fieldId}`}
+                  onClick={(event) => handleNavigate(event, fieldId)}
+                  className="underline decoration-red-200 decoration-dotted underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-200"
+                >
+                  <span className="font-semibold">{label}:</span> {message}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  }
+);
+
+FormErrorSummary.displayName = 'FormErrorSummary';
+
+export default FormErrorSummary;


### PR DESCRIPTION
## Summary
- add a reusable `FormErrorSummary` component that lists validation errors and deep links to fields
- wire the contact app to use the summary, drive focus to the banner on failure, and disable native validation so we control keyboard order
- cover the new focus behavior and anchor navigation with unit tests

## Testing
- yarn test contact.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da51af7cd48328bb7ff8f636c45548