### PR TITLE
[apps] Support multi-selection in clipboard manager

### DIFF
--- a/__tests__/selectionState.test.ts
+++ b/__tests__/selectionState.test.ts
@@ -1,0 +1,36 @@
+import { pruneSelection, replaceSelection, selectRange, toggleSelection } from '../utils/selectionState';
+
+describe('selectionState utilities', () => {
+  test('toggleSelection adds and removes values', () => {
+    const initial = new Set<number>();
+    const added = toggleSelection(initial, 1);
+    expect(Array.from(added)).toEqual([1]);
+    const removed = toggleSelection(added, 1);
+    expect(Array.from(removed)).toEqual([]);
+  });
+
+  test('replaceSelection normalizes to a single value', () => {
+    const replaced = replaceSelection(5);
+    expect(Array.from(replaced)).toEqual([5]);
+    const empty = replaceSelection<number>(undefined);
+    expect(Array.from(empty)).toEqual([]);
+  });
+
+  test('selectRange returns inclusive range and can extend selection', () => {
+    const order = [1, 2, 3, 4, 5];
+    const range = selectRange(new Set<number>(), order, 1, 3);
+    expect(Array.from(range)).toEqual([2, 3, 4]);
+
+    const additive = selectRange(new Set<number>([1]), order, 4, 2, { additive: true });
+    expect(Array.from(additive).sort()).toEqual([1, 3, 4, 5]);
+  });
+
+  test('pruneSelection removes values not in the valid set', () => {
+    const current = new Set<number>([1, 2, 3]);
+    const pruned = pruneSelection(current, [1, 3, 4]);
+    expect(Array.from(pruned).sort()).toEqual([1, 3]);
+
+    const unchanged = pruneSelection(pruned, [1, 3, 4]);
+    expect(unchanged).toBe(pruned);
+  });
+});

--- a/components/apps/ClipboardManager.tsx
+++ b/components/apps/ClipboardManager.tsx
@@ -1,7 +1,19 @@
 "use client";
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, {
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  useRef,
+} from 'react';
 import { getDb } from '../../utils/safeIDB';
+import {
+  pruneSelection,
+  replaceSelection,
+  selectRange,
+  toggleSelection,
+} from '../../utils/selectionState';
 
 interface ClipItem {
   id?: number;
@@ -31,6 +43,10 @@ function getDB() {
 
 const ClipboardManager: React.FC = () => {
   const [items, setItems] = useState<ClipItem[]>([]);
+  const [selection, setSelection] = useState<Set<number>>(() => new Set());
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+  const [anchorIndex, setAnchorIndex] = useState<number | null>(null);
+  const itemRefs = useRef<Array<HTMLDivElement | null>>([]);
 
   const loadItems = useCallback(async () => {
     try {
@@ -88,7 +104,53 @@ const ClipboardManager: React.FC = () => {
     return () => document.removeEventListener('copy', handleCopy);
   }, [handleCopy]);
 
-  const writeToClipboard = async (text: string) => {
+  const orderedIds = useMemo<(number | null)[]>(
+    () => items.map((item) => (typeof item.id === 'number' ? item.id : null)),
+    [items],
+  );
+
+  useEffect(() => {
+    itemRefs.current = itemRefs.current.slice(0, items.length);
+  }, [items.length]);
+
+  useEffect(() => {
+    setSelection((prev) =>
+      pruneSelection(
+        prev,
+        items
+          .map((item) => item.id)
+          .filter((id): id is number => typeof id === 'number'),
+      ),
+    );
+  }, [items]);
+
+  useEffect(() => {
+    if (items.length === 0) {
+      setFocusedIndex(null);
+      setAnchorIndex(null);
+      return;
+    }
+    setFocusedIndex((index) => {
+      if (index == null) return 0;
+      if (index >= items.length) return items.length - 1;
+      return index;
+    });
+    setAnchorIndex((index) => {
+      if (index == null) return index;
+      if (index >= items.length) return items.length - 1;
+      return index;
+    });
+  }, [items]);
+
+  useEffect(() => {
+    if (focusedIndex == null) return;
+    const node = itemRefs.current[focusedIndex];
+    if (node && document.activeElement !== node) {
+      node.focus();
+    }
+  }, [focusedIndex, items]);
+
+  const writeToClipboard = useCallback(async (text: string) => {
     try {
       const perm = await (navigator.permissions as any)?.query?.({
         name: 'clipboard-write' as any,
@@ -98,9 +160,42 @@ const ClipboardManager: React.FC = () => {
     } catch (err) {
       console.error('Clipboard write failed:', err);
     }
-  };
+  }, []);
 
-  const clearHistory = async () => {
+  const selectedItems = useMemo(
+    () => items.filter((item) => typeof item.id === 'number' && selection.has(item.id)),
+    [items, selection],
+  );
+
+  const handleCopySelected = useCallback(async () => {
+    if (selectedItems.length === 0) return;
+    const combined = selectedItems.map((item) => item.text).join('\n\n');
+    await writeToClipboard(combined);
+  }, [selectedItems, writeToClipboard]);
+
+  const handleDeleteSelected = useCallback(async () => {
+    if (selectedItems.length === 0) return;
+    try {
+      const dbp = getDB();
+      if (!dbp) return;
+      const db = await dbp;
+
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const ids = selectedItems
+        .map((item) => item.id)
+        .filter((id): id is number => typeof id === 'number');
+      await Promise.all(ids.map((id) => tx.store.delete(id)));
+      await tx.done;
+      setSelection(new Set<number>());
+      setAnchorIndex(null);
+      setFocusedIndex(null);
+      await loadItems();
+    } catch {
+      // ignore errors
+    }
+  }, [selectedItems, loadItems]);
+
+  const clearHistory = useCallback(async () => {
     try {
       const dbp = getDB();
       if (!dbp) return;
@@ -108,29 +203,148 @@ const ClipboardManager: React.FC = () => {
 
       await db.clear(STORE_NAME);
       setItems([]);
+      setSelection(new Set<number>());
+      setAnchorIndex(null);
+      setFocusedIndex(null);
     } catch {
       // ignore errors
     }
-  };
+  }, []);
+
+  const handleItemClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>, item: ClipItem, index: number) => {
+      const id = item.id;
+      const isAdditive = event.metaKey || event.ctrlKey;
+      const baseAnchor = anchorIndex ?? index;
+      event.preventDefault();
+      setFocusedIndex(index);
+      if (event.shiftKey) {
+        setSelection((prev) =>
+          selectRange(prev, orderedIds, baseAnchor, index, { additive: isAdditive }),
+        );
+        setAnchorIndex(baseAnchor);
+        return;
+      }
+      if (id == null) return;
+      if (isAdditive) {
+        setSelection((prev) => toggleSelection(prev, id));
+        setAnchorIndex(index);
+        return;
+      }
+      setSelection(replaceSelection(id));
+      setAnchorIndex(index);
+      void writeToClipboard(item.text);
+    },
+    [anchorIndex, orderedIds, writeToClipboard],
+  );
+
+  const handleItemKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>, item: ClipItem, index: number) => {
+      const id = item.id;
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        if (items.length === 0) return;
+        const delta = event.key === 'ArrowDown' ? 1 : -1;
+        const nextIndex = Math.max(0, Math.min(items.length - 1, index + delta));
+        if (nextIndex === index) return;
+        const baseAnchor = anchorIndex ?? index;
+        if (event.shiftKey) {
+          setSelection((prev) =>
+            selectRange(prev, orderedIds, baseAnchor, nextIndex, { additive: true }),
+          );
+          setAnchorIndex(baseAnchor);
+        }
+        setFocusedIndex(nextIndex);
+        if (!event.shiftKey) {
+          const nextId = orderedIds[nextIndex];
+          if (nextId != null) {
+            setSelection(replaceSelection(nextId));
+          } else {
+            setSelection(new Set<number>());
+          }
+          setAnchorIndex(nextIndex);
+        }
+        return;
+      }
+      if (event.key === ' ' || event.key === 'Spacebar') {
+        event.preventDefault();
+        if (id == null) return;
+        setSelection((prev) => toggleSelection(prev, id));
+        setAnchorIndex(index);
+        return;
+      }
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        if (id == null) return;
+        setSelection(replaceSelection(id));
+        setAnchorIndex(index);
+        void writeToClipboard(item.text);
+      }
+    },
+    [anchorIndex, items.length, orderedIds, writeToClipboard],
+  );
 
   return (
-    <div className="p-4 space-y-2 text-white bg-ub-cool-grey h-full overflow-auto">
-      <button
-        className="px-2 py-1 bg-gray-700 hover:bg-gray-600"
-        onClick={clearHistory}
-      >
-        Clear History
-      </button>
-      <ul className="space-y-1">
-        {items.map((item) => (
-          <li
-            key={item.id}
-            className="cursor-pointer hover:underline"
-            onClick={() => writeToClipboard(item.text)}
-          >
-            {item.text}
-          </li>
-        ))}
+    <div className="p-4 space-y-3 text-white bg-ub-cool-grey h-full overflow-auto">
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          className="px-2 py-1 rounded bg-gray-700 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          onClick={clearHistory}
+          type="button"
+        >
+          Clear History
+        </button>
+        {selection.size > 0 && (
+          <>
+            <span className="ml-1 text-sm text-gray-300">{selection.size} selected</span>
+            <button
+              type="button"
+              className="px-2 py-1 rounded bg-blue-600 hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+              onClick={handleCopySelected}
+            >
+              Copy Selected
+            </button>
+            <button
+              type="button"
+              className="px-2 py-1 rounded bg-red-600 hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-300"
+              onClick={handleDeleteSelected}
+            >
+              Delete Selected
+            </button>
+          </>
+        )}
+      </div>
+      <ul className="space-y-1" role="listbox" aria-multiselectable="true">
+        {items.map((item, index) => {
+          const id = item.id;
+          const isSelected = typeof id === 'number' && selection.has(id);
+          const isFocused = focusedIndex === index;
+          return (
+            <li key={id ?? index}>
+              <div
+                ref={(node) => {
+                  itemRefs.current[index] = node;
+                }}
+                role="option"
+                className={`w-full cursor-pointer rounded border px-2 py-1 text-left transition focus:outline-none focus:ring-2 ${
+                  isSelected
+                    ? 'border-blue-400 bg-blue-500/40'
+                    : 'border-transparent bg-gray-800 hover:bg-gray-700'
+                }`}
+                tabIndex={isFocused || (focusedIndex == null && index === 0) ? 0 : -1}
+                aria-selected={isSelected}
+                onClick={(event) => handleItemClick(event, item, index)}
+                onKeyDown={(event) => handleItemKeyDown(event, item, index)}
+                onDoubleClick={() => writeToClipboard(item.text)}
+              >
+                <span className="block truncate text-sm">{item.text}</span>
+                <span className="mt-1 block text-xs text-gray-300">
+                  {new Date(item.created).toLocaleString()}
+                </span>
+              </div>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/utils/selectionState.ts
+++ b/utils/selectionState.ts
@@ -1,0 +1,75 @@
+export type SelectionValue = string | number;
+
+export function toggleSelection<T extends SelectionValue>(
+  current: ReadonlySet<T>,
+  value: T | null | undefined,
+): Set<T> {
+  if (value == null) {
+    return new Set(current);
+  }
+  const next = new Set(current);
+  if (next.has(value)) {
+    next.delete(value);
+  } else {
+    next.add(value);
+  }
+  return next;
+}
+
+export function replaceSelection<T extends SelectionValue>(
+  value: T | null | undefined,
+): Set<T> {
+  const next = new Set<T>();
+  if (value != null) {
+    next.add(value);
+  }
+  return next;
+}
+
+export function selectRange<T extends SelectionValue>(
+  current: ReadonlySet<T>,
+  order: Array<T | null | undefined>,
+  anchorIndex: number,
+  targetIndex: number,
+  options: { additive?: boolean } = {},
+): Set<T> {
+  const { additive = false } = options;
+  const next = additive ? new Set(current) : new Set<T>();
+  if (!Array.isArray(order) || order.length === 0) {
+    return next;
+  }
+  const clampedAnchor = Math.max(0, Math.min(order.length - 1, anchorIndex));
+  const clampedTarget = Math.max(0, Math.min(order.length - 1, targetIndex));
+  const start = Math.min(clampedAnchor, clampedTarget);
+  const end = Math.max(clampedAnchor, clampedTarget);
+  for (let index = start; index <= end; index += 1) {
+    const id = order[index];
+    if (id != null) {
+      next.add(id);
+    }
+  }
+  return next;
+}
+
+export function pruneSelection<T extends SelectionValue>(
+  current: ReadonlySet<T>,
+  validValues: Iterable<T>,
+): Set<T> {
+  const valid = new Set(validValues);
+  if (valid.size === 0) {
+    return current.size === 0 ? (current as Set<T>) : new Set<T>();
+  }
+  let changed = false;
+  const next = new Set<T>();
+  current.forEach((value) => {
+    if (valid.has(value)) {
+      next.add(value);
+    } else {
+      changed = true;
+    }
+  });
+  if (!changed && next.size === current.size) {
+    return current as Set<T>;
+  }
+  return next;
+}


### PR DESCRIPTION
## Summary
- add shared selection helpers for toggling, range selection, and pruning
- enhance the clipboard manager with multi-select UI, keyboard support, and batch actions
- cover the selection utilities with unit tests

## Testing
- yarn test selectionState --runInBand
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc2670e8b48328befd65a28c4768f2