### PR TITLE
[a11y] Increase system control touch targets

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -773,7 +773,7 @@ export function WindowEditButtons(props) {
                 <button
                     type="button"
                     aria-label="Window pin"
-                    className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                    className="touch-target touch-target-spacing bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full"
                     onClick={togglePin}
                 >
                     <NextImage
@@ -789,7 +789,7 @@ export function WindowEditButtons(props) {
             <button
                 type="button"
                 aria-label="Window minimize"
-                className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                className="touch-target touch-target-spacing bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full"
                 onClick={props.minimize}
             >
                 <NextImage
@@ -807,7 +807,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window restore"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className="touch-target touch-target-spacing bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full"
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -823,7 +823,7 @@ export function WindowEditButtons(props) {
                         <button
                             type="button"
                             aria-label="Window maximize"
-                            className="mx-1 bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full flex justify-center items-center h-6 w-6"
+                            className="touch-target touch-target-spacing bg-white bg-opacity-0 hover:bg-opacity-10 rounded-full"
                             onClick={props.maximize}
                         >
                             <NextImage
@@ -841,7 +841,7 @@ export function WindowEditButtons(props) {
                 type="button"
                 id={`close-${props.id}`}
                 aria-label="Window close"
-                className="mx-1 focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full flex justify-center items-center h-6 w-6"
+                className="touch-target touch-target-spacing focus:outline-none cursor-default bg-ub-cool-grey bg-opacity-90 hover:bg-opacity-100 rounded-full"
                 onClick={props.close}
             >
                 <NextImage

--- a/components/ui/BatteryIndicator.tsx
+++ b/components/ui/BatteryIndicator.tsx
@@ -179,7 +179,7 @@ const BatteryIndicator: FC<BatteryIndicatorProps> = ({ className = "" }) => {
     <div ref={rootRef} className={`relative flex items-center ${className}`.trim()}>
       <button
         type="button"
-        className="flex h-6 w-6 items-center justify-center rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+        className="touch-target touch-target-spacing rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
         aria-label={tooltip}
         aria-haspopup="true"
         aria-expanded={open}

--- a/components/ui/NetworkIndicator.tsx
+++ b/components/ui/NetworkIndicator.tsx
@@ -559,7 +559,7 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
     <div ref={rootRef} className={classNames("relative flex items-center", className)}>
       <button
         type="button"
-        className="flex h-6 w-6 items-center justify-center rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+        className="touch-target touch-target-spacing rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
         aria-label={summary.tooltip}
         aria-haspopup="true"
         aria-expanded={open}

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -243,7 +243,7 @@ const NotificationBell: React.FC = () => {
         aria-expanded={isOpen}
         aria-controls={panelId}
         onClick={togglePanel}
-        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey transition focus:border-ubb-orange focus:outline-none focus:ring-0 hover:bg-white hover:bg-opacity-10"
+        className="touch-target touch-target-spacing relative rounded-md border border-transparent bg-transparent text-ubt-grey transition focus:border-ubb-orange focus:outline-none focus:ring-0 hover:bg-white hover:bg-opacity-10"
       >
         <svg
           aria-hidden="true"

--- a/components/ui/VolumeControl.tsx
+++ b/components/ui/VolumeControl.tsx
@@ -108,7 +108,7 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
     >
       <button
         type="button"
-        className="flex h-6 w-6 items-center justify-center rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+        className="touch-target touch-target-spacing rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
         aria-label={`Volume ${formatPercent(volume)}`}
         aria-haspopup="true"
         aria-expanded={open}

--- a/styles/components.css
+++ b/styles/components.css
@@ -1,0 +1,15 @@
+/* Shared component utilities */
+
+.touch-target {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
+.touch-target-spacing {
+  margin: 0.25rem;
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,5 @@
 @import './globals.css';
+@import './components.css';
 
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);


### PR DESCRIPTION
## Summary
- add a shared touch-target utility stylesheet that enforces 44px minimum hit area and spacing
- apply the new utility to window chrome, notification, volume, network, and battery controls to meet accessibility guidance

## Testing
- [x] yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db4dab3d6883289d7cafb8e5107efa