### PR TITLE
[ui] respect mobile safe areas

### DIFF
--- a/apps/nessus/components/FiltersDrawer.tsx
+++ b/apps/nessus/components/FiltersDrawer.tsx
@@ -24,11 +24,11 @@ export default function FiltersDrawer({
 }: Props) {
   return (
     <div
-      className={`fixed inset-0 bg-black/50 transition-opacity ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+      className={`global-drawer-backdrop fixed inset-0 bg-black/50 transition-opacity ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
       onClick={onClose}
     >
       <div
-        className={`absolute right-0 top-0 h-full w-64 bg-gray-900 p-4 overflow-y-auto transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}
+        className={`global-drawer-panel absolute right-0 top-0 h-full w-64 bg-gray-900 p-4 overflow-y-auto transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}
         onClick={(e) => e.stopPropagation()}
       >
         <h3 className="text-lg mb-4">Filters</h3>

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -5,7 +5,6 @@ import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import PerformanceGraph from '../ui/PerformanceGraph';
 import WorkspaceSwitcher from '../panel/WorkspaceSwitcher';
-import { NAVBAR_HEIGHT } from '../../utils/uiConstants';
 
 const areWorkspacesEqual = (next, prev) => {
         if (next.length !== prev.length) return false;
@@ -79,14 +78,7 @@ export default class Navbar extends PureComponent {
                         const { workspaces, activeWorkspace } = this.state;
                         return (
                                 <div
-                                        className="main-navbar-vp fixed inset-x-0 top-0 z-50 flex w-full items-center justify-between bg-slate-950/80 text-ubt-grey shadow-lg backdrop-blur-md"
-                                        style={{
-                                                minHeight: `calc(${NAVBAR_HEIGHT}px + var(--safe-area-top, 0px))`,
-                                                paddingTop: `calc(var(--safe-area-top, 0px) + 0.5rem)`,
-                                                paddingBottom: '0.5rem',
-                                                paddingLeft: `calc(0.75rem + var(--safe-area-left, 0px))`,
-                                                paddingRight: `calc(0.75rem + var(--safe-area-right, 0px))`,
-                                        }}
+                                        className="global-header main-navbar-vp fixed inset-x-0 top-0 z-50 flex w-full items-center justify-between bg-slate-950/80 text-ubt-grey shadow-lg backdrop-blur-md"
                                 >
                                         <div className="flex items-center gap-2 text-xs md:text-sm">
                                                 <WhiskerMenu />

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -18,15 +18,8 @@ export default function Taskbar(props) {
     return (
 
         <div
-            className="absolute bottom-0 left-0 z-40 flex w-full items-center justify-start bg-black bg-opacity-50 backdrop-blur-sm"
+            className="global-footer absolute bottom-0 left-0 z-40 flex w-full items-center justify-start bg-black bg-opacity-50 backdrop-blur-sm"
             role="toolbar"
-            style={{
-                minHeight: 'calc(var(--shell-taskbar-height, 2.5rem) + var(--safe-area-bottom, 0px))',
-                paddingTop: '0.35rem',
-                paddingBottom: 'calc(var(--safe-area-bottom, 0px) + 0.35rem)',
-                paddingLeft: 'calc(var(--shell-taskbar-padding-x, 0.75rem) + var(--safe-area-left, 0px))',
-                paddingRight: 'calc(var(--shell-taskbar-padding-x, 0.75rem) + var(--safe-area-right, 0px))',
-            }}
         >
             <div
                 className="flex items-center overflow-x-auto"

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -32,7 +32,7 @@ const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       aria-live="polite"
-      className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
+      className={`global-toast fixed left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
       <span>{message}</span>
       {onAction && actionLabel && (

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -18,7 +18,8 @@ class MyDocument extends Document {
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
-          <script nonce={nonce} src="/theme.js" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <script nonce={nonce} src="/theme.js" defer />
         </Head>
         <body>
           <Main />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,6 +5,11 @@
   /* Base colors */
   --color-bg: #0f1317; /* kali background */
   --color-text: #f5f5f5; /* text on dark backgrounds */
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --safe-area-right: env(safe-area-inset-right, 0px);
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-left: env(safe-area-inset-left, 0px);
+  --global-header-base-height: 56px;
   /* Brand accents */
   --color-primary: #1793d1; /* kali blue accent */
   --color-secondary: #1a1f26; /* complementary dark */
@@ -87,6 +92,41 @@ html[data-theme='matrix'] {
 
 html {
   scrollbar-color: var(--kali-border, var(--color-border)) transparent;
+}
+
+.global-header {
+  min-height: calc(var(--global-header-base-height, 56px) + var(--safe-area-top, 0px));
+  padding-top: calc(var(--safe-area-top, 0px) + 0.5rem);
+  padding-bottom: 0.5rem;
+  padding-left: calc(0.75rem + var(--safe-area-left, 0px));
+  padding-right: calc(0.75rem + var(--safe-area-right, 0px));
+}
+
+.global-footer {
+  min-height: calc(var(--shell-taskbar-height, 2.5rem) + var(--safe-area-bottom, 0px));
+  padding-top: 0.35rem;
+  padding-bottom: calc(var(--safe-area-bottom, 0px) + 0.35rem);
+  padding-left: calc(var(--shell-taskbar-padding-x, 0.75rem) + var(--safe-area-left, 0px));
+  padding-right: calc(var(--shell-taskbar-padding-x, 0.75rem) + var(--safe-area-right, 0px));
+}
+
+.global-drawer-backdrop {
+  padding-top: var(--safe-area-top, 0px);
+  padding-right: var(--safe-area-right, 0px);
+  padding-bottom: var(--safe-area-bottom, 0px);
+  padding-left: var(--safe-area-left, 0px);
+}
+
+.global-drawer-panel {
+  max-height: calc(100% - var(--safe-area-top, 0px) - var(--safe-area-bottom, 0px));
+  padding-top: calc(1rem + var(--safe-area-top, 0px));
+  padding-right: calc(1rem + var(--safe-area-right, 0px));
+  padding-bottom: calc(1rem + var(--safe-area-bottom, 0px));
+  padding-left: calc(1rem + var(--safe-area-left, 0px));
+}
+
+.global-toast {
+  top: calc(1rem + var(--safe-area-top, 0px));
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- add a viewport meta tag so the portfolio scales correctly on iOS
- surface safe area CSS variables globally and apply them to the header, footer, drawer, and toast containers to avoid overlap with system UI

## Testing
- [x] yarn lint


------
https://chatgpt.com/codex/tasks/task_e_68db84d2e08083288f643cc2fe9ffe75