### PR TITLE
[styles] tighten mobile stack spacing

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,63 @@ body{
     color: var(--color-text);
 }
 
+:root {
+    /* Stack utility defaults */
+    --stack-space-0-5: 0.125rem;
+    --stack-space-1: 0.25rem;
+    --stack-space-1-5: 0.375rem;
+    --stack-space-2: var(--space-2);
+    --stack-space-3: var(--space-3);
+    --stack-space-4: var(--space-4);
+    --stack-space-6: var(--space-5);
+    --stack-space-8: var(--space-6);
+}
+
+.space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: var(--stack-space-0-5);
+}
+
+.space-y-1 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: var(--stack-space-1);
+}
+
+.space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: var(--stack-space-1-5);
+}
+
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: var(--stack-space-2);
+}
+
+.space-y-3 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: var(--stack-space-3);
+}
+
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: var(--stack-space-4);
+}
+
+.space-y-6 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: var(--stack-space-6);
+}
+
+.space-y-8 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: var(--stack-space-8);
+}
+
+@media (max-width: 480px) {
+    :root {
+        --stack-space-0-5: calc(var(--space-mobile-1) / 2);
+        --stack-space-1: calc(var(--space-mobile-1) * 0.75);
+        --stack-space-1-5: calc(var(--space-mobile-1) * 1.25);
+        --stack-space-2: var(--space-mobile-1);
+        --stack-space-3: var(--space-mobile-2);
+        --stack-space-4: var(--space-mobile-3);
+        --stack-space-6: var(--space-mobile-4);
+        --stack-space-8: var(--space-mobile-5);
+    }
+}
+
 button, [role="button"], input[type="button"], input[type="submit"], input[type="reset"], .hit-area {
     min-width: var(--hit-area);
     min-height: var(--hit-area);

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -52,6 +52,13 @@
   --space-4: 1rem;
   --space-5: 1.5rem;
   --space-6: 2rem;
+  /* Mobile spacing scale (8–16px rhythm) */
+  --space-mobile-1: 0.5rem;
+  --space-mobile-2: 0.75rem;
+  --space-mobile-3: 1rem;
+  --space-mobile-4: 1.25rem;
+  --space-mobile-5: 1.5rem;
+  --space-mobile-6: 2rem;
 
   /* Radius */
   --radius-sm: 2px;


### PR DESCRIPTION
## Summary
- add a mobile spacing scale to the design tokens to keep rhythm on narrow viewports
- remap common space-y utilities to CSS variables that swap to the mobile scale under 480px

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db84e102d88328a2d302bed2cf560f