### PR TITLE
[components] Make Beta badge responsive

### DIFF
--- a/components/BetaBadge.jsx
+++ b/components/BetaBadge.jsx
@@ -3,9 +3,14 @@ export default function BetaBadge() {
   return (
     <button
       type="button"
-      className="fixed bottom-4 right-4 rounded bg-yellow-500/90 px-2 py-1 text-xs font-semibold text-black"
+      aria-label="Beta program indicator"
+      title="Beta"
+      className="fixed bottom-4 right-4 flex h-8 w-8 items-center justify-center rounded bg-yellow-500/90 text-xs font-semibold text-black shadow-sm transition-transform sm:w-auto sm:px-2 sm:py-1"
     >
-      Beta
+      <span aria-hidden="true" className="text-base leading-none sm:hidden">
+        β
+      </span>
+      <span className="hidden sm:inline">Beta</span>
     </button>
   );
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,18 @@ import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
 const compat = new FlatCompat();
 
 const config = [
+  {
+    files: ['**/*.{js,jsx,ts,tsx,mjs,cjs}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+  },
   { ignores: ['components/apps/Chrome/index.tsx'] },
   {
     plugins: {


### PR DESCRIPTION
## Summary
- hide the beta badge label on small screens while showing an icon with tooltip and aria support
- maintain fixed dimensions on compact viewports to prevent layout shifts when the badge renders
- expand the ESLint flat config so JSX files such as the beta badge are linted consistently

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db4dc28c4883289bbaec66966bc6d0