### PR TITLE
[games] Show Reversi AI thinking feedback

### DIFF
--- a/components/apps/reversiLogic.js
+++ b/components/apps/reversiLogic.js
@@ -180,13 +180,22 @@ export const minimax = (
   return value;
 };
 
-export const bestMove = (board, player, depth, weights = DEFAULT_WEIGHTS) => {
+export const bestMove = (
+  board,
+  player,
+  depth,
+  weights = DEFAULT_WEIGHTS,
+  options = {},
+) => {
   const movesObj = computeLegalMoves(board, player);
   const entries = Object.entries(movesObj);
   if (entries.length === 0) return null;
   const opponent = player === 'B' ? 'W' : 'B';
   let best = null;
   let bestVal = -Infinity;
+  let evaluated = 0;
+  const { onProgress } = options;
+  const totalMoves = entries.length;
   for (const [key, flips] of entries) {
     const [r, c] = key.split('-').map(Number);
     const newBoard = applyMove(board, r, c, player, flips);
@@ -202,6 +211,18 @@ export const bestMove = (board, player, depth, weights = DEFAULT_WEIGHTS) => {
     if (val > bestVal) {
       bestVal = val;
       best = [r, c];
+    }
+    evaluated += 1;
+    if (typeof onProgress === 'function') {
+      onProgress({
+        evaluated,
+        total: totalMoves,
+        candidate: [r, c],
+        score: val,
+        bestMove: best,
+        bestScore: bestVal,
+        completed: evaluated === totalMoves,
+      });
     }
   }
   return best;

--- a/workers/reversi.worker.js
+++ b/workers/reversi.worker.js
@@ -1,7 +1,17 @@
 import { bestMove, DEFAULT_WEIGHTS } from '../components/apps/reversiLogic';
 
+const PROGRESS_THROTTLE_MS = 100;
+
 self.onmessage = (e) => {
   const { board, player, depth, weights = DEFAULT_WEIGHTS } = e.data;
-  const move = bestMove(board, player, depth, weights);
-  self.postMessage({ move });
+  let lastProgress = 0;
+  const sendProgress = (payload) => {
+    const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    if (now - lastProgress >= PROGRESS_THROTTLE_MS || payload.completed) {
+      lastProgress = now;
+      self.postMessage({ type: 'progress', ...payload });
+    }
+  };
+  const move = bestMove(board, player, depth, weights, { onProgress: sendProgress });
+  self.postMessage({ type: 'done', move });
 };


### PR DESCRIPTION
## Summary
- throttle worker progress events and emit AI evaluation updates from the Reversi worker
- surface the worker progress in the UI with a busy indicator and updated status messaging
- keep Reversi difficulty constants module scoped and wire up accessibility tweaks on controls

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db851be2f883288638b392bdaac366