### PR TITLE
[hashcat] Improve StatsChart accessibility

### DIFF
--- a/__tests__/StatsChart.test.tsx
+++ b/__tests__/StatsChart.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import StatsChart from '../components/StatsChart';
+
+describe('StatsChart', () => {
+  it('renders a snapshot for populated values', () => {
+    const { container } = render(<StatsChart count={1200000} time={420} />);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders a snapshot when values are zero', () => {
+    const { container } = render(<StatsChart count={0} time={0} />);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/__tests__/__snapshots__/StatsChart.test.tsx.snap
+++ b/__tests__/__snapshots__/StatsChart.test.tsx.snap
@@ -1,0 +1,253 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`StatsChart renders a snapshot for populated values 1`] = `
+<svg
+  aria-describedby="«r1»"
+  aria-labelledby="«r0»"
+  class="w-full h-28 mt-2"
+  role="img"
+  viewBox="0 0 184 120"
+>
+  <title
+    id="«r0»"
+  >
+    Hash cracking progress overview
+  </title>
+  <desc
+    id="«r1»"
+  >
+    Bar chart comparing 1,200,000 candidates against 420 seconds.
+  </desc>
+  <line
+    stroke="var(--color-ubt-grey, #aea79f)"
+    stroke-width="1.5"
+    vector-effect="non-scaling-stroke"
+    x1="40"
+    x2="40"
+    y1="20"
+    y2="90"
+  />
+  <line
+    stroke="var(--color-ubt-grey, #aea79f)"
+    stroke-width="1.5"
+    vector-effect="non-scaling-stroke"
+    x1="40"
+    x2="164"
+    y1="90"
+    y2="90"
+  />
+  <g
+    aria-hidden="true"
+    fill="var(--color-ubt-grey, #aea79f)"
+    font-size="8"
+  >
+    <text
+      text-anchor="end"
+      x="36"
+      y="96"
+    >
+      0
+    </text>
+    <text
+      text-anchor="end"
+      x="36"
+      y="24"
+    >
+      1,200,000
+    </text>
+  </g>
+  <text
+    fill="var(--color-text, #f5f5f5)"
+    font-size="9"
+    text-anchor="middle"
+    transform="rotate(-90 20 55)"
+    x="20"
+    y="55"
+  >
+    Value
+  </text>
+  <text
+    fill="var(--color-text, #f5f5f5)"
+    font-size="9"
+    text-anchor="middle"
+    x="102"
+    y="108"
+  >
+    Metrics
+  </text>
+  <g>
+    <rect
+      fill="var(--game-color-success)"
+      height="70"
+      rx="4"
+      style="transition: height var(--motion-medium, 300ms) ease-out, y var(--motion-medium, 300ms) ease-out;"
+      width="36"
+      x="50"
+      y="20"
+    >
+      <title>
+        Candidates processed: 1,200,000 candidates
+      </title>
+    </rect>
+    <text
+      fill="var(--color-text, #f5f5f5)"
+      font-size="8.5"
+      text-anchor="middle"
+      x="68"
+      y="100"
+    >
+      Candidates
+    </text>
+  </g>
+  <g>
+    <rect
+      fill="var(--game-color-secondary)"
+      height="0.0245"
+      rx="4"
+      style="transition: height var(--motion-medium, 300ms) ease-out, y var(--motion-medium, 300ms) ease-out;"
+      width="36"
+      x="118"
+      y="89.9755"
+    >
+      <title>
+        Seconds elapsed: 420 seconds
+      </title>
+    </rect>
+    <text
+      fill="var(--color-text, #f5f5f5)"
+      font-size="8.5"
+      text-anchor="middle"
+      x="136"
+      y="100"
+    >
+      Seconds
+    </text>
+  </g>
+</svg>
+`;
+
+exports[`StatsChart renders a snapshot when values are zero 1`] = `
+<svg
+  aria-describedby="«r3»"
+  aria-labelledby="«r2»"
+  class="w-full h-28 mt-2"
+  role="img"
+  viewBox="0 0 184 120"
+>
+  <title
+    id="«r2»"
+  >
+    Hash cracking progress overview
+  </title>
+  <desc
+    id="«r3»"
+  >
+    Bar chart comparing 0 candidates against 0 seconds.
+  </desc>
+  <line
+    stroke="var(--color-ubt-grey, #aea79f)"
+    stroke-width="1.5"
+    vector-effect="non-scaling-stroke"
+    x1="40"
+    x2="40"
+    y1="20"
+    y2="90"
+  />
+  <line
+    stroke="var(--color-ubt-grey, #aea79f)"
+    stroke-width="1.5"
+    vector-effect="non-scaling-stroke"
+    x1="40"
+    x2="164"
+    y1="90"
+    y2="90"
+  />
+  <g
+    aria-hidden="true"
+    fill="var(--color-ubt-grey, #aea79f)"
+    font-size="8"
+  >
+    <text
+      text-anchor="end"
+      x="36"
+      y="96"
+    >
+      0
+    </text>
+    <text
+      text-anchor="end"
+      x="36"
+      y="24"
+    >
+      1
+    </text>
+  </g>
+  <text
+    fill="var(--color-text, #f5f5f5)"
+    font-size="9"
+    text-anchor="middle"
+    transform="rotate(-90 20 55)"
+    x="20"
+    y="55"
+  >
+    Value
+  </text>
+  <text
+    fill="var(--color-text, #f5f5f5)"
+    font-size="9"
+    text-anchor="middle"
+    x="102"
+    y="108"
+  >
+    Metrics
+  </text>
+  <g>
+    <rect
+      fill="var(--game-color-success)"
+      height="0"
+      rx="4"
+      style="transition: height var(--motion-medium, 300ms) ease-out, y var(--motion-medium, 300ms) ease-out;"
+      width="36"
+      x="50"
+      y="90"
+    >
+      <title>
+        Candidates processed: 0 candidates
+      </title>
+    </rect>
+    <text
+      fill="var(--color-text, #f5f5f5)"
+      font-size="8.5"
+      text-anchor="middle"
+      x="68"
+      y="100"
+    >
+      Candidates
+    </text>
+  </g>
+  <g>
+    <rect
+      fill="var(--game-color-secondary)"
+      height="0"
+      rx="4"
+      style="transition: height var(--motion-medium, 300ms) ease-out, y var(--motion-medium, 300ms) ease-out;"
+      width="36"
+      x="118"
+      y="90"
+    >
+      <title>
+        Seconds elapsed: 0 seconds
+      </title>
+    </rect>
+    <text
+      fill="var(--color-text, #f5f5f5)"
+      font-size="8.5"
+      text-anchor="middle"
+      x="136"
+      y="100"
+    >
+      Seconds
+    </text>
+  </g>
+</svg>
+`;

--- a/components/StatsChart.js
+++ b/components/StatsChart.js
@@ -1,19 +1,143 @@
-import React from 'react';
+import React, { useId, useMemo } from 'react';
 
-const StatsChart = ({ count, time }) => {
-  const max = Math.max(count, time, 1);
-  const cH = (count / max) * 80;
-  const tH = (time / max) * 80;
+const StatsChart = ({ count = 0, time = 0 }) => {
+  const chartTitleId = useId();
+  const chartDescId = useId();
+
+  const maxValue = Math.max(count, time, 1);
+  const chartHeight = 70;
+  const baselineY = 90;
+  const axisX = 40;
+  const barWidth = 36;
+  const barSpacing = 32;
+
+  const numberFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(undefined, {
+        maximumFractionDigits: 1,
+      }),
+    []
+  );
+
+  const bars = useMemo(
+    () => [
+      {
+        key: 'candidates',
+        label: 'Candidates processed',
+        shortLabel: 'Candidates',
+        value: count,
+        unit: 'candidates',
+        x: axisX + 10,
+        color: 'var(--game-color-success)',
+      },
+      {
+        key: 'seconds',
+        label: 'Seconds elapsed',
+        shortLabel: 'Seconds',
+        value: time,
+        unit: 'seconds',
+        x: axisX + 10 + barWidth + barSpacing,
+        color: 'var(--game-color-secondary)',
+      },
+    ],
+    [axisX, barSpacing, barWidth, count, time]
+  );
+
+  const chartRight = bars[bars.length - 1].x + barWidth + 10;
+  const axisColor = 'var(--color-ubt-grey, #aea79f)';
+  const textColor = 'var(--color-text, #f5f5f5)';
+  const transition =
+    'height var(--motion-medium, 300ms) ease-out, y var(--motion-medium, 300ms) ease-out';
+
+  const description = `Bar chart comparing ${numberFormatter.format(
+    count
+  )} candidates against ${numberFormatter.format(time)} seconds.`;
+
   return (
-    <svg viewBox="0 0 120 100" className="w-full h-24 mt-2">
-      <rect x="10" y={90 - cH} width="40" height={cH} fill="#10b981" />
-      <rect x="70" y={90 - tH} width="40" height={tH} fill="#3b82f6" />
-      <text x="30" y="95" textAnchor="middle" fontSize="8" fill="white">
-        candidates
+    <svg
+      role="img"
+      aria-labelledby={chartTitleId}
+      aria-describedby={chartDescId}
+      viewBox={`0 0 ${chartRight + 20} 120`}
+      className="w-full h-28 mt-2"
+    >
+      <title id={chartTitleId}>Hash cracking progress overview</title>
+      <desc id={chartDescId}>{description}</desc>
+      <line
+        x1={axisX}
+        y1={baselineY - chartHeight}
+        x2={axisX}
+        y2={baselineY}
+        stroke={axisColor}
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+      />
+      <line
+        x1={axisX}
+        y1={baselineY}
+        x2={chartRight}
+        y2={baselineY}
+        stroke={axisColor}
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+      />
+      <g aria-hidden="true" fill={axisColor} fontSize="8">
+        <text x={axisX - 4} y={baselineY + 6} textAnchor="end">
+          0
+        </text>
+        <text x={axisX - 4} y={baselineY - chartHeight + 4} textAnchor="end">
+          {numberFormatter.format(maxValue)}
+        </text>
+      </g>
+      <text
+        x={axisX / 2}
+        y={baselineY - chartHeight / 2}
+        textAnchor="middle"
+        fontSize="9"
+        fill={textColor}
+        transform={`rotate(-90 ${axisX / 2} ${baselineY - chartHeight / 2})`}
+      >
+        Value
       </text>
-      <text x="90" y="95" textAnchor="middle" fontSize="8" fill="white">
-        seconds
+      <text
+        x={(axisX + chartRight) / 2}
+        y={baselineY + 18}
+        textAnchor="middle"
+        fontSize="9"
+        fill={textColor}
+      >
+        Metrics
       </text>
+      {bars.map((bar) => {
+        const height = (bar.value / maxValue) * chartHeight;
+        const y = baselineY - height;
+        return (
+          <g key={bar.key}>
+            <rect
+              x={bar.x}
+              y={y}
+              width={barWidth}
+              height={height}
+              fill={bar.color}
+              rx="4"
+              style={{ transition }}
+            >
+              <title>
+                {`${bar.label}: ${numberFormatter.format(bar.value)} ${bar.unit}`}
+              </title>
+            </rect>
+            <text
+              x={bar.x + barWidth / 2}
+              y={baselineY + 10}
+              textAnchor="middle"
+              fontSize="8.5"
+              fill={textColor}
+            >
+              {bar.shortLabel}
+            </text>
+          </g>
+        );
+      })}
     </svg>
   );
 };


### PR DESCRIPTION
## Summary
- replace StatsChart hard-coded colors with theme tokens and add descriptive axes, titles, and tooltips
- respect reduced-motion preferences by driving bar transitions from design token timings
- add snapshot coverage for the chart rendering states

## Testing
- [x] yarn test StatsChart -u
- [x] yarn lint


------
https://chatgpt.com/codex/tasks/task_e_68dc26784c38832897c421f828934f88