### PR TITLE
[terminal] Improve responsive layout and add quick actions

### DIFF
--- a/apps/terminal/components/Terminal.tsx
+++ b/apps/terminal/components/Terminal.tsx
@@ -15,8 +15,10 @@ const Terminal = forwardRef<HTMLDivElement, TerminalContainerProps>(
         backdropFilter: 'blur(4px)',
         border: '1px solid var(--color-border)',
         fontFamily: 'monospace',
-        fontSize: 'clamp(1rem, 0.6vw + 1rem, 1.1rem)',
-        lineHeight: 1.4,
+        fontSize:
+          'var(--terminal-font-size, clamp(0.65rem, 0.35vw + 0.75rem, 1rem))',
+        lineHeight: 'var(--terminal-line-height, 1.35)',
+        overflowX: 'hidden',
         ...style,
       }}
       {...props}


### PR DESCRIPTION
## Summary
- scale the terminal font size and line height responsively so 80-column output stays legible without horizontal scrolling
- add a quick command action bar with common shortcuts and ensure palette search has an accessible label
- keep the xterm fit logic in sync with container resizes via dynamic typography updates

## Testing
- [x] yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db4ddd4dd483289e808c774b3db087