### PR TITLE
[ui] Add split pane controls to TabbedWindow

### DIFF
--- a/__tests__/TabbedWindowSplit.test.tsx
+++ b/__tests__/TabbedWindowSplit.test.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import TabbedWindow, { TabDefinition } from '../components/ui/TabbedWindow';
+import { SettingsContext } from '../hooks/useSettings';
+
+type SettingsValue = React.ContextType<typeof SettingsContext>;
+
+const createSettingsValue = (overrides: Partial<SettingsValue> = {}): SettingsValue => ({
+  accent: '#1793d1',
+  wallpaper: 'wall-2',
+  bgImageName: 'wall-2',
+  useKaliWallpaper: false,
+  density: 'regular',
+  reducedMotion: false,
+  fontScale: 1,
+  highContrast: false,
+  largeHitAreas: false,
+  pongSpin: true,
+  allowNetwork: false,
+  haptics: true,
+  theme: 'default',
+  setAccent: jest.fn(),
+  setWallpaper: jest.fn(),
+  setUseKaliWallpaper: jest.fn(),
+  setDensity: jest.fn(),
+  setReducedMotion: jest.fn(),
+  setFontScale: jest.fn(),
+  setHighContrast: jest.fn(),
+  setLargeHitAreas: jest.fn(),
+  setPongSpin: jest.fn(),
+  setAllowNetwork: jest.fn(),
+  setHaptics: jest.fn(),
+  setTheme: jest.fn(),
+  ...overrides,
+});
+
+const renderTabbedWindow = (tabs: TabDefinition[], settings?: Partial<SettingsValue>) =>
+  render(
+    <SettingsContext.Provider value={createSettingsValue(settings)}>
+      <TabbedWindow initialTabs={tabs} />
+    </SettingsContext.Provider>,
+  );
+
+let scrollToSpy: jest.SpyInstance | null = null;
+
+beforeAll(() => {
+  if (!HTMLElement.prototype.scrollTo) {
+    HTMLElement.prototype.scrollTo = function scrollTo(this: HTMLElement, options?: any) {
+      if (typeof options === 'number') {
+        this.scrollTop = options;
+        return;
+      }
+      if (options) {
+        if (typeof options.top === 'number') this.scrollTop = options.top;
+        if (typeof options.left === 'number') this.scrollLeft = options.left;
+      }
+    };
+  }
+});
+
+beforeEach(() => {
+  scrollToSpy = jest
+    .spyOn(HTMLElement.prototype, 'scrollTo')
+    .mockImplementation(function mockScrollTo(this: HTMLElement, options?: any) {
+      if (typeof options === 'number') {
+        this.scrollTop = options;
+        return;
+      }
+      if (options) {
+        if (typeof options.top === 'number') this.scrollTop = options.top;
+        if (typeof options.left === 'number') this.scrollLeft = options.left;
+      }
+    });
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  scrollToSpy?.mockRestore();
+  scrollToSpy = null;
+  window.localStorage.clear();
+});
+
+describe('TabbedWindow split panes', () => {
+  it('allows resizing split panes with keyboard controls', () => {
+    const tabs: TabDefinition[] = [
+      {
+        id: 'alpha',
+        title: 'Alpha',
+        content: <div style={{ height: 800 }}>Alpha content</div>,
+      },
+    ];
+
+    renderTabbedWindow(tabs);
+
+    fireEvent.click(screen.getByRole('button', { name: /split view/i }));
+
+    const separator = screen.getByRole('separator', { name: /resize split panes/i });
+    const firstPane = screen.getByLabelText('Alpha pane 1') as HTMLDivElement;
+
+    expect(parseFloat(firstPane.style.flexBasis)).toBeCloseTo(50, 1);
+
+    fireEvent.keyDown(separator, { key: 'ArrowRight' });
+
+    expect(parseFloat(firstPane.style.flexBasis)).toBeGreaterThan(50);
+  });
+
+  it('persists split layout and orientation per tab', () => {
+    const tabs: TabDefinition[] = [
+      { id: 'alpha', title: 'Alpha', content: <div>Alpha</div> },
+      { id: 'beta', title: 'Beta', content: <div>Beta</div> },
+    ];
+
+    const utils = renderTabbedWindow(tabs);
+
+    const splitButton = screen.getByRole('button', { name: /split view/i });
+    fireEvent.click(splitButton);
+
+    const orientationButton = screen.getByRole('button', { name: /toggle split orientation/i });
+    fireEvent.click(orientationButton);
+
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'horizontal');
+
+    fireEvent.click(screen.getByRole('tab', { name: /beta/i }));
+    expect(splitButton).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(screen.getByRole('tab', { name: /alpha/i }));
+    expect(splitButton).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'horizontal');
+
+    utils.unmount();
+
+    renderTabbedWindow(tabs);
+    expect(screen.getByRole('button', { name: /split view/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'horizontal');
+  });
+
+  it('links pane scroll positions when enabled', async () => {
+    const tallContent = (
+      <div>
+        {Array.from({ length: 200 }).map((_, index) => (
+          <p key={index}>Line {index}</p>
+        ))}
+      </div>
+    );
+    const tabs: TabDefinition[] = [
+      {
+        id: 'scroll',
+        title: 'Scroll',
+        content: () => tallContent,
+      },
+    ];
+
+    renderTabbedWindow(tabs);
+
+    fireEvent.click(screen.getByRole('button', { name: /split view/i }));
+    const linkButton = screen.getByRole('button', { name: /link pane scrolling/i });
+    fireEvent.click(linkButton);
+
+    await act(async () => {});
+
+    const firstPane = screen.getByLabelText('Scroll pane 1') as HTMLDivElement;
+    const secondPane = screen.getByLabelText('Scroll pane 2') as HTMLDivElement;
+
+    firstPane.scrollTop = 120;
+    fireEvent.scroll(firstPane);
+
+    await act(async () => {});
+
+    expect(secondPane.scrollTop).toBe(120);
+    expect(scrollToSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ top: 120, behavior: 'smooth' }),
+    );
+  });
+
+  it('uses instant scroll syncing when reduced motion is enabled', async () => {
+    const tabs: TabDefinition[] = [
+      { id: 'motion', title: 'Motion', content: () => <div style={{ height: 1200 }}>Motion</div> },
+    ];
+
+    renderTabbedWindow(tabs, { reducedMotion: true });
+
+    fireEvent.click(screen.getByRole('button', { name: /split view/i }));
+    const linkButton = screen.getByRole('button', { name: /link pane scrolling/i });
+    fireEvent.click(linkButton);
+
+    await act(async () => {});
+
+    const firstPane = screen.getByLabelText('Motion pane 1') as HTMLDivElement;
+
+    firstPane.scrollTop = 75;
+    fireEvent.scroll(firstPane);
+
+    await act(async () => {});
+
+    expect(scrollToSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ top: 75, behavior: 'auto' }),
+    );
+  });
+});

--- a/components/ui/SplitPane.tsx
+++ b/components/ui/SplitPane.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+type Orientation = 'horizontal' | 'vertical';
+
+type PaneProps = Omit<React.HTMLAttributes<HTMLDivElement>, 'ref'> & {
+  ref?: React.Ref<HTMLDivElement>;
+};
+
+export interface SplitPaneProps {
+  orientation: Orientation;
+  size: number;
+  minSize?: number;
+  maxSize?: number;
+  onSizeChange?: (size: number) => void;
+  children: [React.ReactNode, React.ReactNode];
+  className?: string;
+  firstPaneProps?: PaneProps;
+  secondPaneProps?: PaneProps;
+  dividerLabel?: string;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const SplitPane: React.FC<SplitPaneProps> = ({
+  orientation,
+  size,
+  minSize = 0.1,
+  maxSize = 0.9,
+  onSizeChange,
+  children,
+  className = '',
+  firstPaneProps,
+  secondPaneProps,
+  dividerLabel = 'Resize split panes',
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [activePointerId, setActivePointerId] = useState<number | null>(null);
+  const panes = useMemo(() => React.Children.toArray(children).slice(0, 2), [children]);
+  const [firstChild, secondChild] = panes as [React.ReactNode, React.ReactNode];
+
+  const {
+    ref: firstRef,
+    className: firstClassName,
+    style: firstStyleProps,
+    ...firstRest
+  } = firstPaneProps ?? {};
+  const {
+    ref: secondRef,
+    className: secondClassName,
+    style: secondStyleProps,
+    ...secondRest
+  } = secondPaneProps ?? {};
+
+  const min = Math.max(0, minSize);
+  const max = Math.min(1, maxSize);
+  const clampedSize = clamp(size, min, max);
+
+  const computeSizeFromPointer = useCallback(
+    (event: Pick<PointerEvent, 'clientX' | 'clientY'>) => {
+      const container = containerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return;
+
+      const ratio =
+        orientation === 'horizontal'
+          ? (event.clientX - rect.left) / rect.width
+          : (event.clientY - rect.top) / rect.height;
+      const next = clamp(ratio, min, max);
+      onSizeChange?.(next);
+    },
+    [max, min, onSizeChange, orientation],
+  );
+
+  useEffect(() => {
+    if (activePointerId === null) return;
+
+    const handleMove = (event: PointerEvent) => {
+      event.preventDefault();
+      computeSizeFromPointer(event);
+    };
+
+    const handleEnd = (event: PointerEvent) => {
+      if (event.pointerId !== activePointerId) return;
+      setActivePointerId(null);
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleEnd);
+    window.addEventListener('pointercancel', handleEnd);
+
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleEnd);
+      window.removeEventListener('pointercancel', handleEnd);
+    };
+  }, [activePointerId, computeSizeFromPointer]);
+
+  const startDrag = (event: React.PointerEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.currentTarget.focus({ preventScroll: true });
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setActivePointerId(event.pointerId);
+  };
+
+  const stopDrag = (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (event.pointerId !== activePointerId) return;
+    event.preventDefault();
+    event.currentTarget.releasePointerCapture(event.pointerId);
+    setActivePointerId(null);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    const smallStep = 0.02;
+    const largeStep = 0.1;
+    const step = event.shiftKey ? largeStep : smallStep;
+
+    const adjust = (delta: number) => {
+      const next = clamp(clampedSize + delta, min, max);
+      if (next !== clampedSize) {
+        onSizeChange?.(next);
+      }
+    };
+
+    if (orientation === 'horizontal') {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        adjust(-step);
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        adjust(step);
+      }
+    } else {
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        adjust(-step);
+      } else if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        adjust(step);
+      }
+    }
+  };
+
+  const orientationClass =
+    orientation === 'horizontal' ? 'flex-row' : 'flex-col';
+
+  const separatorOrientation =
+    orientation === 'horizontal' ? 'vertical' : 'horizontal';
+
+  const handleClassName = [
+    'relative flex items-center justify-center bg-gray-800 text-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[--color-focus-ring] focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900',
+    orientation === 'horizontal'
+      ? 'cursor-col-resize min-w-[44px]'
+      : 'cursor-row-resize min-h-[44px]',
+  ].join(' ');
+
+  const lineClass =
+    orientation === 'horizontal'
+      ? 'h-full w-px bg-gray-600'
+      : 'w-full h-px bg-gray-600';
+
+  const firstStyle =
+    orientation === 'horizontal'
+      ? { flexBasis: `${clampedSize * 100}%` }
+      : { flexBasis: `${clampedSize * 100}%` };
+
+  const secondStyle =
+    orientation === 'horizontal'
+      ? { flexBasis: `${(1 - clampedSize) * 100}%` }
+      : { flexBasis: `${(1 - clampedSize) * 100}%` };
+
+  const sharedPaneClasses =
+    'flex-1 min-w-0 min-h-0 overflow-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-[--color-focus-ring] focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900';
+
+  return (
+    <div
+      ref={containerRef}
+      className={`flex ${orientationClass} w-full h-full ${className}`.trim()}
+    >
+      <div
+        {...firstRest}
+        ref={firstRef as React.Ref<HTMLDivElement>}
+        className={`${sharedPaneClasses} ${firstClassName ?? ''}`.trim()}
+        style={{ ...firstStyle, ...(firstStyleProps ?? {}) }}
+      >
+        {firstChild}
+      </div>
+      <button
+        type="button"
+        role="separator"
+        aria-orientation={separatorOrientation}
+        aria-valuenow={Math.round(clampedSize * 100)}
+        aria-valuemin={Math.round(min * 100)}
+        aria-valuemax={Math.round(max * 100)}
+        aria-label={dividerLabel}
+        className={handleClassName}
+        onPointerDown={startDrag}
+        onPointerUp={stopDrag}
+        onPointerCancel={stopDrag}
+        onKeyDown={handleKeyDown}
+      >
+        <span aria-hidden="true" className={lineClass} />
+      </button>
+      <div
+        {...secondRest}
+        ref={secondRef as React.Ref<HTMLDivElement>}
+        className={`${sharedPaneClasses} ${secondClassName ?? ''}`.trim()}
+        style={{ ...secondStyle, ...(secondStyleProps ?? {}) }}
+      >
+        {secondChild}
+      </div>
+    </div>
+  );
+};
+
+export default SplitPane;

--- a/hooks/useTabLayoutStore.ts
+++ b/hooks/useTabLayoutStore.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import { useCallback } from 'react';
+import usePersistentState from './usePersistentState';
+
+type Orientation = 'horizontal' | 'vertical';
+
+export interface TabLayoutState {
+  split: boolean;
+  orientation: Orientation;
+  size: number;
+  linkScroll: boolean;
+}
+
+const DEFAULT_LAYOUT_STATE: TabLayoutState = {
+  split: false,
+  orientation: 'horizontal',
+  size: 0.5,
+  linkScroll: false,
+};
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const isOrientation = (value: unknown): value is Orientation =>
+  value === 'horizontal' || value === 'vertical';
+
+const isTabLayoutState = (value: unknown): value is TabLayoutState =>
+  !!value &&
+  typeof value === 'object' &&
+  'split' in value &&
+  'orientation' in value &&
+  'size' in value &&
+  'linkScroll' in value &&
+  typeof (value as TabLayoutState).split === 'boolean' &&
+  isOrientation((value as TabLayoutState).orientation) &&
+  isFiniteNumber((value as TabLayoutState).size) &&
+  typeof (value as TabLayoutState).linkScroll === 'boolean';
+
+const isLayoutRecord = (
+  value: unknown,
+): value is Record<string, TabLayoutState> => {
+  if (!value || typeof value !== 'object') return false;
+  return Object.values(value as Record<string, unknown>).every((entry) =>
+    isTabLayoutState(entry),
+  );
+};
+
+export interface TabLayoutStore {
+  layouts: Record<string, TabLayoutState>;
+  getLayout: (tabId: string) => TabLayoutState;
+  updateLayout: (
+    tabId: string,
+    updater:
+      | Partial<TabLayoutState>
+      | ((current: TabLayoutState) => TabLayoutState | Partial<TabLayoutState>),
+  ) => void;
+  removeLayout: (tabId: string) => void;
+  clearAll: () => void;
+}
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const mergeLayout = (
+  current: TabLayoutState,
+  next: Partial<TabLayoutState> | TabLayoutState,
+): TabLayoutState => {
+  const merged: TabLayoutState = {
+    ...current,
+    ...next,
+  };
+  merged.size = clamp(merged.size, 0.1, 0.9);
+  return merged;
+};
+
+export default function useTabLayoutStore(): TabLayoutStore {
+  const [layouts, setLayouts, , clearAll] = usePersistentState<Record<string, TabLayoutState>>(
+    'tab-layout-store',
+    {},
+    isLayoutRecord,
+  );
+
+  const getLayout = useCallback(
+    (tabId: string) => ({
+      ...DEFAULT_LAYOUT_STATE,
+      ...(tabId && layouts[tabId] ? layouts[tabId] : {}),
+    }),
+    [layouts],
+  );
+
+  const updateLayout = useCallback<TabLayoutStore['updateLayout']>(
+    (tabId, updater) => {
+      if (!tabId) return;
+      setLayouts((prev) => {
+        const current = { ...DEFAULT_LAYOUT_STATE, ...(prev[tabId] ?? {}) };
+        const result =
+          typeof updater === 'function' ? updater(current) : updater;
+        const nextState = mergeLayout(current, result);
+        return { ...prev, [tabId]: nextState };
+      });
+    },
+    [setLayouts],
+  );
+
+  const removeLayout = useCallback(
+    (tabId: string) => {
+      if (!tabId) return;
+      setLayouts((prev) => {
+        if (!(tabId in prev)) return prev;
+        const next = { ...prev };
+        delete next[tabId];
+        return next;
+      });
+    },
+    [setLayouts],
+  );
+
+  const clearStore = useCallback(() => clearAll(), [clearAll]);
+
+  return {
+    layouts,
+    getLayout,
+    updateLayout,
+    removeLayout,
+    clearAll: clearStore,
+  };
+}
+
+export { DEFAULT_LAYOUT_STATE };


### PR DESCRIPTION
## Summary
- add a SplitPane component with draggable separator and keyboard support
- persist per-tab split settings through a new tab layout store and expose split controls in TabbedWindow
- link pane scrolling with reduce-motion awareness and cover the workflow with focused unit tests

## Testing
- yarn lint
- yarn test __tests__/TabbedWindowSplit.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc622365e08328afe4c5b016667226