### PR TITLE
[desktop] Enhance file explorer context actions

### DIFF
--- a/__tests__/fileExplorerUtils.test.ts
+++ b/__tests__/fileExplorerUtils.test.ts
@@ -1,0 +1,172 @@
+import { renameEntryHandle, serializeEntry, restoreSerializedEntry } from '../components/apps/file-explorer';
+
+describe('file explorer helpers', () => {
+  class MockWritable {
+    private handle: MockFileHandle;
+
+    constructor(handle: MockFileHandle) {
+      this.handle = handle;
+    }
+
+    async write(data: Uint8Array | string | MockFile): Promise<void> {
+      if (data instanceof MockFile) {
+        const buffer = await data.arrayBuffer();
+        this.handle.data = new Uint8Array(buffer);
+        return;
+      }
+      if (typeof data === 'string') {
+        this.handle.data = new TextEncoder().encode(data);
+        return;
+      }
+      this.handle.data = new Uint8Array(data);
+    }
+
+    async close(): Promise<void> {
+      // no-op
+    }
+  }
+
+  class MockFile {
+    private buffer: Uint8Array;
+    readonly name: string;
+
+    constructor(data: Uint8Array | string = new Uint8Array(), name = '') {
+      this.buffer = typeof data === 'string' ? new TextEncoder().encode(data) : new Uint8Array(data);
+      this.name = name;
+    }
+
+    async text(): Promise<string> {
+      return new TextDecoder().decode(this.buffer);
+    }
+
+    async arrayBuffer(): Promise<ArrayBuffer> {
+      return this.buffer.slice().buffer;
+    }
+  }
+
+  class MockFileHandle {
+    readonly kind = 'file';
+    name: string;
+    data: Uint8Array;
+
+    constructor(name: string, data: Uint8Array | string = new Uint8Array()) {
+      this.name = name;
+      this.data = typeof data === 'string' ? new TextEncoder().encode(data) : new Uint8Array(data);
+    }
+
+    async getFile(): Promise<MockFile> {
+      return new MockFile(this.data, this.name);
+    }
+
+    async createWritable(): Promise<MockWritable> {
+      return new MockWritable(this);
+    }
+  }
+
+  class MockDirectoryHandle {
+    readonly kind = 'directory';
+    name: string;
+    private entriesMap: Map<string, MockFileHandle | MockDirectoryHandle> = new Map();
+
+    constructor(name: string) {
+      this.name = name;
+    }
+
+    async getFileHandle(name: string, options: { create?: boolean } = {}): Promise<MockFileHandle> {
+      const entry = this.entriesMap.get(name);
+      if (entry) {
+        if (entry.kind !== 'file') throw new Error(`${name} is not a file`);
+        return entry;
+      }
+      if (options.create) {
+        const file = new MockFileHandle(name);
+        this.entriesMap.set(name, file);
+        return file;
+      }
+      throw new Error(`File ${name} not found`);
+    }
+
+    async getDirectoryHandle(name: string, options: { create?: boolean } = {}): Promise<MockDirectoryHandle> {
+      const entry = this.entriesMap.get(name);
+      if (entry) {
+        if (entry.kind !== 'directory') throw new Error(`${name} is not a directory`);
+        return entry;
+      }
+      if (options.create) {
+        const dir = new MockDirectoryHandle(name);
+        this.entriesMap.set(name, dir);
+        return dir;
+      }
+      throw new Error(`Directory ${name} not found`);
+    }
+
+    async removeEntry(name: string, options: { recursive?: boolean } = {}): Promise<void> {
+      const entry = this.entriesMap.get(name);
+      if (!entry) throw new Error(`Entry ${name} not found`);
+      if (entry.kind === 'directory' && entry.entriesMap.size > 0 && !options.recursive) {
+        throw new Error('Directory not empty');
+      }
+      this.entriesMap.delete(name);
+    }
+
+    async *entries(): AsyncGenerator<[string, MockFileHandle | MockDirectoryHandle]> {
+      for (const [name, handle] of this.entriesMap.entries()) {
+        yield [name, handle];
+      }
+    }
+  }
+
+  const setupDir = async () => {
+    const root = new MockDirectoryHandle('root');
+    const docs = await root.getDirectoryHandle('docs', { create: true });
+    const note = await docs.getFileHandle('notes.txt', { create: true });
+    note.data = new TextEncoder().encode('classified');
+    return { root, docs, note };
+  };
+
+  it('renames file handles while preserving contents', async () => {
+    const { root } = await setupDir();
+    const file = await root.getFileHandle('readme.txt', { create: true });
+    file.data = new TextEncoder().encode('hello world');
+    const entry = { name: 'readme.txt', handle: file } as const;
+
+    const renamed = await renameEntryHandle(root as any, entry as any, 'notes.txt');
+
+    await expect(root.getFileHandle('readme.txt')).rejects.toThrow('File readme.txt not found');
+    const newFile = await root.getFileHandle('notes.txt');
+    const contents = await newFile.getFile();
+    expect(await contents.text()).toBe('hello world');
+    expect((renamed as MockFileHandle).name).toBe('notes.txt');
+  });
+
+  it('renames directories recursively', async () => {
+    const { root, docs } = await setupDir();
+    const entry = { name: 'docs', handle: docs } as const;
+
+    const renamed = await renameEntryHandle(root as any, entry as any, 'archive');
+
+    await expect(root.getDirectoryHandle('docs')).rejects.toThrow('Directory docs not found');
+    const archive = await root.getDirectoryHandle('archive');
+    const restoredNote = await archive.getFileHandle('notes.txt');
+    const file = await restoredNote.getFile();
+    expect(await file.text()).toBe('classified');
+    expect((renamed as MockDirectoryHandle).name).toBe('archive');
+  });
+
+  it('serializes and restores entries for undo', async () => {
+    const { root, docs } = await setupDir();
+    const docEntry = { name: 'docs', handle: docs } as const;
+    const snapshot = await serializeEntry(docEntry as any);
+
+    await root.removeEntry('docs', { recursive: true });
+    await expect(root.getDirectoryHandle('docs')).rejects.toThrow('Directory docs not found');
+
+    await restoreSerializedEntry(snapshot as any, root as any);
+    const restored = await root.getDirectoryHandle('docs');
+    const restoredFile = await restored.getFileHandle('notes.txt');
+    const contents = await restoredFile.getFile();
+    expect(await contents.text()).toBe('classified');
+    expect(snapshot).toMatchObject({ type: 'directory', name: 'docs' });
+  });
+});
+

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 import { getDb } from '../../utils/safeIDB';
 import Breadcrumbs from '../ui/Breadcrumbs';
+import ContextMenu from '../common/ContextMenu';
 
 export async function openFileDialog(options = {}) {
   if (typeof window !== 'undefined' && window.showOpenFilePicker) {
@@ -105,6 +106,14 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
   const workerRef = useRef(null);
   const fallbackInputRef = useRef(null);
   const [locationError, setLocationError] = useState(null);
+  const contextTargetRef = useRef(null);
+  const renameInputRef = useRef(null);
+  const [contextSelection, setContextSelection] = useState(null);
+  const [focusedItem, setFocusedItem] = useState(null);
+  const [renaming, setRenaming] = useState(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState(null);
+  const [undoInfo, setUndoInfo] = useState(null);
 
   const hasWorker = typeof Worker !== 'undefined';
   const {
@@ -116,6 +125,13 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
     deleteFile: opfsDelete,
   } = useOPFS();
   const [unsavedDir, setUnsavedDir] = useState(null);
+
+  useEffect(() => {
+    if (renaming && renameInputRef.current) {
+      renameInputRef.current.focus();
+      renameInputRef.current.select();
+    }
+  }, [renaming]);
 
   useEffect(() => {
     const ok = !!window.showDirectoryPicker;
@@ -131,7 +147,7 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
       setPath([{ name: root.name || '/', handle: root }]);
       await readDir(root);
     })();
-  }, [opfsSupported, root, getDir]);
+  }, [opfsSupported, root, getDir, readDir]);
 
   const saveBuffer = async (name, data) => {
     if (unsavedDir) await opfsWrite(name, data, unsavedDir);
@@ -144,6 +160,163 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
 
   const removeBuffer = async (name) => {
     if (unsavedDir) await opfsDelete(name, unsavedDir);
+  };
+
+  const handleContextMenuCapture = (e) => {
+    const target = e.target instanceof HTMLElement ? e.target.closest('[data-entry]') : null;
+    if (!target) {
+      setContextSelection(null);
+    }
+  };
+
+  const handleKeyDownCapture = (e) => {
+    if (e.shiftKey && e.key === 'F10') {
+      if (focusedItem) {
+        setContextSelection(focusedItem);
+      } else {
+        setContextSelection(null);
+      }
+    }
+  };
+
+  const beginRename = (entry, type) => {
+    setRenaming({ entry, type });
+    setRenameValue(entry?.name ?? '');
+  };
+
+  const cancelRename = () => {
+    setRenaming(null);
+    setRenameValue('');
+  };
+
+  const submitRename = async () => {
+    if (!renaming || !dirHandle) {
+      cancelRename();
+      return;
+    }
+    const newName = renameValue.trim();
+    const originalName = renaming.entry?.name;
+    if (!newName || newName === originalName) {
+      cancelRename();
+      return;
+    }
+    try {
+      const newHandle = await renameEntryHandle(dirHandle, renaming.entry, newName);
+      if (unsavedDir && renaming.type === 'file') {
+        const buffer = await opfsRead(originalName, unsavedDir);
+        if (buffer !== null) {
+          await opfsWrite(newName, buffer, unsavedDir);
+          await opfsDelete(originalName, unsavedDir);
+        }
+      }
+      if (currentFile?.name === originalName && renaming.type === 'file') {
+        setCurrentFile({ ...currentFile, name: newName, handle: newHandle });
+      }
+      await readDir(dirHandle);
+      setContextSelection({ entry: { name: newName, handle: newHandle }, type: renaming.type });
+      setLocationError(null);
+      cancelRename();
+    } catch (err) {
+      const message = err?.message || `Unable to rename ${originalName}`;
+      setLocationError(message);
+    }
+  };
+
+  const handleRenameKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      submitRename();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      cancelRename();
+    }
+  };
+
+  const ensureUniqueName = async (baseName) => {
+    if (!dirHandle) return baseName;
+    const existing = new Set([...dirs, ...files].map((entry) => entry.name));
+    let candidate = baseName;
+    let counter = 1;
+    while (existing.has(candidate)) {
+      candidate = `${baseName} ${counter}`;
+      counter += 1;
+    }
+    return candidate;
+  };
+
+  const createFolder = async () => {
+    if (!dirHandle) return;
+    try {
+      const uniqueName = await ensureUniqueName('New Folder');
+      const newHandle = await dirHandle.getDirectoryHandle(uniqueName, { create: true });
+      await readDir(dirHandle);
+      const newEntry = { name: uniqueName, handle: newHandle };
+      setContextSelection({ entry: newEntry, type: 'directory' });
+      beginRename(newEntry, 'directory');
+      setLocationError(null);
+    } catch (err) {
+      setLocationError(err?.message || 'Unable to create folder');
+    }
+  };
+
+  const confirmDeleteEntry = (entry, type) => {
+    setConfirmDelete({ entry, type });
+  };
+
+  const performDelete = async () => {
+    if (!confirmDelete || !dirHandle) {
+      setConfirmDelete(null);
+      return;
+    }
+    const { entry, type } = confirmDelete;
+    try {
+      if (undoInfo && unsavedDir) {
+        await opfsDelete(undoInfo.bufferName, unsavedDir);
+      }
+      setUndoInfo(null);
+      let snapshot = null;
+      if (unsavedDir) {
+        snapshot = await serializeEntry(entry);
+      }
+      const bufferName = snapshot ? `deleted-${Date.now()}-${entry.name}.json` : null;
+      if (snapshot && unsavedDir && bufferName) {
+        await opfsWrite(bufferName, JSON.stringify(snapshot), unsavedDir);
+      }
+      await dirHandle.removeEntry(entry.name, { recursive: type === 'directory' });
+      if (currentFile?.name === entry.name && type === 'file') {
+        setCurrentFile(null);
+        setContent('');
+      }
+      await readDir(dirHandle);
+      if (bufferName && unsavedDir && snapshot) {
+        setUndoInfo({ bufferName, parent: dirHandle, originalName: entry.name });
+      }
+      setContextSelection(null);
+      setLocationError(null);
+    } catch (err) {
+      setLocationError(err?.message || `Unable to delete ${confirmDelete.entry.name}`);
+    } finally {
+      setConfirmDelete(null);
+    }
+  };
+
+  const undoDelete = async () => {
+    if (!undoInfo || !unsavedDir) return;
+    try {
+      const raw = await opfsRead(undoInfo.bufferName, unsavedDir);
+      if (!raw) {
+        setUndoInfo(null);
+        return;
+      }
+      const snapshot = JSON.parse(raw);
+      await restoreSerializedEntry(snapshot, undoInfo.parent);
+      await opfsDelete(undoInfo.bufferName, unsavedDir);
+      await readDir(undoInfo.parent);
+      setUndoInfo(null);
+      setLocationError(null);
+    } catch (err) {
+      setLocationError(err?.message || 'Unable to undo delete');
+    }
   };
 
   const openFallback = async (e) => {
@@ -315,7 +488,14 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
   if (!supported) {
     return (
       <div className="p-4 flex flex-col h-full">
-        <input ref={fallbackInputRef} type="file" onChange={openFallback} className="hidden" />
+        <input
+          ref={fallbackInputRef}
+          type="file"
+          onChange={openFallback}
+          className="hidden"
+          aria-hidden="true"
+          tabIndex={-1}
+        />
         {!currentFile && (
           <button
             onClick={() => fallbackInputRef.current?.click()}
@@ -324,16 +504,17 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
             Open File
           </button>
         )}
-        {currentFile && (
-          <>
-            <textarea
-              className="flex-1 mt-2 p-2 bg-ub-cool-grey outline-none"
-              value={content}
-              onChange={onChange}
-            />
-            <button
-              onClick={async () => {
-                const handle = await saveFileDialog({ suggestedName: currentFile.name });
+            {currentFile && (
+              <>
+                <textarea
+                  className="flex-1 mt-2 p-2 bg-ub-cool-grey outline-none"
+                  value={content}
+                  onChange={onChange}
+                  aria-label="File contents"
+                />
+                <button
+                  onClick={async () => {
+                    const handle = await saveFileDialog({ suggestedName: currentFile.name });
                 const writable = await handle.createWritable();
                 await writable.write(content);
                 await writable.close();
@@ -348,8 +529,24 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
     );
   }
 
+  const contextMenuItems = [
+    ...(contextSelection
+      ? [
+          {
+            label: 'Rename',
+            onSelect: () => beginRename(contextSelection.entry, contextSelection.type),
+          },
+          {
+            label: 'Delete',
+            onSelect: () => confirmDeleteEntry(contextSelection.entry, contextSelection.type),
+          },
+        ]
+      : []),
+    { label: 'New Folder', onSelect: createFolder },
+  ];
+
   return (
-    <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white text-sm">
+    <div className="w-full h-full flex flex-col bg-ub-cool-grey text-white text-sm relative">
       <div className="flex items-center space-x-2 p-2 bg-ub-warm-grey bg-opacity-40">
         <button onClick={openFolder} className="px-2 py-1 bg-black bg-opacity-50 rounded">
           Open Folder
@@ -372,7 +569,12 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
         )}
       </div>
       <div className="flex flex-1 overflow-hidden">
-        <div className="w-40 overflow-auto border-r border-gray-600">
+        <div
+          ref={contextTargetRef}
+          onContextMenuCapture={handleContextMenuCapture}
+          onKeyDownCapture={handleKeyDownCapture}
+          className="w-40 overflow-auto border-r border-gray-600"
+        >
           <div className="p-2 font-bold">Recent</div>
           {recent.map((r, i) => (
             <div
@@ -384,35 +586,107 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
             </div>
           ))}
           <div className="p-2 font-bold">Directories</div>
-          {dirs.map((d, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openDir(d)}
-            >
-              {d.name}
-            </div>
-          ))}
+          {dirs.map((d, i) => {
+            const isRenaming = renaming?.entry?.handle === d.handle;
+            if (isRenaming) {
+              const inputId = `rename-dir-${i}`;
+              return (
+                <div key={`dir-${i}`} className="px-2 py-1">
+                  <label htmlFor={inputId} className="sr-only">
+                    Rename directory {d.name}
+                  </label>
+                  <input
+                    id={inputId}
+                    ref={renameInputRef}
+                    data-entry="directory"
+                    type="text"
+                    aria-label={`Rename directory ${d.name}`}
+                    value={renameValue}
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onBlur={submitRename}
+                    onKeyDown={handleRenameKeyDown}
+                    className="w-full px-2 py-1 text-black"
+                  />
+                </div>
+              );
+            }
+            return (
+              <button
+                key={`dir-${i}`}
+                type="button"
+                data-entry="directory"
+                className="w-full text-left px-2 py-1 cursor-pointer hover:bg-black hover:bg-opacity-30 focus:outline-none focus:bg-black focus:bg-opacity-30"
+                onClick={() => openDir(d)}
+                onContextMenu={() => {
+                  setContextSelection({ entry: d, type: 'directory' });
+                  setFocusedItem({ entry: d, type: 'directory' });
+                }}
+                onFocus={() => setFocusedItem({ entry: d, type: 'directory' })}
+                onBlur={() => setFocusedItem(null)}
+              >
+                {d.name}
+              </button>
+            );
+          })}
           <div className="p-2 font-bold">Files</div>
-          {files.map((f, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openFile(f)}
-            >
-              {f.name}
-            </div>
-          ))}
+          {files.map((f, i) => {
+            const isRenaming = renaming?.entry?.handle === f.handle;
+            if (isRenaming) {
+              const inputId = `rename-file-${i}`;
+              return (
+                <div key={`file-${i}`} className="px-2 py-1">
+                  <label htmlFor={inputId} className="sr-only">
+                    Rename file {f.name}
+                  </label>
+                  <input
+                    id={inputId}
+                    ref={renameInputRef}
+                    data-entry="file"
+                    type="text"
+                    aria-label={`Rename file ${f.name}`}
+                    value={renameValue}
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onBlur={submitRename}
+                    onKeyDown={handleRenameKeyDown}
+                    className="w-full px-2 py-1 text-black"
+                  />
+                </div>
+              );
+            }
+            return (
+              <button
+                key={`file-${i}`}
+                type="button"
+                data-entry="file"
+                className="w-full text-left px-2 py-1 cursor-pointer hover:bg-black hover:bg-opacity-30 focus:outline-none focus:bg-black focus:bg-opacity-30"
+                onClick={() => openFile(f)}
+                onContextMenu={() => {
+                  setContextSelection({ entry: f, type: 'file' });
+                  setFocusedItem({ entry: f, type: 'file' });
+                }}
+                onFocus={() => setFocusedItem({ entry: f, type: 'file' })}
+                onBlur={() => setFocusedItem(null)}
+              >
+                {f.name}
+              </button>
+            );
+          })}
         </div>
         <div className="flex-1 flex flex-col">
-          {currentFile && (
-            <textarea className="flex-1 p-2 bg-ub-cool-grey outline-none" value={content} onChange={onChange} />
+            {currentFile && (
+            <textarea
+              className="flex-1 p-2 bg-ub-cool-grey outline-none"
+              value={content}
+              onChange={onChange}
+              aria-label="File contents"
+            />
           )}
           <div className="p-2 border-t border-gray-600">
             <input
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Find in files"
+              aria-label="Find in files"
               className="px-1 py-0.5 text-black"
             />
             <button onClick={runSearch} className="ml-2 px-2 py-1 bg-black bg-opacity-50 rounded">
@@ -428,6 +702,205 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
           </div>
         </div>
       </div>
+      {undoInfo && (
+        <div
+          role="status"
+          className="absolute bottom-3 left-1/2 -translate-x-1/2 bg-black bg-opacity-70 px-4 py-2 rounded flex items-center space-x-3 z-30"
+        >
+          <span>
+            Deleted &ldquo;{undoInfo.originalName}&rdquo;
+          </span>
+          <button
+            type="button"
+            className="px-2 py-1 bg-ub-warm-grey rounded text-black"
+            onClick={undoDelete}
+          >
+            Undo
+          </button>
+        </div>
+      )}
+      {confirmDelete && (
+        <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center z-40">
+          <div
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="file-explorer-delete-title"
+            aria-describedby="file-explorer-delete-desc"
+            className="bg-ub-warm-grey text-white p-4 rounded shadow-lg max-w-sm w-72"
+          >
+            <h2 id="file-explorer-delete-title" className="text-lg font-semibold">
+              Delete &ldquo;{confirmDelete.entry.name}&rdquo;?
+            </h2>
+            <p id="file-explorer-delete-desc" className="text-xs mt-2 text-gray-200">
+              The item will be moved to a temporary buffer so it can be restored while this window remains open.
+            </p>
+            <div className="mt-4 flex justify-end space-x-2">
+              <button
+                type="button"
+                className="px-3 py-1 rounded bg-black bg-opacity-40"
+                onClick={() => setConfirmDelete(null)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="px-3 py-1 rounded bg-red-600"
+                onClick={performDelete}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      <ContextMenu targetRef={contextTargetRef} items={contextMenuItems} />
     </div>
   );
+}
+
+async function entryExists(parentHandle, name) {
+  for await (const [existingName] of parentHandle.entries()) {
+    if (existingName === name) return true;
+  }
+  return false;
+}
+
+async function copyDirectoryRecursive(source, target) {
+  for await (const [name, handle] of source.entries()) {
+    if (handle.kind === 'file') {
+      const file = await handle.getFile();
+      const newFile = await target.getFileHandle(name, { create: true });
+      const writable = await newFile.createWritable();
+      await writable.write(file);
+      await writable.close();
+    } else if (handle.kind === 'directory') {
+      const child = await target.getDirectoryHandle(name, { create: true });
+      await copyDirectoryRecursive(handle, child);
+    }
+  }
+}
+
+export async function renameEntryHandle(parentHandle, entry, newName) {
+  if (!parentHandle || !entry?.handle) {
+    throw new Error('Invalid entry');
+  }
+  const trimmed = newName.trim();
+  if (!trimmed) {
+    throw new Error('Name cannot be empty');
+  }
+  if (/[\\/]/.test(trimmed)) {
+    throw new Error('Name cannot contain slashes');
+  }
+  if (entry.name === trimmed) {
+    return entry.handle;
+  }
+  if (await entryExists(parentHandle, trimmed)) {
+    throw new Error(`${trimmed} already exists`);
+  }
+  if (entry.handle.kind === 'file') {
+    const newHandle = await parentHandle.getFileHandle(trimmed, { create: true });
+    try {
+      const file = await entry.handle.getFile();
+      const writable = await newHandle.createWritable();
+      await writable.write(file);
+      await writable.close();
+      await parentHandle.removeEntry(entry.name);
+      return newHandle;
+    } catch (err) {
+      await parentHandle.removeEntry(trimmed).catch(() => {});
+      throw err;
+    }
+  }
+  if (entry.handle.kind === 'directory') {
+    const newDir = await parentHandle.getDirectoryHandle(trimmed, { create: true });
+    try {
+      await copyDirectoryRecursive(entry.handle, newDir);
+      await parentHandle.removeEntry(entry.name, { recursive: true });
+      return newDir;
+    } catch (err) {
+      await parentHandle.removeEntry(trimmed, { recursive: true }).catch(() => {});
+      throw err;
+    }
+  }
+  throw new Error('Unsupported entry type');
+}
+
+export async function serializeEntry(entry) {
+  if (!entry?.handle) return null;
+  if (entry.handle.kind === 'file') {
+    const file = await entry.handle.getFile();
+    const buffer = await file.arrayBuffer();
+    return {
+      type: 'file',
+      name: entry.name,
+      data: bufferToBase64(buffer),
+      encoding: 'base64',
+    };
+  }
+  if (entry.handle.kind === 'directory') {
+    const entries = [];
+    for await (const [name, handle] of entry.handle.entries()) {
+      const child = await serializeEntry({ name, handle });
+      if (child) entries.push(child);
+    }
+    return {
+      type: 'directory',
+      name: entry.name,
+      entries,
+    };
+  }
+  return null;
+}
+
+export async function restoreSerializedEntry(snapshot, parentHandle) {
+  if (!snapshot || !parentHandle) return;
+  if (snapshot.type === 'file') {
+    const fileHandle = await parentHandle.getFileHandle(snapshot.name, { create: true });
+    const writable = await fileHandle.createWritable();
+    if (snapshot.encoding === 'base64') {
+      const bytes = base64ToBuffer(snapshot.data ?? '');
+      await writable.write(bytes);
+    } else {
+      await writable.write(snapshot.data ?? '');
+    }
+    await writable.close();
+    return;
+  }
+  if (snapshot.type === 'directory') {
+    const dirHandle = await parentHandle.getDirectoryHandle(snapshot.name, { create: true });
+    for (const child of snapshot.entries || []) {
+      await restoreSerializedEntry(child, dirHandle);
+    }
+  }
+}
+
+function bufferToBase64(buffer) {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(buffer).toString('base64');
+  }
+  const uint = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < uint.length; i += 1) {
+    binary += String.fromCharCode(uint[i]);
+  }
+  if (typeof btoa === 'function') {
+    return btoa(binary);
+  }
+  throw new Error('Base64 encoding not supported in this environment');
+}
+
+function base64ToBuffer(base64) {
+  if (typeof Buffer !== 'undefined') {
+    return Uint8Array.from(Buffer.from(base64, 'base64'));
+  }
+  if (typeof atob === 'function') {
+    const binary = atob(base64);
+    const length = binary.length;
+    const bytes = new Uint8Array(length);
+    for (let i = 0; i < length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+  throw new Error('Base64 decoding not supported in this environment');
 }


### PR DESCRIPTION
## Summary
- wire the file explorer list to the shared context menu with inline rename, delete confirmation/undo, and new-folder actions
- add OPFS helpers for renaming entries and buffering serialized snapshots for undo flows
- cover rename and delete behaviours with unit tests against mocked OPFS handles

## Testing
- yarn test fileExplorerUtils
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc266c9bbc8328adcf7243ccabbaef