### PR TITLE
[app] add pane snapshot recovery UI

### DIFF
--- a/__tests__/paneErrorBoundaries.test.tsx
+++ b/__tests__/paneErrorBoundaries.test.tsx
@@ -1,0 +1,183 @@
+import React, { useCallback, useState } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import PaneError from '../app/error';
+import GlobalError from '../app/global-error';
+import usePaneSnapshot from '../hooks/usePaneSnapshot';
+import {
+  capturePaneSnapshot,
+  consumePendingPaneRestore,
+  __paneSnapshotInternals,
+} from '../utils/windowLayout';
+
+jest.mock('../lib/client-error-reporter', () => ({
+  reportClientError: jest.fn(),
+}));
+
+describe('Pane snapshot error boundaries', () => {
+  const originalConsoleError = console.error;
+
+  beforeEach(() => {
+    __paneSnapshotInternals.reset();
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  it('enables snapshot restore when a pane snapshot exists', () => {
+    const reset = jest.fn();
+    capturePaneSnapshot('pane-1', { value: 'persisted' });
+
+    render(<PaneError error={new Error('boom')} reset={reset} />);
+
+    const restoreButton = screen.getByRole('button', { name: /restore snapshot/i });
+    expect(restoreButton).toBeEnabled();
+
+    fireEvent.click(restoreButton);
+    expect(reset).toHaveBeenCalled();
+    expect(consumePendingPaneRestore('pane-1')).toEqual({ value: 'persisted' });
+  });
+
+  it('disables restore when no snapshot is registered', () => {
+    const reset = jest.fn();
+    render(<PaneError error={new Error('nope')} reset={reset} />);
+    const restoreButton = screen.getByRole('button', { name: /restore snapshot/i });
+    expect(restoreButton).toBeDisabled();
+  });
+
+  it('renders global error messaging with differentiated actions', () => {
+    const reset = jest.fn();
+    capturePaneSnapshot('pane-2', { data: 1 });
+
+    render(<GlobalError error={new Error('global')} reset={reset} />);
+
+    expect(screen.getByText(/critical desktop error/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload desktop/i })).toBeInTheDocument();
+    const restoreButton = screen.getByRole('button', { name: /restore snapshot/i });
+    expect(restoreButton).toBeEnabled();
+
+    fireEvent.click(restoreButton);
+    expect(reset).toHaveBeenCalled();
+  });
+
+  it('restores a pane snapshot after a crash and clears pending state', async () => {
+    const Harness = () => {
+      const [error, setError] = useState<Error | null>(null);
+      const [shouldThrow, setShouldThrow] = useState(false);
+      const [resetKey, setResetKey] = useState(0);
+
+      const reset = () => {
+        setError(null);
+        setShouldThrow(false);
+        setResetKey((key) => key + 1);
+      };
+
+      return error ? (
+        <PaneError error={error} reset={reset} />
+      ) : (
+        <TestBoundary
+          onError={(err) => setError(err)}
+          resetKey={resetKey}
+        >
+          <ProblemPane
+            key={resetKey}
+            shouldThrow={shouldThrow}
+            onRequestCrash={() => setShouldThrow(true)}
+          />
+        </TestBoundary>
+      );
+    };
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole('button', { name: /mutate & crash/i }));
+
+    const restoreButton = await screen.findByRole('button', {
+      name: /restore snapshot/i,
+    });
+    expect(restoreButton).toBeEnabled();
+
+    fireEvent.click(restoreButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pane-value')).toHaveTextContent('updated');
+    });
+
+    expect(__paneSnapshotInternals.hasPending('test-pane')).toBe(false);
+  });
+});
+
+interface TestBoundaryProps {
+  onError: (error: Error) => void;
+  resetKey: number;
+  children: React.ReactNode;
+}
+
+class TestBoundary extends React.Component<TestBoundaryProps, { hasError: boolean }> {
+  constructor(props: TestBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    this.props.onError(error);
+  }
+
+  componentDidUpdate(prevProps: TestBoundaryProps) {
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return null;
+    }
+    return this.props.children;
+  }
+}
+
+interface ProblemPaneProps {
+  shouldThrow: boolean;
+  onRequestCrash: () => void;
+}
+
+const ProblemPane: React.FC<ProblemPaneProps> = ({ shouldThrow, onRequestCrash }) => {
+  const [value, setValue] = useState('ready');
+
+  const snapshotGetter = useCallback(() => ({ value }), [value]);
+
+  usePaneSnapshot({
+    paneId: 'test-pane',
+    getSnapshot: snapshotGetter,
+    applySnapshot: (snapshot) => {
+      setValue(snapshot.value);
+    },
+  });
+
+  if (shouldThrow) {
+    throw new Error('boom');
+  }
+
+  return (
+    <div>
+      <span data-testid="pane-value">{value}</span>
+      <button
+        type="button"
+        onClick={() => {
+          capturePaneSnapshot('test-pane', { value: 'updated' });
+          setValue('updated');
+          onRequestCrash();
+        }}
+      >
+        Mutate & Crash
+      </button>
+    </div>
+  );
+};

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,24 +1,92 @@
 
 'use client';
 
-import { useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { reportClientError } from '../lib/client-error-reporter';
+import {
+  getLatestPaneSnapshot,
+  queuePaneSnapshotRestore,
+  hasPaneSnapshot,
+} from '../utils/windowLayout';
 
-export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+interface PaneErrorProps {
+  error: Error;
+  reset: () => void;
+}
+
+const baseButtonClasses =
+  'rounded bg-slate-100 px-4 py-2 text-sm font-medium transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-800 dark:hover:bg-slate-700';
+
+export default function Error({ error, reset }: PaneErrorProps) {
+  const [snapshotMeta, setSnapshotMeta] = useState(() => getLatestPaneSnapshot());
+
   useEffect(() => {
     reportClientError(error, error.stack);
+    setSnapshotMeta(getLatestPaneSnapshot());
   }, [error]);
 
+  const hasSnapshotAvailable = useMemo(() => {
+    if (snapshotMeta) return true;
+    return hasPaneSnapshot(snapshotMeta?.paneId);
+  }, [snapshotMeta]);
+
+  const lastSavedLabel = useMemo(() => {
+    if (!snapshotMeta?.updatedAt) return null;
+    try {
+      return new Date(snapshotMeta.updatedAt).toLocaleString();
+    } catch {
+      return null;
+    }
+  }, [snapshotMeta]);
+
+  const handleReload = useCallback(() => {
+    reset();
+  }, [reset]);
+
+  const handleRestore = useCallback(() => {
+    const latest = getLatestPaneSnapshot() ?? snapshotMeta;
+    if (!latest?.paneId) {
+      reset();
+      return;
+    }
+
+    const prepared = queuePaneSnapshotRestore(latest.paneId);
+    if (!prepared) {
+      reset();
+      return;
+    }
+
+    setSnapshotMeta(null);
+    reset();
+  }, [reset, snapshotMeta]);
+
   return (
-    <div className="flex flex-col items-center justify-center gap-4 p-4">
-      <h2 className="text-xl font-semibold">Something went wrong!</h2>
-      <button
-        type="button"
-        onClick={() => reset()}
-        className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
-      >
-        Try again
-      </button>
+    <div className="flex flex-col items-center justify-center gap-3 p-6 text-center">
+      <h2 className="text-xl font-semibold">This pane crashed</h2>
+      <p className="max-w-md text-sm text-slate-600 dark:text-slate-300">
+        The desktop window hit an unexpected error. You can reload the pane to try again, or
+        restore the last captured inputs if you were in the middle of editing.
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <button type="button" onClick={handleReload} className={baseButtonClasses}>
+          Reload pane
+        </button>
+        <button
+          type="button"
+          onClick={handleRestore}
+          disabled={!hasSnapshotAvailable}
+          className={`${baseButtonClasses} bg-blue-600 text-white hover:bg-blue-700 disabled:bg-blue-600 disabled:text-white/70 dark:bg-blue-500 dark:hover:bg-blue-400`}
+        >
+          Restore snapshot
+        </button>
+      </div>
+      <p className="text-xs text-slate-500 dark:text-slate-400">
+        {hasSnapshotAvailable
+          ? lastSavedLabel
+            ? `Snapshot saved ${lastSavedLabel}.`
+            : 'Snapshot ready to restore.'
+          : 'Snapshots capture form inputs before render; add usePaneSnapshot to opt in.'}
+      </p>
     </div>
   );
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,31 +1,91 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { reportClientError } from '../lib/client-error-reporter';
+import {
+  getLatestPaneSnapshot,
+  queuePaneSnapshotRestore,
+  hasPaneSnapshot,
+} from '../utils/windowLayout';
 
-export default function GlobalError({
-  error,
-  reset,
-}: {
+interface GlobalErrorProps {
   error: Error;
   reset: () => void;
-}) {
+}
+
+const baseButtonClasses =
+  'rounded bg-slate-100 px-4 py-2 text-sm font-medium transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-800 dark:hover:bg-slate-700';
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  const [snapshotMeta, setSnapshotMeta] = useState(() => getLatestPaneSnapshot());
+
   useEffect(() => {
     reportClientError(error, error.stack);
+    setSnapshotMeta(getLatestPaneSnapshot());
   }, [error]);
+
+  const hasSnapshotAvailable = useMemo(() => {
+    if (snapshotMeta) return true;
+    return hasPaneSnapshot(snapshotMeta?.paneId);
+  }, [snapshotMeta]);
+
+  const lastSavedLabel = useMemo(() => {
+    if (!snapshotMeta?.updatedAt) return null;
+    try {
+      return new Date(snapshotMeta.updatedAt).toLocaleString();
+    } catch {
+      return null;
+    }
+  }, [snapshotMeta]);
+
+  const handleReload = useCallback(() => {
+    reset();
+  }, [reset]);
+
+  const handleRestore = useCallback(() => {
+    const latest = getLatestPaneSnapshot() ?? snapshotMeta;
+    if (!latest?.paneId) {
+      reset();
+      return;
+    }
+    const prepared = queuePaneSnapshotRestore(latest.paneId);
+    if (!prepared) {
+      reset();
+      return;
+    }
+    setSnapshotMeta(null);
+    reset();
+  }, [reset, snapshotMeta]);
 
   return (
     <html>
       <body>
-        <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
-          <h2 className="text-xl font-semibold">Something went wrong!</h2>
-          <button
-            type="button"
-            onClick={() => reset()}
-            className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
-          >
-            Try again
-          </button>
+        <div className="flex min-h-screen flex-col items-center justify-center gap-3 p-6 text-center">
+          <h2 className="text-xl font-semibold">Critical desktop error</h2>
+          <p className="max-w-xl text-sm text-slate-600 dark:text-slate-300">
+            The entire workspace failed to recover. Reloading the desktop will restart every pane. If you were editing in a
+            single window, you can try restoring its last snapshot first and then reload the workspace.
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <button type="button" onClick={handleReload} className={baseButtonClasses}>
+              Reload desktop
+            </button>
+            <button
+              type="button"
+              onClick={handleRestore}
+              disabled={!hasSnapshotAvailable}
+              className={`${baseButtonClasses} bg-blue-600 text-white hover:bg-blue-700 disabled:bg-blue-600 disabled:text-white/70 dark:bg-blue-500 dark:hover:bg-blue-400`}
+            >
+              Restore snapshot &amp; reload
+            </button>
+          </div>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            {hasSnapshotAvailable
+              ? lastSavedLabel
+                ? `Snapshot saved ${lastSavedLabel}.`
+                : 'Snapshot ready to restore.'
+              : 'Add usePaneSnapshot to panes to capture recoverable form inputs.'}
+          </p>
         </div>
       </body>
     </html>

--- a/hooks/usePaneSnapshot.ts
+++ b/hooks/usePaneSnapshot.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+import {
+  capturePaneSnapshot,
+  clearPaneSnapshot,
+  consumePendingPaneRestore,
+  markPaneActive,
+} from '../utils/windowLayout';
+
+export interface PaneSnapshotOptions<TSnapshot> {
+  paneId: string;
+  getSnapshot: () => TSnapshot;
+  applySnapshot?: (snapshot: TSnapshot) => void;
+  enabled?: boolean;
+  clearOnUnmount?: boolean;
+}
+
+export function usePaneSnapshot<TSnapshot>({
+  paneId,
+  getSnapshot,
+  applySnapshot,
+  enabled = true,
+  clearOnUnmount = false,
+}: PaneSnapshotOptions<TSnapshot>) {
+  const idRef = useRef(paneId);
+
+  useEffect(() => {
+    idRef.current = paneId;
+  }, [paneId]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const restored = consumePendingPaneRestore(idRef.current);
+    if (restored && applySnapshot) {
+      applySnapshot(restored as TSnapshot);
+    }
+  }, [applySnapshot, enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    markPaneActive(idRef.current);
+  }, [enabled, paneId]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    try {
+      const snapshot = getSnapshot();
+      capturePaneSnapshot(idRef.current, snapshot);
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('[usePaneSnapshot] Failed to record snapshot', error);
+      }
+    }
+  }, [enabled, getSnapshot]);
+
+  useEffect(() => {
+    if (!enabled || !clearOnUnmount) return;
+    return () => {
+      clearPaneSnapshot(idRef.current);
+    };
+  }, [enabled, clearOnUnmount]);
+}
+
+export default usePaneSnapshot;

--- a/utils/windowLayout.js
+++ b/utils/windowLayout.js
@@ -66,3 +66,152 @@ export const clampWindowTopPosition = (value, topOffset) => {
   }
   return Math.max(value, safeOffset);
 };
+
+const paneSnapshotStore = new Map();
+const pendingPaneRestores = new Map();
+let activePaneId = null;
+
+const sanitizeSnapshot = (value) => {
+  if (typeof value === 'undefined') {
+    return { ok: false };
+  }
+  try {
+    const serialized = JSON.stringify(value);
+    const parsed = JSON.parse(serialized);
+    return { ok: true, value: parsed };
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('[paneSnapshot] Failed to serialize snapshot', error);
+    }
+    return { ok: false };
+  }
+};
+
+const resolvePaneId = (paneId) => {
+  if (typeof paneId === 'string' && paneId.trim().length > 0) {
+    return paneId;
+  }
+  if (typeof activePaneId === 'string' && activePaneId.trim().length > 0) {
+    return activePaneId;
+  }
+  const first = paneSnapshotStore.keys().next();
+  if (!first.done && typeof first.value === 'string') {
+    return first.value;
+  }
+  return null;
+};
+
+export const markPaneActive = (paneId) => {
+  if (typeof paneId === 'string' && paneId.trim().length > 0) {
+    activePaneId = paneId;
+  } else if (!paneId && activePaneId) {
+    activePaneId = null;
+  }
+};
+
+export const capturePaneSnapshot = (paneId, snapshot) => {
+  const key = resolvePaneId(paneId);
+  if (!key) return false;
+  const result = sanitizeSnapshot(snapshot);
+  if (!result.ok) return false;
+  paneSnapshotStore.set(key, {
+    snapshot: result.value,
+    updatedAt: Date.now(),
+  });
+  activePaneId = key;
+  return true;
+};
+
+export const getPaneSnapshotDetails = (paneId) => {
+  const key = resolvePaneId(paneId);
+  if (!key) return null;
+  const entry = paneSnapshotStore.get(key);
+  if (!entry) return null;
+  return { paneId: key, snapshot: entry.snapshot, updatedAt: entry.updatedAt };
+};
+
+export const hasPaneSnapshot = (paneId) => {
+  if (typeof paneId === 'string' && paneId.trim().length > 0) {
+    return paneSnapshotStore.has(paneId);
+  }
+  if (typeof activePaneId === 'string' && paneSnapshotStore.has(activePaneId)) {
+    return true;
+  }
+  return paneSnapshotStore.size > 0;
+};
+
+export const clearPaneSnapshot = (paneId) => {
+  const key = resolvePaneId(paneId);
+  if (!key) return;
+  paneSnapshotStore.delete(key);
+  pendingPaneRestores.delete(key);
+  if (activePaneId === key) {
+    activePaneId = null;
+  }
+};
+
+export const queuePaneSnapshotRestore = (paneId) => {
+  const key = resolvePaneId(paneId);
+  if (!key) return null;
+  const entry = paneSnapshotStore.get(key);
+  if (!entry) return null;
+  const result = sanitizeSnapshot(entry.snapshot);
+  if (!result.ok) {
+    paneSnapshotStore.delete(key);
+    pendingPaneRestores.delete(key);
+    return null;
+  }
+  pendingPaneRestores.set(key, result.value);
+  return {
+    paneId: key,
+    snapshot: result.value,
+    updatedAt: entry.updatedAt,
+  };
+};
+
+export const consumePendingPaneRestore = (paneId) => {
+  const key = resolvePaneId(paneId);
+  if (!key) return null;
+  if (!pendingPaneRestores.has(key)) return null;
+  const snapshot = pendingPaneRestores.get(key);
+  pendingPaneRestores.delete(key);
+  paneSnapshotStore.delete(key);
+  if (activePaneId === key) {
+    activePaneId = null;
+  }
+  return snapshot;
+};
+
+export const getLatestPaneSnapshot = () => {
+  if (activePaneId) {
+    const entry = getPaneSnapshotDetails(activePaneId);
+    if (entry) return entry;
+  }
+  const first = paneSnapshotStore.entries().next();
+  if (!first.done) {
+    const [paneId, entry] = first.value;
+    if (entry) {
+      return { paneId, snapshot: entry.snapshot, updatedAt: entry.updatedAt };
+    }
+  }
+  return null;
+};
+
+export const __paneSnapshotInternals = {
+  reset() {
+    paneSnapshotStore.clear();
+    pendingPaneRestores.clear();
+    activePaneId = null;
+  },
+  peekStore() {
+    return paneSnapshotStore;
+  },
+  getActivePaneId() {
+    return activePaneId;
+  },
+  hasPending(paneId) {
+    const key = resolvePaneId(paneId);
+    if (!key) return false;
+    return pendingPaneRestores.has(key);
+  },
+};


### PR DESCRIPTION
## Summary
- add a reusable `usePaneSnapshot` hook and extend the window layout utility with pane snapshot storage helpers
- update the pane and global error boundaries to surface reload and snapshot restore controls and show snapshot metadata
- document the snapshot opt-in process and add focused component tests for pane crash recovery

## Testing
- yarn test __tests__/paneErrorBoundaries.test.tsx
- yarn lint
- yarn test *(fails: existing suites depend on browser APIs such as localStorage)*

------
https://chatgpt.com/codex/tasks/task_e_68dc264e988483288d94d1a88671f389