### PR TITLE
[timeline] Improve timeline readability and sticky headers

### DIFF
--- a/__tests__/scrollableTimeline.test.tsx
+++ b/__tests__/scrollableTimeline.test.tsx
@@ -1,30 +1,19 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import ScrollableTimeline from '../components/ScrollableTimeline';
 
-// Provide a minimal IntersectionObserver mock for the test environment
-beforeAll(() => {
-  class IntersectionObserverMock {
-    constructor() {}
-    disconnect() {}
-    observe() {}
-    unobserve() {}
-    takeRecords() { return []; }
-  }
-  // @ts-ignore
-  global.IntersectionObserver = IntersectionObserverMock;
-});
-
 describe('ScrollableTimeline', () => {
-  it('toggles between year and month view', () => {
+  it('renders milestones with sticky day headers', () => {
     render(<ScrollableTimeline />);
-    // Initially shows years
-    const year = screen.getByText('2012');
-    expect(year).toBeInTheDocument();
 
-    // Clicking a year zooms to month view
-    fireEvent.click(year);
-    expect(screen.getByText('2012-09')).toBeInTheDocument();
-    expect(screen.getByText('Back to years')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /career timeline/i })).toBeInTheDocument();
+
+    const dayHeader = screen.getByText(/Sep\s+1,\s+2012/i);
+    expect(dayHeader).toBeInTheDocument();
+    const headerElement = dayHeader.closest('header');
+    expect(headerElement).toHaveClass('sticky');
+
+    const links = screen.getAllByRole('link', { name: /visit resource/i });
+    expect(links.length).toBeGreaterThan(0);
   });
 });
 

--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -1,173 +1,199 @@
-import React, {
-  useState,
-  useMemo,
-  useRef,
-  useEffect,
-} from 'react';
+import React, { useMemo } from 'react';
 import rawMilestones from '../data/milestones.json';
 
 interface Milestone {
-  date: string; // YYYY-MM
+  date: string; // YYYY-MM or YYYY-MM-DD
   title: string;
   image: string;
   link: string;
   tags: string[];
 }
 
-interface GroupedMilestone extends Milestone {
-  month: string;
+interface TimelineEntry extends Milestone {
+  isoDay: string;
+  year: string;
+  weekday: string;
+  dayLabel: string;
+  monthLabel: string;
+}
+
+interface TimelineSection {
+  isoDay: string;
+  year: string;
+  weekday: string;
+  dayLabel: string;
+  entries: TimelineEntry[];
 }
 
 const milestones = rawMilestones as Milestone[];
 
+const MINOR_TICK_SPACING_PX = 112;
+
+const dayFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+const weekdayFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'short' });
+
+const monthFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  year: 'numeric',
+});
+
 const ScrollableTimeline: React.FC = () => {
-  const [view, setView] = useState<'year' | 'month'>('year');
-  const [selectedYear, setSelectedYear] = useState<string | null>(null);
+  const sections = useMemo(() => {
+    const parsedEntries: TimelineEntry[] = milestones
+      .map((milestone) => {
+        const [year, month, rawDay] = milestone.date.split('-');
+        const numericYear = Number(year);
+        const numericMonth = Number(month) - 1;
+        const numericDay = rawDay ? Number(rawDay) : 1;
+        const dateObj = new Date(numericYear, numericMonth, numericDay);
+        const isoDay = `${year}-${month}-${(rawDay || '01').padStart(2, '0')}`;
 
-  const containerRef = useRef<HTMLDivElement>(null);
-  const itemRefs = useRef<(HTMLLIElement | null)[]>([]);
+        return {
+          ...milestone,
+          isoDay,
+          year,
+          weekday: weekdayFormatter.format(dateObj),
+          dayLabel: dayFormatter.format(dateObj),
+          monthLabel: monthFormatter.format(dateObj),
+        };
+      })
+      .sort((a, b) => a.date.localeCompare(b.date));
 
-  const milestonesByYear = useMemo(() => {
-    return milestones.reduce<Record<string, GroupedMilestone[]>>((acc, m) => {
-      const [year, month] = m.date.split('-');
-      const entry: GroupedMilestone = { ...m, month };
-      (acc[year] = acc[year] || []).push(entry);
-      return acc;
-    }, {});
+    const grouped = new Map<string, TimelineSection>();
+    const orderedSections: TimelineSection[] = [];
+
+    parsedEntries.forEach((entry) => {
+      let section = grouped.get(entry.isoDay);
+      if (!section) {
+        section = {
+          isoDay: entry.isoDay,
+          year: entry.year,
+          weekday: entry.weekday,
+          dayLabel: entry.dayLabel,
+          entries: [],
+        };
+        grouped.set(entry.isoDay, section);
+        orderedSections.push(section);
+      }
+      section.entries.push(entry);
+    });
+
+    return orderedSections;
   }, []);
 
-  const years = useMemo(() => Object.keys(milestonesByYear).sort(), [milestonesByYear]);
-
-  const monthItems = useMemo(() => {
-    if (!selectedYear) return [] as GroupedMilestone[];
-    return milestonesByYear[selectedYear].sort((a, b) => a.month.localeCompare(b.month));
-  }, [milestonesByYear, selectedYear]);
-
-  useEffect(() => {
-    const container = containerRef.current as HTMLElement | null;
-    if (container && 'scrollTo' in container) {
-      (container as any).scrollTo({ left: 0 });
-    }
-  }, [view, selectedYear]);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            (entry.target as HTMLElement).focus();
-          }
-        });
-      },
-      { root: container, threshold: 0.6 },
-    );
-    itemRefs.current.forEach((el) => {
-      if (el) observer.observe(el);
-    });
-    return () => observer.disconnect();
-  }, [view, years, monthItems]);
-
   const renderTags = (tags: string[]) => (
-    <ul className="flex flex-wrap gap-1 text-xs md:text-sm text-gray-400">
+    <ul className="flex flex-wrap gap-2 text-xs md:text-sm text-slate-300">
       {tags.map((tag) => (
-        <li key={tag}>#{tag}</li>
+        <li key={tag} className="rounded bg-slate-800/80 px-2 py-0.5">
+          #{tag}
+        </li>
       ))}
     </ul>
   );
 
+  const axisTickStyle = useMemo(
+    () => ({
+      backgroundImage: `repeating-linear-gradient(to bottom, transparent, transparent ${MINOR_TICK_SPACING_PX - 2}px, rgba(148, 163, 184, 0.35) ${MINOR_TICK_SPACING_PX - 2}px, rgba(148, 163, 184, 0.35) ${MINOR_TICK_SPACING_PX}px)`,
+      backgroundRepeat: 'repeat-y',
+      backgroundSize: `100% ${MINOR_TICK_SPACING_PX}px`,
+    }),
+    [],
+  );
+
   return (
-    <div>
-      <div className="flex justify-between mb-4">
-        {view === 'month' && (
-          <button
-            type="button"
-            onClick={() => {
-              setView('year');
-              setSelectedYear(null);
-            }}
-            className="text-sm text-ubt-blue underline"
-          >
-            Back to years
-          </button>
-        )}
-        <div className="text-sm">
-          {view === 'year' ? 'Year view' : `${selectedYear} view`}
-        </div>
-      </div>
-      <div
-        ref={containerRef}
-        className="overflow-x-auto snap-x snap-mandatory focus:outline-none"
-        aria-labelledby="timeline-heading"
-      >
-        <h3 id="timeline-heading" className="sr-only">
-          Timeline
+    <section aria-labelledby="timeline-heading" className="text-slate-100">
+      <div className="mb-4">
+        <h3 id="timeline-heading" className="text-xl font-semibold">
+          Career timeline
         </h3>
-        <ol className="flex space-x-6">
-          {view === 'year'
-            ? years.map((year, index) => {
-                const first = milestonesByYear[year][0];
-                return (
-                  <li
-                    key={year}
-                    ref={(el) => {
-                      itemRefs.current[index] = el;
-                    }}
-                    tabIndex={-1}
-                    className="snap-center flex-shrink-0 w-64 p-4 bg-gray-800 rounded-lg focus:outline-none"
-                  >
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setView('month');
-                        setSelectedYear(year);
-                      }}
-                      className="text-left w-full focus:outline-none"
-                    >
-                      <div className="text-ubt-blue font-bold text-lg mb-2">{year}</div>
-                      <img
-                        src={first.image}
-                        alt={first.title}
-                        className="w-full h-32 object-cover mb-2 rounded"
-                      />
-                      <p className="text-sm md:text-base mb-2">{first.title}</p>
-                      {renderTags(first.tags)}
-                    </button>
-                  </li>
-                );
-              })
-            : monthItems.map((m, index) => (
-                <li
-                  key={`${selectedYear}-${m.month}`}
-                  ref={(el) => {
-                    itemRefs.current[index] = el;
-                  }}
-                  tabIndex={-1}
-                  className="snap-center flex-shrink-0 w-64 p-4 bg-gray-800 rounded-lg focus:outline-none"
-                >
-                  <div className="text-ubt-blue font-bold text-lg mb-2">
-                    {selectedYear}-{m.month}
+        <p className="text-sm text-slate-400">Scroll to explore milestones grouped by day.</p>
+      </div>
+      <div className="relative max-h-[70vh] overflow-y-auto pr-4">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute left-8 top-0 bottom-0 w-8"
+          style={axisTickStyle}
+        />
+        <div aria-hidden className="pointer-events-none absolute left-12 top-0 bottom-0 w-px bg-slate-600/70" />
+        <ol role="list" className="relative space-y-16 pl-24">
+          {sections.map((section, sectionIndex) => {
+            const previousYear = sections[sectionIndex - 1]?.year;
+            const showYearChip = previousYear !== section.year;
+
+            return (
+              <li key={section.isoDay} className="relative">
+                {showYearChip && (
+                  <div className="sticky top-0 -ml-24 mb-2 pl-24">
+                    <span className="inline-flex rounded-full border border-slate-700/70 bg-slate-900/90 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 shadow">
+                      {section.year}
+                    </span>
                   </div>
-                  <a
-                    href={m.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block mb-2"
-                  >
-                    <img
-                      src={m.image}
-                      alt={m.title}
-                      className="w-full h-32 object-cover mb-2 rounded"
-                    />
-                    <p className="text-sm md:text-base">{m.title}</p>
-                  </a>
-                  {renderTags(m.tags)}
-                </li>
-              ))}
+                )}
+                <header className="sticky top-8 -ml-24 z-10 mb-6 pl-24">
+                  <div className="inline-flex items-center gap-3 rounded-full border border-slate-700/60 bg-slate-900/95 px-3 py-1.5 text-sm font-medium text-slate-100 shadow">
+                    <span className="text-xs uppercase tracking-[0.3em] text-slate-400">{section.weekday}</span>
+                    <span>{section.dayLabel}</span>
+                  </div>
+                </header>
+                <span
+                  aria-hidden
+                  className="absolute top-16 left-12 flex h-3 w-3 -translate-x-1/2 items-center justify-center"
+                >
+                  <span className="h-3 w-3 rounded-full border-2 border-slate-900 bg-ubt-blue shadow" />
+                </span>
+                <div className="space-y-6">
+                  {section.entries.map((entry, entryIndex) => {
+                    const entryId = `${section.isoDay}-${entryIndex}`;
+                    return (
+                      <article
+                        key={entryId}
+                        aria-labelledby={`${entryId}-title`}
+                        className="rounded-xl border border-slate-700/60 bg-slate-800/80 p-4 shadow-lg backdrop-blur"
+                      >
+                        <div className="flex flex-col gap-3 md:flex-row">
+                          <div className="md:w-48">
+                            <img
+                              src={entry.image}
+                              alt={entry.title}
+                              className="h-32 w-full rounded-lg object-cover"
+                            />
+                          </div>
+                          <div className="flex-1 space-y-2">
+                            <div>
+                              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-ubt-blue">
+                                {entry.monthLabel}
+                              </p>
+                              <h4 id={`${entryId}-title`} className="text-lg font-semibold leading-tight">
+                                {entry.title}
+                              </h4>
+                            </div>
+                            <a
+                              href={entry.link}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-flex items-center gap-2 text-sm font-medium text-ubt-blue underline"
+                            >
+                              Visit resource
+                              <span aria-hidden>↗</span>
+                            </a>
+                            {renderTags(entry.tags)}
+                          </div>
+                        </div>
+                      </article>
+                    );
+                  })}
+                </div>
+              </li>
+            );
+          })}
         </ol>
       </div>
-    </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
## Summary
- reorganized the timeline into a vertical layout with sticky day headers and clearer labels
- reduced timeline tick density and refreshed styling to keep milestone content legible

## Testing
- yarn test scrollableTimeline

------
https://chatgpt.com/codex/tasks/task_e_68db4dc5b9208328875cb4d4ce226e54