### PR TITLE
[terminal] Add export controls for terminal transcripts

### DIFF
--- a/__tests__/terminal/exportHelpers.test.ts
+++ b/__tests__/terminal/exportHelpers.test.ts
@@ -1,0 +1,24 @@
+import {
+  buildMarkdownExport,
+  buildPlainTextExport,
+  stripAnsiCodes,
+} from '@/apps/terminal/utils/exportHelpers';
+
+describe('terminal export helpers', () => {
+  it('strips ANSI escape codes from input', () => {
+    const raw = '\u001b[31merror\u001b[0m message';
+    expect(stripAnsiCodes(raw)).toBe('error message');
+  });
+
+  it('normalizes newline characters and retains command text', () => {
+    const raw = '└─$ ls\r\nDesktop\rDocuments';
+    expect(buildPlainTextExport(raw)).toBe('└─$ ls\nDesktop\nDocuments');
+  });
+
+  it('creates a markdown fence export without trailing whitespace', () => {
+    const raw = '┌──(kali㉿kali)-[~]\n└─$ help\nAvailable commands:\n';
+    expect(buildMarkdownExport(raw)).toBe(
+      '```bash\n┌──(kali㉿kali)-[~]\n└─$ help\nAvailable commands:\n```',
+    );
+  });
+});

--- a/apps/terminal/utils/exportHelpers.ts
+++ b/apps/terminal/utils/exportHelpers.ts
@@ -1,0 +1,21 @@
+const ANSI_ESCAPE_REGEX = /\u001b\[[0-9;]*m/g;
+
+const normalizeNewlines = (value: string): string =>
+  value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+export const stripAnsiCodes = (value: string): string =>
+  (value ?? '').replace(ANSI_ESCAPE_REGEX, '');
+
+export const buildPlainTextExport = (content: string): string =>
+  normalizeNewlines(stripAnsiCodes(content ?? ''));
+
+export const buildMarkdownExport = (
+  content: string,
+  language = 'bash',
+): string => {
+  const sanitized = buildPlainTextExport(content);
+  const trimmed = sanitized.trimEnd();
+  return `\u0060\u0060\u0060${language}\n${trimmed}\n\u0060\u0060\u0060`;
+};
+
+export default buildPlainTextExport;


### PR DESCRIPTION
## Summary
- add clipboard, markdown, and .txt export actions to the terminal toolbar with success toasts
- capture prompts and typed commands in the in-memory session so exports include full transcripts
- add helper utilities and unit tests for generating plain-text and Markdown exports

## Testing
- yarn lint
- yarn test --runTestsByPath __tests__/terminal/exportHelpers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc267364d88328a75b886e900a3cd5