### PR TITLE
[performance] add safe mode auto fallback

### DIFF
--- a/__tests__/safeMode.test.tsx
+++ b/__tests__/safeMode.test.tsx
@@ -1,0 +1,148 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { FC, ReactNode } from 'react';
+import { SafeModeProvider, useSafeMode } from '../hooks/useSafeMode';
+
+type ObserverOptions = PerformanceObserverInit & { type?: string };
+
+type ObserverCallback = (list: PerformanceObserverEntryList) => void;
+
+class MockPerformanceObserver {
+  public options?: ObserverOptions;
+  private readonly callback: ObserverCallback;
+
+  constructor(callback: ObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe(options: ObserverOptions) {
+    this.options = options;
+  }
+
+  disconnect() {}
+
+  takeRecords(): PerformanceEntryList {
+    return [];
+  }
+
+  trigger(entries: PerformanceEntry[]) {
+    const list: PerformanceObserverEntryList = {
+      getEntries: () => entries,
+      getEntriesByType: () => entries,
+      getEntriesByName: () => entries,
+    } as PerformanceObserverEntryList;
+    this.callback(list);
+  }
+}
+
+describe('SafeModeProvider', () => {
+  const originalObserver = global.PerformanceObserver;
+  let observers: MockPerformanceObserver[];
+
+  beforeEach(() => {
+    observers = [];
+    jest.useFakeTimers();
+    (global as any).PerformanceObserver = jest.fn((callback: ObserverCallback) => {
+      const observer = new MockPerformanceObserver(callback);
+      observers.push(observer);
+      return observer;
+    });
+    Object.defineProperty(performance, 'memory', {
+      value: { usedJSHeapSize: 128 * 1024 * 1024 },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    (global as any).PerformanceObserver = originalObserver;
+    observers = [];
+  });
+
+  const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+    <SafeModeProvider>{children}</SafeModeProvider>
+  );
+
+  const findObserver = (predicate: (observer: MockPerformanceObserver) => boolean) =>
+    observers.find(predicate);
+
+  it('activates safe mode when INP threshold is exceeded', async () => {
+    const { result } = renderHook(() => useSafeMode(), { wrapper });
+
+    const eventObserver = findObserver(
+      (observer) => observer.options?.type === 'event' || observer.options?.entryTypes?.includes('event'),
+    );
+    expect(eventObserver).toBeDefined();
+
+    act(() => {
+      eventObserver?.trigger([
+        {
+          duration: 420,
+          interactionId: 1,
+        } as PerformanceEventTiming,
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.safeModeActive).toBe(true);
+    });
+    expect(result.current.trigger?.reason).toBe('inp');
+    expect(document.documentElement.getAttribute('data-safe-mode')).toBe('true');
+  });
+
+  it('activates safe mode when memory usage exceeds the threshold', async () => {
+    const { result } = renderHook(() => useSafeMode(), { wrapper });
+
+    const longTaskObserver = findObserver(
+      (observer) => observer.options?.type === 'longtask' || observer.options?.entryTypes?.includes('longtask'),
+    );
+    expect(longTaskObserver).toBeDefined();
+
+    (performance as any).memory.usedJSHeapSize = 400 * 1024 * 1024;
+
+    act(() => {
+      longTaskObserver?.trigger([
+        {
+          duration: 50,
+          name: 'longtask',
+        } as PerformanceEntry,
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.safeModeActive).toBe(true);
+    });
+    expect(result.current.trigger?.reason).toBe('memory');
+    expect(document.documentElement.getAttribute('data-safe-mode')).toBe('true');
+  });
+
+  it('supports manual override to disable safe mode', async () => {
+    const { result } = renderHook(() => useSafeMode(), { wrapper });
+    const eventObserver = findObserver(
+      (observer) => observer.options?.type === 'event' || observer.options?.entryTypes?.includes('event'),
+    );
+    expect(eventObserver).toBeDefined();
+
+    act(() => {
+      eventObserver?.trigger([
+        {
+          duration: 320,
+          interactionId: 2,
+        } as PerformanceEventTiming,
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.safeModeActive).toBe(true);
+    });
+
+    act(() => {
+      result.current.disableSafeMode();
+    });
+
+    expect(result.current.safeModeActive).toBe(false);
+    expect(result.current.manualOverride).toBe('forced-off');
+    expect(document.documentElement.getAttribute('data-safe-mode')).toBeNull();
+    expect(result.current.lastTrigger?.reason).toBe('inp');
+  });
+});

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -5,6 +5,7 @@ import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import PerformanceGraph from '../ui/PerformanceGraph';
 import WorkspaceSwitcher from '../panel/WorkspaceSwitcher';
+import SafeModeIndicator from '../ui/SafeModeIndicator';
 import { NAVBAR_HEIGHT } from '../../utils/uiConstants';
 
 const areWorkspacesEqual = (next, prev) => {
@@ -92,6 +93,7 @@ export default class Navbar extends PureComponent {
                                                         />
                                                 )}
                                                 <PerformanceGraph />
+                                                <SafeModeIndicator />
                                         </div>
                                         <div
                                                 className={

--- a/components/ui/SafeModeIndicator.tsx
+++ b/components/ui/SafeModeIndicator.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSafeMode } from '../../hooks/useSafeMode';
+
+const formatMemory = (bytes: number) => `${Math.round(bytes / (1024 * 1024))} MB`;
+
+const formatInp = (value: number) => `${Math.round(value)} ms`;
+
+const SafeModeIndicator = () => {
+  const {
+    safeModeActive,
+    manualOverride,
+    metrics,
+    trigger,
+    lastTrigger,
+    enableSafeMode,
+    disableSafeMode,
+    resetOverride,
+    clearTrigger,
+  } = useSafeMode();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleClick = (event: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+    };
+  }, [open]);
+
+  const statusLabel = useMemo(() => {
+    if (safeModeActive) {
+      if (manualOverride === 'forced-on') {
+        return 'Safe mode manually enabled';
+      }
+      const reason = trigger ?? lastTrigger;
+      if (!reason) return 'Safe mode active';
+      if (reason.reason === 'inp') {
+        return `Safe mode active: INP spike (${formatInp(reason.value)})`;
+      }
+      if (reason.reason === 'memory') {
+        return `Safe mode active: memory spike (${formatMemory(reason.value)})`;
+      }
+      return 'Safe mode active';
+    }
+    if (manualOverride === 'forced-off') {
+      return 'Safe mode manually disabled';
+    }
+    return 'Safe mode monitoring';
+  }, [safeModeActive, manualOverride, trigger, lastTrigger]);
+
+  const details = useMemo(() => {
+    const reference = trigger ?? lastTrigger;
+    if (!reference) {
+      return 'No performance alerts recorded in this session.';
+    }
+    if (reference.reason === 'manual') {
+      return 'Safe mode was enabled manually.';
+    }
+    if (reference.reason === 'inp') {
+      return `Last INP alert at ${formatInp(reference.value)} (threshold ${formatInp(reference.threshold)}).`;
+    }
+    return `Last memory alert at ${formatMemory(reference.value)} (threshold ${formatMemory(reference.threshold)}).`;
+  }, [lastTrigger, trigger]);
+
+  const badgeTone = safeModeActive
+    ? 'border-emerald-300/60 bg-emerald-500/10 text-emerald-100 hover:border-emerald-200/80 hover:bg-emerald-500/20'
+    : manualOverride === 'forced-off'
+      ? 'border-slate-500/40 bg-slate-900/70 text-slate-200 hover:border-slate-300/70 hover:bg-slate-900/90'
+      : 'border-sky-400/40 bg-sky-500/10 text-sky-100 hover:border-sky-200/80 hover:bg-sky-500/20';
+
+  const indicatorTone = safeModeActive
+    ? 'bg-emerald-400'
+    : manualOverride === 'forced-off'
+      ? 'bg-slate-400'
+      : 'bg-sky-400';
+
+  const metricSummary = useMemo(() => {
+    const parts: string[] = [];
+    if (typeof metrics.inp === 'number') parts.push(`INP ${formatInp(metrics.inp)}`);
+    if (typeof metrics.memory === 'number') parts.push(`Memory ${formatMemory(metrics.memory)}`);
+    return parts.length > 0 ? parts.join(' • ') : 'Awaiting metrics';
+  }, [metrics.inp, metrics.memory]);
+
+  return (
+    <div ref={containerRef} className="relative hidden items-center sm:flex">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open ? 'true' : 'false'}
+        className={`flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 ${badgeTone}`}
+        title={statusLabel}
+      >
+        <span className={`h-2 w-2 rounded-full transition-colors ${indicatorTone}`} aria-hidden="true" />
+        <span className="hidden md:inline">Safe mode</span>
+        <span className="md:hidden">Safe</span>
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-2 w-72 max-w-xs rounded-xl border border-slate-800/70 bg-slate-950/95 p-3 text-xs text-slate-100 shadow-xl backdrop-blur">
+          <p className="font-semibold text-slate-50">{statusLabel}</p>
+          <p className="mt-1 text-slate-300">{details}</p>
+          <p className="mt-2 text-slate-400">{metricSummary}</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                enableSafeMode();
+                setOpen(false);
+              }}
+              className="rounded-md border border-emerald-400/70 bg-emerald-500/10 px-2 py-1 font-semibold text-emerald-100 transition hover:border-emerald-300 hover:bg-emerald-500/20"
+            >
+              Force on
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                disableSafeMode();
+                setOpen(false);
+              }}
+              className="rounded-md border border-rose-500/60 bg-rose-500/10 px-2 py-1 font-semibold text-rose-100 transition hover:border-rose-300 hover:bg-rose-500/20"
+            >
+              Force off
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                resetOverride();
+                setOpen(false);
+              }}
+              className="rounded-md border border-sky-500/60 bg-sky-500/10 px-2 py-1 font-semibold text-sky-100 transition hover:border-sky-300 hover:bg-sky-500/20"
+            >
+              Auto
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                clearTrigger();
+                setOpen(false);
+              }}
+              className="rounded-md border border-slate-600/60 bg-slate-800/60 px-2 py-1 font-semibold text-slate-200 transition hover:border-slate-400 hover:bg-slate-800/80"
+            >
+              Clear alert
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SafeModeIndicator;

--- a/hooks/useSafeMode.tsx
+++ b/hooks/useSafeMode.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+const INP_DURATION_THRESHOLD = 250;
+const MEMORY_THRESHOLD_BYTES = 320 * 1024 * 1024; // 320MB
+const MEMORY_POLL_INTERVAL = 10000;
+
+type SafeModeReason = 'inp' | 'memory' | 'manual';
+
+type SafeModeTrigger = {
+  reason: SafeModeReason;
+  value: number;
+  threshold: number;
+  timestamp: number;
+};
+
+type SafeModeMetrics = {
+  inp: number | null;
+  memory: number | null;
+};
+
+type ManualOverrideState = 'auto' | 'forced-on' | 'forced-off';
+
+type SafeModeContextValue = {
+  safeModeActive: boolean;
+  manualOverride: ManualOverrideState;
+  metrics: SafeModeMetrics;
+  trigger: SafeModeTrigger | null;
+  lastTrigger: SafeModeTrigger | null;
+  enableSafeMode: () => void;
+  disableSafeMode: () => void;
+  resetOverride: () => void;
+  clearTrigger: () => void;
+};
+
+const defaultContext: SafeModeContextValue = {
+  safeModeActive: false,
+  manualOverride: 'auto',
+  metrics: { inp: null, memory: null },
+  trigger: null,
+  lastTrigger: null,
+  enableSafeMode: () => {},
+  disableSafeMode: () => {},
+  resetOverride: () => {},
+  clearTrigger: () => {},
+};
+
+const SafeModeContext = createContext<SafeModeContextValue>(defaultContext);
+
+const readMemoryUsage = (): number | null => {
+  if (typeof performance === 'undefined') return null;
+  const anyPerformance = performance as Performance & {
+    memory?: { usedJSHeapSize?: number };
+  };
+  const memory = anyPerformance.memory?.usedJSHeapSize;
+  if (typeof memory !== 'number' || !Number.isFinite(memory)) {
+    return null;
+  }
+  return memory;
+};
+
+type SafeModeProviderProps = {
+  children: ReactNode;
+};
+
+export const SafeModeProvider = ({ children }: SafeModeProviderProps) => {
+  const [manualOverride, setManualOverride] = useState<ManualOverrideState>('auto');
+  const [trigger, setTrigger] = useState<SafeModeTrigger | null>(null);
+  const [lastTrigger, setLastTrigger] = useState<SafeModeTrigger | null>(null);
+  const [metrics, setMetrics] = useState<SafeModeMetrics>({ inp: null, memory: null });
+  const allowAutoRef = useRef(true);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    allowAutoRef.current = manualOverride !== 'forced-off';
+  }, [manualOverride]);
+
+  useEffect(() => () => {
+    mountedRef.current = false;
+  }, []);
+
+  const updateMetrics = useCallback((updates: Partial<SafeModeMetrics>) => {
+    setMetrics((prev) => {
+      let changed = false;
+      const next: SafeModeMetrics = { ...prev };
+      if (Object.prototype.hasOwnProperty.call(updates, 'inp') && updates.inp !== prev.inp) {
+        next.inp = updates.inp ?? null;
+        changed = true;
+      }
+      if (Object.prototype.hasOwnProperty.call(updates, 'memory') && updates.memory !== prev.memory) {
+        next.memory = updates.memory ?? null;
+        changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, []);
+
+  const pushTrigger = useCallback(
+    (reason: SafeModeReason, value: number, threshold: number) => {
+      const entry: SafeModeTrigger = {
+        reason,
+        value,
+        threshold,
+        timestamp: Date.now(),
+      };
+      setLastTrigger(entry);
+      if (!allowAutoRef.current) {
+        return;
+      }
+      setTrigger((prev) => {
+        if (prev && prev.reason === reason && value <= prev.value) {
+          return prev;
+        }
+        return entry;
+      });
+    },
+    [],
+  );
+
+  const sampleMemory = useCallback(() => {
+    const memory = readMemoryUsage();
+    if (memory === null) return;
+    updateMetrics({ memory });
+    if (memory > MEMORY_THRESHOLD_BYTES) {
+      pushTrigger('memory', memory, MEMORY_THRESHOLD_BYTES);
+    }
+  }, [pushTrigger, updateMetrics]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    if (typeof PerformanceObserver === 'undefined') {
+      const interval = window.setInterval(sampleMemory, MEMORY_POLL_INTERVAL);
+      sampleMemory();
+      return () => {
+        window.clearInterval(interval);
+      };
+    }
+
+    const supportedTypes: string[] | undefined = (PerformanceObserver as unknown as {
+      supportedEntryTypes?: string[];
+    }).supportedEntryTypes;
+
+    const supports = (type: string) => !supportedTypes || supportedTypes.includes(type);
+
+    let inpObserver: PerformanceObserver | null = null;
+    if (supports('event')) {
+      try {
+        inpObserver = new PerformanceObserver((list) => {
+          if (!mountedRef.current) return;
+          const entries = list.getEntries() as PerformanceEntry[];
+          let maxDuration = 0;
+          entries.forEach((entry) => {
+            const interactionEntry = entry as PerformanceEventTiming;
+            if (!('interactionId' in interactionEntry) || !interactionEntry.interactionId) {
+              return;
+            }
+            if (interactionEntry.duration > maxDuration) {
+              maxDuration = interactionEntry.duration;
+            }
+          });
+          if (maxDuration > 0) {
+            updateMetrics({ inp: maxDuration });
+            if (maxDuration > INP_DURATION_THRESHOLD) {
+              pushTrigger('inp', maxDuration, INP_DURATION_THRESHOLD);
+            }
+          }
+        });
+        (inpObserver as PerformanceObserver).observe(
+          {
+            type: 'event',
+            buffered: true,
+            durationThreshold: 16,
+          } as PerformanceObserverInit,
+        );
+        const existing = typeof performance?.getEntriesByType === 'function'
+          ? (performance.getEntriesByType('event') as PerformanceEntry[])
+          : [];
+        if (existing.length > 0) {
+          const maxExisting = existing.reduce((acc, entry) => {
+            const eventEntry = entry as PerformanceEventTiming;
+            if (!eventEntry.interactionId) return acc;
+            return Math.max(acc, eventEntry.duration);
+          }, 0);
+          if (maxExisting > 0) {
+            updateMetrics({ inp: maxExisting });
+            if (maxExisting > INP_DURATION_THRESHOLD) {
+              pushTrigger('inp', maxExisting, INP_DURATION_THRESHOLD);
+            }
+          }
+        }
+      } catch {
+        inpObserver = null;
+      }
+    }
+
+    let longTaskObserver: PerformanceObserver | null = null;
+    if (supports('longtask')) {
+      try {
+        longTaskObserver = new PerformanceObserver(() => {
+          if (!mountedRef.current) return;
+          sampleMemory();
+        });
+        longTaskObserver.observe({ entryTypes: ['longtask'], buffered: true });
+      } catch {
+        longTaskObserver = null;
+      }
+    }
+
+    sampleMemory();
+    const interval = window.setInterval(sampleMemory, MEMORY_POLL_INTERVAL);
+
+    return () => {
+      inpObserver?.disconnect();
+      longTaskObserver?.disconnect();
+      window.clearInterval(interval);
+    };
+  }, [pushTrigger, sampleMemory, updateMetrics]);
+
+  const safeModeActive =
+    manualOverride === 'forced-on' || (manualOverride !== 'forced-off' && trigger !== null);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+    const root = document.documentElement;
+    if (safeModeActive) {
+      root.setAttribute('data-safe-mode', 'true');
+      root.dataset.experiments = 'off';
+      root.style.setProperty('--experiments-enabled', '0');
+    } else {
+      root.removeAttribute('data-safe-mode');
+      if (root.dataset) {
+        root.dataset.experiments = 'on';
+      }
+      root.style.setProperty('--experiments-enabled', '1');
+    }
+    return () => {
+      root.removeAttribute('data-safe-mode');
+      if (root.dataset) {
+        delete root.dataset.experiments;
+      }
+      root.style.removeProperty('--experiments-enabled');
+    };
+  }, [safeModeActive]);
+
+  const enableSafeMode = useCallback(() => {
+    setManualOverride('forced-on');
+    setLastTrigger({ reason: 'manual', value: 0, threshold: 0, timestamp: Date.now() });
+  }, []);
+
+  const disableSafeMode = useCallback(() => {
+    setManualOverride('forced-off');
+    setTrigger(null);
+  }, []);
+
+  const resetOverride = useCallback(() => {
+    setManualOverride('auto');
+  }, []);
+
+  const clearTrigger = useCallback(() => {
+    setTrigger(null);
+    setLastTrigger(null);
+  }, []);
+
+  const value = useMemo<SafeModeContextValue>(
+    () => ({
+      safeModeActive,
+      manualOverride,
+      metrics,
+      trigger,
+      lastTrigger,
+      enableSafeMode,
+      disableSafeMode,
+      resetOverride,
+      clearTrigger,
+    }),
+    [
+      clearTrigger,
+      disableSafeMode,
+      enableSafeMode,
+      lastTrigger,
+      manualOverride,
+      metrics,
+      resetOverride,
+      safeModeActive,
+      trigger,
+    ],
+  );
+
+  return <SafeModeContext.Provider value={value}>{children}</SafeModeContext.Provider>;
+};
+
+export const useSafeMode = () => useContext(SafeModeContext);

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -17,6 +17,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { SafeModeProvider } from '../hooks/useSafeMode';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -158,23 +159,25 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <NotificationCenter>
-            <PipPortalProvider>
-              <div aria-live="polite" id="live-region" />
-              <Component {...pageProps} />
-              <ShortcutOverlay />
-              <Analytics
-                beforeSend={(e) => {
-                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                  const evt = e;
-                  if (evt.metadata?.email) delete evt.metadata.email;
-                  return e;
-                }}
-              />
+          <SafeModeProvider>
+            <NotificationCenter>
+              <PipPortalProvider>
+                <div aria-live="polite" id="live-region" />
+                <Component {...pageProps} />
+                <ShortcutOverlay />
+                <Analytics
+                  beforeSend={(e) => {
+                    if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                    const evt = e;
+                    if (evt.metadata?.email) delete evt.metadata.email;
+                    return e;
+                  }}
+                />
 
-              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-            </PipPortalProvider>
-          </NotificationCenter>
+                {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+              </PipPortalProvider>
+            </NotificationCenter>
+          </SafeModeProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>

--- a/styles/index.css
+++ b/styles/index.css
@@ -38,6 +38,15 @@ button:focus-visible {
     scroll-behavior: auto !important;
 }
 
+:root[data-safe-mode='true'] *,
+:root[data-safe-mode='true'] *::before,
+:root[data-safe-mode='true'] *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+}
+
 /* Top NavBar styling */
 
 .top-arrow-up {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -80,6 +80,15 @@
   /* Focus outline */
   --focus-outline-color: var(--color-ubt-blue);
   --focus-outline-width: 2px;
+  /* Experiment guard */
+  --experiments-enabled: 1;
+}
+
+:root[data-safe-mode='true'] {
+  --motion-fast: 0ms;
+  --motion-medium: 0ms;
+  --motion-slow: 0ms;
+  --experiments-enabled: 0;
 }
 
 /* High contrast theme */


### PR DESCRIPTION
## Summary
- monitor INP and memory with a new SafeModeProvider that toggles safe mode tokens when thresholds are exceeded
- surface a navbar indicator with controls to force safe mode on, off, or back to auto and expose the latest alert details
- lock down motion and experiment tokens in CSS and cover the behavior with unit tests simulating INP and memory spikes

## Testing
- yarn test safeMode --runTestsByPath __tests__/safeMode.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da51bd6ec883288e4a44f990d24c28