### PR TITLE
Improve File Explorer recents navigation

### DIFF
--- a/__tests__/fileExplorerRecents.test.ts
+++ b/__tests__/fileExplorerRecents.test.ts
@@ -1,0 +1,56 @@
+import { getGroupIdForTimestamp, groupRecentEntries, RECENT_GROUPS } from '../components/apps/file-explorer/recents';
+
+describe('file explorer recents grouping', () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  it('categorizes timestamps into today, yesterday, and older', () => {
+    const now = Date.UTC(2024, 5, 10, 12, 0, 0);
+    const entries = [
+      { id: 1, name: 'today', lastAccessed: now - 1_000 },
+      { id: 2, name: 'yesterday', lastAccessed: now - DAY_MS },
+      { id: 3, name: 'older', lastAccessed: now - 3 * DAY_MS },
+      { id: 4, name: 'unknown', lastAccessed: undefined as unknown as number },
+    ];
+
+    const result = groupRecentEntries(entries, now);
+    const todayGroup = result.groups.find((group) => group.id === 'today');
+    const yesterdayGroup = result.groups.find((group) => group.id === 'yesterday');
+    const olderGroup = result.groups.find((group) => group.id === 'older');
+
+    expect(todayGroup?.entries.map((entry) => entry.id)).toEqual([1]);
+    expect(yesterdayGroup?.entries.map((entry) => entry.id)).toEqual([2]);
+    expect(olderGroup?.entries.map((entry) => entry.id)).toEqual([3, 4]);
+  });
+
+  it('sorts pinned entries above recency groups', () => {
+    const now = Date.UTC(2024, 5, 10, 12, 0, 0);
+    const entries = [
+      { id: 1, name: 'older pinned', lastAccessed: now - 5 * DAY_MS, pinned: true },
+      { id: 2, name: 'recent pinned', lastAccessed: now - 500, pinned: true },
+      { id: 3, name: 'recent', lastAccessed: now - 100 },
+      { id: 4, name: 'older', lastAccessed: now - 10 * DAY_MS },
+    ];
+
+    const result = groupRecentEntries(entries, now);
+    expect(result.pinned.map((entry) => entry.id)).toEqual([2, 1]);
+    const todayGroup = result.groups.find((group) => group.id === 'today');
+    const olderGroup = result.groups.find((group) => group.id === 'older');
+    expect(todayGroup?.entries.map((entry) => entry.id)).toEqual([3]);
+    expect(olderGroup?.entries.map((entry) => entry.id)).toContain(4);
+  });
+
+  it('provides a fallback group for invalid timestamps', () => {
+    const now = Date.UTC(2024, 5, 10, 12, 0, 0);
+    expect(getGroupIdForTimestamp(NaN, now)).toBe('older');
+    expect(getGroupIdForTimestamp(undefined as unknown as number, now)).toBe('older');
+    const { groups } = groupRecentEntries([{ id: 1, name: 'x', lastAccessed: NaN } as any], now);
+    const olderGroup = groups.find((group) => group.id === 'older');
+    expect(olderGroup?.entries.map((entry) => entry.id)).toEqual([1]);
+  });
+
+  it('returns every configured group even if empty', () => {
+    const now = Date.UTC(2024, 5, 10, 12, 0, 0);
+    const { groups } = groupRecentEntries([], now);
+    expect(groups.map((group) => group.id)).toEqual(RECENT_GROUPS.map((group) => group.id));
+  });
+});

--- a/components/apps/file-explorer/recents.js
+++ b/components/apps/file-explorer/recents.js
@@ -1,0 +1,54 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const RECENT_GROUPS = [
+  { id: 'today', label: 'Today' },
+  { id: 'yesterday', label: 'Yesterday' },
+  { id: 'older', label: 'Older' },
+];
+
+function startOfDay(timestamp) {
+  if (typeof timestamp !== 'number' || Number.isNaN(timestamp)) {
+    return NaN;
+  }
+  const date = new Date(timestamp);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+export function getGroupIdForTimestamp(timestamp, now = Date.now()) {
+  const entryStart = startOfDay(timestamp);
+  if (!Number.isFinite(entryStart)) return 'older';
+
+  const nowStart = startOfDay(now);
+  if (entryStart === nowStart) return 'today';
+
+  const yesterdayStart = startOfDay(now - DAY_MS);
+  if (entryStart === yesterdayStart) return 'yesterday';
+
+  return 'older';
+}
+
+export function groupRecentEntries(entries, now = Date.now()) {
+  const pinned = [];
+  const groups = RECENT_GROUPS.map((group) => ({ ...group, entries: [] }));
+  const groupsById = new Map(groups.map((group) => [group.id, group]));
+
+  const sorted = [...(entries || [])].sort((a, b) => {
+    const aTime = typeof a?.lastAccessed === 'number' ? a.lastAccessed : 0;
+    const bTime = typeof b?.lastAccessed === 'number' ? b.lastAccessed : 0;
+    return bTime - aTime;
+  });
+
+  for (const entry of sorted) {
+    if (!entry) continue;
+    if (entry.pinned) {
+      pinned.push(entry);
+      continue;
+    }
+    const groupId = getGroupIdForTimestamp(entry.lastAccessed, now);
+    const group = groupsById.get(groupId) || groupsById.get('older');
+    group.entries.push(entry);
+  }
+
+  return { pinned, groups };
+}


### PR DESCRIPTION
## Summary
- persist timestamps and pinned state for recent directories and expose grouping helpers
- reorganize the File Explorer sidebar to show pinned items, day-based history, and per-group clearing with keyboard navigation
- add unit tests covering the grouping logic for recents

## Testing
- yarn lint
- yarn test fileExplorerRecents.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc266f91048328ba0fffb7e1969e54