### PR TITLE
[ui] Improve DelayedTooltip pointer handling

### DIFF
--- a/__tests__/DelayedTooltip.test.tsx
+++ b/__tests__/DelayedTooltip.test.tsx
@@ -1,0 +1,222 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DelayedTooltip from '../components/ui/DelayedTooltip';
+
+const getTrigger = () => screen.getByTestId('tooltip-trigger');
+
+const stubCoarsePointer = () => {
+  const originalMatchMedia = window.matchMedia;
+  const originalMaxTouchPoints = navigator.maxTouchPoints;
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: query === '(pointer: coarse)',
+      media: query,
+      onchange: null,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    configurable: true,
+    value: 1,
+  });
+  return () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      configurable: true,
+      value: originalMaxTouchPoints,
+    });
+  };
+};
+
+describe('DelayedTooltip', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  const renderTooltip = () =>
+    render(
+      <DelayedTooltip content={<span>Info</span>}>
+        {({
+          ref,
+          onPointerEnter,
+          onPointerLeave,
+          onPointerCancel,
+          onPointerDown,
+          onFocus,
+          onBlur,
+          dismiss,
+        }) => (
+          <button
+            type="button"
+            ref={ref}
+            data-testid="tooltip-trigger"
+            onPointerEnter={onPointerEnter}
+            onPointerLeave={onPointerLeave}
+            onPointerCancel={onPointerCancel}
+            onPointerDown={onPointerDown}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            onClick={dismiss}
+          >
+            Trigger
+          </button>
+        )}
+      </DelayedTooltip>,
+    );
+
+  test('uses the base delay for mouse pointers', () => {
+    renderTooltip();
+    const trigger = getTrigger();
+
+    act(() => {
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(299);
+    });
+    expect(screen.queryByText('Info')).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(screen.getByText('Info')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.pointerLeave(trigger);
+    });
+  });
+
+  test('extends the delay for touch pointers', () => {
+    const restore = stubCoarsePointer();
+    try {
+      renderTooltip();
+      const trigger = getTrigger();
+
+      act(() => {
+        fireEvent.pointerEnter(trigger, { pointerType: 'touch' });
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(699);
+      });
+      expect(screen.queryByText('Info')).not.toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(1);
+      });
+      expect(screen.getByText('Info')).toBeInTheDocument();
+
+      act(() => {
+        fireEvent.pointerLeave(trigger);
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  test('cancels pending display when a scroll occurs', () => {
+    renderTooltip();
+    const trigger = getTrigger();
+
+    act(() => {
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+    });
+
+    act(() => {
+      fireEvent.scroll(window);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByText('Info')).not.toBeInTheDocument();
+  });
+
+  test('cancels timers when pointer is cancelled', () => {
+    renderTooltip();
+    const trigger = getTrigger();
+
+    act(() => {
+      fireEvent.pointerEnter(trigger, { pointerType: 'touch' });
+    });
+
+    act(() => {
+      fireEvent.pointerCancel(trigger, { pointerType: 'touch' });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByText('Info')).not.toBeInTheDocument();
+  });
+
+  test('dismiss function hides the tooltip programmatically', () => {
+    let dismissFn: (() => void) | null = null;
+
+    render(
+      <DelayedTooltip content={<span>Info</span>}>
+        {(props) => {
+          dismissFn = props.dismiss;
+          return (
+            <button
+              type="button"
+              ref={props.ref}
+              data-testid="tooltip-trigger"
+              onPointerEnter={props.onPointerEnter}
+              onPointerLeave={props.onPointerLeave}
+              onPointerCancel={props.onPointerCancel}
+              onPointerDown={props.onPointerDown}
+              onFocus={props.onFocus}
+              onBlur={props.onBlur}
+            >
+              Trigger
+            </button>
+          );
+        }}
+      </DelayedTooltip>,
+    );
+
+    const trigger = getTrigger();
+
+    act(() => {
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(screen.getByText('Info')).toBeInTheDocument();
+
+    act(() => {
+      dismissFn?.();
+    });
+
+    expect(screen.queryByText('Info')).not.toBeInTheDocument();
+  });
+});
+

--- a/components/apps/app-grid.js
+++ b/components/apps/app-grid.js
@@ -83,7 +83,16 @@ export default function AppGrid({ openApp }) {
     const meta = data.metadata[app.id] ?? buildAppMetadata(app);
     return (
       <DelayedTooltip content={<AppTooltipContent meta={meta} />}>
-        {({ ref, onMouseEnter, onMouseLeave, onFocus, onBlur }) => (
+        {({
+          ref,
+          onPointerEnter,
+          onPointerLeave,
+          onPointerCancel,
+          onPointerDown,
+          onFocus,
+          onBlur,
+          dismiss,
+        }) => (
           <div
             ref={ref}
             style={{
@@ -93,8 +102,10 @@ export default function AppGrid({ openApp }) {
               alignItems: 'center',
               padding: 12,
             }}
-            onMouseEnter={onMouseEnter}
-            onMouseLeave={onMouseLeave}
+            onPointerEnter={onPointerEnter}
+            onPointerLeave={onPointerLeave}
+            onPointerCancel={onPointerCancel}
+            onPointerDown={onPointerDown}
             onFocus={onFocus}
             onBlur={onBlur}
           >
@@ -103,7 +114,10 @@ export default function AppGrid({ openApp }) {
               icon={app.icon}
               name={app.title}
               displayName={<>{app.nodes}</>}
-              openApp={() => openApp && openApp(app.id)}
+              openApp={() => {
+                dismiss();
+                openApp && openApp(app.id);
+              }}
             />
           </div>
         )}
@@ -113,12 +127,13 @@ export default function AppGrid({ openApp }) {
 
   return (
     <div className="flex flex-col items-center h-full">
-      <input
-        className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
-        placeholder="Search"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-      />
+        <input
+          className="mb-6 mt-4 w-2/3 md:w-1/3 px-4 py-2 rounded bg-black bg-opacity-20 text-white focus:outline-none"
+          placeholder="Search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label="Search apps"
+        />
       <div className="w-full flex-1 h-[70vh] outline-none" onKeyDown={handleKeyDown}>
         <AutoSizer>
           {({ height, width }) => {

--- a/pages/apps/index.jsx
+++ b/pages/apps/index.jsx
@@ -61,11 +61,22 @@ const AppsPage = () => {
               key={app.id}
               content={<AppTooltipContent meta={meta} />}
             >
-              {({ ref, onMouseEnter, onMouseLeave, onFocus, onBlur }) => (
+              {({
+                ref,
+                onPointerEnter,
+                onPointerLeave,
+                onPointerCancel,
+                onPointerDown,
+                onFocus,
+                onBlur,
+                dismiss,
+              }) => (
                 <div
                   ref={ref}
-                  onMouseEnter={onMouseEnter}
-                  onMouseLeave={onMouseLeave}
+                  onPointerEnter={onPointerEnter}
+                  onPointerLeave={onPointerLeave}
+                  onPointerCancel={onPointerCancel}
+                  onPointerDown={onPointerDown}
                   className="flex flex-col items-center"
                 >
                   <Link
@@ -74,6 +85,7 @@ const AppsPage = () => {
                     aria-label={app.title}
                     onFocus={onFocus}
                     onBlur={onBlur}
+                    onClick={dismiss}
                   >
                     {app.icon && (
                       <Image


### PR DESCRIPTION
## Summary
- detect pointer type in DelayedTooltip to delay touch interactions, cancel hover timers on scroll/pointer cancellation, and expose a dismiss helper
- update the app grid and apps listing to use pointer handlers and invoke tooltip dismissal when launching entries
- add unit coverage for pointer-based timing, scroll cancellation, and programmatic dismissal

## Testing
- yarn test __tests__/DelayedTooltip.test.tsx
- yarn lint *(fails: `pages/apps/index.jsx` is ignored by the ESLint config and reports a warning)*

------
https://chatgpt.com/codex/tasks/task_e_68db84eb41f883289853df88fee33e6d