### PR TITLE
[perf] prioritize hero media loading

### DIFF
--- a/apps/beef/components/PayloadBuilder.tsx
+++ b/apps/beef/components/PayloadBuilder.tsx
@@ -68,6 +68,7 @@ export default function PayloadBuilder() {
         readOnly
         rows={6}
         className="w-full text-black p-1 rounded"
+        aria-label="Generated payload HTML"
       />
       <div className="border h-48">
         <iframe
@@ -75,6 +76,8 @@ export default function PayloadBuilder() {
           sandbox="allow-scripts"
           srcDoc={page}
           className="w-full h-full border-0"
+          loading="lazy"
+          importance="low"
         />
       </div>
       <p className="text-xs">

--- a/apps/spotify/components/MoodTuner.tsx
+++ b/apps/spotify/components/MoodTuner.tsx
@@ -83,13 +83,19 @@ const MoodTuner = () => {
   return (
     <div className="h-full w-full bg-[var(--color-bg)] text-[var(--color-text)] flex flex-col">
       <div className="p-2 flex items-center gap-2 bg-black bg-opacity-30">
+        <label htmlFor="mood-slider" className="sr-only">
+          Select playlist mood
+        </label>
         <input
+          id="mood-slider"
           type="range"
           min={0}
           max={Math.max(0, moods.length - 1)}
           value={index >= 0 ? index : 0}
           onChange={(e) => setMood(moods[Number(e.target.value)])}
           className="flex-1"
+          aria-label="Select playlist mood"
+          aria-valuetext={mood || 'No mood selected'}
         />
         <span className="capitalize min-w-[4rem] text-center">{mood}</span>
       </div>
@@ -104,6 +110,8 @@ const MoodTuner = () => {
             frameBorder="0"
             allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
             loading="lazy"
+            importance="low"
+            referrerPolicy="no-referrer"
           />
           <div className="flex justify-center space-x-4 p-2 bg-black bg-opacity-30">
             <button

--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -39,7 +39,7 @@ export default function ExternalFrame({ src, title, prefetch = false, onLoad: on
     <>
       {prefetch && (
         <Head>
-          <link rel="prefetch" href={src} />
+          <link rel="prefetch" href={src} as="document" importance="low" />
         </Head>
       )}
       <div className="h-full w-full flex flex-col">
@@ -66,6 +66,8 @@ export default function ExternalFrame({ src, title, prefetch = false, onLoad: on
             sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; geolocation; gyroscope; picture-in-picture; microphone; camera"
             referrerPolicy="no-referrer"
+            loading="lazy"
+            importance="low"
             onLoad={(e) => {
               setLoaded(true);
               onLoadProp?.(e);

--- a/components/apps/beef/index.js
+++ b/components/apps/beef/index.js
@@ -20,6 +20,8 @@ export default function Beef() {
           className="w-full h-48 border"
           sandbox=""
           srcDoc={targetPage}
+          loading="lazy"
+          importance="low"
         />
       ),
       action: 'Next',

--- a/components/apps/firefox/index.tsx
+++ b/components/apps/firefox/index.tsx
@@ -95,13 +95,14 @@ const Firefox: React.FC = () => {
         <label htmlFor="firefox-address" className="sr-only">
           Address
         </label>
-        <input
-          id="firefox-address"
-          value={inputValue}
-          onChange={(event) => setInputValue(event.target.value)}
-          placeholder="Enter a URL"
-          className="flex-1 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-400 focus:border-blue-500 focus:outline-none"
-        />
+          <input
+            id="firefox-address"
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value)}
+            placeholder="Enter a URL"
+            className="flex-1 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-400 focus:border-blue-500 focus:outline-none"
+            aria-label="Address bar"
+          />
         <button
           type="submit"
           className="rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
@@ -132,6 +133,9 @@ const Firefox: React.FC = () => {
             className="h-full w-full border-0"
             sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            referrerPolicy="no-referrer"
+            loading="lazy"
+            importance="low"
           />
         )}
       </div>

--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -179,6 +179,7 @@ const NiktoApp = () => {
             className="w-full p-2 rounded text-black"
             value={host}
             onChange={(e) => setHost(e.target.value)}
+            aria-label="Target host"
           />
         </div>
         <div>
@@ -191,6 +192,7 @@ const NiktoApp = () => {
             className="w-full p-2 rounded text-black"
             value={port}
             onChange={(e) => setPort(e.target.value)}
+            aria-label="Target port"
           />
         </div>
         <div className="flex items-center mt-2">
@@ -200,6 +202,7 @@ const NiktoApp = () => {
             className="mr-2"
             checked={ssl}
             onChange={(e) => setSsl(e.target.checked)}
+            aria-label="Use SSL"
           />
           <label htmlFor="nikto-ssl" className="text-sm">
             SSL
@@ -289,6 +292,8 @@ const NiktoApp = () => {
           title="Nikto HTML Report"
           srcDoc={htmlReport}
           className="w-full h-64 bg-white"
+          loading="lazy"
+          importance="low"
         />
       </div>
       <div>
@@ -305,18 +310,20 @@ const NiktoApp = () => {
         {entries.length > 0 && (
           <div>
             <div className="flex space-x-2 mb-2">
-              <input
-                placeholder="Filter host"
-                value={filterHost}
-                onChange={(e) => setFilterHost(e.target.value)}
-                className="p-1 rounded text-black flex-1"
-              />
-              <input
-                placeholder="Filter path"
-                value={filterPath}
-                onChange={(e) => setFilterPath(e.target.value)}
-                className="p-1 rounded text-black flex-1"
-              />
+            <input
+              placeholder="Filter host"
+              value={filterHost}
+              onChange={(e) => setFilterHost(e.target.value)}
+              className="p-1 rounded text-black flex-1"
+              aria-label="Filter host"
+            />
+            <input
+              placeholder="Filter path"
+              value={filterPath}
+              onChange={(e) => setFilterPath(e.target.value)}
+              className="p-1 rounded text-black flex-1"
+              aria-label="Filter path"
+            />
               <select
                 aria-label="Filter severity"
                 value={filterSeverity}

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -40,6 +40,7 @@ function BootingScreen(props) {
                             alt="Kali Linux dragon emblem"
                             sizes="(max-width: 768px) 12rem, 16rem"
                             priority
+                            fetchPriority="high"
                         />
                     </div>
                     <span className="text-4xl font-semibold tracking-[0.35em] text-sky-200 md:text-5xl">KALI</span>
@@ -55,7 +56,15 @@ function BootingScreen(props) {
                     >
                         {props.isShutDown ? (
                             <div className="flex h-16 w-16 items-center justify-center rounded-full bg-slate-100 text-slate-900 transition group-hover:bg-white">
-                                <Image width={32} height={32} src="/themes/Yaru/status/power-button.svg" alt="Power button" sizes="32px" priority />
+                                <Image
+                                    width={32}
+                                    height={32}
+                                    src="/themes/Yaru/status/power-button.svg"
+                                    alt="Power button"
+                                    sizes="32px"
+                                    loading="lazy"
+                                    fetchPriority="low"
+                                />
                             </div>
                         ) : (
                             <div className="relative flex h-14 w-14 items-center justify-center">

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -27,6 +27,10 @@ export default function LockScreen(props) {
                     src={`/wallpapers/${bgImageName}.webp`}
                     alt=""
                     className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                    loading="eager"
+                    decoding="async"
+                    fetchpriority="high"
+                    importance="high"
                 />
             )}
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -51,6 +51,10 @@ export default function BackgroundImage() {
                         src={`/wallpapers/${bgImageName}.webp`}
                         alt=""
                         className="w-full h-full object-cover"
+                        loading="eager"
+                        decoding="async"
+                        fetchpriority="high"
+                        importance="high"
                     />
                     {needsOverlay && (
                         <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>

--- a/docs/media-loading-guidelines.md
+++ b/docs/media-loading-guidelines.md
@@ -1,0 +1,23 @@
+# Media Loading Guidelines
+
+These rules document how to configure hero imagery, wallpapers, and embedded media to keep the Kali desktop fast and responsive.
+
+## Hero imagery and wallpapers
+- Use `next/image` whenever possible. When an image must remain an HTML `<img>`, add `loading="eager"`, `decoding="async"`, `fetchpriority="high"`, and `importance="high"` so the wallpaper appears immediately.
+- Mark hero assets with `priority` (or `fetchPriority="high"`) so the boot splash, lock screen, and other above-the-fold artwork are requested before lazy content.
+- Define an explicit `sizes` attribute when using `next/image` to avoid oversized downloads on mobile.
+
+## Lazy embeds and thumbnails
+- Any iframe or third-party embed that is not required for first paint must include `loading="lazy"` **and** `importance="low"`. Add `referrerPolicy="no-referrer"` when the embed will accept it to minimise cross-site requests.
+- Thumbnails that trigger heavy embeds must render with `loading="lazy"` and `fetchPriority="low"` so they yield to hero graphics.
+- When prefetching external documents with `<link rel="prefetch">`, set `importance="low"` (and `as="document"` when applicable) to keep speculative fetches from blocking critical requests.
+
+## Verification checklist
+1. After changing media, run the site (`yarn dev`) and open Chrome DevTools → Network tab.
+2. Reload the page with “Disable cache” enabled and confirm:
+   - hero wallpapers and boot imagery appear at the top of the waterfall with high priority;
+   - lazy iframes remain queued until user interaction and show `Priority: Low`.
+3. Capture a screenshot of the waterfall if priority assignments changed.
+4. Run `yarn lint` before opening a PR to ensure JSX attributes and imports are valid.
+
+Following these rules keeps above-the-fold art crisp without starving the simulated desktop of bandwidth.

--- a/pages/hook-flow.tsx
+++ b/pages/hook-flow.tsx
@@ -31,12 +31,17 @@ const HookFlow: React.FC = () => {
         height={120}
         sizes="(max-width: 420px) 100vw, 420px"
         className="mx-auto"
+        loading="lazy"
+        fetchPriority="low"
       />
       <iframe
         title="React Hooks Documentation"
         src="https://react.dev/learn/hooks"
         sandbox="allow-scripts allow-same-origin"
         className="w-full h-96 border"
+        loading="lazy"
+        importance="low"
+        referrerPolicy="no-referrer"
       />
     </main>
   );

--- a/pages/security-education.tsx
+++ b/pages/security-education.tsx
@@ -16,6 +16,8 @@ const InfoFrame = ({ title, link, description }: FrameProps) => (
     referrerPolicy="no-referrer"
     srcDoc={`<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'></head><body><h2>${title}</h2><p>${description}</p><p><a href='${link}' target='_blank' rel='noopener noreferrer'>Official Documentation</a></p></body></html>`}
     style={{ width: '100%', border: '1px solid #ccc', height: '200px' }}
+    loading="lazy"
+    importance="low"
   />
 );
 

--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -39,12 +39,17 @@ const VideoGallery: React.FC = () => {
 
   return (
     <main className="p-4">
+      <label htmlFor="video-search" className="sr-only">
+        Search videos
+      </label>
       <input
         type="text"
         placeholder="Search videos..."
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         className="mb-4 w-full max-w-md px-4 py-2 border rounded"
+        id="video-search"
+        aria-label="Search videos"
       />
       {playing && (
         <div className="mb-4 w-full max-w-2xl aspect-video">
@@ -56,6 +61,8 @@ const VideoGallery: React.FC = () => {
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             referrerPolicy="no-referrer"
             allowFullScreen
+            loading="lazy"
+            importance="low"
           />
         </div>
       )}
@@ -74,6 +81,8 @@ const VideoGallery: React.FC = () => {
               height={360}
               sizes="(max-width: 768px) 100vw, 480px"
               className="w-full"
+              loading="lazy"
+              fetchPriority="low"
             />
             <p className="mt-2 text-sm" style={{ maxInlineSize: '60ch' }}>{video.title}</p>
           </button>


### PR DESCRIPTION
## Summary
- add fetch priority hints for hero wallpapers and boot imagery
- ensure lazy iframes, thumbnails, and external frames defer with importance="low"
- document the new media loading rules for future contributors

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68da51b6fa508328b45c74490735e748