### PR TITLE
[apps] Enhance screen recorder UX

### DIFF
--- a/__tests__/screenRecorder.test.tsx
+++ b/__tests__/screenRecorder.test.tsx
@@ -1,0 +1,262 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ScreenRecorder from '../components/apps/screen-recorder';
+
+const originalMediaStream = globalThis.MediaStream;
+const originalMediaRecorder = (globalThis as any).MediaRecorder;
+const originalAudioContext = globalThis.AudioContext;
+const originalMediaDevices = navigator.mediaDevices;
+const originalCreateObjectURL = URL.createObjectURL;
+
+type TrackKind = 'audio' | 'video';
+
+const createTrack = (kind: TrackKind): MediaStreamTrack => {
+    return {
+        kind,
+        stop: jest.fn(),
+    } as unknown as MediaStreamTrack;
+};
+
+class MockMediaStream {
+    private tracks: MediaStreamTrack[];
+
+    constructor(tracks: MediaStreamTrack[] = []) {
+        this.tracks = [...tracks];
+    }
+
+    addTrack(track: MediaStreamTrack) {
+        this.tracks.push(track);
+    }
+
+    getTracks() {
+        return [...this.tracks];
+    }
+
+    getAudioTracks() {
+        return this.tracks.filter((track) => track.kind === 'audio');
+    }
+
+    getVideoTracks() {
+        return this.tracks.filter((track) => track.kind === 'video');
+    }
+}
+
+class MockAnalyserNode {
+    fftSize = 0;
+    frequencyBinCount = 32;
+    getByteTimeDomainData = jest.fn((array: Uint8Array) => array.fill(128));
+}
+
+class MockMediaStreamSource {
+    connect = jest.fn();
+    disconnect = jest.fn();
+}
+
+class MockAudioContext {
+    createMediaStreamSource() {
+        return new MockMediaStreamSource();
+    }
+
+    createAnalyser() {
+        return new MockAnalyserNode();
+    }
+
+    close = jest.fn().mockResolvedValue(undefined);
+}
+
+class MockMediaRecorder {
+    static instances: MockMediaRecorder[] = [];
+
+    ondataavailable: ((event: BlobEvent) => void) | null = null;
+    onstop: (() => void) | null = null;
+    start: jest.Mock;
+    stop: jest.Mock;
+
+    constructor(public readonly stream: MediaStream) {
+        this.start = jest.fn();
+        this.stop = jest.fn(() => {
+            const blob = new Blob(['mock'], { type: 'video/webm' });
+            this.ondataavailable?.({ data: blob } as BlobEvent);
+            this.onstop?.();
+        });
+        MockMediaRecorder.instances.push(this);
+    }
+
+    static reset() {
+        MockMediaRecorder.instances = [];
+    }
+}
+
+let mockGetDisplayMedia: jest.Mock;
+let mockGetUserMedia: jest.Mock;
+
+beforeEach(() => {
+    jest.useFakeTimers();
+    MockMediaRecorder.reset();
+
+    mockGetDisplayMedia = jest.fn();
+    mockGetUserMedia = jest.fn();
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+        configurable: true,
+        value: {
+            getDisplayMedia: mockGetDisplayMedia,
+            getUserMedia: mockGetUserMedia,
+        },
+    });
+
+    Object.defineProperty(globalThis, 'MediaStream', {
+        configurable: true,
+        writable: true,
+        value: MockMediaStream,
+    });
+
+    Object.defineProperty(globalThis, 'MediaRecorder', {
+        configurable: true,
+        writable: true,
+        value: MockMediaRecorder,
+    });
+
+    Object.defineProperty(globalThis, 'AudioContext', {
+        configurable: true,
+        writable: true,
+        value: MockAudioContext,
+    });
+
+    jest
+        .spyOn(globalThis, 'requestAnimationFrame')
+        .mockImplementation((callback: FrameRequestCallback) => {
+            callback(0);
+            return 1;
+        });
+
+    jest.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        writable: true,
+        value: jest.fn(() => 'blob:mock'),
+    });
+});
+
+afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    if (originalMediaDevices) {
+        Object.defineProperty(navigator, 'mediaDevices', {
+            configurable: true,
+            value: originalMediaDevices,
+        });
+    } else {
+        delete (navigator as any).mediaDevices;
+    }
+
+    Object.defineProperty(globalThis, 'MediaStream', {
+        configurable: true,
+        writable: true,
+        value: originalMediaStream,
+    });
+
+    Object.defineProperty(globalThis, 'MediaRecorder', {
+        configurable: true,
+        writable: true,
+        value: originalMediaRecorder,
+    });
+
+    Object.defineProperty(globalThis, 'AudioContext', {
+        configurable: true,
+        writable: true,
+        value: originalAudioContext,
+    });
+
+    Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        writable: true,
+        value: originalCreateObjectURL,
+    });
+});
+
+test('shows countdown overlay and starts recording after countdown', async () => {
+    const displayStream = new MockMediaStream([createTrack('video'), createTrack('audio')]);
+    mockGetDisplayMedia.mockResolvedValue(displayStream);
+
+    render(<ScreenRecorder />);
+
+    await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /start recording/i }));
+    });
+
+    await waitFor(() => expect(mockGetDisplayMedia).toHaveBeenCalled());
+
+    await screen.findByRole('status');
+
+    for (let i = 0; i < 3; i += 1) {
+        act(() => {
+            jest.advanceTimersByTime(1000);
+        });
+    }
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /stop recording/i })).toBeInTheDocument());
+    expect(MockMediaRecorder.instances[0].start).toHaveBeenCalled();
+});
+
+test('Escape cancels countdown and stops prepared streams', async () => {
+    const videoTrack = createTrack('video');
+    const audioTrack = createTrack('audio');
+    const displayStream = new MockMediaStream([videoTrack, audioTrack]);
+    mockGetDisplayMedia.mockResolvedValue(displayStream);
+
+    render(<ScreenRecorder />);
+
+    await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /start recording/i }));
+    });
+
+    await screen.findByRole('status');
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(MockMediaRecorder.instances).toHaveLength(0);
+    expect((videoTrack.stop as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+    expect((audioTrack.stop as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+});
+
+test('shows permission denied message when capture is blocked', async () => {
+    mockGetDisplayMedia.mockRejectedValue(new DOMException('denied', 'NotAllowedError'));
+
+    render(<ScreenRecorder />);
+
+    fireEvent.click(screen.getByRole('button', { name: /start recording/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/permission denied/i);
+});
+
+test('enabling microphone requests user media and renders audio meter', async () => {
+    const displayStream = new MockMediaStream([createTrack('video')]);
+    const micTrack = createTrack('audio');
+    const microphoneStream = new MockMediaStream([micTrack]);
+    mockGetDisplayMedia.mockResolvedValue(displayStream);
+    mockGetUserMedia.mockResolvedValue(microphoneStream);
+
+    render(<ScreenRecorder />);
+
+    fireEvent.click(screen.getByLabelText(/microphone/i));
+    await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /start recording/i }));
+    });
+
+    await waitFor(() => expect(mockGetDisplayMedia).toHaveBeenCalled());
+    await waitFor(() => expect(mockGetUserMedia).toHaveBeenCalled());
+
+    for (let i = 0; i < 3; i += 1) {
+        act(() => {
+            jest.advanceTimersByTime(1000);
+        });
+    }
+
+    await waitFor(() => expect(screen.getByTestId('audio-meter')).toBeInTheDocument());
+});

--- a/components/apps/screen-recorder.tsx
+++ b/components/apps/screen-recorder.tsx
@@ -1,44 +1,244 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+type CountdownState = 3 | 2 | 1 | 0 | null;
+
+const AUDIO_FALLBACK_LEVEL = 0;
 
 function ScreenRecorder() {
     const [recording, setRecording] = useState(false);
     const [videoUrl, setVideoUrl] = useState<string | null>(null);
+    const [countdown, setCountdown] = useState<CountdownState>(null);
+    const [isPreparing, setIsPreparing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [includeSystemAudio, setIncludeSystemAudio] = useState(true);
+    const [includeMicrophone, setIncludeMicrophone] = useState(false);
+    const [hasAudioInput, setHasAudioInput] = useState(false);
+    const [audioLevel, setAudioLevel] = useState(AUDIO_FALLBACK_LEVEL);
+
     const recorderRef = useRef<MediaRecorder | null>(null);
     const chunksRef = useRef<Blob[]>([]);
-    const streamRef = useRef<MediaStream | null>(null);
+    const combinedStreamRef = useRef<MediaStream | null>(null);
+    const sourceStreamsRef = useRef<MediaStream[]>([]);
+    const countdownTimeoutRef = useRef<number>();
+    const audioContextRef = useRef<AudioContext | null>(null);
+    const analyserRef = useRef<AnalyserNode | null>(null);
+    const audioSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+    const audioRafRef = useRef<number>();
 
-    const startRecording = async () => {
-        try {
-            const stream = await navigator.mediaDevices.getDisplayMedia({
-                video: true,
-                audio: true,
+    const supports = useMemo(() => {
+        if (typeof navigator === 'undefined') {
+            return { system: false, mic: false };
+        }
+        const mediaDevices = navigator.mediaDevices;
+        return {
+            system: Boolean(mediaDevices?.getDisplayMedia),
+            mic: Boolean(mediaDevices?.getUserMedia),
+        };
+    }, []);
+
+    const stopAudioMeter = useCallback(() => {
+        if (audioRafRef.current) {
+            cancelAnimationFrame(audioRafRef.current);
+            audioRafRef.current = undefined;
+        }
+        analyserRef.current = null;
+        if (audioSourceRef.current) {
+            try {
+                audioSourceRef.current.disconnect();
+            } catch {
+                // ignore disconnect errors in mocked environments
+            }
+            audioSourceRef.current = null;
+        }
+        if (audioContextRef.current) {
+            audioContextRef.current.close().catch(() => {
+                // ignore errors closing mocked contexts
             });
-            streamRef.current = stream;
+            audioContextRef.current = null;
+        }
+        setAudioLevel(AUDIO_FALLBACK_LEVEL);
+    }, []);
+
+    const stopAllStreams = useCallback(() => {
+        sourceStreamsRef.current.forEach((stream) => {
+            stream.getTracks().forEach((track) => track.stop());
+        });
+        sourceStreamsRef.current = [];
+        combinedStreamRef.current = null;
+        setHasAudioInput(false);
+    }, []);
+
+    const setupAudioMeter = useCallback((stream: MediaStream) => {
+        if (typeof window === 'undefined') return;
+        const audioTracks = stream.getAudioTracks();
+        if (!audioTracks.length) {
+            setAudioLevel(AUDIO_FALLBACK_LEVEL);
+            return;
+        }
+
+        const AudioContextCtor =
+            window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+        if (!AudioContextCtor) {
+            setAudioLevel(AUDIO_FALLBACK_LEVEL);
+            return;
+        }
+
+        try {
+            const context = new AudioContextCtor();
+            audioContextRef.current = context;
+            const source = context.createMediaStreamSource(stream);
+            audioSourceRef.current = source;
+            const analyser = context.createAnalyser();
+            analyser.fftSize = 256;
+            analyserRef.current = analyser;
+            source.connect(analyser);
+            const dataArray = new Uint8Array(analyser.frequencyBinCount);
+
+            const update = () => {
+                if (!analyserRef.current) return;
+                analyserRef.current.getByteTimeDomainData(dataArray);
+                const sumSquares = dataArray.reduce((sum, value) => {
+                    const centered = value - 128;
+                    return sum + centered * centered;
+                }, 0);
+                const rms = Math.sqrt(sumSquares / dataArray.length);
+                const normalized = Math.min(1, rms / 128);
+                setAudioLevel(Number.isFinite(normalized) ? normalized : AUDIO_FALLBACK_LEVEL);
+                audioRafRef.current = requestAnimationFrame(update);
+            };
+
+            audioRafRef.current = requestAnimationFrame(update);
+        } catch {
+            setAudioLevel(AUDIO_FALLBACK_LEVEL);
+        }
+    }, []);
+
+    const startRecorder = useCallback(() => {
+        const stream = combinedStreamRef.current;
+        if (!stream) return;
+        try {
             const recorder = new MediaRecorder(stream);
             chunksRef.current = [];
-            recorder.ondataavailable = (e: BlobEvent) => {
-                if (e.data.size > 0) chunksRef.current.push(e.data);
+            recorder.ondataavailable = (event: BlobEvent) => {
+                if (event.data.size > 0) {
+                    chunksRef.current.push(event.data);
+                }
             };
             recorder.onstop = () => {
+                stopAudioMeter();
                 const blob = new Blob(chunksRef.current, { type: 'video/webm' });
                 const url = URL.createObjectURL(blob);
                 setVideoUrl(url);
-                stream.getTracks().forEach((t) => t.stop());
+                stopAllStreams();
             };
             recorder.start();
             recorderRef.current = recorder;
             setRecording(true);
-        } catch {
-            // ignore
+            setupAudioMeter(stream);
+        } catch (err) {
+            setError('Unable to start recording in this browser.');
+            stopAllStreams();
         }
-    };
+    }, [setupAudioMeter, stopAllStreams, stopAudioMeter]);
 
-    const stopRecording = () => {
+    useEffect(() => {
+        if (countdown === null) return undefined;
+        if (countdown === 0) {
+            setCountdown(null);
+            startRecorder();
+            return undefined;
+        }
+        countdownTimeoutRef.current = window.setTimeout(() => {
+            setCountdown((prev) => {
+                if (prev === null) return null;
+                const next = (prev - 1) as CountdownState | 0;
+                return next;
+            });
+        }, 1000);
+        return () => {
+            if (countdownTimeoutRef.current) {
+                clearTimeout(countdownTimeoutRef.current);
+            }
+        };
+    }, [countdown, startRecorder]);
+
+    useEffect(() => {
+        if (countdown === null) return undefined;
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setCountdown(null);
+                stopAllStreams();
+                setIsPreparing(false);
+            }
+        };
+        window.addEventListener('keydown', onKeyDown);
+        return () => {
+            window.removeEventListener('keydown', onKeyDown);
+        };
+    }, [countdown, stopAllStreams]);
+
+    const startRecording = useCallback(async () => {
+        if (recording || countdown !== null) return;
+        if (typeof navigator === 'undefined') {
+            setError('Screen recording is not available in this environment.');
+            return;
+        }
+        if (!navigator.mediaDevices?.getDisplayMedia) {
+            setError('Screen recording is not supported in this browser.');
+            return;
+        }
+        setError(null);
+        setVideoUrl(null);
+        setIsPreparing(true);
+
+        try {
+            const displayStream = await navigator.mediaDevices.getDisplayMedia({
+                video: true,
+                audio: includeSystemAudio,
+            });
+            const streams: MediaStream[] = [displayStream];
+            let microphoneStream: MediaStream | null = null;
+
+            if (includeMicrophone) {
+                if (!navigator.mediaDevices.getUserMedia) {
+                    throw new Error('Microphone capture is not supported in this browser.');
+                }
+                microphoneStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+                if (microphoneStream) {
+                    streams.push(microphoneStream);
+                }
+            }
+
+            const combined = new MediaStream();
+            streams.forEach((stream) => {
+                stream.getTracks().forEach((track) => combined.addTrack(track));
+            });
+
+            sourceStreamsRef.current = streams;
+            combinedStreamRef.current = combined;
+            setHasAudioInput(combined.getAudioTracks().length > 0);
+            setIsPreparing(false);
+            setCountdown(3);
+        } catch (err) {
+            stopAllStreams();
+            setIsPreparing(false);
+
+            if (err instanceof DOMException && err.name === 'NotAllowedError') {
+                setError('Permission denied. Please allow screen recording to continue.');
+            } else if (err instanceof Error) {
+                setError(err.message);
+            } else {
+                setError('Unable to start screen recording.');
+            }
+        }
+    }, [countdown, includeMicrophone, includeSystemAudio, recording, stopAllStreams]);
+
+    const stopRecording = useCallback(() => {
         recorderRef.current?.stop();
         setRecording(false);
-    };
+    }, []);
 
-    const saveRecording = async () => {
+    const saveRecording = useCallback(async () => {
         if (!videoUrl) return;
         const blob = new Blob(chunksRef.current, { type: 'video/webm' });
         if ('showSaveFilePicker' in window) {
@@ -56,7 +256,7 @@ function ScreenRecorder() {
                 await writable.write(blob);
                 await writable.close();
             } catch {
-                // ignore
+                // ignore save cancellation
             }
         } else {
             const a = document.createElement('a');
@@ -66,38 +266,95 @@ function ScreenRecorder() {
             a.click();
             a.remove();
         }
-    };
+    }, [videoUrl]);
 
     useEffect(() => {
         return () => {
-            streamRef.current?.getTracks().forEach((t) => t.stop());
+            stopAudioMeter();
+            stopAllStreams();
             recorderRef.current?.stop();
         };
-    }, []);
+    }, [stopAllStreams, stopAudioMeter]);
 
     return (
-        <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white space-y-4 p-4">
-            {!recording && (
-                <button
-                    type="button"
-                    onClick={startRecording}
-                    className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
-                >
-                    Start Recording
-                </button>
+        <div className="relative h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white space-y-4 p-4">
+            <div className="flex flex-col space-y-3 items-center">
+                <fieldset className="flex flex-col space-y-2 text-sm" aria-label="Audio source selection">
+                    <legend className="text-base font-semibold text-white">Audio Sources</legend>
+                    <label className="flex items-center space-x-2">
+                        <input
+                            type="checkbox"
+                            checked={includeSystemAudio}
+                            onChange={(event) => setIncludeSystemAudio(event.target.checked)}
+                            disabled={!supports.system || isPreparing || recording}
+                            aria-label="Toggle system audio capture"
+                        />
+                        <span className="select-none">
+                            System audio{supports.system ? '' : ' (not supported)'}
+                        </span>
+                    </label>
+                    <label className="flex items-center space-x-2">
+                        <input
+                            type="checkbox"
+                            checked={includeMicrophone}
+                            onChange={(event) => setIncludeMicrophone(event.target.checked)}
+                            disabled={!supports.mic || isPreparing || recording}
+                            aria-label="Toggle microphone capture"
+                        />
+                        <span className="select-none">
+                            Microphone{supports.mic ? '' : ' (not supported)'}
+                        </span>
+                    </label>
+                </fieldset>
+
+                {!recording && (
+                    <button
+                        type="button"
+                        onClick={startRecording}
+                        className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark disabled:opacity-50"
+                        disabled={isPreparing}
+                    >
+                        {isPreparing ? 'Preparing…' : 'Start Recording'}
+                    </button>
+                )}
+                {recording && (
+                    <button
+                        type="button"
+                        onClick={stopRecording}
+                        className="px-4 py-2 rounded bg-red-600 hover:bg-red-700"
+                    >
+                        Stop Recording
+                    </button>
+                )}
+            </div>
+
+            {error && <p role="alert" className="text-red-300 text-center max-w-md">{error}</p>}
+
+            {recording && hasAudioInput && (
+                <div className="w-64">
+                    <label htmlFor="audio-meter" className="block text-sm mb-1 text-white">
+                        Microphone level
+                    </label>
+                    <div
+                        id="audio-meter"
+                        role="meter"
+                        aria-valuemin={0}
+                        aria-valuemax={1}
+                        aria-valuenow={Number(audioLevel.toFixed(2))}
+                        className="h-3 w-full bg-black bg-opacity-40 rounded"
+                        data-testid="audio-meter"
+                    >
+                        <div
+                            className="h-3 bg-green-400 rounded"
+                            style={{ width: `${Math.round(audioLevel * 100)}%` }}
+                        />
+                    </div>
+                </div>
             )}
-            {recording && (
-                <button
-                    type="button"
-                    onClick={stopRecording}
-                    className="px-4 py-2 rounded bg-red-600 hover:bg-red-700"
-                >
-                    Stop Recording
-                </button>
-            )}
+
             {videoUrl && !recording && (
-                <>
-                    <video src={videoUrl} controls className="max-w-full" />
+                <div className="flex flex-col items-center space-y-3">
+                    <video src={videoUrl} controls className="max-w-full" aria-label="Recorded session playback" />
                     <button
                         type="button"
                         onClick={saveRecording}
@@ -105,7 +362,15 @@ function ScreenRecorder() {
                     >
                         Save Recording
                     </button>
-                </>
+                </div>
+            )}
+
+            {countdown !== null && countdown > 0 && (
+                <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-70">
+                    <div className="text-6xl font-bold" role="status" aria-live="assertive">
+                        {countdown}
+                    </div>
+                </div>
             )}
         </div>
     );


### PR DESCRIPTION
## Summary
- add a cancellable countdown overlay and permission-aware error handling to the screen recorder
- implement audio source controls with a live AudioContext-powered volume meter during capture
- cover the updated behaviour with mocked MediaRecorder/MediaStream unit tests

## Testing
- yarn test screenRecorder.test.tsx
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc268140fc8328ad41c360285940d0