### PR TITLE
[app] Add safe-area padding and viewport metadata

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,19 @@
+@import '../styles/globals.css';
+
+:root {
+  --app-safe-area-inline-padding: 0px;
+  --app-safe-area-bottom-padding: 0px;
+}
+
+body,
+.app-root {
+  padding-inline: max(
+    var(--app-safe-area-inline-padding),
+    env(safe-area-inset-left),
+    env(safe-area-inset-right)
+  );
+  padding-bottom: max(
+    var(--app-safe-area-bottom-padding),
+    env(safe-area-inset-bottom)
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+import Head from 'next/head';
+
+import './globals.css';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <body>{children}</body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- add an app router layout that injects the standard viewport meta tag
- create global safe-area padding helpers so body and root respect device insets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db4da8a85c8328ae854f6d88a5022d