### PR TITLE
[perf] tune menu image loading

### DIFF
--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -47,12 +47,16 @@ export default function ModuleCard({
           alt="Details"
           width={24}
           height={24}
+          sizes="24px"
+          loading="lazy"
         />
         <Image
           src="/themes/Yaru/status/download.svg"
           alt="Run"
           width={24}
           height={24}
+          sizes="24px"
+          loading="lazy"
         />
       </div>
     </button>

--- a/components/ToolbarIcons.tsx
+++ b/components/ToolbarIcons.tsx
@@ -7,6 +7,7 @@ export function CloseIcon() {
       alt="Close"
       width={16}
       height={16}
+      sizes="16px"
     />
   );
 }
@@ -18,6 +19,7 @@ export function MinimizeIcon() {
       alt="Minimize"
       width={16}
       height={16}
+      sizes="16px"
     />
   );
 }
@@ -29,6 +31,7 @@ export function MaximizeIcon() {
       alt="Maximize"
       width={16}
       height={16}
+      sizes="16px"
     />
   );
 }
@@ -40,6 +43,7 @@ export function RestoreIcon() {
       alt="Restore"
       width={16}
       height={16}
+      sizes="16px"
     />
   );
 }
@@ -51,6 +55,7 @@ export function PinIcon() {
       alt="Pin"
       width={16}
       height={16}
+      sizes="16px"
     />
   );
 }

--- a/components/menu/ApplicationsMenu.tsx
+++ b/components/menu/ApplicationsMenu.tsx
@@ -72,6 +72,8 @@ const CategoryIcon: React.FC<CategoryIconProps> = ({ categoryId, label }) => {
       width={20}
       height={20}
       className="h-5 w-5 flex-shrink-0"
+      sizes="20px"
+      loading="lazy"
       onError={() => {
         if (src !== DEFAULT_CATEGORY_ICON) {
           setSrc(DEFAULT_CATEGORY_ICON);

--- a/components/menu/PlacesMenu.tsx
+++ b/components/menu/PlacesMenu.tsx
@@ -72,6 +72,7 @@ const PlacesMenu: React.FC<PlacesMenuProps> = ({ heading = 'Places', items }) =>
                   height={28}
                   className="h-7 w-7 flex-shrink-0"
                   data-fallback-src={item.icon}
+                  loading="lazy"
                   onError={(event) => {
                     const target = event.currentTarget;
                     if (target.getAttribute(FALLBACK_FLAG) === 'true') {

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -381,6 +381,8 @@ const WhiskerMenu: React.FC = () => {
           width={16}
           height={16}
           className="inline mr-1"
+          sizes="16px"
+          priority
         />
         Applications
       </button>
@@ -439,6 +441,7 @@ const WhiskerMenu: React.FC = () => {
                       height={20}
                       className="h-5 w-5 opacity-80 group-hover:opacity-100"
                       sizes="20px"
+                      loading="lazy"
                     />
                     <span>{cat.label}</span>
                   </span>
@@ -473,6 +476,7 @@ const WhiskerMenu: React.FC = () => {
                       height={24}
                       className="h-6 w-6"
                       sizes="24px"
+                      loading="lazy"
                     />
                   </button>
                 ))}
@@ -545,6 +549,7 @@ const WhiskerMenu: React.FC = () => {
                               height={28}
                               className="h-7 w-7"
                               sizes="28px"
+                              loading="lazy"
                             />
                           </div>
                           <div>

--- a/next.config.js
+++ b/next.config.js
@@ -213,7 +213,6 @@ module.exports = withBundleAnalyzer(
       ignoreDuringBuilds: true,
     },
     images: {
-      unoptimized: true,
       domains: [
         'opengraph.githubassets.com',
         'raw.githubusercontent.com',
@@ -226,8 +225,8 @@ module.exports = withBundleAnalyzer(
         'developer.mozilla.org',
         'en.wikipedia.org',
       ],
-      deviceSizes: [640, 750, 828, 1080, 1200, 1280, 1920, 2048, 3840],
-      imageSizes: [16, 32, 48, 64, 96, 128, 256],
+      deviceSizes: [360, 414, 640, 750, 828, 1080, 1280, 1536, 1920],
+      imageSizes: [16, 20, 24, 32, 48, 64, 96, 128, 256],
     },
     // Security headers are skipped outside production; remove !isProd check to restore them for development.
     ...(isStaticExport || !isProd


### PR DESCRIPTION
## Summary
- calibrate the Next.js image configuration to use optimized device and image sizes
- add explicit sizes hints to menu and shared icon components to improve responsive behavior
- lazy load menu icons and fallback images that render offscreen

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db84e599948328a4c21750a6b23dbc