### PR TITLE
[ghidra] Add streaming hex viewer with search

### DIFF
--- a/__tests__/ghidra-hex-viewer.test.tsx
+++ b/__tests__/ghidra-hex-viewer.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import HexViewer from '../components/apps/ghidra/HexViewer';
+
+const SAMPLE_DATA = {
+  lines: [
+    { offset: 0, hex: '66 6f 6f', ascii: 'foo', sourceLine: 0 },
+    { offset: 16, hex: '62 61 72', ascii: 'bar', sourceLine: 1 },
+    { offset: 32, hex: '66 6f 6f', ascii: 'foo', sourceLine: 2 },
+  ],
+  totalBytes: 48,
+  done: true,
+};
+
+describe('HexViewer search navigation', () => {
+  it('wraps forward search results when reaching the end', async () => {
+    const user = userEvent.setup();
+    const onAnchorChange = jest.fn();
+    render(
+      <HexViewer
+        data={SAMPLE_DATA}
+        caret={{ line: null, offset: null }}
+        onAnchorChange={onAnchorChange}
+        loading={false}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/find/i);
+    await user.type(input, 'foo');
+    await waitFor(() => expect(onAnchorChange).toHaveBeenCalled());
+    onAnchorChange.mockClear();
+
+    const nextButton = screen.getByRole('button', { name: /find next/i });
+    await user.click(nextButton);
+    expect(onAnchorChange).toHaveBeenLastCalledWith({ line: 2, offset: 32 });
+
+    await user.click(nextButton);
+    expect(onAnchorChange).toHaveBeenLastCalledWith({ line: 0, offset: 0 });
+  });
+
+  it('wraps backward search results when reaching the beginning', async () => {
+    const user = userEvent.setup();
+    const onAnchorChange = jest.fn();
+    render(
+      <HexViewer
+        data={SAMPLE_DATA}
+        caret={{ line: null, offset: null }}
+        onAnchorChange={onAnchorChange}
+        loading={false}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/find/i);
+    await user.type(input, 'foo');
+    await waitFor(() => expect(onAnchorChange).toHaveBeenCalled());
+    onAnchorChange.mockClear();
+
+    const prevButton = screen.getByRole('button', { name: /find previous/i });
+    await user.click(prevButton);
+    expect(onAnchorChange).toHaveBeenLastCalledWith({ line: 2, offset: 32 });
+  });
+});

--- a/components/apps/ghidra/HexViewer.js
+++ b/components/apps/ghidra/HexViewer.js
@@ -1,0 +1,202 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+const EMPTY_LINES = [];
+
+const formatOffset = (offset) => offset.toString(16).padStart(8, '0');
+
+const assignViewerRef = (viewerRef, node) => {
+  if (!viewerRef) return;
+  if (typeof viewerRef === 'function') {
+    viewerRef(node);
+  } else if (viewerRef && 'current' in viewerRef) {
+    viewerRef.current = node;
+  }
+};
+
+export default function HexViewer({
+  data,
+  caret,
+  onAnchorChange,
+  loading,
+  viewerRef,
+}) {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [matchIndex, setMatchIndex] = useState(null);
+  const rowRefs = useRef(new Map());
+  const lastMatchOffsetRef = useRef(null);
+
+  const lines = data?.lines ?? EMPTY_LINES;
+
+  const matches = useMemo(() => {
+    if (!searchTerm) return [];
+    const query = searchTerm.toLowerCase();
+    return lines
+      .map((line, idx) => ({ line, idx }))
+      .filter(
+        ({ line }) =>
+          line.ascii.toLowerCase().includes(query) ||
+          line.hex.toLowerCase().includes(query)
+      );
+  }, [lines, searchTerm]);
+
+  useEffect(() => {
+    if (!searchTerm) {
+      setMatchIndex(null);
+      return;
+    }
+
+    if (matches.length === 0) {
+      setMatchIndex(null);
+      return;
+    }
+
+    setMatchIndex((prev) => {
+      const nextIndex = prev === null ? 0 : Math.min(prev, matches.length - 1);
+      const target = matches[nextIndex];
+      if (target && lastMatchOffsetRef.current !== target.line.offset) {
+        lastMatchOffsetRef.current = target.line.offset;
+        onAnchorChange({
+          line: target.line.sourceLine,
+          offset: target.line.offset,
+        });
+      }
+      return nextIndex;
+    });
+  }, [matches, onAnchorChange, searchTerm]);
+
+  useEffect(() => {
+    if (!caret || caret.offset == null) return;
+    lastMatchOffsetRef.current = caret.offset;
+    const node = rowRefs.current.get(caret.offset);
+    if (node && typeof node.scrollIntoView === 'function') {
+      node.scrollIntoView({ block: 'nearest' });
+    }
+  }, [caret]);
+
+  useEffect(() => () => rowRefs.current.clear(), []);
+
+  const handleRowClick = (line) => {
+    lastMatchOffsetRef.current = line.offset;
+    onAnchorChange({ line: line.sourceLine, offset: line.offset });
+  };
+
+  const jumpToMatch = (nextIndex) => {
+    if (matches.length === 0) return;
+    const normalized = ((nextIndex % matches.length) + matches.length) % matches.length;
+    const target = matches[normalized];
+    setMatchIndex(normalized);
+    if (target) {
+      lastMatchOffsetRef.current = target.line.offset;
+      onAnchorChange({ line: target.line.sourceLine, offset: target.line.offset });
+    }
+  };
+
+  const handleNext = () => {
+    if (matchIndex === null) {
+      jumpToMatch(0);
+    } else {
+      jumpToMatch(matchIndex + 1);
+    }
+  };
+
+  const handlePrevious = () => {
+    if (matchIndex === null) {
+      jumpToMatch(matches.length - 1);
+    } else {
+      jumpToMatch(matchIndex - 1);
+    }
+  };
+
+  const currentMatchPosition =
+    matchIndex === null || matches.length === 0 ? 0 : matchIndex + 1;
+
+  return (
+    <div className="flex h-full flex-col bg-gray-900 text-gray-100">
+      <div className="flex items-center gap-2 border-b border-gray-700 p-2 text-sm">
+        <label htmlFor="ghidra-hex-search" className="sr-only">
+          Find in hex view
+        </label>
+        <input
+          id="ghidra-hex-search"
+          type="search"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          placeholder="Find (hex or ASCII)"
+          aria-label="Find in hex view"
+          className="w-full rounded border border-gray-600 bg-gray-800 p-1 text-xs text-gray-100 placeholder:text-gray-400"
+        />
+        <button
+          type="button"
+          onClick={handlePrevious}
+          disabled={matches.length === 0}
+          className="rounded bg-gray-700 px-2 py-1 text-xs disabled:opacity-40"
+          aria-label="Find previous"
+        >
+          Prev
+        </button>
+        <button
+          type="button"
+          onClick={handleNext}
+          disabled={matches.length === 0}
+          className="rounded bg-gray-700 px-2 py-1 text-xs disabled:opacity-40"
+          aria-label="Find next"
+        >
+          Next
+        </button>
+        <span className="text-xs text-gray-400" aria-live="polite">
+          {matches.length === 0 && searchTerm
+            ? '0 / 0'
+            : `${currentMatchPosition} / ${matches.length || 0}`}
+        </span>
+      </div>
+      <div
+        ref={(node) => assignViewerRef(viewerRef, node)}
+        className="flex-1 overflow-auto bg-gray-900"
+        aria-label="Hex viewer"
+      >
+        {loading && lines.length === 0 ? (
+          <div className="p-4 text-xs text-gray-400">Loading hex data…</div>
+        ) : lines.length === 0 ? (
+          <div className="p-4 text-xs text-gray-400">No hex data</div>
+        ) : (
+          <table className="w-full table-fixed border-collapse text-left font-mono text-xs">
+            <thead className="sticky top-0 bg-gray-800 text-gray-300">
+              <tr>
+                <th className="w-24 px-2 py-1">Offset</th>
+                <th className="px-2 py-1">Hex</th>
+                <th className="w-40 px-2 py-1">ASCII</th>
+              </tr>
+            </thead>
+            <tbody>
+              {lines.map((line) => {
+                const isActive = caret && caret.offset === line.offset;
+                return (
+                  <tr
+                    key={line.offset}
+                    ref={(node) => {
+                      if (node) {
+                        rowRefs.current.set(line.offset, node);
+                      } else {
+                        rowRefs.current.delete(line.offset);
+                      }
+                    }}
+                    onClick={() => handleRowClick(line)}
+                    className={`cursor-pointer border-b border-gray-800 ${
+                      isActive ? 'bg-yellow-800 text-black' : 'hover:bg-gray-800'
+                    }`}
+                  >
+                    <td className="px-2 py-1 text-gray-400">
+                      {formatOffset(line.offset)}
+                    </td>
+                    <td className="px-2 py-1 text-gray-100">{line.hex}</td>
+                    <td className="px-2 py-1 text-gray-100">{line.ascii}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/apps/ghidra/hexWorker.js
+++ b/components/apps/ghidra/hexWorker.js
@@ -1,9 +1,54 @@
 /* eslint-env worker */
+const BYTES_PER_LINE = 16;
+const LINES_PER_CHUNK = 128;
+
 self.onmessage = (e) => {
   const { id, code } = e.data;
+  if (!id) return;
+
+  const text = typeof code === 'string' ? code : '';
   const encoder = new TextEncoder();
-  const hex = Array.from(encoder.encode(code))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join(' ');
-  postMessage({ id, hex });
+  const bytes = encoder.encode(text);
+  const totalBytes = bytes.length;
+
+  const byteLineMap = [];
+  let currentLine = 0;
+  for (const char of text) {
+    const encodedChar = encoder.encode(char);
+    for (let i = 0; i < encodedChar.length; i += 1) {
+      byteLineMap.push(currentLine);
+    }
+    if (char === '\n') {
+      currentLine += 1;
+    }
+  }
+
+  postMessage({ id, type: 'start', totalBytes });
+
+  let chunk = [];
+  for (let offset = 0; offset < bytes.length; offset += BYTES_PER_LINE) {
+    const slice = bytes.slice(offset, offset + BYTES_PER_LINE);
+    const hexParts = Array.from(slice).map((b) => b.toString(16).padStart(2, '0'));
+    const ascii = Array.from(slice)
+      .map((b) => (b >= 0x20 && b <= 0x7e ? String.fromCharCode(b) : '.'))
+      .join('');
+    const sourceLine = byteLineMap[offset] ?? 0;
+    chunk.push({
+      offset,
+      hex: hexParts.join(' '),
+      ascii,
+      sourceLine,
+    });
+
+    if (chunk.length === LINES_PER_CHUNK) {
+      postMessage({ id, type: 'chunk', lines: chunk, totalBytes });
+      chunk = [];
+    }
+  }
+
+  if (chunk.length > 0) {
+    postMessage({ id, type: 'chunk', lines: chunk, totalBytes });
+  }
+
+  postMessage({ id, type: 'done', totalBytes });
 };


### PR DESCRIPTION
## Summary
- replace the static hex dump pane with a dedicated HexViewer that streams worker chunks, renders hex and ASCII columns, and keeps caret selection in sync with the decompiler
- expand the ghidra worker to emit chunked messages containing formatted bytes and source line metadata so large files load progressively
- add navigation controls with wraparound search plus unit tests that verify the next/previous behaviour

## Testing
- yarn lint
- yarn test __tests__/ghidra-hex-viewer.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc267bde1c8328a92cddaee45223be