### PR TITLE
[ghidra] Improve function tree filtering and focus

### DIFF
--- a/__tests__/ghidraFunctionTree.test.tsx
+++ b/__tests__/ghidraFunctionTree.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import FunctionTree from '../components/apps/ghidra/FunctionTree';
+
+describe('FunctionTree', () => {
+  const functions = [
+    { name: 'main', calls: [] },
+    { name: 'helper', calls: [] },
+    { name: 'compute', calls: [] },
+  ];
+
+  it('filters functions by name with debounce', () => {
+    jest.useFakeTimers();
+    render(
+      <FunctionTree
+        functions={functions}
+        onSelect={jest.fn()}
+        selected="main"
+        pinned={[]}
+        onTogglePin={jest.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Filter functions'), {
+      target: { value: 'help' },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    expect(screen.getByText('helper')).toBeInTheDocument();
+    expect(screen.queryByText('main')).not.toBeInTheDocument();
+    expect(screen.queryByText('compute')).not.toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
+  it('renders pinned functions in favorites and triggers toggle', () => {
+    const handleToggle = jest.fn();
+    render(
+      <FunctionTree
+        functions={functions}
+        onSelect={jest.fn()}
+        selected="main"
+        pinned={['helper']}
+        onTogglePin={handleToggle}
+      />
+    );
+
+    expect(screen.getByText('Favorites')).toBeInTheDocument();
+    const favoritesSection = screen.getByText('Favorites').closest('div');
+    expect(favoritesSection).not.toBeNull();
+    const [unpinButton] = within(favoritesSection as HTMLElement).getAllByRole(
+      'button',
+      { name: 'Unpin helper' }
+    );
+    fireEvent.click(unpinButton);
+
+    expect(handleToggle).toHaveBeenCalledWith('helper');
+  });
+});

--- a/components/apps/ghidra/FunctionTree.js
+++ b/components/apps/ghidra/FunctionTree.js
@@ -1,14 +1,38 @@
 import React from 'react';
 
-function FunctionNode({ func, funcMap, onSelect, selected }) {
+function FunctionNode({
+  func,
+  funcMap,
+  onSelect,
+  selected,
+  onTogglePin,
+  pinned,
+}) {
+  const isPinned = pinned.has(func.name);
+
   return (
     <li>
-      <button
-        onClick={() => onSelect(func.name)}
-        className={`text-left w-full ${selected === func.name ? 'font-bold' : ''}`}
-      >
-        {func.name}
-      </button>
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={() => onSelect(func.name)}
+          className={`flex-1 text-left ${selected === func.name ? 'font-bold' : ''}`}
+        >
+          {func.name}
+        </button>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onTogglePin(func.name);
+          }}
+          aria-pressed={isPinned}
+          aria-label={`${isPinned ? 'Unpin' : 'Pin'} ${func.name}`}
+          className="text-xs"
+        >
+          {isPinned ? '★' : '☆'}
+        </button>
+      </div>
       {func.calls && func.calls.length > 0 && (
         <ul className="ml-4">
           {func.calls.map((c) =>
@@ -19,6 +43,8 @@ function FunctionNode({ func, funcMap, onSelect, selected }) {
                 funcMap={funcMap}
                 onSelect={onSelect}
                 selected={selected}
+                onTogglePin={onTogglePin}
+                pinned={pinned}
               />
             ) : (
               <li key={c}>{c}</li>
@@ -30,7 +56,24 @@ function FunctionNode({ func, funcMap, onSelect, selected }) {
   );
 }
 
-export default function FunctionTree({ functions, onSelect, selected }) {
+export default function FunctionTree({
+  functions,
+  onSelect,
+  selected,
+  pinned = [],
+  onTogglePin = () => {},
+}) {
+  const [searchTerm, setSearchTerm] = React.useState('');
+  const [debouncedQuery, setDebouncedQuery] = React.useState('');
+
+  React.useEffect(() => {
+    const handle = setTimeout(() => setDebouncedQuery(searchTerm), 150);
+    return () => clearTimeout(handle);
+  }, [searchTerm]);
+
+  const deferredQuery = React.useDeferredValue(debouncedQuery);
+  const normalizedQuery = deferredQuery.trim().toLowerCase();
+
   const funcMap = React.useMemo(() => {
     const map = {};
     functions.forEach((f) => {
@@ -39,25 +82,129 @@ export default function FunctionTree({ functions, onSelect, selected }) {
     return map;
   }, [functions]);
 
+  const pinnedSet = React.useMemo(() => new Set(pinned), [pinned]);
+
+  const favorites = React.useMemo(
+    () => pinned.filter((name) => funcMap[name]).map((name) => funcMap[name]),
+    [pinned, funcMap]
+  );
+
+  const filteredFunctions = React.useMemo(() => {
+    if (!normalizedQuery) return functions;
+    const queryLower = normalizedQuery;
+    return functions.filter((f) => f.name.toLowerCase().includes(queryLower));
+  }, [functions, normalizedQuery]);
+
   const called = React.useMemo(() => {
     const set = new Set();
     functions.forEach((f) => f.calls && f.calls.forEach((c) => set.add(c)));
     return set;
   }, [functions]);
 
-  const roots = functions.filter((f) => !called.has(f.name));
+  const roots = React.useMemo(
+    () => functions.filter((f) => !called.has(f.name)),
+    [functions, called]
+  );
 
   return (
-    <ul className="p-2 text-sm space-y-1">
-      {roots.map((f) => (
-        <FunctionNode
-          key={f.name}
-          func={f}
-          funcMap={funcMap}
-          onSelect={onSelect}
-          selected={selected}
+    <div>
+      <div className="p-2">
+        <input
+          type="text"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          placeholder="Filter functions"
+          className="w-full p-1 rounded text-black"
+          aria-label="Filter functions"
         />
-      ))}
-    </ul>
+      </div>
+      {favorites.length > 0 && (
+        <div className="px-2 mb-2">
+          <h3 className="text-xs uppercase tracking-wide text-gray-400 mb-1">
+            Favorites
+          </h3>
+          <ul className="text-sm space-y-1">
+            {favorites.map((func) => {
+              const isPinned = pinnedSet.has(func.name);
+              return (
+                <li key={`fav-${func.name}`}>
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => onSelect(func.name)}
+                      className={`flex-1 text-left ${
+                        selected === func.name ? 'font-bold' : ''
+                      }`}
+                    >
+                      {func.name}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onTogglePin(func.name);
+                      }}
+                      aria-pressed={isPinned}
+                      aria-label={`Unpin ${func.name}`}
+                      className="text-xs"
+                    >
+                      ★
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+      {normalizedQuery ? (
+        <ul className="p-2 text-sm space-y-1">
+          {filteredFunctions.map((func) => {
+            const isPinned = pinnedSet.has(func.name);
+            return (
+              <li key={func.name}>
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => onSelect(func.name)}
+                    className={`flex-1 text-left ${
+                      selected === func.name ? 'font-bold' : ''
+                    }`}
+                  >
+                    {func.name}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onTogglePin(func.name);
+                    }}
+                    aria-pressed={isPinned}
+                    aria-label={`${isPinned ? 'Unpin' : 'Pin'} ${func.name}`}
+                    className="text-xs"
+                  >
+                    {isPinned ? '★' : '☆'}
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <ul className="p-2 text-sm space-y-1">
+          {roots.map((f) => (
+            <FunctionNode
+              key={f.name}
+              func={f}
+              funcMap={funcMap}
+              onSelect={onSelect}
+              selected={selected}
+              onTogglePin={onTogglePin}
+              pinned={pinnedSet}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a debounced function search input with favorites section and pin controls in the Ghidra function tree
- focus the decompiled pane after selection and integrate pin management in the parent view
- cover filtering and pinning behaviors with targeted unit tests

## Testing
- yarn test __tests__/ghidraFunctionTree.test.tsx
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc267c69f083289da273cf875e9e90