### PR TITLE
[tests] align suites with updated ui behavior

### DIFF
--- a/__tests__/moduleWorkspaceStore.test.tsx
+++ b/__tests__/moduleWorkspaceStore.test.tsx
@@ -18,7 +18,7 @@ describe('ModuleWorkspace key-value store', () => {
     fireEvent.change(screen.getByLabelText(/TARGET/), {
       target: { value: 'host' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Run Command' }));
 
     const stored = getValue('port-scan');
     expect(stored).toBeDefined();

--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -82,7 +82,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });

--- a/__tests__/ubuntu.test.tsx
+++ b/__tests__/ubuntu.test.tsx
@@ -25,15 +25,16 @@ describe('Ubuntu component', () => {
 
   it('renders boot screen then desktop', () => {
     render(<Ubuntu />);
-    const bootLogo = screen.getByAltText('Ubuntu Logo');
-    const bootScreen = bootLogo.parentElement as HTMLElement;
-    expect(bootScreen).toHaveClass('visible');
+    const bootLogo = screen.getByAltText('Kali Linux dragon emblem');
+    const bootScreen = bootLogo.closest('[role="status"]') as HTMLElement | null;
+    expect(bootScreen).not.toBeNull();
+    expect(bootScreen!).toHaveClass('visible');
 
     act(() => {
       jest.advanceTimersByTime(2000);
     });
 
-    expect(bootScreen).toHaveClass('invisible');
+    expect(bootScreen!).toHaveClass('invisible');
     expect(screen.getByTestId('desktop')).toBeInTheDocument();
   });
 

--- a/__tests__/window.test.tsx
+++ b/__tests__/window.test.tsx
@@ -2,6 +2,7 @@ import React, { act } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Window from '../components/base/window';
 import { DESKTOP_TOP_PADDING, SNAP_BOTTOM_INSET } from '../utils/uiConstants';
+import { DEFAULT_WINDOW_TOP_OFFSET } from '../utils/windowLayout';
 
 const computeSnappedHeightPercent = () => {
   const availableHeight = window.innerHeight - DESKTOP_TOP_PADDING - SNAP_BOTTOM_INSET;
@@ -470,7 +471,7 @@ describe('Edge resistance', () => {
       ref.current!.handleDrag({}, { node: winEl, x: -100, y: -50 } as any);
     });
 
-    expect(winEl.style.transform).toBe('translate(0px, 0px)');
+    expect(winEl.style.transform).toBe(`translate(0px, ${DEFAULT_WINDOW_TOP_OFFSET}px)`);
   });
 });
 

--- a/__tests__/youtube.test.tsx
+++ b/__tests__/youtube.test.tsx
@@ -1,117 +1,100 @@
 import React from 'react';
-import { render, screen, within, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import YouTubeApp from '../components/apps/youtube';
 
-const mockVideos = [
+const mockPlaylists = [
   {
-    id: 'a',
-    title: 'Video A',
-    thumbnail: 'a.jpg',
-    channelName: 'Chan A',
-    channelId: 'chanA',
+    id: 'alpha',
+    title: 'Alpha Recon',
+    description: 'Recon techniques playlist',
+    thumbnail: 'alpha.jpg',
+    channelTitle: 'CyberSec Lab',
+    channelId: 'cyber',
+    itemCount: 12,
+    updatedAt: '2024-02-15T00:00:00Z',
   },
   {
-    id: 'b',
-    title: 'Video B',
-    thumbnail: 'b.jpg',
-    channelName: 'Chan B',
-    channelId: 'chanB',
+    id: 'zero',
+    title: 'Zero Day Tutorials',
+    description: 'Deep dives on zero-day research',
+    thumbnail: 'zero.jpg',
+    channelTitle: 'Red Team Academy',
+    channelId: 'red',
+    itemCount: 18,
+    updatedAt: '2024-03-20T00:00:00Z',
+  },
+  {
+    id: 'blue',
+    title: 'Blue Team Basics',
+    description: 'Defensive techniques refresher',
+    thumbnail: 'blue.jpg',
+    channelTitle: 'CyberSec Lab',
+    channelId: 'cyber',
+    itemCount: 8,
+    updatedAt: '2023-12-01T00:00:00Z',
   },
 ];
 
-describe('YouTube search app', () => {
-  beforeEach(() => {
-    window.localStorage.clear();
+const getRenderedTitles = () =>
+  screen
+    .getAllByRole('heading', { level: 3 })
+    .map((element) => element.textContent?.trim())
+    .filter(Boolean);
+
+describe('YouTube playlists explorer', () => {
+  it('renders initial playlists with metadata', () => {
+    render(<YouTubeApp initialResults={mockPlaylists} />);
+
+    mockPlaylists.forEach((playlist) => {
+      expect(screen.getByText(playlist.title)).toBeInTheDocument();
+      expect(screen.getAllByText(playlist.channelTitle)[0]).toBeInTheDocument();
+      expect(screen.getByText(`${playlist.itemCount} videos`)).toBeInTheDocument();
+    });
   });
 
-  it('loads video when thumbnail clicked', async () => {
+  it('filters playlists by channel selection', async () => {
     const user = userEvent.setup();
-    render(<YouTubeApp initialResults={mockVideos} />);
-    await user.click(screen.getByAltText('Video A'));
-    const iframe = screen.getByTitle('YouTube video player');
-    expect(iframe).toHaveAttribute('src', expect.stringContaining('a'));
+    render(<YouTubeApp initialResults={mockPlaylists} />);
+
+    await user.click(screen.getByRole('button', { name: /Red Team Academy/ }));
+
+    expect(screen.getByText('Zero Day Tutorials')).toBeInTheDocument();
+    expect(screen.queryByText('Alpha Recon')).not.toBeInTheDocument();
+    expect(screen.queryByText('Blue Team Basics')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Clear channel filter/i })).toBeInTheDocument();
   });
 
-  it('adds to queue and watch later lists', async () => {
+  it('sorts playlists by title when toggled', async () => {
     const user = userEvent.setup();
-    render(<YouTubeApp initialResults={mockVideos} />);
-    const queueButtons = screen.getAllByRole('button', { name: 'Queue' });
-    const laterButtons = screen.getAllByRole('button', { name: 'Later' });
-    await user.click(queueButtons[0]);
-    await user.click(laterButtons[0]);
+    render(<YouTubeApp initialResults={mockPlaylists} />);
 
-    expect(
-      within(screen.getByTestId('queue-list')).getByText('Video A')
-    ).toBeInTheDocument();
-    const stored = JSON.parse(
-      window.localStorage.getItem('youtube:watch-later') || '[]'
-    );
-    expect(stored).toHaveLength(1);
-    expect(stored[0].id).toBe('a');
-  });
-
-  it('renders watch later playlist from storage', () => {
-    window.localStorage.setItem('youtube:watch-later', JSON.stringify(mockVideos));
-    render(<YouTubeApp initialResults={[]} />);
-    const list = within(screen.getByTestId('watch-later-list'));
-    expect(list.getByText('Video A')).toBeInTheDocument();
-    expect(list.getByText('Video B')).toBeInTheDocument();
-  });
-
-  it('reorders watch later with keyboard', async () => {
-    const user = userEvent.setup();
-    render(<YouTubeApp initialResults={mockVideos} />);
-    const laterButtons = screen.getAllByRole('button', { name: 'Later' });
-    await user.click(laterButtons[0]);
-    await user.click(laterButtons[1]);
-
-    const list = screen.getByTestId('watch-later-list');
-    const first = within(list).getByText('Video A').parentElement as HTMLElement;
-    fireEvent.keyDown(first, { key: 'ArrowDown' });
+    await user.click(screen.getByRole('button', { name: 'Title A → Z' }));
     await waitFor(() => {
-      const items = within(list).getAllByText(/Video/);
-      expect(items[0].textContent).toBe('Video B');
-      expect(items[1].textContent).toBe('Video A');
+      expect(getRenderedTitles()).toEqual([
+        'Alpha Recon',
+        'Blue Team Basics',
+        'Zero Day Tutorials',
+      ]);
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Title Z → A' }));
+    await waitFor(() => {
+      expect(getRenderedTitles()).toEqual([
+        'Zero Day Tutorials',
+        'Blue Team Basics',
+        'Alpha Recon',
+      ]);
     });
   });
 
-  it('saves named clips with timestamps', async () => {
+  it('switches to channel groups layout', async () => {
     const user = userEvent.setup();
-    let curTime = 0;
-    (window as any).YT = {
-      Player: function (_el: any, { events }: any) {
-        const obj = {
-          getCurrentTime: () => curTime,
-          getPlayerState: () => 0,
-          loadVideoById: jest.fn(),
-          pauseVideo: jest.fn(),
-          playVideo: jest.fn(),
-          seekTo: jest.fn(),
-          getPlaybackRate: () => 1,
-        };
-        events?.onReady?.({ target: obj });
-        return obj;
-      },
-      PlayerState: { PLAYING: 1 },
-    };
-    render(<YouTubeApp initialResults={mockVideos} />);
-    await user.click(screen.getByAltText('Video A'));
-    curTime = 5;
-    await user.click(screen.getByLabelText('Set loop start'));
-    curTime = 10;
-    await user.click(screen.getByLabelText('Set loop end'));
-    window.prompt = jest.fn().mockReturnValue('My Clip');
-    await user.click(screen.getByLabelText('Save clip'));
-    const stored = JSON.parse(
-      window.localStorage.getItem('youtube:watch-later') || '[]'
-    );
-    expect(stored[0]).toMatchObject({
-      id: 'a',
-      start: 5,
-      end: 10,
-      name: 'My Clip',
-    });
+    render(<YouTubeApp initialResults={mockPlaylists} />);
+
+    await user.click(screen.getByRole('button', { name: 'Group by channel' }));
+
+    expect(screen.getByRole('heading', { name: 'CyberSec Lab' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Red Team Academy' })).toBeInTheDocument();
   });
 });
-

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { get, set, del } from 'idb-keyval';
+import { safeLocalStorage } from './safeStorage';
 import { getTheme, setTheme } from './theme';
 
 const DEFAULT_SETTINGS = {
@@ -15,6 +16,34 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+};
+
+const getLocalItem = (key) => {
+  if (!safeLocalStorage) return null;
+  try {
+    return safeLocalStorage.getItem(key);
+  } catch (error) {
+    console.warn('Failed to read setting from storage', { key, error });
+    return null;
+  }
+};
+
+const setLocalItem = (key, value) => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(key, value);
+  } catch (error) {
+    console.warn('Failed to persist setting to storage', { key, error });
+  }
+};
+
+const removeLocalItem = (key) => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.removeItem(key);
+  } catch (error) {
+    console.warn('Failed to remove setting from storage', { key, error });
+  }
 };
 
 export async function getAccent() {
@@ -39,28 +68,28 @@ export async function setWallpaper(wallpaper) {
 
 export async function getUseKaliWallpaper() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.useKaliWallpaper;
-  const stored = window.localStorage.getItem('use-kali-wallpaper');
+  const stored = getLocalItem('use-kali-wallpaper');
   return stored === null ? DEFAULT_SETTINGS.useKaliWallpaper : stored === 'true';
 }
 
 export async function setUseKaliWallpaper(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('use-kali-wallpaper', value ? 'true' : 'false');
+  setLocalItem('use-kali-wallpaper', value ? 'true' : 'false');
 }
 
 export async function getDensity() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  return getLocalItem('density') || DEFAULT_SETTINGS.density;
 }
 
 export async function setDensity(density) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
+  setLocalItem('density', density);
 }
 
 export async function getReducedMotion() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  const stored = window.localStorage.getItem('reduced-motion');
+  const stored = getLocalItem('reduced-motion');
   if (stored !== null) {
     return stored === 'true';
   }
@@ -69,70 +98,70 @@ export async function getReducedMotion() {
 
 export async function setReducedMotion(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+  setLocalItem('reduced-motion', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
+  const stored = getLocalItem('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  setLocalItem('font-scale', String(scale));
 }
 
 export async function getHighContrast() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  return getLocalItem('high-contrast') === 'true';
 }
 
 export async function setHighContrast(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+  setLocalItem('high-contrast', value ? 'true' : 'false');
 }
 
 export async function getLargeHitAreas() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
+  return getLocalItem('large-hit-areas') === 'true';
 }
 
 export async function setLargeHitAreas(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
+  setLocalItem('large-hit-areas', value ? 'true' : 'false');
 }
 
 export async function getHaptics() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
-  const val = window.localStorage.getItem('haptics');
+  const val = getLocalItem('haptics');
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
 export async function setHaptics(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('haptics', value ? 'true' : 'false');
+  setLocalItem('haptics', value ? 'true' : 'false');
 }
 
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
+  const val = getLocalItem('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
 export async function setPongSpin(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
+  setLocalItem('pong-spin', value ? 'true' : 'false');
 }
 
 export async function getAllowNetwork() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
+  return getLocalItem('allow-network') === 'true';
 }
 
 export async function setAllowNetwork(value) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+  setLocalItem('allow-network', value ? 'true' : 'false');
 }
 
 export async function resetSettings() {
@@ -141,15 +170,15 @@ export async function resetSettings() {
     del('accent'),
     del('bg-image'),
   ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
-  window.localStorage.removeItem('use-kali-wallpaper');
+  removeLocalItem('density');
+  removeLocalItem('reduced-motion');
+  removeLocalItem('font-scale');
+  removeLocalItem('high-contrast');
+  removeLocalItem('large-hit-areas');
+  removeLocalItem('pong-spin');
+  removeLocalItem('allow-network');
+  removeLocalItem('haptics');
+  removeLocalItem('use-kali-wallpaper');
 }
 
 export async function exportSettings() {


### PR DESCRIPTION
## Summary
- update UI-driven test suites (window manager, Ubuntu boot screen, YouTube playlists, module workspace, and Nmap NSE) to match current component behaviour
- guard settingsStore localStorage access behind safe helpers to prevent jsdom errors during testing

## Testing
- yarn test
- CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68dc16746ff883289781791e718b45d7