### PR TITLE
[ui] Adjust progress bar responsiveness

### DIFF
--- a/components/ui/ProgressBar.tsx
+++ b/components/ui/ProgressBar.tsx
@@ -3,22 +3,26 @@ import React from 'react';
 interface ProgressBarProps {
   progress: number;
   className?: string;
+  label?: React.ReactNode;
 }
 
-export default function ProgressBar({ progress, className = '' }: ProgressBarProps) {
+export default function ProgressBar({ progress, className = '', label }: ProgressBarProps) {
   const clamped = Math.max(0, Math.min(progress, 100));
   return (
-    <div
-      className={`w-32 h-2 bg-gray-300 rounded ${className}`}
-      role="progressbar"
-      aria-valuenow={Math.round(clamped)}
-      aria-valuemin={0}
-      aria-valuemax={100}
-    >
+    <div className={`w-32 ${className}`}>
       <div
-        className="h-full bg-blue-500 transition-all duration-200"
-        style={{ width: `${clamped}%` }}
-      />
+        className="h-3 sm:h-2 bg-gray-200 rounded"
+        role="progressbar"
+        aria-valuenow={Math.round(clamped)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div
+          className="h-full bg-blue-600 transition-all duration-200"
+          style={{ width: `${clamped}%` }}
+        />
+      </div>
+      {label ? <div className="mt-1 text-xs text-gray-800">{label}</div> : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- increase the default mobile height of the progress bar while keeping desktop sizing intact
- add an optional label slot beneath the bar for status text or percentages
- boost default color contrast for better readability at a distance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db4dbc66d483289e55eb5d54690ca2