### PR TITLE
[security-tools] Improve command builder layout and preview

### DIFF
--- a/components/CommandBuilder.tsx
+++ b/components/CommandBuilder.tsx
@@ -9,36 +9,63 @@ interface BuilderProps {
 export default function CommandBuilder({ doc, build }: BuilderProps) {
   const [params, setParams] = useState<Record<string, string>>({});
   const update = (key: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
-    setParams({ ...params, [key]: e.target.value });
+    setParams(prev => ({ ...prev, [key]: e.target.value }));
   };
 
   const command = build(params);
+  const targetPattern = '^(https?:\/\/)?[\w.-]+(?::\d+)?(?:\/.*)?$';
+  const optionsPattern = "^[\w\s\-/:.=\"']*$";
 
   return (
-    <form className="text-xs" onSubmit={(e) => e.preventDefault()} aria-label="command builder">
-      <p className="mb-2" aria-label="inline docs">{doc}</p>
-      <label className="block mb-1">
-        <span className="mr-1">Target</span>
-        <input
-          aria-label="target"
-          value={params.target || ''}
-          onChange={update('target')}
-          className="border p-1 text-black w-full"
-        />
-      </label>
-      <label className="block mb-1">
-        <span className="mr-1">Options</span>
-        <input
-          aria-label="options"
-          value={params.opts || ''}
-          onChange={update('opts')}
-          className="border p-1 text-black w-full"
-        />
-      </label>
-      <div className="mt-2">
+    <form
+      className="text-xs space-y-3"
+      onSubmit={(e) => e.preventDefault()}
+      aria-label="command builder"
+    >
+      <p className="mb-1" aria-label="inline docs">
+        {doc}
+      </p>
+      <fieldset className="space-y-2 rounded border border-white/20 p-2">
+        <legend className="px-1 text-[11px] font-semibold uppercase tracking-wide text-white/70">
+          Command inputs
+        </legend>
+        <label className="flex flex-col gap-1" htmlFor="command-target">
+          <span className="text-[11px] font-medium uppercase tracking-wide text-white/80">
+            Target URL or host
+          </span>
+          <input
+            id="command-target"
+            aria-label="target"
+            value={params.target || ''}
+            onChange={update('target')}
+            className="w-full rounded border border-white/30 bg-white px-2 py-1 text-black"
+            inputMode="url"
+            pattern={targetPattern}
+            placeholder="https://target.local"
+          />
+        </label>
+        <label className="flex flex-col gap-1" htmlFor="command-options">
+          <span className="text-[11px] font-medium uppercase tracking-wide text-white/80">
+            Command options
+          </span>
+          <input
+            id="command-options"
+            aria-label="options"
+            value={params.opts || ''}
+            onChange={update('opts')}
+            className="w-full rounded border border-white/30 bg-white px-2 py-1 text-black"
+            inputMode="text"
+            pattern={optionsPattern}
+            placeholder="-X POST -H 'Accept: application/json'"
+          />
+        </label>
+      </fieldset>
+      <fieldset className="space-y-2 rounded border border-white/20 p-2">
+        <legend className="px-1 text-[11px] font-semibold uppercase tracking-wide text-white/70">
+          Preview
+        </legend>
         <TerminalOutput text={command} ariaLabel="command output" />
-      </div>
+      </fieldset>
     </form>
   );
 }
-

--- a/components/TerminalOutput.tsx
+++ b/components/TerminalOutput.tsx
@@ -16,14 +16,14 @@ export default function TerminalOutput({ text, ariaLabel }: TerminalOutputProps)
   };
   return (
     <div
-      className="bg-black text-green-400 font-mono text-xs p-2 rounded"
+      className="max-w-full overflow-x-auto rounded bg-black p-2 font-mono text-xs text-green-400"
       aria-label={ariaLabel}
     >
       {lines.map((line, idx) => (
-        <div key={idx} className="flex items-start">
-          <span className="flex-1 whitespace-pre-wrap">{line}</span>
+        <div key={idx} className="flex items-start gap-2">
+          <span className="min-w-0 flex-1 whitespace-pre-wrap break-words">{line}</span>
           <button
-            className="ml-2 text-gray-400 hover:text-white"
+            className="shrink-0 text-gray-400 hover:text-white"
             onClick={() => copyLine(line)}
             aria-label="copy line"
           >


### PR DESCRIPTION
## Summary
- group command builder inputs into fieldsets with clearer labels and validation hints
- tune the terminal preview container so command output stays readable at narrow widths

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db84f606ec83288923f70ef3527471