### PR TITLE
[quick-actions] expose keyboard metadata on toolbar buttons

### DIFF
--- a/__tests__/quickActions.test.tsx
+++ b/__tests__/quickActions.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import QuickActions from '../components/layout/QuickActions';
+import QuickActionsPanel from '../apps/settings/components/QuickActionsPanel';
+import { SettingsProvider } from '../hooks/useSettings';
+
+const renderWithSettings = (ui: React.ReactElement) =>
+  render(<SettingsProvider>{ui}</SettingsProvider>);
+
+describe('QuickActions toolbar', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('drag reorder persists order across remounts', async () => {
+    const { unmount } = renderWithSettings(
+      <>
+        <QuickActions />
+        <QuickActionsPanel />
+      </>
+    );
+
+    const moveUpButton = screen.getByRole('button', {
+      name: 'Move Record screen up',
+    });
+
+    fireEvent.click(moveUpButton);
+
+    await waitFor(() => {
+      const order = screen
+        .getAllByTestId(/quick-action-/)
+        .map((btn) => btn.getAttribute('data-testid')?.replace('quick-action-', ''));
+      expect(order.slice(0, 2)).toEqual(['record-screen', 'new-tab']);
+      expect(window.localStorage.getItem('quick-actions')).toContain('record-screen');
+    });
+
+    unmount();
+
+    const stored = JSON.parse(window.localStorage.getItem('quick-actions') ?? '[]');
+    expect(stored.map((item: any) => item.id).slice(0, 2)).toEqual([
+      'record-screen',
+      'new-tab',
+    ]);
+  });
+
+  test('visibility toggles persist through settings panel', async () => {
+    const { unmount } = renderWithSettings(
+      <>
+        <QuickActions />
+        <QuickActionsPanel />
+      </>
+    );
+
+    const checkbox = screen.getByLabelText('Show Record screen');
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Show Record screen')).not.toBeChecked();
+      expect(screen.queryByTestId('quick-action-record-screen')).toBeNull();
+    });
+
+    unmount();
+
+    const stored = JSON.parse(window.localStorage.getItem('quick-actions') ?? '[]');
+    const target = stored.find((item: any) => item.id === 'record-screen');
+    expect(target?.visible).toBe(false);
+  });
+
+  test('record screen button dispatches open-app event', () => {
+    renderWithSettings(<QuickActions />);
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+    dispatchSpy.mockImplementation(() => true);
+
+    const recordButton = screen.getByTestId('quick-action-record-screen');
+    fireEvent.click(recordButton);
+
+    expect(dispatchSpy).toHaveBeenCalled();
+    const event = dispatchSpy.mock.calls.find(([evt]) => evt.type === 'open-app')?.[0];
+    expect(event).toBeInstanceOf(CustomEvent);
+    expect((event as CustomEvent).detail).toBe('screen-recorder');
+
+    dispatchSpy.mockRestore();
+  });
+
+  test('buttons expose aria-keyshortcuts when shortcuts are available', () => {
+    renderWithSettings(<QuickActions />);
+
+    expect(screen.getByTestId('quick-action-record-screen')).toHaveAttribute(
+      'aria-keyshortcuts',
+      'Control+Alt+R',
+    );
+    expect(screen.getByTestId('quick-action-lock-screen')).toHaveAttribute(
+      'aria-keyshortcuts',
+      'Meta+L',
+    );
+  });
+});

--- a/apps/settings/components/QuickActionsPanel.tsx
+++ b/apps/settings/components/QuickActionsPanel.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import React, { useCallback, useMemo, useState } from "react";
+import clsx from "clsx";
+import { useSettings } from "../../../hooks/useSettings";
+import type { QuickActionId } from "../../../types/quickActions";
+import {
+  QUICK_ACTION_DEFINITIONS,
+  isQuickActionId,
+} from "../../../components/layout/QuickActions";
+
+const dragImage = typeof Image !== "undefined" ? new Image() : null;
+
+dragImage?.setAttribute("src", "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==");
+
+type DefinitionMap = Map<QuickActionId, (typeof QUICK_ACTION_DEFINITIONS)[number]>;
+
+const QuickActionsPanel: React.FC = () => {
+  const { quickActions, setQuickActions } = useSettings();
+  const [dragging, setDragging] = useState<QuickActionId | null>(null);
+  const [dropTarget, setDropTarget] = useState<QuickActionId | null>(null);
+
+  const definitionMap = useMemo<DefinitionMap>(() => {
+    const map: DefinitionMap = new Map();
+    QUICK_ACTION_DEFINITIONS.forEach((definition) => {
+      map.set(definition.id, definition);
+    });
+    return map;
+  }, []);
+
+  const reorder = useCallback(
+    (dragId: QuickActionId, targetId: QuickActionId | null) => {
+      if (dragId === targetId) return;
+      const current = quickActions;
+      const sourceIndex = current.findIndex((item) => item.id === dragId);
+      if (sourceIndex === -1) return;
+      const next = current.slice();
+      const [entry] = next.splice(sourceIndex, 1);
+      if (targetId === null) {
+        next.push(entry);
+      } else {
+        const targetIndex = next.findIndex((item) => item.id === targetId);
+        if (targetIndex === -1) {
+          next.push(entry);
+        } else {
+          next.splice(targetIndex, 0, entry);
+        }
+      }
+      setQuickActions(next);
+    },
+    [quickActions, setQuickActions]
+  );
+
+  const moveItem = useCallback(
+    (fromIndex: number, toIndex: number) => {
+      if (fromIndex === toIndex) return;
+      if (toIndex < 0 || toIndex >= quickActions.length) return;
+      const next = quickActions.slice();
+      const [entry] = next.splice(fromIndex, 1);
+      next.splice(toIndex, 0, entry);
+      setQuickActions(next);
+    },
+    [quickActions, setQuickActions]
+  );
+
+  const handleDropOnContainer = useCallback(
+    (event: React.DragEvent<HTMLUListElement>) => {
+      event.preventDefault();
+      const raw = event.dataTransfer?.getData("text/plain");
+      if (!raw || !isQuickActionId(raw)) return;
+      reorder(raw, null);
+      setDragging(null);
+      setDropTarget(null);
+    },
+    [reorder]
+  );
+
+  const handleDropOnItem = useCallback(
+    (event: React.DragEvent<HTMLLIElement>, targetId: QuickActionId) => {
+      event.preventDefault();
+      const raw = event.dataTransfer?.getData("text/plain") || dragging;
+      if (!raw || !isQuickActionId(raw)) return;
+      reorder(raw, targetId);
+      setDragging(null);
+      setDropTarget(null);
+    },
+    [dragging, reorder]
+  );
+
+  const handleToggle = useCallback(
+    (id: QuickActionId) => {
+      const next = quickActions.map((item) =>
+        item.id === id ? { ...item, visible: !item.visible } : item
+      );
+      setQuickActions(next);
+    },
+    [quickActions, setQuickActions]
+  );
+
+  return (
+    <section className="flex flex-col gap-4 px-6 py-6 text-white">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold">Quick actions</h2>
+        <p className="text-sm text-white/70">
+          Drag to reorder the toolbar buttons and toggle their visibility. Changes
+          are saved immediately.
+        </p>
+      </header>
+      <ul
+        role="list"
+        className="flex flex-col gap-3"
+        onDragOver={(event) => event.preventDefault()}
+        onDrop={handleDropOnContainer}
+      >
+        {quickActions.map((item, index) => {
+          const definition = definitionMap.get(item.id);
+          if (!definition) return null;
+          const isDropping = dropTarget === item.id;
+          const inputId = `quick-action-toggle-${item.id}`;
+          const isFirst = index === 0;
+          const isLast = index === quickActions.length - 1;
+          return (
+            <li
+              key={item.id}
+              className={clsx(
+                "flex items-center justify-between rounded-lg border border-white/10 bg-white/5 px-4 py-3 transition",
+                isDropping && "border-cyan-400/80 bg-cyan-500/10",
+                dragging === item.id && "opacity-70"
+              )}
+              draggable
+              onDragStart={(event) => {
+                event.dataTransfer?.setData("text/plain", item.id);
+                if (dragImage) {
+                  event.dataTransfer?.setDragImage(dragImage, 0, 0);
+                }
+                setDragging(item.id);
+              }}
+              onDragEnter={(event) => {
+                event.preventDefault();
+                setDropTarget(item.id);
+              }}
+              onDragLeave={() => {
+                setDropTarget((current) => (current === item.id ? null : current));
+              }}
+              onDragOver={(event) => event.preventDefault()}
+              onDrop={(event) => handleDropOnItem(event, item.id)}
+              onDragEnd={() => {
+                setDragging(null);
+                setDropTarget(null);
+              }}
+              data-testid={`quick-action-settings-${item.id}`}
+            >
+              <div className="flex items-start gap-3">
+                <div className="flex flex-col items-center gap-1 text-white/60">
+                  <button
+                    type="button"
+                    aria-label={`Move ${definition.label} up`}
+                    disabled={isFirst}
+                    onClick={() => moveItem(index, index - 1)}
+                    className="flex h-6 w-6 items-center justify-center rounded border border-white/10 bg-white/5 text-xs disabled:opacity-40"
+                  >
+                    ▲
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Move ${definition.label} down`}
+                    disabled={isLast}
+                    onClick={() => moveItem(index, index + 1)}
+                    className="flex h-6 w-6 items-center justify-center rounded border border-white/10 bg-white/5 text-xs disabled:opacity-40"
+                  >
+                    ▼
+                  </button>
+                </div>
+                <span
+                  className="select-none text-base text-white/40"
+                  aria-hidden="true"
+                >
+                  ≡
+                </span>
+                <div>
+                  <p className="font-medium text-white">{definition.label}</p>
+                  <p className="text-xs text-white/70">{definition.description}</p>
+                  {definition.shortcut && (
+                    <p className="mt-1 text-[11px] uppercase tracking-wide text-white/50">
+                      {definition.shortcut}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <label
+                htmlFor={inputId}
+                className="flex items-center gap-2 text-sm text-white/80"
+              >
+                <input
+                  id={inputId}
+                  type="checkbox"
+                  checked={item.visible}
+                  onChange={() => handleToggle(item.id)}
+                  aria-label={`Show ${definition.label}`}
+                />
+                <span>Show {definition.label}</span>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};
+
+export default QuickActionsPanel;

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
+import QuickActionsPanel from "./components/QuickActionsPanel";
 import {
   resetSettings,
   defaults,
@@ -41,6 +42,7 @@ export default function Settings() {
     { id: "appearance", label: "Appearance" },
     { id: "accessibility", label: "Accessibility" },
     { id: "privacy", label: "Privacy" },
+    { id: "quick-actions", label: "Quick Actions" },
   ] as const;
   type TabId = (typeof tabs)[number]["id"];
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
@@ -157,12 +159,14 @@ export default function Settings() {
             </div>
           </div>
           <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey flex items-center">
+            <label htmlFor="toggle-kali-wallpaper" className="mr-2 text-ubt-grey flex items-center">
               <input
+                id="toggle-kali-wallpaper"
                 type="checkbox"
                 checked={useKaliWallpaper}
                 onChange={(e) => setUseKaliWallpaper(e.target.checked)}
                 className="mr-2"
+                aria-label="Kali Gradient Wallpaper"
               />
               Kali Gradient Wallpaper
             </label>
@@ -231,6 +235,7 @@ export default function Settings() {
           </div>
         </>
       )}
+      {activeTab === "quick-actions" && <QuickActionsPanel />}
       {activeTab === "accessibility" && (
         <>
           <div className="flex justify-center my-4">

--- a/components/layout/QuickActions.tsx
+++ b/components/layout/QuickActions.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import React, {
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+import clsx from "clsx";
+import DelayedTooltip from "../ui/DelayedTooltip";
+import { useSettings } from "../../hooks/useSettings";
+import type { QuickActionId } from "../../types/quickActions";
+
+const PlusIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    className={clsx("h-4 w-4", className)}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
+const RecordIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    className={clsx("h-4 w-4", className)}
+    fill="currentColor"
+  >
+    <circle cx="12" cy="12" r="6" />
+  </svg>
+);
+
+const GearIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    className={clsx("h-4 w-4", className)}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.06a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.06a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.06a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+  </svg>
+);
+
+const LockIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    className={clsx("h-4 w-4", className)}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="5" y="11" width="14" height="10" rx="2" />
+    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+  </svg>
+);
+
+export type QuickActionDefinition = {
+  id: QuickActionId;
+  label: string;
+  description: string;
+  shortcut?: string;
+  icon: React.FC<{ className?: string }>;
+  perform: (handlers: Partial<Record<QuickActionId, () => void>>) => void;
+};
+
+export const QUICK_ACTION_DEFINITIONS: QuickActionDefinition[] = [
+  {
+    id: "new-tab",
+    label: "New Tab",
+    description: "Open a fresh terminal session in a new tab.",
+    shortcut: "Ctrl+Alt+T",
+    icon: PlusIcon,
+    perform: (handlers) => {
+      if (handlers["new-tab"]) {
+        handlers["new-tab"]?.();
+        return;
+      }
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("open-app", { detail: "terminal" }));
+      }
+    },
+  },
+  {
+    id: "record-screen",
+    label: "Record screen",
+    description: "Launch the screen recorder demo window.",
+    shortcut: "Ctrl+Alt+R",
+    icon: RecordIcon,
+    perform: (handlers) => {
+      if (handlers["record-screen"]) {
+        handlers["record-screen"]?.();
+        return;
+      }
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(
+          new CustomEvent("open-app", { detail: "screen-recorder" })
+        );
+      }
+    },
+  },
+  {
+    id: "open-settings",
+    label: "Open settings",
+    description: "Jump directly to the desktop settings app.",
+    shortcut: "Ctrl+,",
+    icon: GearIcon,
+    perform: (handlers) => {
+      if (handlers["open-settings"]) {
+        handlers["open-settings"]?.();
+        return;
+      }
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("open-app", { detail: "settings" }));
+      }
+    },
+  },
+  {
+    id: "lock-screen",
+    label: "Lock screen",
+    description: "Secure the desktop until you log back in.",
+    shortcut: "Super+L",
+    icon: LockIcon,
+    perform: (handlers) => {
+      if (handlers["lock-screen"]) {
+        handlers["lock-screen"]?.();
+      }
+    },
+  },
+];
+
+const QUICK_ACTION_MAP: Record<QuickActionId, QuickActionDefinition> = QUICK_ACTION_DEFINITIONS.reduce(
+  (acc, definition) => ({ ...acc, [definition.id]: definition }),
+  {} as Record<QuickActionId, QuickActionDefinition>
+);
+
+const QUICK_ACTION_IDS = new Set<QuickActionId>(
+  QUICK_ACTION_DEFINITIONS.map((action) => action.id)
+);
+
+export const isQuickActionId = (value: string): value is QuickActionId =>
+  QUICK_ACTION_IDS.has(value as QuickActionId);
+
+export interface QuickActionsProps {
+  className?: string;
+  handlers?: Partial<Record<QuickActionId, () => void>>;
+}
+
+const QuickActions: React.FC<QuickActionsProps> = ({
+  className,
+  handlers = {},
+}) => {
+  const { quickActions, setQuickActions } = useSettings();
+  const [draggedId, setDraggedId] = useState<QuickActionId | null>(null);
+  const [activeDropId, setActiveDropId] = useState<QuickActionId | null>(null);
+
+  const orderedActions = useMemo(
+    () =>
+      quickActions
+        .filter((item) => item.visible)
+        .map((item) => QUICK_ACTION_MAP[item.id])
+        .filter(Boolean),
+    [quickActions]
+  );
+
+  const reorder = useCallback(
+    (dragId: QuickActionId, targetId: QuickActionId | null) => {
+      if (dragId === targetId) return;
+      const current = quickActions;
+      const sourceIndex = current.findIndex((item) => item.id === dragId);
+      if (sourceIndex === -1) return;
+      const next = current.slice();
+      const [entry] = next.splice(sourceIndex, 1);
+      if (targetId === null) {
+        next.push(entry);
+      } else {
+        const targetIndex = next.findIndex((item) => item.id === targetId);
+        if (targetIndex === -1) {
+          next.push(entry);
+        } else {
+          next.splice(targetIndex, 0, entry);
+        }
+      }
+      setQuickActions(next);
+    },
+    [quickActions, setQuickActions]
+  );
+
+  const handleDropOnContainer = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const raw = event.dataTransfer?.getData("text/plain");
+      if (!raw) return;
+      if (!isQuickActionId(raw)) return;
+      reorder(raw, null);
+      setDraggedId(null);
+      setActiveDropId(null);
+    },
+    [reorder]
+  );
+
+  const handleDropOnItem = useCallback(
+    (event: React.DragEvent<HTMLButtonElement>, targetId: QuickActionId) => {
+      event.preventDefault();
+      const raw = event.dataTransfer?.getData("text/plain") || draggedId;
+      if (!raw) return;
+      if (!isQuickActionId(raw)) return;
+      reorder(raw, targetId);
+      setDraggedId(null);
+      setActiveDropId(null);
+    },
+    [draggedId, reorder]
+  );
+
+  const performAction = useCallback(
+    (id: QuickActionId) => {
+      const action = QUICK_ACTION_MAP[id];
+      if (!action) return;
+      action.perform(handlers);
+    },
+    [handlers]
+  );
+
+  if (orderedActions.length === 0) {
+    return (
+      <div
+        className={clsx(
+          "hidden text-xs text-white/60 md:flex md:items-center",
+          className
+        )}
+        role="note"
+      >
+        Add quick actions from Settings → Quick Actions.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={clsx(
+        "hidden items-center gap-2 text-xs text-white/80 md:flex",
+        className
+      )}
+      role="toolbar"
+      aria-label="Quick actions"
+      onDragOver={(event) => event.preventDefault()}
+      onDrop={handleDropOnContainer}
+    >
+      {orderedActions.map((action) => {
+        const Icon = action.icon;
+        const isActiveDrop = activeDropId === action.id;
+        const ariaKeyShortcuts = action.shortcut
+          ?.split(",")
+          .map((combo) =>
+            combo
+              .trim()
+              .replace(/Ctrl/gi, "Control")
+              .replace(/Super/gi, "Meta")
+              .replace(/\s*\+\s*/g, "+")
+          )
+          .join(" ");
+        return (
+          <DelayedTooltip
+            key={action.id}
+            content={
+              <div>
+                <p className="font-medium text-white">{action.label}</p>
+                <p className="mt-1 text-white/80">{action.description}</p>
+                {action.shortcut && (
+                  <p className="mt-1 text-[10px] uppercase tracking-wide text-white/60">
+                    {action.shortcut}
+                  </p>
+                )}
+              </div>
+            }
+          >
+            {({ ref, onBlur, onFocus, onMouseEnter, onMouseLeave }) => (
+              <button
+                ref={ref as (node: HTMLButtonElement | null) => void}
+                type="button"
+                className={clsx(
+                  "flex items-center gap-2 rounded-full border px-3 py-1.5 transition",
+                  "border-white/10 bg-white/10 hover:border-ubt-grey/80 hover:bg-white/20",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300",
+                  draggedId === action.id && "opacity-70",
+                  isActiveDrop && "border-cyan-400/80 bg-cyan-500/20"
+                )}
+                aria-label={
+                  action.shortcut
+                    ? `${action.label} (${action.shortcut})`
+                    : action.label
+                }
+                aria-keyshortcuts={ariaKeyShortcuts}
+                draggable
+                onClick={() => performAction(action.id)}
+                onDragStart={(event) => {
+                  event.dataTransfer?.setData("text/plain", action.id);
+                  event.dataTransfer?.setDragImage(new Image(), 0, 0);
+                  setDraggedId(action.id);
+                }}
+                onDragEnter={(event) => {
+                  event.preventDefault();
+                  setActiveDropId(action.id);
+                }}
+                onDragLeave={() => {
+                  setActiveDropId((current) =>
+                    current === action.id ? null : current
+                  );
+                }}
+                onDragOver={(event) => event.preventDefault()}
+                onDrop={(event) => handleDropOnItem(event, action.id)}
+                onDragEnd={() => {
+                  setDraggedId(null);
+                  setActiveDropId(null);
+                }}
+                onMouseEnter={onMouseEnter}
+                onMouseLeave={onMouseLeave}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                data-testid={`quick-action-${action.id}`}
+              >
+                <Icon className="h-4 w-4" />
+                <span className="font-medium text-white/90">{action.label}</span>
+              </button>
+            )}
+          </DelayedTooltip>
+        );
+      })}
+    </div>
+  );
+};
+
+export default QuickActions;

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -5,6 +5,7 @@ import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
 import PerformanceGraph from '../ui/PerformanceGraph';
 import WorkspaceSwitcher from '../panel/WorkspaceSwitcher';
+import QuickActions from '../layout/QuickActions';
 import { NAVBAR_HEIGHT } from '../../utils/uiConstants';
 
 const areWorkspacesEqual = (next, prev) => {
@@ -88,7 +89,7 @@ export default class Navbar extends PureComponent {
                                                 paddingRight: `calc(0.75rem + var(--safe-area-right, 0px))`,
                                         }}
                                 >
-                                        <div className="flex items-center gap-2 text-xs md:text-sm">
+                                        <div className="flex flex-1 items-center gap-2 text-xs md:text-sm">
                                                 <WhiskerMenu />
                                                 {workspaces.length > 0 && (
                                                         <WorkspaceSwitcher
@@ -99,12 +100,16 @@ export default class Navbar extends PureComponent {
                                                 )}
                                                 <PerformanceGraph />
                                         </div>
-                                        <div
-                                                className={
-                                                        'rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/90 shadow-sm backdrop-blur transition duration-150 ease-in-out hover:border-white/30 hover:bg-white/10'
-                                                }
-                                        >
-                                                <Clock onlyTime={true} showCalendar={true} hour12={false} />
+                                        <div className="hidden items-center gap-4 md:flex">
+                                                <QuickActions
+                                                        handlers={{ 'lock-screen': this.props.lockScreen }}
+                                                        className="text-sm"
+                                                />
+                                                <div
+                                                        className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/90 shadow-sm backdrop-blur transition duration-150 ease-in-out hover:border-white/30 hover:bg-white/10"
+                                                >
+                                                        <Clock onlyTime={true} showCalendar={true} hour12={false} />
+                                                </div>
                                         </div>
                                         <button
                                                 type="button"

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -22,9 +22,12 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getQuickActions as loadQuickActions,
+  setQuickActions as saveQuickActions,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import type { QuickActionConfig } from '../types/quickActions';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -67,6 +70,7 @@ interface SettingsContextValue {
   allowNetwork: boolean;
   haptics: boolean;
   theme: string;
+  quickActions: QuickActionConfig[];
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
   setUseKaliWallpaper: (value: boolean) => void;
@@ -79,6 +83,7 @@ interface SettingsContextValue {
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
   setTheme: (value: string) => void;
+  setQuickActions: (actions: QuickActionConfig[]) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextValue>({
@@ -95,6 +100,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
   theme: 'default',
+  quickActions: defaults.quickActions,
   setAccent: () => {},
   setWallpaper: () => {},
   setUseKaliWallpaper: () => {},
@@ -107,6 +113,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setAllowNetwork: () => {},
   setHaptics: () => {},
   setTheme: () => {},
+  setQuickActions: () => {},
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
@@ -122,6 +129,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
   const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [quickActions, setQuickActionsState] = useState<QuickActionConfig[]>(
+    defaults.quickActions,
+  );
   const fetchRef = useRef<typeof fetch | null>(null);
 
   useEffect(() => {
@@ -138,6 +148,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
       setTheme(loadTheme());
+      setQuickActionsState(await loadQuickActions());
     })();
   }, []);
 
@@ -250,6 +261,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveQuickActions(quickActions);
+  }, [quickActions]);
+
   const bgImageName = useKaliWallpaper ? 'kali-gradient' : wallpaper;
 
   return (
@@ -268,6 +283,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         allowNetwork,
         haptics,
         theme,
+        quickActions,
         setAccent,
         setWallpaper,
         setUseKaliWallpaper,
@@ -280,6 +296,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAllowNetwork,
         setHaptics,
         setTheme,
+        setQuickActions: setQuickActionsState,
       }}
     >
       {children}

--- a/types/quickActions.ts
+++ b/types/quickActions.ts
@@ -1,0 +1,10 @@
+export type QuickActionId =
+  | 'new-tab'
+  | 'record-screen'
+  | 'open-settings'
+  | 'lock-screen';
+
+export interface QuickActionConfig {
+  id: QuickActionId;
+  visible: boolean;
+}

--- a/utils/quickActionsConfig.js
+++ b/utils/quickActionsConfig.js
@@ -1,0 +1,20 @@
+export const QUICK_ACTION_IDS = Object.freeze([
+  'new-tab',
+  'record-screen',
+  'open-settings',
+  'lock-screen',
+]);
+
+export const DEFAULT_QUICK_ACTION_STATE = Object.freeze(
+  QUICK_ACTION_IDS.map((id) => ({ id, visible: true }))
+);
+
+export const QUICK_ACTION_LABELS = Object.freeze({
+  'new-tab': 'New Tab',
+  'record-screen': 'Record screen',
+  'open-settings': 'Open settings',
+  'lock-screen': 'Lock screen',
+});
+
+export const isValidQuickActionId = (value) =>
+  typeof value === 'string' && QUICK_ACTION_IDS.includes(value);

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -2,6 +2,16 @@
 
 import { get, set, del } from 'idb-keyval';
 import { getTheme, setTheme } from './theme';
+import {
+  DEFAULT_QUICK_ACTION_STATE,
+  QUICK_ACTION_IDS,
+  isValidQuickActionId,
+} from './quickActionsConfig';
+
+const hasDOM = () =>
+  typeof window !== 'undefined' &&
+  typeof window.document !== 'undefined' &&
+  window.document !== null;
 
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
@@ -15,51 +25,77 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  quickActions: DEFAULT_QUICK_ACTION_STATE.map((action) => ({ ...action })),
+};
+
+const QUICK_ACTIONS_STORAGE_KEY = 'quick-actions';
+
+const normaliseQuickActions = (value) => {
+  const defaults = DEFAULT_SETTINGS.quickActions;
+  if (!Array.isArray(value)) {
+    return defaults.map((item) => ({ ...item }));
+  }
+  const seen = new Set();
+  const sanitised = [];
+  value.forEach((item) => {
+    if (!item || typeof item !== 'object') return;
+    const { id, visible } = item;
+    if (!isValidQuickActionId(id) || seen.has(id)) return;
+    sanitised.push({ id, visible: Boolean(visible) });
+    seen.add(id);
+  });
+  QUICK_ACTION_IDS.forEach((id) => {
+    if (seen.has(id)) return;
+    const fallback = defaults.find((item) => item.id === id) || { visible: true };
+    sanitised.push({ id, visible: Boolean(fallback.visible) });
+    seen.add(id);
+  });
+  return sanitised;
 };
 
 export async function getAccent() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
+  if (!hasDOM()) return DEFAULT_SETTINGS.accent;
   return (await get('accent')) || DEFAULT_SETTINGS.accent;
 }
 
 export async function setAccent(accent) {
-  if (typeof window === 'undefined') return;
+  if (!hasDOM()) return;
   await set('accent', accent);
 }
 
 export async function getWallpaper() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
+  if (!hasDOM()) return DEFAULT_SETTINGS.wallpaper;
   return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
 }
 
 export async function setWallpaper(wallpaper) {
-  if (typeof window === 'undefined') return;
+  if (!hasDOM()) return;
   await set('bg-image', wallpaper);
 }
 
 export async function getUseKaliWallpaper() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.useKaliWallpaper;
+  if (!hasDOM()) return DEFAULT_SETTINGS.useKaliWallpaper;
   const stored = window.localStorage.getItem('use-kali-wallpaper');
   return stored === null ? DEFAULT_SETTINGS.useKaliWallpaper : stored === 'true';
 }
 
 export async function setUseKaliWallpaper(value) {
-  if (typeof window === 'undefined') return;
+  if (!hasDOM()) return;
   window.localStorage.setItem('use-kali-wallpaper', value ? 'true' : 'false');
 }
 
 export async function getDensity() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
+  if (!hasDOM()) return DEFAULT_SETTINGS.density;
   return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
 }
 
 export async function setDensity(density) {
-  if (typeof window === 'undefined') return;
+  if (!hasDOM()) return;
   window.localStorage.setItem('density', density);
 }
 
 export async function getReducedMotion() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
+  if (!hasDOM()) return DEFAULT_SETTINGS.reducedMotion;
   const stored = window.localStorage.getItem('reduced-motion');
   if (stored !== null) {
     return stored === 'true';
@@ -68,75 +104,104 @@ export async function getReducedMotion() {
 }
 
 export async function setReducedMotion(value) {
-  if (typeof window === 'undefined') return;
+  if (!hasDOM()) return;
   window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
+  if (!hasDOM()) return DEFAULT_SETTINGS.fontScale;
   const stored = window.localStorage.getItem('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
-  if (typeof window === 'undefined') return;
+  if (!hasDOM()) return;
   window.localStorage.setItem('font-scale', String(scale));
 }
 
 export async function getHighContrast() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
+  if (!hasDOM()) return DEFAULT_SETTINGS.highContrast;
   return window.localStorage.getItem('high-contrast') === 'true';
 }
 
 export async function setHighContrast(value) {
-  if (typeof window === 'undefined') return;
+  if (!hasDOM()) return;
   window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
 }
 
 export async function getLargeHitAreas() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
+  if (!hasDOM()) return DEFAULT_SETTINGS.largeHitAreas;
   return window.localStorage.getItem('large-hit-areas') === 'true';
 }
 
 export async function setLargeHitAreas(value) {
-  if (typeof window === 'undefined') return;
+  if (!hasDOM()) return;
   window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
 export async function getHaptics() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
+  if (!hasDOM()) return DEFAULT_SETTINGS.haptics;
   const val = window.localStorage.getItem('haptics');
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
 export async function setHaptics(value) {
-  if (typeof window === 'undefined') return;
+  if (!hasDOM()) return;
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getQuickActions() {
+  if (!hasDOM()) {
+    return DEFAULT_SETTINGS.quickActions.map((item) => ({ ...item }));
+  }
+  try {
+    const stored = window.localStorage.getItem(QUICK_ACTIONS_STORAGE_KEY);
+    if (!stored) {
+      return DEFAULT_SETTINGS.quickActions.map((item) => ({ ...item }));
+    }
+    const parsed = JSON.parse(stored);
+    return normaliseQuickActions(parsed);
+  } catch {
+    return DEFAULT_SETTINGS.quickActions.map((item) => ({ ...item }));
+  }
+}
+
+export async function setQuickActions(value) {
+  if (!hasDOM()) return;
+  const sanitised = normaliseQuickActions(value);
+  try {
+    window.localStorage.setItem(
+      QUICK_ACTIONS_STORAGE_KEY,
+      JSON.stringify(sanitised),
+    );
+  } catch {
+    // ignore persistence errors
+  }
+}
+
 export async function getPongSpin() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
+  if (!hasDOM()) return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
 export async function setPongSpin(value) {
-  if (typeof window === 'undefined') return;
+  if (!hasDOM()) return;
   window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
 }
 
 export async function getAllowNetwork() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
+  if (!hasDOM()) return DEFAULT_SETTINGS.allowNetwork;
   return window.localStorage.getItem('allow-network') === 'true';
 }
 
 export async function setAllowNetwork(value) {
-  if (typeof window === 'undefined') return;
+  if (!hasDOM()) return;
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
 export async function resetSettings() {
-  if (typeof window === 'undefined') return;
+  if (!hasDOM()) return;
   await Promise.all([
     del('accent'),
     del('bg-image'),
@@ -150,6 +215,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
   window.localStorage.removeItem('use-kali-wallpaper');
+  window.localStorage.removeItem(QUICK_ACTIONS_STORAGE_KEY);
 }
 
 export async function exportSettings() {
@@ -165,6 +231,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    quickActions,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -177,6 +244,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getQuickActions(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -192,11 +260,12 @@ export async function exportSettings() {
     haptics,
     useKaliWallpaper,
     theme,
+    quickActions,
   });
 }
 
 export async function importSettings(json) {
-  if (typeof window === 'undefined') return;
+  if (!hasDOM()) return;
   let settings;
   try {
     settings = typeof json === 'string' ? JSON.parse(json) : json;
@@ -217,6 +286,7 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    quickActions,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -230,6 +300,7 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (quickActions !== undefined) await setQuickActions(quickActions);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add `aria-keyshortcuts` metadata to quick action buttons so screen readers announce shortcuts
- normalise shortcut combos to Control/Meta-friendly notation before assigning
- extend quick actions test coverage to verify accessibility attributes

## Testing
- yarn lint
- yarn test quickActions

------
https://chatgpt.com/codex/tasks/task_e_68dc6227a17c83288305fe4f829887e0