### PR TITLE
[error] add correlation ids and reporting helpers

### DIFF
--- a/__tests__/ErrorPageContent.test.tsx
+++ b/__tests__/ErrorPageContent.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ErrorPageContent } from '../components/core/ErrorPageContent';
+import { reportClientError } from '../lib/client-error-reporter';
+
+jest.mock('../lib/client-error-reporter');
+
+const mockedReportClientError = reportClientError as jest.MockedFunction<typeof reportClientError>;
+
+describe('ErrorPageContent', () => {
+  const error = new Error('Boom');
+  const reset = jest.fn();
+
+  beforeEach(() => {
+    mockedReportClientError.mockClear();
+    Object.defineProperty(window.navigator, 'clipboard', {
+      writable: true,
+      value: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it('renders the provided correlation ID', () => {
+    render(
+      <ErrorPageContent
+        error={error}
+        reset={reset}
+        correlationId="test-correlation-id"
+        bugReportUrl="https://example.com/bug"
+      />,
+    );
+
+    expect(screen.getByText(/Correlation ID/)).toHaveTextContent('test-correlation-id');
+    expect(mockedReportClientError).toHaveBeenCalledWith(error, error.stack, 'test-correlation-id');
+  });
+
+  it('copies the correlation ID to the clipboard', async () => {
+    render(
+      <ErrorPageContent
+        error={error}
+        reset={reset}
+        correlationId="copy-me"
+        bugReportUrl="https://example.com/bug"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /copy error id/i }));
+
+    await waitFor(() => {
+      expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith('copy-me');
+    });
+
+    expect(await screen.findByText(/Correlation ID copied to clipboard/i)).toBeInTheDocument();
+  });
+});

--- a/app/api/correlation-id/route.ts
+++ b/app/api/correlation-id/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ correlationId: crypto.randomUUID() });
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,24 +1,33 @@
-
 'use client';
 
-import { useEffect } from 'react';
-import { reportClientError } from '../lib/client-error-reporter';
+import ErrorPageContent from '../components/core/ErrorPageContent';
+import { useCorrelationId } from '../components/core/useCorrelationId';
+
+const BUG_REPORT_BASE = 'https://github.com/Alex-Unnippillil/kali-linux-portfolio/issues/new';
+
+function buildBugReportUrl(correlationId: string) {
+  const url = new URL(BUG_REPORT_BASE);
+  url.searchParams.set('title', 'Bug report');
+  url.searchParams.set(
+    'body',
+    `Please describe what happened.\n\nCorrelation ID: ${correlationId}\n\nSteps to reproduce:\n- `,
+  );
+  url.searchParams.set('labels', 'bug');
+  return url.toString();
+}
 
 export default function Error({ error, reset }: { error: Error; reset: () => void }) {
-  useEffect(() => {
-    reportClientError(error, error.stack);
-  }, [error]);
+  const { correlationId, isLoading, hasError } = useCorrelationId();
+  const bugReportUrl = correlationId ? buildBugReportUrl(correlationId) : undefined;
 
   return (
-    <div className="flex flex-col items-center justify-center gap-4 p-4">
-      <h2 className="text-xl font-semibold">Something went wrong!</h2>
-      <button
-        type="button"
-        onClick={() => reset()}
-        className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
-      >
-        Try again
-      </button>
-    </div>
+    <ErrorPageContent
+      error={error}
+      reset={reset}
+      correlationId={correlationId}
+      bugReportUrl={bugReportUrl}
+      isLoading={isLoading}
+      loadError={hasError}
+    />
   );
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,32 +1,37 @@
 'use client';
 
-import { useEffect } from 'react';
-import { reportClientError } from '../lib/client-error-reporter';
+import ErrorPageContent from '../components/core/ErrorPageContent';
+import { useCorrelationId } from '../components/core/useCorrelationId';
 
-export default function GlobalError({
-  error,
-  reset,
-}: {
-  error: Error;
-  reset: () => void;
-}) {
-  useEffect(() => {
-    reportClientError(error, error.stack);
-  }, [error]);
+const BUG_REPORT_BASE = 'https://github.com/Alex-Unnippillil/kali-linux-portfolio/issues/new';
+
+function buildBugReportUrl(correlationId: string) {
+  const url = new URL(BUG_REPORT_BASE);
+  url.searchParams.set('title', 'Bug report');
+  url.searchParams.set(
+    'body',
+    `Please describe what happened.\n\nCorrelation ID: ${correlationId}\n\nSteps to reproduce:\n- `,
+  );
+  url.searchParams.set('labels', 'bug');
+  return url.toString();
+}
+
+export default function GlobalError({ error, reset }: { error: Error; reset: () => void }) {
+  const { correlationId, isLoading, hasError } = useCorrelationId();
+  const bugReportUrl = correlationId ? buildBugReportUrl(correlationId) : undefined;
 
   return (
-    <html>
+    <html lang="en">
       <body>
-        <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
-          <h2 className="text-xl font-semibold">Something went wrong!</h2>
-          <button
-            type="button"
-            onClick={() => reset()}
-            className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
-          >
-            Try again
-          </button>
-        </div>
+        <ErrorPageContent
+          error={error}
+          reset={reset}
+          correlationId={correlationId}
+          bugReportUrl={bugReportUrl}
+          isLoading={isLoading}
+          loadError={hasError}
+          fullScreen
+        />
       </body>
     </html>
   );

--- a/components/core/ErrorPageContent.tsx
+++ b/components/core/ErrorPageContent.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useId, useState } from 'react';
+import clsx from 'clsx';
+import Toast from '../ui/Toast';
+import { reportClientError } from '../../lib/client-error-reporter';
+
+interface ErrorPageContentProps {
+  error: Error;
+  reset: () => void;
+  correlationId: string | null;
+  bugReportUrl?: string;
+  isLoading?: boolean;
+  loadError?: boolean;
+  fullScreen?: boolean;
+}
+
+export function ErrorPageContent({
+  error,
+  reset,
+  correlationId,
+  bugReportUrl,
+  isLoading = false,
+  loadError = false,
+  fullScreen = false,
+}: ErrorPageContentProps) {
+  const [toastMessage, setToastMessage] = useState('');
+  const instructionsId = useId();
+
+  useEffect(() => {
+    if (!correlationId) {
+      return;
+    }
+
+    reportClientError(error, error.stack, correlationId);
+  }, [correlationId, error]);
+
+  const handleCopy = async () => {
+    if (!correlationId) {
+      setToastMessage(loadError ? 'Correlation ID is unavailable.' : 'Correlation ID is still loading.');
+      return;
+    }
+
+    if (!navigator.clipboard) {
+      setToastMessage('Clipboard API is unavailable. Please copy the ID manually.');
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(correlationId);
+      setToastMessage('Correlation ID copied to clipboard.');
+    } catch (copyError) {
+      console.error('Failed to copy correlation ID', copyError);
+      setToastMessage('Failed to copy the ID. Please try again.');
+    }
+  };
+
+  return (
+    <div
+      className={clsx(
+        'flex w-full flex-col items-center justify-center gap-4 p-4 text-center',
+        fullScreen ? 'min-h-screen' : undefined,
+      )}
+    >
+      <h2 className="text-xl font-semibold">Something went wrong!</h2>
+      <p className="max-w-prose text-sm text-slate-600 dark:text-slate-300">
+        An unexpected error occurred. You can try again, or share the correlation ID below if you need help debugging.
+      </p>
+      <div className="flex flex-col items-center gap-2" aria-live="polite">
+        <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+          Correlation ID:{' '}
+          {isLoading && (
+            <span className="text-xs font-normal text-slate-500">Loading…</span>
+          )}
+          {loadError && !isLoading && (
+            <span className="text-xs font-normal text-red-600 dark:text-red-300">Unavailable</span>
+          )}
+          {correlationId && !isLoading && !loadError && (
+            <code className="rounded bg-slate-100 px-2 py-1 font-mono text-xs dark:bg-slate-800">{correlationId}</code>
+          )}
+        </p>
+        <p id={instructionsId} className="sr-only">
+          Activate the copy button to copy the correlation ID to your clipboard.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={handleCopy}
+            aria-describedby={instructionsId}
+            className={clsx(
+              'rounded px-4 py-2 text-sm font-medium transition focus:outline-none focus-visible:ring focus-visible:ring-slate-400',
+              correlationId && !isLoading && !loadError
+                ? 'bg-slate-100 text-slate-900 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700'
+                : 'cursor-not-allowed bg-slate-200 text-slate-500 dark:bg-slate-700 dark:text-slate-400',
+            )}
+          >
+            Copy error ID
+          </button>
+          <a
+            href={bugReportUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            aria-disabled={!bugReportUrl}
+            tabIndex={bugReportUrl ? undefined : -1}
+            className={clsx(
+              'rounded border px-4 py-2 text-sm font-medium transition focus:outline-none focus-visible:ring focus-visible:ring-slate-400',
+              bugReportUrl
+                ? 'border-slate-300 text-slate-900 hover:border-slate-400 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-100 dark:hover:border-slate-500 dark:hover:bg-slate-800'
+                : 'cursor-not-allowed border-slate-200 text-slate-400 dark:border-slate-700 dark:text-slate-500',
+            )}
+          >
+            Report this issue
+          </a>
+          <button
+            type="button"
+            onClick={() => reset()}
+            className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 focus:outline-none focus-visible:ring focus-visible:ring-slate-400 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+      {toastMessage && <Toast message={toastMessage} onClose={() => setToastMessage('')} />}
+    </div>
+  );
+}
+
+export default ErrorPageContent;

--- a/components/core/useCorrelationId.ts
+++ b/components/core/useCorrelationId.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface CorrelationIdState {
+  correlationId: string | null;
+  isLoading: boolean;
+  hasError: boolean;
+}
+
+async function requestCorrelationId(): Promise<string> {
+  const response = await fetch('/api/correlation-id', { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch correlation ID: ${response.status}`);
+  }
+
+  const { correlationId } = (await response.json()) as { correlationId: string };
+  if (!correlationId) {
+    throw new Error('Correlation ID missing in response');
+  }
+
+  return correlationId;
+}
+
+export function useCorrelationId(): CorrelationIdState {
+  const [state, setState] = useState<CorrelationIdState>({
+    correlationId: null,
+    isLoading: true,
+    hasError: false,
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    requestCorrelationId()
+      .then((id) => {
+        if (active) {
+          setState({ correlationId: id, isLoading: false, hasError: false });
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to request correlation ID', error);
+        if (active) {
+          setState({ correlationId: null, isLoading: false, hasError: true });
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return state;
+}

--- a/lib/client-error-reporter.ts
+++ b/lib/client-error-reporter.ts
@@ -4,15 +4,17 @@ export interface ClientErrorPayload {
   componentStack?: string;
   url: string;
   segment: string;
+  correlationId?: string;
 }
 
-export async function reportClientError(error: Error, componentStack?: string) {
+export async function reportClientError(error: Error, componentStack?: string, correlationId?: string) {
   const payload: ClientErrorPayload = {
     message: error.message,
     stack: error.stack,
     componentStack,
     url: typeof window !== 'undefined' ? window.location.href : '',
     segment: typeof window !== 'undefined' ? window.location.pathname : '',
+    correlationId,
   };
 
   if (process.env.NODE_ENV === 'development') {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,8 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-
-import "./.next/types/routes.d.ts";
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- generate server-side correlation IDs in the app and global error boundaries and provide a prefilled bug report link
- introduce a shared error page component with an accessible copy-to-clipboard action and toast feedback
- include the correlation ID in client error reports and cover the new UI with unit tests

## Testing
- yarn test --runTestsByPath __tests__/ErrorPageContent.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da51b7c9808328b81a14214a803ca3