### PR TITLE
[ui] Improve tooltip touch support

### DIFF
--- a/__tests__/AppTooltipContent.test.tsx
+++ b/__tests__/AppTooltipContent.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AppTooltipContent from '../components/ui/AppTooltipContent';
+
+describe('AppTooltipContent', () => {
+  const meta = {
+    title: 'Example App',
+    description: 'A sample description for the tooltip to render.',
+    path: '/apps/example',
+    keyboard: ['Ctrl + K', 'Shift + A'],
+  };
+
+  it('renders metadata with constrained width and arrow offset', () => {
+    render(<AppTooltipContent meta={meta} placement="bottom" arrowOffset={120} />);
+
+    const container = screen.getByTestId('app-tooltip-content');
+    expect(container).toHaveStyle({ maxWidth: '20rem' });
+    expect(container).toHaveStyle({ width: 'min(20rem, calc(100vw - 2rem))' });
+
+    const arrow = screen.getByTestId('app-tooltip-arrow');
+    expect(arrow.style.left).toBe('120px');
+    expect(arrow.style.top).toBe('-6px');
+  });
+
+  it('positions the arrow below content when placement is top', () => {
+    render(<AppTooltipContent meta={meta} placement="top" arrowOffset={48} />);
+
+    const arrow = screen.getByTestId('app-tooltip-arrow');
+    expect(arrow.style.left).toBe('48px');
+    expect(arrow.style.bottom).toBe('-6px');
+  });
+
+  it('shows fallback text when metadata is unavailable', () => {
+    render(<AppTooltipContent meta={null} />);
+
+    expect(screen.getByText('Metadata unavailable.')).toBeInTheDocument();
+  });
+});

--- a/__tests__/DelayedTooltip.test.tsx
+++ b/__tests__/DelayedTooltip.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import DelayedTooltip from '../components/ui/DelayedTooltip';
+
+const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+
+describe('DelayedTooltip', () => {
+  afterEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    jest.useRealTimers();
+  });
+
+  it('supports touch long-press and constrains tooltip within a 320px viewport', () => {
+    jest.useFakeTimers();
+
+    window.innerWidth = 320;
+    window.innerHeight = 640;
+
+    const triggerRect = {
+      width: 40,
+      height: 40,
+      top: 100,
+      left: 260,
+      right: 300,
+      bottom: 140,
+      x: 260,
+      y: 100,
+      toJSON: () => ({}),
+    } as DOMRect;
+
+    const tooltipRect = {
+      width: 320,
+      height: 96,
+      top: 0,
+      left: 0,
+      right: 320,
+      bottom: 96,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+
+    HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect(this: HTMLElement): DOMRect {
+      if (this.dataset?.testid === 'trigger') {
+        return triggerRect;
+      }
+      if (this.dataset?.delayedTooltipContent === 'true') {
+        return tooltipRect;
+      }
+      return originalGetBoundingClientRect.apply(this);
+    };
+
+    const TestContent: React.FC<{ placement?: string; arrowOffset?: number }> = ({
+      placement,
+      arrowOffset,
+    }) => (
+      <div
+        data-testid="tooltip-props"
+        data-placement={placement}
+        data-arrow={arrowOffset}
+      />
+    );
+
+    render(
+      <DelayedTooltip delay={0} content={<TestContent />}>
+        {({
+          ref,
+          onPointerDown,
+          onPointerUp,
+          onPointerLeave,
+          onPointerCancel,
+        }) => (
+          <button
+            type="button"
+            data-testid="trigger"
+            ref={ref}
+            onPointerDown={onPointerDown}
+            onPointerUp={onPointerUp}
+            onPointerLeave={onPointerLeave}
+            onPointerCancel={onPointerCancel}
+          >
+            Trigger
+          </button>
+        )}
+      </DelayedTooltip>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+
+    act(() => {
+      trigger.dispatchEvent(
+        new PointerEvent('pointerdown', { pointerType: 'touch', bubbles: true }),
+      );
+      jest.runAllTimers();
+    });
+
+    const tooltipContainer = document.querySelector(
+      '[data-delayed-tooltip-content="true"]',
+    ) as HTMLElement;
+
+    expect(tooltipContainer.style.left).toBe('8px');
+    expect(tooltipContainer.style.top).toBe('148px');
+
+    const tooltipProps = screen.getByTestId('tooltip-props');
+    expect(tooltipProps.getAttribute('data-placement')).toBe('bottom');
+    expect(Number(tooltipProps.getAttribute('data-arrow'))).toBeCloseTo(272, 3);
+
+    act(() => {
+      trigger.dispatchEvent(
+        new PointerEvent('pointerup', { pointerType: 'touch', bubbles: true }),
+      );
+      jest.runAllTimers();
+    });
+
+    expect(screen.queryByTestId('tooltip-props')).not.toBeInTheDocument();
+  });
+});

--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -83,7 +83,17 @@ export default function AppGrid({ openApp }) {
     const meta = data.metadata[app.id] ?? buildAppMetadata(app);
     return (
       <DelayedTooltip content={<AppTooltipContent meta={meta} />}>
-        {({ ref, onMouseEnter, onMouseLeave, onFocus, onBlur }) => (
+        {({
+          ref,
+          onMouseEnter,
+          onMouseLeave,
+          onFocus,
+          onBlur,
+          onPointerDown,
+          onPointerUp,
+          onPointerLeave,
+          onPointerCancel,
+        }) => (
           <div
             ref={ref}
             style={{
@@ -97,6 +107,10 @@ export default function AppGrid({ openApp }) {
             onMouseLeave={onMouseLeave}
             onFocus={onFocus}
             onBlur={onBlur}
+            onPointerDown={onPointerDown}
+            onPointerUp={onPointerUp}
+            onPointerLeave={onPointerLeave}
+            onPointerCancel={onPointerCancel}
           >
             <UbuntuApp
               id={app.id}

--- a/components/ui/AppTooltipContent.tsx
+++ b/components/ui/AppTooltipContent.tsx
@@ -7,14 +7,18 @@ type AppTooltipContentProps = {
     path?: string;
     keyboard?: string[];
   } | null;
+  placement?: 'top' | 'bottom';
+  arrowOffset?: number;
 };
 
-const AppTooltipContent: React.FC<AppTooltipContentProps> = ({ meta }) => {
-  if (!meta) {
-    return <span className="text-xs text-gray-200">Metadata unavailable.</span>;
-  }
+const ARROW_OFFSET_FALLBACK = 24;
 
-  return (
+const AppTooltipContent: React.FC<AppTooltipContentProps> = ({
+  meta,
+  placement = 'bottom',
+  arrowOffset = ARROW_OFFSET_FALLBACK,
+}) => {
+  const content = meta ? (
     <div className="space-y-2">
       {meta.title ? (
         <p className="text-sm font-semibold text-white">{meta.title}</p>
@@ -37,6 +41,34 @@ const AppTooltipContent: React.FC<AppTooltipContentProps> = ({ meta }) => {
           ))}
         </ul>
       ) : null}
+    </div>
+  ) : (
+    <span className="text-xs text-gray-200">Metadata unavailable.</span>
+  );
+
+  return (
+    <div
+      data-testid="app-tooltip-content"
+      className="relative text-xs text-white"
+      style={{
+        width: 'min(20rem, calc(100vw - 2rem))',
+        maxWidth: '20rem',
+      }}
+    >
+      <span
+        data-testid="app-tooltip-arrow"
+        aria-hidden="true"
+        className="pointer-events-none absolute h-3 w-3 border border-gray-500/60 bg-ub-grey/95"
+        style={{
+          left: `${arrowOffset}px`,
+          transform: 'translateX(-50%) rotate(45deg)',
+          top: placement === 'bottom' ? '-6px' : undefined,
+          bottom: placement === 'top' ? '-6px' : undefined,
+        }}
+      />
+      <div className="space-y-2 rounded-md border border-gray-500/60 bg-ub-grey/95 px-3 py-2 text-left shadow-xl backdrop-blur">
+        {content}
+      </div>
     </div>
   );
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -107,6 +107,42 @@ if (typeof window !== 'undefined' && !('IntersectionObserver' in window)) {
   global.IntersectionObserver = IntersectionObserverMock as any;
 }
 
+// Provide a PointerEvent polyfill for environments like jsdom that do not
+// expose it by default. Components relying on pointer events (e.g. tooltips)
+// expect `pointerType` to exist when dispatching synthetic events in tests.
+if (typeof window !== 'undefined' && typeof window.PointerEvent === 'undefined') {
+  class PointerEventPolyfill extends MouseEvent {
+    pointerId: number;
+    width: number;
+    height: number;
+    pressure: number;
+    tangentialPressure: number;
+    tiltX: number;
+    tiltY: number;
+    twist: number;
+    pointerType: string;
+    isPrimary: boolean;
+
+    constructor(type: string, props: PointerEventInit = {}) {
+      super(type, props);
+      this.pointerId = props.pointerId ?? 0;
+      this.width = props.width ?? 1;
+      this.height = props.height ?? 1;
+      this.pressure = props.pressure ?? 0;
+      this.tangentialPressure = props.tangentialPressure ?? 0;
+      this.tiltX = props.tiltX ?? 0;
+      this.tiltY = props.tiltY ?? 0;
+      this.twist = props.twist ?? 0;
+      this.pointerType = props.pointerType ?? 'mouse';
+      this.isPrimary = props.isPrimary ?? true;
+    }
+  }
+  // @ts-ignore
+  window.PointerEvent = PointerEventPolyfill as any;
+  // @ts-ignore
+  global.PointerEvent = PointerEventPolyfill as any;
+}
+
 // Simple localStorage mock for environments without it
 if (typeof window !== 'undefined' && !window.localStorage) {
   const store: Record<string, string> = {};

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -61,12 +61,26 @@ const AppsPage = () => {
               key={app.id}
               content={<AppTooltipContent meta={meta} />}
             >
-              {({ ref, onMouseEnter, onMouseLeave, onFocus, onBlur }) => (
+              {({
+                ref,
+                onMouseEnter,
+                onMouseLeave,
+                onFocus,
+                onBlur,
+                onPointerDown,
+                onPointerUp,
+                onPointerLeave,
+                onPointerCancel,
+              }) => (
                 <div
                   ref={ref}
                   onMouseEnter={onMouseEnter}
                   onMouseLeave={onMouseLeave}
                   className="flex flex-col items-center"
+                  onPointerDown={onPointerDown}
+                  onPointerUp={onPointerUp}
+                  onPointerLeave={onPointerLeave}
+                  onPointerCancel={onPointerCancel}
                 >
                   <Link
                     href={`/apps/${app.id}`}


### PR DESCRIPTION
## Summary
- add arrow positioning and width clamps to the shared app tooltip content
- update the delayed tooltip trigger to handle touch long-press with collision-aware placement and arrow offsets
- document the behaviour with focused unit tests covering 320px layouts

## Testing
- yarn test --runTestsByPath __tests__/AppTooltipContent.test.tsx __tests__/DelayedTooltip.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db84e94b488328b2262da82db57f76