### PR TITLE
[ui] Improve mobile safe area handling

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -9,6 +9,7 @@ import useDocPiP from '../../hooks/useDocPiP';
 import {
     clampWindowTopPosition,
     DEFAULT_WINDOW_TOP_OFFSET,
+    measureSafeAreaInset,
     measureWindowTopOffset,
 } from '../../utils/windowLayout';
 import styles from './window.module.css';
@@ -30,7 +31,8 @@ const percentOf = (value, total) => {
 const computeSnapRegions = (viewportWidth, viewportHeight, topInset = DEFAULT_WINDOW_TOP_OFFSET) => {
     const halfWidth = viewportWidth / 2;
     const safeTop = Math.max(topInset, DEFAULT_WINDOW_TOP_OFFSET);
-    const availableHeight = Math.max(0, viewportHeight - safeTop - SNAP_BOTTOM_INSET);
+    const safeBottom = Math.max(0, measureSafeAreaInset('bottom'));
+    const availableHeight = Math.max(0, viewportHeight - safeTop - SNAP_BOTTOM_INSET - safeBottom);
     const topHeight = Math.min(availableHeight, Math.max(viewportHeight / 2, 0));
     return {
         left: { left: 0, top: safeTop, width: halfWidth, height: availableHeight },
@@ -137,7 +139,8 @@ export class Window extends Component {
             : DEFAULT_WINDOW_TOP_OFFSET;
         const windowHeightPx = viewportHeight * (this.state.height / 100.0);
         const windowWidthPx = viewportWidth * (this.state.width / 100.0);
-        const availableVertical = Math.max(viewportHeight - topInset - SNAP_BOTTOM_INSET, 0);
+        const safeAreaBottom = Math.max(0, measureSafeAreaInset('bottom'));
+        const availableVertical = Math.max(viewportHeight - topInset - SNAP_BOTTOM_INSET - safeAreaBottom, 0);
         const availableHorizontal = Math.max(viewportWidth - windowWidthPx, 0);
         const maxTop = Math.max(availableVertical - windowHeightPx, 0);
 
@@ -482,7 +485,10 @@ export class Window extends Component {
             this.setWinowsPosition();
             // translate window to maximize position
             const viewportHeight = window.innerHeight;
-            const availableHeight = Math.max(0, viewportHeight - DESKTOP_TOP_PADDING - SNAP_BOTTOM_INSET);
+            const availableHeight = Math.max(
+                0,
+                viewportHeight - DESKTOP_TOP_PADDING - SNAP_BOTTOM_INSET - Math.max(0, measureSafeAreaInset('bottom')),
+            );
             const heightPercent = percentOf(availableHeight, viewportHeight);
             if (node) {
                 node.style.transform = `translate(-1pt, 0px)`;

--- a/components/desktop/Layout.tsx
+++ b/components/desktop/Layout.tsx
@@ -9,13 +9,20 @@ const Layout = React.forwardRef<HTMLDivElement, LayoutProps>(
       <div
         ref={ref}
         className={clsx(
-          "desktop-shell relative h-screen w-screen overflow-hidden bg-transparent text-white antialiased",
+          "desktop-shell relative min-h-screen w-full overflow-hidden bg-transparent text-white antialiased",
           className,
         )}
         {...props}
       >
         {children}
         <style jsx>{`
+          :global(:root) {
+            --safe-area-top: env(safe-area-inset-top, 0px);
+            --safe-area-right: env(safe-area-inset-right, 0px);
+            --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+            --safe-area-left: env(safe-area-inset-left, 0px);
+          }
+
           .desktop-shell {
             --shell-taskbar-height: 2.5rem;
             --shell-taskbar-padding-x: 0.75rem;
@@ -31,6 +38,19 @@ const Layout = React.forwardRef<HTMLDivElement, LayoutProps>(
             --desktop-icon-font-size: 0.75rem;
             touch-action: manipulation;
             font-size: clamp(0.95rem, 0.9rem + 0.2vw, 1rem);
+            min-height: 100vh;
+          }
+
+          @supports (min-height: 100svh) {
+            .desktop-shell {
+              min-height: 100svh;
+            }
+          }
+
+          @supports (min-height: 100dvh) {
+            .desktop-shell {
+              min-height: 100dvh;
+            }
           }
 
           @media (min-width: 640px) {

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -79,8 +79,14 @@ export default class Navbar extends PureComponent {
                         const { workspaces, activeWorkspace } = this.state;
                         return (
                                 <div
-                                        className="main-navbar-vp fixed inset-x-0 top-0 z-50 flex h-14 w-full items-center justify-between bg-slate-950/80 px-3 text-ubt-grey shadow-lg backdrop-blur-md"
-                                        style={{ minHeight: NAVBAR_HEIGHT }}
+                                        className="main-navbar-vp fixed inset-x-0 top-0 z-50 flex w-full items-center justify-between bg-slate-950/80 text-ubt-grey shadow-lg backdrop-blur-md"
+                                        style={{
+                                                minHeight: `calc(${NAVBAR_HEIGHT}px + var(--safe-area-top, 0px))`,
+                                                paddingTop: `calc(var(--safe-area-top, 0px) + 0.5rem)`,
+                                                paddingBottom: '0.5rem',
+                                                paddingLeft: `calc(0.75rem + var(--safe-area-left, 0px))`,
+                                                paddingRight: `calc(0.75rem + var(--safe-area-right, 0px))`,
+                                        }}
                                 >
                                         <div className="flex items-center gap-2 text-xs md:text-sm">
                                                 <WhiskerMenu />

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -18,11 +18,14 @@ export default function Taskbar(props) {
     return (
 
         <div
-            className="absolute bottom-0 left-0 w-full bg-black bg-opacity-50 flex items-center justify-start z-40 backdrop-blur-sm"
+            className="absolute bottom-0 left-0 z-40 flex w-full items-center justify-start bg-black bg-opacity-50 backdrop-blur-sm"
             role="toolbar"
             style={{
-                height: 'var(--shell-taskbar-height, 2.5rem)',
-                paddingInline: 'var(--shell-taskbar-padding-x, 0.75rem)',
+                minHeight: 'calc(var(--shell-taskbar-height, 2.5rem) + var(--safe-area-bottom, 0px))',
+                paddingTop: '0.35rem',
+                paddingBottom: 'calc(var(--safe-area-bottom, 0px) + 0.35rem)',
+                paddingLeft: 'calc(var(--shell-taskbar-padding-x, 0.75rem) + var(--safe-area-left, 0px))',
+                paddingRight: 'calc(var(--shell-taskbar-padding-x, 0.75rem) + var(--safe-area-right, 0px))',
             }}
         >
             <div

--- a/utils/windowLayout.js
+++ b/utils/windowLayout.js
@@ -1,6 +1,46 @@
 const NAVBAR_SELECTOR = '.main-navbar-vp';
 const DEFAULT_NAVBAR_HEIGHT = 48;
 const WINDOW_TOP_MARGIN = 16;
+const SAFE_AREA_PROPERTIES = {
+  top: '--safe-area-top',
+  right: '--safe-area-right',
+  bottom: '--safe-area-bottom',
+  left: '--safe-area-left',
+};
+
+const parseSafeAreaValue = (value) => {
+  if (typeof value !== 'string') return 0;
+  const trimmed = value.trim();
+  if (!trimmed) return 0;
+  const parsed = parseFloat(trimmed);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const readSafeAreaInset = (computed, property) => {
+  if (!computed || typeof computed.getPropertyValue !== 'function') return 0;
+  return parseSafeAreaValue(computed.getPropertyValue(property));
+};
+
+export const getSafeAreaInsets = () => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return { top: 0, right: 0, bottom: 0, left: 0 };
+  }
+
+  const computed = window.getComputedStyle(document.documentElement);
+  return {
+    top: readSafeAreaInset(computed, SAFE_AREA_PROPERTIES.top),
+    right: readSafeAreaInset(computed, SAFE_AREA_PROPERTIES.right),
+    bottom: readSafeAreaInset(computed, SAFE_AREA_PROPERTIES.bottom),
+    left: readSafeAreaInset(computed, SAFE_AREA_PROPERTIES.left),
+  };
+};
+
+export const measureSafeAreaInset = (side) => {
+  const insets = getSafeAreaInsets();
+  if (!insets || typeof insets !== 'object') return 0;
+  const value = insets[side];
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+};
 
 export const DEFAULT_WINDOW_TOP_OFFSET = DEFAULT_NAVBAR_HEIGHT + WINDOW_TOP_MARGIN;
 


### PR DESCRIPTION
## Summary
- define safe-area CSS variables and dynamic viewport heights for the desktop shell
- adjust the navbar, dock, and icon layout logic to respect safe area insets across pointer modes
- extend window layout helpers so snap regions and maximized states account for bottom safe-area padding

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db0c1f62f883289995007c08172cea