### PR TITLE
[metasploit] Improve module card readability

### DIFF
--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import Image from 'next/image';
 import { ModuleMetadata } from '../modules/metadata';
 
@@ -9,7 +10,7 @@ interface ModuleCardProps {
   query?: string;
 }
 
-function highlight(text: string, query: string | undefined) {
+function highlight(text: string, query: string | undefined): ReactNode {
   if (!query) return text;
   const lower = text.toLowerCase();
   const q = query.toLowerCase();
@@ -33,26 +34,43 @@ export default function ModuleCard({
   return (
     <button
       onClick={() => onSelect(module)}
-      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
-        selected ? 'bg-gray-100' : ''
+      className={`w-full text-left border rounded-xl p-4 sm:p-5 flex flex-col gap-4 transition shadow-sm hover:shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-500 ${
+        selected ? 'bg-gray-100 border-gray-300' : 'bg-white border-gray-200'
       }`}
     >
-      <div className="flex-1 pr-2 font-mono">
-        <h3 className="font-bold">{highlight(module.name, query)}</h3>
-        <p className="text-sm">{highlight(module.description, query)}</p>
+      {module.thumbnail ? (
+        <div className="w-full overflow-hidden rounded-lg bg-gray-100">
+          <Image
+            src={module.thumbnail}
+            alt={`${module.name} thumbnail`}
+            width={480}
+            height={270}
+            className="h-auto w-full object-cover"
+          />
+        </div>
+      ) : null}
+      <div className="flex flex-col gap-2 font-mono">
+        <h3 className="text-base font-semibold leading-tight text-gray-900 sm:text-lg">
+          {highlight(module.name, query)}
+        </h3>
+        <p className="text-sm leading-relaxed text-gray-700 sm:text-base">
+          {highlight(module.description, query)}
+        </p>
       </div>
-      <div className="flex flex-col gap-2 items-center">
+      <div className="flex items-center gap-4">
         <Image
           src="/themes/Yaru/status/about.svg"
           alt="Details"
-          width={24}
-          height={24}
+          width={28}
+          height={28}
+          className="h-7 w-7"
         />
         <Image
           src="/themes/Yaru/status/download.svg"
           alt="Run"
-          width={24}
-          height={24}
+          width={28}
+          height={28}
+          className="h-7 w-7"
         />
       </div>
     </button>

--- a/modules/metadata.ts
+++ b/modules/metadata.ts
@@ -7,6 +7,8 @@ export interface ModuleOption {
 export interface ModuleMetadata {
   name: string;
   description: string;
+  /** Optional preview graphic for the module */
+  thumbnail?: string;
   tags: string[];
   options: ModuleOption[];
 }


### PR DESCRIPTION
## Summary
- stack module card content vertically so thumbnails, copy, and actions follow a consistent flow
- add optional thumbnail support with responsive spacing and typography for smaller screens
- ensure focus-visible rings remain apparent for keyboard users

## Testing
- [x] yarn lint
- [ ] yarn test

## Flags
- None

------
https://chatgpt.com/codex/tasks/task_e_68db84fe4a688328af3291ca524a7404