### PR TITLE
[components] add clipboard toast to terminal output

### DIFF
--- a/__tests__/TerminalOutput.test.tsx
+++ b/__tests__/TerminalOutput.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import TerminalOutput from '../components/TerminalOutput';
+
+describe('TerminalOutput copy interactions', () => {
+  const originalClipboard = navigator.clipboard;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    if (originalClipboard) {
+      Object.assign(navigator, { clipboard: originalClipboard });
+    } else {
+      delete (navigator as Partial<Navigator>).clipboard;
+    }
+    jest.clearAllMocks();
+  });
+
+  it('copies full output and shows success toast', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+
+    render(<TerminalOutput text={'echo hello'} />);
+
+    const copyButton = screen.getByRole('button', { name: /copy output/i });
+    fireEvent.click(copyButton);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('echo hello'));
+    expect(
+      await screen.findByText('Copied to clipboard'),
+    ).toBeInTheDocument();
+  });
+
+  it('announces unsupported clipboard API', () => {
+    delete (navigator as Partial<Navigator>).clipboard;
+
+    render(<TerminalOutput text={'ping 1.1.1.1'} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /copy output/i }));
+
+    expect(
+      screen.getByText('Clipboard copy is unavailable in this browser.'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows error toast when copy fails', async () => {
+    const writeText = jest.fn().mockRejectedValue(new Error('nope'));
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+
+    render(<TerminalOutput text={'nmap localhost'} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /copy output/i }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    expect(
+      await screen.findByText('Unable to copy to clipboard.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/components/CommandBuilder.tsx
+++ b/components/CommandBuilder.tsx
@@ -36,7 +36,12 @@ export default function CommandBuilder({ doc, build }: BuilderProps) {
         />
       </label>
       <div className="mt-2">
-        <TerminalOutput text={command} ariaLabel="command output" />
+        <TerminalOutput
+          text={command}
+          ariaLabel="command output"
+          copyButtonLabel="Copy command"
+          successMessage="Command copied to clipboard"
+        />
       </div>
     </form>
   );

--- a/components/TerminalOutput.tsx
+++ b/components/TerminalOutput.tsx
@@ -1,36 +1,68 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
+import Toast from './ui/Toast';
 
 interface TerminalOutputProps {
   text: string;
   ariaLabel?: string;
+  copyButtonLabel?: string;
+  successMessage?: string;
+  errorMessage?: string;
+  unsupportedMessage?: string;
 }
 
-export default function TerminalOutput({ text, ariaLabel }: TerminalOutputProps) {
-  const lines = text.split('\n');
-  const copyLine = async (line: string) => {
-    try {
-      await navigator.clipboard.writeText(line);
-    } catch {
-      // ignore
+const DEFAULT_COPY_LABEL = 'Copy output';
+const DEFAULT_SUCCESS_MESSAGE = 'Copied to clipboard';
+const DEFAULT_ERROR_MESSAGE = 'Unable to copy to clipboard.';
+const DEFAULT_UNSUPPORTED_MESSAGE =
+  'Clipboard copy is unavailable in this browser.';
+
+export default function TerminalOutput({
+  text,
+  ariaLabel,
+  copyButtonLabel = DEFAULT_COPY_LABEL,
+  successMessage = DEFAULT_SUCCESS_MESSAGE,
+  errorMessage = DEFAULT_ERROR_MESSAGE,
+  unsupportedMessage = DEFAULT_UNSUPPORTED_MESSAGE,
+}: TerminalOutputProps) {
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+
+  const normalizedText = useMemo(() => text?.trimEnd() ?? '', [text]);
+
+  const closeToast = useCallback(() => setToastMessage(null), []);
+
+  const handleCopy = useCallback(async () => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      setToastMessage(unsupportedMessage);
+      return;
     }
-  };
+
+    try {
+      await navigator.clipboard.writeText(normalizedText);
+      setToastMessage(successMessage);
+    } catch {
+      setToastMessage(errorMessage);
+    }
+  }, [errorMessage, normalizedText, successMessage, unsupportedMessage]);
+
   return (
-    <div
-      className="bg-black text-green-400 font-mono text-xs p-2 rounded"
-      aria-label={ariaLabel}
-    >
-      {lines.map((line, idx) => (
-        <div key={idx} className="flex items-start">
-          <span className="flex-1 whitespace-pre-wrap">{line}</span>
-          <button
-            className="ml-2 text-gray-400 hover:text-white"
-            onClick={() => copyLine(line)}
-            aria-label="copy line"
-          >
-            📋
-          </button>
-        </div>
-      ))}
+    <div className="relative" aria-live="polite">
+      <div
+        className="bg-black text-green-400 font-mono text-xs p-2 rounded"
+        aria-label={ariaLabel}
+      >
+        <pre className="whitespace-pre-wrap break-words m-0">{normalizedText}</pre>
+      </div>
+      <button
+        type="button"
+        className="absolute top-2 right-2 rounded bg-ub-grey px-2 py-1 text-[11px] uppercase tracking-wide text-white hover:bg-ubt-grey focus:outline-none focus:ring-2 focus:ring-yellow-400"
+        onClick={handleCopy}
+        aria-label={copyButtonLabel}
+      >
+        {copyButtonLabel}
+      </button>
+      {toastMessage && (
+        <Toast message={toastMessage} onClose={closeToast} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a clipboard copy button with toast feedback to TerminalOutput and CommandBuilder
- show fallback messaging when the clipboard API is unavailable
- cover copy success and failure flows with new TerminalOutput unit tests

## Testing
- [x] yarn test TerminalOutput


------
https://chatgpt.com/codex/tasks/task_e_68da51b0f2ec8328a9b6a9416d89724d