### PR TITLE
[nmap-nse] add custom port presets manager

### DIFF
--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import NmapNSEApp from '../components/apps/nmap-nse';
 
@@ -82,7 +82,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });
@@ -129,6 +129,84 @@ describe('NmapNSEApp', () => {
     );
     expect(
       within(scriptNode.parentElement as HTMLElement).getByText('discovery')
+    ).toBeInTheDocument();
+
+    mockFetch.mockRestore();
+  });
+
+  it('supports creating, validating, and sharing custom port presets', async () => {
+    const mockFetch = jest
+      .spyOn(global, 'fetch')
+      .mockImplementation((url: RequestInfo | URL) =>
+        Promise.resolve({
+          json: () =>
+            Promise.resolve(
+              typeof url === 'string' && url.includes('nmap-results')
+                ? { hosts: [] }
+                : {}
+            ),
+        })
+      );
+
+    const writeText = jest.fn();
+    // @ts-ignore
+    navigator.clipboard = { writeText };
+
+    render(<NmapNSEApp />);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByRole('button', { name: /add preset/i }));
+
+    const nameInput = screen.getAllByLabelText(/preset name/i)[0];
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Web Ports');
+
+    expect(
+      screen.getByRole('button', { name: 'Web Ports' })
+    ).toBeInTheDocument();
+
+    const portsInput = screen.getAllByLabelText(/preset ports/i)[0];
+    await userEvent.clear(portsInput);
+    await userEvent.type(portsInput, '22,80,443');
+
+    expect(screen.getByText(/-p 22,80,443/)).toBeInTheDocument();
+
+    await userEvent.type(portsInput, ',80');
+    expect(screen.getByText(/Duplicate port 80/i)).toBeInTheDocument();
+
+    await userEvent.clear(portsInput);
+    await userEvent.type(portsInput, '1000-1002');
+    expect(screen.queryByText(/Duplicate port/)).not.toBeInTheDocument();
+    expect(screen.getByText(/-p 1000-1002/)).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /export json/i })
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('Web Ports')
+    );
+    const exportPreview = screen.getByLabelText(/Export presets JSON/i);
+    expect(exportPreview).toBeInTheDocument();
+    expect(exportPreview).toHaveAttribute('readOnly');
+    expect(exportPreview.textContent).toContain('1000-1002');
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /delete preset/i })
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Web Ports' })
+      ).not.toBeInTheDocument()
+    );
+
+    const importArea = screen.getByLabelText(/Import presets JSON/i);
+    await userEvent.clear(importArea);
+    fireEvent.change(importArea, {
+      target: { value: '[{"name":"API","ports":"3000,3001"}]' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /import json/i }));
+    expect(
+      await screen.findByRole('button', { name: 'API' })
     ).toBeInTheDocument();
 
     mockFetch.mockRestore();

--- a/components/apps/nmap-nse/PortPresetsEditor.js
+++ b/components/apps/nmap-nse/PortPresetsEditor.js
@@ -1,0 +1,170 @@
+import React, { useState } from 'react';
+
+const PortPresetsEditor = ({
+  presets,
+  errors = {},
+  onCreate,
+  onRename,
+  onUpdatePorts,
+  onDelete,
+  onImport,
+  onExport,
+}) => {
+  const [importText, setImportText] = useState('');
+  const [exportText, setExportText] = useState('');
+
+  const handleCreate = () => {
+    onCreate?.();
+  };
+
+  const handleRename = (id, value) => {
+    onRename?.(id, value);
+  };
+
+  const handlePortsChange = (id, value) => {
+    onUpdatePorts?.(id, value);
+  };
+
+  const handleDelete = (id) => {
+    onDelete?.(id);
+  };
+
+  const handleImport = () => {
+    if (!onImport) return;
+    const success = onImport(importText);
+    if (success) {
+      setImportText('');
+    }
+  };
+
+  const handleExport = async () => {
+    if (!onExport) return;
+    const data = await onExport();
+    if (data) {
+      const text =
+        typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+      setExportText(text);
+    }
+  };
+
+  return (
+    <div className="mt-4 p-3 rounded bg-ub-grey text-black">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-sm font-semibold">Custom port presets</h3>
+        <button
+          type="button"
+          onClick={handleCreate}
+          className="px-2 py-1 rounded bg-black text-white text-xs focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+        >
+          Add preset
+        </button>
+      </div>
+      <div className="space-y-3">
+        {presets.length === 0 && (
+          <p className="text-xs text-gray-700">No custom presets yet.</p>
+        )}
+        {presets.map((preset) => (
+          <div
+            key={preset.id}
+            className="border border-gray-500 rounded p-2 bg-white text-black"
+          >
+            <label
+              className="block text-xs font-semibold text-gray-700"
+              htmlFor={`preset-name-${preset.id}`}
+            >
+              Preset name
+            </label>
+            <input
+              id={`preset-name-${preset.id}`}
+              aria-label="Preset name"
+              value={preset.name}
+              onChange={(e) => handleRename(preset.id, e.target.value)}
+              className="w-full mt-1 mb-2 p-1 border border-gray-400 rounded"
+            />
+            <label
+              className="block text-xs font-semibold text-gray-700"
+              htmlFor={`preset-ports-${preset.id}`}
+            >
+              Preset ports
+            </label>
+            <input
+              id={`preset-ports-${preset.id}`}
+              aria-label="Preset ports"
+              value={preset.ports}
+              onChange={(e) => handlePortsChange(preset.id, e.target.value)}
+              className="w-full mt-1 p-1 border border-gray-400 rounded"
+              placeholder="e.g. 22,80,443 or 1-1024"
+            />
+            {errors[preset.id] && (
+              <p className="mt-1 text-xs text-red-700" role="alert">
+                {errors[preset.id]}
+              </p>
+            )}
+            <div className="mt-2 flex justify-end">
+              <button
+                type="button"
+                onClick={() => handleDelete(preset.id)}
+                className="px-2 py-1 text-xs rounded bg-red-600 text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-400"
+              >
+                Delete preset
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-3">
+        <label
+          className="block text-xs font-semibold text-gray-800"
+          htmlFor="port-preset-import"
+        >
+          Import presets JSON
+        </label>
+        <textarea
+          id="port-preset-import"
+          aria-label="Import presets JSON"
+          value={importText}
+          onChange={(e) => setImportText(e.target.value)}
+          rows={3}
+          className="w-full mt-1 p-2 rounded border border-gray-400"
+          placeholder='[ { "name": "Web", "ports": "80,443" } ]'
+        />
+      </div>
+      <div className="mt-2 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={handleImport}
+          className="px-2 py-1 rounded bg-black text-white text-xs focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+        >
+          Import JSON
+        </button>
+        <button
+          type="button"
+          onClick={handleExport}
+          className="px-2 py-1 rounded bg-black text-white text-xs focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+        >
+          Export JSON
+        </button>
+      </div>
+      {exportText && (
+        <div className="mt-2">
+          <label
+            className="block text-xs font-semibold text-gray-800"
+            htmlFor="port-preset-export"
+          >
+            Export preview
+          </label>
+          <textarea
+            id="port-preset-export"
+            aria-label="Export presets JSON"
+            value={exportText}
+            readOnly
+            rows={3}
+            className="w-full mt-1 p-2 rounded border border-gray-400 bg-gray-100"
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PortPresetsEditor;

--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import Toast from '../../ui/Toast';
 import DiscoveryMap from './DiscoveryMap';
+import PortPresetsEditor from './PortPresetsEditor';
+import { safeLocalStorage } from '../../../utils/safeStorage';
 
 // Basic script metadata. Example output is loaded from public/demo/nmap-nse.json
 const scripts = [
@@ -61,11 +63,70 @@ const phaseInfo = {
   }
 };
 
-const portPresets = [
-  { label: 'Default', flag: '' },
-  { label: 'Common', flag: '-F' },
-  { label: 'Full', flag: '-p-' }
+const builtinPortPresets = [
+  { id: 'builtin-default', label: 'Default', flag: '' },
+  { id: 'builtin-common', label: 'Common', flag: '-F' },
+  { id: 'builtin-full', label: 'Full', flag: '-p-' }
 ];
+
+const PORT_PRESET_STORAGE_KEY = 'nmap-port-presets';
+
+const normalizePortList = (value) =>
+  value
+    .split(',')
+    .map((token) => token.trim())
+    .filter(Boolean)
+    .join(',');
+
+const validatePortList = (value) => {
+  if (!value.trim()) {
+    return 'Enter at least one port.';
+  }
+
+  const tokens = value.split(',').map((token) => token.trim()).filter(Boolean);
+  if (tokens.length === 0) {
+    return 'Enter at least one port.';
+  }
+
+  const seen = new Set();
+
+  for (const token of tokens) {
+    if (/^\d+$/.test(token)) {
+      const port = Number(token);
+      if (port < 1 || port > 65535) {
+        return `Port ${port} must be between 1 and 65535.`;
+      }
+      if (seen.has(port)) {
+        return `Duplicate port ${port}.`;
+      }
+      seen.add(port);
+      continue;
+    }
+
+    if (/^\d+-\d+$/.test(token)) {
+      const [startRaw, endRaw] = token.split('-');
+      const start = Number(startRaw);
+      const end = Number(endRaw);
+      if (start < 1 || end > 65535 || start > end) {
+        return `Invalid range ${token}.`;
+      }
+      for (let port = start; port <= end; port += 1) {
+        if (seen.has(port)) {
+          return `Duplicate port ${port}.`;
+        }
+        seen.add(port);
+      }
+      continue;
+    }
+
+    return `Invalid token "${token}".`;
+  }
+
+  return null;
+};
+
+const createPresetId = () =>
+  `custom-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
 const cvssColor = (score) => {
   if (score >= 9) return 'bg-red-700';
@@ -79,6 +140,11 @@ const NmapNSEApp = () => {
   const [selectedScripts, setSelectedScripts] = useState([scripts[0].name]);
   const [scriptQuery, setScriptQuery] = useState('');
   const [portFlag, setPortFlag] = useState('');
+  const [customPresets, setCustomPresets] = useState([]);
+  const [presetErrors, setPresetErrors] = useState({});
+  const [selectedPresetId, setSelectedPresetId] = useState(
+    builtinPortPresets[0].id
+  );
   const [examples, setExamples] = useState({});
   const [results, setResults] = useState({ hosts: [] });
   const [scriptOptions, setScriptOptions] = useState({});
@@ -98,6 +164,207 @@ const NmapNSEApp = () => {
       .then(setResults)
       .catch(() => setResults({ hosts: [] }));
   }, []);
+
+  useEffect(() => {
+    if (!safeLocalStorage) return;
+    try {
+      const stored = safeLocalStorage.getItem(PORT_PRESET_STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          const mapped = parsed
+            .filter((item) => item && typeof item === 'object')
+            .map((item, index) => ({
+              id:
+                typeof item.id === 'string'
+                  ? item.id
+                  : `custom-${index}-${Date.now()}`,
+              name: typeof item.name === 'string' ? item.name : '',
+              ports: typeof item.ports === 'string' ? item.ports : '',
+            }));
+
+          const errors = mapped.reduce((acc, preset) => {
+            const error = validatePortList(preset.ports);
+            if (error) {
+              acc[preset.id] = error;
+            }
+            return acc;
+          }, {});
+
+          setCustomPresets(mapped);
+          setPresetErrors(errors);
+        }
+      }
+    } catch (e) {
+      // ignore malformed storage
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!safeLocalStorage) return;
+    try {
+      safeLocalStorage.setItem(
+        PORT_PRESET_STORAGE_KEY,
+        JSON.stringify(
+          customPresets.map(({ id, name, ports }) => ({ id, name, ports }))
+        )
+      );
+    } catch (e) {
+      // ignore storage errors
+    }
+  }, [customPresets]);
+
+  const selectBuiltinPreset = (preset) => {
+    setSelectedPresetId(preset.id);
+    setPortFlag(preset.flag);
+  };
+
+  const selectCustomPreset = (preset) => {
+    const normalized = normalizePortList(preset.ports);
+    if (!normalized || presetErrors[preset.id]) return;
+    setSelectedPresetId(preset.id);
+    setPortFlag(`-p ${normalized}`);
+  };
+
+  const handleCreatePreset = () => {
+    const newPreset = {
+      id: createPresetId(),
+      name: `Custom preset ${customPresets.length + 1}`,
+      ports: '80,443',
+    };
+    const error = validatePortList(newPreset.ports);
+    setCustomPresets((prev) => [...prev, newPreset]);
+    setPresetErrors((prev) => {
+      const next = { ...prev };
+      if (error) {
+        next[newPreset.id] = error;
+      } else {
+        delete next[newPreset.id];
+      }
+      return next;
+    });
+    setSelectedPresetId(newPreset.id);
+    setPortFlag(`-p ${normalizePortList(newPreset.ports)}`);
+  };
+
+  const handleRenamePreset = (id, name) => {
+    setCustomPresets((prev) =>
+      prev.map((preset) =>
+        preset.id === id
+          ? {
+              ...preset,
+              name,
+            }
+          : preset
+      )
+    );
+  };
+
+  const handlePortsChange = (id, ports) => {
+    const error = validatePortList(ports);
+    setCustomPresets((prev) =>
+      prev.map((preset) =>
+        preset.id === id
+          ? {
+              ...preset,
+              ports,
+            }
+          : preset
+      )
+    );
+    setPresetErrors((prev) => {
+      const next = { ...prev };
+      if (error) {
+        next[id] = error;
+      } else {
+        delete next[id];
+      }
+      return next;
+    });
+    if (!error && selectedPresetId === id) {
+      const normalized = normalizePortList(ports);
+      setPortFlag(normalized ? `-p ${normalized}` : '');
+    }
+  };
+
+  const handleDeletePreset = (id) => {
+    setCustomPresets((prev) => prev.filter((preset) => preset.id !== id));
+    setPresetErrors((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    if (selectedPresetId === id) {
+      setSelectedPresetId(builtinPortPresets[0].id);
+      setPortFlag(builtinPortPresets[0].flag);
+    }
+  };
+
+  const handleImportPresets = (text) => {
+    try {
+      const parsed = JSON.parse(text);
+      if (!Array.isArray(parsed)) {
+        throw new Error('Invalid format');
+      }
+
+      const mapped = parsed.map((item, index) => ({
+        id: createPresetId(),
+        name:
+          item && typeof item.name === 'string'
+            ? item.name
+            : `Imported preset ${index + 1}`,
+        ports:
+          item && typeof item.ports === 'string' ? item.ports : '',
+      }));
+
+      const errors = mapped.reduce((acc, preset) => {
+        const error = validatePortList(preset.ports);
+        if (error) {
+          acc[preset.id] = error;
+        }
+        return acc;
+      }, {});
+
+      setCustomPresets(mapped);
+      setPresetErrors(errors);
+
+      const firstValid = mapped.find((preset) => !errors[preset.id]);
+      if (firstValid) {
+        setSelectedPresetId(firstValid.id);
+        setPortFlag(`-p ${normalizePortList(firstValid.ports)}`);
+      } else {
+        setSelectedPresetId(builtinPortPresets[0].id);
+        setPortFlag(builtinPortPresets[0].flag);
+      }
+
+      setToast('Presets imported');
+      return true;
+    } catch (e) {
+      setToast('Import failed');
+      return false;
+    }
+  };
+
+  const handleExportPresets = async () => {
+    const data = customPresets.map((preset) => ({
+      name: preset.name,
+      ports: normalizePortList(preset.ports),
+    }));
+    const json = JSON.stringify(data, null, 2);
+
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(json);
+        setToast('Presets copied to clipboard');
+      } else {
+        setToast('Export ready below');
+      }
+    } catch (e) {
+      setToast('Export ready below');
+    }
+
+    return json;
+  };
 
   const toggleScript = (name) => {
     setSelectedScripts((prev) => {
@@ -203,6 +470,7 @@ const NmapNSEApp = () => {
             id="target"
             value={target}
             onChange={(e) => setTarget(e.target.value)}
+            aria-label="Target"
             className="w-full p-2 text-black"
           />
         </div>
@@ -215,6 +483,7 @@ const NmapNSEApp = () => {
             value={scriptQuery}
             onChange={(e) => setScriptQuery(e.target.value)}
             placeholder="Search scripts"
+            aria-label="Search scripts"
             className="w-full p-2 text-black mb-2"
           />
           <div className="max-h-64 overflow-y-auto grid grid-cols-1 sm:grid-cols-2 gap-2">
@@ -225,6 +494,7 @@ const NmapNSEApp = () => {
                     type="checkbox"
                     checked={selectedScripts.includes(s.name)}
                     onChange={() => toggleScript(s.name)}
+                    aria-label={s.name}
                   />
                   <span className="font-mono">{s.name}</span>
                 </label>
@@ -247,6 +517,7 @@ const NmapNSEApp = () => {
                       }))
                     }
                     placeholder="arg=value"
+                    aria-label={`${s.name} arguments`}
                     className="w-full p-1 border rounded text-black"
                   />
                 )}
@@ -259,20 +530,51 @@ const NmapNSEApp = () => {
         </div>
         <div className="mb-4">
           <p className="block text-sm mb-1">Port presets</p>
-          <div className="flex gap-2">
-            {portPresets.map((p) => (
+          <div className="flex flex-wrap gap-2">
+            {builtinPortPresets.map((preset) => (
               <button
-                key={p.label}
+                key={preset.id}
                 type="button"
-                onClick={() => setPortFlag(p.flag)}
+                onClick={() => selectBuiltinPreset(preset)}
                 className={`px-2 py-1 rounded text-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow ${
-                  portFlag === p.flag ? 'bg-ub-yellow' : 'bg-ub-grey'
+                  selectedPresetId === preset.id
+                    ? 'bg-ub-yellow'
+                    : 'bg-ub-grey'
                 }`}
               >
-                {p.label}
+                {preset.label}
               </button>
             ))}
+            {customPresets.map((preset) => {
+              const normalized = normalizePortList(preset.ports);
+              const hasError = Boolean(presetErrors[preset.id]);
+              return (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() => selectCustomPreset(preset)}
+                  disabled={hasError || !normalized}
+                  className={`px-2 py-1 rounded text-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow ${
+                    selectedPresetId === preset.id
+                      ? 'bg-ub-yellow'
+                      : 'bg-ub-grey'
+                  } ${hasError || !normalized ? 'opacity-60 cursor-not-allowed' : ''}`}
+                >
+                  {preset.name || 'Unnamed preset'}
+                </button>
+              );
+            })}
           </div>
+          <PortPresetsEditor
+            presets={customPresets}
+            errors={presetErrors}
+            onCreate={handleCreatePreset}
+            onRename={handleRenamePreset}
+            onUpdatePorts={handlePortsChange}
+            onDelete={handleDeletePreset}
+            onImport={handleImportPresets}
+            onExport={handleExportPresets}
+          />
         </div>
         <div className="flex items-center mb-4">
           <pre className="flex-1 bg-black text-green-400 p-2 rounded overflow-auto">


### PR DESCRIPTION
## Summary
- add a reusable port preset editor with create/rename/delete and JSON import/export
- persist custom presets to localStorage and expose them in the Nmap NSE port selector with validation
- cover preset CRUD flows with a new unit test suite update

## Testing
- yarn test nmapNse
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc26808c8c8328b372e3b19b7597fa