### PR TITLE
[ui] add route change abort confirmation modal

### DIFF
--- a/components/UseRouteAbortGuard.tsx
+++ b/components/UseRouteAbortGuard.tsx
@@ -1,28 +1,238 @@
-import { useEffect } from 'react';
+"use client";
+
+import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import RouteChangeConfirmationModal, {
+  type ConfirmationDialogCopy,
+} from './common/RouteChangeConfirmationModal';
+
+export interface RouteAbortConfirmationConfig {
+  title?: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+export type RouteAbortController = AbortController & {
+  shouldConfirm: () => boolean;
+  getConfirmation: () => RouteAbortConfirmationConfig | undefined;
+  setConfirmation: (config?: RouteAbortConfirmationConfig) => void;
+  clearConfirmation: () => void;
+};
 
 declare global {
   interface Window {
-    routeAbortController?: AbortController;
+    routeAbortController?: RouteAbortController;
   }
 }
 
+interface PendingNavigation {
+  proceed: () => Promise<boolean> | boolean | void;
+  resolve?: (value: boolean) => void;
+  reject?: (reason?: unknown) => void;
+  copy: ConfirmationDialogCopy;
+}
+
+const DEFAULT_DIALOG_COPY: ConfirmationDialogCopy = {
+  title: 'Abort running task?',
+  description: 'Leaving this screen will stop the current operation.',
+  confirmLabel: 'Leave',
+  cancelLabel: 'Stay',
+};
+
+const createRouteAbortController = (): RouteAbortController => {
+  const controller = new AbortController() as RouteAbortController;
+  const { signal } = controller;
+  const abortListeners = new Set<EventListenerOrEventListenerObject>();
+  let confirmation: RouteAbortConfirmationConfig | undefined;
+
+  const originalAdd = signal.addEventListener.bind(signal);
+  signal.addEventListener = ((type, listener, options) => {
+    if (type === 'abort' && listener) {
+      abortListeners.add(listener);
+    }
+    return originalAdd(type, listener as EventListenerOrEventListenerObject, options);
+  }) as typeof signal.addEventListener;
+
+  const originalRemove = signal.removeEventListener.bind(signal);
+  signal.removeEventListener = ((type, listener, options) => {
+    if (type === 'abort' && listener) {
+      abortListeners.delete(listener);
+    }
+    return originalRemove(type, listener as EventListenerOrEventListenerObject, options);
+  }) as typeof signal.removeEventListener;
+
+  const descriptor = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(signal),
+    'onabort',
+  );
+
+  if (descriptor?.get && descriptor?.set && descriptor.configurable !== false) {
+    Object.defineProperty(signal, 'onabort', {
+      configurable: true,
+      enumerable: descriptor.enumerable ?? false,
+      get() {
+        return descriptor.get!.call(signal);
+      },
+      set(value) {
+        const previous = descriptor.get!.call(signal);
+        if (previous) {
+          abortListeners.delete(previous as EventListenerOrEventListenerObject);
+        }
+        descriptor.set!.call(signal, value);
+        if (value) {
+          abortListeners.add(value);
+        }
+      },
+    });
+  }
+
+  controller.shouldConfirm = () =>
+    !controller.signal.aborted && (abortListeners.size > 0 || Boolean(confirmation));
+
+  controller.getConfirmation = () => confirmation;
+
+  controller.setConfirmation = (config?: RouteAbortConfirmationConfig) => {
+    confirmation = config;
+  };
+
+  controller.clearConfirmation = () => {
+    confirmation = undefined;
+  };
+
+  return controller;
+};
+
+const getRouteAbortController = () =>
+  (typeof window !== 'undefined' ? window.routeAbortController : undefined);
+
 export default function UseRouteAbortGuard() {
   const router = useRouter();
+  const [pendingNavigation, setPendingNavigation] = useState<PendingNavigation | null>(
+    null,
+  );
 
   useEffect(() => {
-    window.routeAbortController = new AbortController();
-    const handleRouteChange = () => {
-      window.routeAbortController?.abort();
-      window.routeAbortController = new AbortController();
+    const assignController = () => {
+      window.routeAbortController = createRouteAbortController();
     };
-    router.events.on('routeChangeStart', handleRouteChange);
+
+    assignController();
+
+    const handleRouteChangeStart = () => {
+      window.routeAbortController?.abort();
+      assignController();
+    };
+
+    router.events.on('routeChangeStart', handleRouteChangeStart);
+
     return () => {
-      router.events.off('routeChangeStart', handleRouteChange);
+      router.events.off('routeChangeStart', handleRouteChangeStart);
       window.routeAbortController?.abort();
       delete window.routeAbortController;
     };
   }, [router.events]);
 
-  return null;
+  useEffect(() => {
+    const originalPush = router.push.bind(router);
+    const originalReplace = router.replace.bind(router);
+    const originalBack = router.back.bind(router);
+
+    const wrapAsyncNavigation = (
+      method: typeof router.push,
+    ): typeof router.push => {
+      return (async (...args) => {
+        const controller = getRouteAbortController();
+        if (!controller?.shouldConfirm?.()) {
+          return method(...args);
+        }
+
+        const copy = {
+          ...DEFAULT_DIALOG_COPY,
+          ...controller.getConfirmation?.(),
+        } satisfies ConfirmationDialogCopy;
+
+        return new Promise<boolean>((resolve, reject) => {
+          setPendingNavigation({
+            copy,
+            proceed: () => method(...args),
+            resolve,
+            reject,
+          });
+        });
+      }) as typeof router.push;
+    };
+
+    router.push = wrapAsyncNavigation(originalPush);
+    router.replace = wrapAsyncNavigation(originalReplace as typeof router.push) as typeof router.replace;
+
+    router.back = () => {
+      const controller = getRouteAbortController();
+      if (!controller?.shouldConfirm?.()) {
+        originalBack();
+        return;
+      }
+
+      const copy = {
+        ...DEFAULT_DIALOG_COPY,
+        ...controller.getConfirmation?.(),
+      } satisfies ConfirmationDialogCopy;
+
+      setPendingNavigation({
+        copy,
+        proceed: () => {
+          originalBack();
+          return true;
+        },
+      });
+    };
+
+    return () => {
+      router.push = originalPush;
+      router.replace = originalReplace;
+      router.back = originalBack;
+    };
+  }, [router]);
+
+  const handleConfirm = useCallback(() => {
+    if (!pendingNavigation) return;
+    const nav = pendingNavigation;
+    const controller = getRouteAbortController();
+    controller?.abort();
+    controller?.clearConfirmation?.();
+    setPendingNavigation(null);
+
+    Promise.resolve(nav.proceed())
+      .then((result) => {
+        const value = typeof result === 'boolean' ? result : true;
+        nav.resolve?.(value);
+      })
+      .catch((error) => {
+        nav.reject?.(error);
+      });
+  }, [pendingNavigation]);
+
+  const handleCancel = useCallback(() => {
+    if (!pendingNavigation) return;
+    const nav = pendingNavigation;
+    const controller = getRouteAbortController();
+    controller?.clearConfirmation?.();
+    nav.reject?.(new Error('Navigation cancelled by user'));
+    setPendingNavigation(null);
+  }, [pendingNavigation]);
+
+  const dialogCopy = pendingNavigation?.copy ?? DEFAULT_DIALOG_COPY;
+
+  return (
+    <RouteChangeConfirmationModal
+      isOpen={Boolean(pendingNavigation)}
+      title={dialogCopy.title}
+      description={dialogCopy.description}
+      confirmLabel={dialogCopy.confirmLabel}
+      cancelLabel={dialogCopy.cancelLabel}
+      onConfirm={handleConfirm}
+      onCancel={handleCancel}
+    />
+  );
 }
+

--- a/components/common/RouteChangeConfirmationModal.tsx
+++ b/components/common/RouteChangeConfirmationModal.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import Modal from '../base/Modal';
+
+export interface ConfirmationDialogCopy {
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+interface RouteChangeConfirmationModalProps extends ConfirmationDialogCopy {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const overlaySafeAreaStyle: React.CSSProperties = {
+  paddingTop: 'env(safe-area-inset-top)',
+  paddingBottom: 'env(safe-area-inset-bottom)',
+  paddingLeft: 'env(safe-area-inset-left)',
+  paddingRight: 'env(safe-area-inset-right)',
+};
+
+const RouteChangeConfirmationModal: React.FC<RouteChangeConfirmationModalProps> = ({
+  isOpen,
+  title,
+  description,
+  confirmLabel = 'Leave',
+  cancelLabel = 'Stay',
+  onConfirm,
+  onCancel,
+}) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onCancel}>
+      <div
+        className="fixed inset-0 z-[1000] flex items-end justify-center bg-black/70 px-4 sm:items-center"
+        style={overlaySafeAreaStyle}
+        onClick={onCancel}
+      >
+        <div
+          className="w-full max-w-md rounded-t-3xl border border-white/10 bg-gray-900 text-white shadow-2xl sm:rounded-3xl"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="space-y-3 px-6 pt-8 text-left">
+            <h2 className="text-2xl font-semibold tracking-tight">{title}</h2>
+            {description ? (
+              <p className="text-base leading-relaxed text-gray-300">{description}</p>
+            ) : null}
+          </div>
+          <div className="grid gap-3 px-6 pb-8 pt-6 sm:grid-cols-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="w-full rounded-full border border-white/30 bg-transparent py-4 text-lg font-semibold text-white transition focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900"
+            >
+              {cancelLabel}
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              className="w-full rounded-full bg-red-600 py-4 text-lg font-semibold text-white transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-2 focus:ring-offset-gray-900"
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default RouteChangeConfirmationModal;
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,6 +14,7 @@ import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import NotificationCenter from '../components/common/NotificationCenter';
 import PipPortalProvider from '../components/common/PipPortal';
+import UseRouteAbortGuard from '../components/UseRouteAbortGuard';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
@@ -158,6 +159,7 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
+          <UseRouteAbortGuard />
           <NotificationCenter>
             <PipPortalProvider>
               <div aria-live="polite" id="live-region" />


### PR DESCRIPTION
## Summary
- add a reusable confirmation modal styled for touch targets and safe-area padding
- extend the route abort guard to show the modal before aborting and to expose confirmation copy helpers
- wire the guard into the app shell so abortable navigations prompt before cancelling work

## Testing
- yarn lint *(fails: ESLint reports `pages/_app.jsx` is ignored because no matching configuration was supplied; same warning occurs when running eslint directly)*

------
https://chatgpt.com/codex/tasks/task_e_68db8516b05883288fb9f77c13ee204a