### PR TITLE
[ui] stabilize viewport heights on mobile

### DIFF
--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -1,7 +1,8 @@
 body {
   font-family: Arial, sans-serif;
   background: var(--color-bg);
-  height: 100vh;
+  height: var(--viewport-height-small, 100vh);
+  min-height: var(--viewport-height-small, 100vh);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/apps/sticky_notes/styles.css
+++ b/apps/sticky_notes/styles.css
@@ -2,7 +2,8 @@ body {
   font-family: sans-serif;
   margin: 0;
   padding: 0;
-  height: 100vh;
+  height: var(--viewport-height-small, 100vh);
+  min-height: var(--viewport-height-small, 100vh);
   background: var(--color-bg);
 }
 

--- a/apps/weather_widget/styles.css
+++ b/apps/weather_widget/styles.css
@@ -4,7 +4,8 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  height: var(--viewport-height-small, 100vh);
+  min-height: var(--viewport-height-small, 100vh);
   margin: 0;
 }
 

--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -30,6 +30,7 @@ export default function AppGrid({ openApp }) {
   const gridRef = useRef(null);
   const columnCountRef = useRef(1);
   const [focusedIndex, setFocusedIndex] = useState(0);
+  const viewportSmall = 'var(--viewport-height-small, 100vh)';
 
   const filtered = useMemo(() => {
     if (!query) return apps.map((app) => ({ ...app, nodes: app.title }));
@@ -117,9 +118,14 @@ export default function AppGrid({ openApp }) {
         className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
         placeholder="Search"
         value={query}
+        aria-label="Search applications"
         onChange={(e) => setQuery(e.target.value)}
       />
-      <div className="w-full flex-1 h-[70vh] outline-none" onKeyDown={handleKeyDown}>
+      <div
+        className="w-full flex-1 outline-none"
+        style={{ height: `calc(${viewportSmall} * 0.7)` }}
+        onKeyDown={handleKeyDown}
+      >
         <AutoSizer>
           {({ height, width }) => {
             const columnCount = getColumnCount(width);

--- a/components/desktop/Layout.tsx
+++ b/components/desktop/Layout.tsx
@@ -38,19 +38,7 @@ const Layout = React.forwardRef<HTMLDivElement, LayoutProps>(
             --desktop-icon-font-size: 0.75rem;
             touch-action: manipulation;
             font-size: clamp(0.95rem, 0.9rem + 0.2vw, 1rem);
-            min-height: 100vh;
-          }
-
-          @supports (min-height: 100svh) {
-            .desktop-shell {
-              min-height: 100svh;
-            }
-          }
-
-          @supports (min-height: 100dvh) {
-            .desktop-shell {
-              min-height: 100dvh;
-            }
+            min-height: var(--viewport-height-large, 100vh);
           }
 
           @media (min-width: 640px) {

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -153,6 +153,12 @@ const WhiskerMenu: React.FC = () => {
   const menuRef = useRef<HTMLDivElement>(null);
   const categoryListRef = useRef<HTMLDivElement>(null);
   const categoryButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const viewportSmall = 'var(--viewport-height-small, 100vh)';
+  const viewportLarge = 'var(--viewport-height-large, 100vh)';
+  const overlayMaxHeight = `calc(${viewportLarge} * 0.8)`;
+  const categoryPanelMaxHeight = `calc(${viewportSmall} * 0.36)`;
+  const categoryListMaxHeight = `calc(${viewportSmall} * 0.32)`;
+  const resultsPanelMaxHeight = `calc(${viewportSmall} * 0.44)`;
 
 
   const allApps: AppMeta[] = apps as any;
@@ -387,10 +393,10 @@ const WhiskerMenu: React.FC = () => {
       {isVisible && (
         <div
           ref={menuRef}
-          className={`absolute top-full left-1/2 mt-3 z-50 flex max-h-[80vh] w-[min(100vw-1.5rem,680px)] -translate-x-1/2 flex-col overflow-x-hidden overflow-y-auto rounded-xl border border-[#1f2a3a] bg-[#0b121c] text-white shadow-[0_20px_40px_rgba(0,0,0,0.45)] transition-all duration-200 ease-out sm:left-0 sm:mt-1 sm:w-[680px] sm:max-h-[440px] sm:-translate-x-0 sm:flex-row sm:overflow-hidden ${
+          className={`absolute top-full left-1/2 mt-3 z-50 flex w-[min(100vw-1.5rem,680px)] -translate-x-1/2 flex-col overflow-x-hidden overflow-y-auto rounded-xl border border-[#1f2a3a] bg-[#0b121c] text-white shadow-[0_20px_40px_rgba(0,0,0,0.45)] transition-all duration-200 ease-out sm:left-0 sm:mt-1 sm:w-[680px] sm:max-h-[440px] sm:-translate-x-0 sm:flex-row sm:overflow-hidden ${
             isOpen ? 'opacity-100 translate-y-0 scale-100' : 'pointer-events-none opacity-0 -translate-y-2 scale-95'
           }`}
-          style={{ transitionDuration: `${TRANSITION_DURATION}ms` }}
+          style={{ transitionDuration: `${TRANSITION_DURATION}ms`, maxHeight: overlayMaxHeight }}
           tabIndex={-1}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node)) {
@@ -398,14 +404,18 @@ const WhiskerMenu: React.FC = () => {
             }
           }}
         >
-          <div className="flex w-full max-h-[36vh] flex-col overflow-y-auto bg-gradient-to-b from-[#111c2b] via-[#101a27] to-[#0d1622] sm:max-h-[420px] sm:w-[260px] sm:overflow-visible">
+          <div
+            className="flex w-full flex-col overflow-y-auto bg-gradient-to-b from-[#111c2b] via-[#101a27] to-[#0d1622] sm:max-h-[420px] sm:w-[260px] sm:overflow-visible"
+            style={{ maxHeight: categoryPanelMaxHeight }}
+          >
             <div className="flex items-center gap-2 border-b border-[#1d2a3c] px-4 py-3 text-xs uppercase tracking-[0.2em] text-[#4aa8ff]">
               <span className="inline-flex h-2 w-2 rounded-full bg-[#4aa8ff]" aria-hidden />
               Categories
             </div>
             <div
               ref={categoryListRef}
-              className="flex max-h-[32vh] flex-1 flex-col gap-1 overflow-y-auto px-3 py-3 sm:max-h-full sm:px-2"
+              className="flex flex-1 flex-col gap-1 overflow-y-auto px-3 py-3 sm:max-h-full sm:px-2"
+              style={{ maxHeight: categoryListMaxHeight }}
               role="listbox"
               aria-label="Application categories"
               tabIndex={0}
@@ -455,7 +465,10 @@ const WhiskerMenu: React.FC = () => {
               </div>
             </div>
           </div>
-          <div className="flex max-h-[44vh] flex-1 flex-col bg-[#0f1a29] sm:max-h-full">
+          <div
+            className="flex flex-1 flex-col bg-[#0f1a29] sm:max-h-full"
+            style={{ maxHeight: resultsPanelMaxHeight }}
+          >
             <div className="border-b border-[#1d2a3c] px-4 py-4 sm:px-5">
               <div className="mb-4 flex flex-wrap items-center gap-3">
                 {favoriteApps.slice(0, 6).map((app) => (

--- a/public/apps/frogger/index.css
+++ b/public/apps/frogger/index.css
@@ -1,2 +1,8 @@
-body { margin:0; background:#000; display:flex; justify-content:center; align-items:center; height:100vh; }
+body { margin:0; background:#000; display:flex; justify-content:center; align-items:center; height:100vh; min-height:100vh; }
+@supports (height: 100svh) {
+  body { height:100svh; min-height:100svh; }
+}
+@supports (height: 100lvh) {
+  body { height:100lvh; min-height:100lvh; }
+}
 canvas { background:#222; }

--- a/public/apps/pong/index.css
+++ b/public/apps/pong/index.css
@@ -1,2 +1,8 @@
-body { margin:0; background:#000; display:flex; justify-content:center; align-items:center; height:100vh; }
+body { margin:0; background:#000; display:flex; justify-content:center; align-items:center; height:100vh; min-height:100vh; }
+@supports (height: 100svh) {
+  body { height:100svh; min-height:100svh; }
+}
+@supports (height: 100lvh) {
+  body { height:100lvh; min-height:100lvh; }
+}
 canvas { background:#000; }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,7 +21,21 @@
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   --kali-text: #f5f5f5;
+  --viewport-height-small: 100vh;
+  --viewport-height-large: 100vh;
   accent-color: var(--color-control-accent);
+}
+
+@supports (height: 100svh) {
+  :root {
+    --viewport-height-small: 100svh;
+  }
+}
+
+@supports (height: 100lvh) {
+  :root {
+    --viewport-height-large: 100lvh;
+  }
 }
 
 body {


### PR DESCRIPTION
## Summary
- introduce viewport height CSS variables that fall back to svh and lvh when supported
- update the desktop layout, whisker menu, and app grid to consume the new viewport metrics
- align in-app and static game styles with the safer viewport units to avoid jumps on mobile

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db4daa457c8328a55935e397619c78