### PR TITLE
feat(nmap-nse): add result view toggles and pivot summary

### DIFF
--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -3,49 +3,67 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import NmapNSEApp from '../components/apps/nmap-nse';
 
+const SAMPLE_RESULTS = {
+  hosts: [
+    {
+      ip: '192.0.2.1',
+      ports: [
+        {
+          port: 80,
+          service: 'http',
+          cvss: 5,
+          scripts: [
+            {
+              name: 'http-title',
+              output: 'Example Domain',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const SAMPLE_OUTPUTS = {
+  'http-title': 'Sample output',
+  'ftp-anon': 'FTP output',
+};
+
+const mockFetch = (results = SAMPLE_RESULTS, outputs = SAMPLE_OUTPUTS) =>
+  jest
+    .spyOn(global, 'fetch')
+    .mockImplementation((url: RequestInfo | URL) =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve(
+            typeof url === 'string' && url.includes('nmap-results')
+              ? results
+              : outputs
+          ),
+      })
+    );
+
 describe('NmapNSEApp', () => {
   it('shows example output for selected script', async () => {
-    const mockFetch = jest
-      .spyOn(global, 'fetch')
-      .mockImplementation((url: RequestInfo | URL) =>
-        Promise.resolve({
-          json: () =>
-            Promise.resolve(
-              typeof url === 'string' && url.includes('nmap-results')
-                ? { hosts: [] }
-                : { 'ftp-anon': 'FTP output' }
-            ),
-        })
-      );
+    const fetchSpy = mockFetch({ hosts: [] }, { 'ftp-anon': 'FTP output' });
 
     render(<NmapNSEApp />);
-    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
 
     await userEvent.click(screen.getByLabelText(/ftp-anon/i));
     expect(await screen.findByText('FTP output')).toBeInTheDocument();
 
-    mockFetch.mockRestore();
+    fetchSpy.mockRestore();
   });
 
   it('copies command to clipboard', async () => {
-    const mockFetch = jest
-      .spyOn(global, 'fetch')
-      .mockImplementation((url: RequestInfo | URL) =>
-        Promise.resolve({
-          json: () =>
-            Promise.resolve(
-              typeof url === 'string' && url.includes('nmap-results')
-                ? { hosts: [] }
-                : {}
-            ),
-        })
-      );
+    const fetchSpy = mockFetch({ hosts: [] }, {});
     const writeText = jest.fn();
     // @ts-ignore
     navigator.clipboard = { writeText };
 
     render(<NmapNSEApp />);
-    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
     await userEvent.click(
       screen.getByRole('button', { name: /copy command/i })
     );
@@ -53,28 +71,17 @@ describe('NmapNSEApp', () => {
       expect.stringContaining('nmap')
     );
 
-    mockFetch.mockRestore();
+    fetchSpy.mockRestore();
   });
 
   it('copies example output to clipboard', async () => {
-    const mockFetch = jest
-      .spyOn(global, 'fetch')
-      .mockImplementation((url: RequestInfo | URL) =>
-        Promise.resolve({
-          json: () =>
-            Promise.resolve(
-              typeof url === 'string' && url.includes('nmap-results')
-                ? { hosts: [] }
-                : { 'http-title': 'Sample output' }
-            ),
-        })
-      );
+    const fetchSpy = mockFetch({ hosts: [] }, { 'http-title': 'Sample output' });
     const writeText = jest.fn();
     // @ts-ignore
     navigator.clipboard = { writeText };
 
     render(<NmapNSEApp />);
-    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
 
     await userEvent.click(
       screen.getByRole('button', { name: /copy output/i })
@@ -82,55 +89,79 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
-    mockFetch.mockRestore();
+    fetchSpy.mockRestore();
   });
 
   it('renders script results with category badges', async () => {
-    const mockFetch = jest
-      .spyOn(global, 'fetch')
-      .mockImplementation((url: RequestInfo | URL) =>
-        Promise.resolve({
-          json: () =>
-            Promise.resolve(
-              typeof url === 'string' && url.includes('nmap-results')
-                ? {
-                    hosts: [
-                      {
-                        ip: '192.0.2.1',
-                        ports: [
-                          {
-                            port: 80,
-                            service: 'http',
-                            cvss: 5,
-                            scripts: [
-                              {
-                                name: 'http-title',
-                                output: 'Example Domain',
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  }
-                : {}
-            ),
-        })
-      );
+    const fetchSpy = mockFetch(SAMPLE_RESULTS, {});
 
     render(<NmapNSEApp />);
-    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
 
-    const hostNode = await screen.findByText('192.0.2.1');
-    const scriptNode = within(hostNode.parentElement as HTMLElement).getByText(
+    const hostButton = await screen.findByRole('button', { name: '192.0.2.1' });
+    const scriptNode = within(hostButton.closest('li') as HTMLElement).getByText(
       'http-title'
     );
     expect(
       within(scriptNode.parentElement as HTMLElement).getByText('discovery')
     ).toBeInTheDocument();
 
-    mockFetch.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it('allows toggling result views', async () => {
+    const fetchSpy = mockFetch(SAMPLE_RESULTS, SAMPLE_OUTPUTS);
+
+    render(<NmapNSEApp />);
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+
+    const rawTab = screen.getByRole('tab', { name: /raw json/i });
+    const pivotTab = screen.getByRole('tab', {
+      name: /hosts\/services pivot table/i,
+    });
+
+    await userEvent.click(rawTab);
+    expect(
+      screen.getByText(/"ip": "192\.0\.2\.1"/, { selector: 'pre' })
+    ).toBeInTheDocument();
+
+    await userEvent.click(pivotTab);
+    expect(
+      await screen.findByRole('button', { name: /http on 192.0.2.1/i })
+    ).toBeInTheDocument();
+
+    fetchSpy.mockRestore();
+  });
+
+  it('retains selected host and service when switching views', async () => {
+    const fetchSpy = mockFetch(SAMPLE_RESULTS, SAMPLE_OUTPUTS);
+
+    render(<NmapNSEApp />);
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+
+    const serviceButton = await screen.findByRole('button', {
+      name: /http on 192.0.2.1/i,
+    });
+    await userEvent.click(serviceButton);
+    expect(serviceButton).toHaveAttribute('aria-pressed', 'true');
+
+    await userEvent.click(
+      screen.getByRole('tab', { name: /hosts\/services pivot table/i })
+    );
+
+    const pivotCell = await screen.findByRole('button', {
+      name: /http on 192.0.2.1/i,
+    });
+    expect(pivotCell).toHaveAttribute('aria-pressed', 'true');
+
+    await userEvent.click(screen.getByRole('tab', { name: /parsed tree/i }));
+    const serviceButtonAgain = await screen.findByRole('button', {
+      name: /http on 192.0.2.1/i,
+    });
+    expect(serviceButtonAgain).toHaveAttribute('aria-pressed', 'true');
+
+    fetchSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- store the demo scan JSON and expose Raw JSON, Parsed Tree, and Hosts/Services pivot table views with copy controls
- keep host/service selections consistent while navigating views and highlight the active rows across the tree and pivot table
- expand the Jest suite to cover view toggling and selection persistence

## Testing
- yarn test __tests__/nmapNse.test.tsx
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc2680cb0c832895658e37fe5b68cc