### PR TITLE
[pdf-viewer] Improve search navigation

### DIFF
--- a/__tests__/pdfviewer.test.tsx
+++ b/__tests__/pdfviewer.test.tsx
@@ -3,11 +3,68 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PdfViewer from '../components/common/PdfViewer';
 
+const scrollIntoViewMock = jest.fn();
+
+beforeAll(() => {
+  Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: scrollIntoViewMock,
+  });
+});
+
+beforeEach(() => {
+  scrollIntoViewMock.mockClear();
+});
+
+const textContentByPage = {
+  1: {
+    items: [
+      {
+        str: 'hello world',
+        transform: [1, 0, 0, 10, 10, 110],
+        width: 40,
+        height: 10,
+      },
+      {
+        str: 'intro text',
+        transform: [1, 0, 0, 10, 10, 90],
+        width: 30,
+        height: 10,
+      },
+    ],
+  },
+  2: {
+    items: [
+      {
+        str: 'HELLO again',
+        transform: [1, 0, 0, 10, 10, 110],
+        width: 50,
+        height: 10,
+      },
+    ],
+  },
+  3: {
+    items: [
+      {
+        str: 'closing notes',
+        transform: [1, 0, 0, 10, 10, 110],
+        width: 60,
+        height: 10,
+      },
+    ],
+  },
+};
+
 jest.mock('pdfjs-dist', () => {
-  const getPage = jest.fn(async () => ({
-    getViewport: () => ({ width: 100, height: 100, scale: 1 }),
+  const getPage = jest.fn(async (pageNumber: number) => ({
+    getViewport: ({ scale }: { scale: number }) => ({
+      width: 100 * scale,
+      height: 120 * scale,
+      scale,
+      transform: [scale, 0, 0, -scale, 0, 120 * scale],
+    }),
     render: () => ({ promise: Promise.resolve() }),
-    getTextContent: async () => ({ items: [{ str: 'hello world' }] }),
+    getTextContent: async () => textContentByPage[pageNumber] ?? { items: [] },
   }));
   const getDocument = jest.fn(() => ({
     promise: Promise.resolve({
@@ -15,25 +72,70 @@ jest.mock('pdfjs-dist', () => {
       getPage,
     }),
   }));
-  return { getDocument, GlobalWorkerOptions: { workerSrc: '' } };
+  return {
+    getDocument,
+    GlobalWorkerOptions: { workerSrc: '' },
+    Util: {
+      transform: (_viewport: number[], transform: number[]) => transform,
+    },
+  };
 });
 
 describe('PdfViewer', () => {
-  it('renders PDF and searches text', async () => {
+  it('renders PDF and shows indexed search results', async () => {
     const user = userEvent.setup();
     render(<PdfViewer url="/sample.pdf" />);
-    const canvas = await screen.findByTestId('pdf-canvas');
-    expect(canvas).toBeInTheDocument();
-    await user.type(screen.getByPlaceholderText(/search/i), 'hello');
-    await user.click(screen.getByText('Search'));
-    expect(await screen.findByText('Page 1')).toBeInTheDocument();
+
+    await screen.findByTestId('pdf-canvas');
+
+    const input = screen.getByPlaceholderText(/search/i);
+    await user.type(input, 'hello');
+    await user.click(screen.getByRole('button', { name: /search/i }));
+
+    await screen.findByTestId('search-results');
+    expect(screen.getByText('Match 1 of 2')).toBeInTheDocument();
+
+    const items = await screen.findAllByTestId('search-result-item');
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent('Match 1: Page 1');
+    expect(items[1]).toHaveTextContent('Match 2: Page 2');
+  });
+
+  it('navigates matches with keyboard shortcuts and buttons', async () => {
+    const user = userEvent.setup();
+    render(<PdfViewer url="/sample.pdf" />);
+
+    await screen.findByTestId('pdf-canvas');
+
+    const input = screen.getByPlaceholderText(/search/i);
+    await user.type(input, 'hello');
+    await user.keyboard('{Enter}');
+
+    await screen.findByText('Match 1 of 2');
+    let options = await screen.findAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{Enter}');
+    await screen.findByText('Match 2 of 2');
+    options = await screen.findAllByRole('option');
+    expect(options[1]).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{Shift>}{Enter}{/Shift}');
+    await screen.findByText('Match 1 of 2');
+    options = await screen.findAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+
+    const previousButton = screen.getByRole('button', { name: /previous/i });
+    await user.click(previousButton);
+    await screen.findByText('Match 2 of 2');
   });
 
   it('supports keyboard navigation through thumbnails', async () => {
     const user = userEvent.setup();
     render(<PdfViewer url="/sample.pdf" />);
+
     const options = await screen.findAllByRole('option');
-    options[0].focus();
+    await user.click(options[0]);
     await user.keyboard('{ArrowRight}');
     const updated = await screen.findAllByRole('option');
     expect(updated[1]).toHaveFocus();

--- a/components/common/PdfViewer/index.tsx
+++ b/components/common/PdfViewer/index.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import useRovingTabIndex from '../../../hooks/useRovingTabIndex';
 import type { PDFDocumentProxy } from 'pdfjs-dist';
 import type { TextItem } from 'pdfjs-dist/types/src/display/api';
@@ -9,14 +15,36 @@ interface PdfViewerProps {
   url: string;
 }
 
+interface MatchRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface SearchMatch {
+  index: number;
+  page: number;
+  rect: MatchRect;
+}
+
+const PAGE_SCALE = 1.5;
+const THUMBNAIL_SCALE = 0.2;
+
 const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const highlightCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const [pdf, setPdf] = useState<PDFDocumentProxy | null>(null);
   const [page, setPage] = useState(1);
   const [thumbs, setThumbs] = useState<HTMLCanvasElement[]>([]);
   const [query, setQuery] = useState('');
-  const [matches, setMatches] = useState<number[]>([]);
+  const [matches, setMatches] = useState<SearchMatch[]>([]);
+  const [activeMatchIndex, setActiveMatchIndex] = useState(-1);
+  const [lastSearch, setLastSearch] = useState('');
   const thumbListRef = useRef<HTMLDivElement | null>(null);
+  const thumbRefs = useRef<(HTMLCanvasElement | null)[]>([]);
+  const pdfjsRef = useRef<typeof import('pdfjs-dist')>();
+  const searchInFlight = useRef(0);
 
   useRovingTabIndex(
     thumbListRef as React.RefObject<HTMLElement>,
@@ -29,6 +57,8 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
     (async () => {
       try {
         const pdfjsLib = await import('pdfjs-dist');
+        if (!mounted) return;
+        pdfjsRef.current = pdfjsLib;
         pdfjsLib.GlobalWorkerOptions.workerSrc =
           `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsLib.version}/pdf.worker.min.js`;
         const loadedPdf = await pdfjsLib.getDocument(url).promise;
@@ -44,97 +74,338 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
 
   useEffect(() => {
     if (!pdf) return;
+    let cancelled = false;
     const render = async () => {
       const pg = await pdf.getPage(page);
-      const viewport = pg.getViewport({ scale: 1.5 });
-      const canvas = canvasRef.current!;
-      canvas.height = viewport.height;
+      if (cancelled) return;
+      const viewport = pg.getViewport({ scale: PAGE_SCALE });
+      const canvas = canvasRef.current;
+      if (!canvas) return;
       canvas.width = viewport.width;
-      await pg
-        .render({ canvasContext: canvas.getContext('2d')!, viewport, canvas })
-        .promise;
-
-
+      canvas.height = viewport.height;
+      const context = canvas.getContext('2d');
+      if (!context) return;
+      await pg.render({ canvasContext: context, viewport }).promise;
+      if (cancelled) return;
+      const highlightCanvas = highlightCanvasRef.current;
+      if (highlightCanvas) {
+        highlightCanvas.width = viewport.width;
+        highlightCanvas.height = viewport.height;
+      }
     };
     render();
+    return () => {
+      cancelled = true;
+    };
   }, [pdf, page]);
 
   useEffect(() => {
     if (!pdf) return;
+    let cancelled = false;
     const loadThumbs = async () => {
       const arr: HTMLCanvasElement[] = [];
       for (let i = 1; i <= pdf.numPages; i++) {
         const pg = await pdf.getPage(i);
-        const viewport = pg.getViewport({ scale: 0.2 });
+        if (cancelled) return;
+        const viewport = pg.getViewport({ scale: THUMBNAIL_SCALE });
         const canvas = document.createElement('canvas');
-        canvas.height = viewport.height;
         canvas.width = viewport.width;
-        await pg
-          .render({ canvasContext: canvas.getContext('2d')!, viewport, canvas })
-          .promise;
-
+        canvas.height = viewport.height;
+        const context = canvas.getContext('2d');
+        if (!context) continue;
+        await pg.render({ canvasContext: context, viewport }).promise;
+        if (cancelled) return;
         arr.push(canvas);
       }
-      setThumbs(arr);
+      if (!cancelled) {
+        setThumbs(arr);
+      }
     };
     loadThumbs();
+    return () => {
+      cancelled = true;
+    };
   }, [pdf]);
 
-  const search = async () => {
+  useEffect(() => {
+    const highlightCanvas = highlightCanvasRef.current;
+    const baseCanvas = canvasRef.current;
+    if (!highlightCanvas || !baseCanvas) return;
+    highlightCanvas.width = baseCanvas.width;
+    highlightCanvas.height = baseCanvas.height;
+    const context = highlightCanvas.getContext('2d');
+    if (!context) return;
+    context.clearRect(0, 0, highlightCanvas.width, highlightCanvas.height);
+    const pageMatches = matches.filter((match) => match.page === page);
+    pageMatches.forEach((match) => {
+      const { x, y, width, height } = match.rect;
+      const adjustedHeight = Math.max(height, 4);
+      const adjustedWidth = Math.max(width, 4);
+      const topLeftY = highlightCanvas.height - (y + adjustedHeight);
+      context.fillStyle =
+        match.index === activeMatchIndex
+          ? 'rgba(59, 130, 246, 0.5)'
+          : 'rgba(59, 130, 246, 0.25)';
+      context.fillRect(x, topLeftY, adjustedWidth, adjustedHeight);
+      if (typeof context.strokeRect === 'function') {
+        context.strokeStyle =
+          match.index === activeMatchIndex
+            ? 'rgba(37, 99, 235, 0.9)'
+            : 'rgba(59, 130, 246, 0.6)';
+        context.lineWidth = match.index === activeMatchIndex ? 2 : 1;
+        context.strokeRect(x, topLeftY, adjustedWidth, adjustedHeight);
+      }
+    });
+  }, [matches, page, activeMatchIndex]);
+
+  useEffect(() => {
+    if (!matches.length || activeMatchIndex === -1) return;
+    const activeMatch = matches[activeMatchIndex];
+    if (activeMatch?.page === page) return;
+    const firstOnPage = matches.findIndex((match) => match.page === page);
+    if (firstOnPage !== -1 && firstOnPage !== activeMatchIndex) {
+      setActiveMatchIndex(firstOnPage);
+    }
+  }, [page, matches, activeMatchIndex]);
+
+  useEffect(() => {
+    const container = thumbListRef.current;
+    const activeThumb = thumbRefs.current[page - 1];
+    if (!container || !activeThumb || typeof activeThumb.scrollIntoView !== 'function') {
+      return;
+    }
+    activeThumb.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+  }, [page]);
+
+  const search = useCallback(async (): Promise<void> => {
     if (!pdf) return;
-    const found: number[] = [];
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) {
+      setMatches([]);
+      setActiveMatchIndex(-1);
+      setLastSearch('');
+      return;
+    }
+    const requestId = ++searchInFlight.current;
+    const found: SearchMatch[] = [];
     for (let i = 1; i <= pdf.numPages; i++) {
-      const pg = await pdf.getPage(i);
-      const textContent = await pg.getTextContent();
-      const text = (textContent.items as TextItem[])
-        .map((it) => it.str)
-        .join(' ');
-      if (text.toLowerCase().includes(query.toLowerCase())) found.push(i);
+      const pageProxy = await pdf.getPage(i);
+      const viewport = pageProxy.getViewport({ scale: PAGE_SCALE });
+      const textContent = await pageProxy.getTextContent();
+      (textContent.items as TextItem[]).forEach((item) => {
+        if (!item?.str) return;
+        if (!item.transform) return;
+        if (item.str.toLowerCase().includes(normalized)) {
+          const transform = pdfjsRef.current?.Util?.transform
+            ? pdfjsRef.current.Util.transform(viewport.transform, item.transform)
+            : item.transform;
+          const width = Math.max(
+            Math.abs(item.width ?? transform?.[0] ?? 0),
+            4,
+          );
+          const height = Math.max(
+            Math.abs((item as unknown as { height?: number }).height ?? transform?.[3] ?? 0),
+            4,
+          );
+          const x = transform?.[4] ?? 0;
+          const baselineY = transform?.[5] ?? 0;
+          const y = baselineY - height;
+          found.push({
+            index: found.length,
+            page: i,
+            rect: { x, y, width, height },
+          });
+        }
+      });
+    }
+    if (searchInFlight.current !== requestId) {
+      return;
     }
     setMatches(found);
-    if (found[0]) setPage(found[0]);
-  };
+    if (found.length > 0) {
+      setActiveMatchIndex(0);
+      setPage(found[0].page);
+    } else {
+      setActiveMatchIndex(-1);
+    }
+    setLastSearch(query);
+  }, [pdf, query]);
+
+  const goToMatch = useCallback(
+    (index: number) => {
+      if (!matches.length) return;
+      const normalizedIndex = ((index % matches.length) + matches.length) % matches.length;
+      const match = matches[normalizedIndex];
+      setActiveMatchIndex(normalizedIndex);
+      setPage(match.page);
+    },
+    [matches],
+  );
+
+  const goToNextMatch = useCallback(() => {
+    if (!matches.length) return;
+    if (activeMatchIndex === -1) {
+      goToMatch(0);
+      return;
+    }
+    goToMatch(activeMatchIndex + 1);
+  }, [matches, activeMatchIndex, goToMatch]);
+
+  const goToPreviousMatch = useCallback(() => {
+    if (!matches.length) return;
+    if (activeMatchIndex === -1) {
+      goToMatch(matches.length - 1);
+      return;
+    }
+    goToMatch(activeMatchIndex - 1);
+  }, [matches, activeMatchIndex, goToMatch]);
+
+  const handleQueryKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key !== 'Enter') return;
+      event.preventDefault();
+      if (!query.trim()) {
+        void search();
+        return;
+      }
+      if (matches.length > 0 && query === lastSearch) {
+        if (event.shiftKey) {
+          goToPreviousMatch();
+        } else {
+          goToNextMatch();
+        }
+        return;
+      }
+      void search();
+    },
+    [goToNextMatch, goToPreviousMatch, lastSearch, matches.length, query, search],
+  );
+
+  const matchSummary = useMemo(() => {
+    if (!matches.length || activeMatchIndex === -1) return '';
+    return `Match ${activeMatchIndex + 1} of ${matches.length}`;
+  }, [matches, activeMatchIndex]);
+
+  const hasMatches = matches.length > 0;
+  thumbRefs.current.length = thumbs.length;
 
   return (
-    <div>
-      <div className="flex gap-2 mb-2">
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2">
         <input
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={handleQueryKeyDown}
           placeholder="Search"
+          aria-label="Search document"
+          className="w-full max-w-xs rounded border border-slate-500 bg-slate-900 px-2 py-1 text-sm text-slate-100 placeholder-slate-400 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
         />
-        <button onClick={search}>Search</button>
+        <button
+          type="button"
+          onClick={() => {
+            void search();
+          }}
+          className="rounded bg-sky-600 px-3 py-1 text-sm font-medium text-white transition hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
+        >
+          Search
+        </button>
+        {hasMatches && matchSummary && (
+          <div
+            className="flex items-center gap-2 text-sm text-slate-200"
+            data-testid="search-navigation"
+          >
+            <button
+              type="button"
+              onClick={goToPreviousMatch}
+              className="rounded border border-slate-500 px-2 py-1 transition hover:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500"
+            >
+              Previous
+            </button>
+            <span>{matchSummary}</span>
+            <button
+              type="button"
+              onClick={goToNextMatch}
+              className="rounded border border-slate-500 px-2 py-1 transition hover:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500"
+            >
+              Next
+            </button>
+          </div>
+        )}
       </div>
-      <canvas ref={canvasRef} data-testid="pdf-canvas" />
+      <div className="relative w-full overflow-hidden rounded border border-slate-700 bg-black">
+        <canvas
+          ref={canvasRef}
+          role="img"
+          aria-label={`Document page ${page}`}
+          data-testid="pdf-canvas"
+          className="block max-w-full"
+        />
+        <canvas
+          ref={highlightCanvasRef}
+          data-testid="pdf-highlight-layer"
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 block"
+        />
+      </div>
       <div
-        className="flex gap-2 overflow-x-auto mt-2"
+        className="flex gap-2 overflow-x-auto pb-2"
         role="listbox"
         aria-orientation="horizontal"
         ref={thumbListRef}
       >
-        {thumbs.map((t, i) => (
+        {thumbs.map((thumb, index) => (
           <canvas
-            key={i + 1}
+            key={index + 1}
             role="option"
-            tabIndex={page === i + 1 ? 0 : -1}
-            aria-selected={page === i + 1}
-            data-testid={`thumb-${i + 1}`}
-            onClick={() => setPage(i + 1)}
-            onFocus={() => setPage(i + 1)}
+            tabIndex={page === index + 1 ? 0 : -1}
+            aria-selected={page === index + 1}
+            aria-label={`Thumbnail of page ${index + 1}`}
+            data-testid={`thumb-${index + 1}`}
+            data-active={page === index + 1}
+            onClick={() => setPage(index + 1)}
+            onFocus={() => setPage(index + 1)}
             ref={(el) => {
-              if (el) el.getContext('2d')?.drawImage(t, 0, 0);
+              thumbRefs.current[index] = el;
+              if (el) {
+                const context = el.getContext('2d');
+                if (context) {
+                  context.clearRect(0, 0, el.width, el.height);
+                  context.drawImage(thumb, 0, 0, el.width, el.height);
+                }
+              }
             }}
-            width={t.width}
-            height={t.height}
+            width={thumb.width}
+            height={thumb.height}
+            className={`rounded border ${
+              page === index + 1
+                ? 'border-sky-500 ring-2 ring-sky-400'
+                : 'border-transparent'
+            }`}
           />
         ))}
       </div>
-      {matches.length > 0 && (
-        <div data-testid="search-results">
-          {matches.map((m) => (
-            <div key={m}>Page {m}</div>
+      {hasMatches && (
+        <ol
+          className="space-y-1 text-sm text-slate-200"
+          data-testid="search-results"
+          aria-label="Search results"
+        >
+          {matches.map((match) => (
+            <li key={`${match.page}-${match.index}`} data-testid="search-result-item">
+              <button
+                type="button"
+                onClick={() => goToMatch(match.index)}
+                className={`w-full rounded border px-2 py-1 text-left transition ${
+                  activeMatchIndex === match.index
+                    ? 'border-sky-400 bg-sky-900/40'
+                    : 'border-slate-600 bg-slate-800/60 hover:border-sky-400'
+                }`}
+              >
+                Match {match.index + 1}: Page {match.page}
+              </button>
+            </li>
           ))}
-        </div>
+        </ol>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- enrich the PDF viewer search experience with indexed results, highlight overlays, keyboard navigation, and thumbnail sync
- render next/previous controls with a searchable results list for quicker match access
- cover the new navigation behavior with focused unit tests

## Testing
- yarn test pdfviewer
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc26894c188328a5cd4c166ca66f18