### PR TITLE
[ui] Improve popover focus handling

### DIFF
--- a/__tests__/contextMenu.accessibility.test.tsx
+++ b/__tests__/contextMenu.accessibility.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ContextMenu from '../components/common/ContextMenu';
+
+describe('ContextMenu focus management', () => {
+  function Wrapper() {
+    const targetRef = React.useRef<HTMLButtonElement>(null);
+    const items = React.useMemo(
+      () => [
+        { label: 'Open', onSelect: jest.fn() },
+        { label: 'Delete', onSelect: jest.fn() },
+      ],
+      [],
+    );
+
+    return (
+      <div>
+        <button data-testid="trigger" ref={targetRef} type="button">
+          Trigger
+        </button>
+        <ContextMenu targetRef={targetRef} items={items} />
+      </div>
+    );
+  }
+
+  test('focuses first item on open, traps tab, and restores trigger on close', async () => {
+    const { getByTestId } = render(<Wrapper />);
+    const trigger = getByTestId('trigger');
+
+    trigger.focus();
+    fireEvent.contextMenu(trigger, { pageX: 10, pageY: 10 });
+
+    const firstItem = await screen.findByRole('menuitem', { name: 'Open' });
+    const secondItem = await screen.findByRole('menuitem', { name: 'Delete' });
+
+    await waitFor(() => expect(firstItem).toHaveFocus());
+
+    fireEvent.keyDown(firstItem, { key: 'ArrowDown' });
+    expect(secondItem).toHaveFocus();
+
+    fireEvent.keyDown(secondItem, { key: 'Tab' });
+    expect(firstItem).toHaveFocus();
+
+    fireEvent.keyDown(firstItem, { key: 'Tab', shiftKey: true });
+    expect(secondItem).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+});

--- a/__tests__/quickSettings.accessibility.test.tsx
+++ b/__tests__/quickSettings.accessibility.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import QuickSettings from '../components/ui/QuickSettings';
+
+jest.mock('../hooks/usePersistentState', () => ({
+  __esModule: true,
+  default: (key: string, initial: unknown) => {
+    let value = typeof initial === 'function' ? (initial as () => unknown)() : initial;
+    const setValue = (next: unknown) => {
+      value =
+        typeof next === 'function' ? (next as (prev: unknown) => unknown)(value) : next;
+    };
+    return [value, setValue] as const;
+  },
+}));
+
+describe('QuickSettings focus management', () => {
+  test('focuses the first control and traps tab navigation', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+
+    render(<QuickSettings open={true} onClose={onClose} />);
+
+    const themeButton = await screen.findByRole('button', { name: /Theme/i });
+    const soundToggle = await screen.findByRole('checkbox', { name: 'Sound' });
+    const networkToggle = await screen.findByRole('checkbox', { name: 'Network' });
+    const reducedMotionToggle = await screen.findByRole('checkbox', { name: 'Reduced motion' });
+
+    await waitFor(() => expect(themeButton).toHaveFocus());
+
+    await user.tab();
+    expect(soundToggle).toHaveFocus();
+
+    await user.tab();
+    expect(networkToggle).toHaveFocus();
+
+    await user.tab();
+    expect(reducedMotionToggle).toHaveFocus();
+
+    await user.tab();
+    expect(themeButton).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(reducedMotionToggle).toHaveFocus();
+
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('restores focus to the toggle button when closed with Escape', async () => {
+    const user = userEvent.setup();
+
+    function Wrapper() {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <div>
+          <button type="button" onClick={() => setOpen(true)} data-testid="toggle">
+            Toggle settings
+          </button>
+          <QuickSettings open={open} onClose={() => setOpen(false)} />
+        </div>
+      );
+    }
+
+    render(<Wrapper />);
+
+    const toggle = screen.getByTestId('toggle');
+    toggle.focus();
+    await user.click(toggle);
+
+    const themeButton = await screen.findByRole('button', { name: /Theme/i });
+    await waitFor(() => expect(themeButton).toHaveFocus());
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => expect(toggle).toHaveFocus());
+  });
+});

--- a/components/common/PdfViewer/index.tsx
+++ b/components/common/PdfViewer/index.tsx
@@ -18,11 +18,7 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
   const [matches, setMatches] = useState<number[]>([]);
   const thumbListRef = useRef<HTMLDivElement | null>(null);
 
-  useRovingTabIndex(
-    thumbListRef as React.RefObject<HTMLElement>,
-    thumbs.length > 0,
-    'horizontal',
-  );
+  useRovingTabIndex(thumbListRef, thumbs.length > 0, 'horizontal');
 
   useEffect(() => {
     let mounted = true;
@@ -96,16 +92,18 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
   };
 
   return (
-    <div>
-      <div className="flex gap-2 mb-2">
-        <input
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search"
-        />
-        <button onClick={search}>Search</button>
-      </div>
-      <canvas ref={canvasRef} data-testid="pdf-canvas" />
+      <div>
+        <div className="flex gap-2 mb-2">
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search"
+            aria-label="Search document"
+          />
+          <button onClick={search}>Search</button>
+        </div>
+        <canvas ref={canvasRef} data-testid="pdf-canvas" role="img" aria-label="Current page" />
       <div
         className="flex gap-2 overflow-x-auto mt-2"
         role="listbox"
@@ -113,12 +111,13 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
         ref={thumbListRef}
       >
         {thumbs.map((t, i) => (
-          <canvas
-            key={i + 1}
-            role="option"
-            tabIndex={page === i + 1 ? 0 : -1}
-            aria-selected={page === i + 1}
-            data-testid={`thumb-${i + 1}`}
+            <canvas
+              key={i + 1}
+              role="option"
+              tabIndex={page === i + 1 ? 0 : -1}
+              aria-selected={page === i + 1}
+              aria-label={`Go to page ${i + 1}`}
+              data-testid={`thumb-${i + 1}`}
             onClick={() => setPage(i + 1)}
             onFocus={() => setPage(i + 1)}
             ref={(el) => {

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -111,12 +111,17 @@ export default class Navbar extends PureComponent {
                                                 id="status-bar"
                                                 aria-label="System status"
                                                 onClick={this.handleStatusToggle}
+                                                aria-haspopup="dialog"
+                                                aria-expanded={this.state.status_card}
                                                 className={
                                                         'relative rounded-full border border-transparent px-3 py-1 text-xs font-medium text-white/80 transition duration-150 ease-in-out hover:border-white/20 hover:bg-white/10 focus:border-ubb-orange focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300'
                                                 }
                                         >
                                                 <Status />
-                                                <QuickSettings open={this.state.status_card} />
+                                                <QuickSettings
+                                                        open={this.state.status_card}
+                                                        onClose={() => this.setState({ status_card: false })}
+                                                />
                                         </button>
 				</div>
 			);

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,17 +1,24 @@
 "use client";
 
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import useFocusTrap from '../../hooks/useFocusTrap';
+import useEscapeKey from '../../hooks/useEscapeKey';
+import { useEffect, useRef } from 'react';
 
 interface Props {
   open: boolean;
+  onClose: () => void;
 }
 
-const QuickSettings = ({ open }: Props) => {
+const QuickSettings = ({ open, onClose }: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(panelRef, open);
+  useEscapeKey(onClose, open);
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -23,12 +30,18 @@ const QuickSettings = ({ open }: Props) => {
 
   return (
     <div
+      ref={panelRef}
+      role="dialog"
+      aria-modal="true"
+      aria-hidden={!open}
+      aria-label="Quick settings"
       className={`absolute bg-ub-cool-grey rounded-md py-4 top-9 right-3 shadow border-black border border-opacity-20 ${
         open ? '' : 'hidden'
       }`}
     >
       <div className="px-4 pb-2">
         <button
+          type="button"
           className="w-full flex justify-between"
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
         >
@@ -36,22 +49,33 @@ const QuickSettings = ({ open }: Props) => {
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
+      <label className="px-4 pb-2 flex items-center justify-between gap-4">
+        <span className="flex-1">Sound</span>
+        <input
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+          aria-label="Sound"
+        />
+      </label>
+      <label className="px-4 pb-2 flex items-center justify-between gap-4">
+        <span className="flex-1">Network</span>
+        <input
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+          aria-label="Network"
+        />
+      </label>
+      <label className="px-4 flex items-center justify-between gap-4">
+        <span className="flex-1">Reduced motion</span>
         <input
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
+          aria-label="Reduced motion"
         />
-      </div>
+      </label>
     </div>
   );
 };

--- a/docs/keyboard-only-test-plan.md
+++ b/docs/keyboard-only-test-plan.md
@@ -21,3 +21,8 @@
 1. After resizing or snapping, press **Tab** to move focus inside the window.
 2. Continue pressing **Tab** to confirm focus can leave the window and is not trapped.
 3. Shift+Tab moves focus backward as expected.
+
+## Contextual actions and quick settings
+1. With any desktop tile or taskbar item focused, press **Shift + F10** to open its context menu. The first menu item should receive focus automatically.
+2. Use arrow keys to move between menu items. Press **Escape** to close the menu and return focus to the item that opened it.
+3. Open the quick settings popover from the system status button and verify focus lands on the Theme toggle. Tab forward and backward to confirm focus stays within the popover until you dismiss it with **Escape**.

--- a/hooks/useEscapeKey.ts
+++ b/hooks/useEscapeKey.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+export default function useEscapeKey(
+  handler: () => void,
+  active: boolean = true,
+) {
+  useEffect(() => {
+    if (!active) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handler();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handler, active]);
+}

--- a/hooks/useFocusTrap.ts
+++ b/hooks/useFocusTrap.ts
@@ -1,4 +1,5 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import type { MutableRefObject, RefObject } from 'react';
 
 function getFocusableElements(container: HTMLElement): HTMLElement[] {
   const selectors = [
@@ -12,10 +13,48 @@ function getFocusableElements(container: HTMLElement): HTMLElement[] {
   return Array.from(container.querySelectorAll<HTMLElement>(selectors.join(',')));
 }
 
-export default function useFocusTrap(ref: React.RefObject<HTMLElement>, active: boolean = true) {
+export interface FocusTrapOptions {
+  /**
+   * Automatically focus the first focusable element when the trap becomes
+   * active. Defaults to true because most popovers/dialogs should transfer
+   * focus on open.
+   */
+  focusFirstOnActivate?: boolean;
+  /**
+   * Restore focus to the element that was focused before the trap activated
+   * once it deactivates. Enabled by default.
+   */
+  restoreFocus?: boolean;
+}
+
+type FocusTrapRef = RefObject<HTMLElement | null> | MutableRefObject<HTMLElement | null>;
+
+export default function useFocusTrap(
+  ref: FocusTrapRef,
+  active: boolean = true,
+  options: FocusTrapOptions = {},
+) {
+  const { focusFirstOnActivate = true, restoreFocus = true } = options;
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
   useEffect(() => {
     const node = ref.current;
     if (!node || !active) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    if (restoreFocus && previouslyFocused && !node.contains(previouslyFocused)) {
+      previousFocusRef.current = previouslyFocused;
+    } else if (!restoreFocus) {
+      previousFocusRef.current = null;
+    }
+
+    if (focusFirstOnActivate) {
+      const focusable = getFocusableElements(node);
+      const target = focusable[0] ?? node;
+      if (!node.contains(document.activeElement) && typeof target?.focus === 'function') {
+        target.focus();
+      }
+    }
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'Tab') return;
@@ -50,6 +89,13 @@ export default function useFocusTrap(ref: React.RefObject<HTMLElement>, active: 
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('focusin', handleFocus);
+      if (restoreFocus) {
+        const previous = previousFocusRef.current;
+        if (previous && previous.isConnected) {
+          previous.focus();
+        }
+        previousFocusRef.current = null;
+      }
     };
-  }, [ref, active]);
+  }, [ref, active, focusFirstOnActivate, restoreFocus]);
 }

--- a/hooks/useRovingTabIndex.ts
+++ b/hooks/useRovingTabIndex.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import type { MutableRefObject, RefObject } from 'react';
 
 /**
  * Enables roving tab index and arrow key navigation within a container.
@@ -6,8 +7,10 @@ import { useEffect } from 'react';
  * or role="option" will participate in the roving behaviour. This covers
  * common patterns such as tabs, menus and listboxes.
  */
+type RovingRef = RefObject<HTMLElement | null> | MutableRefObject<HTMLElement | null>;
+
 export default function useRovingTabIndex(
-  ref: React.RefObject<HTMLElement>,
+  ref: RovingRef,
   active: boolean = true,
   orientation: 'horizontal' | 'vertical' = 'horizontal'
 ) {
@@ -25,10 +28,19 @@ export default function useRovingTabIndex(
     let index = items.findIndex((el) => el.tabIndex === 0);
     if (index === -1) index = 0;
     items.forEach((el, i) => (el.tabIndex = i === index ? 0 : -1));
+    if (!node.contains(document.activeElement)) {
+      items[index].focus();
+    }
 
     const handleKey = (e: KeyboardEvent) => {
-      const forward = orientation === 'horizontal' ? ['ArrowRight', 'ArrowDown'] : ['ArrowDown'];
-      const backward = orientation === 'horizontal' ? ['ArrowLeft', 'ArrowUp'] : ['ArrowUp'];
+      const forward =
+        orientation === 'horizontal'
+          ? ['ArrowRight', 'ArrowDown']
+          : ['ArrowDown', 'ArrowRight'];
+      const backward =
+        orientation === 'horizontal'
+          ? ['ArrowLeft', 'ArrowUp']
+          : ['ArrowUp', 'ArrowLeft'];
       if (forward.includes(e.key)) {
         e.preventDefault();
         index = (index + 1) % items.length;


### PR DESCRIPTION
## Summary
- enhance focus management hooks and add a reusable Escape key listener
- ensure context menu and quick settings popovers autofocus, trap focus, and restore the trigger on close
- document keyboard shortcuts and cover focus traversal with new React Testing Library tests

## Testing
- yarn lint
- yarn test --runTestsByPath __tests__/contextMenu.accessibility.test.tsx __tests__/quickSettings.accessibility.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc265f560c8328bd34bcc26181d2cb