### PR TITLE
[desktop] add contextual docs sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ play/pause and track controls include keyboard hotkeys.
 - **`components/apps/GameLayout.tsx`** - standardized layout and help toggle for games.
 - **`components/apps/radare2`** - dual hex/disassembly panes with seek/find/xref; graph mode from JSON fixtures; per-file notes and bookmarks.
 - **`components/common/PipPortal.tsx`** - renders arbitrary UI inside a Document Picture-in-Picture window. See [`docs/pip-portal.md`](./docs/pip-portal.md).
+- **`components/common/DocsSidecar.tsx`** - attaches contextual documentation to windows. Content is sourced from Markdown/JSON entries declared in [`docs/app-docs.json`](./docs/app-docs.json) and fetched via `/api/docs/[id]`.
 
 ---
 
@@ -477,7 +478,8 @@ play/pause and track controls include keyboard hotkeys.
    ```
 3. Add metadata (icon, title) where appropriate.
 4. If the app needs persistent state, use `usePersistentState(key, initial, validator)`.
-5. If the app embeds external sites, **whitelist** the domain in `next.config.js` CSP (`connect-src`, `frame-src`, `img-src`) and `images.domains`.
+5. (Optional) To surface inline docs, add an entry to [`docs/app-docs.json`](./docs/app-docs.json) that points to a Markdown or JSON file under `docs/`. The sidecar will render it when the app window is open.
+6. If the app embeds external sites, **whitelist** the domain in `next.config.js` CSP (`connect-src`, `frame-src`, `img-src`) and `images.domains`.
 
 ---
 

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -6,6 +6,7 @@ import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
 import useDocPiP from '../../hooks/useDocPiP';
+import DocsSidecar from '../common/DocsSidecar';
 import {
     clampWindowTopPosition,
     DEFAULT_WINDOW_TOP_OFFSET,
@@ -687,10 +688,15 @@ export class Window extends Component {
                         />
                         {(this.id === "settings"
                             ? <Settings />
-                            : <WindowMainScreen screen={this.props.screen} title={this.props.title}
+                            : <WindowMainScreen
+                                screen={this.props.screen}
+                                title={this.props.title}
                                 addFolder={this.props.id === "terminal" ? this.props.addFolder : null}
                                 openApp={this.props.openApp}
-                                context={this.props.context} />)}
+                                context={this.props.context}
+                                docs={this.props.docs}
+                                appId={this.id}
+                            />)}
                     </div>
                 </Draggable >
             </>
@@ -852,23 +858,33 @@ export function WindowEditButtons(props) {
 }
 
 // Window's Main Screen
-export class WindowMainScreen extends Component {
-    constructor() {
-        super();
-        this.state = {
-            setDarkBg: false,
-        }
-    }
-    componentDidMount() {
-        setTimeout(() => {
-            this.setState({ setDarkBg: true });
+export function WindowMainScreen(props) {
+    const [hasDarkBg, setHasDarkBg] = React.useState(false);
+
+    React.useEffect(() => {
+        const timer = setTimeout(() => {
+            setHasDarkBg(true);
         }, 3000);
-    }
-    render() {
+        return () => clearTimeout(timer);
+    }, []);
+
+    const containerClass = "w-full flex-grow z-20 max-h-full windowMainScreen" + (hasDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey");
+    const content = (
+        <div className="h-full w-full overflow-y-auto">
+            {props.screen(props.addFolder, props.openApp, props.context)}
+        </div>
+    );
+
+    if (props.docs) {
+        const appId = props.appId || props.id || 'window';
         return (
-            <div className={"w-full flex-grow z-20 max-h-full overflow-y-auto windowMainScreen" + (this.state.setDarkBg ? " bg-ub-drk-abrgn " : " bg-ub-cool-grey")}>
-                {this.props.screen(this.props.addFolder, this.props.openApp, this.props.context)}
+            <div className={containerClass}>
+                <DocsSidecar appId={appId} doc={props.docs}>
+                    {content}
+                </DocsSidecar>
             </div>
-        )
+        );
     }
+
+    return <div className={containerClass}>{content}</div>;
 }

--- a/components/common/DocsSidecar.tsx
+++ b/components/common/DocsSidecar.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import clsx from "clsx";
+import DOMPurify from "dompurify";
+import { marked } from "marked";
+
+import { trackEvent } from "@/lib/analytics-client";
+import usePersistentState from "@/hooks/usePersistentState";
+import type { AppDocConfig } from "@/types/app-docs";
+
+interface DocsSidecarProps {
+  appId: string;
+  doc: AppDocConfig;
+  children: ReactNode;
+}
+
+interface DocPayload {
+  id: string;
+  title: string;
+  summary?: string;
+  markdown: string;
+}
+
+type DocState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "ready"; title: string; summary?: string; html: string };
+
+const COMPACT_MEDIA_QUERY = "(max-width: 1023px)";
+
+function sanitizeMarkdown(markdown: string) {
+  const rendered = marked.parse(markdown) as string;
+  return DOMPurify.sanitize(rendered);
+}
+
+export default function DocsSidecar({ appId, doc, children }: DocsSidecarProps) {
+  const docId = doc.docId ?? appId;
+  const [persistedOpen, setPersistedOpen] = usePersistentState<boolean>(
+    `docs-sidecar:${docId}`,
+    () => doc.defaultOpen ?? false,
+    (value): value is boolean => typeof value === "boolean",
+  );
+  const [overlayOpen, setOverlayOpen] = useState(false);
+  const [isCompact, setIsCompact] = useState(false);
+  const [docState, setDocState] = useState<DocState>({ status: "idle" });
+  const hasTrackedView = useRef(false);
+
+  const isOpen = isCompact ? overlayOpen : persistedOpen;
+  const panelId = useMemo(() => `docs-sidecar-panel-${docId}`, [docId]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mediaQuery = window.matchMedia(COMPACT_MEDIA_QUERY);
+    const updateMatches = (matches: boolean) => {
+      setIsCompact(matches);
+    };
+
+    updateMatches(mediaQuery.matches);
+
+    const handler = (event: MediaQueryListEvent) => updateMatches(event.matches);
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handler);
+      return () => mediaQuery.removeEventListener("change", handler);
+    }
+
+    mediaQuery.addListener(handler);
+    return () => mediaQuery.removeListener(handler);
+  }, []);
+
+  useEffect(() => {
+    if (!isCompact) {
+      setOverlayOpen(false);
+    }
+  }, [isCompact]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (docState.status === "ready") return;
+
+    let isCancelled = false;
+    const controller = new AbortController();
+    setDocState((prev) => (prev.status === "loading" ? prev : { status: "loading" }));
+
+    fetch(`/api/docs/${encodeURIComponent(docId)}`, { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load docs: ${response.status}`);
+        }
+        return response.json() as Promise<DocPayload>;
+      })
+      .then((payload) => {
+        if (isCancelled) return;
+        const html = sanitizeMarkdown(payload.markdown);
+        setDocState({
+          status: "ready",
+          title: payload.title,
+          summary: payload.summary ?? doc.summary,
+          html,
+        });
+        if (!hasTrackedView.current) {
+          trackEvent("docs_sidecar_view", {
+            appId,
+            docId,
+          });
+          hasTrackedView.current = true;
+        }
+      })
+      .catch((error) => {
+        if (isCancelled || error.name === "AbortError") return;
+        console.error("DocsSidecar failed to load content", error);
+        setDocState({ status: "error" });
+      });
+
+    return () => {
+      isCancelled = true;
+      controller.abort();
+    };
+  }, [appId, doc.summary, docId, docState.status, isOpen]);
+
+  const toggle = useCallback(() => {
+    if (isCompact) {
+      setOverlayOpen((value) => !value);
+    } else {
+      setPersistedOpen((value) => !value);
+    }
+  }, [isCompact, setPersistedOpen]);
+
+  const closeOverlay = useCallback(() => {
+    setOverlayOpen(false);
+  }, []);
+
+  const retry = useCallback(() => {
+    setDocState({ status: "idle" });
+  }, []);
+
+  const headerTitle = docState.status === "ready" ? docState.title : doc.title;
+  const headerSummary = docState.status === "ready" ? docState.summary : doc.summary;
+
+  const panel = (
+    <aside
+      key={panelId}
+      id={panelId}
+      role="complementary"
+      aria-label={`${headerTitle} documentation`}
+      className="flex h-full w-full max-w-md flex-col border-l border-white/10 bg-slate-900/80 text-white backdrop-blur"
+    >
+      <header className="border-b border-white/10 px-4 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-xs font-semibold uppercase tracking-wide text-sky-200">Docs</p>
+            <h2 className="truncate text-base font-semibold leading-tight">{headerTitle}</h2>
+            {headerSummary ? (
+              <p className="mt-1 text-xs text-slate-200/80">{headerSummary}</p>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            onClick={toggle}
+            className="rounded border border-white/10 bg-white/5 px-2 py-1 text-xs font-medium text-white transition hover:bg-white/10 focus:outline-none focus-visible:ring"
+          >
+            Hide
+          </button>
+        </div>
+      </header>
+      <div className="docs-sidecar-content flex-1 overflow-y-auto px-4 py-4 text-sm leading-relaxed">
+        {docState.status === "loading" && (
+          <p className="text-slate-200/80">Loading documentation…</p>
+        )}
+        {docState.status === "error" && (
+          <div className="space-y-3">
+            <p className="text-red-200">Unable to load documentation right now.</p>
+            <button
+              type="button"
+              onClick={retry}
+              className="rounded border border-white/20 bg-white/10 px-3 py-1 text-xs font-semibold text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        {docState.status === "ready" && (
+          <div className="prose prose-invert max-w-none text-sm" dangerouslySetInnerHTML={{ __html: docState.html }} />
+        )}
+        {docState.status === "idle" && (
+          <p className="text-slate-200/80">Select “Show Docs” to load guidance for this app.</p>
+        )}
+      </div>
+    </aside>
+  );
+
+  return (
+    <div className="relative flex h-full min-h-0">
+      <div
+        className={clsx(
+          "relative flex min-h-0 flex-1 flex-col",
+          !isCompact && persistedOpen ? "md:pr-80 lg:pr-96" : "",
+        )}
+      >
+        <div className="pointer-events-none absolute right-3 top-3 z-30 flex gap-2">
+          <button
+            type="button"
+            onClick={toggle}
+            aria-expanded={isOpen}
+            aria-controls={panelId}
+            className="pointer-events-auto rounded border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white transition hover:bg-white/10 focus:outline-none focus-visible:ring"
+          >
+            {isOpen ? "Hide Docs" : "Show Docs"}
+          </button>
+        </div>
+        <div className="h-full w-full overflow-y-auto">{children}</div>
+      </div>
+      {!isCompact && persistedOpen ? (
+        <div className="hidden h-full flex-col md:flex">{panel}</div>
+      ) : null}
+      {isCompact && isOpen ? (
+        <div className="absolute inset-0 z-40 flex bg-black/60 backdrop-blur-sm">
+          <button
+            type="button"
+            className="flex-1"
+            aria-label="Close documentation overlay"
+            onClick={closeOverlay}
+          />
+          <div className="w-full max-w-md">{panel}</div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -8,6 +8,7 @@ const BackgroundImage = dynamic(
     { ssr: false }
 );
 import apps, { games } from '../../apps.config';
+import appDocs from '../../docs/app-docs.json';
 import Window from '../base/window';
 import UbuntuApp from '../base/ubuntu_app';
 import AllApplications from '../screen/all-applications'
@@ -1304,6 +1305,7 @@ export class Desktop extends Component {
             if (this.state.closed_windows[app.id] === false) {
 
                 const pos = this.state.window_positions[app.id];
+                const docConfig = appDocs?.[app.id];
                 const props = {
                     title: app.title,
                     id: app.id,
@@ -1325,6 +1327,7 @@ export class Desktop extends Component {
                     onPositionChange: (x, y) => this.updateWindowPosition(app.id, x, y),
                     snapEnabled: this.props.snapEnabled,
                     context: this.state.window_context[app.id],
+                    docs: docConfig,
                 }
 
                 windowsJsx.push(

--- a/docs/app-docs.json
+++ b/docs/app-docs.json
@@ -1,0 +1,23 @@
+{
+  "terminal": {
+    "title": "Terminal Quickstart",
+    "summary": "Keyboard shortcuts and demo scripts for the web terminal.",
+    "source": "docs/apps/terminal.md",
+    "defaultOpen": false
+  },
+  "hydra": {
+    "title": "Hydra Simulation Playbook",
+    "summary": "Step-by-step guidance for the credential spraying demo.",
+    "source": "docs/apps/hydra.json"
+  },
+  "nmap-nse": {
+    "title": "Nmap NSE Walkthrough",
+    "summary": "Highlights the simulated workflow for NSE scripts.",
+    "source": "docs/nmap-nse-walkthrough.md"
+  },
+  "reconng": {
+    "title": "Recon-ng Workflow",
+    "summary": "Key modules and signals to explore in the Recon-ng sandbox.",
+    "source": "docs/reconng.md"
+  }
+}

--- a/docs/apps/hydra.json
+++ b/docs/apps/hydra.json
@@ -1,0 +1,29 @@
+{
+  "title": "Hydra Simulation Playbook",
+  "intro": "Learn how to demonstrate credential spraying safely inside the Hydra simulation.",
+  "sections": [
+    {
+      "heading": "Prerequisites",
+      "body": [
+        "Launch the Hydra app from the desktop or taskbar.",
+        "Select the demo target provided in the left rail."
+      ]
+    },
+    {
+      "heading": "Workflow",
+      "steps": [
+        "Choose an attack profile such as **Spray** or **Brute**.",
+        "Press **Run Simulation** to replay the canned credential attempts.",
+        "Watch the activity feed for lockout thresholds and policy reminders."
+      ]
+    },
+    {
+      "heading": "Tips",
+      "body": [
+        "Enable **Verbose Mode** to show each generated request.",
+        "Use **Reset Demo** between walkthroughs to restore the fake service state.",
+        "Share the generated report from the **Export** dropdown once the run completes."
+      ]
+    }
+  ]
+}

--- a/docs/apps/terminal.md
+++ b/docs/apps/terminal.md
@@ -1,0 +1,22 @@
+# Terminal Quickstart
+
+Launch the simulated Kali terminal and explore the curated command history for demos. The panel mirrors a familiar Bash prompt while keeping the experience read-only and safe.
+
+## Launch checklist
+- Open the **Terminal** app from the dock or desktop shortcut.
+- Select a saved scenario from the left rail to pre-fill commands.
+- Use the `Reset Session` control to clear the buffer between demos.
+
+## Keyboard helpers
+- <kbd>Ctrl</kbd> + <kbd>L</kbd> clears the viewport.
+- <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd> copies highlighted output.
+- <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>V</kbd> pastes clipboard text into the input.
+
+## Demo scripts
+Each scenario injects the exact commands used in the walkthroughs contained in this portfolio. Scroll the console to review progress markers and captured output.
+
+1. **Recon Sweep** &mdash; enumerates mock hosts with `nmap` presets.
+2. **Credential Audit** &mdash; runs the fake Hydra spray with structured logs.
+3. **Post Exploitation** &mdash; displays sanitized Metasploit module output.
+
+> **Note:** All commands execute against synthetic data. No network traffic or destructive actions are triggered.

--- a/lib/analytics-client.ts
+++ b/lib/analytics-client.ts
@@ -4,7 +4,8 @@ export type EventName =
   | 'contact_submit'
   | 'contact_submit_error'
   | 'outbound_link_click'
-  | 'download_click';
+  | 'download_click'
+  | 'docs_sidecar_view';
 
 export function trackEvent(
   name: EventName,
@@ -12,7 +13,6 @@ export function trackEvent(
 ) {
   try {
     // Dynamically require to avoid ESM issues in test environment
-    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
     const { track } = require('@vercel/analytics');
     track(name, props);
   } catch {

--- a/pages/api/docs/[id].ts
+++ b/pages/api/docs/[id].ts
@@ -1,0 +1,151 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { AppDocConfig } from '@/types/app-docs';
+
+interface DocResponseBody {
+  id: string;
+  title: string;
+  summary?: string;
+  markdown: string;
+}
+
+type DocsIndex = Record<string, AppDocConfig>;
+
+let docsIndexCache: DocsIndex | null = null;
+
+const DOCS_ROOT = path.join(process.cwd(), 'docs');
+const INDEX_PATH = path.join(DOCS_ROOT, 'app-docs.json');
+
+async function loadDocsIndex(): Promise<DocsIndex> {
+  if (docsIndexCache) {
+    return docsIndexCache;
+  }
+  const raw = await fs.readFile(INDEX_PATH, 'utf8');
+  const parsed = JSON.parse(raw) as DocsIndex;
+  docsIndexCache = parsed;
+  return parsed;
+}
+
+function resolveDocPath(source: string) {
+  const resolved = path.resolve(process.cwd(), source);
+  if (!resolved.startsWith(DOCS_ROOT)) {
+    throw new Error('Invalid documentation source path');
+  }
+  return resolved;
+}
+
+function toBulletList(items: unknown[]): string | null {
+  const valid = items
+    .map((item) => (typeof item === 'string' ? item.trim() : ''))
+    .filter(Boolean);
+  if (!valid.length) return null;
+  return valid.map((item) => `- ${item}`).join('\n');
+}
+
+function toOrderedList(items: unknown[]): string | null {
+  const valid = items
+    .map((item, index) => (typeof item === 'string' ? `${index + 1}. ${item.trim()}` : ''))
+    .filter(Boolean);
+  if (!valid.length) return null;
+  return valid.join('\n');
+}
+
+function convertJsonDoc(value: unknown): { markdown: string; title?: string } {
+  if (!value || typeof value !== 'object') {
+    const fallback = JSON.stringify(value, null, 2);
+    return { markdown: `\`\`\`json\n${fallback}\n\`\`\`` };
+  }
+
+  const doc = value as Record<string, unknown>;
+  const parts: string[] = [];
+  const intro = typeof doc.intro === 'string' ? doc.intro.trim() : '';
+  if (intro) {
+    parts.push(intro);
+  }
+
+  const sections = Array.isArray(doc.sections) ? doc.sections : [];
+  sections.forEach((section) => {
+    if (!section || typeof section !== 'object') return;
+    const sectionData = section as Record<string, unknown>;
+    const heading = typeof sectionData.heading === 'string' ? sectionData.heading.trim() : '';
+    if (heading) {
+      parts.push(`## ${heading}`);
+    }
+
+    const body = sectionData.body;
+    if (typeof body === 'string') {
+      const text = body.trim();
+      if (text) parts.push(text);
+    } else if (Array.isArray(body)) {
+      const bullets = toBulletList(body);
+      if (bullets) parts.push(bullets);
+    }
+
+    const steps = sectionData.steps;
+    if (Array.isArray(steps)) {
+      const ordered = toOrderedList(steps);
+      if (ordered) parts.push(ordered);
+    }
+  });
+
+  if (!parts.length) {
+    const fallback = JSON.stringify(value, null, 2);
+    return { markdown: `\`\`\`json\n${fallback}\n\`\`\`` };
+  }
+
+  const title = typeof doc.title === 'string' ? doc.title : undefined;
+  return { markdown: parts.join('\n\n'), title };
+}
+
+async function loadMarkdownForDoc(config: AppDocConfig): Promise<{ markdown: string; title?: string }> {
+  const docPath = resolveDocPath(config.source);
+  const raw = await fs.readFile(docPath, 'utf8');
+
+  if (config.source.endsWith('.json')) {
+    const parsed = JSON.parse(raw);
+    return convertJsonDoc(parsed);
+  }
+
+  return { markdown: raw };
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<DocResponseBody | { error: string }>,
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  const { id } = req.query;
+  if (typeof id !== 'string') {
+    res.status(400).json({ error: 'Missing documentation id' });
+    return;
+  }
+
+  try {
+    const docsIndex = await loadDocsIndex();
+    const docConfig = docsIndex[id];
+
+    if (!docConfig) {
+      res.status(404).json({ error: 'Documentation not found' });
+      return;
+    }
+
+    const { markdown, title: derivedTitle } = await loadMarkdownForDoc(docConfig);
+    const response: DocResponseBody = {
+      id,
+      markdown,
+      title: docConfig.title || derivedTitle || 'Documentation',
+      summary: docConfig.summary,
+    };
+
+    res.status(200).json(response);
+  } catch (error) {
+    console.error('Failed to load documentation', error);
+    res.status(500).json({ error: 'Failed to load documentation' });
+  }
+}

--- a/types/app-docs.ts
+++ b/types/app-docs.ts
@@ -1,0 +1,22 @@
+export interface AppDocConfig {
+  /**
+   * Title displayed in the documentation sidecar header.
+   */
+  title: string;
+  /**
+   * Optional teaser copy that appears under the title.
+   */
+  summary?: string;
+  /**
+   * Relative path (from the repository root) to the source file inside `docs/`.
+   */
+  source: string;
+  /**
+   * Identifier used by the API route. Defaults to the app id when omitted.
+   */
+  docId?: string;
+  /**
+   * Whether the panel should start open on wide layouts for first-time visitors.
+   */
+  defaultOpen?: boolean;
+}


### PR DESCRIPTION
## Summary
- add a DocsSidecar component that attaches contextual documentation to app windows with responsive drawer behavior and analytics
- serve Markdown/JSON files under docs/ through a new /api/docs/[id] endpoint with JSON-to-Markdown conversion
- seed initial terminal and hydra guides and update contributor docs on wiring inline help

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da51aff6448328b5d971119d325386