### PR TITLE
[desktop] restore wallpaper and app icons

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1771,8 +1771,8 @@ export class Desktop extends Component {
                 id="desktop"
                 role="main"
                 ref={this.desktopRef}
-                className={" h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse bg-transparent relative overflow-hidden overscroll-none window-parent"}
-                style={{ paddingTop: DESKTOP_TOP_PADDING }}
+                className={" min-h-screen h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse bg-transparent relative overflow-hidden overscroll-none window-parent"}
+                style={{ paddingTop: DESKTOP_TOP_PADDING, minHeight: '100dvh' }}
             >
 
                 {/* Window Area */}


### PR DESCRIPTION
## Summary
- ensure the desktop root maintains a viewport-height minimum so the wallpaper and icons render across the full screen
- add a dynamic viewport fallback to keep the taskbar reachable on varied display sizes

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dd6d8bc6bc8328bb23c0e83e31f921