### PR TITLE
[ui] Improve progress bar accessibility

### DIFF
--- a/components/apps/gedit.js
+++ b/components/apps/gedit.js
@@ -153,18 +153,27 @@ export class Gedit extends Component {
                 <div className="relative flex-grow flex flex-col bg-ub-gedit-dark font-normal windowMainScreen">
                     <div className="absolute left-0 top-0 h-full px-2 bg-ub-gedit-darker"></div>
                     <div className="relative">
-                        <input id="sender-name" value={this.state.name} onChange={this.handleChange('name')} onBlur={this.handleBlur('name')} aria-invalid={nameInvalid} aria-describedby="name-status" className={`w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent ${nameInvalid ? 'border border-red-500' : nameValid ? 'border border-emerald-500' : ''}`} placeholder="Your Email / Name :" spellCheck="false" autoComplete="off" type="text" />
+                        <label htmlFor="sender-name" className="sr-only">
+                            Your email or name
+                        </label>
+                        <input id="sender-name" value={this.state.name} onChange={this.handleChange('name')} onBlur={this.handleBlur('name')} aria-invalid={nameInvalid} aria-describedby="name-status" aria-label="Your email or name" className={`w-full text-ubt-gedit-orange focus:bg-ub-gedit-light outline-none font-medium text-sm pl-6 py-0.5 bg-transparent ${nameInvalid ? 'border border-red-500' : nameValid ? 'border border-emerald-500' : ''}`} placeholder="Your Email / Name :" spellCheck="false" autoComplete="off" type="text" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold light text-sm text-ubt-gedit-blue">1</span>
                         <p id="name-status" className={`text-xs mt-1 ${nameInvalid ? 'text-red-400' : nameValid ? 'text-emerald-400' : 'sr-only'}`} aria-live="polite">
                             {nameInvalid ? 'Name must not be empty' : nameValid ? 'Looks good' : ''}
                         </p>
                     </div>
                     <div className="relative">
-                        <input id="sender-subject" value={this.state.subject} onChange={this.handleChange('subject')} className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" />
+                        <label htmlFor="sender-subject" className="sr-only">
+                            Subject
+                        </label>
+                        <input id="sender-subject" value={this.state.subject} onChange={this.handleChange('subject')} aria-label="Subject" className=" w-full my-1 text-ubt-gedit-blue focus:bg-ub-gedit-light gedit-subject outline-none text-sm font-normal pl-6 py-0.5 bg-transparent" placeholder="subject (may be a feedback for this website!)" spellCheck="false" autoComplete="off" type="text" />
                         <span className="absolute left-1 top-1/2 transform -translate-y-1/2 font-bold  text-sm text-ubt-gedit-blue">2</span>
                     </div>
                     <div className="relative flex-grow">
-                        <textarea id="sender-message" value={this.state.message} onChange={this.handleChange('message')} onBlur={this.handleBlur('message')} aria-invalid={messageInvalid} aria-describedby="message-status" className={`w-full gedit-message font-light text-sm resize-none h-full windowMainScreen outline-none tracking-wider pl-6 py-1 bg-transparent ${messageInvalid ? 'border border-red-500' : messageValid ? 'border border-emerald-500' : ''}`} placeholder="Message" spellCheck="false" autoComplete="none" type="text" />
+                        <label htmlFor="sender-message" className="sr-only">
+                            Message
+                        </label>
+                        <textarea id="sender-message" value={this.state.message} onChange={this.handleChange('message')} onBlur={this.handleBlur('message')} aria-invalid={messageInvalid} aria-describedby="message-status" aria-label="Message" className={`w-full gedit-message font-light text-sm resize-none h-full windowMainScreen outline-none tracking-wider pl-6 py-1 bg-transparent ${messageInvalid ? 'border border-red-500' : messageValid ? 'border border-emerald-500' : ''}`} placeholder="Message" spellCheck="false" autoComplete="none" type="text" />
                         <span className="absolute left-1 top-1 font-bold  text-sm text-ubt-gedit-blue">3</span>
                         <p id="message-status" className={`text-xs mt-1 ${messageInvalid ? 'text-red-400' : messageValid ? 'text-emerald-400' : 'sr-only'}`} aria-live="polite">
                             {messageInvalid ? 'Message must not be empty' : messageValid ? 'Looks good' : ''}
@@ -190,7 +199,11 @@ export class Gedit extends Component {
                     this.state.sending && (
                         <div className="flex justify-center items-center h-full w-full bg-gray-400 bg-opacity-30 absolute top-0 left-0">
                             {this.state.showProgress ? (
-                                <ProgressBar progress={this.state.progress} />
+                                <ProgressBar
+                                    progress={this.state.progress}
+                                    label={`Sending message (${Math.round(this.state.progress)}%)`}
+                                    description="Please wait while we deliver your message."
+                                />
                             ) : (
                                 <Image
                                     className="w-8 motion-safe:animate-spin"

--- a/components/ui/ProgressBar.tsx
+++ b/components/ui/ProgressBar.tsx
@@ -1,24 +1,49 @@
-import React from 'react';
+import React, { useId } from 'react';
 
 interface ProgressBarProps {
   progress: number;
   className?: string;
+  label?: string;
+  description?: string;
 }
 
-export default function ProgressBar({ progress, className = '' }: ProgressBarProps) {
+export default function ProgressBar({
+  progress,
+  className = '',
+  label,
+  description,
+}: ProgressBarProps) {
   const clamped = Math.max(0, Math.min(progress, 100));
+  const baseId = useId();
+  const labelId = label ? `${baseId}-label` : undefined;
+  const descriptionId = description ? `${baseId}-description` : undefined;
+
   return (
-    <div
-      className={`w-32 h-2 bg-gray-300 rounded ${className}`}
-      role="progressbar"
-      aria-valuenow={Math.round(clamped)}
-      aria-valuemin={0}
-      aria-valuemax={100}
-    >
+    <div className={`flex flex-col gap-1 w-32 ${className}`}>
       <div
-        className="h-full bg-blue-500 transition-all duration-200"
-        style={{ width: `${clamped}%` }}
-      />
+        className="w-full h-3 bg-gray-300 rounded"
+        role="progressbar"
+        aria-valuenow={Math.round(clamped)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-labelledby={labelId}
+        aria-describedby={descriptionId}
+      >
+        <div
+          className="h-full bg-blue-500 transition-all duration-200"
+          style={{ width: `${clamped}%` }}
+        />
+      </div>
+      {label ? (
+        <span id={labelId} className="text-xs text-gray-700">
+          {label}
+        </span>
+      ) : null}
+      {description ? (
+        <span id={descriptionId} className="text-xs text-gray-500">
+          {description}
+        </span>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- increase the progress bar height and add optional label/description props with accessible associations
- render the textual label below the bar and update the gedit overlay to surface a live progress message
- add hidden labels and aria attributes to the gedit form controls to satisfy accessibility linting

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db84ef3a50832893b447b4be2e332b