### PR TITLE
[ui] Stack ModuleCard content vertically

### DIFF
--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -33,27 +33,55 @@ export default function ModuleCard({
   return (
     <button
       onClick={() => onSelect(module)}
-      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
+      className={`w-full text-left border rounded-lg p-4 flex flex-col gap-4 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
         selected ? 'bg-gray-100' : ''
       }`}
     >
-      <div className="flex-1 pr-2 font-mono">
-        <h3 className="font-bold">{highlight(module.name, query)}</h3>
-        <p className="text-sm">{highlight(module.description, query)}</p>
+      <div className="flex flex-col items-center justify-center gap-3">
+        <div className="flex flex-col items-center gap-2">
+          <span className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+            <Image
+              src="/themes/Yaru/status/about.svg"
+              alt="Module details"
+              width={28}
+              height={28}
+            />
+          </span>
+          <span className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+            Details
+          </span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <span className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+            <Image
+              src="/themes/Yaru/status/download.svg"
+              alt="Run module"
+              width={28}
+              height={28}
+            />
+          </span>
+          <span className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+            Run
+          </span>
+        </div>
       </div>
-      <div className="flex flex-col gap-2 items-center">
-        <Image
-          src="/themes/Yaru/status/about.svg"
-          alt="Details"
-          width={24}
-          height={24}
-        />
-        <Image
-          src="/themes/Yaru/status/download.svg"
-          alt="Run"
-          width={24}
-          height={24}
-        />
+      <div className="flex flex-col gap-2 font-mono text-gray-800">
+        <h3 className="text-base font-bold text-center sm:text-left">
+          {highlight(module.name, query)}
+        </h3>
+        <p className="text-sm leading-relaxed text-center sm:text-left">
+          {highlight(module.description, query)}
+        </p>
+      </div>
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2">
+          <span className="inline-flex w-full items-center justify-center rounded-md border border-gray-200 bg-white px-4 py-3 text-sm font-semibold text-gray-700 shadow-sm">
+            View module details
+          </span>
+          <span className="inline-flex w-full items-center justify-center rounded-md border border-gray-200 bg-white px-4 py-3 text-sm font-semibold text-gray-700 shadow-sm">
+            Run selected module
+          </span>
+        </div>
       </div>
     </button>
   );


### PR DESCRIPTION
## Summary
- stack ModuleCard imagery above descriptions and actions for a mobile-friendly layout
- add larger touch targets and spacing to keep the card readable on small screens

## Testing
- yarn dev

------
https://chatgpt.com/codex/tasks/task_e_68db4dd0e2bc83288883e2bbe3513783