### PR TITLE
[tooling] add copy deck lint checks

### DIFF
--- a/data/copy/deck.json
+++ b/data/copy/deck.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "desktop-hero",
+    "tagline": "Spin up a Kali desktop in your browser.",
+    "secondary": "Launch simulated tools, games, and workflows—no installs or external targets required."
+  },
+  {
+    "id": "apps-grid",
+    "tagline": "Curated apps for red teaming practice.",
+    "secondary": "Mix offensive tooling demos with utilities and retro games to keep sessions approachable."
+  }
+]

--- a/docs/copy-deck.md
+++ b/docs/copy-deck.md
@@ -1,0 +1,42 @@
+# Copy deck guidelines
+
+The desktop launcher and marketing surfaces read short bits of copy from JSON
+files stored in `data/copy/`. Each file exports an array of entries with the
+following shape:
+
+```json
+{
+  "id": "desktop-hero",
+  "tagline": "Spin up a Kali desktop in your browser.",
+  "secondary": "Launch simulated tools, games, and workflows—no installs or external targets required."
+}
+```
+
+## Authoring rules
+
+- **Location.** Add or edit entries in `data/copy/*.json`. Keep samples that
+  mirror production content under `public/fixtures/` for designers and
+  copywriters.
+- **Identifier.** `id` must be a unique, kebab-case string. Reuse the same id if
+  a piece of copy powers multiple surfaces.
+- **Tagline length.** The `tagline` string should be concise—no more than
+  60 characters once trimmed. Aim for one sentence fragment without a period.
+- **Secondary line length.** The `secondary` string provides a fuller
+  explanation and is capped at 140 characters. Keep it to a single sentence.
+- **Whitespace.** Trailing or leading spaces are disallowed. The lint rule trims
+  entries before measuring the length and fails on stray whitespace.
+- **Encoding.** UTF-8 text is supported. Smart quotes and em dashes are fine as
+  long as the length constraints are respected.
+
+## Linting
+
+`yarn lint` now runs `scripts/lint-copy-deck.mjs`, which scans every
+`data/copy/*.json` file and rejects entries that violate the rules above. Run it
+locally after editing copy to spot issues early:
+
+```bash
+node scripts/lint-copy-deck.mjs
+```
+
+The script reports each offending field with the file name and entry id so you
+can adjust the text quickly.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,3 +22,5 @@ yarn dev
 See the [Architecture](./architecture.md) document for an overview of how the project is organized.
 
 For app contributions, see the [New App Checklist](./new-app-checklist.md).
+
+For marketing copy updates, review the [Copy Deck Guidelines](./copy-deck.md).

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "jest",
     "dedupe:check": "yarn dedupe --check",
     "test:watch": "jest --watch",
-    "lint": "node scripts/lint-changed.mjs",
+    "lint": "node scripts/lint-changed.mjs && node scripts/lint-copy-deck.mjs",
     "tsc": "tsc",
     "typecheck": "tsc --noEmit",
     "a11y": "node scripts/a11y.mjs",

--- a/public/fixtures/copy-deck.sample.json
+++ b/public/fixtures/copy-deck.sample.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "unique-id",
+    "tagline": "One-line hook under sixty characters.",
+    "secondary": "Supporting sentence that stays concise while highlighting the simulated experience."
+  }
+]

--- a/scripts/lint-copy-deck.mjs
+++ b/scripts/lint-copy-deck.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+const COPY_DIR = path.join(ROOT_DIR, 'data', 'copy');
+
+const LIMITS = {
+  tagline: { max: 60 },
+  secondary: { max: 140 },
+};
+
+const countCharacters = (value) => Array.from(value).length;
+
+const loadDeckFiles = async () => {
+  try {
+    const files = await fs.readdir(COPY_DIR, { withFileTypes: true });
+    return files
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+      .map((entry) => path.join(COPY_DIR, entry.name));
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+};
+
+const validateEntry = (entry, index, errors, seenIds, sourceName) => {
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+    errors.push(`${sourceName}: entry at index ${index} must be an object.`);
+    return;
+  }
+
+  const { id, tagline, secondary } = entry;
+  const context = id ? `entry "${id}"` : `entry at index ${index}`;
+
+  if (typeof id !== 'string' || id.trim() === '') {
+    errors.push(`${sourceName}: ${context} must include a non-empty string id.`);
+  } else if (seenIds.has(id)) {
+    errors.push(`${sourceName}: duplicate id "${id}".`);
+  } else {
+    seenIds.add(id);
+  }
+
+  for (const [field, limit] of Object.entries(LIMITS)) {
+    const value = entry[field];
+    if (typeof value !== 'string') {
+      errors.push(`${sourceName}: ${context} must include a string ${field}.`);
+      continue;
+    }
+
+    if (value !== value.trim()) {
+      errors.push(`${sourceName}: ${context} has leading or trailing whitespace in ${field}.`);
+    }
+
+    const length = countCharacters(value.trim());
+    if (length === 0) {
+      errors.push(`${sourceName}: ${context} must include a non-empty ${field}.`);
+    }
+    if (limit.max && length > limit.max) {
+      errors.push(
+        `${sourceName}: ${context} ${field} is ${length} characters (max ${limit.max}).`,
+      );
+    }
+  }
+};
+
+const run = async () => {
+  const deckFiles = await loadDeckFiles();
+  if (deckFiles.length === 0) {
+    console.log('No copy deck files found. Skipping copy deck lint.');
+    return;
+  }
+
+  const errors = [];
+
+  for (const filePath of deckFiles) {
+    const sourceName = path.relative(ROOT_DIR, filePath);
+    let raw;
+    try {
+      raw = await fs.readFile(filePath, 'utf8');
+    } catch (error) {
+      errors.push(`${sourceName}: unable to read file (${error.message}).`);
+      continue;
+    }
+
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch (error) {
+      errors.push(`${sourceName}: invalid JSON (${error.message}).`);
+      continue;
+    }
+
+    if (!Array.isArray(data)) {
+      errors.push(`${sourceName}: top-level JSON must be an array of entries.`);
+      continue;
+    }
+
+    const seenIds = new Set();
+    data.forEach((entry, index) => {
+      validateEntry(entry, index, errors, seenIds, sourceName);
+    });
+  }
+
+  if (errors.length > 0) {
+    console.error('Copy deck lint failed:\n');
+    errors.forEach((message) => {
+      console.error(` • ${message}`);
+    });
+    process.exit(1);
+  }
+
+  console.log(`Copy deck lint passed for ${deckFiles.length} file${deckFiles.length === 1 ? '' : 's'}.`);
+};
+
+run().catch((error) => {
+  console.error('Unexpected error while linting copy deck entries:');
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add copy deck JSON storage and a public fixture for marketing copy examples
- document contributor rules for taglines and secondary lines and link the guide from onboarding docs
- add a node-based lint that enforces length limits and wire it into the existing lint script

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da51b0751c832893a483da6a0bcb1d