### PR TITLE
[ui] improve form error focus handling

### DIFF
--- a/__tests__/liveRegion.test.tsx
+++ b/__tests__/liveRegion.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import Toast from '../components/ui/Toast';
 import FormError from '../components/ui/FormError';
 
@@ -15,5 +15,27 @@ describe('live region components', () => {
     render(<FormError>Required field</FormError>);
     const region = screen.getByRole('status');
     expect(region).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('FormError focuses the first invalid field it describes', async () => {
+    render(
+      <div>
+        <input
+          aria-invalid="true"
+          aria-describedby="first-error"
+          data-testid="first-field"
+        />
+        <input
+          aria-invalid="true"
+          aria-describedby="second-error"
+          data-testid="second-field"
+        />
+        <FormError id="first-error">First error</FormError>
+        <FormError id="second-error">Second error</FormError>
+      </div>
+    );
+
+    const firstField = screen.getByTestId('first-field');
+    await waitFor(() => expect(document.activeElement).toBe(firstField));
   });
 });

--- a/components/ui/FormError.tsx
+++ b/components/ui/FormError.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 interface FormErrorProps {
   id?: string;
@@ -6,15 +6,43 @@ interface FormErrorProps {
   children: React.ReactNode;
 }
 
-const FormError = ({ id, className = '', children }: FormErrorProps) => (
-  <p
-    id={id}
-    role="status"
-    aria-live="polite"
-    className={`text-red-600 text-sm mt-2 ${className}`.trim()}
-  >
-    {children}
-  </p>
-);
+const baseClassName = 'mt-2 text-sm text-red-500 block leading-snug';
+
+const FormError = ({ id, className = '', children }: FormErrorProps) => {
+  useEffect(() => {
+    if (typeof window === 'undefined' || !id) return;
+
+    const describedField = document.querySelector<HTMLElement>(
+      `[aria-describedby~="${id}"][aria-invalid="true"]`
+    );
+
+    if (!describedField) return;
+
+    const firstInvalidField = document.querySelector<HTMLElement>(
+      '[aria-invalid="true"]'
+    );
+
+    if (!firstInvalidField || firstInvalidField !== describedField) return;
+
+    if (typeof describedField.scrollIntoView === 'function') {
+      describedField.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
+    if (document.activeElement !== describedField) {
+      const focusable = describedField as HTMLElement & {
+        focus(options?: FocusOptions): void;
+      };
+      focusable.focus?.({ preventScroll: true });
+    }
+  }, [id, children]);
+
+  const classes = [baseClassName, className].filter(Boolean).join(' ');
+
+  return (
+    <p id={id} role="status" aria-live="polite" className={classes}>
+      {children}
+    </p>
+  );
+};
 
 export default FormError;


### PR DESCRIPTION
## Summary
- ensure form errors render with consistent spacing beneath their inputs
- automatically focus and scroll the first invalid field when validation fails
- add a regression test to confirm the focus behaviour remains accessible

## Testing
- yarn test __tests__/liveRegion.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db4dbf2a5883288415451934070dde