### PR TITLE
[styles] Introduce fluid spacing and typography tokens

### DIFF
--- a/components/apps/About/index.tsx
+++ b/components/apps/About/index.tsx
@@ -179,19 +179,19 @@ function About() {
           priority
         />
       </div>
-      <div className=" mt-4 md:mt-8 text-lg md:text-2xl text-center px-1">
-        <div>
+      <div className="mt-4 md:mt-8 text-center px-1">
+        <p className="text-heading-sm">
           My name is <span className="font-bold">Alex Unnippillil</span>,{' '}
-        </div>
-        <div className="font-normal ml-1">
+        </p>
+        <p className="font-normal ml-1 text-body-lg">
           I&apos;m a <span className="text-ubt-blue font-bold"> Cybersecurity Specialist!</span>
-        </div>
+        </p>
       </div>
       <div className=" mt-4 relative md:my-8 pt-px bg-white w-32 md:w-48">
         <div className="bg-white absolute rounded-full p-0.5 md:p-1 top-0 transform -translate-y-1/2 left-0" />
         <div className="bg-white absolute rounded-full p-0.5 md:p-1 top-0 transform -translate-y-1/2 right-0" />
       </div>
-      <ul className=" mt-4 leading-tight tracking-tight text-sm md:text-base w-5/6 md:w-3/4 emoji-list">
+      <ul className="mt-4 text-body-sm w-5/6 md:w-3/4 emoji-list">
         <li className="list-pc">
           I&apos;m a <span className=" font-medium">Technology Enthusiast</span> who thrives on learning and mastering the rapidly
           evolving world of tech. I completed four years of a{' '}

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -262,10 +262,10 @@ const ContactApp: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gray-900 text-white p-6">
-      <h1 className="mb-6 text-2xl">Contact</h1>
+      <h1 className="mb-6 font-semibold text-heading-md">Contact</h1>
       {banner && (
         <div
-          className={`mb-6 rounded p-3 text-sm ${
+          className={`mb-6 rounded p-3 text-body-sm ${
             banner.type === 'success' ? 'bg-green-600' : 'bg-red-600'
           }`}
         >
@@ -273,7 +273,7 @@ const ContactApp: React.FC = () => {
         </div>
       )}
       {fallback && (
-        <p className="mb-6 text-sm">
+        <p className="mb-6 text-body-sm">
           Service unavailable. You can{' '}
           <button
             type="button"
@@ -299,7 +299,7 @@ const ContactApp: React.FC = () => {
         </p>
       )}
       <form onSubmit={handleSubmit} className="space-y-6 max-w-md">
-        <div className="relative">
+        <div className="relative text-body-md">
           <input
             id="contact-name"
             className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
@@ -315,7 +315,7 @@ const ContactApp: React.FC = () => {
             Name
           </label>
         </div>
-        <div className="relative">
+        <div className="relative text-body-md">
           <input
             id="contact-email"
             type="email"
@@ -339,7 +339,7 @@ const ContactApp: React.FC = () => {
             </FormError>
           )}
         </div>
-        <div className="relative">
+        <div className="relative text-body-md">
           <textarea
             id="contact-message"
             className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"

--- a/components/ui/FormError.tsx
+++ b/components/ui/FormError.tsx
@@ -11,7 +11,7 @@ const FormError = ({ id, className = '', children }: FormErrorProps) => (
     id={id}
     role="status"
     aria-live="polite"
-    className={`text-red-600 text-sm mt-2 ${className}`.trim()}
+    className={`text-red-600 text-body-sm mt-2 ${className}`.trim()}
   >
     {children}
   </p>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -24,6 +24,62 @@
   accent-color: var(--color-control-accent);
 }
 
+.text-body-sm,
+.text-body-md,
+.text-body-lg,
+.text-heading-sm,
+.text-heading-md,
+.text-heading-lg,
+.text-heading-xl {
+  font-family: var(--font-family-base);
+  color: inherit;
+}
+
+.text-body-sm,
+.text-body-md,
+.text-body-lg {
+  line-height: var(--line-height-body);
+  overflow-wrap: break-word;
+  text-wrap: pretty;
+}
+
+.text-body-sm {
+  font-size: var(--font-size-body-sm);
+}
+
+.text-body-md {
+  font-size: var(--font-size-body-md);
+}
+
+.text-body-lg {
+  font-size: var(--font-size-body-lg);
+}
+
+.text-heading-sm,
+.text-heading-md,
+.text-heading-lg,
+.text-heading-xl {
+  line-height: var(--line-height-heading);
+  overflow-wrap: break-word;
+  text-wrap: balance;
+}
+
+.text-heading-sm {
+  font-size: var(--font-size-heading-sm);
+}
+
+.text-heading-md {
+  font-size: var(--font-size-heading-md);
+}
+
+.text-heading-lg {
+  font-size: var(--font-size-heading-lg);
+}
+
+.text-heading-xl {
+  font-size: var(--font-size-heading-xl);
+}
+
 body {
   background: var(--kali-bg);
   color: var(--kali-text);

--- a/styles/index.css
+++ b/styles/index.css
@@ -9,6 +9,8 @@ body{
     font-display: swap;
     background-color: var(--color-bg);
     color: var(--color-text);
+    font-size: var(--font-size-body-md);
+    line-height: var(--line-height-body);
 }
 
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -45,13 +45,24 @@
   --game-color-warning: #d97706;
   --game-color-danger: #b91c1c;
 
-  /* Spacing scale */
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.5rem;
-  --space-6: 2rem;
+  /* Spacing scale (fluid between 320px and 1440px viewports) */
+  --space-1: clamp(0.25rem, calc(0.3571vw + 0.1786rem), 0.5rem);
+  --space-2: clamp(0.5rem, calc(0.3571vw + 0.4286rem), 0.75rem);
+  --space-3: clamp(0.75rem, calc(0.3571vw + 0.6786rem), 1rem);
+  --space-4: clamp(1rem, calc(0.7143vw + 0.8571rem), 1.5rem);
+  --space-5: clamp(1.5rem, calc(0.7143vw + 1.3571rem), 2rem);
+  --space-6: clamp(2rem, calc(1.4286vw + 1.7143rem), 3rem);
+
+  /* Typography scale */
+  --font-size-body-sm: clamp(0.75rem, calc(0.1786vw + 0.7143rem), 0.875rem);
+  --font-size-body-md: clamp(0.875rem, calc(0.1786vw + 0.8393rem), 1rem);
+  --font-size-body-lg: clamp(1rem, calc(0.1786vw + 0.9643rem), 1.125rem);
+  --font-size-heading-sm: clamp(1.25rem, calc(0.3571vw + 1.1786rem), 1.5rem);
+  --font-size-heading-md: clamp(1.5rem, calc(0.5357vw + 1.3929rem), 1.875rem);
+  --font-size-heading-lg: clamp(1.75rem, calc(0.7143vw + 1.6071rem), 2.25rem);
+  --font-size-heading-xl: clamp(2.25rem, calc(1.0714vw + 2.0357rem), 3rem);
+  --line-height-body: 1.6;
+  --line-height-heading: 1.25;
 
   /* Radius */
   --radius-sm: 2px;


### PR DESCRIPTION
## Summary
- replace fixed spacing tokens with fluid clamp-based values tuned for compact and large viewports
- add responsive heading and body typography tokens plus utility classes for consistent wrapping
- refit About and Contact app typography to the new tokens to improve mobile readability

## Testing
- [ ] yarn lint *(fails: existing unlabeled control warnings in legacy About and Contact markup)*

------
https://chatgpt.com/codex/tasks/task_e_68db4da95ae8832897af4e1f8ed0604b