### PR TITLE
[ui] Add vertical volume control with gesture support

### DIFF
--- a/components/ui/VolumeControl.tsx
+++ b/components/ui/VolumeControl.tsx
@@ -32,7 +32,8 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
   );
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
-  const sliderRef = useRef<HTMLInputElement>(null);
+  const sliderRef = useRef<HTMLDivElement>(null);
+  const [dragging, setDragging] = useState(false);
 
   const level: VolumeLevel = useMemo(() => {
     if (volume <= 0.001) return "muted";
@@ -64,11 +65,92 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
     setClampedVolume((current) => current + delta);
   };
 
-  const handleRangeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    event.stopPropagation();
-    const next = Number(event.target.value) / 100;
-    setClampedVolume(next);
-  };
+  const adjustVolume = useCallback(
+    (delta: number) => {
+      setClampedVolume((current) => current + delta);
+    },
+    [setClampedVolume],
+  );
+
+  const updateVolumeFromClientY = useCallback(
+    (clientY: number) => {
+      const slider = sliderRef.current;
+      if (!slider) return;
+      const rect = slider.getBoundingClientRect();
+      if (rect.height === 0) return;
+      const relative = (rect.bottom - clientY) / rect.height;
+      setClampedVolume(relative);
+    },
+    [setClampedVolume],
+  );
+
+  const handleSliderPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const target = event.currentTarget;
+      target.setPointerCapture?.(event.pointerId);
+      setDragging(true);
+      updateVolumeFromClientY(event.clientY);
+    },
+    [updateVolumeFromClientY],
+  );
+
+  const handleSliderPointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!dragging) return;
+      event.preventDefault();
+      updateVolumeFromClientY(event.clientY);
+    },
+    [dragging, updateVolumeFromClientY],
+  );
+
+  const handleSliderPointerUp = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      event.currentTarget.releasePointerCapture?.(event.pointerId);
+      setDragging(false);
+      updateVolumeFromClientY(event.clientY);
+    },
+    [updateVolumeFromClientY],
+  );
+
+  const handleSliderKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      switch (event.key) {
+        case "ArrowUp":
+        case "ArrowRight":
+          event.preventDefault();
+          adjustVolume(event.shiftKey ? 0.1 : 0.05);
+          break;
+        case "ArrowDown":
+        case "ArrowLeft":
+          event.preventDefault();
+          adjustVolume(event.shiftKey ? -0.1 : -0.05);
+          break;
+        case "Home":
+          event.preventDefault();
+          setClampedVolume(0);
+          break;
+        case "End":
+          event.preventDefault();
+          setClampedVolume(1);
+          break;
+        case "PageUp":
+          event.preventDefault();
+          adjustVolume(0.2);
+          break;
+        case "PageDown":
+          event.preventDefault();
+          adjustVolume(-0.2);
+          break;
+        default:
+          break;
+      }
+    },
+    [adjustVolume, setClampedVolume],
+  );
 
   useEffect(() => {
     if (!open) return undefined;
@@ -128,7 +210,7 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
       </button>
       {open && (
         <div
-          className="absolute bottom-full right-0 z-50 mb-2 min-w-[9rem] rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-2 text-xs text-white shadow-lg"
+          className="absolute bottom-full left-1/2 z-50 mb-2 w-32 -translate-x-1/2 rounded-md border border-black border-opacity-30 bg-ub-cool-grey px-3 py-3 text-xs text-white shadow-lg sm:left-auto sm:right-0 sm:translate-x-0"
           onClick={(event) => event.stopPropagation()}
           onPointerDown={(event) => event.stopPropagation()}
           onWheel={handleWheel}
@@ -137,20 +219,59 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
             <span>Volume</span>
             <span className="font-semibold text-white">{formatPercent(volume)}</span>
           </div>
-          <input
-            ref={sliderRef}
-            type="range"
-            min={0}
-            max={100}
-            step={1}
-            value={Math.round(volume * 100)}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-valuenow={Math.round(volume * 100)}
-            aria-label="Volume level"
-            className="h-1 w-full cursor-pointer accent-ubt-blue"
-            onChange={handleRangeChange}
-          />
+          <div className="flex flex-col items-center gap-3">
+            <button
+              type="button"
+              className="flex h-7 w-7 items-center justify-center rounded-full border border-white/30 bg-white/10 text-base font-semibold text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+              aria-label="Increase volume"
+              onClick={() => adjustVolume(0.05)}
+              onPointerDown={(event) => event.stopPropagation()}
+            >
+              +
+            </button>
+            <div
+              ref={sliderRef}
+              role="slider"
+              tabIndex={0}
+              aria-label="Volume level"
+              aria-orientation="vertical"
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={Math.round(volume * 100)}
+              aria-valuetext={`Volume ${formatPercent(volume)}`}
+              className="relative flex h-32 w-10 select-none flex-col items-center justify-center rounded-full bg-black/25 py-3 outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ubt-blue focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1724] touch-none"
+              onPointerDown={handleSliderPointerDown}
+              onPointerMove={handleSliderPointerMove}
+              onPointerUp={handleSliderPointerUp}
+              onPointerCancel={handleSliderPointerUp}
+              onKeyDown={handleSliderKeyDown}
+            >
+              <div className="relative h-full w-1.5 rounded-full bg-white/20">
+                <div
+                  className="absolute inset-x-0 bottom-0 rounded-full bg-ubt-blue transition-all duration-150 ease-out"
+                  style={{ height: `${volume * 100}%` }}
+                />
+              </div>
+              <div
+                className="absolute left-1/2 top-0 flex h-full w-full -translate-x-1/2"
+                aria-hidden="true"
+              >
+                <div
+                  className="absolute left-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border border-white bg-white shadow transition-transform duration-150 ease-out"
+                  style={{ top: `${(1 - volume) * 100}%` }}
+                />
+              </div>
+            </div>
+            <button
+              type="button"
+              className="flex h-7 w-7 items-center justify-center rounded-full border border-white/30 bg-white/10 text-base font-semibold text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+              aria-label="Decrease volume"
+              onClick={() => adjustVolume(-0.05)}
+              onPointerDown={(event) => event.stopPropagation()}
+            >
+              -
+            </button>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- replace the old horizontal range input with a vertical slider and +/- buttons
- add pointer drag handling, keyboard controls, and smoother knob transitions
- tweak the popover layout so it stays centered on small screens and stable near edges

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db84f48f8c8328a7e7a2f48868a47e