### PR TITLE
[ui] Add reusable scroll lock for overlays

### DIFF
--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
+import { lockScroll, unlockScroll } from '../../utils/scrollLock';
 
 interface ModalProps {
     isOpen: boolean;
@@ -106,6 +107,14 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
             inertRootRef.current?.removeAttribute('inert');
         };
     }, [isOpen, getOverlayRoot]);
+
+    useEffect(() => {
+        if (!isOpen) return undefined;
+        lockScroll();
+        return () => {
+            unlockScroll();
+        };
+    }, [isOpen]);
 
     if (!isOpen || !portalRef.current) return null;
 

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -14,6 +14,7 @@ import {
   NotificationPriority,
 } from '../../hooks/useNotifications';
 import { PRIORITY_ORDER } from '../../utils/notifications/ruleEngine';
+import { lockScroll, unlockScroll } from '../../utils/scrollLock';
 
 const focusableSelector =
   'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
@@ -113,6 +114,14 @@ const NotificationBell: React.FC = () => {
       return !prev;
     });
   }, []);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    lockScroll();
+    return () => {
+      unlockScroll();
+    };
+  }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;

--- a/styles/overlays.css
+++ b/styles/overlays.css
@@ -1,0 +1,9 @@
+/*
+Overlay usage notes
+====================
+- Use the helpers in `utils/scrollLock` to keep the page from jumping when an overlay (modal, sheet, notification flyout, etc.) opens.
+- Call `lockScroll()` when the overlay mounts or becomes visible and `unlockScroll()` in the cleanup handler when it closes.
+- The helper compensates for scrollbar width so layout stays stable even on pages with vertical scrollbars.
+- Helpers are reference-counted which means multiple overlays can be open simultaneously without fighting for scroll state.
+- Future overlay components should wire these helpers via `useEffect` or their mounting lifecycle so the behaviour stays consistent across the desktop shell.
+*/

--- a/utils/scrollLock.ts
+++ b/utils/scrollLock.ts
@@ -1,0 +1,84 @@
+let lockCount = 0;
+let originalOverflow: string | null = null;
+let originalPaddingRight: string | null = null;
+
+const getWindow = (): (Window & typeof globalThis) | null => {
+  if (typeof globalThis === 'undefined') {
+    return null;
+  }
+
+  return 'document' in globalThis
+    ? (globalThis as Window & typeof globalThis)
+    : null;
+};
+
+const getDocument = (): Document | null => {
+  const win = getWindow();
+  return win?.document ?? null;
+};
+
+const getBody = (): HTMLBodyElement | null => {
+  const doc = getDocument();
+  return doc?.body ?? null;
+};
+
+const getScrollbarWidth = (): number => {
+  const win = getWindow();
+  const doc = getDocument();
+  if (!win || !doc) return 0;
+  return Math.max(0, win.innerWidth - doc.documentElement.clientWidth);
+};
+
+const applyLock = () => {
+  const body = getBody();
+  const win = getWindow();
+  if (!body || !win) return;
+
+  if (lockCount === 0) {
+    originalOverflow = body.style.overflow;
+    originalPaddingRight = body.style.paddingRight;
+
+    const scrollbarWidth = getScrollbarWidth();
+    if (scrollbarWidth > 0) {
+      const computedPadding = parseFloat(win.getComputedStyle(body).paddingRight) || 0;
+      body.style.paddingRight = `${computedPadding + scrollbarWidth}px`;
+    }
+
+    body.style.overflow = 'hidden';
+  }
+
+  lockCount += 1;
+};
+
+const releaseLock = () => {
+  if (lockCount === 0) return;
+
+  lockCount -= 1;
+
+  if (lockCount > 0) return;
+
+  const body = getBody();
+  if (!body) return;
+
+  body.style.overflow = originalOverflow ?? '';
+  body.style.paddingRight = originalPaddingRight ?? '';
+
+  originalOverflow = null;
+  originalPaddingRight = null;
+};
+
+export const lockScroll = () => {
+  applyLock();
+};
+
+export const unlockScroll = () => {
+  releaseLock();
+};
+
+export const toggleScrollLock = (shouldLock: boolean) => {
+  if (shouldLock) {
+    lockScroll();
+  } else {
+    unlockScroll();
+  }
+};


### PR DESCRIPTION
## Summary
- add a shared scrollLock utility that locks body overflow and compensates for scrollbar width
- apply the scroll lock helper to NotificationBell and the base modal so overlays prevent background scrolling
- document the overlay guidance in styles/overlays.css for future sheets and dialogs

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db84e518f08328a9846d5beaca15d1