### PR TITLE
[ui] Add container query helpers

### DIFF
--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -180,7 +180,7 @@ const PopularModules: React.FC = () => {
   };
 
   return (
-    <div className="p-4 space-y-4 bg-ub-cool-grey text-white min-h-screen">
+    <div className="p-4 space-y-4 bg-ub-cool-grey text-white min-h-screen cq-inline">
       <p className="text-sm">
         All modules are simulated; no network activity occurs. This interface is
         non-operational.
@@ -203,9 +203,10 @@ const PopularModules: React.FC = () => {
         placeholder="Search modules"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
+        aria-label="Search modules"
         className="w-full p-2 text-black rounded"
       />
-      <div className="flex flex-wrap gap-2">
+      <div className="cq-pill-cluster">
         <button
           onClick={() => setFilter('')}
           className={`px-2 py-1 text-sm rounded focus:outline-none focus:ring-2 focus:ring-blue-400 ${
@@ -250,9 +251,9 @@ const PopularModules: React.FC = () => {
       </div>
       {selected ? (
         <div className="space-y-2">
-          <form className="space-y-2">
+          <form className="cq-inline cq-form-grid">
             {selected.options.map((o) => (
-              <label key={o.name} className="block text-sm">
+              <label key={o.name} className="cq-form-grid__field text-sm">
                 {o.label}
                 <input
                   aria-label={o.label}
@@ -266,7 +267,7 @@ const PopularModules: React.FC = () => {
               </label>
             ))}
           </form>
-          <div className="flex items-start gap-2">
+          <div className="cq-inline cq-stack-md">
             <pre
               data-testid="command-preview"
               className="flex-1 bg-black text-green-400 p-2 overflow-auto font-mono"
@@ -276,22 +277,24 @@ const PopularModules: React.FC = () => {
             <button
               type="button"
               onClick={copyCommand}
-              className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400 cq-stack-md__aside"
             >
               Copy
             </button>
           </div>
-          <div className="space-y-1">
-            <label className="block text-sm">
-              Filter logs
+            <div className="space-y-1">
+              <label className="block text-sm" htmlFor="popular-modules-log-filter">
+                Filter logs
+              </label>
               <input
+                id="popular-modules-log-filter"
                 placeholder="Filter logs"
                 type="text"
                 value={logFilter}
                 onChange={(e) => setLogFilter(e.target.value)}
-                className="w-full p-1 mt-1 text-black rounded"
+                aria-label="Filter logs"
+                className="w-full p-1 text-black rounded"
               />
-            </label>
             <button
               type="button"
               onClick={copyLogs}

--- a/styles/containers.css
+++ b/styles/containers.css
@@ -1,0 +1,100 @@
+/*
+ * Container query helpers
+ * -----------------------
+ * Apply the `.cq-inline` class to any element that should establish a container
+ * context. Combine it with the layout helpers below to create responsive
+ * modules that adapt based on their available inline size instead of the
+ * viewport. Example usage:
+ *
+ *   <section class="cq-inline cq-stack-md">
+ *     ...
+ *   </section>
+ *
+ *   <form class="cq-inline cq-form-grid">
+ *     ...
+ *   </form>
+ */
+
+.cq-inline {
+  container-type: inline-size;
+}
+
+/* Split layouts that collapse into a vertical stack when space is limited. */
+.cq-stack-md {
+  display: flex;
+  align-items: flex-start;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+}
+
+.cq-stack-md > * {
+  flex: 1 1 0;
+  min-inline-size: 0;
+}
+
+.cq-stack-md__aside {
+  flex: 0 0 auto;
+}
+
+/* Compact breakpoint: medium modules under ~900px tighten spacing. */
+@container (max-width: 56rem) {
+  .cq-stack-md {
+    gap: clamp(0.5rem, 1.5vw, 1rem);
+  }
+}
+
+/* Narrow breakpoint: stack content vertically for handheld windows. */
+@container (max-width: 48rem) {
+  .cq-stack-md {
+    flex-direction: column;
+  }
+
+  .cq-stack-md__aside {
+    width: 100%;
+  }
+}
+
+/* Chip clusters wrap into balanced columns at compact widths. */
+.cq-pill-cluster {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+@container (max-width: 36rem) {
+  .cq-pill-cluster {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  }
+}
+
+/* Option forms auto-flow into columns and collapse to a single column when
+ * constrained. */
+.cq-form-grid {
+  display: grid;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.cq-form-grid__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+@container (max-width: 40rem) {
+  .cq-form-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Utility: make action buttons span the full width when stacked. */
+@container (max-width: 40rem) {
+  .cq-stack-md__aside {
+    display: flex;
+    inline-size: 100%;
+  }
+
+  .cq-stack-md__aside > * {
+    inline-size: 100%;
+  }
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,5 @@
 @import './globals.css';
+@import './containers.css';
 
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);


### PR DESCRIPTION
## Summary
- add a container query helper stylesheet that documents usage and defines shared stack, form, and pill cluster utilities
- load the helpers globally so components can opt into inline-size containers
- refactor the PopularModules interface to adopt the new helpers for better nested responsiveness

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db4dae94088328bd2fc331e60dc2cc