### PR TITLE
[ui] Improve toggle switch accessibility and drag handling

### DIFF
--- a/__tests__/ToggleSwitch.test.tsx
+++ b/__tests__/ToggleSwitch.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import ToggleSwitch from "../components/ToggleSwitch";
+
+describe("ToggleSwitch", () => {
+  it("renders provided label and caption for clarity", () => {
+    render(
+      <ToggleSwitch
+        checked={false}
+        onChange={() => {}}
+        label="Sample Label"
+        caption="Helpful caption"
+      />
+    );
+
+    expect(screen.getByText("Sample Label")).toBeInTheDocument();
+    expect(screen.getByText("Helpful caption")).toBeInTheDocument();
+  });
+
+  it("does not toggle when a vertical scroll gesture is detected", () => {
+    const handleChange = jest.fn();
+    render(
+      <ToggleSwitch checked={false} onChange={handleChange} label="Scroll Guard" />
+    );
+
+    const switchButton = screen.getByRole("switch");
+
+    fireEvent.pointerDown(switchButton, {
+      clientX: 0,
+      clientY: 0,
+      pointerType: "touch",
+      buttons: 1,
+    });
+    fireEvent.pointerMove(switchButton, {
+      clientX: 0,
+      clientY: 40,
+      pointerType: "touch",
+      buttons: 1,
+    });
+    fireEvent.wheel(switchButton, { deltaY: 40 });
+    fireEvent.pointerUp(switchButton, {
+      clientX: 0,
+      clientY: 40,
+      pointerType: "touch",
+    });
+    fireEvent.click(switchButton);
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it("toggles after an intentional tap interaction", () => {
+    const handleChange = jest.fn();
+    render(
+      <ToggleSwitch checked={false} onChange={handleChange} label="Drag Toggle" />
+    );
+
+    const switchButton = screen.getByRole("switch");
+
+    fireEvent.pointerDown(switchButton, {
+      clientX: 0,
+      clientY: 0,
+      pointerType: "touch",
+      buttons: 1,
+    });
+    fireEvent.pointerUp(switchButton, {
+      clientX: 0,
+      clientY: 0,
+      pointerType: "touch",
+      buttons: 0,
+    });
+    fireEvent.click(switchButton);
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenNthCalledWith(1, true);
+
+    fireEvent.click(switchButton);
+
+    expect(handleChange).toHaveBeenCalledTimes(2);
+    expect(handleChange).toHaveBeenNthCalledWith(2, true);
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -127,7 +127,7 @@ export default function Settings() {
               />
             )}
           </div>
-          <div className="flex justify-center my-4">
+          <div className="flex items-center justify-center my-4">
             <label className="mr-2 text-ubt-grey">Theme:</label>
             <select
               value={theme}
@@ -140,7 +140,7 @@ export default function Settings() {
               <option value="matrix">Matrix</option>
             </select>
           </div>
-          <div className="flex justify-center my-4">
+          <div className="flex items-center justify-center my-4">
             <label className="mr-2 text-ubt-grey">Accent:</label>
             <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
               {ACCENT_OPTIONS.map((c) => (
@@ -156,14 +156,16 @@ export default function Settings() {
               ))}
             </div>
           </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey flex items-center">
-              <input
-                type="checkbox"
-                checked={useKaliWallpaper}
-                onChange={(e) => setUseKaliWallpaper(e.target.checked)}
-                className="mr-2"
-              />
+          <div className="flex items-center justify-center my-4">
+            <input
+              id="kali-gradient-wallpaper"
+              type="checkbox"
+              checked={useKaliWallpaper}
+              onChange={(e) => setUseKaliWallpaper(e.target.checked)}
+              className="mr-2"
+              aria-label="Enable Kali gradient wallpaper"
+            />
+            <label htmlFor="kali-gradient-wallpaper" className="text-ubt-grey">
               Kali Gradient Wallpaper
             </label>
           </div>
@@ -258,28 +260,31 @@ export default function Settings() {
               <option value="compact">Compact</option>
             </select>
           </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">Reduced Motion:</span>
+          <div className="flex justify-center my-4">
             <ToggleSwitch
               checked={reducedMotion}
               onChange={setReducedMotion}
-              ariaLabel="Reduced Motion"
+              label="Reduced Motion"
+              caption="Limit animations and motion effects."
+              containerClassName="w-full max-w-xs justify-between"
             />
           </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">High Contrast:</span>
+          <div className="flex justify-center my-4">
             <ToggleSwitch
               checked={highContrast}
               onChange={setHighContrast}
-              ariaLabel="High Contrast"
+              label="High Contrast"
+              caption="Increase interface contrast for readability."
+              containerClassName="w-full max-w-xs justify-between"
             />
           </div>
-          <div className="flex justify-center my-4 items-center">
-            <span className="mr-2 text-ubt-grey">Haptics:</span>
+          <div className="flex justify-center my-4">
             <ToggleSwitch
               checked={haptics}
               onChange={setHaptics}
-              ariaLabel="Haptics"
+              label="Haptics"
+              caption="Enable simulated vibration feedback."
+              containerClassName="w-full max-w-xs justify-between"
             />
           </div>
           <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">

--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -1,25 +1,132 @@
 "use client";
-import React from "react";
+import React, { useId, useRef } from "react";
+
+type PointerState = {
+  hadPointerInteraction: boolean;
+  startX: number;
+  startY: number;
+  isScrollLike: boolean;
+};
+
+const DRAG_THRESHOLD = 12;
 
 interface ToggleSwitchProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
   className?: string;
-  ariaLabel: string;
+  containerClassName?: string;
+  ariaLabel?: string;
+  label?: string;
+  labelClassName?: string;
+  caption?: string;
+  captionClassName?: string;
 }
 
 export default function ToggleSwitch({
   checked,
   onChange,
   className = "",
+  containerClassName = "",
   ariaLabel,
+  label,
+  labelClassName = "text-ubt-grey",
+  caption,
+  captionClassName = "text-xs text-ubt-grey opacity-80",
 }: ToggleSwitchProps) {
-  return (
+  const labelId = useId();
+  const captionId = useId();
+  const pointerState = useRef<PointerState>({
+    hadPointerInteraction: false,
+    startX: 0,
+    startY: 0,
+    isScrollLike: false,
+  });
+
+  const resetPointerState = () => {
+    pointerState.current.hadPointerInteraction = false;
+    pointerState.current.isScrollLike = false;
+    pointerState.current.startX = 0;
+    pointerState.current.startY = 0;
+  };
+
+  const evaluateScrollIntent = (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (!pointerState.current.hadPointerInteraction) return;
+
+    const state = pointerState.current;
+    const nativeEvent = event.nativeEvent as PointerEvent | undefined;
+    const clientX =
+      event.clientX ?? nativeEvent?.clientX ?? nativeEvent?.pageX ?? 0;
+    const clientY =
+      event.clientY ?? nativeEvent?.clientY ?? nativeEvent?.pageY ?? 0;
+
+    const dx = clientX - state.startX;
+    const dy = clientY - state.startY;
+    const absDx = Math.abs(dx);
+    const absDy = Math.abs(dy);
+    const isVerticalScroll = absDy > absDx && absDy >= DRAG_THRESHOLD;
+
+    if (isVerticalScroll) {
+      state.isScrollLike = true;
+    }
+  };
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
+    const nativeEvent = event.nativeEvent as PointerEvent | undefined;
+    pointerState.current.startX =
+      event.clientX ?? nativeEvent?.clientX ?? nativeEvent?.pageX ?? 0;
+    pointerState.current.startY =
+      event.clientY ?? nativeEvent?.clientY ?? nativeEvent?.pageY ?? 0;
+    pointerState.current.hadPointerInteraction = true;
+    pointerState.current.isScrollLike = false;
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLButtonElement>) => {
+    evaluateScrollIntent(event);
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLButtonElement>) => {
+    evaluateScrollIntent(event);
+  };
+
+  const handlePointerCancel = () => {
+    resetPointerState();
+  };
+
+  const handleWheel = (event: React.WheelEvent<HTMLButtonElement>) => {
+    if (!pointerState.current.hadPointerInteraction) return;
+
+    if (Math.abs(event.deltaY) >= DRAG_THRESHOLD) {
+      pointerState.current.isScrollLike = true;
+    }
+  };
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const state = pointerState.current;
+
+    if (state.hadPointerInteraction && state.isScrollLike) {
+      event.preventDefault();
+      resetPointerState();
+      return;
+    }
+
+    onChange(!checked);
+    resetPointerState();
+  };
+
+  const button = (
     <button
+      type="button"
       role="switch"
       aria-checked={checked}
-      aria-label={ariaLabel}
-      onClick={() => onChange(!checked)}
+      aria-labelledby={label ? labelId : undefined}
+      aria-describedby={caption ? captionId : undefined}
+      aria-label={label ? undefined : ariaLabel}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+      onWheel={handleWheel}
+      onClick={handleClick}
       className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
         checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
       } ${className}`.trim()}
@@ -30,5 +137,31 @@ export default function ToggleSwitch({
         }`}
       />
     </button>
+  );
+
+  if (!label && !caption) {
+    if (!containerClassName) {
+      return button;
+    }
+
+    return <div className={`flex items-center gap-3 ${containerClassName}`.trim()}>{button}</div>;
+  }
+
+  return (
+    <div className={`flex items-center gap-3 ${containerClassName}`.trim()}>
+      <div className="flex flex-col">
+        {label && (
+          <span id={labelId} className={labelClassName}>
+            {label}
+          </span>
+        )}
+        {caption && (
+          <span id={captionId} className={captionClassName}>
+            {caption}
+          </span>
+        )}
+      </div>
+      {button}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add drag threshold handling and wheel guard to the shared ToggleSwitch while supporting visible labels and captions
- update settings and panel preferences toggles to use the new labeling helpers for clearer copy
- add regression tests that cover intentional taps and scroll gestures on the toggle switch

## Testing
- yarn lint
- yarn test ToggleSwitch


------
https://chatgpt.com/codex/tasks/task_e_68db4dd837b4832898a34b7a94681ec3