### PR TITLE
[notifications] add quiet hours scheduling and DND controls

### DIFF
--- a/__tests__/notificationCenter.quietHours.test.tsx
+++ b/__tests__/notificationCenter.quietHours.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import NotificationCenter from '../components/common/NotificationCenter';
+import { useNotifications } from '../hooks/useNotifications';
+
+const NotificationsHarness = React.forwardRef<
+  ReturnType<typeof useNotifications> | null,
+  Record<string, never>
+>((_, ref) => {
+  const ctx = useNotifications();
+  React.useImperativeHandle(ref, () => ctx, [ctx]);
+  return null;
+});
+
+NotificationsHarness.displayName = 'NotificationsHarness';
+
+describe('NotificationCenter quiet hours queue', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-04-01T23:15:00'));
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('releases queued notifications after quiet hours end', () => {
+    const ref = React.createRef<ReturnType<typeof useNotifications>>();
+
+    render(
+      <NotificationCenter>
+        <NotificationsHarness ref={ref} />
+      </NotificationCenter>,
+    );
+
+    const ctx = () => {
+      if (!ref.current) {
+        throw new Error('Notifications context not ready');
+      }
+      return ref.current;
+    };
+
+    act(() => {
+      ctx().setQuietHours(prev => ({ ...prev, enabled: true, start: '22:00', end: '07:00' }));
+    });
+
+    act(() => {
+      ctx().pushNotification({ appId: 'queued-app', title: 'Nightly result' });
+    });
+
+    expect(ctx().notifications).toHaveLength(0);
+
+    jest.setSystemTime(new Date('2024-04-02T07:05:00'));
+
+    act(() => {
+      jest.advanceTimersByTime(60_000);
+    });
+
+    expect(ctx().notifications).toHaveLength(1);
+    expect(ctx().notifications[0]).toMatchObject({
+      appId: 'queued-app',
+      title: 'Nightly result',
+    });
+  });
+});

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -5,6 +5,7 @@ export type {
   AppNotification,
   PushNotificationInput,
   NotificationPriority,
+  QuietHoursSettings,
 } from '../components/common/NotificationCenter';
 export type {
   ClassificationResult,


### PR DESCRIPTION
## Summary
- extend the notification context with quiet hours scheduling, DND persistence, and queued delivery
- add settings UI in the bell dropdown to manage quiet hours, toggle DND, and surface muted status
- cover the queue release behavior with a quiet hours unit test

## Testing
- yarn test __tests__/notificationCenter.quietHours.test.tsx --watchAll=false
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc266983f48328a473636bcc956503