### PR TITLE
[settings] add shortcut editor with chord support

### DIFF
--- a/__tests__/apps/settings/shortcutParser.test.ts
+++ b/__tests__/apps/settings/shortcutParser.test.ts
@@ -1,0 +1,42 @@
+import {
+  keyboardEventToShortcut,
+  normalizeShortcutString,
+  normalizeShortcutTokens,
+} from '../../../apps/settings/utils/shortcutParser';
+
+describe('normalizeShortcutString', () => {
+  it('orders modifiers and uppercases letters', () => {
+    expect(normalizeShortcutString('shift + ctrl + a')).toBe('Ctrl+Shift+A');
+  });
+
+  it('deduplicates modifiers and trims whitespace', () => {
+    expect(normalizeShortcutString('Ctrl + alt + Ctrl + K')).toBe('Ctrl+Alt+K');
+  });
+
+  it('normalizes meta aliases and special keys', () => {
+    expect(normalizeShortcutString('cmd + option + space')).toBe('Alt+Meta+Space');
+  });
+
+  it('handles function keys and punctuation', () => {
+    expect(normalizeShortcutString('f5')).toBe('F5');
+    expect(normalizeShortcutString('ctrl + ,')).toBe('Ctrl+,');
+  });
+});
+
+describe('normalizeShortcutTokens', () => {
+  it('drops empty tokens', () => {
+    expect(normalizeShortcutTokens(['', 'ctrl', 'A'])).toBe('Ctrl+A');
+  });
+});
+
+describe('keyboardEventToShortcut', () => {
+  it('builds chords from keyboard events', () => {
+    const event = new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, altKey: true });
+    expect(keyboardEventToShortcut(event)).toBe('Ctrl+Alt+K');
+  });
+
+  it('captures modifier-only chords', () => {
+    const event = new KeyboardEvent('keydown', { key: 'Control', ctrlKey: true });
+    expect(keyboardEventToShortcut(event)).toBe('Ctrl');
+  });
+});

--- a/apps/settings/components/KeymapOverlay.tsx
+++ b/apps/settings/components/KeymapOverlay.tsx
@@ -1,51 +1,14 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import useKeymap from '../keymapRegistry';
+import ShortcutEditor from './ShortcutEditor';
 
 interface KeymapOverlayProps {
   open: boolean;
   onClose: () => void;
 }
 
-const formatEvent = (e: KeyboardEvent) => {
-  const parts = [
-    e.ctrlKey ? 'Ctrl' : '',
-    e.altKey ? 'Alt' : '',
-    e.shiftKey ? 'Shift' : '',
-    e.metaKey ? 'Meta' : '',
-    e.key.length === 1 ? e.key.toUpperCase() : e.key,
-  ];
-  return parts.filter(Boolean).join('+');
-};
-
 export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
-  const { shortcuts, updateShortcut } = useKeymap();
-  const [rebinding, setRebinding] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!rebinding) return;
-    const handler = (e: KeyboardEvent) => {
-      e.preventDefault();
-      const combo = formatEvent(e);
-      updateShortcut(rebinding, combo);
-      setRebinding(null);
-    };
-    window.addEventListener('keydown', handler, { once: true });
-    return () => window.removeEventListener('keydown', handler);
-  }, [rebinding, updateShortcut]);
-
   if (!open) return null;
-
-  const keyCounts = shortcuts.reduce<Map<string, number>>((map, s) => {
-    map.set(s.keys, (map.get(s.keys) || 0) + 1);
-    return map;
-  }, new Map());
-  const conflicts = new Set(
-    Array.from(keyCounts.entries())
-      .filter(([, count]) => count > 1)
-      .map(([key]) => key)
-  );
 
   return (
     <div
@@ -59,7 +22,6 @@ export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
           <button
             type="button"
             onClick={() => {
-              setRebinding(null);
               onClose();
             }}
             className="text-sm underline"
@@ -67,29 +29,7 @@ export default function KeymapOverlay({ open, onClose }: KeymapOverlayProps) {
             Close
           </button>
         </div>
-        <ul className="space-y-1">
-          {shortcuts.map((s) => (
-            <li
-              key={s.description}
-              data-conflict={conflicts.has(s.keys) ? 'true' : 'false'}
-              className={
-                conflicts.has(s.keys)
-                  ? 'flex justify-between bg-red-600/70 px-2 py-1 rounded'
-                  : 'flex justify-between px-2 py-1'
-              }
-            >
-              <span className="flex-1">{s.description}</span>
-              <span className="font-mono mr-2">{s.keys}</span>
-              <button
-                type="button"
-                onClick={() => setRebinding(s.description)}
-                className="px-2 py-1 bg-ub-orange text-white rounded text-sm"
-              >
-                {rebinding === s.description ? 'Press keys...' : 'Rebind'}
-              </button>
-            </li>
-          ))}
-        </ul>
+        <ShortcutEditor />
       </div>
     </div>
   );

--- a/apps/settings/components/ShortcutEditor.tsx
+++ b/apps/settings/components/ShortcutEditor.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import useKeymap from '../keymapRegistry';
+import { keyboardEventToShortcut } from '../utils/shortcutParser';
+
+interface ShortcutEditorProps {
+  className?: string;
+}
+
+type ConflictMap = Map<string, string[]>;
+
+const buildConflictMap = (entries: { description: string; keys: string }[]) => {
+  const map: ConflictMap = new Map();
+  entries.forEach(({ description, keys }) => {
+    if (!keys) return;
+    const existing = map.get(keys) ?? [];
+    existing.push(description);
+    map.set(keys, existing);
+  });
+  return map;
+};
+
+export default function ShortcutEditor({ className }: ShortcutEditorProps) {
+  const { shortcuts, updateShortcut, resetShortcut } = useKeymap();
+  const [recording, setRecording] = useState<string | null>(null);
+
+  const conflicts = useMemo(() => buildConflictMap(shortcuts), [shortcuts]);
+
+  const handleReset = useCallback(
+    (description: string) => {
+      resetShortcut(description);
+      setRecording((active) => (active === description ? null : active));
+    },
+    [resetShortcut]
+  );
+
+  return (
+    <div className={className}>
+      <p className="text-sm text-ubt-grey">
+        Click a shortcut, then press the desired keys. Press Esc to cancel without saving.
+      </p>
+      <ul className="mt-4 space-y-3">
+        {shortcuts.map((shortcut) => {
+          const { description, keys, defaultKeys, isDefault } = shortcut;
+          const conflictEntries = conflicts.get(keys) ?? [];
+          const conflictWith = conflictEntries.filter((name) => name !== description);
+          const hasConflict = conflictWith.length > 0;
+          const isRecording = recording === description;
+
+          return (
+            <li key={description} data-conflict={hasConflict ? 'true' : 'false'}>
+              <div
+                className={`rounded-lg border p-3 transition-colors ${
+                  hasConflict
+                    ? 'border-red-500/70 bg-red-500/10'
+                    : 'border-gray-700/70 bg-black/40'
+                }`}
+              >
+                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold text-white">{description}</p>
+                    <p className="text-xs text-ubt-grey">
+                      Default: <span className="font-mono">{defaultKeys}</span>
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="text"
+                      readOnly
+                      value={isRecording ? 'Press keys…' : keys}
+                      onFocus={() => setRecording(description)}
+                      onBlur={() =>
+                        setRecording((current) =>
+                          current === description ? null : current
+                        )
+                      }
+                      onKeyDown={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+
+                        if (event.key === 'Escape') {
+                          setRecording(null);
+                          event.currentTarget.blur();
+                          return;
+                        }
+
+                        const chord = keyboardEventToShortcut(event.nativeEvent);
+                        if (!chord) return;
+                        updateShortcut(description, chord);
+                        setRecording(null);
+                        event.currentTarget.blur();
+                      }}
+                      aria-label={`Shortcut for ${description}`}
+                      className={`w-40 rounded border px-2 py-1 font-mono text-sm text-white outline-none focus:ring-2 focus:ring-ub-orange ${
+                        isRecording
+                          ? 'border-ub-orange bg-black/40'
+                          : 'border-gray-600 bg-black/60'
+                      }`}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleReset(description)}
+                      disabled={isDefault}
+                      className={`rounded border px-2 py-1 text-xs transition-colors ${
+                        isDefault
+                          ? 'cursor-not-allowed border-gray-600 text-gray-500'
+                          : 'border-ub-orange text-ub-orange hover:bg-ub-orange hover:text-white'
+                      }`}
+                    >
+                      Reset
+                    </button>
+                  </div>
+                </div>
+                {hasConflict && (
+                  <div className="mt-3 space-y-2 rounded border border-red-500/60 bg-red-500/10 p-3 text-xs text-red-100">
+                    <p>
+                      Conflicts with{' '}
+                      {conflictWith.map((name, index) => (
+                        <span key={name} className="font-semibold">
+                          {index > 0 ? ', ' : ''}
+                          {name}
+                        </span>
+                      ))}
+                      .
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleReset(description)}
+                        className="rounded border border-red-300 px-2 py-1 text-xs text-red-100 hover:bg-red-500/30"
+                      >
+                        Reset this action
+                      </button>
+                      {conflictWith.map((name) => (
+                        <button
+                          key={name}
+                          type="button"
+                          onClick={() => handleReset(name)}
+                          className="rounded border border-red-300 px-2 py-1 text-xs text-red-100 hover:bg-red-500/30"
+                        >
+                          Reset {name}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -1,14 +1,38 @@
+import { useEffect, useMemo } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
+import { normalizeShortcutString } from './utils/shortcutParser';
 
-export interface Shortcut {
+interface ShortcutDefinition {
   description: string;
   keys: string;
 }
 
-const DEFAULT_SHORTCUTS: Shortcut[] = [
+export interface Shortcut {
+  description: string;
+  keys: string;
+  defaultKeys: string;
+  isDefault: boolean;
+}
+
+const DEFAULT_SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
 ];
+
+export const DEFAULT_SHORTCUTS = DEFAULT_SHORTCUT_DEFINITIONS.map(
+  ({ description, keys }) => ({
+    description,
+    keys: normalizeShortcutString(keys),
+  })
+);
+
+const DEFAULT_SHORTCUT_MAP = DEFAULT_SHORTCUTS.reduce<Record<string, string>>(
+  (acc, shortcut) => {
+    acc[shortcut.description] = shortcut.keys;
+    return acc;
+  },
+  {}
+);
 
 const validator = (value: unknown): value is Record<string, string> => {
   return (
@@ -22,29 +46,59 @@ const validator = (value: unknown): value is Record<string, string> => {
 };
 
 export function useKeymap() {
-  const initial = DEFAULT_SHORTCUTS.reduce<Record<string, string>>(
-    (acc, s) => {
-      acc[s.description] = s.keys;
-      return acc;
-    },
-    {}
-  );
-
   const [map, setMap] = usePersistentState<Record<string, string>>(
     'keymap',
-    initial,
+    DEFAULT_SHORTCUT_MAP,
     validator
   );
 
-  const shortcuts = DEFAULT_SHORTCUTS.map(({ description, keys }) => ({
-    description,
-    keys: map[description] || keys,
-  }));
+  useEffect(() => {
+    const updates: Record<string, string> = {};
+    let changed = false;
+    Object.entries(map).forEach(([description, value]) => {
+      if (typeof value !== 'string') return;
+      const normalized = normalizeShortcutString(value);
+      if (normalized && normalized !== value) {
+        updates[description] = normalized;
+        changed = true;
+      }
+    });
+    if (changed) {
+      setMap((prev) => ({ ...prev, ...updates }));
+    }
+  }, [map, setMap]);
 
-  const updateShortcut = (description: string, keys: string) =>
-    setMap({ ...map, [description]: keys });
+  const shortcuts = useMemo(
+    () =>
+      DEFAULT_SHORTCUTS.map(({ description, keys: defaultKeys }) => {
+        const stored = map[description];
+        const normalized = stored
+          ? normalizeShortcutString(stored)
+          : defaultKeys;
+        const resolved = normalized || defaultKeys;
+        return {
+          description,
+          keys: resolved,
+          defaultKeys,
+          isDefault: resolved === defaultKeys,
+        };
+      }),
+    [map]
+  );
 
-  return { shortcuts, updateShortcut };
+  const updateShortcut = (description: string, keys: string) => {
+    const normalized = normalizeShortcutString(keys);
+    if (!normalized) return;
+    setMap((prev) => ({ ...prev, [description]: normalized }));
+  };
+
+  const resetShortcut = (description: string) => {
+    const defaultValue = DEFAULT_SHORTCUT_MAP[description];
+    if (!defaultValue) return;
+    setMap((prev) => ({ ...prev, [description]: defaultValue }));
+  };
+
+  return { shortcuts, updateShortcut, resetShortcut };
 }
 
 export default useKeymap;

--- a/apps/settings/utils/shortcutParser.ts
+++ b/apps/settings/utils/shortcutParser.ts
@@ -1,0 +1,128 @@
+export const MODIFIER_ORDER = ['Ctrl', 'Alt', 'Shift', 'Meta'] as const;
+
+type Modifier = (typeof MODIFIER_ORDER)[number];
+
+const MODIFIER_ALIASES: Record<string, Modifier> = {
+  ctrl: 'Ctrl',
+  control: 'Ctrl',
+  option: 'Alt',
+  alt: 'Alt',
+  shift: 'Shift',
+  meta: 'Meta',
+  cmd: 'Meta',
+  command: 'Meta',
+  super: 'Meta',
+  win: 'Meta',
+};
+
+const SPECIAL_KEYS: Record<string, string> = {
+  '': '',
+  ' ': 'Space',
+  space: 'Space',
+  escape: 'Escape',
+  esc: 'Escape',
+  enter: 'Enter',
+  return: 'Enter',
+  tab: 'Tab',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  del: 'Delete',
+  insert: 'Insert',
+  home: 'Home',
+  end: 'End',
+  pageup: 'PageUp',
+  pagedown: 'PageDown',
+  arrowup: 'ArrowUp',
+  arrowdown: 'ArrowDown',
+  arrowleft: 'ArrowLeft',
+  arrowright: 'ArrowRight',
+};
+
+const isModifier = (token: string): token is Modifier =>
+  MODIFIER_ORDER.includes(token as Modifier);
+
+const normalizePrimaryKey = (token: string | undefined): string => {
+  if (!token) return '';
+  const trimmed = token.trim();
+  if (!trimmed) return '';
+  const lower = trimmed.toLowerCase();
+  if (lower in SPECIAL_KEYS) {
+    return SPECIAL_KEYS[lower];
+  }
+  if (/^f\d{1,2}$/i.test(trimmed)) {
+    return trimmed.toUpperCase();
+  }
+  if (lower.startsWith('arrow')) {
+    const direction = lower.slice('arrow'.length);
+    if (direction) {
+      return `Arrow${direction.charAt(0).toUpperCase()}${direction.slice(1)}`;
+    }
+  }
+  if (trimmed.length === 1) {
+    return trimmed.toUpperCase();
+  }
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+};
+
+const normalizeToken = (token: string): Modifier | string => {
+  const trimmed = token.trim();
+  if (!trimmed) return '';
+  const lower = trimmed.toLowerCase();
+  if (lower in MODIFIER_ALIASES) {
+    return MODIFIER_ALIASES[lower];
+  }
+  if (isModifier(trimmed as Modifier)) {
+    return trimmed as Modifier;
+  }
+  return normalizePrimaryKey(trimmed);
+};
+
+export const normalizeShortcutTokens = (tokens: string[]): string => {
+  const modifierSet = new Set<Modifier>();
+  let primary = '';
+
+  tokens.forEach((token) => {
+    const normalized = normalizeToken(token);
+    if (!normalized) return;
+    if (isModifier(normalized)) {
+      modifierSet.add(normalized);
+      return;
+    }
+    primary = normalized;
+  });
+
+  const parts = MODIFIER_ORDER.filter((modifier) => modifierSet.has(modifier));
+  if (primary) {
+    parts.push(primary);
+  }
+  return parts.join('+');
+};
+
+export const normalizeShortcutString = (value: string): string => {
+  if (!value) return '';
+  const tokens = value
+    .split('+')
+    .map((token) => token.trim())
+    .filter(Boolean);
+  return normalizeShortcutTokens(tokens);
+};
+
+export const keyboardEventToShortcut = (event: KeyboardEvent): string => {
+  const tokens: string[] = [];
+  if (event.ctrlKey) tokens.push('Ctrl');
+  if (event.altKey) tokens.push('Alt');
+  if (event.shiftKey) tokens.push('Shift');
+  if (event.metaKey) tokens.push('Meta');
+
+  const key = event.key;
+  const modifierKey = key === 'Control' || key === 'Shift' || key === 'Alt' || key === 'Meta';
+
+  if (!modifierKey || tokens.length === 0) {
+    tokens.push(key);
+  }
+
+  const combo = normalizeShortcutTokens(tokens);
+  return combo;
+};
+
+export default keyboardEventToShortcut;

--- a/components/common/ShortcutOverlay.tsx
+++ b/components/common/ShortcutOverlay.tsx
@@ -2,17 +2,7 @@
 
 import React, { useEffect, useState, useCallback } from 'react';
 import useKeymap from '../../apps/settings/keymapRegistry';
-
-const formatEvent = (e: KeyboardEvent) => {
-  const parts = [
-    e.ctrlKey ? 'Ctrl' : '',
-    e.altKey ? 'Alt' : '',
-    e.shiftKey ? 'Shift' : '',
-    e.metaKey ? 'Meta' : '',
-    e.key.length === 1 ? e.key.toUpperCase() : e.key,
-  ];
-  return parts.filter(Boolean).join('+');
-};
+import { keyboardEventToShortcut } from '../../apps/settings/utils/shortcutParser';
 
 const ShortcutOverlay: React.FC = () => {
   const [open, setOpen] = useState(false);
@@ -31,7 +21,7 @@ const ShortcutOverlay: React.FC = () => {
       const show =
         shortcuts.find((s) => s.description === 'Show keyboard shortcuts')?.keys ||
         '?';
-      if (formatEvent(e) === show) {
+      if (keyboardEventToShortcut(e) === show) {
         e.preventDefault();
         toggle();
       } else if (e.key === 'Escape' && open) {


### PR DESCRIPTION
## Summary
- add a ShortcutEditor surface for recording shortcuts with conflict messaging and per-action resets
- normalize stored shortcut chords and expose metadata via useKeymap while reusing the editor inside the keymap overlay
- share a shortcut parser utility with updated overlays and add unit tests for chord normalization

## Testing
- yarn lint
- yarn test --runTestsByPath __tests__/apps/settings/shortcutParser.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68dc266968188328ad6aa35051fece3c