### PR TITLE
[apps] Make resource monitor charts responsive

### DIFF
--- a/__tests__/resourceMonitor.test.tsx
+++ b/__tests__/resourceMonitor.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import ResourceMonitor from '../components/apps/resource_monitor';
+
+describe('ResourceMonitor', () => {
+  let observers: Map<Element, ResizeObserverCallback>;
+  const originalDevicePixelRatio = window.devicePixelRatio;
+
+  beforeEach(() => {
+    observers = new Map();
+
+    class ResizeObserverMock {
+      callback: ResizeObserverCallback;
+
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+      }
+
+      observe = (target: Element) => {
+        observers.set(target, this.callback);
+      };
+
+      unobserve = (target: Element) => {
+        observers.delete(target);
+      };
+
+      disconnect = () => {
+        observers.clear();
+      };
+
+      takeRecords = () => [];
+    }
+
+    globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+    Object.defineProperty(window, 'devicePixelRatio', {
+      configurable: true,
+      value: 1,
+    });
+  });
+
+  afterEach(() => {
+    delete (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+    Object.defineProperty(window, 'devicePixelRatio', {
+      configurable: true,
+      value: originalDevicePixelRatio,
+    });
+  });
+
+  it('updates canvas dimensions in response to container resize events', async () => {
+    render(<ResourceMonitor />);
+
+    const container = await screen.findByTestId('resource-chart-cpu');
+    await waitFor(() => {
+      expect(observers.has(container)).toBe(true);
+    });
+
+    const callback = observers.get(container);
+    expect(typeof callback).toBe('function');
+
+    await act(async () => {
+      callback?.([
+        {
+          target: container,
+          contentRect: { width: 420, height: 160 },
+        } as unknown as ResizeObserverEntry,
+      ]);
+    });
+
+    const canvas = within(container).getByRole('img', { name: /cpu usage chart/i });
+    await waitFor(() => {
+      expect(Number(canvas.getAttribute('width'))).toBeGreaterThanOrEqual(420);
+      expect(Number(canvas.getAttribute('height'))).toBeGreaterThanOrEqual(160);
+    });
+  });
+});

--- a/components/apps/resource_monitor.js
+++ b/components/apps/resource_monitor.js
@@ -1,7 +1,62 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
-// Number of samples to keep in the timeline
 const MAX_POINTS = 60;
+const LABEL_COLOR_VAR = '--resource-chart-label-color';
+
+const formatUnitSuffix = (unit = '') => {
+  if (!unit) return '';
+  return unit.startsWith('%') ? unit : ` ${unit}`;
+};
+
+const getCssVariable = (element, variableName, fallback) => {
+  if (!element || typeof window === 'undefined' || typeof getComputedStyle !== 'function') {
+    return fallback;
+  }
+  const value = getComputedStyle(element).getPropertyValue(variableName);
+  return value ? value.trim() || fallback : fallback;
+};
+
+function drawChart(canvas, values, strokeColor, label, unit, maxVal, labelColor, size) {
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  const ratio = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+  const logicalWidth = size?.width || canvas.width / ratio || 0;
+  const logicalHeight = size?.height || canvas.height / ratio || 0;
+  const width = Math.max(1, Math.round(logicalWidth * ratio));
+  const height = Math.max(1, Math.round(logicalHeight * ratio));
+
+  if (canvas.width !== width || canvas.height !== height) {
+    canvas.width = width;
+    canvas.height = height;
+  }
+
+  ctx.save();
+  ctx.scale(ratio, ratio);
+  ctx.clearRect(0, 0, logicalWidth, logicalHeight);
+  ctx.strokeStyle = strokeColor;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  values.forEach((v, i) => {
+    const x = (i / (values.length - 1 || 1)) * logicalWidth;
+    const y = logicalHeight - (v / maxVal) * logicalHeight;
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  });
+  ctx.stroke();
+  const latest = values[values.length - 1] || 0;
+  const suffix = formatUnitSuffix(unit);
+  ctx.fillStyle = labelColor;
+  ctx.font = '12px sans-serif';
+  ctx.fillText(`${label}: ${latest.toFixed(1)}${suffix}`, 4, 12);
+  ctx.restore();
+}
 
 const ResourceMonitor = () => {
   const cpuCanvas = useRef(null);
@@ -12,6 +67,7 @@ const ResourceMonitor = () => {
 
   const dataRef = useRef({ cpu: [], mem: [], fps: [], net: [] });
   const displayRef = useRef({ cpu: [], mem: [], fps: [], net: [] });
+  const timestampsRef = useRef({ cpu: [], mem: [], fps: [], net: [] });
   const animRef = useRef();
   const lastDrawRef = useRef(0);
   const THROTTLE_MS = 1000;
@@ -19,19 +75,288 @@ const ResourceMonitor = () => {
   const [paused, setPaused] = useState(false);
   const [stress, setStress] = useState(false);
   const [fps, setFps] = useState(0);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [latestSamples, setLatestSamples] = useState({
+    cpu: null,
+    mem: null,
+    fps: null,
+    net: null,
+  });
+  const [chartSizes, setChartSizes] = useState({
+    cpu: { width: 300, height: 100 },
+    mem: { width: 300, height: 100 },
+    fps: { width: 300, height: 100 },
+    net: { width: 300, height: 100 },
+  });
 
   const stressWindows = useRef([]);
   const stressEls = useRef([]);
   const containerRef = useRef(null);
+  const chartContainersRef = useRef({ cpu: null, mem: null, fps: null, net: null });
+  const resizeObserverRef = useRef(null);
 
   useEffect(() => () => cancelAnimationFrame(animRef.current), []);
 
-  // Spawn worker for network speed tests
   useEffect(() => {
-    if (typeof window === 'undefined' || typeof Worker !== 'function') return;
-    workerRef.current = new Worker(
-      new URL('./speedtest.worker.js', import.meta.url),
-    );
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const updatePreference = (event) => setPrefersReducedMotion(event.matches);
+    setPrefersReducedMotion(mediaQuery.matches);
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', updatePreference);
+      return () => mediaQuery.removeEventListener('change', updatePreference);
+    }
+    mediaQuery.addListener(updatePreference);
+    return () => mediaQuery.removeListener(updatePreference);
+  }, []);
+
+  const chartConfigs = useMemo(
+    () => [
+      {
+        key: 'cpu',
+        canvasRef: cpuCanvas,
+        ariaLabel: 'CPU usage chart',
+        tooltipLabel: 'CPU usage',
+        legendLabel: 'CPU',
+        unit: '%',
+        max: 100,
+        strokeVar: '--resource-chart-cpu-stroke',
+        fallbackColor: '#00ff00',
+      },
+      {
+        key: 'mem',
+        canvasRef: memCanvas,
+        ariaLabel: 'Memory usage chart',
+        tooltipLabel: 'Memory usage',
+        legendLabel: 'Memory',
+        unit: '%',
+        max: 100,
+        strokeVar: '--resource-chart-mem-stroke',
+        fallbackColor: '#ffd700',
+      },
+      {
+        key: 'fps',
+        canvasRef: fpsCanvas,
+        ariaLabel: 'FPS chart',
+        tooltipLabel: 'Frame rate',
+        legendLabel: 'FPS',
+        unit: 'fps',
+        max: 120,
+        strokeVar: '--resource-chart-fps-stroke',
+        fallbackColor: '#00ffff',
+      },
+      {
+        key: 'net',
+        canvasRef: netCanvas,
+        ariaLabel: 'Network speed chart',
+        tooltipLabel: 'Network throughput',
+        legendLabel: 'Network',
+        unit: 'Mbps',
+        max: 100,
+        strokeVar: '--resource-chart-net-stroke',
+        fallbackColor: '#ff00ff',
+      },
+    ],
+    [cpuCanvas, memCanvas, fpsCanvas, netCanvas],
+  );
+
+  const updateCanvasSize = useCallback((key, width, height) => {
+    setChartSizes((prev) => {
+      if (!prev[key]) return prev;
+      const nextWidth = Math.max(1, Math.round(width));
+      const nextHeight = Math.max(1, Math.round(height));
+      if (nextWidth === 0 || nextHeight === 0) return prev;
+      if (
+        prev[key].width === nextWidth &&
+        prev[key].height === nextHeight
+      ) {
+        return prev;
+      }
+      return {
+        ...prev,
+        [key]: { width: nextWidth, height: nextHeight },
+      };
+    });
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    if (typeof ResizeObserver === 'undefined') {
+      const handleResize = () => {
+        Object.entries(chartContainersRef.current).forEach(([key, node]) => {
+          if (!node) return;
+          const rect = node.getBoundingClientRect();
+          if (rect.width && rect.height) {
+            updateCanvasSize(key, rect.width, rect.height);
+          }
+        });
+      };
+      handleResize();
+      window.addEventListener('resize', handleResize);
+      return () => window.removeEventListener('resize', handleResize);
+    }
+    const observer = new ResizeObserver((entries) => {
+      entries.forEach((entry) => {
+        const key = entry.target.getAttribute('data-chart-key');
+        if (!key) return;
+        const { width, height } = entry.contentRect;
+        updateCanvasSize(key, width, height);
+      });
+    });
+    resizeObserverRef.current = observer;
+    Object.values(chartContainersRef.current).forEach((node) => {
+      if (node) observer.observe(node);
+    });
+    return () => observer.disconnect();
+  }, [updateCanvasSize]);
+
+  const registerContainer = useCallback(
+    (key) => (node) => {
+      const existing = chartContainersRef.current[key];
+      if (resizeObserverRef.current && existing) {
+        resizeObserverRef.current.unobserve(existing);
+      }
+      chartContainersRef.current[key] = node;
+      if (!node) return;
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.observe(node);
+      } else {
+        const rect = node.getBoundingClientRect();
+        if (rect.width && rect.height) {
+          updateCanvasSize(key, rect.width, rect.height);
+        }
+      }
+    },
+    [updateCanvasSize],
+  );
+
+  const drawCharts = useCallback(
+    (dataset = dataRef.current) => {
+      chartConfigs.forEach((config) => {
+        const canvas = config.canvasRef.current;
+        if (!canvas) return;
+        const strokeColor = getCssVariable(
+          canvas,
+          config.strokeVar,
+          config.fallbackColor,
+        );
+        const labelColor = getCssVariable(canvas, LABEL_COLOR_VAR, '#ffffff');
+        drawChart(
+          canvas,
+          dataset[config.key] || [],
+          strokeColor,
+          config.legendLabel,
+          config.unit,
+          config.max,
+          labelColor,
+          chartSizes[config.key],
+        );
+      });
+    },
+    [chartConfigs, chartSizes],
+  );
+
+  useEffect(() => {
+    drawCharts();
+    displayRef.current = {
+      cpu: [...dataRef.current.cpu],
+      mem: [...dataRef.current.mem],
+      fps: [...dataRef.current.fps],
+      net: [...dataRef.current.net],
+    };
+  }, [drawCharts]);
+
+  useEffect(() => {
+    if (!prefersReducedMotion) return undefined;
+    cancelAnimationFrame(animRef.current);
+    drawCharts();
+    displayRef.current = {
+      cpu: [...dataRef.current.cpu],
+      mem: [...dataRef.current.mem],
+      fps: [...dataRef.current.fps],
+      net: [...dataRef.current.net],
+    };
+    return undefined;
+  }, [prefersReducedMotion, drawCharts]);
+
+  const pushSample = useCallback((key, value) => {
+    const safeValue = Number.isFinite(value) ? value : 0;
+    const arr = dataRef.current[key];
+    const tsArr = timestampsRef.current[key];
+    arr.push(safeValue);
+    tsArr.push(new Date().toISOString());
+    if (arr.length > MAX_POINTS) arr.shift();
+    if (tsArr.length > MAX_POINTS) tsArr.shift();
+    setLatestSamples((prev) => {
+      const timestamp = tsArr[tsArr.length - 1];
+      const current = prev[key];
+      if (current && current.timestamp === timestamp && current.value === safeValue) {
+        return prev;
+      }
+      return {
+        ...prev,
+        [key]: { value: safeValue, timestamp },
+      };
+    });
+  }, []);
+
+  const animateCharts = useCallback(() => {
+    const target = {
+      cpu: [...dataRef.current.cpu],
+      mem: [...dataRef.current.mem],
+      fps: [...dataRef.current.fps],
+      net: [...dataRef.current.net],
+    };
+    if (prefersReducedMotion) {
+      drawCharts(target);
+      displayRef.current = target;
+      return;
+    }
+    const from = {
+      cpu: [...displayRef.current.cpu],
+      mem: [...displayRef.current.mem],
+      fps: [...displayRef.current.fps],
+      net: [...displayRef.current.net],
+    };
+    const start = performance.now();
+    const duration = 300;
+
+    const step = (now) => {
+      const t = Math.min(1, (now - start) / duration);
+      const interpolated = {};
+      Object.keys(target).forEach((key) => {
+        const fromArr = from[key];
+        const toArr = target[key];
+        interpolated[key] = toArr.map((v, i) => {
+          const base = fromArr[i] ?? fromArr[fromArr.length - 1] ?? v;
+          return base + (v - base) * t;
+        });
+      });
+      drawCharts(interpolated);
+      if (t < 1) {
+        animRef.current = requestAnimationFrame(step);
+      } else {
+        displayRef.current = target;
+      }
+    };
+
+    cancelAnimationFrame(animRef.current);
+    animRef.current = requestAnimationFrame(step);
+  }, [drawCharts, prefersReducedMotion]);
+
+  const scheduleDraw = useCallback(() => {
+    const now = performance.now();
+    if (now - lastDrawRef.current >= THROTTLE_MS) {
+      lastDrawRef.current = now;
+      animateCharts();
+    }
+  }, [animateCharts]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof Worker !== 'function') return undefined;
+    workerRef.current = new Worker(new URL('./speedtest.worker.js', import.meta.url));
     workerRef.current.onmessage = (e) => {
       const { speed } = e.data || {};
       pushSample('net', speed);
@@ -39,7 +364,7 @@ const ResourceMonitor = () => {
     };
     workerRef.current.postMessage({ type: 'start' });
     return () => workerRef.current?.terminate();
-  }, [scheduleDraw]);
+  }, [pushSample, scheduleDraw]);
 
   useEffect(() => {
     if (workerRef.current) {
@@ -47,7 +372,6 @@ const ResourceMonitor = () => {
     }
   }, [paused]);
 
-  // Sampling loop using requestAnimationFrame
   useEffect(() => {
     let raf;
     let lastFrame = performance.now();
@@ -60,7 +384,7 @@ const ResourceMonitor = () => {
       if (!paused) setFps(currentFps);
 
       if (!paused && now - lastSample >= 1000) {
-        const target = 1000 / 60; // 60 FPS ideal frame time
+        const target = 1000 / 60;
         const cpu = Math.min(100, Math.max(0, ((dt - target) / target) * 100));
         let mem = 0;
         if (performance && performance.memory) {
@@ -77,12 +401,12 @@ const ResourceMonitor = () => {
     };
     raf = requestAnimationFrame(sample);
     return () => cancelAnimationFrame(raf);
-  }, [paused, scheduleDraw]);
+  }, [paused, pushSample, scheduleDraw]);
 
-  // Stress test animation – many moving windows
   useEffect(() => {
     let raf;
     const animate = () => {
+      if (prefersReducedMotion) return;
       if (stress && !paused) {
         const rect = containerRef.current?.getBoundingClientRect();
         stressWindows.current.forEach((w, i) => {
@@ -98,11 +422,12 @@ const ResourceMonitor = () => {
       }
       raf = requestAnimationFrame(animate);
     };
-    raf = requestAnimationFrame(animate);
+    if (!prefersReducedMotion) {
+      raf = requestAnimationFrame(animate);
+    }
     return () => cancelAnimationFrame(raf);
-  }, [stress, paused]);
+  }, [stress, paused, prefersReducedMotion]);
 
-  // Create or clear stress windows when toggled
   useEffect(() => {
     if (stress) {
       const rect = containerRef.current?.getBoundingClientRect();
@@ -120,55 +445,21 @@ const ResourceMonitor = () => {
     }
   }, [stress]);
 
-  const pushSample = (key, value) => {
-    const arr = dataRef.current[key];
-    arr.push(value);
-    if (arr.length > MAX_POINTS) arr.shift();
-  };
-
-  const drawCharts = (dataset = dataRef.current) => {
-    drawChart(cpuCanvas.current, dataset.cpu, '#00ff00', 'CPU %', 100);
-    drawChart(memCanvas.current, dataset.mem, '#ffd700', 'Memory %', 100);
-    drawChart(fpsCanvas.current, dataset.fps, '#00ffff', 'FPS', 120);
-    drawChart(netCanvas.current, dataset.net, '#ff00ff', 'Mbps', 100);
-  };
-
-  const animateCharts = useCallback(() => {
-    const from = { ...displayRef.current };
-    const to = { ...dataRef.current };
-    const start = performance.now();
-    const duration = 300;
-
-    const step = (now) => {
-      const t = Math.min(1, (now - start) / duration);
-      const interpolated = {};
-      ['cpu', 'mem', 'fps', 'net'].forEach((key) => {
-        const fromArr = from[key];
-        const toArr = to[key];
-        interpolated[key] = toArr.map((v, i) => {
-          const a = fromArr[i] ?? fromArr[fromArr.length - 1] ?? 0;
-          return a + (v - a) * t;
-        });
-      });
-      drawCharts(interpolated);
-      if (t < 1) {
-        animRef.current = requestAnimationFrame(step);
-      } else {
-        displayRef.current = to;
+  const formatTooltip = useCallback(
+    (config) => {
+      const sample = latestSamples[config.key];
+      if (!sample) {
+        return `${config.tooltipLabel} samples not yet available`;
       }
-    };
-
-    cancelAnimationFrame(animRef.current);
-    animRef.current = requestAnimationFrame(step);
-  }, []);
-
-  const scheduleDraw = useCallback(() => {
-    const now = performance.now();
-    if (now - lastDrawRef.current >= THROTTLE_MS) {
-      lastDrawRef.current = now;
-      animateCharts();
-    }
-  }, [animateCharts]);
+      const timestamp = new Date(sample.timestamp);
+      const formatted = Number.isNaN(timestamp.valueOf())
+        ? sample.timestamp
+        : timestamp.toLocaleString();
+      const suffix = formatUnitSuffix(config.unit);
+      return `${config.tooltipLabel}: ${sample.value.toFixed(1)}${suffix} sampled at ${formatted}`;
+    },
+    [latestSamples],
+  );
 
   const togglePause = () => setPaused((p) => !p);
   const toggleStress = () => setStress((s) => !s);
@@ -187,39 +478,31 @@ const ResourceMonitor = () => {
         </button>
         <span className="ml-auto text-sm">FPS: {fps.toFixed(1)}</span>
       </div>
-      <div className="flex flex-1 items-center justify-evenly gap-4 p-4">
-        <canvas
-          ref={cpuCanvas}
-          width={300}
-          height={100}
-          role="img"
-          aria-label="CPU usage chart"
-          className="bg-ub-dark-grey"
-        />
-        <canvas
-          ref={memCanvas}
-          width={300}
-          height={100}
-          role="img"
-          aria-label="Memory usage chart"
-          className="bg-ub-dark-grey"
-        />
-        <canvas
-          ref={fpsCanvas}
-          width={300}
-          height={100}
-          role="img"
-          aria-label="FPS chart"
-          className="bg-ub-dark-grey"
-        />
-        <canvas
-          ref={netCanvas}
-          width={300}
-          height={100}
-          role="img"
-          aria-label="Network speed chart"
-          className="bg-ub-dark-grey"
-        />
+      <div className="grid flex-1 gap-4 p-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 auto-rows-fr">
+        {chartConfigs.map((config) => {
+          const tooltip = formatTooltip(config);
+          const ariaDescription = `${config.ariaLabel}. ${tooltip}`;
+          const size = chartSizes[config.key];
+          return (
+            <div
+              key={config.key}
+              ref={registerContainer(config.key)}
+              data-chart-key={config.key}
+              data-testid={`resource-chart-${config.key}`}
+              className="relative w-full h-32 sm:h-36 xl:h-40 bg-ub-dark-grey rounded overflow-hidden"
+              title={tooltip}
+            >
+              <canvas
+                ref={config.canvasRef}
+                width={size.width}
+                height={size.height}
+                role="img"
+                aria-label={ariaDescription}
+                className="absolute inset-0 w-full h-full"
+              />
+            </div>
+          );
+        })}
       </div>
       {stressWindows.current.map((_, i) => (
         <div
@@ -233,29 +516,6 @@ const ResourceMonitor = () => {
     </div>
   );
 };
-
-function drawChart(canvas, values, color, label, maxVal) {
-  if (!canvas) return;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return;
-  const w = canvas.width;
-  const h = canvas.height;
-  ctx.clearRect(0, 0, w, h);
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  values.forEach((v, i) => {
-    const x = (i / (values.length - 1 || 1)) * w;
-    const y = h - (v / maxVal) * h;
-    if (i === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
-  });
-  ctx.stroke();
-  const latest = values[values.length - 1] || 0;
-  ctx.fillStyle = '#ffffff';
-  ctx.font = '12px sans-serif';
-  ctx.fillText(`${label}: ${latest.toFixed(1)}`, 4, 12);
-}
 
 export default ResourceMonitor;
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -38,6 +38,11 @@
   --kali-panel-highlight: rgba(255, 255, 255, 0.05);
   --kali-terminal-green: #00ff00;
   --kali-terminal-text: #f5f5f5;
+  --resource-chart-label-color: #ffffff;
+  --resource-chart-cpu-stroke: #00ff00;
+  --resource-chart-mem-stroke: #ffd700;
+  --resource-chart-fps-stroke: #00ffff;
+  --resource-chart-net-stroke: #ff00ff;
 
   /* Game palette tokens */
   --game-color-secondary: #1d4ed8;
@@ -104,6 +109,11 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --resource-chart-label-color: #ffffff;
+  --resource-chart-cpu-stroke: #ffff00;
+  --resource-chart-mem-stroke: #ff8800;
+  --resource-chart-fps-stroke: #00ffff;
+  --resource-chart-net-stroke: #ff00ff;
 }
 
 /* Dyslexia-friendly fonts */


### PR DESCRIPTION
## Summary
- redesign the resource monitor charts to size against their containers and respect reduced motion preferences
- move chart stroke colors into theme tokens and expose tooltips with sampled value timestamps
- add a unit test covering the ResizeObserver-driven resizing logic

## Testing
- yarn test __tests__/resourceMonitor.test.tsx
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc268c169883289a8bf32fc84381bf