### PR TITLE
[ui] add welcome tour onboarding flow

### DIFF
--- a/__tests__/WelcomeTour.test.tsx
+++ b/__tests__/WelcomeTour.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import WelcomeTour from '../components/common/WelcomeTour';
+import { WelcomeTourProvider, useWelcomeTour } from '../hooks/useWelcomeTour';
+import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';
+
+jest.mock('../hooks/usePrefersReducedMotion', () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
+}));
+
+const mockedUsePrefersReducedMotion = usePrefersReducedMotion as jest.MockedFunction<
+  typeof usePrefersReducedMotion
+>;
+
+const renderWithProvider = (children: React.ReactNode) =>
+  render(<WelcomeTourProvider>{children}</WelcomeTourProvider>);
+
+describe('WelcomeTour', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockedUsePrefersReducedMotion.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    mockedUsePrefersReducedMotion.mockReset();
+  });
+
+  it('persists progress between mounts', () => {
+    const { unmount } = renderWithProvider(<WelcomeTour />);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/Step 1 of/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    expect(screen.getByText(/Step 2 of/i)).toBeInTheDocument();
+
+    unmount();
+
+    renderWithProvider(<WelcomeTour />);
+    expect(screen.getByText(/Step 2 of/i)).toBeInTheDocument();
+  });
+
+  it('can restart the tour after skipping', () => {
+    let controls: ReturnType<typeof useWelcomeTour> | null = null;
+
+    const Controller = () => {
+      controls = useWelcomeTour();
+      return null;
+    };
+
+    renderWithProvider(
+      <>
+        <WelcomeTour />
+        <Controller />
+      </>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Skip welcome tour/i }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Resume welcome tour/i })).toBeInTheDocument();
+
+    act(() => {
+      controls?.restartTour();
+    });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/Step 1 of/i)).toBeInTheDocument();
+  });
+
+  it('respects reduced motion preference', () => {
+    mockedUsePrefersReducedMotion.mockReturnValue(true);
+
+    renderWithProvider(<WelcomeTour />);
+
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-reduced-motion', 'true');
+  });
+});

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { getUnlockedThemes } from '../utils/theme';
 import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
+import { useWelcomeTour } from '../hooks/useWelcomeTour';
 
 interface Props {
   highScore?: number;
@@ -10,6 +11,15 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
   const { accent, setAccent, theme, setTheme } = useSettings();
+  const { state: tourState, restartTour, resumeTour } = useWelcomeTour();
+  const isTourActive = tourState.status === 'active';
+  const canResume = tourState.status === 'skipped';
+  const tourStatusDescription = {
+    'not-started': 'The welcome tour will launch the next time the desktop loads.',
+    active: 'The welcome tour is currently running.',
+    skipped: 'The welcome tour is paused. Resume to continue where you left off.',
+    completed: 'You completed the welcome tour. Restart anytime for a refresher.',
+  }[tourState.status];
 
   return (
     <div>
@@ -52,6 +62,34 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
               ))}
             </div>
           </label>
+          <section aria-label="Welcome tour" className="mt-4 space-y-2">
+            <h3 className="text-sm font-semibold">Welcome tour</h3>
+            <p className="text-xs text-gray-400" aria-live="polite">
+              {tourStatusDescription}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={restartTour}
+                className="rounded bg-slate-800 px-3 py-1 text-xs font-semibold text-white shadow focus:outline-none focus-visible:ring focus-visible:ring-slate-300"
+              >
+                Restart welcome tour
+              </button>
+              <button
+                type="button"
+                onClick={resumeTour}
+                disabled={!canResume}
+                className="rounded border border-slate-700 px-3 py-1 text-xs font-semibold text-slate-200 transition disabled:cursor-not-allowed disabled:opacity-50 hover:border-slate-500 hover:text-white focus:outline-none focus-visible:ring focus-visible:ring-slate-300"
+              >
+                Resume where I left off
+              </button>
+            </div>
+            {isTourActive && (
+              <p className="text-xs text-blue-300" role="status">
+                The tour overlay is currently visible.
+              </p>
+            )}
+          </section>
         </div>
       )}
     </div>

--- a/components/common/WelcomeTour.tsx
+++ b/components/common/WelcomeTour.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import usePrefersReducedMotion from '../../hooks/usePrefersReducedMotion';
+import { useWelcomeTour } from '../../hooks/useWelcomeTour';
+
+const STEPS = [
+  {
+    title: 'Welcome to the Kali Portfolio desktop',
+    description:
+      'This workspace mirrors the Kali Linux UI. Explore simulated security tools, retro games, and utilities without leaving your browser.',
+  },
+  {
+    title: 'Open apps from the launcher grid',
+    description:
+      'Activate the dock launcher or press Alt+Space to browse applications. Use arrow keys and Enter to open windows instantly.',
+  },
+  {
+    title: 'Arrange and manage windows',
+    description:
+      'Drag windows, snap them to edges, or use built-in layouts. Window controls let you minimize, maximize, or close each experience.',
+  },
+  {
+    title: 'Stay on top of notifications',
+    description:
+      'The top bar shows status indicators and the notification center. Keep an eye on background jobs and simulated alerts there.',
+  },
+  {
+    title: 'Personalize your environment',
+    description:
+      'Open Settings to change wallpapers, switch themes, or tweak accessibility options like reduced motion and large hit areas.',
+  },
+  {
+    title: 'Need quick assistance?',
+    description:
+      'Press ? to open the keyboard shortcut guide, or revisit this tour anytime from Settings if you need a refresher.',
+  },
+];
+
+const totalSteps = STEPS.length;
+
+const isFocusableTarget = (element: EventTarget | null) => {
+  if (!(element instanceof HTMLElement)) return false;
+  return (
+    element.tagName === 'INPUT' ||
+    element.tagName === 'TEXTAREA' ||
+    element.isContentEditable ||
+    element.closest('[contenteditable="true"]') !== null
+  );
+};
+
+const WelcomeTour = () => {
+  const { state, startTour, resumeTour, restartTour, skipTour, completeTour, setStep } = useWelcomeTour();
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const headingRef = useRef<HTMLHeadingElement | null>(null);
+  const resumeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const previousStatusRef = useRef(state.status);
+
+  const activeStepIndex = useMemo(() => {
+    if (totalSteps === 0) return 0;
+    return Math.min(state.currentStep ?? 0, totalSteps - 1);
+  }, [state.currentStep]);
+
+  useEffect(() => {
+    if (state.status === 'not-started') {
+      startTour();
+    }
+  }, [state.status, startTour]);
+
+  useEffect(() => {
+    if (state.status === 'active' && state.currentStep >= totalSteps) {
+      completeTour();
+    }
+  }, [state.status, state.currentStep, completeTour]);
+
+  useEffect(() => {
+    if (state.status === 'active' && headingRef.current) {
+      headingRef.current.focus();
+    }
+  }, [state.status, activeStepIndex]);
+
+  useEffect(() => {
+    if (state.status === 'active' && previousStatusRef.current !== 'active') {
+      previousFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    }
+
+    if (state.status !== 'active' && previousStatusRef.current === 'active') {
+      if (state.status === 'skipped' && resumeButtonRef.current) {
+        resumeButtonRef.current.focus();
+      } else if (previousFocusRef.current) {
+        previousFocusRef.current.focus();
+      }
+      previousFocusRef.current = null;
+    }
+
+    previousStatusRef.current = state.status;
+  }, [state.status]);
+
+  const handleNext = useCallback(() => {
+    if (activeStepIndex >= totalSteps - 1) {
+      completeTour();
+    } else {
+      setStep((prev) => prev + 1);
+    }
+  }, [activeStepIndex, completeTour, setStep]);
+
+  const handlePrevious = useCallback(() => {
+    if (activeStepIndex > 0) {
+      setStep(activeStepIndex - 1);
+    }
+  }, [activeStepIndex, setStep]);
+
+  const handleKeydown = useCallback(
+    (event: KeyboardEvent) => {
+      if (state.status !== 'active') return;
+      if (isFocusableTarget(event.target)) return;
+
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        handleNext();
+      } else if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        handlePrevious();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        skipTour();
+      }
+    },
+    [handleNext, handlePrevious, skipTour, state.status],
+  );
+
+  useEffect(() => {
+    if (state.status !== 'active') return;
+    window.addEventListener('keydown', handleKeydown);
+    return () => {
+      window.removeEventListener('keydown', handleKeydown);
+    };
+  }, [handleKeydown, state.status]);
+
+  const handleStepSelect = useCallback(
+    (index: number) => {
+      setStep(Math.max(0, Math.min(index, totalSteps - 1)));
+    },
+    [setStep],
+  );
+
+  if (state.status !== 'active' && state.status !== 'skipped') {
+    return null;
+  }
+
+  const currentStep = STEPS[activeStepIndex];
+  const headingId = `welcome-tour-step-${activeStepIndex}-title`;
+  const descriptionId = `welcome-tour-step-${activeStepIndex}-description`;
+  const progressLabel = `Step ${activeStepIndex + 1} of ${totalSteps}`;
+
+  return (
+    <>
+      {state.status === 'skipped' && (
+        <button
+          ref={resumeButtonRef}
+          type="button"
+          className="fixed bottom-4 right-4 z-40 rounded-full bg-slate-800 px-4 py-2 text-sm font-medium text-white shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-slate-300"
+          onClick={resumeTour}
+          aria-label="Resume welcome tour"
+        >
+          Resume welcome tour
+        </button>
+      )}
+      {state.status === 'active' && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-8">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={headingId}
+            aria-describedby={descriptionId}
+            className={`w-full max-w-xl rounded-lg bg-slate-900 p-6 text-white shadow-2xl focus:outline-none focus-visible:ring focus-visible:ring-slate-300 ${
+              prefersReducedMotion ? '' : 'transition-transform duration-200 ease-out'
+            }`}
+            data-reduced-motion={prefersReducedMotion ? 'true' : 'false'}
+            style={prefersReducedMotion ? undefined : { transform: 'translateY(0)' }}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-slate-400" aria-live="polite">
+                  {progressLabel}
+                </p>
+                <h2
+                  ref={headingRef}
+                  tabIndex={-1}
+                  id={headingId}
+                  className="mt-2 text-2xl font-semibold"
+                >
+                  {currentStep.title}
+                </h2>
+              </div>
+              <button
+                type="button"
+                onClick={skipTour}
+                className="text-sm font-medium text-slate-300 underline decoration-slate-500 decoration-dotted transition hover:text-white focus:outline-none focus-visible:ring focus-visible:ring-slate-300"
+                aria-label="Skip welcome tour"
+              >
+                Skip
+              </button>
+            </div>
+            <p id={descriptionId} className="mt-4 text-base leading-relaxed text-slate-200">
+              {currentStep.description}
+            </p>
+            <nav className="mt-6" aria-label="Tour progress">
+              <ol className="flex items-center gap-2" role="list">
+                {STEPS.map((step, index) => (
+                  <li key={step.title}>
+                    <button
+                      type="button"
+                      aria-label={`Go to step ${index + 1}: ${step.title}`}
+                      aria-current={index === activeStepIndex ? 'step' : undefined}
+                      className={`h-2.5 w-10 rounded-full ${
+                        index === activeStepIndex ? 'bg-sky-400' : 'bg-slate-600 hover:bg-slate-500'
+                      } focus:outline-none focus-visible:ring focus-visible:ring-slate-200`}
+                      onClick={() => handleStepSelect(index)}
+                    />
+                  </li>
+                ))}
+              </ol>
+            </nav>
+            <div className="mt-6 flex items-center justify-between gap-3">
+              <button
+                type="button"
+                onClick={handlePrevious}
+                disabled={activeStepIndex === 0}
+                className="rounded-md border border-slate-600 px-3 py-2 text-sm font-medium text-slate-200 transition disabled:cursor-not-allowed disabled:opacity-50 hover:border-slate-500 hover:text-white focus:outline-none focus-visible:ring focus-visible:ring-slate-300"
+              >
+                Back
+              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={restartTour}
+                  className="rounded-md border border-transparent px-3 py-2 text-xs font-semibold text-slate-300 underline decoration-dotted transition hover:text-white focus:outline-none focus-visible:ring focus-visible:ring-slate-300"
+                >
+                  Restart
+                </button>
+                <button
+                  type="button"
+                  onClick={handleNext}
+                  className="rounded-md bg-sky-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-400 focus:outline-none focus-visible:ring focus-visible:ring-slate-300"
+                >
+                  {activeStepIndex === totalSteps - 1 ? 'Finish' : 'Next'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default WelcomeTour;

--- a/hooks/useWelcomeTour.tsx
+++ b/hooks/useWelcomeTour.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, ReactNode } from 'react';
+import usePersistentState from './usePersistentState';
+
+export type WelcomeTourStatus = 'not-started' | 'active' | 'skipped' | 'completed';
+
+export interface WelcomeTourState {
+  status: WelcomeTourStatus;
+  currentStep: number;
+}
+
+interface WelcomeTourContextValue {
+  state: WelcomeTourState;
+  startTour: () => void;
+  resumeTour: () => void;
+  restartTour: () => void;
+  skipTour: () => void;
+  completeTour: () => void;
+  setStep: (step: number | ((prev: number) => number)) => void;
+  resetProgress: () => void;
+}
+
+const initialState: WelcomeTourState = {
+  status: 'not-started',
+  currentStep: 0,
+};
+
+const isWelcomeTourState = (value: unknown): value is WelcomeTourState => {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<WelcomeTourState>;
+  return (
+    typeof candidate.currentStep === 'number' &&
+    candidate.currentStep >= 0 &&
+    candidate.status !== undefined &&
+    ['not-started', 'active', 'skipped', 'completed'].includes(candidate.status)
+  );
+};
+
+const WelcomeTourContext = createContext<WelcomeTourContextValue | undefined>(undefined);
+
+export function WelcomeTourProvider({ children }: { children: ReactNode }) {
+  const [state, setState, resetState] = usePersistentState<WelcomeTourState>(
+    'welcome-tour-progress',
+    initialState,
+    isWelcomeTourState,
+  );
+
+  const startTour = useCallback(() => {
+    setState((prev) => {
+      if (prev.status === 'active') return prev;
+      return {
+        status: 'active',
+        currentStep: Math.max(0, prev.currentStep ?? 0),
+      };
+    });
+  }, [setState]);
+
+  const resumeTour = useCallback(() => {
+    setState((prev) => ({
+      status: 'active',
+      currentStep: Math.max(0, prev.currentStep ?? 0),
+    }));
+  }, [setState]);
+
+  const restartTour = useCallback(() => {
+    setState({
+      status: 'active',
+      currentStep: 0,
+    });
+  }, [setState]);
+
+  const skipTour = useCallback(() => {
+    setState((prev) => ({
+      status: 'skipped',
+      currentStep: Math.max(0, prev.currentStep ?? 0),
+    }));
+  }, [setState]);
+
+  const completeTour = useCallback(() => {
+    setState((prev) => ({
+      status: 'completed',
+      currentStep: Math.max(0, prev.currentStep ?? 0),
+    }));
+  }, [setState]);
+
+  const setStep = useCallback(
+    (step: number | ((prev: number) => number)) => {
+      setState((prev) => {
+        const nextStep = typeof step === 'function' ? (step as (prev: number) => number)(prev.currentStep) : step;
+        return {
+          ...prev,
+          currentStep: nextStep < 0 ? 0 : nextStep,
+        };
+      });
+    },
+    [setState],
+  );
+
+  const resetProgress = useCallback(() => {
+    resetState();
+  }, [resetState]);
+
+  const value = useMemo<WelcomeTourContextValue>(
+    () => ({
+      state,
+      startTour,
+      resumeTour,
+      restartTour,
+      skipTour,
+      completeTour,
+      setStep,
+      resetProgress,
+    }),
+    [state, startTour, resumeTour, restartTour, skipTour, completeTour, setStep, resetProgress],
+  );
+
+  return <WelcomeTourContext.Provider value={value}>{children}</WelcomeTourContext.Provider>;
+}
+
+export function useWelcomeTour() {
+  const context = useContext(WelcomeTourContext);
+  if (!context) {
+    throw new Error('useWelcomeTour must be used within a WelcomeTourProvider');
+  }
+  return context;
+}
+
+export function useWelcomeTourState() {
+  return useWelcomeTour().state;
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -12,11 +12,13 @@ import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import WelcomeTour from '../components/common/WelcomeTour';
 import NotificationCenter from '../components/common/NotificationCenter';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { WelcomeTourProvider } from '../hooks/useWelcomeTour';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -158,23 +160,26 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <NotificationCenter>
-            <PipPortalProvider>
-              <div aria-live="polite" id="live-region" />
-              <Component {...pageProps} />
-              <ShortcutOverlay />
-              <Analytics
-                beforeSend={(e) => {
-                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                  const evt = e;
-                  if (evt.metadata?.email) delete evt.metadata.email;
-                  return e;
-                }}
-              />
+          <WelcomeTourProvider>
+            <NotificationCenter>
+              <PipPortalProvider>
+                <div aria-live="polite" id="live-region" />
+                <Component {...pageProps} />
+                <WelcomeTour />
+                <ShortcutOverlay />
+                <Analytics
+                  beforeSend={(e) => {
+                    if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                    const evt = e;
+                    if (evt.metadata?.email) delete evt.metadata.email;
+                    return e;
+                  }}
+                />
 
-              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-            </PipPortalProvider>
-          </NotificationCenter>
+                {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+              </PipPortalProvider>
+            </NotificationCenter>
+          </WelcomeTourProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- add a persistent welcome tour overlay with keyboard navigation, skip/resume controls, and reduced-motion support
- create a reusable welcome tour state provider and wire it into the app shell and settings drawer
- cover tour persistence, restart, and motion preference handling with focused unit tests

## Testing
- yarn test WelcomeTour
- yarn lint *(fails: File ignored because no matching configuration was supplied for pages/_app.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6229983083288080ebdc5f0e3b31