### PR TITLE
[search] offload menu filtering to worker

### DIFF
--- a/__tests__/whiskerMenu.search.test.tsx
+++ b/__tests__/whiskerMenu.search.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import WhiskerMenu from '../components/menu/WhiskerMenu';
+
+const OriginalWorker = (global as any).Worker;
+
+const globalScope = globalThis as { requestAnimationFrame?: typeof requestAnimationFrame };
+
+if (typeof globalScope.requestAnimationFrame !== 'function') {
+  globalScope.requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(cb, 0);
+}
+
+describe('WhiskerMenu worker-powered search', () => {
+  afterEach(() => {
+    (global as any).Worker = OriginalWorker;
+  });
+
+  it('filters applications via the search worker and reports metrics', async () => {
+    class WorkerMock {
+      public onmessage: ((event: MessageEvent) => void) | null = null;
+
+      public onerror: ((event: ErrorEvent) => void) | null = null;
+
+      private apps = new Map<string, any>();
+
+      constructor() {
+        // no-op
+      }
+
+      postMessage = jest.fn((message: any) => {
+        if (message.type === 'initialize') {
+          this.apps = new Map(message.payload.apps.map((app: any) => [app.id, app]));
+          setTimeout(() => {
+            this.onmessage?.({ data: { type: 'ready' } } as MessageEvent);
+          }, 0);
+        }
+        if (message.type === 'search') {
+          const { query, appIds, requestId } = message.payload;
+          setTimeout(() => {
+            const normalized = String(query).toLowerCase();
+            const apps = (appIds ?? Array.from(this.apps.keys()))
+              .map((id: string) => this.apps.get(id))
+              .filter((app: any) => app && app.title.toLowerCase().includes(normalized));
+            this.onmessage?.({
+              data: {
+                type: 'result',
+                payload: {
+                  requestId,
+                  duration: 0.8,
+                  apps,
+                },
+              },
+            } as MessageEvent);
+          }, 20);
+        }
+      });
+
+      terminate = jest.fn();
+    }
+
+    (global as any).Worker = WorkerMock as any;
+
+    render(<WhiskerMenu />);
+
+    fireEvent.click(screen.getByRole('button', { name: /applications/i }));
+    const input = await screen.findByPlaceholderText(/search applications/i);
+    const resultsContainer = await screen.findByTestId('search-results');
+    fireEvent.change(input, { target: { value: 'calc' } });
+
+    expect(await screen.findByText(/Searching/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Searching/i)).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/No applications match/i)).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(Number(resultsContainer.getAttribute('data-search-duration'))).toBeGreaterThan(0);
+    });
+  });
+
+  it('falls back gracefully when the worker errors', async () => {
+    class ErrorWorkerMock {
+      public onmessage: ((event: MessageEvent) => void) | null = null;
+
+      public onerror: ((event: ErrorEvent) => void) | null = null;
+
+      postMessage = jest.fn((message: any) => {
+        if (message.type === 'search') {
+          setTimeout(() => {
+            this.onerror?.({ message: 'boom' } as ErrorEvent);
+          }, 0);
+        }
+      });
+
+      terminate = jest.fn();
+    }
+
+    (global as any).Worker = ErrorWorkerMock as any;
+
+    render(<WhiskerMenu />);
+
+    fireEvent.click(screen.getByRole('button', { name: /applications/i }));
+    const input = await screen.findByPlaceholderText(/search applications/i);
+    fireEvent.change(input, { target: { value: 'calc' } });
+
+    const calculatorButtons = await screen.findAllByRole('button', { name: /Calculator/i });
+    expect(calculatorButtons.length).toBeGreaterThan(0);
+
+    expect(screen.getByText(/Search worker error/i)).toBeInTheDocument();
+  });
+
+  it('terminates the worker when the menu closes', async () => {
+    const terminateSpy = jest.fn();
+    const createdWorkers: any[] = [];
+
+    class LifecycleWorkerMock {
+      public onmessage: ((event: MessageEvent) => void) | null = null;
+
+      public onerror: ((event: ErrorEvent) => void) | null = null;
+
+      public postMessage = jest.fn((message: any) => {
+        if (message.type === 'initialize') {
+          setTimeout(() => {
+            this.onmessage?.({ data: { type: 'ready' } } as MessageEvent);
+          }, 0);
+        }
+      });
+
+      public terminate = terminateSpy;
+
+      constructor() {
+        createdWorkers.push(this);
+      }
+    }
+
+    (global as any).Worker = LifecycleWorkerMock as any;
+
+    render(<WhiskerMenu />);
+
+    fireEvent.click(screen.getByRole('button', { name: /applications/i }));
+    const input = await screen.findByPlaceholderText(/search applications/i);
+    fireEvent.change(input, { target: { value: 'calc' } });
+
+    await waitFor(() => {
+      expect(createdWorkers.length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(createdWorkers[0].postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'search' }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /applications/i }));
+
+    await waitFor(() => {
+      expect(terminateSpy).toHaveBeenCalled();
+    }, { timeout: 500 });
+  });
+});

--- a/workers/searchIndexer.ts
+++ b/workers/searchIndexer.ts
@@ -1,0 +1,150 @@
+export type SearchWorkerInitializeMessage = {
+  type: 'initialize';
+  payload: {
+    apps: WorkerAppMeta[];
+  };
+};
+
+export type SearchWorkerSearchMessage = {
+  type: 'search';
+  payload: {
+    query: string;
+    appIds?: string[];
+    requestId: number;
+  };
+};
+
+export type SearchWorkerShutdownMessage = {
+  type: 'shutdown';
+};
+
+export type WorkerAppMeta = {
+  id: string;
+  title: string;
+  icon: string;
+  disabled?: boolean;
+  favourite?: boolean;
+};
+
+type SearchWorkerRequest =
+  | SearchWorkerInitializeMessage
+  | SearchWorkerSearchMessage
+  | SearchWorkerShutdownMessage;
+
+type SearchWorkerResultMessage = {
+  type: 'result';
+  payload: {
+    requestId: number;
+    duration: number;
+    apps: WorkerAppMeta[];
+  };
+};
+
+type SearchWorkerReadyMessage = {
+  type: 'ready';
+};
+
+type SearchWorkerErrorMessage = {
+  type: 'error';
+  payload: {
+    message: string;
+    requestId?: number;
+  };
+};
+
+type SearchWorkerResponse =
+  | SearchWorkerResultMessage
+  | SearchWorkerReadyMessage
+  | SearchWorkerErrorMessage;
+
+type IndexedApp = WorkerAppMeta & {
+  normalizedTitle: string;
+};
+
+const toNormalized = (value: string) => value.normalize('NFKD').toLowerCase();
+
+let index = new Map<string, IndexedApp>();
+
+const postResponse = (response: SearchWorkerResponse) => {
+  (self as unknown as DedicatedWorkerGlobalScope).postMessage(response);
+};
+
+const handleInitialize = (apps: WorkerAppMeta[]) => {
+  index = new Map(
+    apps.map(app => [app.id, { ...app, normalizedTitle: toNormalized(app.title) }]),
+  );
+  postResponse({ type: 'ready' });
+};
+
+const handleSearch = (query: string, appIds: string[] | undefined, requestId: number) => {
+  if (!index || index.size === 0) {
+    postResponse({
+      type: 'error',
+      payload: {
+        requestId,
+        message: 'Search index is not ready.',
+      },
+    });
+    return;
+  }
+
+  const normalizedQuery = toNormalized(query.trim());
+  const sourceApps = (appIds && appIds.length > 0
+    ? appIds.map(id => index.get(id)).filter((app): app is IndexedApp => Boolean(app))
+    : Array.from(index.values()));
+
+  const start = performance.now();
+  const matched =
+    normalizedQuery.length === 0
+      ? sourceApps
+      : sourceApps.filter(app => app.normalizedTitle.includes(normalizedQuery));
+  const duration = performance.now() - start;
+
+  postResponse({
+    type: 'result',
+    payload: {
+      requestId,
+      duration,
+      apps: matched.map(({ normalizedTitle, ...meta }) => meta),
+    },
+  });
+};
+
+const handleShutdown = () => {
+  index.clear();
+};
+
+self.onmessage = (event: MessageEvent<SearchWorkerRequest>) => {
+  const message = event.data;
+  if (!message) return;
+
+  try {
+    switch (message.type) {
+      case 'initialize':
+        handleInitialize(message.payload.apps);
+        break;
+      case 'search':
+        handleSearch(message.payload.query, message.payload.appIds, message.payload.requestId);
+        break;
+      case 'shutdown':
+        handleShutdown();
+        break;
+      default: {
+        const exhaustiveCheck: never = message;
+        throw new Error(`Unknown message type: ${(exhaustiveCheck as any)?.type ?? 'unknown'}`);
+      }
+    }
+  } catch (error) {
+    const messageText =
+      error instanceof Error ? error.message : 'An unexpected error occurred in the search worker.';
+    postResponse({
+      type: 'error',
+      payload: {
+        message: messageText,
+        requestId: message.type === 'search' ? message.payload.requestId : undefined,
+      },
+    });
+  }
+};
+
+export {}; // ensure module scope


### PR DESCRIPTION
## Summary
- add a dedicated `searchIndexer` worker that indexes app metadata and filters results off the main thread
- refactor the Whisker menu search UI to communicate with the worker, surface loading/error states, and record timings
- add Jest coverage that exercises worker success, error fallback, and lifecycle termination with a `requestAnimationFrame` polyfill

## Testing
- yarn lint
- yarn test __tests__/whiskerMenu.search.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da51b378848328a3237841b1125a39