### PR TITLE
[a11y] Add DocsViewer help link integration

### DIFF
--- a/__tests__/HelpLink.test.tsx
+++ b/__tests__/HelpLink.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import HelpLink from '../components/common/HelpLink';
+import DocsViewer from '../components/common/DocsViewer';
+import {
+  __TEST__,
+  DOCS_HASH_PREFIX,
+  openDocAnchor,
+  registerDocAnchor,
+} from '../components/common/docsRegistry';
+
+describe('HelpLink', () => {
+  beforeEach(() => {
+    __TEST__.reset();
+    window.location.hash = '';
+  });
+
+  it('derives accessible name from registered anchors', () => {
+    registerDocAnchor({
+      id: 'settings.theme',
+      title: 'Theme preferences',
+      description: 'Walkthrough for configuring accent colours.',
+      srHint: 'Opens Docs Viewer showing Theme preferences section.',
+    });
+
+    render(<HelpLink anchor="settings.theme" />);
+
+    expect(
+      screen.getByRole('link', {
+        name: /learn about theme preferences/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back gracefully when anchor metadata is missing', async () => {
+    const user = userEvent.setup();
+    render(<HelpLink anchor="missing-anchor" />);
+
+    const link = screen.getByRole('link', {
+      name: /open documentation viewer/i,
+    });
+    await user.click(link);
+    expect(window.location.hash).toBe(`${DOCS_HASH_PREFIX}missing-anchor`);
+  });
+
+  it('activates DocsViewer via hash navigation', async () => {
+    registerDocAnchor({
+      id: 'settings/theme',
+      title: 'Theme and appearance',
+      description: 'Covers wallpapers, density, and accessibility.',
+      content: () => (
+        <div>
+          <p>Theme quick start</p>
+        </div>
+      ),
+    });
+
+    const user = userEvent.setup();
+
+    render(
+      <div>
+        <HelpLink anchor="settings/theme" />
+        <DocsViewer />
+      </div>,
+    );
+
+    await user.click(
+      screen.getByRole('link', {
+        name: /theme and appearance/i,
+      }),
+    );
+
+    expect(window.location.hash).toBe(`${DOCS_HASH_PREFIX}${encodeURIComponent('settings/theme')}`);
+    expect(
+      await screen.findByRole('heading', { name: 'Theme and appearance' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Theme quick start')).toBeInTheDocument();
+  });
+
+  it('supports keyboard activation with the Space key', async () => {
+    registerDocAnchor({
+      id: 'settings.fonts',
+      title: 'Icon and font scaling',
+    });
+
+    const user = userEvent.setup();
+
+    render(
+      <div>
+        <HelpLink anchor="settings.fonts" />
+        <DocsViewer />
+      </div>,
+    );
+
+    const link = screen.getByRole('link', {
+      name: /icon and font scaling/i,
+    });
+
+    link.focus();
+    await user.keyboard('{Space}');
+
+    expect(window.location.hash).toBe(`${DOCS_HASH_PREFIX}settings.fonts`);
+    expect(
+      await screen.findByRole('heading', { name: 'Icon and font scaling' }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('docsRegistry helpers', () => {
+  beforeEach(() => {
+    __TEST__.reset();
+    window.location.hash = '';
+  });
+
+  it('openDocAnchor updates the hash and emits events', () => {
+    const listener = jest.fn();
+    window.addEventListener('hashchange', listener);
+
+    registerDocAnchor({
+      id: 'networking.vlan',
+      title: 'VLAN discovery',
+    });
+
+    const result = openDocAnchor('networking.vlan');
+
+    expect(result).toBe(`${DOCS_HASH_PREFIX}networking.vlan`);
+    expect(window.location.hash).toBe(`${DOCS_HASH_PREFIX}networking.vlan`);
+    expect(listener).toHaveBeenCalled();
+
+    window.removeEventListener('hashchange', listener);
+  });
+});
+

--- a/components/common/DocsViewer.tsx
+++ b/components/common/DocsViewer.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import clsx from 'clsx';
+
+import {
+  DOCS_HASH_PREFIX,
+  getDocAnchorByTarget,
+  resolveDocTarget,
+  subscribeDocAnchors,
+  type DocAnchorEntry,
+} from './docsRegistry';
+
+const parseDocsHash = (hash: string): string | null => {
+  if (!hash || !hash.startsWith(DOCS_HASH_PREFIX)) return null;
+  const encoded = hash.slice(DOCS_HASH_PREFIX.length);
+  if (!encoded) return null;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return encoded;
+  }
+};
+
+const useCurrentAnchor = () => {
+  const [target, setTarget] = useState<string | null>(() =>
+    typeof window === 'undefined' ? null : parseDocsHash(window.location.hash),
+  );
+  const [registryVersion, setRegistryVersion] = useState(0);
+
+  useEffect(() => {
+    const unsubscribe = subscribeDocAnchors(() =>
+      setRegistryVersion(v => v + 1),
+    );
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handle = () => {
+      setTarget(parseDocsHash(window.location.hash));
+    };
+    handle();
+    window.addEventListener('hashchange', handle);
+    return () => window.removeEventListener('hashchange', handle);
+  }, []);
+
+  return useMemo(() => {
+    if (!target) return null;
+    const entry = getDocAnchorByTarget(target) ?? resolveDocTarget(target);
+    return entry ?? null;
+  }, [target, registryVersion]);
+};
+
+interface DocsViewerProps {
+  className?: string;
+  /** Content rendered when no anchor is active. */
+  emptyState?: React.ReactNode;
+}
+
+const renderContent = (anchor: DocAnchorEntry | null) => {
+  if (!anchor) return null;
+  if (typeof anchor.content === 'function') {
+    return anchor.content();
+  }
+  return anchor.content ?? null;
+};
+
+const DocsViewer: React.FC<DocsViewerProps> = ({ className, emptyState = null }) => {
+  const anchor = useCurrentAnchor();
+  const containerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!anchor) return;
+    const el = containerRef.current;
+    if (!el) return;
+    if (typeof el.focus === 'function') {
+      el.focus();
+    }
+  }, [anchor?.target]);
+
+  if (!anchor) return emptyState;
+
+  const description = anchor.description ?? `Showing documentation for ${anchor.title}.`;
+  const content = renderContent(anchor);
+
+  return (
+    <section
+      id="docs-viewer"
+      ref={node => {
+        containerRef.current = node;
+      }}
+      role="region"
+      tabIndex={-1}
+      aria-live="polite"
+      aria-label="Documentation viewer"
+      className={clsx('docs-viewer focus:outline-none', className)}
+      data-docs-target={anchor.target}
+    >
+      <h2 className="text-lg font-semibold text-white">{anchor.title}</h2>
+      <p className="mt-2 text-sm text-ubt-grey">{description}</p>
+      {content && <div className="mt-4 text-sm leading-relaxed text-white">{content}</div>}
+    </section>
+  );
+};
+
+export default DocsViewer;
+

--- a/components/common/HelpLink.tsx
+++ b/components/common/HelpLink.tsx
@@ -1,0 +1,97 @@
+import React, { useId } from 'react';
+import clsx from 'clsx';
+
+import {
+  getDocAnchor,
+  openDocAnchor,
+  resolveDocTarget,
+} from './docsRegistry';
+
+interface HelpLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  /**
+   * Identifier of the documentation anchor to open. Must match a registered
+   * anchor id.
+   */
+  anchor: string;
+  /**
+   * Visible label for the link. Defaults to “What’s this?”.
+   */
+  children?: React.ReactNode;
+}
+
+const DEFAULT_LABEL = "What's this?";
+
+const announceFor = (anchorId: string) => {
+  const entry = getDocAnchor(anchorId) ?? resolveDocTarget(anchorId);
+  if (!entry) {
+    return {
+      name: `${DEFAULT_LABEL} Open documentation viewer`,
+      hint: 'Opens documentation viewer in a side panel.',
+      target: anchorId,
+    };
+  }
+
+  const hint = entry.srHint ?? entry.description;
+  const name = `${DEFAULT_LABEL} Learn about ${entry.title} in Docs Viewer`;
+  return {
+    name,
+    hint:
+      hint ?? `Opens the Docs Viewer to ${entry.title}.`,
+    target: entry.target,
+  };
+};
+
+const HelpLink = React.forwardRef<HTMLAnchorElement, HelpLinkProps>(
+  ({ anchor, className, children, onClick, onKeyDown, ...props }, ref) => {
+    const srId = useId();
+    const { name, hint, target } = announceFor(anchor);
+
+    const follow = () => {
+      openDocAnchor(target);
+    };
+
+    const handleClick: React.MouseEventHandler<HTMLAnchorElement> = event => {
+      event.preventDefault();
+      follow();
+      onClick?.(event);
+    };
+
+    const handleKeyDown: React.KeyboardEventHandler<HTMLAnchorElement> = event => {
+      if (event.key === ' ' || event.key === 'Spacebar' || event.key === 'Space') {
+        event.preventDefault();
+        follow();
+      }
+      onKeyDown?.(event);
+    };
+
+    const href = `#docs/${encodeURIComponent(target)}`;
+
+    return (
+      <a
+        {...props}
+        ref={ref}
+        href={href}
+        data-docs-target={target}
+        className={clsx(
+          'ml-2 text-sm text-ubt-grey underline decoration-dotted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 hover:text-white',
+          className,
+        )}
+        aria-label={name}
+        aria-describedby={srId}
+        aria-controls="docs-viewer"
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+      >
+        {children ?? DEFAULT_LABEL}
+        <span id={srId} className="sr-only">
+          {hint}
+        </span>
+      </a>
+    );
+  },
+);
+
+HelpLink.displayName = 'HelpLink';
+
+export default HelpLink;
+

--- a/components/common/docsRegistry.ts
+++ b/components/common/docsRegistry.ts
@@ -1,0 +1,164 @@
+import type { ReactNode } from 'react';
+
+export interface DocAnchor {
+  /**
+   * Unique identifier used when rendering help links in the UI.
+   */
+  id: string;
+  /**
+   * Human readable title displayed within the documentation viewer.
+   */
+  title: string;
+  /**
+   * Optional description that is surfaced to assistive technology users and
+   * shown inside the DocsViewer panel.
+   */
+  description?: string;
+  /**
+   * Optional custom slug used for the hash fragment. Defaults to the id.
+   */
+  hash?: string;
+  /**
+    * Additional hint announced by screen readers when the help link gains
+    * focus. Falls back to `description` when omitted.
+    */
+  srHint?: string;
+  /**
+   * Arbitrary content rendered within the DocsViewer when this anchor is
+   * active. Accepts either a React node or a lazily evaluated function.
+   */
+  content?: ReactNode | (() => ReactNode);
+}
+
+export interface DocAnchorEntry extends DocAnchor {
+  /**
+   * Normalised target that is appended to the `#docs/` hash.
+   */
+  target: string;
+}
+
+const anchorsById = new Map<string, DocAnchorEntry>();
+const anchorsByTarget = new Map<string, DocAnchorEntry>();
+
+type RegistryListener = (anchors: DocAnchorEntry[]) => void;
+const listeners = new Set<RegistryListener>();
+
+export const DOCS_HASH_PREFIX = '#docs/';
+
+const toEntry = (input: DocAnchor): DocAnchorEntry => {
+  const id = input.id.trim();
+  if (!id) {
+    throw new Error('Doc anchor id is required.');
+  }
+
+  const trimmedHash = input.hash?.trim();
+  const target = trimmedHash && trimmedHash.length > 0 ? trimmedHash : id;
+
+  return {
+    ...input,
+    id,
+    target,
+  };
+};
+
+const snapshot = (): DocAnchorEntry[] => Array.from(anchorsById.values());
+
+const notify = () => {
+  const anchors = snapshot();
+  listeners.forEach(listener => {
+    try {
+      listener(anchors);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Docs registry listener failed', error);
+    }
+  });
+};
+
+export const registerDocAnchor = (anchor: DocAnchor): (() => void) => {
+  const entry = toEntry(anchor);
+
+  anchorsById.set(entry.id, entry);
+  anchorsByTarget.set(entry.target, entry);
+
+  notify();
+
+  return () => {
+    const current = anchorsById.get(entry.id);
+    if (!current || current.target !== entry.target) return;
+
+    anchorsById.delete(entry.id);
+    anchorsByTarget.delete(entry.target);
+    notify();
+  };
+};
+
+export const unregisterDocAnchor = (id: string) => {
+  const entry = anchorsById.get(id);
+  if (!entry) return;
+
+  anchorsById.delete(id);
+  anchorsByTarget.delete(entry.target);
+  notify();
+};
+
+export const getDocAnchor = (id: string): DocAnchorEntry | null =>
+  anchorsById.get(id) ?? null;
+
+export const getDocAnchorByTarget = (target: string): DocAnchorEntry | null =>
+  anchorsByTarget.get(target) ?? null;
+
+export const listDocAnchors = (): DocAnchorEntry[] => snapshot();
+
+export const subscribeDocAnchors = (listener: RegistryListener): (() => void) => {
+  listeners.add(listener);
+  listener(snapshot());
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const dispatchHashChange = () => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+  } catch {
+    const event = document.createEvent('HTMLEvents');
+    event.initEvent('hashchange', true, true);
+    window.dispatchEvent(event);
+  }
+};
+
+const buildDocsHash = (target: string) =>
+  `${DOCS_HASH_PREFIX}${encodeURIComponent(target)}`;
+
+export const resolveDocTarget = (idOrTarget: string): DocAnchorEntry | null => {
+  const byId = anchorsById.get(idOrTarget);
+  if (byId) return byId;
+  const decoded = decodeURIComponent(idOrTarget);
+  return anchorsByTarget.get(decoded) ?? null;
+};
+
+export const openDocAnchor = (idOrTarget: string): string => {
+  const entry = resolveDocTarget(idOrTarget);
+  const target = entry?.target ?? idOrTarget;
+  const hash = buildDocsHash(target);
+
+  if (typeof window !== 'undefined') {
+    if (window.location.hash !== hash) {
+      window.location.hash = hash;
+    }
+    dispatchHashChange();
+  }
+
+  return hash;
+};
+
+export const __TEST__ = {
+  reset: () => {
+    anchorsById.clear();
+    anchorsByTarget.clear();
+    listeners.clear();
+  },
+};
+


### PR DESCRIPTION
## Summary
- add a shared docs anchor registry that supports hash navigation and viewer updates
- introduce an accessible HelpLink component that opens DocsViewer sections with screen reader hints
- implement a lightweight DocsViewer panel and unit tests covering keyboard activation and registry hooks

## Testing
- [x] yarn test -- HelpLink.test.tsx

## Flags
- None

------
https://chatgpt.com/codex/tasks/task_e_68dc62474b58832887958ae071b028af