### PR TITLE
[perf] centralize responsive image defaults

### DIFF
--- a/apps/About/index.tsx
+++ b/apps/About/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import AboutApp from '../../components/apps/About';
 
 function GitHubIcon({ className }: { className?: string }) {

--- a/apps/beef/index.tsx
+++ b/apps/beef/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import BeefApp from '../../components/apps/beef';
 
 type Severity = 'Low' | 'Medium' | 'High';

--- a/apps/ghidra/components/DemoRunner.tsx
+++ b/apps/ghidra/components/DemoRunner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import GhidraApp from '../../../components/apps/ghidra';
 
 export default function DemoRunner() {

--- a/apps/settings/components/BackgroundSlideshow.tsx
+++ b/apps/settings/components/BackgroundSlideshow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import { useEffect, useRef, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import { useSettings } from '../../../hooks/useSettings';
@@ -70,6 +70,7 @@ export default function BackgroundSlideshow() {
               type="checkbox"
               checked={selected.includes(file)}
               onChange={() => toggle(file)}
+              aria-label={`Toggle ${file} wallpaper`}
             />
           </label>
         ))}
@@ -83,6 +84,7 @@ export default function BackgroundSlideshow() {
           value={Math.round(intervalMs / 1000)}
           onChange={(e) => setIntervalMs(Number(e.target.value) * 1000)}
           className="w-20 bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+          aria-label="Wallpaper rotation interval in seconds"
         />
       </div>
       <button

--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import ExternalFrame from '../../components/ExternalFrame';
 import { CloseIcon, MaximizeIcon, MinimizeIcon } from '../../components/ToolbarIcons';
 import { kaliTheme } from '../../styles/themes/kali';

--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import { ModuleMetadata } from '../modules/metadata';
 
 interface ModuleCardProps {

--- a/components/ToolbarIcons.tsx
+++ b/components/ToolbarIcons.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 
 export function CloseIcon() {
   return (

--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import Head from 'next/head';
 import ReactGA from 'react-ga4';
 import GitHubStars from '../../GitHubStars';
@@ -355,6 +355,7 @@ const SkillSection = ({ title, badges }: { title: string; badges: { src: string;
         className="mt-2 w-full px-2 py-1 rounded text-black"
         value={filter}
         onChange={(e) => setFilter(e.target.value)}
+        aria-label={`${title} badge filter`}
       />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
         {filteredBadges.map((badge) => (

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import ReactGA from 'react-ga4';
 import GitHubStars from '../GitHubStars';
 import Certs from './certs';
@@ -307,6 +307,7 @@ const SkillSection = ({ title, badges }) => {
         className="mt-2 w-full px-2 py-1 rounded text-black"
         value={filter}
         onChange={(e) => setFilter(e.target.value)}
+        aria-label={`${title} badge filter`}
       />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
         {filteredBadges.map(badge => (

--- a/components/apps/certs.js
+++ b/components/apps/certs.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 
 const certBadges = [
   {

--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import ReactGA from 'react-ga4';
 import emailjs from '@emailjs/browser';
 import ProgressBar from '../ui/ProgressBar';
@@ -153,18 +153,18 @@ export class Gedit extends Component {
                 <div className="relative flex-grow flex flex-col bg-ub-gedit-dark font-normal windowMainScreen">
                     <div className="absolute left-0 top-0 h-full px-2 bg-ub-gedit-darker"></div>
                     <div className="relative">
-                        <input id="sender-name" value={this.state.name} onChange={this.handleChange('name')} onBlur={this.handleBlur('name')} aria-invalid={nameInvalid} aria-describedby="name-status" className={`w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent ${nameInvalid ? 'border border-red-500' : nameValid ? 'border border-emerald-500' : ''}`} placeholder="Your Email / Name :" spellCheck="false" autoComplete="off" type="text" />
+                        <input id="sender-name" value={this.state.name} onChange={this.handleChange('name')} onBlur={this.handleBlur('name')} aria-invalid={nameInvalid} aria-describedby="name-status" className={`w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent ${nameInvalid ? 'border border-red-500' : nameValid ? 'border border-emerald-500' : ''}`} placeholder="Your Email / Name :" spellCheck="false" autoComplete="off" type="text" aria-label="Your email or name" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold light text-sm text-ubt-gedit-blue">1</span>
                         <p id="name-status" className={`text-xs mt-1 ${nameInvalid ? 'text-red-400' : nameValid ? 'text-emerald-400' : 'sr-only'}`} aria-live="polite">
                             {nameInvalid ? 'Name must not be empty' : nameValid ? 'Looks good' : ''}
                         </p>
                     </div>
                     <div className="relative">
-                        <input id="sender-subject" value={this.state.subject} onChange={this.handleChange('subject')} className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" />
+                        <input id="sender-subject" value={this.state.subject} onChange={this.handleChange('subject')} className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" aria-label="Message subject" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold  text-sm text-ubt-gedit-blue">2</span>
                     </div>
                     <div className="relative flex-grow">
-                        <textarea id="sender-message" value={this.state.message} onChange={this.handleChange('message')} onBlur={this.handleBlur('message')} aria-invalid={messageInvalid} aria-describedby="message-status" className={`w-full gedit-message font-light text-sm resize-none h-full windowMainScreen outline-none tracking-wider pl-6 py-1 bg-transparent ${messageInvalid ? 'border border-red-500' : messageValid ? 'border border-emerald-500' : ''}`} placeholder="Message" spellCheck="false" autoComplete="none" type="text" />
+                        <textarea id="sender-message" value={this.state.message} onChange={this.handleChange('message')} onBlur={this.handleBlur('message')} aria-invalid={messageInvalid} aria-describedby="message-status" className={`w-full gedit-message font-light text-sm resize-none h-full windowMainScreen outline-none tracking-wider pl-6 py-1 bg-transparent ${messageInvalid ? 'border border-red-500' : messageValid ? 'border border-emerald-500' : ''}`} placeholder="Message" spellCheck="false" autoComplete="none" type="text" aria-label="Message body" />
                         <span className="absolute left-1 top-1 font-bold  text-sm text-ubt-gedit-blue">3</span>
                         <p id="message-status" className={`text-xs mt-1 ${messageInvalid ? 'text-red-400' : messageValid ? 'text-emerald-400' : 'sr-only'}`} aria-live="polite">
                             {messageInvalid ? 'Message must not be empty' : messageValid ? 'Looks good' : ''}

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import Waterfall from './Waterfall';
 import BurstChart from './BurstChart';
 import { protocolName, getRowColor, matchesDisplayFilter } from './utils';
@@ -302,11 +302,11 @@ const WiresharkApp = ({ initialPackets = [] }) => {
           className="px-2 py-1 bg-gray-800 rounded text-white"
         />
         <datalist id="bpf-suggestions">
-          <option value="tcp" />
-          <option value="udp" />
-          <option value="icmp" />
-          <option value="port 80" />
-          <option value="host 10.0.0.1" />
+          <option value="tcp">tcp</option>
+          <option value="udp">udp</option>
+          <option value="icmp">icmp</option>
+          <option value="port 80">port 80</option>
+          <option value="host 10.0.0.1">host 10.0.0.1</option>
         </datalist>
         <a
           href="https://www.wireshark.org/docs/dfref/"
@@ -321,6 +321,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
           onClick={handlePause}
           className="px-3 py-1 bg-gray-700 rounded"
           aria-pressed={paused}
+          aria-label={paused ? 'Resume capture playback' : 'Pause capture playback'}
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
@@ -349,6 +350,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
             protocolFilter === '' ? 'bg-gray-700' : 'bg-gray-800'
           }`}
           onClick={() => setProtocolFilter('')}
+          aria-label="Show all protocols"
         >
           All
         </button>
@@ -359,6 +361,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
               protocolFilter === proto ? 'bg-gray-700' : 'bg-gray-800'
             }`}
             onClick={() => setProtocolFilter(proto)}
+            aria-label={`Filter ${proto} traffic`}
           >
             {proto}
           </button>
@@ -370,6 +373,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
             view === 'packets' ? 'bg-gray-700' : 'bg-gray-800'
           }`}
           onClick={() => setView('packets')}
+          aria-label="Show packet list"
         >
           Packets
         </button>
@@ -378,6 +382,7 @@ const WiresharkApp = ({ initialPackets = [] }) => {
             view === 'flows' ? 'bg-gray-700' : 'bg-gray-800'
           }`}
           onClick={() => setView('flows')}
+          aria-label="Show flow summaries"
         >
           Flows
         </button>

--- a/components/base/ubuntu_app.js
+++ b/components/base/ubuntu_app.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import Image from 'next/image'
+import Image from '@/components/common/Image'
 
 export class UbuntuApp extends Component {
     constructor() {

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { Component } from 'react';
-import NextImage from 'next/image';
+import Image from '@/components/common/Image';
 import Draggable from 'react-draggable';
 import Settings from '../apps/settings';
 import ReactGA from 'react-ga4';
@@ -776,7 +776,7 @@ export function WindowEditButtons(props) {
                     className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                     onClick={togglePin}
                 >
-                    <NextImage
+                    <Image
                         src="/themes/Yaru/window/window-pin-symbolic.svg"
                         alt="Kali window pin"
                         className="h-4 w-4 inline"
@@ -792,7 +792,7 @@ export function WindowEditButtons(props) {
                 className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                 onClick={props.minimize}
             >
-                <NextImage
+                <Image
                     src="/themes/Yaru/window/window-minimize-symbolic.svg"
                     alt="Kali window minimize"
                     className="h-4 w-4 inline"
@@ -810,7 +810,7 @@ export function WindowEditButtons(props) {
                             className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                             onClick={props.maximize}
                         >
-                            <NextImage
+                            <Image
                                 src="/themes/Yaru/window/window-restore-symbolic.svg"
                                 alt="Kali window restore"
                                 className="h-4 w-4 inline"
@@ -826,7 +826,7 @@ export function WindowEditButtons(props) {
                             className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
                             onClick={props.maximize}
                         >
-                            <NextImage
+                            <Image
                                 src="/themes/Yaru/window/window-maximize-symbolic.svg"
                                 alt="Kali window maximize"
                                 className="h-4 w-4 inline"
@@ -844,7 +844,7 @@ export function WindowEditButtons(props) {
                 className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
                 onClick={props.close}
             >
-                <NextImage
+                <Image
                     src="/themes/Yaru/window/window-close-symbolic.svg"
                     alt="Kali window close"
                     className="h-4 w-4 inline"

--- a/components/common/Image.tsx
+++ b/components/common/Image.tsx
@@ -1,0 +1,50 @@
+import { forwardRef } from 'react';
+import NextImage, { type ImageProps as NextImageProps } from 'next/image';
+
+const MOBILE_MAX_WIDTH = 640;
+const TABLET_MAX_WIDTH = 1024;
+const DEFAULT_RESPONSIVE_SIZES = `(max-width: ${MOBILE_MAX_WIDTH}px) 100vw, (max-width: ${TABLET_MAX_WIDTH}px) 50vw, 640px`;
+const DEFAULT_FILL_SIZES = `(max-width: ${MOBILE_MAX_WIDTH}px) 100vw, 100vw`;
+
+function resolveSizes({
+  sizes,
+  width,
+  fill,
+}: Pick<NextImageProps, 'sizes' | 'width' | 'fill'>): NextImageProps['sizes'] {
+  if (sizes) return sizes;
+  if (fill) return DEFAULT_FILL_SIZES;
+
+  if (typeof width === 'number') {
+    if (width <= 256) {
+      return `${width}px`;
+    }
+
+    return `(max-width: ${MOBILE_MAX_WIDTH}px) 100vw, ${width}px`;
+  }
+
+  return DEFAULT_RESPONSIVE_SIZES;
+}
+
+export type ImageProps = NextImageProps;
+
+const Image = forwardRef<HTMLImageElement, NextImageProps>(function Image(
+  { priority, loading, sizes, width, fill, ...rest },
+  ref,
+) {
+  const computedSizes = resolveSizes({ sizes, width, fill });
+  const computedLoading = priority ? undefined : loading ?? 'lazy';
+
+  return (
+    <NextImage
+      ref={ref}
+      priority={priority}
+      loading={computedLoading}
+      sizes={computedSizes}
+      width={width}
+      fill={fill}
+      {...rest}
+    />
+  );
+});
+
+export default Image;

--- a/components/menu/ApplicationsMenu.tsx
+++ b/components/menu/ApplicationsMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 
 export type KaliCategory = {
   id: string;

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 

--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Image from 'next/image'
+import Image from '@/components/common/Image'
 
 const bootMessages = [
     'Securing environment',

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);

--- a/components/ui/VolumeControl.tsx
+++ b/components/ui/VolumeControl.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from "next/image";
+import Image from "@/components/common/Image";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import usePersistentState from "../../hooks/usePersistentState";
 

--- a/lib/appRegistry.ts
+++ b/lib/appRegistry.ts
@@ -6,10 +6,11 @@ export type AppMetadata = {
   icon?: string;
 };
 
-type AppEntry = {
+export type AppEntry = {
   id: string;
   title: string;
   icon?: string;
+  disabled?: boolean;
 };
 
 const DEFAULT_KEYBOARD_HINTS = [

--- a/next.config.js
+++ b/next.config.js
@@ -226,8 +226,26 @@ module.exports = withBundleAnalyzer(
         'developer.mozilla.org',
         'en.wikipedia.org',
       ],
-      deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
-      imageSizes: [16, 32, 48, 64, 96, 128, 256],
+      deviceSizes: [
+        320,
+        360,
+        375,
+        390,
+        414,
+        480,
+        540,
+        640,
+        750,
+        828,
+        1080,
+        1200,
+        1280,
+        1920,
+        2048,
+        3840,
+      ],
+      // Align with icon tokens (16–96px) and large preview usage.
+      imageSizes: [16, 20, 24, 28, 32, 48, 64, 96, 128, 256],
     },
     // Security headers are skipped outside production; remove !isProd check to restore them for development.
     ...(isStaticExport || !isProd

--- a/pages/apps/index.tsx
+++ b/pages/apps/index.tsx
@@ -1,17 +1,19 @@
-import Image from 'next/image';
-import { useEffect, useMemo, useState } from 'react';
+import Image from '@/components/common/Image';
 import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
 import DelayedTooltip from '../../components/ui/DelayedTooltip';
 import AppTooltipContent from '../../components/ui/AppTooltipContent';
 import {
   buildAppMetadata,
   loadAppRegistry,
+  type AppEntry,
+  type AppMetadata,
 } from '../../lib/appRegistry';
 
 const AppsPage = () => {
-  const [apps, setApps] = useState([]);
+  const [apps, setApps] = useState<AppEntry[]>([]);
   const [query, setQuery] = useState('');
-  const [metadata, setMetadata] = useState({});
+  const [metadata, setMetadata] = useState<Record<string, AppMetadata>>({});
 
   useEffect(() => {
     let isMounted = true;
@@ -48,6 +50,7 @@ const AppsPage = () => {
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Search apps"
         className="mb-4 w-full rounded border p-2"
+        aria-label="Search apps"
       />
       <div
         id="app-grid"

--- a/pages/hook-flow.tsx
+++ b/pages/hook-flow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import React, { useState } from 'react';
 
 const HookFlow: React.FC = () => {

--- a/pages/qr/index.tsx
+++ b/pages/qr/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import React, { useEffect, useRef, useState } from 'react';
 import QRCode from 'qrcode';
 import { BrowserQRCodeReader, NotFoundException } from '@zxing/library';
@@ -207,6 +207,7 @@ const QRPage: React.FC = () => {
               value={text}
               onChange={(e) => setText(e.target.value)}
               className="w-full rounded border p-2"
+              aria-label="Text to encode"
             />
             <button
               type="submit"
@@ -227,6 +228,7 @@ const QRPage: React.FC = () => {
               value={url}
               onChange={(e) => setUrl(e.target.value)}
               className="w-full rounded border p-2"
+              aria-label="URL to encode"
             />
             <button
               type="submit"
@@ -245,6 +247,7 @@ const QRPage: React.FC = () => {
                 value={ssid}
                 onChange={(e) => setSsid(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Wi-Fi network name"
               />
             </label>
             <label className="block text-sm">
@@ -254,6 +257,7 @@ const QRPage: React.FC = () => {
                 value={wifiPassword}
                 onChange={(e) => setWifiPassword(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Wi-Fi password"
               />
             </label>
             <label className="block text-sm">
@@ -262,6 +266,7 @@ const QRPage: React.FC = () => {
                 value={wifiType}
                 onChange={(e) => setWifiType(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Wi-Fi encryption type"
               >
                 <option value="WPA">WPA/WPA2</option>
                 <option value="WEP">WEP</option>
@@ -285,6 +290,7 @@ const QRPage: React.FC = () => {
                 value={vName}
                 onChange={(e) => setVName(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Full name"
               />
             </label>
             <label className="block text-sm">
@@ -294,6 +300,7 @@ const QRPage: React.FC = () => {
                 value={vOrg}
                 onChange={(e) => setVOrg(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Organization"
               />
             </label>
             <label className="block text-sm">
@@ -303,6 +310,7 @@ const QRPage: React.FC = () => {
                 value={vPhone}
                 onChange={(e) => setVPhone(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Phone number"
               />
             </label>
             <label className="block text-sm">
@@ -312,6 +320,7 @@ const QRPage: React.FC = () => {
                 value={vEmail}
                 onChange={(e) => setVEmail(e.target.value)}
                 className="mt-1 w-full rounded border p-2"
+                aria-label="Email address"
               />
             </label>
             <button
@@ -351,7 +360,7 @@ const QRPage: React.FC = () => {
         )}
       </div>
       <div className="w-full max-w-md">
-        <video ref={videoRef} className="h-48 w-full rounded border" />
+        <video ref={videoRef} className="h-48 w-full rounded border" aria-label="Live camera preview for scanning" />
         {scanResult && (
           <p className="mt-2 text-center text-sm">Decoded: {scanResult}</p>
         )}

--- a/pages/qr/vcard.tsx
+++ b/pages/qr/vcard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import React, { useEffect, useState } from 'react';
 import QRCode from 'qrcode';
 
@@ -71,42 +71,46 @@ const VCardPage: React.FC = () => {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
       <form className="w-full max-w-md space-y-2">
-        <label className="block text-sm">
-          Full Name
-          <input
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className="mt-1 w-full rounded border p-2"
-          />
-        </label>
-        <label className="block text-sm">
-          Organization
-          <input
-            type="text"
-            value={org}
-            onChange={(e) => setOrg(e.target.value)}
-            className="mt-1 w-full rounded border p-2"
-          />
-        </label>
-        <label className="block text-sm">
-          Phone
-          <input
-            type="tel"
-            value={phone}
-            onChange={(e) => setPhone(e.target.value)}
-            className="mt-1 w-full rounded border p-2"
-          />
-        </label>
-        <label className="block text-sm">
-          Email
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="mt-1 w-full rounded border p-2"
-          />
-        </label>
+          <label className="block text-sm">
+            Full Name
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-1 w-full rounded border p-2"
+              aria-label="Full name"
+            />
+          </label>
+          <label className="block text-sm">
+            Organization
+            <input
+              type="text"
+              value={org}
+              onChange={(e) => setOrg(e.target.value)}
+              className="mt-1 w-full rounded border p-2"
+              aria-label="Organization"
+            />
+          </label>
+          <label className="block text-sm">
+            Phone
+            <input
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              className="mt-1 w-full rounded border p-2"
+              aria-label="Phone number"
+            />
+          </label>
+          <label className="block text-sm">
+            Email
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="mt-1 w-full rounded border p-2"
+              aria-label="Email address"
+            />
+          </label>
       </form>
       {vcard && (
         <div className="flex flex-col items-center gap-2">

--- a/pages/video-gallery.tsx
+++ b/pages/video-gallery.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image';
+import Image from '@/components/common/Image';
 import React, { useEffect, useState } from 'react';
 
 interface Video {
@@ -45,6 +45,7 @@ const VideoGallery: React.FC = () => {
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         className="mb-4 w-full max-w-md px-4 py-2 border rounded"
+        aria-label="Search videos"
       />
       {playing && (
         <div className="mb-4 w-full max-w-2xl aspect-video">


### PR DESCRIPTION
## Summary
- introduce a common Image wrapper that standardizes responsive sizing and lazy loading defaults
- expand Next.js image deviceSizes/imageSizes for key mobile breakpoints and icon tokens
- convert the apps index page to TypeScript and add aria-labels where lint surfaced missing labels

## Testing
- `yarn lint`
- Lighthouse mobile validation (pending - requires browser)


------
https://chatgpt.com/codex/tasks/task_e_68db4daddeac8328b39b00efab6eedf6