### PR TITLE
[apps] restructure command builder form

### DIFF
--- a/components/CommandBuilder.tsx
+++ b/components/CommandBuilder.tsx
@@ -15,26 +15,60 @@ export default function CommandBuilder({ doc, build }: BuilderProps) {
   const command = build(params);
 
   return (
-    <form className="text-xs" onSubmit={(e) => e.preventDefault()} aria-label="command builder">
-      <p className="mb-2" aria-label="inline docs">{doc}</p>
-      <label className="block mb-1">
-        <span className="mr-1">Target</span>
-        <input
-          aria-label="target"
-          value={params.target || ''}
-          onChange={update('target')}
-          className="border p-1 text-black w-full"
-        />
-      </label>
-      <label className="block mb-1">
-        <span className="mr-1">Options</span>
-        <input
-          aria-label="options"
-          value={params.opts || ''}
-          onChange={update('opts')}
-          className="border p-1 text-black w-full"
-        />
-      </label>
+    <form
+      className="text-xs space-y-4"
+      onSubmit={(e) => e.preventDefault()}
+      aria-labelledby="command-builder-heading"
+    >
+      <p id="command-builder-heading" className="font-semibold">
+        {doc}
+      </p>
+
+      <fieldset className="space-y-2" aria-labelledby="target-details-heading">
+        <legend id="target-details-heading" className="text-[0.8rem] font-semibold">
+          Target details
+        </legend>
+        <div className="grid gap-2 md:grid-cols-2">
+          <label className="flex flex-col gap-1">
+            <span>Target</span>
+            <input
+              aria-label="target"
+              value={params.target || ''}
+              onChange={update('target')}
+              className="border p-1 text-black w-full"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span>Port</span>
+            <input
+              aria-label="port"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              value={params.port || ''}
+              onChange={update('port')}
+              className="border p-1 text-black w-full"
+            />
+          </label>
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-2" aria-labelledby="command-options-heading">
+        <legend id="command-options-heading" className="text-[0.8rem] font-semibold">
+          Command options
+        </legend>
+        <div className="grid gap-2">
+          <label className="flex flex-col gap-1">
+            <span>Options</span>
+            <input
+              aria-label="options"
+              value={params.opts || ''}
+              onChange={update('opts')}
+              className="border p-1 text-black w-full"
+            />
+          </label>
+        </div>
+      </fieldset>
+
       <div className="mt-2">
         <TerminalOutput text={command} ariaLabel="command output" />
       </div>

--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -134,6 +134,7 @@ export default function SecurityTools() {
             value={query}
             onChange={e => setQuery(e.target.value)}
             placeholder="Search all tools"
+            aria-label="search all tools"
             className="w-full mb-2 p-1 text-black text-xs"
           />
           {query ? (
@@ -200,7 +201,18 @@ export default function SecurityTools() {
               <div>
                 <CommandBuilder
                   doc="Build a curl command. Output is copy-only and not executed."
-                  build={({ target = '', opts = '' }) => `curl ${opts} ${target}`.trim()}
+                  build={({ target = '', port = '', opts = '' }) => {
+                    const host = target ? target.trim() : '';
+                    const portSegment = port ? `:${port.trim()}` : '';
+                    const segments = ['curl'];
+                    if (opts.trim()) {
+                      segments.push(opts.trim());
+                    }
+                    if (host) {
+                      segments.push(`${host}${portSegment}`);
+                    }
+                    return segments.join(' ');
+                  }}
                 />
               </div>
             )}
@@ -238,9 +250,19 @@ export default function SecurityTools() {
             {active === 'yara' && (
             <div>
               <p className="text-xs mb-2">Simplified YARA tester using sample text. Pattern matching is simulated.</p>
-              <textarea value={yaraRule} onChange={e=>setYaraRule(e.target.value)} className="w-full h-24 text-black p-1" />
+              <textarea
+                value={yaraRule}
+                onChange={e=>setYaraRule(e.target.value)}
+                aria-label="yara rule"
+                className="w-full h-24 text-black p-1"
+              />
               <div className="text-xs mt-2 mb-1">Sample file:</div>
-              <textarea value={sampleText} readOnly className="w-full h-24 text-black p-1" />
+              <textarea
+                value={sampleText}
+                readOnly
+                aria-label="sample text"
+                className="w-full h-24 text-black p-1"
+              />
               <button onClick={runYara} className="mt-2 px-2 py-1 bg-ub-green text-black text-xs">Scan</button>
               {yaraResult && <div className="mt-2 text-xs">{yaraResult}</div>}
             </div>


### PR DESCRIPTION
## Summary
- group the command builder inputs into target and options fieldsets with responsive layout
- add a dedicated port field that uses mobile numeric keyboards and keeps mobile layout stacked
- label search and textarea controls in the security tools lab for accessibility while supporting the new command output

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db4dd688fc8328af508b8259b5e265