### PR TITLE
[settings] Lockable themes UI

### DIFF
--- a/__tests__/SettingsDrawer.test.tsx
+++ b/__tests__/SettingsDrawer.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SettingsDrawer from '../components/SettingsDrawer';
+import { useSettings } from '../hooks/useSettings';
+
+jest.mock('../hooks/useSettings', () => {
+  const actual = jest.requireActual('../hooks/useSettings');
+  return {
+    ...actual,
+    useSettings: jest.fn(),
+  };
+});
+
+const mockUseSettings = useSettings as jest.MockedFunction<typeof useSettings>;
+
+const setupSettingsMock = () => {
+  const setTheme = jest.fn();
+  const setAccent = jest.fn();
+  mockUseSettings.mockReturnValue({
+    accent: '#1793d1',
+    setAccent,
+    theme: 'default',
+    setTheme,
+  } as unknown as ReturnType<typeof useSettings>);
+  return { setTheme, setAccent };
+};
+
+describe('SettingsDrawer theme locks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders locked themes as disabled with guidance', async () => {
+    const user = userEvent.setup();
+    setupSettingsMock();
+
+    render(<SettingsDrawer highScore={0} />);
+    await user.click(screen.getByRole('button', { name: /settings/i }));
+
+    const neonLock = screen.getByRole('button', {
+      name: /neon theme locked/i,
+    });
+    expect(neonLock).toBeDisabled();
+    expect(neonLock).toHaveAttribute('data-locked', 'true');
+    expect(neonLock).toHaveAttribute(
+      'title',
+      expect.stringContaining('Reach 100 points')
+    );
+    expect(
+      screen.getByText(/Beat the required high score/i)
+    ).toBeInTheDocument();
+  });
+
+  test('updates unlocks when the high score increases', async () => {
+    const user = userEvent.setup();
+    const { setTheme } = setupSettingsMock();
+
+    const view = render(<SettingsDrawer highScore={0} />);
+    await user.click(screen.getByRole('button', { name: /settings/i }));
+
+    expect(
+      screen.getByRole('button', { name: /neon theme locked/i })
+    ).toBeDisabled();
+
+    view.rerender(<SettingsDrawer highScore={150} />);
+
+    const neonOption = await screen.findByRole('radio', {
+      name: /neon theme/i,
+    });
+    expect(neonOption).toHaveAttribute('aria-checked', 'false');
+    await user.click(neonOption);
+    expect(setTheme).toHaveBeenCalledWith('neon');
+    expect(
+      screen.queryByRole('button', { name: /neon theme locked/i })
+    ).not.toBeInTheDocument();
+  });
+
+  test('locked preview reflects the current high score in its message', async () => {
+    const user = userEvent.setup();
+    setupSettingsMock();
+
+    render(<SettingsDrawer highScore={50} />);
+    await user.click(screen.getByRole('button', { name: /settings/i }));
+
+    const guidance = screen.getAllByText(/Current high score: 50\./i);
+    expect(guidance.length).toBeGreaterThan(0);
+    guidance.forEach((node) => {
+      expect(node).toBeVisible();
+    });
+  });
+});

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,15 +1,59 @@
-import { useState } from 'react';
-import { getUnlockedThemes } from '../utils/theme';
+import { useMemo, useState } from 'react';
+import { THEME_UNLOCKS, isThemeUnlocked } from '../utils/theme';
 import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
 
 interface Props {
   highScore?: number;
 }
 
+type ThemeEntry = {
+  id: string;
+  label: string;
+  requiredScore: number;
+};
+
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
-  const unlocked = getUnlockedThemes(highScore);
   const { accent, setAccent, theme, setTheme } = useSettings();
+
+  const { unlockedThemes, lockedThemes } = useMemo(() => {
+    const sortedThemes = Object.entries(THEME_UNLOCKS).sort(
+      ([nameA, scoreA], [nameB, scoreB]) =>
+        scoreA - scoreB || nameA.localeCompare(nameB)
+    );
+
+    const partitioned = sortedThemes.reduce(
+      (acc, [themeName, requiredScore]) => {
+        const unlocked = isThemeUnlocked(themeName, highScore);
+        const entry = {
+          id: themeName,
+          label: themeName.charAt(0).toUpperCase() + themeName.slice(1),
+          requiredScore,
+        };
+
+        if (unlocked) {
+          acc.unlocked.push(entry);
+        } else {
+          acc.locked.push(entry);
+        }
+
+        return acc;
+      },
+      { unlocked: [] as ThemeEntry[], locked: [] as ThemeEntry[] }
+    );
+
+    return {
+      unlockedThemes: partitioned.unlocked,
+      lockedThemes: partitioned.locked,
+    };
+  }, [highScore]);
+
+  const handleThemeSelect = (value: string) => {
+    if (theme === value) return;
+    const available = unlockedThemes.some((entry) => entry.id === value);
+    if (!available) return;
+    setTheme(value);
+  };
 
   return (
     <div>
@@ -20,18 +64,68 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
         <div role="dialog">
           <label>
             Theme
-            <select
-              aria-label="theme-select"
-              value={theme}
-              onChange={(e) => setTheme(e.target.value)}
+            <div
+              role="radiogroup"
+              aria-label="unlocked-themes"
+              className="flex flex-wrap gap-2 mt-1"
             >
-              {unlocked.map((t) => (
-                <option key={t} value={t}>
-                  {t}
-                </option>
+              {unlockedThemes.map(({ id, label }) => (
+                <button
+                  key={id}
+                  type="button"
+                  role="radio"
+                  aria-checked={theme === id}
+                  aria-label={`${label} theme`}
+                  className={`px-3 py-2 rounded border transition-colors ${
+                    theme === id
+                      ? 'bg-white/10 border-white/40'
+                      : 'bg-black/10 border-white/10 hover:border-white/30'
+                  }`}
+                  title={`Switch to the ${label} theme`}
+                  onClick={() => handleThemeSelect(id)}
+                >
+                  <span className="block text-sm font-medium">{label}</span>
+                  {theme === id && (
+                    <span className="sr-only">(selected)</span>
+                  )}
+                </button>
               ))}
-            </select>
+            </div>
           </label>
+          {lockedThemes.length > 0 && (
+            <div className="mt-4" aria-label="locked-themes">
+              <p className="text-sm font-semibold">Locked themes</p>
+              <p className="text-xs text-white/70">
+                Beat the required high score to unlock additional looks.
+              </p>
+              <div className="flex flex-wrap gap-2 mt-2">
+                {lockedThemes.map(({ id, label, requiredScore }) => {
+                  const message = `Reach ${requiredScore} points to unlock the ${label} theme. Current high score: ${highScore}.`;
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      aria-label={`${label} theme locked. Reach ${requiredScore} points to unlock.`}
+                      className="px-3 py-2 rounded border border-dashed border-white/20 bg-black/30 text-left flex flex-col gap-1 opacity-60 cursor-not-allowed"
+                      title={message}
+                      aria-disabled="true"
+                      disabled
+                      data-locked="true"
+                    >
+                      <span className="flex items-center gap-2 text-sm font-medium">
+                        <span aria-hidden="true">🔒</span>
+                        <span>{label}</span>
+                      </span>
+                      <span className="text-xs text-white/80">
+                        Reach {requiredScore} points to unlock. Current high score:{' '}
+                        {highScore}.
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
           <label>
             Accent
             <div


### PR DESCRIPTION
## Summary
- split the settings drawer theme selector into unlocked radios and locked previews with tooltip guidance
- disable interaction on locked themes while surfacing unlock instructions and a disabled preview style
- add unit tests covering locked state rendering and dynamic unlocks based on the current high score

## Testing
- yarn test SettingsDrawer.test.tsx
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc266695a88328bb98f0bcab1ff055