### PR TITLE
[ui] Improve tooltip interactions on mobile

### DIFF
--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -83,7 +83,15 @@ export default function AppGrid({ openApp }) {
     const meta = data.metadata[app.id] ?? buildAppMetadata(app);
     return (
       <DelayedTooltip content={<AppTooltipContent meta={meta} />}>
-        {({ ref, onMouseEnter, onMouseLeave, onFocus, onBlur }) => (
+        {({
+          ref,
+          onPointerDown,
+          onPointerUp,
+          onPointerLeave,
+          onPointerCancel,
+          onFocus,
+          onBlur,
+        }) => (
           <div
             ref={ref}
             style={{
@@ -93,10 +101,6 @@ export default function AppGrid({ openApp }) {
               alignItems: 'center',
               padding: 12,
             }}
-            onMouseEnter={onMouseEnter}
-            onMouseLeave={onMouseLeave}
-            onFocus={onFocus}
-            onBlur={onBlur}
           >
             <UbuntuApp
               id={app.id}
@@ -104,6 +108,12 @@ export default function AppGrid({ openApp }) {
               name={app.title}
               displayName={<>{app.nodes}</>}
               openApp={() => openApp && openApp(app.id)}
+              onPointerDown={onPointerDown}
+              onPointerUp={onPointerUp}
+              onPointerCancel={onPointerCancel}
+              onPointerLeave={onPointerLeave}
+              onFocus={onFocus}
+              onBlur={onBlur}
             />
           </div>
         )}
@@ -118,6 +128,7 @@ export default function AppGrid({ openApp }) {
         placeholder="Search"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
+        aria-label="Search apps"
       />
       <div className="w-full flex-1 h-[70vh] outline-none" onKeyDown={handleKeyDown}>
         <AutoSizer>

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -38,6 +38,9 @@ export class UbuntuApp extends Component {
             onPointerMove,
             onPointerUp,
             onPointerCancel,
+            onPointerLeave,
+            onFocus: onFocusProp,
+            onBlur: onBlurProp,
             style,
         } = this.props;
 
@@ -68,6 +71,7 @@ export class UbuntuApp extends Component {
                 onPointerMove={onPointerMove}
                 onPointerUp={onPointerUp}
                 onPointerCancel={onPointerCancel}
+                onPointerLeave={onPointerLeave}
                 style={combinedStyle}
                 className={(this.state.launching ? " app-icon-launch " : "") + (dragging ? " opacity-70 " : "") +
                     " m-px z-10 bg-white bg-opacity-0 hover:bg-opacity-20 focus:bg-white focus:bg-opacity-50 focus:border-yellow-700 focus:border-opacity-100 border border-transparent outline-none rounded select-none flex flex-col justify-start items-center text-center font-normal text-white transition-hover transition-active "}
@@ -76,7 +80,17 @@ export class UbuntuApp extends Component {
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.openApp(); } }}
                 tabIndex={this.props.disabled ? -1 : 0}
                 onMouseEnter={this.handlePrefetch}
-                onFocus={this.handlePrefetch}
+                onFocus={(event) => {
+                    this.handlePrefetch();
+                    if (typeof onFocusProp === 'function') {
+                        onFocusProp(event);
+                    }
+                }}
+                onBlur={(event) => {
+                    if (typeof onBlurProp === 'function') {
+                        onBlurProp(event);
+                    }
+                }}
             >
                 <Image
                     width={48}

--- a/components/ui/AppTooltipContent.tsx
+++ b/components/ui/AppTooltipContent.tsx
@@ -15,7 +15,7 @@ const AppTooltipContent: React.FC<AppTooltipContentProps> = ({ meta }) => {
   }
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2 break-words text-left">
       {meta.title ? (
         <p className="text-sm font-semibold text-white">{meta.title}</p>
       ) : null}

--- a/components/ui/DelayedTooltip.tsx
+++ b/components/ui/DelayedTooltip.tsx
@@ -10,8 +10,10 @@ import { createPortal } from 'react-dom';
 
 type TriggerProps = {
   ref: (node: HTMLElement | null) => void;
-  onMouseEnter: (event: React.MouseEvent<HTMLElement>) => void;
-  onMouseLeave: (event: React.MouseEvent<HTMLElement>) => void;
+  onPointerDown: (event: React.PointerEvent<HTMLElement>) => void;
+  onPointerUp: (event: React.PointerEvent<HTMLElement>) => void;
+  onPointerLeave: (event: React.PointerEvent<HTMLElement>) => void;
+  onPointerCancel: (event: React.PointerEvent<HTMLElement>) => void;
   onFocus: (event: React.FocusEvent<HTMLElement>) => void;
   onBlur: (event: React.FocusEvent<HTMLElement>) => void;
 };
@@ -22,10 +24,19 @@ type DelayedTooltipProps = {
   children: (triggerProps: TriggerProps) => React.ReactElement;
 };
 
-const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+const isBrowser = () =>
+  typeof globalThis !== 'undefined' &&
+  typeof (globalThis as typeof globalThis & { document?: unknown }).document !== 'undefined';
+
+const useIsomorphicLayoutEffect = isBrowser() ? useLayoutEffect : useEffect;
 
 const DEFAULT_OFFSET = 8;
+const AUTO_DISMISS_DELAY = 2000;
+
+const getTimestamp = () =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
 
 const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
   content,
@@ -36,7 +47,9 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const [visible, setVisible] = useState(false);
   const [position, setPosition] = useState({ top: 0, left: 0 });
-  const timerRef = useRef<number | null>(null);
+  const showTimerRef = useRef<number | null>(null);
+  const dismissTimerRef = useRef<number | null>(null);
+  const pressStartRef = useRef<number | null>(null);
   const [portalEl, setPortalEl] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -52,69 +65,168 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
   }, []);
 
   const clearTimer = useCallback(() => {
-    if (timerRef.current !== null) {
-      window.clearTimeout(timerRef.current);
-      timerRef.current = null;
+    if (showTimerRef.current !== null) {
+      window.clearTimeout(showTimerRef.current);
+      showTimerRef.current = null;
+    }
+  }, []);
+
+  const clearDismissTimer = useCallback(() => {
+    if (dismissTimerRef.current !== null) {
+      window.clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
     }
   }, []);
 
   const show = useCallback(() => {
     clearTimer();
-    timerRef.current = window.setTimeout(() => {
+    clearDismissTimer();
+    showTimerRef.current = window.setTimeout(() => {
       setVisible(true);
     }, delay);
-  }, [clearTimer, delay]);
+  }, [clearDismissTimer, clearTimer, delay]);
 
   const hide = useCallback(() => {
     clearTimer();
+    clearDismissTimer();
     setVisible(false);
-  }, [clearTimer]);
+  }, [clearDismissTimer, clearTimer]);
 
-  useEffect(() => () => clearTimer(), [clearTimer]);
+  const showInstantly = useCallback(() => {
+    clearTimer();
+    clearDismissTimer();
+    setVisible(true);
+  }, [clearDismissTimer, clearTimer]);
 
-  useIsomorphicLayoutEffect(() => {
-    if (!visible || !triggerRef.current || !tooltipRef.current) {
+  const scheduleDismiss = useCallback(() => {
+    clearDismissTimer();
+    dismissTimerRef.current = window.setTimeout(() => {
+      setVisible(false);
+    }, AUTO_DISMISS_DELAY);
+  }, [clearDismissTimer]);
+
+  useEffect(
+    () => () => {
+      clearTimer();
+      clearDismissTimer();
+    },
+    [clearDismissTimer, clearTimer],
+  );
+
+  const updatePosition = useCallback(() => {
+    if (!triggerRef.current || !tooltipRef.current) {
       return;
     }
+
     const triggerRect = triggerRef.current.getBoundingClientRect();
     const tooltipRect = tooltipRef.current.getBoundingClientRect();
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
 
-    let top = triggerRect.bottom + DEFAULT_OFFSET;
     let left =
       triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
-
+    const maxLeft = Math.max(
+      DEFAULT_OFFSET,
+      viewportWidth - tooltipRect.width - DEFAULT_OFFSET,
+    );
     if (left < DEFAULT_OFFSET) {
       left = DEFAULT_OFFSET;
     }
-    if (left + tooltipRect.width > viewportWidth - DEFAULT_OFFSET) {
-      left = viewportWidth - tooltipRect.width - DEFAULT_OFFSET;
+    if (left > maxLeft) {
+      left = maxLeft;
     }
 
-    if (top + tooltipRect.height > viewportHeight - DEFAULT_OFFSET) {
-      top = triggerRect.top - tooltipRect.height - DEFAULT_OFFSET;
-      if (top < DEFAULT_OFFSET) {
-        top = Math.max(
-          DEFAULT_OFFSET,
-          viewportHeight - tooltipRect.height - DEFAULT_OFFSET,
-        );
+    let top = triggerRect.bottom + DEFAULT_OFFSET;
+    const fitsBelow = top + tooltipRect.height <= viewportHeight - DEFAULT_OFFSET;
+    if (!fitsBelow) {
+      const aboveTop = triggerRect.top - tooltipRect.height - DEFAULT_OFFSET;
+      if (aboveTop >= DEFAULT_OFFSET) {
+        top = aboveTop;
+      } else {
+        top = viewportHeight - tooltipRect.height - DEFAULT_OFFSET;
       }
     }
 
+    const maxTop = Math.max(
+      DEFAULT_OFFSET,
+      viewportHeight - tooltipRect.height - DEFAULT_OFFSET,
+    );
+    if (top < DEFAULT_OFFSET) {
+      top = DEFAULT_OFFSET;
+    }
+    if (top > maxTop) {
+      top = maxTop;
+    }
+
     setPosition({ top, left });
-  }, [visible, content]);
+  }, []);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!visible) {
+      return;
+    }
+    updatePosition();
+  }, [visible, content, updatePosition]);
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+    const handleReposition = () => {
+      updatePosition();
+    };
+    window.addEventListener('resize', handleReposition);
+    window.addEventListener('scroll', handleReposition, true);
+    return () => {
+      window.removeEventListener('resize', handleReposition);
+      window.removeEventListener('scroll', handleReposition, true);
+    };
+  }, [updatePosition, visible]);
+
+  const getNow = () =>
+    typeof performance !== 'undefined' ? performance.now() : Date.now();
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      if (event.pointerType === 'mouse' && event.button !== 0) {
+        return;
+      }
+      pressStartRef.current = getTimestamp();
+      clearDismissTimer();
+      show();
+    },
+    [clearDismissTimer, show],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    const startedAt = pressStartRef.current;
+    pressStartRef.current = null;
+    const pressDuration = startedAt ? getTimestamp() - startedAt : 0;
+    clearTimer();
+    if (pressDuration < delay) {
+      showInstantly();
+    }
+    scheduleDismiss();
+  }, [clearTimer, delay, scheduleDismiss, showInstantly]);
+
+  const handlePointerLeave = useCallback(() => {
+    pressStartRef.current = null;
+    hide();
+  }, [hide]);
+
+  const handlePointerCancel = useCallback(() => {
+    pressStartRef.current = null;
+    hide();
+  }, [hide]);
 
   const triggerProps: TriggerProps = {
     ref: (node) => {
       triggerRef.current = node;
     },
-    onMouseEnter: () => {
-      show();
-    },
-    onMouseLeave: () => {
-      hide();
-    },
+    onPointerDown: handlePointerDown,
+    onPointerUp: handlePointerUp,
+    onPointerLeave: handlePointerLeave,
+    onPointerCancel: handlePointerCancel,
     onFocus: () => {
       show();
     },
@@ -122,6 +234,8 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
       hide();
     },
   };
+
+  const tooltipMaxWidth = `min(20rem, calc(100vw - ${DEFAULT_OFFSET * 2}px))`;
 
   return (
     <>
@@ -135,6 +249,7 @@ const DelayedTooltip: React.FC<DelayedTooltipProps> = ({
                 top: position.top,
                 left: position.left,
                 zIndex: 1000,
+                maxWidth: tooltipMaxWidth,
               }}
               className="pointer-events-none max-w-xs rounded-md border border-gray-500/60 bg-ub-grey/95 px-3 py-2 text-xs text-white shadow-xl backdrop-blur"
             >

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,8 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-
-import "./.next/types/routes.d.ts";
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/pages/apps/index.tsx
+++ b/pages/apps/index.tsx
@@ -1,17 +1,21 @@
 import Image from 'next/image';
-import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import DelayedTooltip from '../../components/ui/DelayedTooltip';
+import { useEffect, useMemo, useState } from 'react';
 import AppTooltipContent from '../../components/ui/AppTooltipContent';
+import DelayedTooltip from '../../components/ui/DelayedTooltip';
 import {
   buildAppMetadata,
   loadAppRegistry,
 } from '../../lib/appRegistry';
 
-const AppsPage = () => {
-  const [apps, setApps] = useState([]);
+type RegistryData = Awaited<ReturnType<typeof loadAppRegistry>>;
+type RegistryApp = RegistryData['apps'][number];
+type RegistryMetadata = RegistryData['metadata'];
+
+const AppsPage = (): JSX.Element => {
+  const [apps, setApps] = useState<RegistryApp[]>([]);
   const [query, setQuery] = useState('');
-  const [metadata, setMetadata] = useState({});
+  const [metadata, setMetadata] = useState<RegistryMetadata>({} as RegistryMetadata);
 
   useEffect(() => {
     let isMounted = true;
@@ -26,7 +30,7 @@ const AppsPage = () => {
     };
   }, []);
 
-  const filteredApps = useMemo(
+  const filteredApps = useMemo<RegistryApp[]>(
     () =>
       apps.filter(
         (app) =>
@@ -48,6 +52,7 @@ const AppsPage = () => {
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Search apps"
         className="mb-4 w-full rounded border p-2"
+        aria-label="Search apps"
       />
       <div
         id="app-grid"
@@ -61,17 +66,27 @@ const AppsPage = () => {
               key={app.id}
               content={<AppTooltipContent meta={meta} />}
             >
-              {({ ref, onMouseEnter, onMouseLeave, onFocus, onBlur }) => (
+              {({
+                ref,
+                onPointerDown,
+                onPointerUp,
+                onPointerLeave,
+                onPointerCancel,
+                onFocus,
+                onBlur,
+              }) => (
                 <div
                   ref={ref}
-                  onMouseEnter={onMouseEnter}
-                  onMouseLeave={onMouseLeave}
                   className="flex flex-col items-center"
                 >
                   <Link
                     href={`/apps/${app.id}`}
                     className="flex h-full w-full flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
                     aria-label={app.title}
+                    onPointerDown={onPointerDown}
+                    onPointerUp={onPointerUp}
+                    onPointerLeave={onPointerLeave}
+                    onPointerCancel={onPointerCancel}
                     onFocus={onFocus}
                     onBlur={onBlur}
                   >


### PR DESCRIPTION
## Summary
- add long-press driven tooltip triggering with auto-dismiss timing and viewport clamping
- ensure tooltip content wraps cleanly and forward pointer/focus events through UbuntuApp
- migrate the apps listing page to TypeScript while wiring pointer handlers for the new tooltip API

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db4dbe4cb483289c5f068c175cc2b9