### PR TITLE
[desktop] Open apps on single click

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -714,7 +714,11 @@ export class Desktop extends Component {
             this.preventNextIconClick = true;
             this.updateIconPosition(dragState.id, position.x, position.y, true);
         } else {
-            this.setState({ draggingIconId: null });
+            event.preventDefault();
+            event.stopPropagation();
+            this.setState({ draggingIconId: null }, () => {
+                this.openApp(dragState.id);
+            });
         }
     };
 


### PR DESCRIPTION
## Summary
- open desktop applications on pointer release when no drag movement occurs so single clicks launch windows while drag gestures still work

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dd72a2a8e883289fcdb262b007e5f3