### PR TITLE
[ui] Convert install button to sticky bar

### DIFF
--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -1,35 +1,66 @@
 "use client";
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { trackEvent } from '@/lib/analytics-client';
 import { showA2HS } from '@/src/pwa/a2hs';
 
 const InstallButton: React.FC = () => {
-  const [visible, setVisible] = useState(false);
+  const [isRendered, setIsRendered] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const hideTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
-    const handler = () => setVisible(true);
-    (window as any).addEventListener('a2hs:available', handler);
-    return () => (window as any).removeEventListener('a2hs:available', handler);
+    const handler = () => {
+      setIsRendered(true);
+      requestAnimationFrame(() => setIsVisible(true));
+    };
+
+    const win = window as any;
+    win.addEventListener('a2hs:available', handler);
+
+    return () => {
+      win.removeEventListener('a2hs:available', handler);
+      if (hideTimeoutRef.current) {
+        window.clearTimeout(hideTimeoutRef.current);
+      }
+    };
   }, []);
 
   const handleInstall = async () => {
     const shown = await showA2HS();
     if (shown) {
       trackEvent('cta_click', { location: 'install_button' });
-      setVisible(false);
+      setIsVisible(false);
+      if (hideTimeoutRef.current) {
+        window.clearTimeout(hideTimeoutRef.current);
+      }
+      hideTimeoutRef.current = window.setTimeout(() => {
+        setIsRendered(false);
+      }, 350);
     }
   };
 
-  if (!visible) return null;
+  if (!isRendered) return null;
 
   return (
-    <button
-      onClick={handleInstall}
-      className="fixed bottom-4 right-4 bg-ubt-blue text-white px-3 py-1 rounded"
+    <div
+      className={`fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 transition-transform duration-300 ease-out ${
+        isVisible ? 'translate-y-0' : 'translate-y-full'
+      }`}
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) + 1rem)' }}
+      aria-live="polite"
     >
-      Install
-    </button>
+      <div className="pointer-events-auto flex w-full max-w-md items-center justify-between gap-3 rounded-full bg-ubt-blue/95 px-4 py-3 text-white shadow-lg backdrop-blur">
+        <span className="text-sm font-medium">Install this app for quick access</span>
+        <button
+          type="button"
+          onClick={handleInstall}
+          className="rounded-full bg-white/15 px-4 py-2 text-sm font-semibold text-white transition-colors duration-150 ease-out hover:bg-white/25 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+        >
+          Install
+        </button>
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- replace the floating install install CTA with a sticky bottom bar that respects safe-area insets
- add show/hide animation handling while preserving the existing analytics event

## Testing
- [x] yarn lint


------
https://chatgpt.com/codex/tasks/task_e_68db84fc81f0832893752169e5e644fa