### PR TITLE
[pwa] throttle install prompt

### DIFF
--- a/__tests__/pwa/a2hs.integration.test.ts
+++ b/__tests__/pwa/a2hs.integration.test.ts
@@ -1,0 +1,92 @@
+import { act } from '@testing-library/react';
+
+const mockSupport = () => {
+  Object.defineProperty(window, 'onbeforeinstallprompt', {
+    configurable: true,
+    writable: true,
+    value: null,
+  });
+};
+
+const createPromptEvent = () => {
+  const event: any = new Event('beforeinstallprompt');
+  event.preventDefault = jest.fn();
+  event.prompt = jest.fn().mockResolvedValue(undefined);
+  event.userChoice = Promise.resolve({ outcome: 'dismissed', platform: 'test' });
+  return event;
+};
+
+describe('Add to Home Screen flow', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    localStorage.clear();
+    mockSupport();
+  });
+
+  afterEach(() => {
+    delete (window as any).onbeforeinstallprompt;
+    jest.useRealTimers();
+  });
+
+  test('dispatches availability only after navigation threshold is met', async () => {
+    const { initA2HS, recordNavigationEvent } = await import('@/src/pwa/a2hs');
+    const listener = jest.fn();
+    window.addEventListener('a2hs:available', listener);
+
+    initA2HS({ navigationThreshold: 2 });
+
+    const event = createPromptEvent();
+    await act(async () => {
+      window.dispatchEvent(event);
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+
+    recordNavigationEvent();
+    expect(listener).not.toHaveBeenCalled();
+
+    recordNavigationEvent();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  test('suppresses prompts for 30 days after dismissal', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+
+    const { initA2HS, recordNavigationEvent, dismissA2HS, isA2HSSuppressed } = await import('@/src/pwa/a2hs');
+    const listener = jest.fn();
+    window.addEventListener('a2hs:available', listener);
+
+    initA2HS({ navigationThreshold: 1 });
+
+    await act(async () => {
+      window.dispatchEvent(createPromptEvent());
+    });
+
+    recordNavigationEvent();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    dismissA2HS();
+    expect(isA2HSSuppressed()).toBe(true);
+
+    listener.mockClear();
+
+    await act(async () => {
+      window.dispatchEvent(createPromptEvent());
+    });
+
+    recordNavigationEvent();
+    expect(listener).not.toHaveBeenCalled();
+
+    const thirtyOneDaysMs = 31 * 24 * 60 * 60 * 1000;
+    localStorage.setItem('a2hs.dismissedAt', (Date.now() - thirtyOneDaysMs).toString());
+
+    await act(async () => {
+      window.dispatchEvent(createPromptEvent());
+    });
+
+    recordNavigationEvent();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/components/pwa/A2HSChip.tsx
+++ b/components/pwa/A2HSChip.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import clsx from 'clsx';
+import { trackEvent } from '@/lib/analytics-client';
+import {
+  dismissA2HS,
+  initA2HS,
+  isA2HSSuppressed,
+  isBeforeInstallPromptSupported,
+  recordNavigationEvent,
+  showA2HS,
+} from '@/src/pwa/a2hs';
+
+const CHIP_CONTAINER =
+  'fixed bottom-4 right-4 z-[1000] flex items-center gap-2 rounded-full bg-slate-900/90 px-3 py-2 text-sm text-white shadow-lg backdrop-blur';
+const ACTION_BUTTON =
+  'rounded-full border border-white/40 px-3 py-1 text-xs font-medium uppercase tracking-wide transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 focus-visible:ring-white';
+
+const A2HSChip = () => {
+  const router = useRouter();
+  const [visible, setVisible] = useState(false);
+  const [supported] = useState(() => isBeforeInstallPromptSupported());
+
+  useEffect(() => {
+    if (!supported) return;
+    initA2HS();
+
+    const handleAvailable = () => {
+      if (isA2HSSuppressed()) return;
+      setVisible(true);
+    };
+
+    window.addEventListener('a2hs:available', handleAvailable);
+
+    return () => {
+      window.removeEventListener('a2hs:available', handleAvailable);
+    };
+  }, [supported]);
+
+  useEffect(() => {
+    if (!supported) return;
+
+    const handleNavigation = () => {
+      recordNavigationEvent();
+    };
+
+    recordNavigationEvent();
+    router.events?.on('routeChangeComplete', handleNavigation);
+
+    return () => {
+      router.events?.off('routeChangeComplete', handleNavigation);
+    };
+  }, [router.events, supported]);
+
+  const handleInstall = useCallback(async () => {
+    const shown = await showA2HS();
+    if (shown) {
+      trackEvent('cta_click', { location: 'a2hs_chip_install' });
+      setVisible(false);
+    }
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    dismissA2HS();
+    setVisible(false);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className={CHIP_CONTAINER} role="dialog" aria-live="polite">
+      <span className="font-medium">Install this app?</span>
+      <div className="flex items-center gap-1">
+        <button type="button" className={clsx(ACTION_BUTTON, 'bg-white/10')} onClick={handleInstall}>
+          Install
+        </button>
+        <button type="button" className={ACTION_BUTTON} onClick={handleDismiss}>
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default A2HSChip;
+

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,9 @@ const compat = new FlatCompat();
 const config = [
   { ignores: ['components/apps/Chrome/index.tsx'] },
   {
+    files: ['**/*.{js,jsx,ts,tsx}'],
+  },
+  {
     plugins: {
       'no-top-level-window': noTopLevelWindow,
     },

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -15,7 +15,7 @@ import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import NotificationCenter from '../components/common/NotificationCenter';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
-import Script from 'next/script';
+import A2HSChip from '../components/pwa/A2HSChip';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
 
 import { Ubuntu } from 'next/font/google';
@@ -149,7 +149,6 @@ function MyApp(props) {
 
   return (
     <ErrorBoundary>
-      <Script src="/a2hs.js" strategy="beforeInteractive" />
       <div className={ubuntu.className}>
         <a
           href="#app-grid"
@@ -173,6 +172,7 @@ function MyApp(props) {
               />
 
               {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+              <A2HSChip />
             </PipPortalProvider>
           </NotificationCenter>
         </SettingsProvider>

--- a/src/pwa/a2hs.ts
+++ b/src/pwa/a2hs.ts
@@ -1,20 +1,86 @@
+import { safeLocalStorage } from '../../utils/safeStorage';
+
 interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[];
   readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
   prompt(): Promise<void>;
 }
 
-let deferredPrompt: BeforeInstallPromptEvent | null = null;
+type InitOptions = {
+  navigationThreshold?: number;
+};
 
-export function initA2HS() {
-  if (typeof window === 'undefined') return;
+const DEFAULT_NAVIGATION_THRESHOLD = 3;
+const A2HS_AVAILABLE_EVENT = 'a2hs:available';
+const DISMISSAL_STORAGE_KEY = 'a2hs.dismissedAt';
+const DISMISSAL_SUPPRESSION_MS = 30 * 24 * 60 * 60 * 1000;
+
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+let initialized = false;
+let navigationThreshold = DEFAULT_NAVIGATION_THRESHOLD;
+let navigationCount = 0;
+let availabilityDispatched = false;
+let hasSupport = false;
+
+const isWithinSuppressionWindow = (timestamp: number) => {
+  if (Number.isNaN(timestamp)) return false;
+  return Date.now() - timestamp < DISMISSAL_SUPPRESSION_MS;
+};
+
+export const isBeforeInstallPromptSupported = () => {
+  if (typeof window === 'undefined') return false;
+  return 'onbeforeinstallprompt' in window;
+};
+
+export const isA2HSSuppressed = () => {
+  const stored = safeLocalStorage?.getItem(DISMISSAL_STORAGE_KEY);
+  if (!stored) return false;
+  const timestamp = Number.parseInt(stored, 10);
+  return isWithinSuppressionWindow(timestamp);
+};
+
+const maybeDispatchAvailability = () => {
+  if (!deferredPrompt || availabilityDispatched) return;
+  if (navigationCount < navigationThreshold) return;
+  if (isA2HSSuppressed()) return;
+  availabilityDispatched = true;
+  window.dispatchEvent(new Event(A2HS_AVAILABLE_EVENT));
+};
+
+export function initA2HS(options: InitOptions = {}) {
+  if (typeof window === 'undefined' || initialized) return;
+  hasSupport = isBeforeInstallPromptSupported();
+  if (!hasSupport) return;
+
+  initialized = true;
+  navigationThreshold = Math.max(1, options.navigationThreshold ?? DEFAULT_NAVIGATION_THRESHOLD);
+
   window.addEventListener('beforeinstallprompt', (e: Event) => {
     const event = e as BeforeInstallPromptEvent;
     event.preventDefault();
     deferredPrompt = event;
-    window.dispatchEvent(new Event('a2hs:available'));
+    availabilityDispatched = false;
+    navigationCount = Math.max(navigationCount, 0);
+    maybeDispatchAvailability();
   });
 }
+
+export const recordNavigationEvent = () => {
+  if (typeof window === 'undefined' || !hasSupport) return;
+  navigationCount += 1;
+  maybeDispatchAvailability();
+};
+
+export const dismissA2HS = () => {
+  safeLocalStorage?.setItem(DISMISSAL_STORAGE_KEY, Date.now().toString());
+  availabilityDispatched = false;
+  deferredPrompt = null;
+  navigationCount = 0;
+};
+
+export const clearA2HSDismissal = () => {
+  safeLocalStorage?.removeItem(DISMISSAL_STORAGE_KEY);
+};
 
 export async function showA2HS() {
   if (!deferredPrompt) return false;
@@ -22,5 +88,7 @@ export async function showA2HS() {
   deferredPrompt = null;
   await promptEvent.prompt();
   await promptEvent.userChoice;
+  navigationCount = 0;
+  availabilityDispatched = false;
   return true;
 }


### PR DESCRIPTION
## Summary
- extend the Add to Home Screen helper to track navigation activity, persist dismissals, and guard against unsupported browsers
- add a client-side chip that listens for `a2hs:available`, records navigation events, and exposes install/dismiss controls
- cover the flow with integration tests and adjust lint configuration to include JSX files

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc2661cadc8328a2b4f1992ce7fee5