### PR TITLE
[apps] Add floating controls to screen recorder

### DIFF
--- a/__tests__/screenRecorderShortcuts.test.tsx
+++ b/__tests__/screenRecorderShortcuts.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import ScreenRecorder from '../components/apps/screen-recorder';
+
+describe('ScreenRecorder keyboard shortcuts', () => {
+  let originalMediaDevices: typeof navigator.mediaDevices | undefined;
+  let originalMediaRecorder: typeof MediaRecorder | undefined;
+  let originalCreateObjectURL: typeof URL.createObjectURL | undefined;
+  let originalWindowCreateObjectURL: typeof URL.createObjectURL | undefined;
+  let recorderInstance: {
+    stop: jest.Mock;
+  } | null = null;
+
+  beforeEach(() => {
+    localStorage.clear();
+    recorderInstance = null;
+    originalMediaDevices = navigator.mediaDevices;
+    originalMediaRecorder = (global as any).MediaRecorder;
+    originalCreateObjectURL = URL.createObjectURL;
+    originalWindowCreateObjectURL = typeof window === 'undefined' ? undefined : window.URL?.createObjectURL;
+
+    const mockTrack = { stop: jest.fn() };
+    const mockStream = {
+      getTracks: () => [mockTrack],
+    } as unknown as MediaStream;
+
+    (navigator as any).mediaDevices = {
+      getDisplayMedia: jest.fn().mockResolvedValue(mockStream),
+    };
+
+    class MockMediaRecorder {
+      public ondataavailable: ((event: any) => void) | null = null;
+      public onstop: (() => void) | null = null;
+      public start = jest.fn();
+      public stop = jest.fn(() => {
+        this.onstop?.();
+      });
+
+      constructor(public stream: MediaStream) {
+        recorderInstance = this as unknown as { stop: jest.Mock };
+      }
+    }
+
+    (global as any).MediaRecorder = MockMediaRecorder as unknown as typeof MediaRecorder;
+
+    const createObjectURLMock = jest.fn(() => 'blob:mock-url');
+    (URL as any).createObjectURL = createObjectURLMock;
+    if (typeof window !== 'undefined') {
+      (window.URL as any).createObjectURL = createObjectURLMock;
+    }
+  });
+
+  afterEach(() => {
+    if (originalMediaDevices) (navigator as any).mediaDevices = originalMediaDevices;
+    else delete (navigator as any).mediaDevices;
+
+    if (originalMediaRecorder) (global as any).MediaRecorder = originalMediaRecorder;
+    else delete (global as any).MediaRecorder;
+
+    if (originalCreateObjectURL) URL.createObjectURL = originalCreateObjectURL;
+    else delete (URL as any).createObjectURL;
+
+    if (typeof window !== 'undefined') {
+      if (originalWindowCreateObjectURL) window.URL.createObjectURL = originalWindowCreateObjectURL;
+      else delete (window.URL as any).createObjectURL;
+    }
+  });
+
+  const startAndConfirmRecording = async () => {
+    render(<ScreenRecorder />);
+
+    fireEvent.click(screen.getByRole('button', { name: /start recording/i }));
+
+    await screen.findByRole('button', { name: /stop recording/i });
+
+    expect(recorderInstance).not.toBeNull();
+  };
+
+  test('Ctrl+Shift+R stops an active recording', async () => {
+    await startAndConfirmRecording();
+
+    fireEvent.keyDown(window, { key: 'r', ctrlKey: true, shiftKey: true });
+
+    await waitFor(() => {
+      expect(recorderInstance?.stop).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /stop recording/i })).not.toBeInTheDocument();
+    });
+  });
+
+  test('Cmd+Shift+R stops an active recording', async () => {
+    await startAndConfirmRecording();
+
+    fireEvent.keyDown(window, { key: 'R', metaKey: true, shiftKey: true });
+
+    await waitFor(() => {
+      expect(recorderInstance?.stop).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /stop recording/i })).not.toBeInTheDocument();
+    });
+  });
+});
+

--- a/components/apps/screen-recorder.tsx
+++ b/components/apps/screen-recorder.tsx
@@ -1,11 +1,62 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import Draggable, { ControlPosition, DraggableData, DraggableEvent } from 'react-draggable';
+
+const CONTROL_STORAGE_KEY = 'screen-recorder-control-position';
+const DEFAULT_CONTROL_POSITION: ControlPosition = { x: 32, y: 32 };
+
+const isValidPosition = (value: unknown): value is ControlPosition => {
+    if (!value || typeof value !== 'object') return false;
+    const candidate = value as { x?: unknown; y?: unknown };
+    return (
+        typeof candidate.x === 'number' &&
+        Number.isFinite(candidate.x) &&
+        typeof candidate.y === 'number' &&
+        Number.isFinite(candidate.y)
+    );
+};
 
 function ScreenRecorder() {
     const [recording, setRecording] = useState(false);
     const [videoUrl, setVideoUrl] = useState<string | null>(null);
+    const [isMinimized, setIsMinimized] = useState(false);
+    const [controlPosition, setControlPosition] = useState<ControlPosition>(DEFAULT_CONTROL_POSITION);
+    const [isClient, setIsClient] = useState(false);
     const recorderRef = useRef<MediaRecorder | null>(null);
     const chunksRef = useRef<Blob[]>([]);
     const streamRef = useRef<MediaStream | null>(null);
+    const dragNodeRef = useRef<HTMLDivElement>(null);
+    const controlBarRef = useRef<HTMLDivElement>(null);
+    const restoreButtonRef = useRef<HTMLButtonElement>(null);
+    const startButtonRef = useRef<HTMLButtonElement>(null);
+    const prevRecordingRef = useRef(recording);
+
+    const persistPosition = useCallback((position: ControlPosition) => {
+        setControlPosition(position);
+        if (typeof window === 'undefined') return;
+        try {
+            window.localStorage.setItem(CONTROL_STORAGE_KEY, JSON.stringify(position));
+        } catch {
+            // ignore storage errors
+        }
+    }, []);
+
+    const handleDrag = useCallback((_event: DraggableEvent, data: DraggableData) => {
+        setControlPosition({ x: data.x, y: data.y });
+    }, []);
+
+    const handleDragStop = useCallback(
+        (_event: DraggableEvent, data: DraggableData) => {
+            persistPosition({ x: data.x, y: data.y });
+        },
+        [persistPosition],
+    );
+
+    const stopRecording = useCallback(() => {
+        recorderRef.current?.stop();
+        setRecording(false);
+        setIsMinimized(false);
+    }, []);
 
     const startRecording = async () => {
         try {
@@ -16,26 +67,26 @@ function ScreenRecorder() {
             streamRef.current = stream;
             const recorder = new MediaRecorder(stream);
             chunksRef.current = [];
+            setVideoUrl(null);
             recorder.ondataavailable = (e: BlobEvent) => {
                 if (e.data.size > 0) chunksRef.current.push(e.data);
             };
             recorder.onstop = () => {
                 const blob = new Blob(chunksRef.current, { type: 'video/webm' });
-                const url = URL.createObjectURL(blob);
+                const canCreateUrl = typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function';
+                const url = canCreateUrl ? URL.createObjectURL(blob) : null;
                 setVideoUrl(url);
                 stream.getTracks().forEach((t) => t.stop());
             };
             recorder.start();
             recorderRef.current = recorder;
             setRecording(true);
+            setIsMinimized(false);
         } catch {
             // ignore
+            setRecording(false);
+            setIsMinimized(false);
         }
-    };
-
-    const stopRecording = () => {
-        recorderRef.current?.stop();
-        setRecording(false);
     };
 
     const saveRecording = async () => {
@@ -75,11 +126,136 @@ function ScreenRecorder() {
         };
     }, []);
 
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        setIsClient(true);
+        try {
+            const stored = window.localStorage.getItem(CONTROL_STORAGE_KEY);
+            if (!stored) return;
+            const parsed = JSON.parse(stored);
+            if (isValidPosition(parsed)) {
+                setControlPosition(parsed);
+            }
+        } catch {
+            // ignore malformed storage entries
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!recording) return undefined;
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (!event.shiftKey || event.key.toLowerCase() !== 'r') return;
+            const isCtrlCombo = event.ctrlKey && !event.metaKey;
+            const isMetaCombo = event.metaKey && !event.ctrlKey;
+            if (!isCtrlCombo && !isMetaCombo) return;
+            event.preventDefault();
+            stopRecording();
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [recording, stopRecording]);
+
+    useEffect(() => {
+        if (!recording) return undefined;
+        const timeout = window.setTimeout(() => {
+            if (isMinimized) {
+                restoreButtonRef.current?.focus({ preventScroll: true });
+            } else {
+                controlBarRef.current?.focus({ preventScroll: true });
+            }
+        }, 0);
+        return () => window.clearTimeout(timeout);
+    }, [isMinimized, recording]);
+
+    useEffect(() => {
+        const prevRecording = prevRecordingRef.current;
+        if (prevRecording && !recording) {
+            setIsMinimized(false);
+            if (typeof window !== 'undefined') {
+                const timeout = window.setTimeout(() => {
+                    startButtonRef.current?.focus({ preventScroll: true });
+                }, 0);
+                prevRecordingRef.current = recording;
+                return () => window.clearTimeout(timeout);
+            }
+        }
+        prevRecordingRef.current = recording;
+        return undefined;
+    }, [recording]);
+
+    const floatingControls = useMemo(() => {
+        if (!isClient || !recording || typeof document === 'undefined') return null;
+
+        const content = (
+            <Draggable
+                nodeRef={dragNodeRef}
+                position={controlPosition}
+                onDrag={handleDrag}
+                onStop={handleDragStop}
+                bounds="body"
+            >
+                <div ref={dragNodeRef} className="fixed top-0 left-0 z-[2000]">
+                    <div className="pointer-events-auto">
+                        {isMinimized ? (
+                            <button
+                                ref={restoreButtonRef}
+                                type="button"
+                                onClick={() => setIsMinimized(false)}
+                                className="rounded bg-ub-dracula px-3 py-2 text-sm font-medium text-white shadow focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-black focus:ring-ub-accent"
+                            >
+                                Restore recording controls
+                            </button>
+                        ) : (
+                            <div
+                                ref={controlBarRef}
+                                tabIndex={-1}
+                                role="dialog"
+                                aria-label="Screen recording controls"
+                                className="flex items-center gap-3 rounded bg-ub-dracula px-4 py-3 text-sm text-white shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-black focus:ring-ub-accent"
+                            >
+                                <span className="font-semibold" aria-live="polite">
+                                    Recording…
+                                </span>
+                                <button
+                                    type="button"
+                                    onClick={() => setIsMinimized(true)}
+                                    className="rounded bg-ub-cool-grey px-2 py-1 text-xs font-medium text-white hover:bg-ub-grey focus:outline-none focus:ring-2 focus:ring-ub-accent"
+                                >
+                                    Minimize
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={stopRecording}
+                                    className="rounded bg-red-600 px-3 py-1 text-sm font-semibold text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-300"
+                                >
+                                    Stop (Ctrl+Shift+R)
+                                </button>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </Draggable>
+        );
+
+        return createPortal(content, document.body);
+    }, [
+        controlPosition,
+        handleDrag,
+        handleDragStop,
+        isClient,
+        isMinimized,
+        recording,
+        stopRecording,
+    ]);
+
     return (
         <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white space-y-4 p-4">
             {!recording && (
                 <button
                     type="button"
+                    ref={startButtonRef}
                     onClick={startRecording}
                     className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
                 >
@@ -97,7 +273,7 @@ function ScreenRecorder() {
             )}
             {videoUrl && !recording && (
                 <>
-                    <video src={videoUrl} controls className="max-w-full" />
+                    <video src={videoUrl} controls className="max-w-full" aria-label="Screen recording preview" />
                     <button
                         type="button"
                         onClick={saveRecording}
@@ -107,6 +283,7 @@ function ScreenRecorder() {
                     </button>
                 </>
             )}
+            {floatingControls}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add a draggable floating screen recorder control bar with minimization, keyboard shortcut handling, and persisted position
- reset focus appropriately when toggling controls and guard URL blob creation in non-browser environments
- add tests covering Ctrl/Cmd+Shift+R shortcut behavior

## Testing
- yarn test screenRecorderShortcuts --runTestsByPath __tests__/screenRecorderShortcuts.test.tsx
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc2683b5a883288cd45c906ad940cf