### PR TITLE
[styles] Stabilize viewport height across apps

### DIFF
--- a/apps/calculator/styles.css
+++ b/apps/calculator/styles.css
@@ -1,7 +1,8 @@
 body {
   font-family: Arial, sans-serif;
   background: var(--color-bg);
-  height: 100vh;
+  min-height: var(--app-viewport-height, 100vh);
+  height: var(--app-viewport-height, 100vh);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/apps/sticky_notes/styles.css
+++ b/apps/sticky_notes/styles.css
@@ -2,7 +2,8 @@ body {
   font-family: sans-serif;
   margin: 0;
   padding: 0;
-  height: 100vh;
+  min-height: var(--app-viewport-height, 100vh);
+  height: var(--app-viewport-height, 100vh);
   background: var(--color-bg);
 }
 

--- a/apps/weather_widget/styles.css
+++ b/apps/weather_widget/styles.css
@@ -4,7 +4,8 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  min-height: var(--app-viewport-height, 100vh);
+  height: var(--app-viewport-height, 100vh);
   margin: 0;
 }
 

--- a/components/desktop/Layout.tsx
+++ b/components/desktop/Layout.tsx
@@ -9,7 +9,7 @@ const Layout = React.forwardRef<HTMLDivElement, LayoutProps>(
       <div
         ref={ref}
         className={clsx(
-          "desktop-shell relative min-h-screen w-full overflow-hidden bg-transparent text-white antialiased",
+          "desktop-shell viewport-full-height relative w-full overflow-hidden bg-transparent text-white antialiased",
           className,
         )}
         {...props}
@@ -38,19 +38,7 @@ const Layout = React.forwardRef<HTMLDivElement, LayoutProps>(
             --desktop-icon-font-size: 0.75rem;
             touch-action: manipulation;
             font-size: clamp(0.95rem, 0.9rem + 0.2vw, 1rem);
-            min-height: 100vh;
-          }
-
-          @supports (min-height: 100svh) {
-            .desktop-shell {
-              min-height: 100svh;
-            }
-          }
-
-          @supports (min-height: 100dvh) {
-            .desktop-shell {
-              min-height: 100dvh;
-            }
+            min-height: var(--app-viewport-height, 100vh);
           }
 
           @media (min-width: 640px) {

--- a/public/apps/frogger/index.css
+++ b/public/apps/frogger/index.css
@@ -1,2 +1,24 @@
-body { margin:0; background:#000; display:flex; justify-content:center; align-items:center; height:100vh; }
-canvas { background:#222; }
+body {
+  margin: 0;
+  background: #000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100lvh;
+  height: 100vh;
+  height: 100svh;
+  height: 100lvh;
+}
+
+@supports (height: 100dvh) {
+  body {
+    min-height: 100dvh;
+    height: 100dvh;
+  }
+}
+
+canvas {
+  background: #222;
+}

--- a/public/apps/pong/index.css
+++ b/public/apps/pong/index.css
@@ -1,2 +1,24 @@
-body { margin:0; background:#000; display:flex; justify-content:center; align-items:center; height:100vh; }
-canvas { background:#000; }
+body {
+  margin: 0;
+  background: #000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100lvh;
+  height: 100vh;
+  height: 100svh;
+  height: 100lvh;
+}
+
+@supports (height: 100dvh) {
+  body {
+    min-height: 100dvh;
+    height: 100dvh;
+  }
+}
+
+canvas {
+  background: #000;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -99,3 +99,31 @@ html {
   background-color: var(--kali-border, var(--color-border));
   border-radius: 6px;
 }
+
+/* Viewport sizing utilities */
+:root {
+  --app-viewport-height: 100vh;
+}
+
+@supports (height: 100svh) {
+  :root {
+    --app-viewport-height: 100svh;
+  }
+}
+
+@supports (height: 100lvh) {
+  :root {
+    --app-viewport-height: 100lvh;
+  }
+}
+
+@supports (height: 100dvh) {
+  :root {
+    --app-viewport-height: 100dvh;
+  }
+}
+
+.viewport-full-height {
+  min-height: var(--app-viewport-height, 100vh);
+  height: var(--app-viewport-height, 100vh);
+}


### PR DESCRIPTION
## Summary
- add a global dynamic viewport height custom property and utility class
- migrate calculator, sticky notes, weather widget, and arcade canvases to the shared viewport sizing
- update the desktop layout container to consume the centralized viewport utility

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db84d411ac832898fc3a8ed19d8adf