### PR TITLE
[settings] enhance settings import/export flow

### DIFF
--- a/__tests__/settingsStore.test.ts
+++ b/__tests__/settingsStore.test.ts
@@ -1,0 +1,168 @@
+import {
+  setAccent,
+  setWallpaper,
+  setUseKaliWallpaper,
+  setDensity,
+  setReducedMotion,
+  setFontScale,
+  setHighContrast,
+  setLargeHitAreas,
+  setPongSpin,
+  setAllowNetwork,
+  setHaptics,
+  exportSettings,
+  importSettings,
+  resetSettings,
+  getAccent,
+  getWallpaper,
+  getUseKaliWallpaper,
+  getDensity,
+  getReducedMotion,
+  getFontScale,
+  getHighContrast,
+  getLargeHitAreas,
+  getPongSpin,
+  getAllowNetwork,
+  getHaptics,
+  defaults,
+} from '../utils/settingsStore';
+import { setTheme, getTheme } from '../utils/theme';
+
+describe('settingsStore import/export', () => {
+  beforeEach(async () => {
+    await resetSettings();
+    if (typeof window !== 'undefined') {
+      window.localStorage.clear();
+    }
+  });
+
+  it('round-trips preferences, layout, and shortcuts', async () => {
+    await setAccent('#38a169');
+    await setWallpaper('wall-5');
+    await setUseKaliWallpaper(true);
+    await setDensity('compact');
+    await setReducedMotion(true);
+    await setFontScale(1.2);
+    await setHighContrast(true);
+    await setLargeHitAreas(true);
+    await setPongSpin(false);
+    await setAllowNetwork(true);
+    await setHaptics(false);
+    setTheme('neon');
+
+    window.localStorage.setItem(
+      'desktop-session',
+      JSON.stringify({
+        windows: [{ id: 'terminal', x: 200, y: 150 }],
+        wallpaper: 'wall-5',
+        dock: ['terminal', 'browser'],
+      }),
+    );
+    window.localStorage.setItem(
+      'keymap',
+      JSON.stringify({
+        'Show keyboard shortcuts': 'Shift+/',
+        'Open settings': 'Cmd+,',
+      }),
+    );
+    window.localStorage.setItem('snap-enabled', JSON.stringify(false));
+
+    const exported = await exportSettings();
+    const parsed = JSON.parse(exported);
+
+    expect(parsed.version).toBe(1);
+    expect(parsed.preferences).toMatchObject({
+      accent: '#38a169',
+      wallpaper: 'wall-5',
+      useKaliWallpaper: true,
+      density: 'compact',
+      reducedMotion: true,
+      fontScale: 1.2,
+      highContrast: true,
+      largeHitAreas: true,
+      pongSpin: false,
+      allowNetwork: true,
+      haptics: false,
+      theme: 'neon',
+      snapEnabled: false,
+    });
+    expect(parsed.layout).toMatchObject({
+      wallpaper: 'wall-5',
+      dock: ['terminal', 'browser'],
+    });
+    expect(parsed.layout.windows).toEqual([{ id: 'terminal', x: 200, y: 150 }]);
+    expect(parsed.shortcuts['Show keyboard shortcuts']).toBe('Shift+/');
+
+    await resetSettings();
+    window.localStorage.clear();
+
+    const result = await importSettings(exported);
+    expect(result.success).toBe(true);
+
+    expect(await getAccent()).toBe('#38a169');
+    expect(await getWallpaper()).toBe('wall-5');
+    expect(await getUseKaliWallpaper()).toBe(true);
+    expect(await getDensity()).toBe('compact');
+    expect(await getReducedMotion()).toBe(true);
+    expect(await getFontScale()).toBeCloseTo(1.2);
+    expect(await getHighContrast()).toBe(true);
+    expect(await getLargeHitAreas()).toBe(true);
+    expect(await getPongSpin()).toBe(false);
+    expect(await getAllowNetwork()).toBe(true);
+    expect(await getHaptics()).toBe(false);
+    expect(getTheme()).toBe('neon');
+
+    const storedSession = JSON.parse(window.localStorage.getItem('desktop-session') || 'null');
+    expect(storedSession).toMatchObject({
+      wallpaper: 'wall-5',
+      dock: ['terminal', 'browser'],
+    });
+    expect(storedSession.windows).toEqual([{ id: 'terminal', x: 200, y: 150 }]);
+
+    const storedShortcuts = JSON.parse(window.localStorage.getItem('keymap') || '{}');
+    expect(storedShortcuts['Show keyboard shortcuts']).toBe('Shift+/');
+    expect(storedShortcuts['Open settings']).toBe('Cmd+,');
+
+    const snapSetting = JSON.parse(window.localStorage.getItem('snap-enabled') || 'null');
+    expect(snapSetting).toBe(false);
+  });
+
+  it('resetSettings restores defaults and clears stored layout', async () => {
+    await setAccent('#ff0000');
+    await setWallpaper('wall-4');
+    await setUseKaliWallpaper(true);
+    await setDensity('compact');
+    await setReducedMotion(true);
+    await setFontScale(1.5);
+    await setHighContrast(true);
+    await setLargeHitAreas(true);
+    await setPongSpin(false);
+    await setAllowNetwork(true);
+    await setHaptics(false);
+    setTheme('neon');
+
+    window.localStorage.setItem(
+      'desktop-session',
+      JSON.stringify({ windows: [{ id: 'notes', x: 10, y: 20 }], wallpaper: 'wall-4', dock: ['notes'] }),
+    );
+
+    await resetSettings();
+
+    expect(await getAccent()).toBe(defaults.accent);
+    expect(await getWallpaper()).toBe(defaults.wallpaper);
+    expect(await getUseKaliWallpaper()).toBe(defaults.useKaliWallpaper);
+    expect(await getDensity()).toBe(defaults.density);
+    expect(await getReducedMotion()).toBe(defaults.reducedMotion);
+    expect(await getFontScale()).toBeCloseTo(defaults.fontScale);
+    expect(await getHighContrast()).toBe(defaults.highContrast);
+    expect(await getLargeHitAreas()).toBe(defaults.largeHitAreas);
+    expect(await getPongSpin()).toBe(defaults.pongSpin);
+    expect(await getAllowNetwork()).toBe(defaults.allowNetwork);
+    expect(await getHaptics()).toBe(defaults.haptics);
+    expect(getTheme()).toBe('default');
+
+    expect(window.localStorage.getItem('desktop-session')).toBeNull();
+    expect(window.localStorage.getItem('keymap')).toBeNull();
+    expect(window.localStorage.getItem('snap-enabled')).toBeNull();
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -72,21 +72,24 @@ export default function Settings() {
 
   const handleImport = async (file: File) => {
     const text = await file.text();
-    await importSettingsData(text);
-    try {
-      const parsed = JSON.parse(text);
-      if (parsed.accent !== undefined) setAccent(parsed.accent);
-      if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
-      if (parsed.density !== undefined) setDensity(parsed.density);
-      if (parsed.reducedMotion !== undefined)
-        setReducedMotion(parsed.reducedMotion);
-      if (parsed.fontScale !== undefined) setFontScale(parsed.fontScale);
-      if (parsed.highContrast !== undefined)
-        setHighContrast(parsed.highContrast);
-      if (parsed.theme !== undefined) setTheme(parsed.theme);
-    } catch (err) {
-      console.error("Invalid settings", err);
+    const result = await importSettingsData(text);
+    if (!result?.success) {
+      console.error(result?.error || "Invalid settings file");
+      return;
     }
+    const preferences = result.data?.preferences ?? {};
+    if (preferences.accent !== undefined) setAccent(preferences.accent);
+    if (preferences.wallpaper !== undefined) setWallpaper(preferences.wallpaper);
+    if (preferences.density !== undefined) setDensity(preferences.density as any);
+    if (preferences.reducedMotion !== undefined)
+      setReducedMotion(preferences.reducedMotion);
+    if (preferences.fontScale !== undefined) setFontScale(preferences.fontScale);
+    if (preferences.highContrast !== undefined)
+      setHighContrast(preferences.highContrast);
+    if (preferences.theme !== undefined) setTheme(preferences.theme);
+    if (preferences.useKaliWallpaper !== undefined)
+      setUseKaliWallpaper(preferences.useKaliWallpaper);
+    if (preferences.haptics !== undefined) setHaptics(preferences.haptics);
   };
 
   const handleReset = async () => {
@@ -163,6 +166,7 @@ export default function Settings() {
                 checked={useKaliWallpaper}
                 onChange={(e) => setUseKaliWallpaper(e.target.checked)}
                 className="mr-2"
+                aria-label="Use Kali gradient wallpaper"
               />
               Kali Gradient Wallpaper
             </label>

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,6 +1,29 @@
-import { useState } from 'react';
+import { useRef, useState, type ChangeEvent } from 'react';
 import { getUnlockedThemes } from '../utils/theme';
 import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
+import FormError from './ui/FormError';
+import useNotifications from '../hooks/useNotifications';
+import {
+  defaults,
+  exportSettings as exportSettingsData,
+  importSettings as importSettingsData,
+  resetSettings as resetSettingsData,
+} from '../utils/settingsStore';
+
+type Preferences = {
+  accent?: string;
+  wallpaper?: string;
+  useKaliWallpaper?: boolean;
+  density?: string;
+  reducedMotion?: boolean;
+  fontScale?: number;
+  highContrast?: boolean;
+  largeHitAreas?: boolean;
+  pongSpin?: boolean;
+  allowNetwork?: boolean;
+  haptics?: boolean;
+  theme?: string;
+};
 
 interface Props {
   highScore?: number;
@@ -8,22 +31,176 @@ interface Props {
 
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [isImporting, setIsImporting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const unlocked = getUnlockedThemes(highScore);
-  const { accent, setAccent, theme, setTheme } = useSettings();
+  const {
+    accent,
+    setAccent,
+    theme,
+    setTheme,
+    setWallpaper,
+    setUseKaliWallpaper,
+    setDensity,
+    setReducedMotion,
+    setFontScale,
+    setHighContrast,
+    setLargeHitAreas,
+    setPongSpin,
+    setAllowNetwork,
+    setHaptics,
+  } = useSettings();
+  const { pushNotification } = useNotifications();
+
+  const applyPreferencesToContext = (preferences: Preferences) => {
+    if (typeof preferences.accent === 'string') setAccent(preferences.accent);
+    if (typeof preferences.wallpaper === 'string') setWallpaper(preferences.wallpaper);
+    if (typeof preferences.useKaliWallpaper === 'boolean') {
+      setUseKaliWallpaper(preferences.useKaliWallpaper);
+    }
+    if (typeof preferences.density === 'string') {
+      setDensity(preferences.density as 'regular' | 'compact');
+    }
+    if (typeof preferences.reducedMotion === 'boolean') {
+      setReducedMotion(preferences.reducedMotion);
+    }
+    if (typeof preferences.fontScale === 'number') setFontScale(preferences.fontScale);
+    if (typeof preferences.highContrast === 'boolean') {
+      setHighContrast(preferences.highContrast);
+    }
+    if (typeof preferences.largeHitAreas === 'boolean') {
+      setLargeHitAreas(preferences.largeHitAreas);
+    }
+    if (typeof preferences.pongSpin === 'boolean') setPongSpin(preferences.pongSpin);
+    if (typeof preferences.allowNetwork === 'boolean') {
+      setAllowNetwork(preferences.allowNetwork);
+    }
+    if (typeof preferences.haptics === 'boolean') setHaptics(preferences.haptics);
+    if (typeof preferences.theme === 'string') setTheme(preferences.theme);
+  };
+
+  const handleExport = async () => {
+    setImportError(null);
+    const data = await exportSettingsData();
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'settings.json';
+    anchor.click();
+    URL.revokeObjectURL(url);
+    pushNotification({
+      appId: 'settings',
+      title: 'Settings exported',
+      body: 'Saved settings.json with your layout and preferences.',
+    });
+  };
+
+  const handleImportChange = async (
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
+    if (isImporting) {
+      event.target.value = '';
+      return;
+    }
+    const file = event.target.files?.[0];
+    if (!file) {
+      setImportError('Please choose a settings JSON file.');
+      return;
+    }
+    setImportError(null);
+    if (
+      !window.confirm(
+        'Import settings from the selected file? This will overwrite your current layout, shortcuts, and preferences.',
+      )
+    ) {
+      event.target.value = '';
+      return;
+    }
+
+    setIsImporting(true);
+    try {
+      const text = await file.text();
+      const result = await importSettingsData(text);
+      if (!result?.success) {
+        setImportError(result?.error || 'Unable to import settings.');
+        return;
+      }
+      applyPreferencesToContext(result.data?.preferences ?? {});
+      setImportError(null);
+      pushNotification({
+        appId: 'settings',
+        title: 'Settings imported',
+        body: 'Desktop layout, shortcuts, and preferences restored.',
+      });
+    } catch (error) {
+      console.error('Failed to import settings', error);
+      setImportError('Unable to read the selected file.');
+    } finally {
+      setIsImporting(false);
+      event.target.value = '';
+    }
+  };
+
+  const handleReset = async () => {
+    setImportError(null);
+    const confirmed = window.confirm(
+      'Reset all desktop settings to their defaults? This clears layout, shortcuts, and saved preferences.',
+    );
+    if (!confirmed) return;
+
+    await resetSettingsData();
+    applyPreferencesToContext({
+      accent: defaults.accent,
+      wallpaper: defaults.wallpaper,
+      useKaliWallpaper: defaults.useKaliWallpaper,
+      density: defaults.density,
+      reducedMotion: defaults.reducedMotion,
+      fontScale: defaults.fontScale,
+      highContrast: defaults.highContrast,
+      largeHitAreas: defaults.largeHitAreas,
+      pongSpin: defaults.pongSpin,
+      allowNetwork: defaults.allowNetwork,
+      haptics: defaults.haptics,
+      theme: 'default',
+    });
+    pushNotification({
+      appId: 'settings',
+      title: 'Settings reset',
+      body: 'Restored default appearance and layout.',
+    });
+  };
+
+  const handleToggle = () => {
+    setOpen((prev) => {
+      if (prev) {
+        setImportError(null);
+      }
+      return !prev;
+    });
+  };
 
   return (
     <div>
-      <button aria-label="settings" onClick={() => setOpen(!open)}>
+      <button aria-label="settings" onClick={handleToggle}>
         Settings
       </button>
       {open && (
-        <div role="dialog">
-          <label>
-            Theme
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="mt-3 space-y-4 rounded-md bg-black/70 p-4 text-sm text-white"
+        >
+          <div>
+            <label className="block text-xs font-semibold uppercase tracking-wide text-white/60">
+              Theme
+            </label>
             <select
               aria-label="theme-select"
               value={theme}
               onChange={(e) => setTheme(e.target.value)}
+              className="mt-1 w-full rounded border border-white/20 bg-black/60 px-2 py-1 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ub-orange"
             >
               {unlocked.map((t) => (
                 <option key={t} value={t}>
@@ -31,13 +208,15 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
                 </option>
               ))}
             </select>
-          </label>
-          <label>
-            Accent
+          </div>
+          <div>
+            <span className="block text-xs font-semibold uppercase tracking-wide text-white/60">
+              Accent
+            </span>
             <div
               aria-label="accent-color-picker"
               role="radiogroup"
-              className="flex gap-2 mt-1"
+              className="mt-2 flex flex-wrap gap-2"
             >
               {ACCENT_OPTIONS.map((c) => (
                 <button
@@ -46,12 +225,65 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
                   role="radio"
                   aria-checked={accent === c}
                   onClick={() => setAccent(c)}
-                  className={`w-6 h-6 rounded-full border-2 ${accent === c ? 'border-white' : 'border-transparent'}`}
+                  className={`h-6 w-6 rounded-full border-2 transition ${
+                    accent === c ? 'border-white' : 'border-transparent'
+                  }`}
                   style={{ backgroundColor: c }}
                 />
               ))}
             </div>
-          </label>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={handleExport}
+              className="rounded bg-ub-orange px-3 py-2 text-sm font-medium text-black shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ub-orange"
+            >
+              Export settings
+            </button>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className={`rounded px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+                importError
+                  ? 'border border-red-500 text-red-100 focus-visible:outline-red-500'
+                  : 'bg-ub-orange text-black shadow focus-visible:outline-ub-orange'
+              } ${isImporting ? 'opacity-70' : ''}`}
+              disabled={isImporting}
+              aria-describedby={importError ? 'settings-import-error' : undefined}
+            >
+              {isImporting ? 'Importing…' : 'Import settings'}
+              <span className="ml-1 text-red-200">*</span>
+            </button>
+            <button
+              type="button"
+              onClick={handleReset}
+              className="rounded border border-white/30 px-3 py-2 text-sm font-medium transition hover:border-ub-orange hover:text-ub-orange focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ub-orange"
+            >
+              Reset to defaults
+            </button>
+            <input
+              ref={fileInputRef}
+              id="settings-import"
+              type="file"
+              accept="application/json"
+              className="hidden"
+              onChange={handleImportChange}
+              required
+              aria-required="true"
+              aria-invalid={importError ? 'true' : 'false'}
+              aria-label="Import settings file"
+            />
+          </div>
+          {importError && (
+            <FormError id="settings-import-error" className="mt-0">
+              {importError}
+            </FormError>
+          )}
+          <p className="text-xs text-white/60">
+            Export bundles layout, theme, shortcuts, and accessibility preferences into a single
+            JSON file.
+          </p>
         </div>
       )}
     </div>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -89,6 +89,7 @@ export function Settings() {
                         checked={useKaliWallpaper}
                         onChange={(e) => setUseKaliWallpaper(e.target.checked)}
                         className="mr-2"
+                        aria-label="Use Kali gradient wallpaper"
                     />
                     Kali Gradient Wallpaper
                 </label>
@@ -135,6 +136,7 @@ export function Settings() {
                     value={fontScale}
                     onChange={(e) => setFontScale(parseFloat(e.target.value))}
                     className="ubuntu-slider"
+                    aria-label="Adjust font size"
                 />
             </div>
             <div className="flex justify-center my-4">
@@ -144,6 +146,7 @@ export function Settings() {
                         checked={reducedMotion}
                         onChange={(e) => setReducedMotion(e.target.checked)}
                         className="mr-2"
+                        aria-label="Enable reduced motion"
                     />
                     Reduced Motion
                 </label>
@@ -155,6 +158,7 @@ export function Settings() {
                         checked={largeHitAreas}
                         onChange={(e) => setLargeHitAreas(e.target.checked)}
                         className="mr-2"
+                        aria-label="Enable large hit areas"
                     />
                     Large Hit Areas
                 </label>
@@ -166,6 +170,7 @@ export function Settings() {
                         checked={highContrast}
                         onChange={(e) => setHighContrast(e.target.checked)}
                         className="mr-2"
+                        aria-label="Enable high contrast"
                     />
                     High Contrast
                 </label>
@@ -177,6 +182,7 @@ export function Settings() {
                         checked={allowNetwork}
                         onChange={(e) => setAllowNetwork(e.target.checked)}
                         className="mr-2"
+                        aria-label="Allow network requests"
                     />
                     Allow Network Requests
                 </label>
@@ -188,6 +194,7 @@ export function Settings() {
                         checked={haptics}
                         onChange={(e) => setHaptics(e.target.checked)}
                         className="mr-2"
+                        aria-label="Enable haptics"
                     />
                     Haptics
                 </label>
@@ -199,6 +206,7 @@ export function Settings() {
                         checked={pongSpin}
                         onChange={(e) => setPongSpin(e.target.checked)}
                         className="mr-2"
+                        aria-label="Enable pong spin"
                     />
                     Pong Spin
                 </label>
@@ -288,23 +296,26 @@ export function Settings() {
                 type="file"
                 accept="application/json"
                 ref={fileInput}
+                aria-label="Import settings file"
                 onChange={async (e) => {
                     const file = e.target.files && e.target.files[0];
                     if (!file) return;
                     const text = await file.text();
-                    await importSettingsData(text);
-                    try {
-                        const parsed = JSON.parse(text);
-                        if (parsed.accent !== undefined) setAccent(parsed.accent);
-                        if (parsed.wallpaper !== undefined) setWallpaper(parsed.wallpaper);
-                        if (parsed.density !== undefined) setDensity(parsed.density);
-                        if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
-                        if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
-                        if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
-                        if (parsed.theme !== undefined) { setTheme(parsed.theme); }
-                    } catch (err) {
-                        console.error('Invalid settings', err);
+                    const result = await importSettingsData(text);
+                    if (!result?.success) {
+                        console.error(result?.error || 'Invalid settings file');
+                        e.target.value = '';
+                        return;
                     }
+                    const preferences = result.data?.preferences || {};
+                    if (preferences.accent !== undefined) setAccent(preferences.accent);
+                    if (preferences.wallpaper !== undefined) setWallpaper(preferences.wallpaper);
+                    if (preferences.density !== undefined) setDensity(preferences.density);
+                    if (preferences.reducedMotion !== undefined) setReducedMotion(preferences.reducedMotion);
+                    if (preferences.largeHitAreas !== undefined) setLargeHitAreas(preferences.largeHitAreas);
+                    if (preferences.highContrast !== undefined) setHighContrast(preferences.highContrast);
+                    if (preferences.theme !== undefined) { setTheme(preferences.theme); }
+                    if (preferences.useKaliWallpaper !== undefined) setUseKaliWallpaper(preferences.useKaliWallpaper);
                     e.target.value = '';
                 }}
                 className="hidden"

--- a/test-log.md
+++ b/test-log.md
@@ -37,3 +37,9 @@ Attempted to load each route under `/apps` in Chromium, Firefox, and WebKit. All
 
 - Development middleware now appends `'unsafe-eval'` to `script-src` when `NODE_ENV !== 'production'` so the Next.js dev bundle can run inside headless browsers (e.g., Playwright) and capture screenshots.
 - Removed the manual note that explained screenshots were unavailable due to the stricter dev CSP; the automation workaround is no longer needed.
+## Settings import/export QA (2025-09-30)
+
+- `yarn lint`
+- `yarn test __tests__/settingsStore.test.ts --runInBand`
+
+Both commands completed without new errors. Full `yarn test` continues to fail due to existing unrelated suites.


### PR DESCRIPTION
## Summary
- add export, import, and reset controls to the settings drawer with confirmations, inline errors, and success toasts
- expand the settings store helpers to bundle layout, shortcuts, and preferences while enforcing validation and reset behavior
- update settings apps to consume the richer import payload and log recent lint/test verification in the repository test log
- add regression tests covering settings export/import round-trips and defaults restoration

## Testing
- yarn lint
- yarn test __tests__/settingsStore.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dc2664ebf88328af3dd2dc6693fcdd