### PR TITLE
[ui] add global command palette

### DIFF
--- a/__tests__/CommandPalette.test.tsx
+++ b/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,125 @@
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import CommandPalette from '../components/common/CommandPalette';
+import { SettingsContext } from '../hooks/useSettings';
+import { loadCommandPaletteItems } from '../utils/commandPaletteData';
+
+jest.mock('next/router', () => {
+  const pushMock = jest.fn();
+  return {
+    useRouter: () => ({
+      push: pushMock,
+    }),
+    __esModule: true,
+    pushMock,
+  };
+});
+
+jest.mock('../utils/commandPaletteData', () => ({
+  loadCommandPaletteItems: jest.fn(),
+}));
+
+type PaletteItem = Awaited<ReturnType<typeof loadCommandPaletteItems>> extends Array<infer Item>
+  ? Item
+  : never;
+
+const createPaletteItems = (): PaletteItem[] => [
+  {
+    id: 'terminal',
+    title: 'Terminal',
+    description: 'Simulated shell environment',
+    icon: '/terminal.svg',
+    keywords: ['terminal', 'shell'],
+    group: 'app',
+    action: { type: 'open-app', target: 'terminal' },
+  } as PaletteItem,
+  {
+    id: 'command-help-keyboard',
+    title: 'Keyboard Reference',
+    description: 'View keyboard shortcuts and desktop tips.',
+    keywords: ['keyboard', 'help', 'shortcuts'],
+    group: 'help',
+    action: { type: 'navigate', target: '/keyboard-reference' },
+  } as PaletteItem,
+];
+
+const baseSettings = {
+  accent: '#1793d1',
+  wallpaper: 'wall-1',
+  bgImageName: 'wall-1',
+  useKaliWallpaper: false,
+  density: 'regular' as const,
+  reducedMotion: false,
+  fontScale: 1,
+  highContrast: false,
+  largeHitAreas: false,
+  pongSpin: false,
+  allowNetwork: false,
+  haptics: false,
+  theme: 'default',
+  setAccent: jest.fn(),
+  setWallpaper: jest.fn(),
+  setUseKaliWallpaper: jest.fn(),
+  setDensity: jest.fn(),
+  setReducedMotion: jest.fn(),
+  setFontScale: jest.fn(),
+  setHighContrast: jest.fn(),
+  setLargeHitAreas: jest.fn(),
+  setPongSpin: jest.fn(),
+  setAllowNetwork: jest.fn(),
+  setHaptics: jest.fn(),
+  setTheme: jest.fn(),
+};
+
+const renderWithSettings = (ui: ReactElement) =>
+  render(<SettingsContext.Provider value={baseSettings}>{ui}</SettingsContext.Provider>);
+
+describe('CommandPalette', () => {
+  const mockedLoader = loadCommandPaletteItems as jest.MockedFunction<typeof loadCommandPaletteItems>;
+  const pushMock = (jest.requireMock('next/router') as { pushMock: jest.Mock }).pushMock;
+
+  beforeEach(() => {
+    mockedLoader.mockResolvedValue(createPaletteItems());
+    pushMock.mockReset();
+  });
+
+  it('opens on Ctrl+K and launches the selected app with Enter', async () => {
+    renderWithSettings(<CommandPalette />);
+
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+
+    try {
+      fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+
+      await waitFor(() => expect(mockedLoader).toHaveBeenCalled());
+
+      const input = await screen.findByLabelText('Search apps and commands');
+      fireEvent.change(input, { target: { value: 'term' } });
+
+      await screen.findByRole('option', { name: /Terminal/i });
+
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      const openEvent = dispatchSpy.mock.calls.find(([event]) => event.type === 'open-app')?.[0];
+      expect(openEvent).toBeDefined();
+      expect(openEvent?.detail).toBe('terminal');
+    } finally {
+      dispatchSpy.mockRestore();
+    }
+  });
+
+  it('supports Cmd+K and navigates to help entries', async () => {
+    renderWithSettings(<CommandPalette />);
+
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+
+    const input = await screen.findByLabelText('Search apps and commands');
+    fireEvent.change(input, { target: { value: 'keyboard' } });
+
+    await screen.findByRole('option', { name: /Keyboard Reference/i });
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(pushMock).toHaveBeenCalledWith('/keyboard-reference');
+  });
+});

--- a/__tests__/commandPaletteSearch.test.ts
+++ b/__tests__/commandPaletteSearch.test.ts
@@ -1,0 +1,44 @@
+import { rankPaletteItems, SearchableItem } from '../utils/commandPaletteSearch';
+
+describe('rankPaletteItems', () => {
+  const items: SearchableItem[] = [
+    {
+      id: 'terminal',
+      title: 'Terminal',
+      description: 'Simulated shell environment',
+      keywords: ['shell', 'cli'],
+    },
+    {
+      id: 'settings',
+      title: 'Settings',
+      description: 'Adjust preferences and themes',
+      keywords: ['preferences', 'theme'],
+    },
+    {
+      id: 'keyboard-reference',
+      title: 'Keyboard Reference',
+      description: 'View keyboard shortcuts',
+      keywords: ['help', 'shortcuts'],
+    },
+  ];
+
+  it('returns all items when query is empty', () => {
+    const results = rankPaletteItems(items, '');
+    expect(results).toHaveLength(items.length);
+  });
+
+  it('prioritizes closer fuzzy matches', () => {
+    const results = rankPaletteItems(items, 'term');
+    expect(results[0]?.id).toBe('terminal');
+  });
+
+  it('matches on keywords as well as titles', () => {
+    const results = rankPaletteItems(items, 'pref');
+    expect(results[0]?.id).toBe('settings');
+  });
+
+  it('limits results to the provided count', () => {
+    const results = rankPaletteItems(items, '', 2);
+    expect(results).toHaveLength(2);
+  });
+});

--- a/components/common/CommandPalette.tsx
+++ b/components/common/CommandPalette.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import clsx from 'clsx';
+import { useRouter } from 'next/router';
+import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+import { rankPaletteItems } from '../../utils/commandPaletteSearch';
+import { loadCommandPaletteItems, type PaletteItem } from '../../utils/commandPaletteData';
+
+const OPTION_ID_PREFIX = 'command-option-';
+
+const useSafeRouter = () => {
+  try {
+    return useRouter();
+  } catch (error) {
+    return null;
+  }
+};
+
+const CommandPalette = () => {
+  const router = useSafeRouter();
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [items, setItems] = useState<PaletteItem[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const itemsCache = useRef<PaletteItem[] | null>(null);
+
+  const loadItems = useCallback(async () => {
+    if (itemsCache.current) return itemsCache.current;
+    try {
+      const data = await loadCommandPaletteItems();
+      itemsCache.current = data;
+      return data;
+    } catch (error) {
+      console.error('Failed to load command palette metadata', error);
+      itemsCache.current = [];
+      throw error;
+    }
+  }, []);
+
+  const closePalette = useCallback(() => {
+    setOpen(false);
+    setQuery('');
+    setActiveIndex(0);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+
+    loadItems()
+      .then((data) => {
+        if (cancelled) return;
+        setItems(data);
+      })
+      .catch(() => {
+        if (!cancelled) setItems([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, loadItems]);
+
+  useEffect(() => {
+    if (!open) return;
+    const timer = window.setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [open]);
+
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      const { key, ctrlKey, metaKey } = event;
+      const target = event.target as HTMLElement | null;
+      const isEditable = target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable;
+
+      if ((ctrlKey || metaKey) && key.toLowerCase() === 'k') {
+        if (isEditable) return;
+        event.preventDefault();
+        setOpen(true);
+        return;
+      }
+
+      if (key === 'Escape' && open) {
+        event.preventDefault();
+        closePalette();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  }, [open, closePalette]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  const results = useMemo(() => rankPaletteItems(items, query, 12), [items, query]);
+  const clampedIndex = results.length ? Math.min(activeIndex, results.length - 1) : -1;
+  const activeItem = clampedIndex >= 0 ? results[clampedIndex] : undefined;
+
+  const handleSelect = useCallback(
+    (item: PaletteItem) => {
+      if (!item) return;
+      switch (item.action.type) {
+        case 'open-app': {
+          const event = new CustomEvent('open-app', { detail: item.action.target });
+          window.dispatchEvent(event);
+          break;
+        }
+        case 'navigate': {
+          if (router?.push) {
+            const result = router.push(item.action.target);
+            if (result && typeof (result as Promise<unknown>).catch === 'function') {
+              (result as Promise<unknown>).catch((err) => {
+                console.error('Failed to navigate from command palette', err);
+              });
+            }
+          } else if (typeof window !== 'undefined') {
+            window.location.assign(item.action.target);
+          }
+          break;
+        }
+        case 'callback':
+          item.action.fn();
+          break;
+        default:
+          break;
+      }
+      closePalette();
+    },
+    [router, closePalette],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (!results.length) return;
+
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setActiveIndex((index) => (index + 1) % results.length);
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setActiveIndex((index) => (index - 1 + results.length) % results.length);
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
+        const item = results[clampedIndex >= 0 ? clampedIndex : 0];
+        if (item) handleSelect(item);
+      } else if (event.key === 'Tab') {
+        event.preventDefault();
+        setActiveIndex((index) => (index + (event.shiftKey ? -1 : 1) + results.length) % results.length);
+      }
+    },
+    [results, clampedIndex, handleSelect],
+  );
+
+  if (!open) return null;
+
+  const activeOptionId = activeItem ? `${OPTION_ID_PREFIX}${activeItem.id}` : undefined;
+
+  return (
+    <div
+      className={clsx(
+        'fixed inset-0 z-[150] flex items-start justify-center bg-black/70 px-4 py-16 sm:py-24',
+        prefersReducedMotion ? 'transition-none' : 'transition-opacity duration-150 ease-out',
+      )}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="command-palette-title"
+      data-reduced-motion={prefersReducedMotion ? 'true' : 'false'}
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          event.preventDefault();
+          closePalette();
+        }
+      }}
+    >
+      <div className="w-full max-w-2xl rounded-lg bg-gray-900/95 text-white shadow-xl ring-1 ring-white/20">
+        <div className="border-b border-white/10 p-4">
+          <h2 id="command-palette-title" className="text-lg font-semibold text-white">
+            Command Palette
+          </h2>
+          <label
+            id="command-palette-input-label"
+            htmlFor="command-palette-input"
+            className="block text-sm font-semibold text-white/70"
+          >
+            Search apps and commands
+          </label>
+          <input
+            ref={inputRef}
+            id="command-palette-input"
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type to search..."
+            className="mt-2 w-full rounded-md bg-black/40 px-3 py-2 text-base text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-sky-400"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-expanded="true"
+            aria-controls="command-palette-options"
+            aria-labelledby="command-palette-title command-palette-input-label"
+            aria-activedescendant={activeOptionId}
+          />
+        </div>
+        <div className="max-h-80 overflow-y-auto" role="presentation">
+          <ul
+            id="command-palette-options"
+            role="listbox"
+            aria-label="Command palette results"
+            className="divide-y divide-white/5"
+          >
+            {results.length === 0 ? (
+              <li className="p-6 text-center text-sm text-white/60" role="presentation">
+                No matches found. Try a different search term.
+              </li>
+            ) : (
+              results.map((item) => {
+                const optionId = `${OPTION_ID_PREFIX}${item.id}`;
+                return (
+                  <li
+                    key={item.id}
+                    id={optionId}
+                    role="option"
+                    aria-selected={activeItem?.id === item.id}
+                    className={clsx(
+                      'flex cursor-pointer items-start gap-3 px-5 py-4 text-left hover:bg-white/10',
+                      activeItem?.id === item.id ? 'bg-white/10' : 'bg-transparent',
+                    )}
+                    onMouseEnter={() => {
+                      const index = results.findIndex((result) => result.id === item.id);
+                      if (index !== -1) setActiveIndex(index);
+                    }}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      handleSelect(item);
+                    }}
+                  >
+                    {item.icon ? (
+                      <img src={item.icon} alt="" className="h-8 w-8 flex-shrink-0 rounded" />
+                    ) : (
+                      <div className="h-8 w-8 flex-shrink-0 rounded bg-white/10" aria-hidden="true" />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-semibold">{item.title}</span>
+                        <span className="text-xs uppercase tracking-wide text-white/60">{item.group}</span>
+                      </div>
+                      <p className="mt-1 text-sm text-white/70">{item.description}</p>
+                    </div>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        </div>
+        <div className="flex items-center justify-between px-5 py-3 text-xs text-white/50">
+          <span>Press Esc to close</span>
+          <span>
+            <kbd className="rounded border border-white/20 px-1 py-0.5">Ctrl</kbd>
+            <span className="mx-1">+</span>
+            <kbd className="rounded border border-white/20 px-1 py-0.5">K</kbd>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CommandPalette;

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -3,6 +3,7 @@
 import React, { Component } from 'react';
 import BootingScreen from './screen/booting_screen';
 import Desktop from './screen/desktop';
+import CommandPalette from './common/CommandPalette';
 import LockScreen from './screen/lock_screen';
 import Navbar from './screen/navbar';
 import Layout from './desktop/Layout';
@@ -129,7 +130,8 @@ export default class Ubuntu extends Component {
 				/>
                                 <Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
                                 <Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
+                                <CommandPalette />
                 </Layout>
         );
-	}
+        }
 }

--- a/utils/commandPaletteData.ts
+++ b/utils/commandPaletteData.ts
@@ -1,0 +1,86 @@
+import type { SearchableItem } from './commandPaletteSearch';
+
+type PaletteAction =
+  | { type: 'open-app'; target: string }
+  | { type: 'navigate'; target: string }
+  | { type: 'callback'; fn: () => void };
+
+export type PaletteItem = SearchableItem & {
+  icon?: string;
+  group: 'app' | 'command' | 'help';
+  action: PaletteAction;
+};
+
+const createKeywordSet = (values: (string | undefined)[]) =>
+  values
+    .flatMap((value) =>
+      value
+        ? value
+            .split(/[\s/\-]+/)
+            .map((part) => part.trim())
+            .filter(Boolean)
+        : [],
+    )
+    .filter(Boolean);
+
+export const loadCommandPaletteItems = async (): Promise<PaletteItem[]> => {
+  const [{ default: appList = [], games = [] }, { buildAppMetadata }] = await Promise.all([
+    import('../apps.config'),
+    import('../lib/appRegistry'),
+  ]);
+
+  const entries = [...(Array.isArray(appList) ? appList : []), ...(Array.isArray(games) ? games : [])]
+    .filter((entry) => !entry.disabled);
+
+  const items: PaletteItem[] = entries.map((entry) => {
+    const metadata = buildAppMetadata({ id: entry.id, title: entry.title, icon: entry.icon });
+    const keywords = createKeywordSet([
+      entry.id,
+      entry.title,
+      metadata.description,
+      ...(metadata.keyboard ?? []),
+    ]);
+    return {
+      id: entry.id,
+      title: metadata.title,
+      description: metadata.description,
+      icon: entry.icon,
+      keywords,
+      group: 'app',
+      action: { type: 'open-app', target: entry.id },
+    };
+  });
+
+  const settingsIcon = items.find((item) => item.id === 'settings')?.icon;
+
+  const extraItems: PaletteItem[] = [
+    {
+      id: 'command-settings',
+      title: 'Open Settings',
+      description: 'Adjust desktop preferences, themes, and accessibility options.',
+      icon: settingsIcon,
+      keywords: ['settings', 'preferences', 'theme', 'accessibility', 'control', 'config'],
+      group: 'command',
+      action: { type: 'open-app', target: 'settings' },
+    },
+    {
+      id: 'command-help-keyboard',
+      title: 'Keyboard Reference',
+      description: 'View keyboard shortcuts and desktop navigation tips.',
+      keywords: ['help', 'shortcuts', 'keyboard', 'reference', 'documentation'],
+      group: 'help',
+      action: { type: 'navigate', target: '/keyboard-reference' },
+    },
+  ];
+
+  const seen = new Set<string>();
+  const combined = [...items, ...extraItems].filter((item) => {
+    if (seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+
+  return combined.sort((a, b) => a.title.localeCompare(b.title));
+};
+
+export type { PaletteAction };

--- a/utils/commandPaletteSearch.ts
+++ b/utils/commandPaletteSearch.ts
@@ -1,0 +1,105 @@
+export type SearchableItem = {
+  id: string;
+  title: string;
+  description?: string;
+  keywords?: string[];
+};
+
+const normalize = (value: string) => value.toLowerCase();
+
+const tokenize = (query: string) =>
+  query
+    .toLowerCase()
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+
+const fuzzyScore = (text: string, query: string): number | null => {
+  if (!query) return 0;
+  const haystack = normalize(text);
+  const needle = normalize(query);
+  let score = 0;
+  let lastIndex = -1;
+
+  for (let i = 0; i < needle.length; i += 1) {
+    const char = needle[i];
+    const index = haystack.indexOf(char, lastIndex + 1);
+    if (index === -1) {
+      return null;
+    }
+    score += index - lastIndex;
+    lastIndex = index;
+  }
+
+  return score + (haystack.length - needle.length);
+};
+
+const BEST_SCORE = Number.NEGATIVE_INFINITY;
+const WORST_SCORE = Number.POSITIVE_INFINITY;
+
+const scoreItem = (item: SearchableItem, tokens: string[]): number => {
+  if (!tokens.length) return BEST_SCORE;
+
+  const haystacks = [
+    item.title,
+    item.description ?? '',
+    ...(item.keywords ?? []),
+  ].map((value) => normalize(value));
+
+  let total = 0;
+  for (const token of tokens) {
+    let bestForToken = WORST_SCORE;
+    for (const text of haystacks) {
+      if (!text) continue;
+      const score = fuzzyScore(text, token);
+      if (score === null) continue;
+      if (score < bestForToken) {
+        bestForToken = score;
+      }
+      if (bestForToken === 0) break;
+    }
+    if (bestForToken === WORST_SCORE) return WORST_SCORE;
+    total += bestForToken;
+  }
+
+  // Prefer direct substring matches by giving them a small boost.
+  if (item.title && tokens.some((token) => normalize(item.title).includes(token))) {
+    total -= 5;
+  }
+
+  return total;
+};
+
+export const rankPaletteItems = <T extends SearchableItem>(
+  items: T[],
+  query: string,
+  limit = 15,
+): T[] => {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return items.slice(0, limit);
+  }
+
+  const tokens = tokenize(trimmed);
+  if (!tokens.length) {
+    return items.slice(0, limit);
+  }
+
+  return items
+    .map((item, index) => ({
+      item,
+      score: scoreItem(item, tokens),
+      index,
+    }))
+    .filter(({ score }) => score !== WORST_SCORE)
+    .sort((a, b) => {
+      if (a.score === b.score) {
+        return a.index - b.index;
+      }
+      return a.score - b.score;
+    })
+    .slice(0, limit)
+    .map(({ item }) => item);
+};
+
+export { fuzzyScore };


### PR DESCRIPTION
## Summary
- add a global command palette component with keyboard shortcuts, fuzzy search, and accessible markup
- aggregate app metadata and helpers to power the palette listings and search scoring
- register palette inside the desktop shell so it is always available and add focused unit/integration tests

## Testing
- yarn lint
- yarn test --runTestsByPath __tests__/commandPaletteSearch.test.ts __tests__/CommandPalette.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc26538b0c83289ec1d5308d8078a3