### PR TITLE
[components] Restyle beta badge

### DIFF
--- a/components/BetaBadge.jsx
+++ b/components/BetaBadge.jsx
@@ -3,9 +3,23 @@ export default function BetaBadge() {
   return (
     <button
       type="button"
-      className="fixed bottom-4 right-4 rounded bg-yellow-500/90 px-2 py-1 text-xs font-semibold text-black"
+      aria-label="Beta preview"
+      className="beta-badge fixed bottom-4 right-4 inline-flex h-10 min-w-[2.5rem] items-center justify-center rounded-full bg-[var(--beta-badge-bg)] text-xs font-semibold text-[var(--beta-badge-fg)] shadow-md transition-colors duration-150 hover:bg-[var(--beta-badge-bg-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--beta-badge-outline)] sm:min-w-0 sm:gap-2 sm:rounded sm:px-3 sm:py-1"
     >
-      Beta
+      <span aria-hidden="true" className="flex h-4 w-4 items-center justify-center text-[var(--beta-badge-icon)] sm:h-3.5 sm:w-3.5">
+        <svg
+          className="h-full w-full"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 3.75 9.94 8.9l-5.19.38 3.98 3.25-1.26 5.01L12 15.69l4.53 1.85-1.26-5.01 3.98-3.25-5.19-.38L12 3.75Z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+      <span className="hidden text-[var(--beta-badge-fg)] sm:inline">Beta</span>
     </button>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -22,6 +22,12 @@
   --color-control-accent: var(--color-accent);
   --kali-text: #f5f5f5;
   accent-color: var(--color-control-accent);
+
+  --beta-badge-bg: rgba(234, 179, 8, 0.9);
+  --beta-badge-bg-hover: rgba(250, 204, 21, 0.95);
+  --beta-badge-fg: #1f2937;
+  --beta-badge-icon: #92400e;
+  --beta-badge-outline: var(--color-focus-ring);
 }
 
 body {
@@ -42,6 +48,11 @@ html[data-theme='dark'] {
   --color-border: #333333;
   --color-terminal: #00ff00;
   --color-dark: #0a0a0a;
+
+  --beta-badge-bg: rgba(217, 119, 6, 0.9);
+  --beta-badge-bg-hover: rgba(250, 204, 21, 0.9);
+  --beta-badge-fg: #111827;
+  --beta-badge-icon: #fbbf24;
 }
 
 /* Neon theme */
@@ -57,6 +68,11 @@ html[data-theme='neon'] {
   --color-border: #333333;
   --color-terminal: #39ff14;
   --color-dark: #000000;
+
+  --beta-badge-bg: color-mix(in srgb, var(--color-accent) 80%, rgba(0, 0, 0, 0.1));
+  --beta-badge-bg-hover: var(--color-accent);
+  --beta-badge-fg: #0f172a;
+  --beta-badge-icon: #fef9c3;
 }
 
 /* Matrix theme */
@@ -72,6 +88,11 @@ html[data-theme='matrix'] {
   --color-border: #003300;
   --color-terminal: #00ff00;
   --color-dark: #000000;
+
+  --beta-badge-bg: color-mix(in srgb, var(--color-accent) 75%, rgba(0, 0, 0, 0.15));
+  --beta-badge-bg-hover: color-mix(in srgb, var(--color-accent) 85%, rgba(0, 0, 0, 0.05));
+  --beta-badge-fg: #001b0b;
+  --beta-badge-icon: #bbf7d0;
 
 }
 


### PR DESCRIPTION
## Summary
- switch the Beta badge to an icon-first button that stays compact on mobile and keeps a consistent footprint when the label appears
- theme the badge through CSS variables so it adapts across the existing light, dark, neon, and matrix palettes

## Testing
- yarn test betaBadge.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68db84f5c22c8328969d56652c08276e