### PR TITLE
[apps] Add attack mode primer and persistent wordlists

### DIFF
--- a/__tests__/hashcat.test.tsx
+++ b/__tests__/hashcat.test.tsx
@@ -4,6 +4,10 @@ import HashcatApp, { detectHashType } from '../components/apps/hashcat';
 import progressInfo from '../components/apps/hashcat/progress.json';
 
 describe('HashcatApp', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it('auto-detects hash types', () => {
     expect(detectHashType('d41d8cd98f00b204e9800998ecf8427e')).toBe('0');
     expect(detectHashType('da39a3ee5e6b4b0d3255bfef95601890afd80709')).toBe('100');
@@ -112,6 +116,40 @@ describe('HashcatApp', () => {
     expect(
       getByText(/\/usr\/share\/wordlists\/rockyou\.txt/)
     ).toBeInTheDocument();
+  });
+
+  it('persists custom wordlists to localStorage', () => {
+    const { getByLabelText, getByText } = render(<HashcatApp />);
+    fireEvent.change(getByLabelText('Wordlist Name'), {
+      target: { value: 'custom-list.txt' },
+    });
+    fireEvent.change(getByLabelText('Wordlist Entries (one per line)'), {
+      target: { value: 'alpha\nbeta' },
+    });
+    fireEvent.click(getByText('Add Wordlist'));
+
+    const stored = JSON.parse(
+      window.localStorage.getItem('hashcatWordlists') || '[]'
+    ) as Array<{ name?: string }>;
+    expect(stored.some((entry) => entry.name === 'custom-list.txt')).toBe(
+      true
+    );
+  });
+
+  it('restores custom wordlists from localStorage', () => {
+    window.localStorage.setItem(
+      'hashcatWordlists',
+      JSON.stringify([
+        { id: 'custom-1', name: 'persisted.txt', entries: 2, size: 12 },
+      ])
+    );
+
+    const { getByLabelText, getByTestId } = render(<HashcatApp />);
+    fireEvent.change(getByLabelText('Wordlist:'), {
+      target: { value: 'custom-1' },
+    });
+
+    expect(getByTestId('wordlist-meta').textContent).toContain('persisted.txt');
   });
 
   it('displays GPU requirement notice', () => {

--- a/components/StatsChart.js
+++ b/components/StatsChart.js
@@ -6,12 +6,36 @@ const StatsChart = ({ count, time }) => {
   const tH = (time / max) * 80;
   return (
     <svg viewBox="0 0 120 100" className="w-full h-24 mt-2">
-      <rect x="10" y={90 - cH} width="40" height={cH} fill="#10b981" />
-      <rect x="70" y={90 - tH} width="40" height={tH} fill="#3b82f6" />
-      <text x="30" y="95" textAnchor="middle" fontSize="8" fill="white">
+      <rect
+        x="10"
+        y={90 - cH}
+        width="40"
+        height={cH}
+        fill="var(--game-color-success, var(--color-accent, #10b981))"
+      />
+      <rect
+        x="70"
+        y={90 - tH}
+        width="40"
+        height={tH}
+        fill="var(--color-primary, var(--color-accent, #3b82f6))"
+      />
+      <text
+        x="30"
+        y="95"
+        textAnchor="middle"
+        fontSize="8"
+        fill="var(--color-text, #ffffff)"
+      >
         candidates
       </text>
-      <text x="90" y="95" textAnchor="middle" fontSize="8" fill="white">
+      <text
+        x="90"
+        y="95"
+        textAnchor="middle"
+        fontSize="8"
+        fill="var(--color-text, #ffffff)"
+      >
         seconds
       </text>
     </svg>

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -50,6 +50,101 @@ const attackModes = [
   { value: '7', label: 'Hybrid Mask + Wordlist' },
 ];
 
+const attackModeDetails = [
+  {
+    value: '0',
+    title: 'Straight',
+    icon: '📄',
+    diagram: ['📁 Wordlist', '⚙️ Rules (optional)', '🎯 Hash'],
+    bullets: [
+      'Iterates the chosen wordlist as-is.',
+      'Ideal for curated dictionaries.',
+      'Rule engine tweaks words on the fly.',
+    ],
+  },
+  {
+    value: '3',
+    title: 'Brute-force',
+    icon: '💣',
+    diagram: ['🎲 Charset', '🔁 Mask', '🎯 Hash'],
+    bullets: [
+      'Searches every candidate defined by the mask.',
+      'Great for short or structured passwords.',
+      'GPU intensive — monitor keyspace growth.',
+    ],
+  },
+  {
+    value: '6',
+    title: 'Wordlist + Mask',
+    icon: '🧩',
+    diagram: ['📁 Wordlist', '➕ Mask', '🎯 Hash'],
+    bullets: [
+      'Appends mask tokens to each dictionary entry.',
+      'Useful for suffix patterns like years or digits.',
+      'Combine with rules for layered mutations.',
+    ],
+  },
+  {
+    value: '7',
+    title: 'Mask + Wordlist',
+    icon: '🔀',
+    diagram: ['🔁 Mask', '➕ Wordlist', '🎯 Hash'],
+    bullets: [
+      'Prefixes dictionary words with mask content.',
+      'Pairs well with username-based guesses.',
+      'Keeps hybrid attacks flexible.',
+    ],
+  },
+];
+
+const defaultWordlists = [
+  {
+    id: 'rockyou',
+    name: 'rockyou.txt',
+    entries: 14344392,
+    size: 139_921_497,
+  },
+  {
+    id: 'top100',
+    name: 'top-100.txt',
+    entries: 100,
+    size: 900,
+  },
+];
+
+const WORDLIST_STORAGE_KEY = 'hashcatWordlists';
+
+const loadStoredWordlists = () => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const stored = window.localStorage.getItem(WORDLIST_STORAGE_KEY);
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((item) => item && typeof item.id === 'string')
+      .map((item) => ({
+        id: item.id,
+        name: item.name || 'custom.txt',
+        entries: Number(item.entries) || 0,
+        size: Number(item.size) || 0,
+      }));
+  } catch (error) {
+    return [];
+  }
+};
+
+const formatBytes = (value) => {
+  if (!value) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const index = Math.min(
+    units.length - 1,
+    Math.floor(Math.log(value) / Math.log(1024))
+  );
+  const size = value / 1024 ** index;
+  return `${size.toFixed(size >= 10 || index === 0 ? 0 : 1)} ${units[index]}`;
+};
+
 const ruleSets = {
   none: [],
   best64: ['c', 'u', 'l', 'r', 'd', 'p', 't', 's'],
@@ -166,6 +261,12 @@ function HashcatApp() {
   const [pattern, setPattern] = useState('');
   const [wordlistUrl, setWordlistUrl] = useState('');
   const [wordlist, setWordlist] = useState('');
+  const [customWordlists, setCustomWordlists] = useState(() =>
+    loadStoredWordlists()
+  );
+  const [newWordlistName, setNewWordlistName] = useState('');
+  const [newWordlistEntries, setNewWordlistEntries] = useState('');
+  const [wordlistStatus, setWordlistStatus] = useState(null);
   const [progress, setProgress] = useState(0);
   const [result, setResult] = useState('');
   const [isCracking, setIsCracking] = useState(false);
@@ -217,6 +318,14 @@ function HashcatApp() {
     }, 3000);
     return () => clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(
+      WORDLIST_STORAGE_KEY,
+      JSON.stringify(customWordlists)
+    );
+  }, [customWordlists]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -324,261 +433,491 @@ function HashcatApp() {
     setWordlistUrl(url);
   };
 
+  const combinedWordlists = [...defaultWordlists, ...customWordlists];
+  const selectedWordlist =
+    combinedWordlists.find((item) => item.id === wordlist) || null;
+
+  const handleAddWordlist = () => {
+    setWordlistStatus(null);
+    const entries = newWordlistEntries
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (!entries.length) {
+      setWordlistStatus({ type: 'error', text: 'Add at least one entry.' });
+      return;
+    }
+    const name = (newWordlistName || '').trim() ||
+      `custom-${customWordlists.length + 1}.txt`;
+    const payload = entries.join('\n');
+    const size = new TextEncoder().encode(payload).length;
+    const newList = {
+      id: `custom-${Date.now()}`,
+      name,
+      entries: entries.length,
+      size,
+    };
+    setCustomWordlists((prev) => [...prev, newList]);
+    setNewWordlistEntries('');
+    setNewWordlistName('');
+    setWordlistStatus({
+      type: 'success',
+      text: `${name} saved (${entries.length.toLocaleString()} entries).`,
+    });
+  };
+
+  const handleRemoveWordlist = (id) => {
+    const removed = customWordlists.find((item) => item.id === id);
+    setCustomWordlists((prev) => prev.filter((item) => item.id !== id));
+    if (wordlist === id) {
+      setWordlist('');
+    }
+    if (removed) {
+      setWordlistStatus({
+        type: 'info',
+        text: `${removed.name} removed.`,
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (!wordlistStatus) return undefined;
+    const timeout = setTimeout(() => setWordlistStatus(null), 5000);
+    return () => clearTimeout(timeout);
+  }, [wordlistStatus]);
+
   return (
-    <div className="h-full w-full flex flex-col items-center justify-center gap-4 bg-ub-cool-grey text-white">
-      <div>
-        <label className="mr-2" htmlFor="hash-input">
-          Hash:
-        </label>
-        <input
-          id="hash-input"
-          type="text"
-          aria-label="Hash value"
-          className="text-black px-2 py-1"
-          value={hashInput}
-          onChange={handleHashChange}
-        />
-      </div>
-      <div>
-        <label className="mr-2" htmlFor="hash-filter">
-          Filter Modes:
-        </label>
-        <input
-          id="hash-filter"
-          type="text"
-          aria-label="Filter hash modes"
-          className="text-black px-2 py-1"
-          value={hashFilter}
-          onChange={(e) => setHashFilter(e.target.value)}
-        />
-      </div>
-      <div>
-        <label className="mr-2" htmlFor="hash-type">
-          Hash Type:
-        </label>
-        <select
-          id="hash-type"
-          className="text-black px-2 py-1"
-          value={hashType}
-          onChange={(e) => setHashType(e.target.value)}
-        >
-          {filteredHashTypes.length ? (
-            filteredHashTypes.map((h) => (
-              <option key={h.id} value={h.id}>
-                {h.id} - {h.name} ({h.summary})
-              </option>
-            ))
-          ) : (
-            <option disabled>No modes</option>
-          )}
-        </select>
-      </div>
-      <div>
-        <label className="mr-2" htmlFor="attack-mode">
-          Attack Mode:
-        </label>
-        <select
-          id="attack-mode"
-          className="text-black px-2 py-1"
-          value={attackMode}
-          onChange={(e) => setAttackMode(e.target.value)}
-        >
-          {attackModes.map((m) => (
-            <option key={m.value} value={m.value}>
-              {m.value} - {m.label}
-            </option>
-          ))}
-        </select>
-      </div>
-      {showMask && (
-        <div>
-          <label className="block" htmlFor="mask-input">
-            Mask
-          </label>
-          <input
-            id="mask-input"
-            type="text"
-            aria-label="Mask pattern"
-            className="text-black px-2 py-1 w-full"
-            value={mask}
-            onChange={(e) => setMask(e.target.value)}
-          />
-          <div className="space-x-2 mt-1">
-            {['?l', '?u', '?d', '?s', '?a'].map((t) => (
-              <button
-                key={t}
-                type="button"
-                onClick={() => appendMask(t)}
-                aria-label={`Add ${t} to mask`}
+    <div className="h-full w-full flex flex-col lg:flex-row gap-4 bg-ub-cool-grey text-white p-4 overflow-y-auto">
+      <main className="flex-1 flex flex-col items-center gap-4">
+        <div className="w-full max-w-3xl flex flex-col gap-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="block text-sm" htmlFor="hash-input">
+                Hash:
+              </label>
+              <input
+                id="hash-input"
+                type="text"
+                aria-label="Hash value"
+                className="mt-1 w-full text-black px-2 py-1"
+                value={hashInput}
+                onChange={handleHashChange}
+              />
+            </div>
+            <div>
+              <label className="block text-sm" htmlFor="hash-filter">
+                Filter Modes:
+              </label>
+              <input
+                id="hash-filter"
+                type="text"
+                aria-label="Filter hash modes"
+                className="mt-1 w-full text-black px-2 py-1"
+                value={hashFilter}
+                onChange={(e) => setHashFilter(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="block text-sm" htmlFor="hash-type">
+                Hash Type:
+              </label>
+              <select
+                id="hash-type"
+                className="mt-1 w-full text-black px-2 py-1"
+                value={hashType}
+                onChange={(e) => setHashType(e.target.value)}
               >
-                {t}
-              </button>
-            ))}
+                {filteredHashTypes.length ? (
+                  filteredHashTypes.map((h) => (
+                    <option key={h.id} value={h.id}>
+                      {h.id} - {h.name} ({h.summary})
+                    </option>
+                  ))
+                ) : (
+                  <option disabled>No modes</option>
+                )}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm" htmlFor="attack-mode">
+                Attack Mode:
+              </label>
+              <select
+                id="attack-mode"
+                className="mt-1 w-full text-black px-2 py-1"
+                value={attackMode}
+                onChange={(e) => setAttackMode(e.target.value)}
+              >
+                {attackModes.map((m) => (
+                  <option key={m.value} value={m.value}>
+                    {m.value} - {m.label}
+                  </option>
+                ))}
+              </select>
+            </div>
           </div>
-          {mask && (
-            <div className="mt-2">
-              <p>Candidate space: {maskStats.count.toLocaleString()}</p>
-              <p className="text-sm">
-                Estimated @1M/s: {formatTime(maskStats.time)}
-              </p>
-              <StatsChart count={maskStats.count} time={maskStats.time} />
+          {showMask && (
+            <div>
+              <label className="block" htmlFor="mask-input">
+                Mask
+              </label>
+              <input
+                id="mask-input"
+                type="text"
+                aria-label="Mask pattern"
+                className="text-black px-2 py-1 w-full mt-1"
+                value={mask}
+                onChange={(e) => setMask(e.target.value)}
+              />
+              <div className="space-x-2 mt-1">
+                {['?l', '?u', '?d', '?s', '?a'].map((t) => (
+                  <button
+                    key={t}
+                    type="button"
+                    onClick={() => appendMask(t)}
+                    aria-label={`Add ${t} to mask`}
+                    className="px-2 py-1 bg-black/40 border border-white/10 rounded"
+                  >
+                    {t}
+                  </button>
+                ))}
+              </div>
+              {mask && (
+                <div className="mt-2">
+                  <p>Candidate space: {maskStats.count.toLocaleString()}</p>
+                  <p className="text-sm">
+                    Estimated @1M/s: {formatTime(maskStats.time)}
+                  </p>
+                  <StatsChart count={maskStats.count} time={maskStats.time} />
+                </div>
+              )}
             </div>
           )}
-        </div>
-      )}
-      <div>
-        <label className="mr-2" htmlFor="rule-set">
-          Rule Set:
-        </label>
-        <select
-          id="rule-set"
-          className="text-black px-2 py-1"
-          value={ruleSet}
-          onChange={(e) => setRuleSet(e.target.value)}
-        >
-          <option value="none">None</option>
-          <option value="best64">best64</option>
-          <option value="quick">quick</option>
-        </select>
-        <pre className="bg-black p-2 text-xs mt-2 overflow-auto h-24">
-          {rulePreview || '(no rules)'}
-        </pre>
-      </div>
-      <div>Detected: {selectedHash}</div>
-      <div>Summary: {selected.summary}</div>
-      <div>Example hash: {selected.example}</div>
-      <div>Expected output: {selected.output}</div>
-      <div>Description: {selected.description}</div>
-      <button type="button" onClick={runBenchmark}>
-        Run Benchmark
-      </button>
-      {benchmark && (
-        <div data-testid="benchmark-output">{benchmark}</div>
-      )}
-      <div>
-        <label className="mr-2" htmlFor="wordlist-select">
-          Wordlist:
-        </label>
-        <select
-          id="wordlist-select"
-          className="text-black px-2 py-1"
-          value={wordlist}
-          onChange={(e) => setWordlist(e.target.value)}
-        >
-          <option value="">Select wordlist (demo)</option>
-          <option value="rockyou">rockyou.txt</option>
-          <option value="top100">top-100.txt</option>
-        </select>
-        <div className="text-xs mt-1">
-          Wordlist selection is simulated. Common files live under{' '}
-          <code>/usr/share/wordlists/</code> e.g.{' '}
-          <code>/usr/share/wordlists/rockyou.txt</code>. Learn more at{' '}
-          <a
-            className="underline"
-            href="https://hashcat.net/wiki/doku.php?id=wordlists"
-            target="_blank"
-            rel="noreferrer"
-          >
-            hashcat.net
-          </a>
-          .
-        </div>
-        <div className="text-xs mt-1">
-          Sample entries: <code>password123</code>, <code>qwerty</code>,{' '}
-          <code>letmein</code>
-        </div>
-      </div>
-      <div>
-        <label className="mr-2" htmlFor="word-pattern">
-          Wordlist Pattern:
-        </label>
-        <input
-          id="word-pattern"
-          type="text"
-          aria-label="Wordlist pattern"
-          className="text-black px-2 py-1"
-          value={pattern}
-          onChange={(e) => setPattern(e.target.value)}
-        />
-        <button className="ml-2" type="button" onClick={createWordlist}>
-          Generate
-        </button>
-        {wordlistUrl && (
-          <a
-            className="ml-2 underline"
-            href={wordlistUrl}
-            download="wordlist.txt"
-          >
-            Download
-          </a>
-        )}
-        <div className="text-xs mt-1">Uploading wordlists is disabled.</div>
-      </div>
-      <div className="mt-2">
-        <div className="text-sm">Demo Command:</div>
-        <div className="flex items-center">
-          <code
-            className="bg-black px-2 py-1 text-xs"
-            data-testid="demo-command"
-          >
-            {`hashcat -m ${hashType} -a ${attackMode} ${
-              hashInput || 'hash.txt'
-            } ${wordlist ? `${wordlist}.txt` : 'wordlist.txt'}${
-              showMask && mask ? ` ${mask}` : ''
-            }${ruleSet !== 'none' ? ` -r ${ruleSet}.rule` : ''}`}
-          </code>
-          <button
-            className="ml-2"
-            type="button"
-            onClick={() => {
-              if (navigator?.clipboard?.writeText) {
-                navigator.clipboard.writeText(
-                  `hashcat -m ${hashType} -a ${attackMode} ${
-                    hashInput || 'hash.txt'
-                  } ${wordlist ? `${wordlist}.txt` : 'wordlist.txt'}${
-                    showMask && mask ? ` ${mask}` : ''
-                  }${ruleSet !== 'none' ? ` -r ${ruleSet}.rule` : ''}`
-                );
-              }
-            }}
-          >
-            Copy
-          </button>
-        </div>
-      </div>
-      <div className="mt-4 w-full max-w-md">
-        <div className="text-sm">Sample Output:</div>
-        <pre className="bg-black p-2 text-xs overflow-auto">
-          hashcat (demo) starting
+          <div>
+            <label className="mr-2" htmlFor="rule-set">
+              Rule Set:
+            </label>
+            <select
+              id="rule-set"
+              className="text-black px-2 py-1"
+              value={ruleSet}
+              onChange={(e) => setRuleSet(e.target.value)}
+            >
+              <option value="none">None</option>
+              <option value="best64">best64</option>
+              <option value="quick">quick</option>
+            </select>
+            <pre className="bg-black p-2 text-xs mt-2 overflow-auto h-24">
+              {rulePreview || '(no rules)'}
+            </pre>
+          </div>
+          <div className="grid gap-1 text-sm md:grid-cols-2">
+            <div>Detected: {selectedHash}</div>
+            <div>Summary: {selected.summary}</div>
+            <div>Example hash: {selected.example}</div>
+            <div>Expected output: {selected.output}</div>
+            <div className="md:col-span-2">Description: {selected.description}</div>
+          </div>
+          <div>
+            <button
+              type="button"
+              onClick={runBenchmark}
+              className="px-3 py-1 bg-black/40 border border-white/10 rounded"
+            >
+              Run Benchmark
+            </button>
+            {benchmark && (
+              <div data-testid="benchmark-output" className="mt-2">
+                {benchmark}
+              </div>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm" htmlFor="wordlist-select">
+              Wordlist:
+            </label>
+            <select
+              id="wordlist-select"
+              className="mt-1 text-black px-2 py-1 w-full"
+              value={wordlist}
+              onChange={(e) => setWordlist(e.target.value)}
+            >
+              <option value="">Select wordlist (demo)</option>
+              {combinedWordlists.map((list) => (
+                <option key={list.id} value={list.id}>
+                  {list.name} ({list.entries.toLocaleString()} entries)
+                </option>
+              ))}
+            </select>
+            {selectedWordlist && (
+              <div
+                className="text-xs mt-1"
+                data-testid="wordlist-meta"
+              >
+                {selectedWordlist.name} •{' '}
+                {selectedWordlist.entries.toLocaleString()} entries •{' '}
+                {formatBytes(selectedWordlist.size)}
+              </div>
+            )}
+            <div className="text-xs mt-1">
+              Wordlist selection is simulated. Common files live under{' '}
+              <code>/usr/share/wordlists/</code> e.g.{' '}
+              <code>/usr/share/wordlists/rockyou.txt</code>. Learn more at{' '}
+              <a
+                className="underline"
+                href="https://hashcat.net/wiki/doku.php?id=wordlists"
+                target="_blank"
+                rel="noreferrer"
+              >
+                hashcat.net
+              </a>
+              .
+            </div>
+            <div className="text-xs mt-1">
+              Sample entries: <code>password123</code>, <code>qwerty</code>,{' '}
+              <code>letmein</code>
+            </div>
+          </div>
+          <div className="bg-black/40 border border-white/10 rounded p-3">
+            <h3 className="text-sm font-semibold">Custom wordlists</h3>
+            <p className="text-xs text-gray-300">
+              Persisted locally with <code>localStorage</code>; no uploads leave
+              your browser.
+            </p>
+            <div className="mt-2">
+              <label
+                className="block text-xs uppercase tracking-wide"
+                htmlFor="custom-wordlist-name"
+              >
+                Wordlist Name
+              </label>
+              <input
+                id="custom-wordlist-name"
+                type="text"
+                className="mt-1 w-full text-black px-2 py-1"
+                aria-label="Wordlist Name"
+                value={newWordlistName}
+                onChange={(e) => setNewWordlistName(e.target.value)}
+              />
+            </div>
+            <div className="mt-2">
+              <label
+                className="block text-xs uppercase tracking-wide"
+                htmlFor="custom-wordlist-entries"
+              >
+                Wordlist Entries (one per line)
+              </label>
+              <textarea
+                id="custom-wordlist-entries"
+                className="mt-1 w-full h-24 text-black px-2 py-1"
+                aria-label="Wordlist Entries (one per line)"
+                value={newWordlistEntries}
+                onChange={(e) => setNewWordlistEntries(e.target.value)}
+              />
+            </div>
+            <button
+              type="button"
+              className="mt-3 px-3 py-1 bg-kali-blue text-black rounded"
+              onClick={handleAddWordlist}
+            >
+              Add Wordlist
+            </button>
+            {wordlistStatus && (
+              <div
+                className={`mt-2 text-xs ${
+                  wordlistStatus.type === 'error'
+                    ? 'text-red-300'
+                    : wordlistStatus.type === 'success'
+                    ? 'text-green-300'
+                    : 'text-blue-300'
+                }`}
+                role="status"
+                aria-live="polite"
+              >
+                {wordlistStatus.text}
+              </div>
+            )}
+            {customWordlists.length > 0 && (
+              <ul
+                className="mt-3 space-y-2 text-xs"
+                aria-label="Custom wordlists"
+              >
+                {customWordlists.map((list) => (
+                  <li
+                    key={list.id}
+                    className="flex items-center justify-between gap-2 bg-black/30 border border-white/5 rounded px-2 py-2"
+                  >
+                    <span>
+                      {list.name} • {list.entries.toLocaleString()} entries •{' '}
+                      {formatBytes(list.size)}
+                    </span>
+                    <button
+                      type="button"
+                      className="text-red-300 hover:text-red-200"
+                      onClick={() => handleRemoveWordlist(list.id)}
+                      aria-label={`Remove ${list.name}`}
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <div>
+            <label className="mr-2" htmlFor="word-pattern">
+              Wordlist Pattern:
+            </label>
+            <input
+              id="word-pattern"
+              type="text"
+              aria-label="Wordlist pattern"
+              className="text-black px-2 py-1"
+              value={pattern}
+              onChange={(e) => setPattern(e.target.value)}
+            />
+            <button className="ml-2" type="button" onClick={createWordlist}>
+              Generate
+            </button>
+            {wordlistUrl && (
+              <a
+                className="ml-2 underline"
+                href={wordlistUrl}
+                download="wordlist.txt"
+              >
+                Download
+              </a>
+            )}
+            <div className="text-xs mt-1">Uploading wordlists is disabled.</div>
+          </div>
+          <div className="mt-2">
+            <div className="text-sm">Demo Command:</div>
+            <div className="flex items-center flex-wrap gap-2">
+              <code
+                className="bg-black px-2 py-1 text-xs"
+                data-testid="demo-command"
+              >
+                {`hashcat -m ${hashType} -a ${attackMode} ${
+                  hashInput || 'hash.txt'
+                } ${selectedWordlist ? selectedWordlist.name : 'wordlist.txt'}${
+                  showMask && mask ? ` ${mask}` : ''
+                }${ruleSet !== 'none' ? ` -r ${ruleSet}.rule` : ''}`}
+              </code>
+              <button
+                className="px-2 py-1 bg-black/40 border border-white/10 rounded"
+                type="button"
+                onClick={() => {
+                  if (navigator?.clipboard?.writeText) {
+                    navigator.clipboard.writeText(
+                      `hashcat -m ${hashType} -a ${attackMode} ${
+                        hashInput || 'hash.txt'
+                      } ${
+                        selectedWordlist ? selectedWordlist.name : 'wordlist.txt'
+                      }${showMask && mask ? ` ${mask}` : ''}${
+                        ruleSet !== 'none' ? ` -r ${ruleSet}.rule` : ''
+                      }`
+                    );
+                  }
+                }}
+              >
+                Copy
+              </button>
+            </div>
+          </div>
+          <div className="mt-4 w-full max-w-md">
+            <div className="text-sm">Sample Output:</div>
+            <pre className="bg-black p-2 text-xs overflow-auto">
+              hashcat (demo) starting
 
-          5f4dcc3b5aa765d61d8327deb882cf99:password
+              5f4dcc3b5aa765d61d8327deb882cf99:password
 
-          Session completed.
-        </pre>
-      </div>
-      <Gauge value={gpuUsage} />
-      <div className="text-xs">Note: real hashcat requires a compatible GPU.</div>
-      {!isCracking ? (
-        <button type="button" onClick={startCracking}>
-          Start Cracking
-        </button>
-      ) : (
-        <button type="button" onClick={() => cancelCracking()}>
-          Cancel
-        </button>
-      )}
-      <ProgressGauge
-        progress={progress}
-        info={info}
-        reduceMotion={prefersReducedMotion}
-      />
-      {result && <div>Result: {result}</div>}
-      <pre className="bg-black text-green-400 p-2 rounded text-xs w-full max-w-md overflow-x-auto mt-4">
-        {sampleOutput}
-      </pre>
-      <div className="text-xs mt-4">
-        This tool simulates hash cracking for educational purposes only.
-      </div>
+              Session completed.
+            </pre>
+          </div>
+          <Gauge value={gpuUsage} />
+          <div className="text-xs">
+            Note: real hashcat requires a compatible GPU.
+          </div>
+          {!isCracking ? (
+            <button
+              type="button"
+              onClick={startCracking}
+              className="px-3 py-1 bg-kali-blue text-black rounded"
+            >
+              Start Cracking
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => cancelCracking()}
+              className="px-3 py-1 bg-black/40 border border-white/10 rounded"
+            >
+              Cancel
+            </button>
+          )}
+          <ProgressGauge
+            progress={progress}
+            info={info}
+            reduceMotion={prefersReducedMotion}
+          />
+          {result && <div>Result: {result}</div>}
+          <pre className="bg-black text-green-400 p-2 rounded text-xs w-full max-w-md overflow-x-auto mt-4">
+            {sampleOutput}
+          </pre>
+          <div className="text-xs mt-4">
+            This tool simulates hash cracking for educational purposes only.
+          </div>
+        </div>
+      </main>
+      <aside className="lg:w-72 flex-shrink-0 bg-black/40 border border-white/10 rounded-lg p-4 space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold">Attack mode primer</h2>
+          <p className="text-xs text-gray-300 mt-1">
+            Each mode balances speed and coverage differently. Compare them at a
+            glance while you tune parameters.
+          </p>
+        </div>
+        <ul className="space-y-3 text-sm">
+          {attackModeDetails.map((mode) => {
+            const active = mode.value === attackMode;
+            return (
+              <li
+                key={mode.value}
+                className={`rounded-md border p-3 transition-colors ${
+                  active
+                    ? 'border-kali-blue bg-kali-blue-glow/20'
+                    : 'border-white/10 bg-black/20'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-semibold">
+                    {mode.value} · {mode.title}
+                  </span>
+                  <span aria-hidden="true" className="text-lg">
+                    {mode.icon}
+                  </span>
+                </div>
+                <div
+                  className="flex items-center gap-1 text-xs text-gray-300 mt-2"
+                  aria-hidden="true"
+                >
+                  {mode.diagram.map((step, idx) => (
+                    <React.Fragment key={`${mode.value}-diagram-${step}`}>
+                      <span>{step}</span>
+                      {idx < mode.diagram.length - 1 && <span>➜</span>}
+                    </React.Fragment>
+                  ))}
+                </div>
+                <ul className="list-disc list-inside text-xs text-gray-100 mt-2">
+                  {mode.bullets.map((bullet) => (
+                    <li key={bullet}>{bullet}</li>
+                  ))}
+                </ul>
+              </li>
+            );
+          })}
+        </ul>
+      </aside>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add an attack mode primer panel with quick diagrams for the hashcat simulation
- allow users to manage custom wordlists with size/count metadata saved to localStorage
- update the shared stats chart to pull colors from the theme for better primer alignment

## Testing
- [x] yarn lint
- [x] yarn test hashcat

------
https://chatgpt.com/codex/tasks/task_e_68dc26767df88328b785f98569fb21bf