### PR TITLE
[firefox] Clone simulation sessions into new tabs

### DIFF
--- a/__tests__/firefox.test.tsx
+++ b/__tests__/firefox.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Firefox from '../components/apps/firefox';
 
@@ -41,5 +41,73 @@ describe('Firefox app', () => {
       expect(screen.getByRole('heading', { name: 'Kali NetHunter & Downloads' })).toBeInTheDocument()
     );
     expect(localStorage.getItem('firefox:last-url')).toBe('https://www.kali.org/get-kali/#kali-platforms');
+  });
+
+  it('duplicates history when opening the address with Cmd+Enter', async () => {
+    const user = userEvent.setup();
+    render(<Firefox />);
+    const input = screen.getByLabelText('Address');
+
+    await user.clear(input);
+    await user.type(input, 'example.com{enter}');
+    await user.clear(input);
+    await user.type(input, 'https://www.kali.org/tools/{enter}');
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Kali Linux Tools Catalog' })).toBeInTheDocument()
+    );
+
+    await user.clear(input);
+    await user.type(input, 'https://www.kali.org/docs/');
+    fireEvent.keyDown(input, { key: 'Enter', metaKey: true });
+
+    await waitFor(() =>
+      expect(screen.getByRole('tab', { name: /kali linux documentation/i })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      )
+    );
+
+    const persisted = localStorage.getItem('firefox:tabs-state');
+    expect(persisted).not.toBeNull();
+    const parsed = JSON.parse(persisted ?? '[]');
+    expect(parsed).toHaveLength(2);
+    const newTabState = parsed.find((tab: any) => tab.title === 'Kali Linux Documentation');
+    expect(newTabState).toBeDefined();
+    expect(newTabState.history).toEqual([
+      'https://www.kali.org/docs/',
+      'https://example.com/',
+      'https://www.kali.org/tools/',
+      'https://www.kali.org/docs/',
+    ]);
+  });
+
+  it('opens simulation links in a background tab on middle click', async () => {
+    render(<Firefox />);
+    const link = await screen.findByRole('link', { name: 'What is Kali Linux?' });
+    fireEvent(
+      link,
+      new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true, shiftKey: false }),
+    );
+
+    await waitFor(() => expect(screen.getAllByRole('tab')).toHaveLength(2));
+
+    const tabs = screen.getAllByRole('tab');
+    const activeTab = tabs.find((tab) => tab.getAttribute('aria-selected') === 'true');
+    expect(activeTab).toHaveTextContent(/kali linux documentation/i);
+
+    const backgroundTab = tabs.find((tab) => tab !== activeTab);
+    expect(backgroundTab).toHaveTextContent(/www\.kali\.org/i);
+    expect(backgroundTab).toHaveAttribute('aria-selected', 'false');
+
+    const persisted = localStorage.getItem('firefox:tabs-state');
+    expect(persisted).not.toBeNull();
+    const parsed = JSON.parse(persisted ?? '[]');
+    expect(parsed).toHaveLength(2);
+    const middleTab = parsed.find((tab: any) => tab.title === 'www.kali.org');
+    expect(middleTab).toBeDefined();
+    expect(middleTab.history).toEqual([
+      'https://www.kali.org/docs/',
+      'https://www.kali.org/docs/introduction/what-is-kali-linux/',
+    ]);
   });
 });

--- a/components/apps/firefox/index.tsx
+++ b/components/apps/firefox/index.tsx
@@ -1,9 +1,25 @@
-import React, { FormEvent, useMemo, useState } from 'react';
-import { FirefoxSimulationView, SIMULATIONS, toSimulationKey } from './simulations';
+'use client';
+
+import React, {
+  FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import TabbedWindow, { TabDefinition, useTab } from '../../ui/TabbedWindow';
+import {
+  FirefoxSimulationView,
+  FirefoxSimulation,
+  SIMULATIONS,
+  toSimulationKey,
+} from './simulations';
 
 const DEFAULT_URL = 'https://www.kali.org/docs/';
 const STORAGE_KEY = 'firefox:last-url';
 const START_URL_KEY = 'firefox:start-url';
+const TABS_STORAGE_KEY = 'firefox:tabs-state';
 
 const BOOKMARKS = [
   { label: 'OffSec', url: 'https://www.offsec.com/?utm_source=kali&utm_medium=os&utm_campaign=firefox' },
@@ -22,16 +38,17 @@ const normaliseUrl = (value: string) => {
     return DEFAULT_URL;
   }
   try {
-    const hasProtocol = /^(https?:)?\/\//i.test(trimmed);
-    if (hasProtocol) {
-      const url = new URL(trimmed, window.location.href);
+    if (/^https?:\/\//i.test(trimmed)) {
+      const url = new URL(trimmed);
       if (url.protocol === 'http:' || url.protocol === 'https:') {
         return url.toString();
       }
       return DEFAULT_URL;
     }
-    const candidate = new URL(`https://${trimmed}`);
-    return candidate.toString();
+    if (/^\/\//.test(trimmed)) {
+      return new URL(`https:${trimmed}`).toString();
+    }
+    return new URL(`https://${trimmed}`).toString();
   } catch {
     return DEFAULT_URL;
   }
@@ -45,46 +62,135 @@ const getSimulation = (value: string) => {
   return SIMULATIONS[key] ?? null;
 };
 
-const Firefox: React.FC = () => {
-  const initialUrl = useMemo(() => {
-    if (typeof window === 'undefined') {
-      return DEFAULT_URL;
+const deriveTitle = (url: string, simulation: FirefoxSimulation | null) => {
+  if (simulation) {
+    return simulation.heading;
+  }
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+};
+
+type FirefoxSessionSnapshot = {
+  id: string;
+  title: string;
+  history: string[];
+  historyIndex: number;
+  inputValue: string;
+};
+
+const shouldActivate = (shiftKey: boolean | undefined, defaultActivate: boolean) =>
+  shiftKey ? !defaultActivate : defaultActivate;
+
+interface FirefoxSessionProps {
+  id: string;
+  initialSnapshot: FirefoxSessionSnapshot;
+  createTab: (snapshot?: Partial<FirefoxSessionSnapshot>) => TabDefinition;
+  onSnapshot: (snapshot: FirefoxSessionSnapshot) => void;
+}
+
+const FirefoxSession: React.FC<FirefoxSessionProps> = ({
+  id,
+  initialSnapshot,
+  createTab,
+  onSnapshot,
+}) => {
+  const { requestTab, setTitle } = useTab();
+  const [history, setHistory] = useState(() => [...initialSnapshot.history]);
+  const [historyIndex, setHistoryIndex] = useState(initialSnapshot.historyIndex);
+  const [inputValue, setInputValue] = useState(initialSnapshot.inputValue);
+  const lastTitleRef = useRef(initialSnapshot.title);
+
+  const currentUrl = history[historyIndex] ?? DEFAULT_URL;
+  const simulation = useMemo(() => getSimulation(currentUrl), [currentUrl]);
+
+  useEffect(() => {
+    const title = deriveTitle(currentUrl, simulation);
+    if (lastTitleRef.current !== title) {
+      setTitle(title);
+      lastTitleRef.current = title;
     }
-    try {
-      const start = sessionStorage.getItem(START_URL_KEY);
-      if (start) {
-        sessionStorage.removeItem(START_URL_KEY);
-        const url = normaliseUrl(start);
-        localStorage.setItem(STORAGE_KEY, url);
-        return url;
+    onSnapshot({
+      id,
+      title,
+      history,
+      historyIndex,
+      inputValue,
+    });
+  }, [currentUrl, history, historyIndex, id, inputValue, onSnapshot, setTitle, simulation]);
+
+  const pushHistory = useCallback(
+    (value: string) => {
+      const url = normaliseUrl(value);
+      const base = history.slice(0, historyIndex + 1);
+      const nextHistory = [...base, url];
+      setHistory(nextHistory);
+      setHistoryIndex(nextHistory.length - 1);
+      setInputValue(url);
+    },
+    [history, historyIndex],
+  );
+
+  const openClone = useCallback(
+    (targetUrl: string | null, activate: boolean) => {
+      const base = history.slice(0, historyIndex + 1);
+      let nextHistory = base;
+      let nextIndex = base.length - 1;
+      let nextInput = inputValue;
+      if (targetUrl) {
+        const url = normaliseUrl(targetUrl);
+        nextHistory = [...base, url];
+        nextIndex = nextHistory.length - 1;
+        nextInput = url;
       }
-      const last = localStorage.getItem(STORAGE_KEY);
-      return last ? normaliseUrl(last) : DEFAULT_URL;
-    } catch {
-      return DEFAULT_URL;
-    }
-  }, []);
-
-  const [address, setAddress] = useState(initialUrl);
-  const [inputValue, setInputValue] = useState(initialUrl);
-  const [simulation, setSimulation] = useState(() => getSimulation(initialUrl));
-
-  const updateAddress = (value: string) => {
-    const url = normaliseUrl(value);
-    setAddress(url);
-    setInputValue(url);
-    setSimulation(getSimulation(url));
-    try {
-      localStorage.setItem(STORAGE_KEY, url);
-    } catch {
-      /* ignore persistence errors */
-    }
-  };
+      const tab = createTab({ history: nextHistory, historyIndex: nextIndex, inputValue: nextInput });
+      requestTab(tab, { activate });
+    },
+    [createTab, history, historyIndex, inputValue, requestTab],
+  );
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    updateAddress(inputValue);
+    pushHistory(inputValue);
   };
+
+  const handleBookmarkClick = (event: React.MouseEvent<HTMLButtonElement>, url: string) => {
+    if (event.metaKey || event.ctrlKey) {
+      event.preventDefault();
+      openClone(url, shouldActivate(event.shiftKey, true));
+      return;
+    }
+    pushHistory(url);
+  };
+
+  const handleBookmarkAuxClick = (event: React.MouseEvent<HTMLButtonElement>, url: string) => {
+    if (event.button === 1) {
+      event.preventDefault();
+      openClone(url, shouldActivate(event.shiftKey, false));
+    }
+  };
+
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      const openInNewTab = event.metaKey || event.ctrlKey;
+      const activate = shouldActivate(event.shiftKey, true);
+      event.preventDefault();
+      if (openInNewTab) {
+        openClone(event.currentTarget.value, activate);
+      } else {
+        pushHistory(event.currentTarget.value);
+      }
+    }
+  };
+
+  const handleSimulationLinkNewTab = useCallback(
+    (url: string, options: { activate: boolean }) => {
+      openClone(url, options.activate);
+    },
+    [openClone],
+  );
 
   return (
     <div className="flex h-full flex-col bg-ub-cool-grey text-gray-100">
@@ -92,13 +198,15 @@ const Firefox: React.FC = () => {
         onSubmit={handleSubmit}
         className="flex items-center gap-2 border-b border-gray-700 bg-gray-900 px-3 py-2"
       >
-        <label htmlFor="firefox-address" className="sr-only">
+        <label htmlFor={`firefox-address-${id}`} className="sr-only">
           Address
         </label>
         <input
-          id="firefox-address"
+          id={`firefox-address-${id}`}
+          aria-label="Address"
           value={inputValue}
           onChange={(event) => setInputValue(event.target.value)}
+          onKeyDown={handleInputKeyDown}
           placeholder="Enter a URL"
           className="flex-1 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-400 focus:border-blue-500 focus:outline-none"
         />
@@ -114,7 +222,8 @@ const Firefox: React.FC = () => {
           <button
             key={bookmark.url}
             type="button"
-            onClick={() => updateAddress(bookmark.url)}
+            onClick={(event) => handleBookmarkClick(event, bookmark.url)}
+            onAuxClick={(event) => handleBookmarkAuxClick(event, bookmark.url)}
             className="rounded bg-gray-800 px-3 py-1 font-medium text-gray-200 transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
           >
             {bookmark.label}
@@ -123,12 +232,15 @@ const Firefox: React.FC = () => {
       </nav>
       <div className="flex-1 bg-black">
         {simulation ? (
-          <FirefoxSimulationView simulation={simulation} />
+          <FirefoxSimulationView
+            simulation={simulation}
+            onOpenLinkInNewTab={(url, opts) => handleSimulationLinkNewTab(url, opts)}
+          />
         ) : (
           <iframe
-            key={address}
+            key={currentUrl}
             title="Firefox"
-            src={address}
+            src={currentUrl}
             className="h-full w-full border-0"
             sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
@@ -136,6 +248,150 @@ const Firefox: React.FC = () => {
         )}
       </div>
     </div>
+  );
+};
+
+const Firefox: React.FC = () => {
+  const idCounterRef = useRef(0);
+  const openTabsRef = useRef<string[]>([]);
+  const snapshotsRef = useRef<Record<string, FirefoxSessionSnapshot>>({});
+
+  const generateId = useCallback(() => {
+    idCounterRef.current += 1;
+    return `firefox-tab-${Date.now()}-${idCounterRef.current}`;
+  }, []);
+
+  const prepareSnapshot = useCallback(
+    (input: Partial<FirefoxSessionSnapshot> = {}): FirefoxSessionSnapshot => {
+      const history =
+        input.history && input.history.length > 0
+          ? input.history.map((value) => normaliseUrl(value))
+          : [normaliseUrl(input.inputValue ?? DEFAULT_URL)];
+      let historyIndex = input.historyIndex ?? history.length - 1;
+      if (historyIndex < 0 || historyIndex >= history.length) {
+        historyIndex = history.length - 1;
+      }
+      const currentUrl = history[historyIndex] ?? DEFAULT_URL;
+      const inputValue = input.inputValue ? normaliseUrl(input.inputValue) : currentUrl;
+      const simulation = getSimulation(currentUrl);
+      const title = input.title ?? deriveTitle(currentUrl, simulation);
+      const id = input.id ?? generateId();
+      return { id, title, history, historyIndex, inputValue };
+    },
+    [generateId],
+  );
+
+  const persistSnapshots = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const data = openTabsRef.current
+      .map((tabId) => snapshotsRef.current[tabId])
+      .filter((snapshot): snapshot is FirefoxSessionSnapshot => Boolean(snapshot));
+    try {
+      localStorage.setItem(TABS_STORAGE_KEY, JSON.stringify(data));
+    } catch {
+      // ignore persistence errors
+    }
+  }, []);
+
+  const handleSessionSnapshot = useCallback(
+    (snapshot: FirefoxSessionSnapshot) => {
+      snapshotsRef.current[snapshot.id] = snapshot;
+      try {
+        const current = snapshot.history[snapshot.historyIndex] ?? DEFAULT_URL;
+        localStorage.setItem(STORAGE_KEY, current);
+      } catch {
+        // ignore persistence errors
+      }
+      persistSnapshots();
+    },
+    [persistSnapshots],
+  );
+
+  const createTabFromSnapshot = useCallback(
+    (input: Partial<FirefoxSessionSnapshot> = {}): TabDefinition => {
+      const snapshot = prepareSnapshot(input);
+      snapshotsRef.current[snapshot.id] = snapshot;
+      return {
+        id: snapshot.id,
+        title: snapshot.title,
+        content: (
+          <FirefoxSession
+            key={snapshot.id}
+            id={snapshot.id}
+            initialSnapshot={snapshot}
+            createTab={createTabFromSnapshot}
+            onSnapshot={handleSessionSnapshot}
+          />
+        ),
+      };
+    },
+    [handleSessionSnapshot, prepareSnapshot],
+  );
+
+  const createNewTab = useCallback(() => createTabFromSnapshot({ history: [DEFAULT_URL] }), [createTabFromSnapshot]);
+
+  const initialTabs = useMemo(() => {
+    const snapshots: Partial<FirefoxSessionSnapshot>[] = [];
+    if (typeof window !== 'undefined') {
+      try {
+        const start = sessionStorage.getItem(START_URL_KEY);
+        if (start) {
+          sessionStorage.removeItem(START_URL_KEY);
+          snapshots.push({ history: [normaliseUrl(start)] });
+        } else {
+          const raw = localStorage.getItem(TABS_STORAGE_KEY);
+          if (raw) {
+            const parsed = JSON.parse(raw);
+            if (Array.isArray(parsed) && parsed.length > 0) {
+              parsed.forEach((item: Partial<FirefoxSessionSnapshot>) => {
+                snapshots.push(item);
+              });
+            }
+          }
+        }
+      } catch {
+        // ignore storage parse errors
+      }
+      if (snapshots.length === 0) {
+        try {
+          const last = localStorage.getItem(STORAGE_KEY);
+          if (last) {
+            snapshots.push({ history: [normaliseUrl(last)] });
+          }
+        } catch {
+          // ignore persistence errors
+        }
+      }
+    }
+    if (snapshots.length === 0) {
+      snapshots.push({ history: [DEFAULT_URL] });
+    }
+    const tabs = snapshots.map((snapshot) => createTabFromSnapshot(snapshot));
+    openTabsRef.current = tabs.map((tab) => tab.id);
+    return tabs;
+  }, [createTabFromSnapshot]);
+
+  const handleTabsChange = useCallback(
+    (tabs: TabDefinition[]) => {
+      openTabsRef.current = tabs.map((tab) => tab.id);
+      persistSnapshots();
+    },
+    [persistSnapshots],
+  );
+
+  useEffect(() => {
+    persistSnapshots();
+  }, [persistSnapshots]);
+
+  return (
+    <TabbedWindow
+      className="h-full bg-ub-cool-grey text-gray-100"
+      initialTabs={initialTabs}
+      onNewTab={createNewTab}
+      onTabsChange={handleTabsChange}
+    />
   );
 };
 

--- a/components/apps/firefox/simulations.tsx
+++ b/components/apps/firefox/simulations.tsx
@@ -528,7 +528,18 @@ export const SIMULATIONS = Object.fromEntries([
   }),
 ]) as Record<string, FirefoxSimulation>;
 
-export const FirefoxSimulationView: React.FC<{ simulation: FirefoxSimulation }> = ({ simulation }) => (
+interface FirefoxSimulationViewProps {
+  simulation: FirefoxSimulation;
+  onOpenLinkInNewTab?: (url: string, options: { activate: boolean }) => void;
+}
+
+const resolveActivation = (shiftKey: boolean, defaultActivate: boolean) =>
+  shiftKey ? !defaultActivate : defaultActivate;
+
+export const FirefoxSimulationView: React.FC<FirefoxSimulationViewProps> = ({
+  simulation,
+  onOpenLinkInNewTab,
+}) => (
   <div className="flex h-full flex-col overflow-hidden bg-gray-950 text-gray-100">
     <header className="border-b border-gray-800 px-6 py-5">
       <h1 className="text-2xl font-semibold text-white">{simulation.heading}</h1>
@@ -538,6 +549,20 @@ export const FirefoxSimulationView: React.FC<{ simulation: FirefoxSimulation }> 
         target="_blank"
         rel="noreferrer"
         className="mt-4 inline-flex items-center gap-2 rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
+        onClick={(event) => {
+          if (event.metaKey || event.ctrlKey) {
+            onOpenLinkInNewTab?.(simulation.externalUrl, {
+              activate: resolveActivation(event.shiftKey, true),
+            });
+          }
+        }}
+        onAuxClick={(event) => {
+          if (event.button === 1) {
+            onOpenLinkInNewTab?.(simulation.externalUrl, {
+              activate: resolveActivation(event.shiftKey, false),
+            });
+          }
+        }}
       >
         {simulation.ctaLabel ?? 'Open official site'}
         <span aria-hidden="true" className="text-xs">↗</span>
@@ -558,6 +583,21 @@ export const FirefoxSimulationView: React.FC<{ simulation: FirefoxSimulation }> 
                       target="_blank"
                       rel="noreferrer"
                       className="font-medium text-blue-300 hover:text-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
+                      onClick={(event) => {
+                        if (event.metaKey || event.ctrlKey) {
+                          onOpenLinkInNewTab?.(link.href, {
+                            activate: resolveActivation(event.shiftKey, true),
+                          });
+                        }
+                      }}
+                      onAuxClick={(event) => {
+                        if (event.button === 1) {
+                          event.preventDefault();
+                          onOpenLinkInNewTab?.(link.href, {
+                            activate: resolveActivation(event.shiftKey, false),
+                          });
+                        }
+                      }}
                     >
                       {link.label}
                     </a>


### PR DESCRIPTION
## Summary
- extend the shared TabbedWindow context so tabs can update their own title and request additional tabs
- refactor the Firefox simulation into persisted tabbed sessions that clone history when opening in new tabs
- capture modifier based navigation in the simulation view and add tests covering duplicated state

## Testing
- yarn lint
- yarn test __tests__/firefox.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc267260e48328a6ca29b5a863fd9b