### PR TITLE
[desktop] enforce boot splash before desktop loads

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -95,6 +95,7 @@ export class Desktop extends Component {
 
         this.validAppIds = new Set(apps.map((app) => app.id));
 
+        this.desktopReadySent = false;
     }
 
     createEmptyWorkspaceState = () => ({
@@ -1214,8 +1215,17 @@ export class Desktop extends Component {
         }, () => {
             this.ensureIconPositions(desktop_apps);
             if (typeof callback === 'function') callback();
+            this.notifyReady();
         });
         this.initFavourite = { ...favourite_apps };
+    }
+
+    notifyReady = () => {
+        if (this.desktopReadySent) return;
+        this.desktopReadySent = true;
+        if (typeof this.props.onReady === 'function') {
+            this.props.onReady();
+        }
     }
 
     updateAppsData = () => {


### PR DESCRIPTION
## Summary
- ensure the Ubuntu shell always plays the boot splash with a minimum duration on every load and on wake
- add a readiness notification from the desktop screen so the splash only dismisses once initial apps/state are prepared

## Testing
- [x] yarn lint
- [ ] yarn test --watch=false *(fails in existing suites such as `game2048` and `moduleWorkspaceStore`)*

------
https://chatgpt.com/codex/tasks/task_e_68dd760e49b08328b0c1223ae577912d