### PR TITLE
[apps] Add reusable template picker and presets for tool sims

### DIFF
--- a/__tests__/hashcat.test.tsx
+++ b/__tests__/hashcat.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, fireEvent, waitFor, act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import HashcatApp, { detectHashType } from '../components/apps/hashcat';
 import progressInfo from '../components/apps/hashcat/progress.json';
 
@@ -126,5 +127,30 @@ describe('HashcatApp', () => {
     expect(
       getByText(/hashcat \(v6\.2\.6\) starting in benchmark mode/)
     ).toBeInTheDocument();
+  });
+
+  it('applies template configuration after preview', async () => {
+    const user = userEvent.setup();
+    localStorage.clear();
+    render(<HashcatApp />);
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: /load template md5 wordlist audit/i,
+      })
+    );
+
+    await user.click(
+      await screen.findByRole('button', { name: /apply selected fields/i })
+    );
+
+    expect(await screen.findByLabelText('Hash value')).toHaveValue(
+      '5f4dcc3b5aa765d61d8327deb882cf99'
+    );
+    expect(screen.getByLabelText('Attack Mode:')).toHaveValue('0');
+    expect(screen.getByLabelText('Wordlist:')).toHaveValue('rockyou');
+    expect(
+      screen.queryByLabelText(/Preview changes for MD5 Wordlist Audit/i)
+    ).not.toBeInTheDocument();
   });
 });

--- a/__tests__/hydra.test.tsx
+++ b/__tests__/hydra.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import HydraApp from '../components/apps/hydra';
 
 describe('Hydra wordlists', () => {
@@ -141,5 +142,39 @@ describe('Hydra session restore', () => {
     await act(async () => {
       runResolve();
     });
+  });
+});
+
+describe('Hydra templates', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('loads template data with preview confirmation', async () => {
+    const user = userEvent.setup();
+    render(<HydraApp />);
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: /load template ssh admin sweep/i,
+      })
+    );
+
+    const targetToggle = await screen.findByLabelText(
+      'Apply template value for Target'
+    );
+    expect(targetToggle).toBeChecked();
+
+    await user.click(
+      await screen.findByRole('button', { name: /apply selected fields/i })
+    );
+
+    expect(
+      screen.getByPlaceholderText('192.168.0.1')
+    ).toHaveValue('10.20.30.40:22');
+    expect(screen.getAllByText('vpn-admins.txt').length).toBeGreaterThan(0);
+    expect(
+      screen.queryByLabelText(/Preview changes for SSH Admin Sweep/i)
+    ).not.toBeInTheDocument();
   });
 });

--- a/components/common/TemplateDiffPreview.tsx
+++ b/components/common/TemplateDiffPreview.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { ToolTemplate } from './TemplatePicker';
+import {
+  TemplateFieldDiff,
+  formatTemplateValue,
+} from '../../utils/templateUtils';
+
+interface TemplateDiffPreviewProps {
+  template: ToolTemplate;
+  diffs: TemplateFieldDiff[];
+  onToggle: (field: string, apply: boolean) => void;
+  onApply: () => void;
+  onCancel: () => void;
+  fieldLabels?: Record<string, string>;
+}
+
+const TemplateDiffPreview: React.FC<TemplateDiffPreviewProps> = ({
+  template,
+  diffs,
+  onToggle,
+  onApply,
+  onCancel,
+  fieldLabels = {},
+}) => {
+  const changedDiffs = diffs.filter((diff) => diff.changed);
+
+  return (
+    <section
+      className="mb-4 border border-ub-yellow/60 bg-black/60 rounded p-4"
+      aria-label={`Preview changes for ${template.name}`}
+    >
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-3">
+        <div>
+          <h2 className="text-base font-semibold text-white">{template.name}</h2>
+          <p className="text-sm text-gray-300">{template.description}</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-1 rounded bg-gray-700 text-sm text-white"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onApply}
+            className="px-3 py-1 rounded bg-ub-yellow text-black font-semibold"
+          >
+            Apply selected fields
+          </button>
+        </div>
+      </div>
+
+      {changedDiffs.length === 0 ? (
+        <p className="text-sm text-gray-300">
+          All template values already match your current configuration.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {changedDiffs.map((diff) => {
+            const label = fieldLabels[diff.key] || diff.key;
+            return (
+              <div
+                key={diff.key}
+                className="border border-gray-700 rounded p-3 bg-gray-900/60"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-white">{label}</p>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-2 text-xs text-gray-300">
+                      <div>
+                        <p className="uppercase text-gray-500 tracking-wide mb-1">
+                          Current
+                        </p>
+                        <pre className="whitespace-pre-wrap break-words bg-black/40 p-2 rounded border border-gray-800">
+                          {formatTemplateValue(diff.currentValue)}
+                        </pre>
+                      </div>
+                      <div>
+                        <p className="uppercase text-gray-500 tracking-wide mb-1">
+                          Template
+                        </p>
+                        <pre className="whitespace-pre-wrap break-words bg-black/40 p-2 rounded border border-gray-800">
+                          {formatTemplateValue(diff.templateValue)}
+                        </pre>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex-shrink-0 mt-1">
+                    <label className="inline-flex items-center gap-2 text-xs text-gray-200">
+                      <input
+                        type="checkbox"
+                        checked={diff.apply}
+                        onChange={(event) => onToggle(diff.key, event.target.checked)}
+                        aria-label={`Apply template value for ${label}`}
+                      />
+                      Apply
+                    </label>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default TemplateDiffPreview;

--- a/components/common/TemplatePicker.tsx
+++ b/components/common/TemplatePicker.tsx
@@ -1,0 +1,222 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+export interface ToolTemplate {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  metadata?: Record<string, string>;
+  fields: Record<string, unknown>;
+}
+
+interface TemplatePickerProps {
+  tool: string;
+  templates: ToolTemplate[];
+  onSelect: (template: ToolTemplate) => void;
+  recentLimit?: number;
+}
+
+const storageKey = (tool: string) => `template-recent-${tool}`;
+
+const TemplatePicker: React.FC<TemplatePickerProps> = ({
+  tool,
+  templates,
+  onSelect,
+  recentLimit = 3,
+}) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [activeTags, setActiveTags] = useState<string[]>([]);
+  const [recent, setRecent] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const raw = window.localStorage.getItem(storageKey(tool));
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        setRecent(parsed.filter((id) => templates.some((t) => t.id === id)));
+      }
+    } catch {
+      // ignore storage errors
+    }
+  }, [tool, templates]);
+
+  const allTags = useMemo(() => {
+    const tags = new Set<string>();
+    templates.forEach((template) => {
+      template.tags.forEach((tag) => tags.add(tag));
+    });
+    return Array.from(tags).sort((a, b) => a.localeCompare(b));
+  }, [templates]);
+
+  const filteredTemplates = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    return templates.filter((template) => {
+      const matchesSearch = term
+        ? [
+            template.name,
+            template.description,
+            ...(template.tags || []),
+            ...Object.values(template.metadata || {}),
+          ]
+            .join(' ')
+            .toLowerCase()
+            .includes(term)
+        : true;
+
+      const matchesTags = activeTags.length
+        ? activeTags.every((tag) => template.tags.includes(tag))
+        : true;
+
+      return matchesSearch && matchesTags;
+    });
+  }, [templates, searchTerm, activeTags]);
+
+  const updateRecent = (templateId: string) => {
+    if (typeof window === 'undefined') return;
+    setRecent((prev) => {
+      const next = [templateId, ...prev.filter((id) => id !== templateId)].slice(
+        0,
+        recentLimit
+      );
+      try {
+        window.localStorage.setItem(storageKey(tool), JSON.stringify(next));
+      } catch {
+        // ignore storage write errors
+      }
+      return next;
+    });
+  };
+
+  const handleSelect = (template: ToolTemplate) => {
+    updateRecent(template.id);
+    onSelect(template);
+  };
+
+  const toggleTag = (tag: string) => {
+    setActiveTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    );
+  };
+
+  return (
+    <section className="mb-4" aria-label={`${tool} template picker`}>
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2 mb-3">
+        <input
+          type="search"
+          placeholder="Search templates"
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+          className="w-full md:w-64 px-2 py-1 rounded text-black"
+          aria-label="Search templates"
+        />
+        {allTags.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {allTags.map((tag) => {
+              const isActive = activeTags.includes(tag);
+              return (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => toggleTag(tag)}
+                  className={`px-2 py-1 rounded text-xs uppercase tracking-wide transition-colors ${
+                    isActive
+                      ? 'bg-ub-yellow text-black'
+                      : 'bg-ub-grey text-black hover:bg-ub-mid'
+                  }`}
+                  aria-pressed={isActive}
+                >
+                  {tag}
+                </button>
+              );
+            })}
+            {activeTags.length > 0 && (
+              <button
+                type="button"
+                className="px-2 py-1 rounded text-xs bg-gray-700 text-white"
+                onClick={() => setActiveTags([])}
+              >
+                Clear filters
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {recent.length > 0 && (
+        <div className="mb-3" aria-label="Recent templates">
+          <p className="text-xs uppercase text-gray-300 mb-1">Recent</p>
+          <div className="flex flex-wrap gap-2">
+            {recent
+              .map((id) => templates.find((template) => template.id === id))
+              .filter(Boolean)
+              .map((template) => (
+                <button
+                  key={template!.id}
+                  type="button"
+                  className="px-3 py-1 rounded bg-gray-700 text-sm hover:bg-gray-600 transition"
+                  onClick={() => handleSelect(template!)}
+                >
+                  {template!.name}
+                </button>
+              ))}
+          </div>
+        </div>
+      )}
+
+      <div className="grid gap-3" role="list">
+        {filteredTemplates.map((template) => (
+          <article
+            key={template.id}
+            className="border border-gray-700 rounded p-3 bg-black/40"
+            role="listitem"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-base font-semibold text-white">{template.name}</h3>
+                <p className="text-sm text-gray-300 mb-2">{template.description}</p>
+              </div>
+              <button
+                type="button"
+                className="px-3 py-1 bg-ub-yellow text-black rounded font-semibold"
+                onClick={() => handleSelect(template)}
+                aria-label={`Load template ${template.name}`}
+              >
+                Load template
+              </button>
+            </div>
+            {template.metadata && (
+              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs text-gray-400 mb-2">
+                {Object.entries(template.metadata).map(([key, value]) => (
+                  <div key={key} className="flex gap-2">
+                    <dt className="uppercase tracking-wide text-gray-500">
+                      {key}
+                    </dt>
+                    <dd className="text-gray-300">{value}</dd>
+                  </div>
+                ))}
+              </dl>
+            )}
+            <div className="flex flex-wrap gap-2">
+              {template.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="px-2 py-0.5 rounded-full bg-gray-800 text-xs text-gray-200"
+                >
+                  #{tag}
+                </span>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+
+      {filteredTemplates.length === 0 && (
+        <p className="text-sm text-gray-400 mt-4">No templates match your search.</p>
+      )}
+    </section>
+  );
+};
+
+export default TemplatePicker;

--- a/data/templates/hashcat.json
+++ b/data/templates/hashcat.json
@@ -1,0 +1,55 @@
+[
+  {
+    "id": "hashcat-md5-wordlist",
+    "name": "MD5 Wordlist Audit",
+    "description": "Crack legacy MD5 hashes with a trusted corporate wordlist.",
+    "tags": ["wordlist", "md5", "audit"],
+    "metadata": {
+      "difficulty": "Beginner",
+      "attack": "Straight"
+    },
+    "fields": {
+      "hashType": "0",
+      "hashInput": "5f4dcc3b5aa765d61d8327deb882cf99",
+      "attackMode": "0",
+      "wordlist": "rockyou",
+      "ruleSet": "best64"
+    }
+  },
+  {
+    "id": "hashcat-mask-spearfish",
+    "name": "Spearphish Brute Force",
+    "description": "Combine hybrid attack with a targeted suffix mask.",
+    "tags": ["mask", "hybrid", "sha1"],
+    "metadata": {
+      "difficulty": "Intermediate",
+      "attack": "Hybrid mask"
+    },
+    "fields": {
+      "hashType": "100",
+      "hashInput": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+      "attackMode": "6",
+      "mask": "?l?l?l?d!",
+      "wordlist": "executive-names",
+      "ruleSet": "quick"
+    }
+  },
+  {
+    "id": "hashcat-benchmark",
+    "name": "Benchmark Session",
+    "description": "Preload hashcat with demo data to highlight GPU utilisation.",
+    "tags": ["benchmark", "demo", "training"],
+    "metadata": {
+      "difficulty": "Beginner",
+      "attack": "Brute-force"
+    },
+    "fields": {
+      "hashType": "3200",
+      "hashInput": "$2b$12$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "attackMode": "3",
+      "mask": "?a?a?a?a",
+      "wordlist": "",
+      "ruleSet": "none"
+    }
+  }
+]

--- a/data/templates/hydra.json
+++ b/data/templates/hydra.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "hydra-ssh-admin",
+    "name": "SSH Admin Sweep",
+    "description": "Simulate a credential spray against hardened SSH endpoints.",
+    "tags": ["ssh", "spray", "infrastructure"],
+    "metadata": {
+      "difficulty": "Intermediate",
+      "wordlists": "Targeted admins"
+    },
+    "fields": {
+      "target": "10.20.30.40:22",
+      "service": "ssh",
+      "charset": "abc123!@#",
+      "rule": "1:4",
+      "userLists": [
+        {
+          "name": "vpn-admins.txt",
+          "content": "root\nsecops\nvpnadmin\n"
+        }
+      ],
+      "passLists": [
+        {
+          "name": "quarterly-reset.txt",
+          "content": "Spring2024!\nWinter2023!\nPassword123!\n"
+        }
+      ],
+      "selectedUser": "vpn-admins.txt",
+      "selectedPass": "quarterly-reset.txt"
+    }
+  },
+  {
+    "id": "hydra-https-form",
+    "name": "HTTPS Form Audit",
+    "description": "Demonstrate credential stuffing against a demo login form.",
+    "tags": ["http-post-form", "web", "credential"],
+    "metadata": {
+      "difficulty": "Beginner",
+      "workflow": "Form mode"
+    },
+    "fields": {
+      "target": "portal.example.com/login",
+      "service": "http-post-form",
+      "charset": "abcd1234",
+      "rule": "1:3",
+      "userLists": [
+        {
+          "name": "marketing-users.txt",
+          "content": "amanda\nkeith\npriya\n"
+        }
+      ],
+      "passLists": [
+        {
+          "name": "top-passwords.txt",
+          "content": "Password1\nSummer2023\nCompany2024\n"
+        }
+      ],
+      "selectedUser": "marketing-users.txt",
+      "selectedPass": "top-passwords.txt"
+    }
+  },
+  {
+    "id": "hydra-service-benchmark",
+    "name": "Service Benchmark",
+    "description": "Load demo wordlists while keeping the target blank for dry runs.",
+    "tags": ["benchmark", "dry-run", "training"],
+    "metadata": {
+      "difficulty": "Beginner",
+      "workflow": "Lab prep"
+    },
+    "fields": {
+      "target": "",
+      "service": "ssh",
+      "charset": "abcde12345",
+      "rule": "2:4",
+      "userLists": [
+        {
+          "name": "lab-users.txt",
+          "content": "student\ntrainer\nobserver\n"
+        }
+      ],
+      "passLists": [
+        {
+          "name": "lab-passwords.txt",
+          "content": "lab12345\nclass2024\ntrainme\n"
+        }
+      ],
+      "selectedUser": "lab-users.txt",
+      "selectedPass": "lab-passwords.txt"
+    }
+  }
+]

--- a/data/templates/nmap.json
+++ b/data/templates/nmap.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "nmap-web-enum",
+    "name": "Web Application Recon",
+    "description": "Focus on HTTP and TLS enumeration against a staging web host.",
+    "tags": ["web", "http", "recon"],
+    "metadata": {
+      "difficulty": "Beginner",
+      "scenario": "Perimeter review"
+    },
+    "fields": {
+      "target": "dev.intra.example",
+      "portFlag": "-p 80,443,8080",
+      "selectedScripts": ["http-title", "http-enum", "ssl-cert"],
+      "scriptOptions": {
+        "http-enum": "path=/admin",
+        "ssl-cert": "showvalid=true"
+      }
+    }
+  },
+  {
+    "id": "nmap-smb-health",
+    "name": "Internal SMB Health Check",
+    "description": "Audit SMB services with OS discovery and anonymous login checks.",
+    "tags": ["internal", "smb", "discovery"],
+    "metadata": {
+      "difficulty": "Intermediate",
+      "scenario": "Lateral movement hunt"
+    },
+    "fields": {
+      "target": "fileserver.corp.lan",
+      "portFlag": "-p 445 --reason",
+      "selectedScripts": ["smb-os-discovery", "ftp-anon"],
+      "scriptOptions": {
+        "ftp-anon": "maxlist=10"
+      }
+    }
+  },
+  {
+    "id": "nmap-dns-brute",
+    "name": "Subdomain Discovery",
+    "description": "Brute-force DNS subdomains while profiling exposed HTTP services.",
+    "tags": ["dns", "brute", "recon"],
+    "metadata": {
+      "difficulty": "Advanced",
+      "scenario": "Attack surface mapping"
+    },
+    "fields": {
+      "target": "corp.example",
+      "portFlag": "-p 80,443 -T4",
+      "selectedScripts": ["dns-brute", "http-title"],
+      "scriptOptions": {
+        "dns-brute": "threads=8,filestore=./dns-results"
+      }
+    }
+  }
+]

--- a/utils/templateUtils.ts
+++ b/utils/templateUtils.ts
@@ -1,0 +1,92 @@
+export interface TemplateFieldDiff {
+  key: string;
+  currentValue: unknown;
+  templateValue: unknown;
+  changed: boolean;
+  apply: boolean;
+}
+
+type Primitive = string | number | boolean | null;
+
+type NormalizedValue = Primitive | NormalizedValue[] | { [key: string]: NormalizedValue };
+
+const normalizeValue = (value: unknown): NormalizedValue => {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeValue(item)) as NormalizedValue[];
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, val]) => [key, normalizeValue(val)] as const);
+    return entries.reduce<Record<string, NormalizedValue>>((acc, [key, val]) => {
+      acc[key] = val;
+      return acc;
+    }, {});
+  }
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value === null
+  ) {
+    return value as Primitive;
+  }
+  return null;
+};
+
+const normalizedEqual = (a: unknown, b: unknown): boolean => {
+  return JSON.stringify(normalizeValue(a)) === JSON.stringify(normalizeValue(b));
+};
+
+export const isEmptyValue = (value: unknown): boolean => {
+  if (value == null) return true;
+  if (typeof value === 'string') return value.trim().length === 0;
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === 'object') return Object.keys(value as object).length === 0;
+  return false;
+};
+
+export const computeTemplateDiff = (
+  fields: Record<string, unknown>,
+  currentValues: Record<string, unknown>
+): TemplateFieldDiff[] => {
+  return Object.entries(fields).map(([key, templateValue]) => {
+    const currentValue = currentValues[key];
+    const changed = !normalizedEqual(currentValue, templateValue);
+    const apply = changed && isEmptyValue(currentValue);
+    return { key, currentValue, templateValue, changed, apply };
+  });
+};
+
+export const updateDiffSelection = (
+  diffs: TemplateFieldDiff[],
+  key: string,
+  apply: boolean
+): TemplateFieldDiff[] =>
+  diffs.map((diff) => (diff.key === key ? { ...diff, apply } : diff));
+
+export const formatTemplateValue = (value: unknown): string => {
+  if (value == null) return '—';
+  if (typeof value === 'string') return value.length ? value : '—';
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) {
+    if (value.every((item) => typeof item === 'string')) {
+      return (value as string[]).join(', ') || '—';
+    }
+    if (
+      value.every(
+        (item) =>
+          item && typeof item === 'object' && 'name' in (item as Record<string, unknown>)
+      )
+    ) {
+      return (value as Array<Record<string, unknown>>)
+        .map((item) => String(item.name))
+        .join(', ');
+    }
+    return JSON.stringify(value, null, 2);
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value, null, 2);
+  }
+  return '—';
+};


### PR DESCRIPTION
## Summary
- add curated template JSON presets for the Nmap, Hydra, and Hashcat simulators
- build a reusable template picker with diff preview utilities and recent history support
- integrate template loading flows into each simulator with opt-in field application and tests

## Testing
- yarn test --runTestsByPath __tests__/nmapNse.test.tsx __tests__/hydra.test.tsx __tests__/hashcat.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc6244be30832893a46315153e389c