### PR TITLE
[security-tools] Add command sanitization and warnings

### DIFF
--- a/__tests__/sanitizeCommand.test.ts
+++ b/__tests__/sanitizeCommand.test.ts
@@ -1,0 +1,47 @@
+import { quotePosix, sanitizeShellInput } from '../utils/sanitizeCommand';
+
+describe('quotePosix', () => {
+  it('wraps input in single quotes', () => {
+    expect(quotePosix('example')).toBe("'example'");
+  });
+
+  it('escapes existing single quotes', () => {
+    expect(quotePosix("O'Reilly")).toBe("'O'\\''Reilly'");
+  });
+
+  it('returns empty quotes for empty string', () => {
+    expect(quotePosix('')).toBe("''");
+  });
+});
+
+describe('sanitizeShellInput', () => {
+  it('trims whitespace and normalizes newlines', () => {
+    expect(sanitizeShellInput('  hello\nworld  ').sanitized).toBe('hello world');
+  });
+
+  it('detects semicolons and provides a fix', () => {
+    const result = sanitizeShellInput('ls; rm -rf /');
+
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatchObject({
+      id: 'semicolon',
+      indicator: ';',
+      fixLabel: 'Wrap in POSIX-safe quotes',
+      fixValue: "'ls; rm -rf /'",
+    });
+  });
+
+  it('detects double ampersands', () => {
+    const result = sanitizeShellInput('echo ok && reboot');
+
+    expect(result.warnings[0].id).toBe('double-ampersand');
+  });
+
+  it('suppresses warnings once the value is safely quoted', () => {
+    expect(sanitizeShellInput("'ls; rm -rf /'").warnings).toHaveLength(0);
+  });
+
+  it('returns no warnings for safe input', () => {
+    expect(sanitizeShellInput('curl https://example.com').warnings).toHaveLength(0);
+  });
+});

--- a/components/CommandBuilder.tsx
+++ b/components/CommandBuilder.tsx
@@ -1,38 +1,180 @@
-import { useState } from 'react';
+import { ChangeEvent, RefObject, useMemo, useRef, useState } from 'react';
 import TerminalOutput from './TerminalOutput';
+import { quotePosix, sanitizeShellInput } from '../utils/sanitizeCommand';
+import type { SanitizationWarning } from '../utils/sanitizeCommand';
 
 interface BuilderProps {
   doc: string;
   build: (params: Record<string, string>) => string;
 }
 
+type BuilderField = 'target' | 'opts';
+
+interface FieldWarning extends SanitizationWarning {
+  field: BuilderField;
+}
+
 export default function CommandBuilder({ doc, build }: BuilderProps) {
   const [params, setParams] = useState<Record<string, string>>({});
-  const update = (key: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+  const targetRef = useRef<HTMLInputElement>(null);
+  const optionsRef = useRef<HTMLInputElement>(null);
+
+  const schedule = (callback: () => void) => {
+    if (typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function') {
+      callback();
+      return;
+    }
+
+    window.requestAnimationFrame(callback);
+  };
+
+  const update = (key: BuilderField) => (e: ChangeEvent<HTMLInputElement>) => {
     setParams({ ...params, [key]: e.target.value });
   };
 
-  const command = build(params);
+  const wrapSelection = (key: BuilderField, ref: RefObject<HTMLInputElement>) => () => {
+    const input = ref.current;
+
+    if (!input) return;
+
+    const { selectionStart, selectionEnd, value } = input;
+    const hasSelection =
+      selectionStart !== null &&
+      selectionEnd !== null &&
+      selectionStart !== selectionEnd &&
+      selectionStart >= 0 &&
+      selectionEnd >= 0;
+
+    const selectedText = hasSelection ? value.slice(selectionStart, selectionEnd) : value;
+    const quoted = quotePosix(selectedText);
+    const nextValue = hasSelection
+      ? value.slice(0, selectionStart) + quoted + value.slice(selectionEnd)
+      : quoted;
+
+    setParams({ ...params, [key]: nextValue });
+
+    schedule(() => {
+      const nextSelectionStart = hasSelection ? selectionStart : nextValue.length;
+      const nextSelectionEnd = hasSelection ? selectionStart + quoted.length : nextValue.length;
+      input.setSelectionRange(nextSelectionStart, nextSelectionEnd);
+    });
+  };
+
+  const sanitized = useMemo(() => {
+    const targetResult = sanitizeShellInput(params.target || '');
+    const optsResult = sanitizeShellInput(params.opts || '');
+
+    const warnings: FieldWarning[] = [
+      ...targetResult.warnings.map((warning) => ({ ...warning, field: 'target' as const })),
+      ...optsResult.warnings.map((warning) => ({ ...warning, field: 'opts' as const })),
+    ];
+
+    return {
+      target: targetResult.sanitized,
+      opts: optsResult.sanitized,
+      warnings,
+    };
+  }, [params]);
+
+  const command = useMemo(
+    () =>
+      build({
+        ...params,
+        target: sanitized.target,
+        opts: sanitized.opts,
+      }),
+    [build, params, sanitized.target, sanitized.opts],
+  );
+
+  const applyFix = (warning: FieldWarning) => {
+    if (!warning.fixValue) return;
+
+    setParams((prev) => ({
+      ...prev,
+      [warning.field]: warning.fixValue ?? prev[warning.field],
+    }));
+
+    const ref = warning.field === 'target' ? targetRef : optionsRef;
+    const input = ref.current;
+    if (!input) return;
+
+    schedule(() => {
+      const value = warning.fixValue as string;
+      input.setSelectionRange(value.length, value.length);
+    });
+  };
+
+  const renderWarnings = () =>
+    sanitized.warnings.map((warning) => (
+      <div
+        key={`${warning.field}-${warning.id}`}
+        className="mb-2 rounded border border-yellow-600 bg-yellow-900/60 p-2 text-yellow-100"
+        role="alert"
+      >
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold">
+              Potentially unsafe operator detected: <code>{warning.indicator}</code>
+            </p>
+            <p className="text-xs">{warning.message}</p>
+          </div>
+          {warning.fixLabel && warning.fixValue && (
+            <button
+              type="button"
+              onClick={() => applyFix(warning)}
+              className="self-start rounded bg-yellow-700 px-2 py-1 text-xs font-semibold text-black hover:bg-yellow-500"
+            >
+              {warning.fixLabel}
+            </button>
+          )}
+        </div>
+      </div>
+    ));
 
   return (
     <form className="text-xs" onSubmit={(e) => e.preventDefault()} aria-label="command builder">
-      <p className="mb-2" aria-label="inline docs">{doc}</p>
-      <label className="block mb-1">
-        <span className="mr-1">Target</span>
+      <p className="mb-2" aria-label="inline docs">
+        {doc}
+      </p>
+
+      {renderWarnings()}
+
+      <label className="mb-1 block">
+        <div className="mb-1 flex items-center justify-between">
+          <span className="mr-1">Target</span>
+          <button
+            type="button"
+            onClick={wrapSelection('target', targetRef)}
+            className="rounded bg-gray-700 px-2 py-1 text-[10px] font-semibold text-white hover:bg-gray-600"
+          >
+            Quote selection
+          </button>
+        </div>
         <input
+          ref={targetRef}
           aria-label="target"
           value={params.target || ''}
           onChange={update('target')}
-          className="border p-1 text-black w-full"
+          className="w-full border p-1 text-black"
         />
       </label>
-      <label className="block mb-1">
-        <span className="mr-1">Options</span>
+      <label className="mb-1 block">
+        <div className="mb-1 flex items-center justify-between">
+          <span className="mr-1">Options</span>
+          <button
+            type="button"
+            onClick={wrapSelection('opts', optionsRef)}
+            className="rounded bg-gray-700 px-2 py-1 text-[10px] font-semibold text-white hover:bg-gray-600"
+          >
+            Quote selection
+          </button>
+        </div>
         <input
+          ref={optionsRef}
           aria-label="options"
           value={params.opts || ''}
           onChange={update('opts')}
-          className="border p-1 text-black w-full"
+          className="w-full border p-1 text-black"
         />
       </label>
       <div className="mt-2">
@@ -41,4 +183,3 @@ export default function CommandBuilder({ doc, build }: BuilderProps) {
     </form>
   );
 }
-

--- a/utils/sanitizeCommand.ts
+++ b/utils/sanitizeCommand.ts
@@ -1,0 +1,91 @@
+export interface SanitizationWarning {
+  id: string;
+  indicator: string;
+  message: string;
+  fixLabel?: string;
+  fixValue?: string;
+}
+
+export interface SanitizationResult {
+  sanitized: string;
+  warnings: SanitizationWarning[];
+}
+
+const DANGEROUS_PATTERNS: Array<{
+  id: string;
+  indicator: string;
+  pattern: RegExp;
+  message: string;
+}> = [
+  {
+    id: 'semicolon',
+    indicator: ';',
+    pattern: /;/,
+    message: 'Semicolons can be used to chain multiple commands.',
+  },
+  {
+    id: 'double-ampersand',
+    indicator: '&&',
+    pattern: /&&/,
+    message: '"&&" will run a follow-up command when the previous command succeeds.',
+  },
+  {
+    id: 'double-pipe',
+    indicator: '||',
+    pattern: /\|\|/,
+    message: '"||" can run an alternate command when the previous command fails.',
+  },
+  {
+    id: 'subshell',
+    indicator: '$(...)',
+    pattern: /\$\(/,
+    message: 'Subshell execution is blocked in the demo environment.',
+  },
+  {
+    id: 'backtick',
+    indicator: '`',
+    pattern: /`/,
+    message: 'Backticks execute subshells in many shells.',
+  },
+  {
+    id: 'redirect',
+    indicator: '>',
+    pattern: />|</,
+    message: 'Redirection operators can alter files outside the sandbox.',
+  },
+];
+
+const SINGLE_QUOTE = "'";
+
+export function quotePosix(value: string): string {
+  if (value === '') {
+    return "''";
+  }
+
+  return SINGLE_QUOTE + value.replace(/'/g, "'\\''") + SINGLE_QUOTE;
+}
+
+export function sanitizeShellInput(value: string): SanitizationResult {
+  const normalized = value.replace(/\r?\n/g, ' ').trim();
+  const warnings: SanitizationWarning[] = [];
+  const alreadyQuoted = /^'(?:[^']|'\\'')*'$/.test(normalized);
+
+  if (!alreadyQuoted) {
+    for (const pattern of DANGEROUS_PATTERNS) {
+      if (!pattern.pattern.test(normalized)) continue;
+
+      warnings.push({
+        id: pattern.id,
+        indicator: pattern.indicator,
+        message: pattern.message,
+        fixLabel: normalized ? 'Wrap in POSIX-safe quotes' : undefined,
+        fixValue: normalized ? quotePosix(normalized) : undefined,
+      });
+    }
+  }
+
+  return {
+    sanitized: normalized,
+    warnings,
+  };
+}


### PR DESCRIPTION
## Summary
- add reusable shell sanitization helper and quote utility
- integrate warnings, fixes, and quote selection controls into the command builder UI
- cover sanitization behavior with dedicated unit tests

## Testing
- yarn lint
- yarn test sanitizeCommand

------
https://chatgpt.com/codex/tasks/task_e_68dc2675673483288e9c20938111fad2