### PR TITLE
[apps] Improve command builder validation and previews

### DIFF
--- a/__tests__/command-builder.test.tsx
+++ b/__tests__/command-builder.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CommandBuilder from '../components/CommandBuilder';
+
+describe('CommandBuilder validation', () => {
+  const build = ({ target = '', opts = '' }) => `curl ${opts} ${target}`.trim();
+  const fields = [
+    {
+      key: 'target',
+      label: 'Target URL or Host',
+      required: true,
+      placeholder: 'https://example.com',
+      example: 'https://demo.target',
+    },
+    {
+      key: 'opts',
+      label: 'Curl Flags',
+      required: false,
+      placeholder: '-I --user-agent "Demo"',
+      example: '-I --user-agent "Demo"',
+    },
+  ];
+
+  it('prevents submission and focuses the first missing required field', async () => {
+    const user = userEvent.setup();
+    render(<CommandBuilder doc="demo" build={build} fields={fields} />);
+
+    const submitButton = screen.getByRole('button', { name: /build command/i });
+    await user.click(submitButton);
+
+    const targetInput = screen.getByLabelText(/target url or host/i);
+    expect(targetInput).toHaveFocus();
+    expect(targetInput).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('allows submission when required fields are filled and optional fields stay blank', async () => {
+    const user = userEvent.setup();
+    render(<CommandBuilder doc="demo" build={build} fields={fields} />);
+
+    const targetInput = screen.getByLabelText(/target url or host/i);
+    await user.type(targetInput, 'https://example.com');
+
+    const submitButton = screen.getByRole('button', { name: /build command/i });
+    await user.click(submitButton);
+
+    expect(targetInput).toHaveAttribute('aria-invalid', 'false');
+
+    const optionalField = screen.getByLabelText(/curl flags/i);
+    expect(optionalField).toHaveAttribute('aria-invalid', 'false');
+  });
+});

--- a/components/CommandBuilder.tsx
+++ b/components/CommandBuilder.tsx
@@ -1,42 +1,182 @@
-import { useState } from 'react';
+import { diffWords } from 'diff';
+import { useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent } from 'react';
+import { z } from 'zod';
 import TerminalOutput from './TerminalOutput';
+
+const fieldSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  required: z.boolean().optional().default(false),
+  placeholder: z.string().optional(),
+  example: z.string().optional(),
+  defaultValue: z.string().optional(),
+});
+
+type FieldDefinition = z.infer<typeof fieldSchema>;
 
 interface BuilderProps {
   doc: string;
   build: (params: Record<string, string>) => string;
+  fields: FieldDefinition[];
 }
 
-export default function CommandBuilder({ doc, build }: BuilderProps) {
-  const [params, setParams] = useState<Record<string, string>>({});
-  const update = (key: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
-    setParams({ ...params, [key]: e.target.value });
+export default function CommandBuilder({ doc, build, fields }: BuilderProps) {
+  const parsedFields = useMemo(() => fieldSchema.array().parse(fields), [fields]);
+
+  const baseParams = useMemo(() => {
+    return parsedFields.reduce<Record<string, string>>((acc, field) => {
+      if (typeof field.defaultValue === 'string') {
+        acc[field.key] = field.defaultValue;
+      }
+      return acc;
+    }, {});
+  }, [parsedFields]);
+
+  const [params, setParams] = useState<Record<string, string>>(() => ({ ...baseParams }));
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const inputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+
+  useEffect(() => {
+    setParams({ ...baseParams });
+    setErrors({});
+  }, [baseParams]);
+
+  const update = (key: string, field: FieldDefinition) => (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setParams((prev) => ({ ...prev, [key]: value }));
+    if (field.required) {
+      setErrors((prev) => {
+        if (value.trim()) {
+          const { [key]: _removed, ...rest } = prev;
+          return rest;
+        }
+        return prev;
+      });
+    }
   };
 
-  const command = build(params);
+  const validate = () => {
+    const nextErrors: Record<string, string> = {};
+    parsedFields.forEach((field) => {
+      if (field.required && !params[field.key]?.trim()) {
+        nextErrors[field.key] = `${field.label} is required.`;
+      }
+    });
+
+    setErrors(nextErrors);
+
+    if (Object.keys(nextErrors).length > 0) {
+      const firstInvalid = parsedFields.find((field) => nextErrors[field.key]);
+      if (firstInvalid) {
+        inputRefs.current[firstInvalid.key]?.focus();
+      }
+      return false;
+    }
+
+    return true;
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    validate();
+  };
+
+  const command = useMemo(() => build(params), [build, params]);
+  const baseCommand = useMemo(() => build(baseParams), [build, baseParams]);
+  const diff = useMemo(() => diffWords(baseCommand, command), [baseCommand, command]);
 
   return (
-    <form className="text-xs" onSubmit={(e) => e.preventDefault()} aria-label="command builder">
-      <p className="mb-2" aria-label="inline docs">{doc}</p>
-      <label className="block mb-1">
-        <span className="mr-1">Target</span>
-        <input
-          aria-label="target"
-          value={params.target || ''}
-          onChange={update('target')}
-          className="border p-1 text-black w-full"
-        />
-      </label>
-      <label className="block mb-1">
-        <span className="mr-1">Options</span>
-        <input
-          aria-label="options"
-          value={params.opts || ''}
-          onChange={update('opts')}
-          className="border p-1 text-black w-full"
-        />
-      </label>
-      <div className="mt-2">
-        <TerminalOutput text={command} ariaLabel="command output" />
+    <form
+      className="text-xs space-y-3"
+      onSubmit={handleSubmit}
+      aria-label="command builder"
+    >
+      <p className="mb-1 text-slate-200" aria-label="inline docs">
+        {doc}
+      </p>
+      <div className="space-y-2">
+        {parsedFields.map((field) => {
+          const value = params[field.key] ?? '';
+          const isRequiredBlank = field.required && !value.trim();
+          const errorMessage = errors[field.key];
+          const hasError = Boolean(errorMessage);
+          const showInvalid = hasError || isRequiredBlank;
+          const borderClass = showInvalid ? 'border-red-500 focus:border-red-400' : 'border-slate-500 focus:border-sky-400';
+          const exampleClasses = showInvalid ? 'text-red-300' : 'text-slate-300';
+          const helperText = field.required ? 'Required' : 'Optional';
+
+          return (
+            <div key={field.key}>
+              <label className="mb-1 block font-semibold text-slate-100" htmlFor={`builder-${field.key}`}>
+                {field.label}
+                {field.required && <span className="ml-1 text-red-400" aria-hidden="true">*</span>}
+              </label>
+              <input
+                id={`builder-${field.key}`}
+                ref={(node) => {
+                  inputRefs.current[field.key] = node;
+                }}
+                aria-label={field.label.toLowerCase()}
+                aria-invalid={showInvalid ? 'true' : 'false'}
+                className={`w-full rounded border bg-white p-1 text-black focus:outline-none ${borderClass}`}
+                placeholder={field.placeholder}
+                value={value}
+                onChange={update(field.key, field)}
+              />
+              <div className={`mt-1 text-[11px] ${exampleClasses}`}>
+                <span className="font-semibold">{helperText}.</span>{' '}
+                {field.example ? (
+                  <span>
+                    Example: <code className="font-mono text-[10px]">{field.example}</code>
+                  </span>
+                ) : (
+                  <span>Provide a value to customize the command.</span>
+                )}
+                {errorMessage && (
+                  <span className="mt-1 block text-red-200">{errorMessage}</span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <button
+        type="submit"
+        className="rounded bg-sky-600 px-3 py-1 font-semibold text-white transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-300"
+      >
+        Build Command
+      </button>
+      <div className="space-y-2">
+        <div>
+          <h3 className="mb-1 font-semibold uppercase tracking-wide text-slate-300">Command Preview</h3>
+          <TerminalOutput text={command} ariaLabel="command output" />
+        </div>
+        <div>
+          <h3 className="mb-1 font-semibold uppercase tracking-wide text-slate-300">Live Diff</h3>
+          <pre className="whitespace-pre-wrap rounded border border-slate-600 bg-slate-900 p-2 font-mono text-[11px] text-slate-100" aria-label="command diff">
+            {diff.map((part, index) => {
+              if (part.added) {
+                return (
+                  <span key={`added-${index}`} className="bg-green-700/60 text-green-100">
+                    {part.value}
+                  </span>
+                );
+              }
+              if (part.removed) {
+                return (
+                  <span key={`removed-${index}`} className="bg-red-700/60 text-red-100 line-through">
+                    {part.value}
+                  </span>
+                );
+              }
+              return (
+                <span key={`context-${index}`} className="text-slate-100">
+                  {part.value}
+                </span>
+              );
+            })}
+          </pre>
+        </div>
       </div>
     </form>
   );

--- a/components/apps/security-tools/index.js
+++ b/components/apps/security-tools/index.js
@@ -202,6 +202,22 @@ export default function SecurityTools() {
                   <CommandBuilder
                     doc="Build a curl command. Output is copy-only and not executed."
                     build={({ target = '', opts = '' }) => `curl ${opts} ${target}`.trim()}
+                    fields={[
+                      {
+                        key: 'target',
+                        label: 'Target URL or Host',
+                        required: true,
+                        placeholder: 'https://example.com',
+                        example: 'https://demo.target',
+                      },
+                      {
+                        key: 'opts',
+                        label: 'Curl Flags',
+                        required: false,
+                        placeholder: '-I --user-agent "Demo"',
+                        example: '-I --user-agent "Demo"',
+                      },
+                    ]}
                   />
                 </div>
               )}


### PR DESCRIPTION
## Summary
- add a schema-driven command builder configuration with inline examples and validation cues
- show a live diff preview of changes to the base command alongside the command output
- cover required-field validation with dedicated unit tests

## Testing
- [x] yarn test command-builder
- [x] yarn lint

## Flags
- [x] No feature flags toggled

------
https://chatgpt.com/codex/tasks/task_e_68dc267517c48328bce1e1e6f4124d2a