### PR TITLE
[openvas] interactive task history chart

### DIFF
--- a/__tests__/openvasFilters.test.ts
+++ b/__tests__/openvasFilters.test.ts
@@ -1,0 +1,60 @@
+import {
+  applyTaskFilters,
+  calculateFilterMetrics,
+  createInitialFilterState,
+  summarizeFilteredData,
+  taskFilterReducer,
+} from '../components/apps/openvas/taskFilters';
+
+const sampleData = [
+  { status: 'success', latency: 220 },
+  { status: 'fail', latency: 1400 },
+  { status: 'success', latency: 780 },
+  { status: 'fail', latency: 320 },
+];
+
+describe('openvas task filter state', () => {
+  it('toggles status filters without mutating other keys', () => {
+    const initial = createInitialFilterState();
+    const next = taskFilterReducer(initial, {
+      type: 'toggle-status',
+      status: 'success',
+      enabled: false,
+    });
+    expect(next.statuses.success).toBe(false);
+    expect(next.statuses.fail).toBe(true);
+    // Ensure the original state is not mutated and unrelated keys are preserved.
+    expect(initial.statuses.success).toBe(true);
+    expect(next.maxLatency).toBeNull();
+  });
+
+  it('applies status and latency filters with logical AND', () => {
+    const state = {
+      statuses: { success: false, fail: true },
+      maxLatency: 300,
+    };
+    const result = applyTaskFilters(sampleData, state);
+    expect(result).toHaveLength(0);
+
+    const relaxed = {
+      statuses: { success: false, fail: true },
+      maxLatency: 400,
+    };
+    const relaxedResult = applyTaskFilters(sampleData, relaxed);
+    expect(relaxedResult).toHaveLength(1);
+    expect(relaxedResult[0].latency).toBe(320);
+  });
+
+  it('summarizes filtered data based on calculated metrics', () => {
+    const metrics = calculateFilterMetrics(sampleData);
+    expect(metrics).toMatchObject({
+      total: 4,
+      success: 2,
+      fail: 2,
+    });
+    const summary = summarizeFilteredData(sampleData, metrics);
+    expect(summary).toContain('Showing 4 runs');
+    expect(summary).toContain('Success: 2');
+    expect(summary).toContain('Failure: 2');
+  });
+});

--- a/components/apps/openvas/task-history.json
+++ b/components/apps/openvas/task-history.json
@@ -1,8 +1,8 @@
 [
-  { "time": "08:00", "status": "Queued" },
-  { "time": "08:05", "status": "Running" },
-  { "time": "08:45", "status": "Completed" },
-  { "time": "09:00", "status": "Queued" },
-  { "time": "09:05", "status": "Running" },
-  { "time": "09:30", "status": "Completed" }
+  { "time": "2024-06-01T08:00:00Z", "status": "success", "latency": 320 },
+  { "time": "2024-06-01T08:05:00Z", "status": "success", "latency": 450 },
+  { "time": "2024-06-01T08:15:00Z", "status": "fail", "latency": 1180 },
+  { "time": "2024-06-01T08:20:00Z", "status": "success", "latency": 380 },
+  { "time": "2024-06-01T08:25:00Z", "status": "success", "latency": 290 },
+  { "time": "2024-06-01T08:30:00Z", "status": "fail", "latency": 1560 }
 ]

--- a/components/apps/openvas/task-overview.js
+++ b/components/apps/openvas/task-overview.js
@@ -1,31 +1,215 @@
-import React from 'react';
+import React, { useMemo, useReducer } from 'react';
 import FeedStatusCard from './feed-status-card';
 import TaskRunChart from './task-run-chart';
+import history from './task-history.json';
+import {
+  applyTaskFilters,
+  calculateFilterMetrics,
+  createInitialFilterState,
+  summarizeFilteredData,
+  taskFilterReducer,
+} from './taskFilters';
+
+const generateHistory = () => {
+  const baseTimestamp = history.length
+    ? Date.parse(history[0].time)
+    : Date.now();
+  const runs = [];
+  const batches = 400;
+  for (let batch = 0; batch < batches; batch += 1) {
+    history.forEach((entry, idx) => {
+      const offset = batch * history.length + idx;
+      const time = new Date(baseTimestamp + offset * 5 * 60 * 1000).toISOString();
+      const jitter = ((offset % 7) - 3) * 12;
+      const latency = Math.max(120, entry.latency + jitter);
+      const status = offset % 11 === 0 ? 'fail' : entry.status;
+      runs.push({
+        id: `${time}-${offset}`,
+        time,
+        status,
+        latency,
+      });
+    });
+  }
+  return runs;
+};
+
+const statusOptions = [
+  { id: 'success', label: 'Success' },
+  { id: 'fail', label: 'Fail' },
+];
 
 const TaskOverview = () => {
-  const tasks = [
-    { name: 'Internal Network Scan', status: 'Completed' },
-    { name: 'External Perimeter', status: 'Running' },
-    { name: 'Web App Audit', status: 'Queued' }
-  ];
+  const data = useMemo(generateHistory, []);
+  const [filters, dispatch] = useReducer(
+    taskFilterReducer,
+    undefined,
+    createInitialFilterState
+  );
+
+  const filteredData = useMemo(
+    () => applyTaskFilters(data, filters),
+    [data, filters]
+  );
+
+  const metrics = useMemo(
+    () => calculateFilterMetrics(filteredData),
+    [filteredData]
+  );
+
+  const summary = useMemo(
+    () => summarizeFilteredData(filteredData, metrics),
+    [filteredData, metrics]
+  );
+
+  const summaryId = 'task-overview-summary';
 
   return (
-    <div className="mb-4">
+    <div className="mb-4 space-y-4">
       <FeedStatusCard />
-      <div className="p-4 bg-gray-800 rounded">
-        <h3 className="text-md font-bold mb-2">Demo Task Overview</h3>
-        <h4 className="text-sm font-bold mb-1">Run History</h4>
-        <TaskRunChart />
-        <ul className="text-sm space-y-1 mt-2">
-          {tasks.map((t) => (
-            <li key={t.name} className="flex justify-between">
-              <span>{t.name}</span>
-              <span>{t.status}</span>
-            </li>
-          ))}
-        </ul>
-        <p className="text-xs text-gray-400 mt-2">
-          All task data is canned for demonstration purposes.
+      <div className="space-y-4 rounded bg-gray-800 p-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h3 className="text-md font-bold">Demo Task Overview</h3>
+            <p className="text-xs text-gray-300">
+              Visualize task runs with interactive zoom, panning, and filter controls.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => dispatch({ type: 'reset' })}
+            className="self-start rounded bg-gray-700 px-3 py-1 text-xs font-medium text-white hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-ubt-blue"
+          >
+            Reset filters
+          </button>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <fieldset className="space-y-2">
+            <legend className="text-sm font-semibold text-white">Status</legend>
+            {statusOptions.map((option) => {
+              const inputId = `task-status-${option.id}`;
+              const labelId = `${inputId}-label`;
+              return (
+                <label
+                  key={option.id}
+                  htmlFor={inputId}
+                  className="flex cursor-pointer select-none items-center gap-2 text-sm text-gray-200"
+                >
+                  <input
+                    id={inputId}
+                    type="checkbox"
+                    checked={filters.statuses[option.id]}
+                    onChange={(event) =>
+                      dispatch({
+                        type: 'toggle-status',
+                        status: option.id,
+                        enabled: event.target.checked,
+                      })
+                    }
+                    aria-labelledby={labelId}
+                    className="h-4 w-4 rounded border-gray-500 bg-gray-900 text-ubt-blue focus:ring-ubt-blue"
+                  />
+                  <span id={labelId}>{option.label}</span>
+                </label>
+              );
+            })}
+          </fieldset>
+
+          <div className="flex flex-col gap-2 text-sm text-gray-200" role="group" aria-labelledby="max-latency-label">
+            <span id="max-latency-label" className="font-semibold">
+              Maximum latency (ms)
+            </span>
+            <div className="flex items-center gap-2">
+              <input
+                id="max-latency-slider"
+                type="range"
+                min="0"
+                max="2000"
+                step="50"
+                value={filters.maxLatency ?? 2000}
+                onChange={(event) =>
+                  dispatch({
+                    type: 'set-max-latency',
+                    maxLatency:
+                      event.target.valueAsNumber === 2000
+                        ? null
+                        : event.target.valueAsNumber,
+                  })
+                }
+                aria-describedby="latency-hint"
+                aria-labelledby="max-latency-label"
+                className="grow"
+              />
+              <div className="flex flex-col gap-1">
+                <label htmlFor="max-latency-input" className="text-xs text-gray-300">
+                  Manual entry
+                </label>
+                <input
+                  id="max-latency-input"
+                  type="number"
+                  min="0"
+                  max="2000"
+                  step="10"
+                  value={filters.maxLatency ?? ''}
+                  onChange={(event) =>
+                    dispatch({
+                      type: 'set-max-latency',
+                      maxLatency:
+                        event.target.value === ''
+                          ? null
+                          : Number(event.target.value),
+                    })
+                  }
+                  aria-labelledby="max-latency-label"
+                  className="w-24 rounded border border-gray-600 bg-gray-900 px-2 py-1 text-right text-sm text-white focus:border-ubt-blue focus:outline-none"
+                />
+              </div>
+            </div>
+            <span id="latency-hint" className="text-xs text-gray-400">
+              Leave blank or set to 2000 to include all latencies.
+            </span>
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          <div className="rounded border border-gray-700 p-3 text-sm text-gray-200">
+            <p className="text-xs uppercase text-gray-400">Runs</p>
+            <p className="text-lg font-semibold text-white">{metrics.total}</p>
+          </div>
+          <div className="rounded border border-gray-700 p-3 text-sm text-gray-200">
+            <p className="text-xs uppercase text-gray-400">Success</p>
+            <p className="text-lg font-semibold text-white">{metrics.success}</p>
+          </div>
+          <div className="rounded border border-gray-700 p-3 text-sm text-gray-200">
+            <p className="text-xs uppercase text-gray-400">Failures</p>
+            <p className="text-lg font-semibold text-white">{metrics.fail}</p>
+          </div>
+        </div>
+
+        <div>
+          <h4 className="text-sm font-bold text-white">Run History</h4>
+          <TaskRunChart data={filteredData} />
+        </div>
+
+        <div
+          id={summaryId}
+          role="status"
+          aria-live="polite"
+          className="rounded border border-gray-700 bg-gray-900/50 p-3 text-xs text-gray-200"
+        >
+          <p className="font-semibold text-white">Filtered summary</p>
+          <p>{summary}</p>
+          {metrics.total > 0 && (
+            <p className="mt-1 text-gray-300">
+              Min latency: {Math.round(metrics.minLatency ?? 0)} ms · Max latency:{' '}
+              {Math.round(metrics.maxLatency ?? 0)} ms
+            </p>
+          )}
+        </div>
+
+        <p className="text-xs text-gray-400">
+          All task data is canned for demonstration purposes and generated locally for performance experiments.
         </p>
       </div>
     </div>

--- a/components/apps/openvas/task-run-chart.js
+++ b/components/apps/openvas/task-run-chart.js
@@ -1,61 +1,321 @@
-import React from 'react';
-import history from './task-history.json';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
-const statuses = ['Queued', 'Running', 'Completed'];
-const colors = {
-  Queued: 'fill-blue-500',
-  Running: 'fill-yellow-500',
-  Completed: 'fill-green-500',
+const STATUS_COLORS = {
+  success: '#10b981',
+  fail: '#ef4444',
 };
 
-const TaskRunChart = () => {
-  const height = 40;
-  const width = history.length * 20 + 20;
-  const points = history
-    .map((d, i) => {
-      const x = i * 20 + 10;
-      const y =
-        height - (statuses.indexOf(d.status) / (statuses.length - 1)) * height;
-      return `${x},${y}`;
-    })
-    .join(' ');
+const padding = { top: 12, right: 12, bottom: 28, left: 48 };
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const buildSampledIndices = (start, end, stride) => {
+  const indices = [];
+  for (let i = start; i <= end; i += stride) {
+    indices.push(i);
+  }
+  if (indices.length === 0 || indices[indices.length - 1] !== end) {
+    indices.push(end);
+  }
+  return indices;
+};
+
+const TaskRunChart = ({ data, height = 220 }) => {
+  const containerRef = useRef(null);
+  const canvasRef = useRef(null);
+  const brushRef = useRef(null);
+  const [dimensions, setDimensions] = useState({ width: 640, height });
+  const [view, setView] = useState({ start: 0, end: Math.max(0, data.length - 1) });
+  const [brushState, setBrushState] = useState(null);
+
+  useEffect(() => {
+    setView((current) => {
+      if (data.length === 0) {
+        return { start: 0, end: 0 };
+      }
+      const maxIndex = data.length - 1;
+      const span = Math.max(1, current.end - current.start);
+      if (current.end > maxIndex) {
+        const newEnd = maxIndex;
+        const newStart = clamp(newEnd - span, 0, newEnd);
+        return { start: newStart, end: newEnd };
+      }
+      return {
+        start: clamp(current.start, 0, maxIndex - span),
+        end: clamp(current.start + span, 0, maxIndex),
+      };
+    });
+  }, [data]);
+
+  useEffect(() => {
+    if (!containerRef.current || typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver((entries) => {
+      entries.forEach((entry) => {
+        const { width } = entry.contentRect;
+        setDimensions((prev) => ({ ...prev, width }));
+      });
+    });
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  const maxLatency = useMemo(() => {
+    return data.reduce((max, item) => Math.max(max, item.latency), 0);
+  }, [data]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const devicePixelRatio =
+      typeof window !== 'undefined' && window.devicePixelRatio ? window.devicePixelRatio : 1;
+    const width = Math.max(1, Math.floor(dimensions.width));
+    const heightPx = Math.max(1, Math.floor(dimensions.height));
+    const chartWidth = Math.max(1, width - padding.left - padding.right);
+    const chartHeight = Math.max(1, heightPx - padding.top - padding.bottom);
+
+    canvas.width = width * devicePixelRatio;
+    canvas.height = heightPx * devicePixelRatio;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${heightPx}px`;
+    ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+    ctx.clearRect(0, 0, width, heightPx);
+
+    ctx.fillStyle = '#1f2937';
+    ctx.fillRect(0, 0, width, heightPx);
+
+    if (!data.length || maxLatency === 0) {
+      ctx.fillStyle = '#d1d5db';
+      ctx.font = '12px sans-serif';
+      ctx.fillText('No data available', padding.left, padding.top + chartHeight / 2);
+      return;
+    }
+
+    const viewStart = Math.floor(clamp(view.start, 0, Math.max(0, data.length - 1)));
+    const viewEnd = Math.ceil(clamp(view.end, viewStart, Math.max(viewStart, data.length - 1)));
+    const visibleCount = Math.max(1, viewEnd - viewStart + 1);
+    const stride = Math.max(1, Math.floor(visibleCount / chartWidth));
+    const sampledIndices = buildSampledIndices(viewStart, viewEnd, stride);
+
+    const getX = (index) => {
+      const relativeIndex = index - viewStart;
+      const fraction = visibleCount <= 1 ? 0 : relativeIndex / (visibleCount - 1);
+      return padding.left + fraction * chartWidth;
+    };
+
+    const getY = (latency) => {
+      const fraction = latency / maxLatency;
+      return padding.top + (1 - fraction) * chartHeight;
+    };
+
+    ctx.strokeStyle = '#374151';
+    ctx.lineWidth = 1;
+    ctx.font = '11px sans-serif';
+    ctx.fillStyle = '#9ca3af';
+    const yTicks = 4;
+    for (let i = 0; i <= yTicks; i += 1) {
+      const value = (maxLatency / yTicks) * i;
+      const y = padding.top + chartHeight - (chartHeight * i) / yTicks;
+      ctx.beginPath();
+      ctx.moveTo(padding.left, y);
+      ctx.lineTo(width - padding.right, y);
+      ctx.stroke();
+      ctx.fillText(`${Math.round(value)} ms`, 6, y - 2);
+    }
+
+    ctx.beginPath();
+    sampledIndices.forEach((index, idx) => {
+      const item = data[index];
+      const x = getX(index);
+      const y = getY(item.latency);
+      if (idx === 0) {
+        ctx.moveTo(x, y);
+      } else {
+        ctx.lineTo(x, y);
+      }
+    });
+    ctx.lineWidth = 1.5;
+    ctx.strokeStyle = '#e5e7eb';
+    ctx.stroke();
+
+    sampledIndices.forEach((index) => {
+      const item = data[index];
+      const x = getX(index);
+      const y = getY(item.latency);
+      ctx.beginPath();
+      ctx.arc(x, y, 3, 0, Math.PI * 2);
+      ctx.fillStyle = STATUS_COLORS[item.status] || '#60a5fa';
+      ctx.fill();
+    });
+  }, [data, dimensions, maxLatency, view]);
+
+  const chartWidth = Math.max(1, dimensions.width - padding.left - padding.right);
+
+  const toChartX = (clientX) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return null;
+    const rect = canvas.getBoundingClientRect();
+    const x = clientX - rect.left;
+    return clamp(x, padding.left, padding.left + chartWidth);
+  };
+
+  const handlePointerDown = (event) => {
+    if (event.button !== 0) return;
+    const start = toChartX(event.clientX);
+    if (start === null) return;
+    brushRef.current = { start, end: start, active: true };
+    setBrushState({ start, end: start, active: true });
+    event.preventDefault();
+  };
+
+  const handlePointerMove = (event) => {
+    if (!brushRef.current?.active) return;
+    const end = toChartX(event.clientX);
+    if (end === null) return;
+    const next = { ...brushRef.current, end };
+    brushRef.current = next;
+    setBrushState(next);
+  };
+
+  const commitBrush = () => {
+    if (!brushRef.current) return;
+    const { start, end } = brushRef.current;
+    brushRef.current = null;
+    setBrushState(null);
+    if (Math.abs(end - start) < 4) {
+      return;
+    }
+    const left = Math.min(start, end);
+    const right = Math.max(start, end);
+    const leftFraction = (left - padding.left) / chartWidth;
+    const rightFraction = (right - padding.left) / chartWidth;
+    if (!Number.isFinite(leftFraction) || !Number.isFinite(rightFraction)) {
+      return;
+    }
+    setView((current) => {
+      const span = Math.max(1, current.end - current.start);
+      const absoluteStart = current.start + leftFraction * span;
+      const absoluteEnd = current.start + rightFraction * span;
+      const maxIndex = Math.max(0, data.length - 1);
+      const newStart = clamp(Math.floor(absoluteStart), 0, maxIndex);
+      const newEnd = clamp(Math.ceil(absoluteEnd), newStart, maxIndex);
+      return {
+        start: newStart,
+        end: newEnd,
+      };
+    });
+  };
+
+  const handlePointerUp = () => {
+    commitBrush();
+  };
+
+  const handlePointerLeave = (event) => {
+    if (event.buttons === 0) {
+      commitBrush();
+    }
+  };
+
+  const handleKeyDown = (event) => {
+    if (!data.length) return;
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+      event.preventDefault();
+      const direction = event.key === 'ArrowLeft' ? -1 : 1;
+      setView((current) => {
+        const span = Math.max(1, current.end - current.start);
+        const step = Math.max(1, Math.round(span * 0.1));
+        const delta = step * direction;
+        const maxIndex = Math.max(0, data.length - 1);
+        let nextStart = current.start + delta;
+        let nextEnd = current.end + delta;
+        if (nextStart < 0) {
+          nextEnd += -nextStart;
+          nextStart = 0;
+        }
+        if (nextEnd > maxIndex) {
+          const overflow = nextEnd - maxIndex;
+          nextStart = Math.max(0, nextStart - overflow);
+          nextEnd = maxIndex;
+        }
+        return { start: nextStart, end: nextEnd };
+      });
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      setView({ start: 0, end: Math.max(0, data.length - 1) });
+    }
+  };
+
+  const handleDoubleClick = () => {
+    setView({ start: 0, end: Math.max(0, data.length - 1) });
+  };
+
+  const instructionsId = 'task-run-chart-instructions';
+
   return (
-    <svg
-      viewBox={`0 0 ${width} ${height + 10}`}
-      className="w-full h-24 mb-2"
-      role="img"
-      aria-label="Task runs and status changes over time"
-    >
-      {statuses.map((s, idx) => {
-        const y = height - (idx / (statuses.length - 1)) * height;
-        return (
-          <g key={s}>
-            <line
-              x1="0"
-              y1={y}
-              x2={width}
-              y2={y}
-              className="stroke-gray-600"
-              strokeWidth="0.5"
-            />
-            <text
-              x="0"
-              y={y - 1}
-              className="fill-white text-[8px]"
-            >
-              {s}
-            </text>
-          </g>
-        );
-      })}
-      <polyline points={points} fill="none" stroke="white" strokeWidth="1" />
-      {history.map((d, i) => {
-        const x = i * 20 + 10;
-        const y =
-          height - (statuses.indexOf(d.status) / (statuses.length - 1)) * height;
-        return <circle key={d.time} cx={x} cy={y} r="2" className={colors[d.status]} />;
-      })}
-    </svg>
+    <div className="space-y-2">
+      <p id={instructionsId} className="text-xs text-gray-300">
+        Drag to brush and zoom. Use the left and right arrow keys to pan. Double click or press Escape to reset the view.
+      </p>
+      <div
+        ref={containerRef}
+        tabIndex={0}
+        role="group"
+        aria-describedby={instructionsId}
+        onKeyDown={handleKeyDown}
+        onDoubleClick={handleDoubleClick}
+        className="relative rounded border border-gray-600 focus:outline-none focus:ring-2 focus:ring-ubt-blue"
+        style={{ height }}
+      >
+        <canvas
+          ref={canvasRef}
+          className="w-full h-full"
+          role="img"
+          aria-label="Task run latency chart"
+          aria-describedby={instructionsId}
+        />
+        {brushState && (
+          <div
+            className="absolute bg-blue-400/30 border border-blue-300 pointer-events-none"
+            style={{
+              top: padding.top,
+              height: dimensions.height - padding.top - padding.bottom,
+              left: Math.min(brushState.start, brushState.end),
+              width: Math.max(2, Math.abs(brushState.end - brushState.start)),
+            }}
+          />
+        )}
+        <div
+          className="absolute inset-0 cursor-crosshair"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerLeave={handlePointerLeave}
+        />
+      </div>
+      <div className="flex items-center justify-between text-xs text-gray-300">
+        <span>
+          View range: {Math.floor(view.start)} – {Math.ceil(view.end)} of {Math.max(0, data.length - 1)}
+        </span>
+        <button
+          type="button"
+          onClick={() => setView({ start: 0, end: Math.max(0, data.length - 1) })}
+          className="rounded bg-gray-700 px-2 py-1 text-xs font-medium text-white hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-ubt-blue"
+        >
+          Reset view
+        </button>
+      </div>
+      <div className="flex gap-4 text-xs text-gray-300">
+        <div className="flex items-center gap-1">
+          <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: STATUS_COLORS.success }} />
+          Success
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: STATUS_COLORS.fail }} />
+          Fail
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/components/apps/openvas/taskFilters.js
+++ b/components/apps/openvas/taskFilters.js
@@ -1,0 +1,108 @@
+export const INITIAL_FILTER_STATE = Object.freeze({
+  statuses: Object.freeze({
+    success: true,
+    fail: true,
+  }),
+  maxLatency: null,
+});
+
+export const createInitialFilterState = () => ({
+  statuses: { ...INITIAL_FILTER_STATE.statuses },
+  maxLatency: INITIAL_FILTER_STATE.maxLatency,
+});
+
+export const clampLatency = (value) => {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) {
+    return null;
+  }
+  return Math.max(0, Number(value));
+};
+
+export function taskFilterReducer(state, action) {
+  switch (action.type) {
+    case 'toggle-status': {
+      const { status, enabled } = action;
+      if (!(status in state.statuses)) {
+        return state;
+      }
+      return {
+        ...state,
+        statuses: {
+          ...state.statuses,
+          [status]: enabled,
+        },
+      };
+    }
+    case 'set-max-latency': {
+      return {
+        ...state,
+        maxLatency: clampLatency(action.maxLatency),
+      };
+    }
+    case 'reset':
+      return createInitialFilterState();
+    default:
+      return state;
+  }
+}
+
+export const applyTaskFilters = (data, filters) => {
+  const enabledStatuses = Object.entries(filters.statuses)
+    .filter(([, isEnabled]) => isEnabled)
+    .map(([status]) => status);
+  const limit = filters.maxLatency;
+  return data.filter((item) => {
+    if (enabledStatuses.length > 0 && !enabledStatuses.includes(item.status)) {
+      return false;
+    }
+    if (typeof limit === 'number' && limit !== null && item.latency > limit) {
+      return false;
+    }
+    return true;
+  });
+};
+
+export const calculateFilterMetrics = (data) => {
+  if (data.length === 0) {
+    return {
+      total: 0,
+      success: 0,
+      fail: 0,
+      averageLatency: 0,
+      minLatency: null,
+      maxLatency: null,
+    };
+  }
+
+  let successCount = 0;
+  let failCount = 0;
+  let sum = 0;
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+
+  data.forEach((item) => {
+    if (item.status === 'success') successCount += 1;
+    if (item.status === 'fail') failCount += 1;
+    sum += item.latency;
+    min = Math.min(min, item.latency);
+    max = Math.max(max, item.latency);
+  });
+
+  return {
+    total: data.length,
+    success: successCount,
+    fail: failCount,
+    averageLatency: sum / data.length,
+    minLatency: min,
+    maxLatency: max,
+  };
+};
+
+export const summarizeFilteredData = (data, metrics) => {
+  const snapshot = metrics ?? calculateFilterMetrics(data);
+  if (snapshot.total === 0) {
+    return 'No task runs match the current filters.';
+  }
+  const averageLatency = Math.round(snapshot.averageLatency);
+  return `Showing ${snapshot.total} runs. Success: ${snapshot.success}. Failure: ${snapshot.fail}. Average latency: ${averageLatency} ms.`;
+};


### PR DESCRIPTION
## Summary
- replace the OpenVAS task overview list with a canvas-based chart that supports brushing zoom, keyboard panning, and virtualized rendering for large datasets
- add shared filtering utilities, status/latency controls, and accessible summaries for the filtered results
- cover the filter reducer and summary helpers with unit tests

## Testing
- yarn test openvasFilters
- yarn lint


------
https://chatgpt.com/codex/tasks/task_e_68dc267a60c88328882451f789e2d8e1