### PR TITLE
[UI] improve Lab Mode mobile layout

### DIFF
--- a/components/LabMode.tsx
+++ b/components/LabMode.tsx
@@ -28,15 +28,41 @@ export default function LabMode({ children }: Props) {
     }
   };
 
+  const statusMessage = enabled
+    ? 'Lab Mode enabled: all actions are simulated.'
+    : 'Lab Mode disabled: enable to use training features.';
+
   return (
-    <div className="w-full h-full">
-      <div className="bg-ub-yellow text-black p-2 text-xs flex justify-between items-center" aria-label="training banner">
-        <span>{enabled ? 'Lab Mode enabled: all actions are simulated.' : 'Lab Mode disabled: enable to use training features.'}</span>
-        <button onClick={toggle} className="px-2 py-1 bg-ub-green text-black" type="button">
-          {enabled ? 'Disable' : 'Enable'}
-        </button>
+    <div className="flex h-full w-full flex-col">
+      <div
+        className="bg-ub-yellow text-black"
+        aria-label="training banner"
+      >
+        <div className="flex flex-col gap-2 p-3 text-xs sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+          <div className="space-y-1">
+            <p className="text-sm font-semibold">Lab Mode</p>
+            <p className="leading-snug">{statusMessage}</p>
+          </div>
+          <div className="flex w-full flex-col gap-1 sm:w-auto sm:flex-row sm:items-center sm:justify-end sm:gap-2">
+            <button
+              onClick={toggle}
+              className="w-full rounded bg-ub-green px-3 py-1 text-center font-semibold uppercase tracking-wide text-black sm:w-auto"
+              type="button"
+              aria-pressed={enabled}
+            >
+              {enabled ? 'Turn Off' : 'Turn On'}
+            </button>
+            <span className="text-[10px] font-semibold uppercase tracking-wide text-black/80 text-center sm:text-left">
+              Status: {enabled ? 'On' : 'Off'}
+            </span>
+          </div>
+        </div>
       </div>
-      {enabled && <div className="h-full overflow-auto">{children}</div>}
+      {enabled && (
+        <div className="flex-1 overflow-y-auto overflow-x-hidden p-2">
+          <div className="min-w-0">{children}</div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- stack Lab Mode controls vertically on narrow viewports while keeping status messaging concise
- prevent horizontal overflow by constraining the content region when Lab Mode is active

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db4ddb26cc8328968246cce8af3657