### PR TITLE
[tests] Add visual regression automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,38 @@ jobs:
       - run: yarn dedupe --check
       - run: yarn npm audit
 
+  visual-tests:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn dedupe --check
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run visual regression suite
+        run: npx playwright test tests/visual-baseline.spec.ts --reporter=list
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-visual-report
+          path: playwright-report
+          if-no-files-found: ignore
+      - name: Upload visual diffs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-visual-diffs
+          path: |
+            tests/__screenshots__
+            test-results
+          if-no-files-found: ignore
+
   vercel-preview:
     runs-on: ubuntu-latest
     needs: install

--- a/docs/visual-regression.md
+++ b/docs/visual-regression.md
@@ -1,0 +1,43 @@
+# Visual regression testing
+
+This project uses Playwright to capture baseline screenshots for key desktop routes and compare them during CI. Follow the steps below to work with the suite.
+
+## Running locally
+
+1. Install dependencies and Playwright browsers if you have not already:
+   ```bash
+   yarn install
+   npx playwright install chromium
+   ```
+2. Start the development server in a new terminal:
+   ```bash
+   yarn dev
+   ```
+3. In another terminal, execute the visual regression suite:
+   ```bash
+   npx playwright test tests/visual-baseline.spec.ts
+   ```
+
+## Updating baselines
+
+If a legitimate UI change modifies a captured route, update the stored baselines:
+
+```bash
+npx playwright test tests/visual-baseline.spec.ts --update-snapshots
+```
+
+Review the updated images under `tests/__screenshots__`. Commit only the images relevant to your change.
+
+## Reviewing diffs
+
+When a comparison fails locally or in CI, Playwright writes the expected, actual, and diff images to `test-results/`. Launch the interactive report for additional context:
+
+```bash
+npx playwright show-report
+```
+
+In CI, the `visual-tests` job uploads both the Playwright HTML report and the generated diff assets as workflow artifacts whenever the job fails. Download these artifacts from the failed run to inspect the regression without rerunning the suite locally.
+
+## Adding coverage
+
+To extend coverage, edit `tests/visual-baseline.spec.ts` and append a new entry to the routes array. Choose stable views without heavy animation to keep the suite reliable.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,24 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './tests',
   testMatch: /.*\.spec\.ts/,
+  snapshotPathTemplate: '{testDir}/__screenshots__/{testFilePath}/{projectName}/{arg}{ext}',
+  webServer: {
+    command: 'yarn dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  expect: {
+    toHaveScreenshot: {
+      animations: 'disabled',
+      maxDiffPixelRatio: 0.002,
+      scale: 'css',
+    },
+  },
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    viewport: { width: 1440, height: 900 },
+    colorScheme: 'dark',
+    trace: 'on-first-retry',
   },
 });

--- a/tests/visual-baseline.spec.ts
+++ b/tests/visual-baseline.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+const routes = [
+  { name: 'home', path: '/' },
+  { name: 'apps', path: '/apps' },
+  { name: 'profile', path: '/profile' },
+];
+
+test.describe('visual regression baselines', () => {
+  for (const route of routes) {
+    test(`captures ${route.name} route`, async ({ page }) => {
+      await page.goto(route.path, { waitUntil: 'networkidle' });
+      await page.waitForTimeout(250);
+      await expect(page).toHaveScreenshot(`${route.name}.png`, {
+        fullPage: true,
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- extend the Playwright configuration to capture baseline screenshots with a tighter diff threshold
- add coverage for core routes and document how to refresh baselines and review diffs
- run the visual regression suite in CI and upload the report and diff assets on failure

## Testing
- npx playwright test tests/visual-baseline.spec.ts --list

------
https://chatgpt.com/codex/tasks/task_e_68da51bc2e68832885d21048d2092bca