### PR TITLE
[apps] Fix checkers layout typing and harden YouTube playlists

### DIFF
--- a/apps/checkers/index.tsx
+++ b/apps/checkers/index.tsx
@@ -235,7 +235,12 @@ export default function CheckersPage() {
     });
   };
 
-  const layoutStyle = useMemo<React.CSSProperties>(
+  type LayoutCSSVariables = {
+    '--panel-height': string;
+    '--board-size': string;
+  };
+
+  const layoutStyle = useMemo<React.CSSProperties & LayoutCSSVariables>(
     () => ({
       '--panel-height': '10rem',
       '--board-size': 'clamp(10rem, min(90vw, calc(100vh - var(--panel-height))), 36rem)',


### PR DESCRIPTION
## Summary
- declare a CSS variable type for the checkers layout hook so the Next build accepts the custom properties
- normalize YouTube playlist data before sorting/filtering to handle partial objects and avoid localeCompare crashes
- add helper utilities that keep channel metadata consistent across filters and cards

## Testing
- `CI=1 yarn build`
- `yarn lint`
- `yarn test --watchAll=false __tests__/youtube.test.tsx` *(fails: legacy test expects queue/watch-later UI that is not present in current YouTube app)*

------
https://chatgpt.com/codex/tasks/task_e_68dc10ba1f88832883df93d9d0a3748b