### PR TITLE
[ui] Add shared empty state component

### DIFF
--- a/__tests__/EmptyState.test.tsx
+++ b/__tests__/EmptyState.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EmptyState from '../components/common/EmptyState';
+
+describe('EmptyState', () => {
+  it('renders fallback copy for the provided variant', () => {
+    render(<EmptyState variant="no-data" />);
+
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+
+    const heading = screen.getByRole('heading', { level: 2, name: /no data available/i });
+    expect(heading).toBeInTheDocument();
+
+    const description = screen.getByText(/activity will appear here once it is recorded/i);
+    expect(description).toBeInTheDocument();
+    expect(status).toHaveAttribute('aria-labelledby', heading.getAttribute('id'));
+    expect(status).toHaveAttribute('aria-describedby', description.getAttribute('id'));
+  });
+
+  it('merges feature configuration for actions and documentation links', async () => {
+    const onClear = jest.fn();
+    render(
+      <EmptyState
+        featureId="launcher-search"
+        variant="filtered-out"
+        primaryAction={{ onClick: onClear }}
+      />,
+    );
+
+    const clearButton = screen.getByRole('button', {
+      name: /clear the current search query/i,
+    });
+    await userEvent.click(clearButton);
+    expect(onClear).toHaveBeenCalledTimes(1);
+
+    const docsLink = screen.getByRole('link', { name: /app catalog/i });
+    expect(docsLink).toHaveAttribute('href', 'https://unnippillil.com/apps');
+    expect(docsLink).toHaveAttribute('target', '_blank');
+  });
+
+  it('creates accessible labels for custom documentation link overrides', () => {
+    render(
+      <EmptyState
+        title="Custom state"
+        description="Demonstration description"
+        docsLink={{ href: '#docs', label: 'Read docs' }}
+      />,
+    );
+
+    const docs = screen.getByRole('link', { name: /open documentation for custom state/i });
+    expect(docs).toHaveAttribute('href', '#docs');
+  });
+});

--- a/components/apps/todoist.js
+++ b/components/apps/todoist.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import * as chrono from 'chrono-node';
 import { RRule } from 'rrule';
+import EmptyState from '../common/EmptyState';
 import { parseRecurring } from '../../apps/todoist/utils/recurringParser';
 
 const STORAGE_KEY = 'portfolio-tasks';
@@ -55,6 +56,11 @@ export default function Todoist() {
     typeof window !== 'undefined' &&
       window.matchMedia('(prefers-reduced-motion: reduce)').matches
   );
+  const focusQuickAdd = useCallback(() => {
+    if (quickRef.current && typeof quickRef.current.focus === 'function') {
+      quickRef.current.focus();
+    }
+  }, []);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -671,10 +677,13 @@ export default function Todoist() {
           {WIP_LIMITS[name] ? ` (${groups[name].length}/${WIP_LIMITS[name]})` : ''}
         </h2>
         {filtered.length === 0 ? (
-          <div className="flex flex-col items-center text-gray-500 mt-3">
-            <img src="/empty-tasks.svg" alt="" className="w-16 h-16 mb-1.5" />
-            <span className="text-sm">No tasks</span>
-          </div>
+          <EmptyState
+            className="mt-3 bg-transparent text-gray-200"
+            featureId="todoist-board"
+            variant="no-data"
+            illustration={{ src: '/empty-tasks.svg', alt: '', className: 'mb-1.5' }}
+            primaryAction={{ onClick: focusQuickAdd }}
+          />
         ) : (
           Object.keys(bySection).map((sec) => (
             <div key={sec} className="mb-4">

--- a/components/common/EmptyState.tsx
+++ b/components/common/EmptyState.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import React, { useId } from "react";
+import classNames from "clsx";
+import {
+  EMPTY_STATE_FEATURE_CONFIG,
+  EmptyStateActionConfig,
+  EmptyStateDocsLinkConfig,
+  EmptyStateFeatureConfig,
+  EmptyStateVariantConfig,
+  resolveEmptyStateConfig,
+} from "./emptyStatePresets";
+
+export type EmptyStateVariant = "no-permission" | "no-data" | "filtered-out";
+
+export interface EmptyStateActionProps
+  extends Partial<EmptyStateActionConfig> {
+  onClick?: () => void;
+}
+
+export interface EmptyStateDocsLinkProps
+  extends Partial<EmptyStateDocsLinkConfig> {}
+
+export type EmptyStateIllustration =
+  | {
+      kind?: "image";
+      src: string;
+      alt?: string;
+      className?: string;
+    }
+  | {
+      kind: "node";
+      element: React.ReactNode;
+      ariaHidden?: boolean;
+      className?: string;
+    };
+
+export interface EmptyStateProps {
+  variant?: EmptyStateVariant;
+  featureId?: keyof typeof EMPTY_STATE_FEATURE_CONFIG | string;
+  title?: string;
+  description?: string;
+  illustration?: EmptyStateIllustration;
+  primaryAction?: EmptyStateActionProps;
+  secondaryAction?: EmptyStateActionProps;
+  docsLink?: EmptyStateDocsLinkProps;
+  className?: string;
+}
+
+const VARIANT_DEFAULTS: Record<EmptyStateVariant, Required<Pick<EmptyStateVariantConfig, "title" | "description">>> = {
+  "no-permission": {
+    title: "Permission required",
+    description: "You do not currently have permission to view this area.",
+  },
+  "no-data": {
+    title: "No data available",
+    description: "There is nothing to show just yet. Activity will appear here once it is recorded.",
+  },
+  "filtered-out": {
+    title: "No results found",
+    description: "Nothing matches your filters. Try broadening the criteria to see content.",
+  },
+};
+
+function mergeAction(
+  base: EmptyStateActionConfig | undefined,
+  override: EmptyStateActionProps | undefined,
+): (EmptyStateActionConfig & { onClick?: () => void }) | undefined {
+  if (!base && !override) return undefined;
+  const label = override?.label ?? base?.label;
+  const href = override?.href ?? base?.href;
+  const ariaLabel = override?.ariaLabel ?? base?.ariaLabel;
+  const target = override?.target ?? base?.target;
+  const onClick = override?.onClick ?? undefined;
+  if (!label) return undefined;
+  if (!href && !onClick) return undefined;
+  return { label, href, ariaLabel, target, onClick };
+}
+
+function mergeDocsLink(
+  base: EmptyStateDocsLinkConfig | undefined,
+  override: EmptyStateDocsLinkProps | undefined,
+): EmptyStateDocsLinkConfig | undefined {
+  if (!base && !override) return undefined;
+  const href = override?.href ?? base?.href;
+  const label = override?.label ?? base?.label;
+  const ariaLabel = override?.ariaLabel ?? base?.ariaLabel;
+  const target = override?.target ?? base?.target;
+  if (!href || !label) return undefined;
+  return { href, label, ariaLabel, target };
+}
+
+function resolveIllustration(illustration: EmptyStateIllustration | undefined) {
+  if (!illustration) return null;
+  if ("element" in illustration) {
+    return (
+      <div
+        className={classNames("text-[var(--kali-blue)]", illustration.className)}
+        aria-hidden={illustration.ariaHidden ?? true}
+      >
+        {illustration.element}
+      </div>
+    );
+  }
+  return (
+    <img
+      src={illustration.src}
+      alt={illustration.alt ?? ""}
+      className={classNames("h-16 w-16", illustration.className)}
+    />
+  );
+}
+
+export default function EmptyState({
+  variant = "no-data",
+  featureId,
+  title,
+  description,
+  illustration,
+  primaryAction,
+  secondaryAction,
+  docsLink,
+  className,
+}: EmptyStateProps) {
+  const headingId = useId();
+  const descriptionId = useId();
+
+  const variantDefaults = VARIANT_DEFAULTS[variant];
+  const featureConfig = resolveEmptyStateConfig(featureId, variant);
+
+  const resolvedTitle = title ?? featureConfig?.title ?? variantDefaults.title;
+  const resolvedDescription =
+    description ?? featureConfig?.description ?? variantDefaults.description;
+
+  const resolvedPrimaryAction = mergeAction(featureConfig?.primaryAction, primaryAction);
+  const resolvedSecondaryAction = mergeAction(
+    featureConfig?.secondaryAction,
+    secondaryAction,
+  );
+  const resolvedDocsLink = mergeDocsLink(featureConfig?.docsLink, docsLink);
+
+  const illustrationNode = resolveIllustration(illustration);
+
+  const actionGroup =
+    resolvedPrimaryAction || resolvedSecondaryAction || resolvedDocsLink ? (
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {resolvedPrimaryAction && (
+          <ActionButton action={resolvedPrimaryAction} variant="primary" />
+        )}
+        {resolvedSecondaryAction && (
+          <ActionButton action={resolvedSecondaryAction} variant="secondary" />
+        )}
+        {resolvedDocsLink && (
+          <a
+            className="inline-flex items-center rounded-full border border-white/20 px-3 py-1 text-xs font-medium text-white transition hover:border-white/40 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kali-blue)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f172a]"
+            href={resolvedDocsLink.href}
+            target={resolvedDocsLink.target}
+            rel={resolvedDocsLink.target === "_blank" ? "noopener noreferrer" : undefined}
+            aria-label={
+              resolvedDocsLink.ariaLabel ?? `Open documentation for ${resolvedTitle}`
+            }
+          >
+            {resolvedDocsLink.label}
+          </a>
+        )}
+      </div>
+    ) : null;
+
+  return (
+    <section
+      role="status"
+      aria-live="polite"
+      aria-labelledby={headingId}
+      aria-describedby={resolvedDescription ? descriptionId : undefined}
+      className={classNames(
+        "flex flex-col items-center gap-3 rounded-md bg-black/20 px-4 py-6 text-center text-sm text-gray-200",
+        className,
+      )}
+    >
+      {illustrationNode}
+      <h2 id={headingId} className="text-base font-semibold text-white">
+        {resolvedTitle}
+      </h2>
+      {resolvedDescription && (
+        <p id={descriptionId} className="max-w-md text-xs text-gray-300 sm:text-sm">
+          {resolvedDescription}
+        </p>
+      )}
+      {actionGroup}
+    </section>
+  );
+}
+
+interface ActionButtonProps {
+  action: EmptyStateActionConfig & { onClick?: () => void };
+  variant: "primary" | "secondary";
+}
+
+function ActionButton({ action, variant }: ActionButtonProps) {
+  const { label, href, onClick, ariaLabel, target } = action;
+  const baseClass = classNames(
+    "inline-flex items-center rounded-full px-4 py-1.5 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kali-blue)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f172a]",
+    variant === "primary"
+      ? "bg-[var(--kali-blue)] text-white hover:bg-[#53b9ff]"
+      : "border border-white/20 text-white hover:border-white/40 hover:bg-white/10",
+  );
+
+  if (href) {
+    return (
+      <a
+        className={baseClass}
+        href={href}
+        target={target}
+        rel={target === "_blank" ? "noopener noreferrer" : undefined}
+        aria-label={ariaLabel ?? label}
+        onClick={onClick}
+      >
+        {label}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={baseClass}
+      onClick={onClick}
+      aria-label={ariaLabel ?? label}
+    >
+      {label}
+    </button>
+  );
+}
+
+export {
+  EMPTY_STATE_FEATURE_CONFIG,
+  resolveEmptyStateConfig,
+  type EmptyStateVariantConfig,
+  type EmptyStateFeatureConfig,
+};

--- a/components/common/emptyStatePresets.ts
+++ b/components/common/emptyStatePresets.ts
@@ -1,0 +1,116 @@
+import type { EmptyStateVariant } from "./EmptyState";
+
+export interface EmptyStateActionConfig {
+  label: string;
+  href?: string;
+  ariaLabel?: string;
+  target?: string;
+}
+
+export interface EmptyStateDocsLinkConfig {
+  label: string;
+  href: string;
+  ariaLabel?: string;
+  target?: string;
+}
+
+export interface EmptyStateVariantConfig {
+  title?: string;
+  description?: string;
+  primaryAction?: EmptyStateActionConfig;
+  secondaryAction?: EmptyStateActionConfig;
+  docsLink?: EmptyStateDocsLinkConfig;
+}
+
+export interface EmptyStateFeatureConfig {
+  default?: EmptyStateVariantConfig;
+  variants?: Partial<Record<EmptyStateVariant, EmptyStateVariantConfig>>;
+}
+
+export type EmptyStateFeatureMap = Record<string, EmptyStateFeatureConfig>;
+
+export const EMPTY_STATE_FEATURE_CONFIG: EmptyStateFeatureMap = {
+  "launcher-search": {
+    variants: {
+      "filtered-out": {
+        title: "No applications match your search",
+        description: "Adjust your filters or browse the catalog to discover more tools.",
+        primaryAction: {
+          label: "Clear search",
+          ariaLabel: "Clear the current search query",
+        },
+        docsLink: {
+          label: "Browse app catalog",
+          href: "https://unnippillil.com/apps",
+          ariaLabel: "Open the portfolio app catalog",
+          target: "_blank",
+        },
+      },
+    },
+  },
+  "todoist-board": {
+    variants: {
+      "no-data": {
+        title: "No tasks in this view",
+        description: "Create a task to start tracking work or import a template project.",
+        primaryAction: {
+          label: "Add a task",
+          ariaLabel: "Focus the quick add task input",
+        },
+        secondaryAction: {
+          label: "View keyboard shortcuts",
+          href: "https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/TASKS_UI_POLISH.md",
+          ariaLabel: "Open task management shortcuts documentation",
+          target: "_blank",
+        },
+      },
+    },
+  },
+  "network-share-logs": {
+    variants: {
+      "no-data": {
+        title: "No share activity yet",
+        description: "Generate a QR code or NFC share to populate the activity log.",
+        docsLink: {
+          label: "Share workflow reference",
+          href: "https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/captive-portal-service.md",
+          ariaLabel: "Open network sharing workflow reference",
+          target: "_blank",
+        },
+      },
+    },
+  },
+  "network-permissions": {
+    variants: {
+      "no-permission": {
+        title: "Network access is disabled",
+        description: "Enable network features in Settings to allow simulated requests and sharing.",
+        primaryAction: {
+          label: "Open Settings",
+          ariaLabel: "Open the Settings app to manage permissions",
+        },
+        docsLink: {
+          label: "Privacy controls",
+          href: "https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/getting-started.md#privacy",
+          ariaLabel: "Learn about privacy controls",
+          target: "_blank",
+        },
+      },
+    },
+  },
+};
+
+export function resolveEmptyStateConfig(
+  featureId: string | undefined,
+  variant: EmptyStateVariant | undefined,
+): EmptyStateVariantConfig | undefined {
+  if (!featureId) return undefined;
+  const featureConfig = EMPTY_STATE_FEATURE_CONFIG[featureId];
+  if (!featureConfig) return undefined;
+  const base = featureConfig.default ?? {};
+  if (!variant) {
+    return Object.keys(base).length > 0 ? base : undefined;
+  }
+  const variantConfig = featureConfig.variants?.[variant] ?? {};
+  return { ...base, ...variantConfig };
+}

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import Image from 'next/image';
+import EmptyState from '../common/EmptyState';
 import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 
@@ -268,6 +269,11 @@ const WhiskerMenu: React.FC = () => {
     setIsOpen(false);
   };
 
+  const clearSearch = useCallback(() => {
+    setQuery('');
+    setHighlight(0);
+  }, []);
+
   useEffect(() => {
     if (!isOpen && isVisible) {
       hideTimer.current = setTimeout(() => {
@@ -524,26 +530,34 @@ const WhiskerMenu: React.FC = () => {
             </div>
             <div className="flex-1 overflow-y-auto px-3 py-3 sm:px-3">
               {currentApps.length === 0 ? (
-                <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-gray-500">
-                  <span className="flex h-12 w-12 items-center justify-center rounded-full bg-[#121f33] text-[#4aa8ff]">
-                    <svg
-                      width="24"
-                      height="24"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      aria-hidden="true"
-                    >
-                      <circle cx="12" cy="12" r="9" />
-                      <line x1="12" y1="8" x2="12" y2="12" />
-                      <line x1="12" y1="16" x2="12.01" y2="16" />
-                    </svg>
-                  </span>
-                  <p>No applications match your search.</p>
-                </div>
+                <EmptyState
+                  className="h-full justify-center bg-transparent"
+                  featureId="launcher-search"
+                  variant="filtered-out"
+                  illustration={{
+                    kind: 'node',
+                    className:
+                      'flex h-12 w-12 items-center justify-center rounded-full bg-[#121f33] text-[#4aa8ff]',
+                    element: (
+                      <svg
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                      >
+                        <circle cx="12" cy="12" r="9" />
+                        <line x1="12" y1="8" x2="12" y2="12" />
+                        <line x1="12" y1="16" x2="12.01" y2="16" />
+                      </svg>
+                    ),
+                  }}
+                  primaryAction={{ onClick: clearSearch }}
+                />
               ) : (
                 <ul className="space-y-2">
                   {currentApps.map((app, idx) => (

--- a/components/ui/NetworkIndicator.tsx
+++ b/components/ui/NetworkIndicator.tsx
@@ -5,6 +5,7 @@ import type { FC, MouseEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import usePersistentState from "../../hooks/usePersistentState";
+import EmptyState from "../common/EmptyState";
 
 type NetworkType = "wired" | "wifi";
 type SignalStrength = "excellent" | "good" | "fair" | "weak";
@@ -446,6 +447,12 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
     [allowNetwork, online, wifiEnabled, connectedNetwork],
   );
 
+  const openSettingsApp = useCallback(() => {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("open-app", { detail: "settings" }));
+    }
+  }, []);
+
   const handleToggle = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     setOpen((prev) => !prev);
@@ -591,10 +598,41 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
             <p className="mt-1 text-[11px] text-gray-300">{summary.description}</p>
             {summary.meta && <p className="mt-1 text-[11px] text-gray-400">{summary.meta}</p>}
           </div>
-          {summary.notice && (
-            <div className="mb-3 rounded border border-red-500/50 bg-red-900/30 p-2 text-[11px] text-red-200">
-              {summary.notice}
-            </div>
+          {!allowNetwork ? (
+            <EmptyState
+              className="mb-3 border border-red-500/40 bg-red-900/30"
+              featureId="network-permissions"
+              variant="no-permission"
+              illustration={{
+                kind: "node",
+                className:
+                  "flex h-10 w-10 items-center justify-center rounded-full bg-red-900/60 text-red-200",
+                element: (
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M12 2 3 6v6c0 5 3.6 9.4 9 10 5.4-.6 9-5 9-10V6z" />
+                    <line x1="12" y1="8" x2="12" y2="13" />
+                    <circle cx="12" cy="16.5" r="1" />
+                  </svg>
+                ),
+              }}
+              primaryAction={{ onClick: openSettingsApp }}
+            />
+          ) : (
+            summary.notice && (
+              <div className="mb-3 rounded border border-red-500/50 bg-red-900/30 p-2 text-[11px] text-red-200">
+                {summary.notice}
+              </div>
+            )
           )}
           <label className="mb-3 flex items-center justify-between text-[11px] uppercase tracking-wide text-gray-200">
             <span className="text-white normal-case">Wi-Fi</span>
@@ -666,7 +704,11 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
           {showLogs && (
             <div className="mt-2 max-h-32 overflow-y-auto rounded border border-white/10 bg-black/30 p-2 text-[11px] text-gray-200">
               {shareLogs.length === 0 ? (
-                <p>No share activity recorded yet.</p>
+                <EmptyState
+                  className="bg-transparent"
+                  featureId="network-share-logs"
+                  variant="no-data"
+                />
               ) : (
                 <ul className="space-y-1">
                   {shareLogs


### PR DESCRIPTION
## Summary
- add a reusable EmptyState component with accessible defaults and feature-based presets
- replace ad-hoc empty messages in the launcher, Todoist board, and network indicator with the shared component
- introduce targeted unit tests covering variant rendering and accessibility labels

## Testing
- [x] yarn test EmptyState

## Flags
- None

------
https://chatgpt.com/codex/tasks/task_e_68dc6243c2188328956ae5c23a32a6e3