### PR TITLE
[common] Add onboarding checklist experience

### DIFF
--- a/__tests__/onboardingChecklist.test.tsx
+++ b/__tests__/onboardingChecklist.test.tsx
@@ -1,0 +1,95 @@
+import { ReactNode } from 'react';
+import { render, screen, act, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Checklist, { ChecklistProvider, useChecklist } from '../components/common/Checklist';
+import { SettingsProvider } from '../hooks/useSettings';
+
+describe('onboarding checklist', () => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <SettingsProvider>
+      <ChecklistProvider>{children}</ChecklistProvider>
+    </SettingsProvider>
+  );
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('manual completion persists between sessions', async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<Checklist />, { wrapper });
+
+    const terminalHeading = await screen.findByRole('heading', { name: /Launch the Terminal/i });
+    const terminalItem = terminalHeading.closest('li');
+    if (!terminalItem) throw new Error('Terminal task not found');
+
+    const markButton = within(terminalItem).getByRole('button', { name: /Mark as done/i });
+    await user.click(markButton);
+
+    expect(within(terminalItem).getByText(/Completed manually/i)).toBeInTheDocument();
+
+    // Validate localStorage snapshot
+    const stored = window.localStorage.getItem('onboarding-checklist');
+    expect(stored).toContain('launch-terminal');
+
+    unmount();
+
+    render(<Checklist />, { wrapper });
+
+    const persistedHeading = await screen.findByRole('heading', { name: /Launch the Terminal/i });
+    const persistedItem = persistedHeading.closest('li');
+    if (!persistedItem) throw new Error('Terminal task not found after remount');
+
+    expect(within(persistedItem).getByText(/Completed manually/i)).toBeInTheDocument();
+    expect(within(persistedItem).queryByRole('button', { name: /Mark as done/i })).not.toBeInTheDocument();
+    expect(within(persistedItem).getByRole('button', { name: /Undo/i })).toBeInTheDocument();
+  });
+
+  test('auto completion reacts to app events', async () => {
+    const StatusProbe = () => {
+      const { tasks } = useChecklist();
+      const terminal = tasks.find((task) => task.id === 'launch-terminal');
+      return <span data-testid="terminal-status">{terminal?.completed ? 'done' : 'pending'}</span>;
+    };
+
+    const statusRender = render(<StatusProbe />, { wrapper });
+    expect(screen.getByTestId('terminal-status').textContent).toBe('pending');
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('open-app', { detail: 'terminal' }));
+    });
+
+    expect(screen.getByTestId('terminal-status').textContent).toBe('done');
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('checklist:nmap-scan'));
+    });
+
+    statusRender.unmount();
+
+    const checklistView = render(<Checklist />, { wrapper });
+    const scanHeading = await screen.findByRole('heading', { name: /Run the Nmap NSE demo/i });
+    const scanItem = scanHeading.closest('li');
+    if (!scanItem) throw new Error('Scan task not found');
+    expect(within(scanItem).getByText(/Completed automatically/i)).toBeInTheDocument();
+    checklistView.unmount();
+  });
+
+  test('manual completion supports undo', async () => {
+    const user = userEvent.setup();
+    render(<Checklist />, { wrapper });
+
+    const browserHeading = await screen.findByRole('heading', { name: /Open the Firefox demo/i });
+    const browserItem = browserHeading.closest('li');
+    if (!browserItem) throw new Error('Browser task not found');
+
+    const markButton = within(browserItem).getByRole('button', { name: /Mark as done/i });
+    await user.click(markButton);
+
+    const undoButton = within(browserItem).getByRole('button', { name: /Undo/i });
+    await user.click(undoButton);
+
+    expect(within(browserItem).getByRole('button', { name: /Mark as done/i })).toBeInTheDocument();
+    expect(within(browserItem).queryByText(/Completed manually/i)).not.toBeInTheDocument();
+  });
+});

--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -165,6 +165,24 @@ const NmapNSEApp = () => {
     setToast('Output selected');
   };
 
+  const runDemoScan = () => {
+    setToast('Simulated scan running');
+    if (typeof window !== 'undefined') {
+      try {
+        window.dispatchEvent(
+          new CustomEvent('checklist:nmap-scan', {
+            detail: {
+              target,
+              scripts: selectedScripts,
+            },
+          }),
+        );
+      } catch {
+        // ignore dispatch errors
+      }
+    }
+  };
+
   const handleOutputKey = (e) => {
     if (e.ctrlKey && e.key.toLowerCase() === 'c') {
       e.preventDefault();
@@ -204,6 +222,7 @@ const NmapNSEApp = () => {
             value={target}
             onChange={(e) => setTarget(e.target.value)}
             className="w-full p-2 text-black"
+            aria-label="Scan target"
           />
         </div>
         <div className="mb-4">
@@ -216,6 +235,7 @@ const NmapNSEApp = () => {
             onChange={(e) => setScriptQuery(e.target.value)}
             placeholder="Search scripts"
             className="w-full p-2 text-black mb-2"
+            aria-label="Filter scripts"
           />
           <div className="max-h-64 overflow-y-auto grid grid-cols-1 sm:grid-cols-2 gap-2">
             {filteredScripts.map((s) => (
@@ -225,6 +245,7 @@ const NmapNSEApp = () => {
                     type="checkbox"
                     checked={selectedScripts.includes(s.name)}
                     onChange={() => toggleScript(s.name)}
+                    aria-label={`Toggle script ${s.name}`}
                   />
                   <span className="font-mono">{s.name}</span>
                 </label>
@@ -248,6 +269,7 @@ const NmapNSEApp = () => {
                     }
                     placeholder="arg=value"
                     className="w-full p-1 border rounded text-black"
+                    aria-label={`Arguments for ${s.name}`}
                   />
                 )}
               </div>
@@ -274,17 +296,26 @@ const NmapNSEApp = () => {
             ))}
           </div>
         </div>
-        <div className="flex items-center mb-4">
+        <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center">
           <pre className="flex-1 bg-black text-green-400 p-2 rounded overflow-auto">
             {command}
           </pre>
-          <button
-            type="button"
-            onClick={copyCommand}
-            className="ml-2 px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
-          >
-            Copy Command
-          </button>
+          <div className="flex gap-2 self-end sm:self-auto">
+            <button
+              type="button"
+              onClick={copyCommand}
+              className="px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+            >
+              Copy Command
+            </button>
+            <button
+              type="button"
+              onClick={runDemoScan}
+              className="px-2 py-1 bg-blue-500 text-white rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-300"
+            >
+              Run Demo Scan
+            </button>
+          </div>
         </div>
       </div>
       <div className="md:w-1/2 p-4 bg-black overflow-y-auto">

--- a/components/common/Checklist.tsx
+++ b/components/common/Checklist.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import clsx from "clsx";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import usePersistentState from "../../hooks/usePersistentState";
+import { useSettings } from "../../hooks/useSettings";
+
+type ChecklistCompletionSource = "auto" | "manual";
+
+interface ChecklistTaskDefinition {
+  id: string;
+  title: string;
+  description: string;
+  hint?: string;
+}
+
+interface ChecklistEntryState {
+  completedAt: string;
+  source: ChecklistCompletionSource;
+}
+
+interface ChecklistPersistence {
+  version: number;
+  completed: Record<string, ChecklistEntryState>;
+}
+
+interface ChecklistItem extends ChecklistTaskDefinition {
+  completed: boolean;
+  completedAt?: string;
+  source?: ChecklistCompletionSource;
+  canUndo: boolean;
+}
+
+interface ChecklistContextValue {
+  tasks: ChecklistItem[];
+  total: number;
+  completedCount: number;
+  remainingCount: number;
+  markTaskDone: (id: string) => void;
+  undoTask: (id: string) => void;
+}
+
+const STORAGE_KEY = "onboarding-checklist";
+const STORAGE_VERSION = 1;
+
+const TASKS: ChecklistTaskDefinition[] = [
+  {
+    id: "launch-terminal",
+    title: "Launch the Terminal",
+    description: "Open the Terminal app to explore the simulated shell.",
+    hint: "Find it in the launcher or the shortcuts on the desktop.",
+  },
+  {
+    id: "launch-browser",
+    title: "Open the Firefox demo",
+    description: "Start the Firefox simulation to browse the internal docs.",
+  },
+  {
+    id: "open-file",
+    title: "Open a file",
+    description: "Use the Files app to open any file from the virtual workspace.",
+  },
+  {
+    id: "run-nmap-scan",
+    title: "Run the Nmap NSE demo",
+    description: "Kick off the simulated scan to review parsed findings.",
+  },
+];
+
+const ChecklistContext = createContext<ChecklistContextValue | null>(null);
+
+const isValidPersistence = (value: unknown): value is ChecklistPersistence => {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Partial<ChecklistPersistence>;
+  if (record.version !== STORAGE_VERSION) return false;
+  if (!record.completed || typeof record.completed !== "object") return false;
+  for (const key of Object.keys(record.completed)) {
+    const entry = (record.completed as Record<string, unknown>)[key] as Partial<ChecklistEntryState>;
+    if (!entry || typeof entry !== "object") return false;
+    if (typeof entry.completedAt !== "string") return false;
+    if (entry.source !== "auto" && entry.source !== "manual") return false;
+  }
+  return true;
+};
+
+const buildInitialState = (): ChecklistPersistence => ({
+  version: STORAGE_VERSION,
+  completed: {},
+});
+
+export function ChecklistProvider({ children }: { children: ReactNode }) {
+  const { reducedMotion } = useSettings();
+  const [state, setState] = usePersistentState<ChecklistPersistence>(
+    STORAGE_KEY,
+    buildInitialState,
+    isValidPersistence,
+  );
+  const prevCompletedRef = useRef(0);
+  const [justCompletedAll, setJustCompletedAll] = useState(false);
+
+  const completeTask = useCallback(
+    (id: string, source: ChecklistCompletionSource) => {
+      setState((prev) => {
+        const current = prev.completed[id];
+        if (current) {
+          return prev;
+        }
+        const next: ChecklistPersistence = {
+          ...prev,
+          completed: {
+            ...prev.completed,
+            [id]: { completedAt: new Date().toISOString(), source },
+          },
+        };
+        return next;
+      });
+    },
+    [setState],
+  );
+
+  const markTaskDone = useCallback(
+    (id: string) => {
+      completeTask(id, "manual");
+    },
+    [completeTask],
+  );
+
+  const undoTask = useCallback(
+    (id: string) => {
+      setState((prev) => {
+        const entry = prev.completed[id];
+        if (!entry || entry.source !== "manual") {
+          return prev;
+        }
+        const nextCompleted = { ...prev.completed };
+        delete nextCompleted[id];
+        return {
+          ...prev,
+          completed: nextCompleted,
+        };
+      });
+    },
+    [setState],
+  );
+
+  useEffect(() => {
+    const handleAppOpen = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      const appId = typeof detail === "string" ? detail : detail?.id;
+      if (appId === "terminal") {
+        completeTask("launch-terminal", "auto");
+      }
+      if (appId === "firefox") {
+        completeTask("launch-browser", "auto");
+      }
+    };
+
+    const handleFileOpened = () => {
+      completeTask("open-file", "auto");
+    };
+
+    const handleScan = () => {
+      completeTask("run-nmap-scan", "auto");
+    };
+
+    if (typeof window !== "undefined") {
+      window.addEventListener("open-app", handleAppOpen as EventListener);
+      window.addEventListener("checklist:file-opened", handleFileOpened);
+      window.addEventListener("checklist:nmap-scan", handleScan);
+      return () => {
+        window.removeEventListener("open-app", handleAppOpen as EventListener);
+        window.removeEventListener("checklist:file-opened", handleFileOpened);
+        window.removeEventListener("checklist:nmap-scan", handleScan);
+      };
+    }
+
+    return () => {};
+  }, [completeTask]);
+
+  const tasks = useMemo<ChecklistItem[]>(() => {
+    return TASKS.map((task) => {
+      const entry = state.completed[task.id];
+      return {
+        ...task,
+        completed: Boolean(entry),
+        completedAt: entry?.completedAt,
+        source: entry?.source,
+        canUndo: entry?.source === "manual",
+      };
+    });
+  }, [state.completed]);
+
+  const completedCount = useMemo(
+    () => tasks.filter((task) => task.completed).length,
+    [tasks],
+  );
+  const remainingCount = tasks.length - completedCount;
+
+  useEffect(() => {
+    if (tasks.length === 0) return;
+    if (completedCount === tasks.length && prevCompletedRef.current < tasks.length) {
+      setJustCompletedAll(true);
+    }
+    prevCompletedRef.current = completedCount;
+  }, [completedCount, tasks.length]);
+
+  useEffect(() => {
+    if (!justCompletedAll) return;
+    if (typeof window === "undefined" || reducedMotion) {
+      setJustCompletedAll(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const confettiModule = await import("canvas-confetti");
+        if (!cancelled) {
+          confettiModule.default({ particleCount: 120, spread: 70, origin: { y: 0.6 } });
+        }
+      } catch {
+        // ignore failures to load confetti in unsupported environments
+      } finally {
+        if (!cancelled) {
+          setJustCompletedAll(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [justCompletedAll, reducedMotion]);
+
+  const value = useMemo<ChecklistContextValue>(
+    () => ({
+      tasks,
+      total: tasks.length,
+      completedCount,
+      remainingCount,
+      markTaskDone,
+      undoTask,
+    }),
+    [tasks, completedCount, remainingCount, markTaskDone, undoTask],
+  );
+
+  return <ChecklistContext.Provider value={value}>{children}</ChecklistContext.Provider>;
+}
+
+export const useChecklist = () => {
+  const ctx = useContext(ChecklistContext);
+  if (!ctx) {
+    throw new Error("useChecklist must be used within a ChecklistProvider");
+  }
+  return ctx;
+};
+
+interface ChecklistProps {
+  className?: string;
+}
+
+const Checklist = ({ className }: ChecklistProps) => {
+  const { tasks, total, completedCount, remainingCount, markTaskDone, undoTask } = useChecklist();
+  const progress = total === 0 ? 0 : Math.round((completedCount / total) * 100);
+
+  return (
+    <section
+      aria-labelledby="onboarding-checklist"
+      className={clsx(
+        "w-80 max-w-full rounded-lg border border-white/10 bg-slate-900/80 p-4 text-white shadow-lg",
+        className,
+      )}
+    >
+      <header className="mb-4">
+        <h2 id="onboarding-checklist" className="text-sm font-semibold uppercase tracking-wide text-cyan-200">
+          Onboarding Checklist
+        </h2>
+        <p className="mt-1 text-xs text-slate-200">
+          {completedCount} of {total} tasks complete
+        </p>
+        <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-slate-700">
+          <div
+            className="h-full rounded-full bg-cyan-500 transition-all"
+            style={{ width: `${progress}%` }}
+            role="progressbar"
+            aria-valuenow={completedCount}
+            aria-valuemin={0}
+            aria-valuemax={total}
+            aria-label="Onboarding checklist progress"
+          />
+        </div>
+        {remainingCount === 0 ? (
+          <p className="mt-2 text-xs font-medium text-emerald-300">All tasks complete. Nice work!</p>
+        ) : (
+          <p className="mt-2 text-xs text-slate-300">
+            {remainingCount === 1 ? "One task left" : `${remainingCount} tasks remaining`}
+          </p>
+        )}
+      </header>
+      <ul className="space-y-3">
+        {tasks.map((task) => (
+          <li
+            key={task.id}
+            className={clsx(
+              "rounded-md border border-white/10 bg-slate-950/40 p-3",
+              task.completed && "border-emerald-500/50 bg-emerald-500/10",
+            )}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="text-sm font-medium text-white">{task.title}</h3>
+                <p className="mt-1 text-xs text-slate-200">{task.description}</p>
+                {task.hint && !task.completed && (
+                  <p className="mt-1 text-[11px] text-slate-400">Hint: {task.hint}</p>
+                )}
+                {task.completed && (
+                  <p className="mt-2 text-[11px] text-emerald-200">
+                    Completed {task.source === "auto" ? "automatically" : "manually"}
+                  </p>
+                )}
+              </div>
+              <div className="flex flex-col items-end gap-2">
+                {!task.completed && (
+                  <button
+                    type="button"
+                    onClick={() => markTaskDone(task.id)}
+                    className="rounded bg-cyan-500 px-3 py-1 text-xs font-semibold text-slate-950 shadow hover:bg-cyan-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+                  >
+                    Mark as done
+                  </button>
+                )}
+                {task.canUndo && (
+                  <button
+                    type="button"
+                    onClick={() => undoTask(task.id)}
+                    className="rounded border border-cyan-400 px-2 py-0.5 text-[11px] font-semibold text-cyan-200 hover:bg-cyan-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+                  >
+                    Undo
+                  </button>
+                )}
+                {task.completed && !task.canUndo && (
+                  <span className="rounded bg-emerald-500/20 px-2 py-0.5 text-[11px] font-semibold text-emerald-200">
+                    Done
+                  </span>
+                )}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export const ChecklistStatusBadge = ({ className }: { className?: string }) => {
+  const { total, completedCount, remainingCount } = useChecklist();
+  if (total === 0) return null;
+  const allDone = remainingCount === 0;
+  const label = allDone
+    ? "Onboarding checklist complete"
+    : `${remainingCount} onboarding ${remainingCount === 1 ? "task" : "tasks"} remaining`;
+  return (
+    <span
+      className={clsx(
+        "ml-2 inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold",
+        allDone ? "bg-emerald-500/20 text-emerald-200" : "bg-white/10 text-white/80",
+        className,
+      )}
+      aria-label={label}
+    >
+      {allDone ? "All set" : `${completedCount}/${total}`}
+    </span>
+  );
+};
+
+export default Checklist;

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import Checklist from '../common/Checklist';
 
 interface Props {
   open: boolean;
@@ -36,21 +37,35 @@ const QuickSettings = ({ open }: Props) => {
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
+      <label className="px-4 pb-2 flex items-center justify-between">
         <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
+        <input
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+          aria-label="Toggle sound"
+        />
+      </label>
+      <label className="px-4 pb-2 flex items-center justify-between">
         <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
+        <input
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+          aria-label="Toggle network"
+        />
+      </label>
+      <label className="px-4 flex items-center justify-between">
         <span>Reduced motion</span>
         <input
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
+          aria-label="Toggle reduced motion"
         />
+      </label>
+      <div className="mt-4 border-t border-white/10 px-4 pt-4">
+        <Checklist />
       </div>
     </div>
   );

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -4,6 +4,7 @@ import { useSettings } from '../../hooks/useSettings';
 import VolumeControl from '../ui/VolumeControl';
 import NetworkIndicator from '../ui/NetworkIndicator';
 import BatteryIndicator from '../ui/BatteryIndicator';
+import { ChecklistStatusBadge } from '../common/Checklist';
 
 export default function Status() {
   const { allowNetwork } = useSettings();
@@ -47,6 +48,7 @@ export default function Status() {
       />
       <VolumeControl className="mx-1.5" />
       <BatteryIndicator className="mx-1.5" />
+      <ChecklistStatusBadge />
       <span className="mx-1">
         <SmallArrow angle="down" className=" status-symbol" />
       </span>


### PR DESCRIPTION
## Summary
- add an onboarding checklist provider with persistent tasks, event hooks, and confetti rewards
- surface the checklist inside quick settings and expose a status badge in the system tray
- dispatch verification events from the Files and Nmap demos and migrate _app to TypeScript to host the provider

## Testing
- yarn lint
- yarn test onboardingChecklist --runTestsByPath __tests__/onboardingChecklist.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68dc6242858883289a76754a4a284312