### PR TITLE
[apps] add summary and accordions to explainer pane

### DIFF
--- a/components/ExplainerPane.tsx
+++ b/components/ExplainerPane.tsx
@@ -1,3 +1,5 @@
+import { useId, useState } from 'react';
+
 interface Resource {
   label: string;
   url: string;
@@ -6,35 +8,113 @@ interface Resource {
 interface Props {
   lines: string[];
   resources: Resource[];
+  summary?: string;
 }
 
-export default function ExplainerPane({ lines, resources }: Props) {
+export default function ExplainerPane({ lines, resources, summary }: Props) {
+  const [keyPointsOpen, setKeyPointsOpen] = useState(true);
+  const [learnMoreOpen, setLearnMoreOpen] = useState(true);
+
+  const summaryHeadingId = useId();
+  const keyPointsBaseId = useId();
+  const learnMoreBaseId = useId();
+
+  const keyPointsButtonId = `${keyPointsBaseId}-button`;
+  const keyPointsPanelId = `${keyPointsBaseId}-panel`;
+  const learnMoreButtonId = `${learnMoreBaseId}-button`;
+  const learnMorePanelId = `${learnMoreBaseId}-panel`;
+
+  const summaryText = summary ?? lines[0] ?? '';
+  const keyPointItems = summary || !summaryText ? lines : lines.slice(1);
+
   return (
     <aside
       className="text-xs p-2 border-l border-ub-cool-grey overflow-auto h-full"
       aria-label="explainer pane"
     >
-      <h3 className="font-bold mb-2">Key Points</h3>
-      <ul className="list-disc list-inside mb-4">
-        {lines.map((line, i) => (
-          <li key={i}>{line}</li>
-        ))}
-      </ul>
-      <h3 className="font-bold mb-2">Learn More</h3>
-      <ul className="list-disc list-inside">
-        {resources.map((r, i) => (
-          <li key={i}>
-            <a
-              href={r.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline"
-            >
-              {r.label}
-            </a>
-          </li>
-        ))}
-      </ul>
+      {summaryText ? (
+        <section aria-labelledby={summaryHeadingId} className="mb-4">
+          <h2 id={summaryHeadingId} className="text-sm font-semibold mb-1">
+            Summary
+          </h2>
+          <p>{summaryText}</p>
+        </section>
+      ) : null}
+
+      <section>
+        <h2 className="text-sm font-semibold">
+          <button
+            id={keyPointsButtonId}
+            type="button"
+            aria-expanded={keyPointsOpen}
+            aria-controls={keyPointsPanelId}
+            onClick={() => setKeyPointsOpen((open) => !open)}
+            className="flex w-full items-center justify-between text-left"
+          >
+            <span>Key Points</span>
+            <span aria-hidden="true">{keyPointsOpen ? '−' : '+'}</span>
+          </button>
+        </h2>
+        <div
+          id={keyPointsPanelId}
+          role="region"
+          aria-labelledby={keyPointsButtonId}
+          hidden={!keyPointsOpen}
+          className="mt-2 mb-4"
+        >
+          {keyPointItems.length > 0 ? (
+            <ul className="list-disc list-inside">
+              {keyPointItems.map((line, i) => (
+                <li key={i}>{line}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>No key points available.</p>
+          )}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-sm font-semibold">
+          <button
+            id={learnMoreButtonId}
+            type="button"
+            aria-expanded={learnMoreOpen}
+            aria-controls={learnMorePanelId}
+            onClick={() => setLearnMoreOpen((open) => !open)}
+            className="flex w-full items-center justify-between text-left"
+          >
+            <span>Learn More</span>
+            <span aria-hidden="true">{learnMoreOpen ? '−' : '+'}</span>
+          </button>
+        </h2>
+        <div
+          id={learnMorePanelId}
+          role="region"
+          aria-labelledby={learnMoreButtonId}
+          hidden={!learnMoreOpen}
+          className="mt-2"
+        >
+          {resources.length > 0 ? (
+            <ul className="list-disc list-inside">
+              {resources.map((r, i) => (
+                <li key={i}>
+                  <a
+                    href={r.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    {r.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>No resources available.</p>
+          )}
+        </div>
+      </section>
     </aside>
   );
 }

--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -135,6 +135,7 @@ export default function SecurityTools() {
             onChange={e => setQuery(e.target.value)}
             placeholder="Search all tools"
             className="w-full mb-2 p-1 text-black text-xs"
+            aria-label="Search demo tool data"
           />
           {query ? (
             <div className="text-xs">
@@ -238,9 +239,19 @@ export default function SecurityTools() {
             {active === 'yara' && (
             <div>
               <p className="text-xs mb-2">Simplified YARA tester using sample text. Pattern matching is simulated.</p>
-              <textarea value={yaraRule} onChange={e=>setYaraRule(e.target.value)} className="w-full h-24 text-black p-1" />
+                <textarea
+                  value={yaraRule}
+                  onChange={e=>setYaraRule(e.target.value)}
+                  className="w-full h-24 text-black p-1"
+                  aria-label="Enter simulated YARA rule"
+                />
               <div className="text-xs mt-2 mb-1">Sample file:</div>
-              <textarea value={sampleText} readOnly className="w-full h-24 text-black p-1" />
+                <textarea
+                  value={sampleText}
+                  readOnly
+                  className="w-full h-24 text-black p-1"
+                  aria-label="Read-only sample text for YARA demo"
+                />
               <button onClick={runYara} className="mt-2 px-2 py-1 bg-ub-green text-black text-xs">Scan</button>
               {yaraResult && <div className="mt-2 text-xs">{yaraResult}</div>}
             </div>
@@ -276,6 +287,7 @@ export default function SecurityTools() {
         )}
         </div>
         <ExplainerPane
+          summary="Quick overview of this lab and its supporting references."
           lines={["Use this lab to explore static security data."]}
           resources={[
             { label: 'NIST SP 800-115', url: 'https://csrc.nist.gov/publications/detail/sp/800-115/final' },


### PR DESCRIPTION
## Summary
- add a summary section to the shared ExplainerPane and expose an optional prop for custom copy
- wrap the key points and learn more lists in accessible accordion controls with button semantics
- provide descriptive labels for search and YARA text areas in the security tools lab

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68db84f6f0648328af9984059ba6eedc