### PR TITLE
[ui] Enhance tabbed window drag interactions

### DIFF
--- a/__tests__/TabbedWindow.test.tsx
+++ b/__tests__/TabbedWindow.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import TabbedWindow, { TabDefinition } from '../components/ui/TabbedWindow';
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  // @ts-ignore
+  global.ResizeObserver = ResizeObserverMock;
+
+  if (typeof window.PointerEvent === 'undefined') {
+    class PointerEventPolyfill extends MouseEvent {
+      pointerId: number;
+      pointerType?: string;
+      isPrimary?: boolean;
+
+      constructor(type: string, eventInitDict?: PointerEventInit) {
+        super(type, eventInitDict);
+        this.pointerId = eventInitDict?.pointerId ?? 0;
+        this.pointerType = eventInitDict?.pointerType ?? 'mouse';
+        this.isPrimary = eventInitDict?.isPrimary ?? true;
+      }
+    }
+    // @ts-ignore
+    window.PointerEvent = PointerEventPolyfill as unknown as typeof PointerEvent;
+    // @ts-ignore
+    global.PointerEvent = window.PointerEvent;
+  }
+
+  if (!HTMLElement.prototype.setPointerCapture) {
+    Object.defineProperty(HTMLElement.prototype, 'setPointerCapture', {
+      value: jest.fn(),
+      configurable: true,
+    });
+  }
+
+  if (!HTMLElement.prototype.releasePointerCapture) {
+    Object.defineProperty(HTMLElement.prototype, 'releasePointerCapture', {
+      value: jest.fn(),
+      configurable: true,
+    });
+  }
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+const createTabs = (): TabDefinition[] => [
+  { id: 'one', title: 'One', content: <div>one</div> },
+  { id: 'two', title: 'Two', content: <div>two</div> },
+  { id: 'three', title: 'Three', content: <div>three</div> },
+];
+
+test('reorders tabs via pointer drag and announces the new position', async () => {
+  render(<TabbedWindow initialTabs={createTabs()} storageKey="test-tabs" />);
+
+  const tablist = screen.getByRole('tablist');
+  Object.defineProperty(tablist, 'getBoundingClientRect', {
+    value: () => ({ left: 0, top: 0, width: 300, height: 40, right: 300, bottom: 40 }),
+    configurable: true,
+  });
+  Object.defineProperty(tablist, 'scrollLeft', { value: 0, writable: true });
+
+  const tabs = within(tablist).getAllByRole('tab');
+  tabs.forEach((tab, index) => {
+    Object.defineProperty(tab, 'offsetLeft', { value: index * 100, configurable: true });
+    Object.defineProperty(tab, 'offsetWidth', { value: 100, configurable: true });
+  });
+
+  const firstTab = tabs[0];
+  fireEvent.pointerDown(firstTab, { pointerId: 1, clientX: 10, button: 0 });
+  act(() => {
+    firstTab.dispatchEvent(
+      new PointerEvent('pointermove', { pointerId: 1, clientX: 140, bubbles: true }),
+    );
+    firstTab.dispatchEvent(
+      new PointerEvent('pointermove', { pointerId: 1, clientX: 260, bubbles: true }),
+    );
+  });
+
+  await waitFor(() => {
+    const activeIndicators = Array.from(
+      document.querySelectorAll('[data-testid="tab-drop-indicator"]'),
+    ).filter((el) => el.getAttribute('data-active') === 'true');
+    expect(activeIndicators).toHaveLength(1);
+  });
+
+  act(() => {
+    firstTab.dispatchEvent(
+      new PointerEvent('pointerup', { pointerId: 1, clientX: 260, bubbles: true }),
+    );
+  });
+
+  await waitFor(() => {
+    const orderedTitles = within(tablist)
+      .getAllByRole('tab')
+      .map((tab) => tab.querySelector('span')?.textContent);
+    expect(orderedTitles).toEqual(['Two', 'Three', 'One']);
+  });
+
+  expect(screen.getByRole('status')).toHaveTextContent('One moved to position 3 of 3.');
+  await waitFor(() =>
+    expect(window.localStorage.getItem('test-tabs:order')).toBe(
+      JSON.stringify(['two', 'three', 'one']),
+    ),
+  );
+});
+
+test('restores persisted tab order on mount', async () => {
+  window.localStorage.setItem('persisted-tabs:order', JSON.stringify(['beta', 'gamma', 'alpha']));
+
+  const tabs: TabDefinition[] = [
+    { id: 'alpha', title: 'Alpha', content: <div>alpha</div> },
+    { id: 'beta', title: 'Beta', content: <div>beta</div> },
+    { id: 'gamma', title: 'Gamma', content: <div>gamma</div> },
+  ];
+
+  render(<TabbedWindow initialTabs={tabs} storageKey="persisted-tabs" />);
+
+  const tablist = screen.getByRole('tablist');
+
+  await waitFor(() => {
+    const titles = within(tablist)
+      .getAllByRole('tab')
+      .map((tab) => tab.querySelector('span')?.textContent);
+    expect(titles).toEqual(['Beta', 'Gamma', 'Alpha']);
+  });
+});

--- a/apps/http/index.tsx
+++ b/apps/http/index.tsx
@@ -50,6 +50,7 @@ const HTTPBuilder: React.FC = () => {
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
+            aria-label="URL"
           />
         </div>
       </form>
@@ -76,6 +77,7 @@ const HTTPPreview: React.FC = () => {
       className="min-h-screen bg-gray-900 text-white"
       initialTabs={[createTab()]}
       onNewTab={createTab}
+      storageKey="http-tabs"
     />
   );
 };

--- a/apps/hydra/index.tsx
+++ b/apps/hydra/index.tsx
@@ -19,7 +19,7 @@ const HydraPreview: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gray-900 text-white">
-      <TabbedWindow initialTabs={[createTab()]} onNewTab={createTab} />
+      <TabbedWindow initialTabs={[createTab()]} onNewTab={createTab} storageKey="hydra-tabs" />
       <StrategyTrainer />
     </div>
   );

--- a/apps/reaver/index.tsx
+++ b/apps/reaver/index.tsx
@@ -259,6 +259,7 @@ const ReaverPanel: React.FC = () => {
               value={rate}
               onChange={(e) => setRate(Number(e.target.value) || 1)}
               className="w-20 p-1 bg-gray-800 rounded text-white"
+              aria-label="Attempts per second"
             />
             <button
               type="button"
@@ -367,6 +368,7 @@ const ReaverPage: React.FC = () => {
       className="min-h-screen bg-gray-900 text-white"
       initialTabs={[createTab()]}
       onNewTab={createTab}
+      storageKey="reaver-tabs"
     />
   );
 };

--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -35,6 +35,7 @@ const SSHBuilder: React.FC = () => {
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
             value={user}
             onChange={(e) => setUser(e.target.value)}
+            aria-label="Username"
           />
         </div>
         <div>
@@ -47,6 +48,7 @@ const SSHBuilder: React.FC = () => {
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
             value={host}
             onChange={(e) => setHost(e.target.value)}
+            aria-label="Host"
           />
         </div>
         <div>
@@ -59,6 +61,7 @@ const SSHBuilder: React.FC = () => {
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
             value={port}
             onChange={(e) => setPort(e.target.value)}
+            aria-label="Port"
           />
         </div>
       </form>
@@ -85,6 +88,7 @@ const SSHPreview: React.FC = () => {
       className="min-h-screen bg-gray-900 text-white"
       initialTabs={[createTab()]}
       onNewTab={createTab}
+      storageKey="ssh-tabs"
     />
   );
 };

--- a/apps/terminal/tabs/index.tsx
+++ b/apps/terminal/tabs/index.tsx
@@ -21,6 +21,7 @@ const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
       className="h-full w-full"
       initialTabs={[createTab()]}
       onNewTab={createTab}
+      storageKey="terminal-tabs"
     />
   );
 };


### PR DESCRIPTION
## Summary
- persist tab order in TabbedWindow and announce reorders via an ARIA live region
- add pointer-based drag handling with animated drop indicators for TabbedWindow tabs
- wire storage keys and missing aria-labels into each TabbedWindow consumer and add focused unit coverage

## Testing
- yarn lint
- yarn test __tests__/TabbedWindow.test.tsx --runInBand
- yarn test *(fails due to pre-existing suite failures)*

------
https://chatgpt.com/codex/tasks/task_e_68dc264b48c08328bda94125d190e962