### PR TITLE
[components] add external docs confirmation link

### DIFF
--- a/__tests__/externalDocsLink.test.tsx
+++ b/__tests__/externalDocsLink.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ExternalDocsLink from '../components/common/ExternalDocsLink';
+
+const STORAGE_KEY = 'external-docs:preferences';
+
+describe('ExternalDocsLink', () => {
+  let openSpy: jest.SpyInstance<Window | null, [url?: string | URL | undefined, target?: string | undefined, features?: string | undefined]>;
+  let root: HTMLDivElement;
+
+  beforeEach(() => {
+    openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    localStorage.clear();
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    root.setAttribute('id', '__next');
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+    root.remove();
+  });
+
+  it('stores a domain preference when remembering the choice and bypasses the dialog afterwards', () => {
+    const { getByRole } = render(
+      <ExternalDocsLink href="https://example.com/docs">External docs</ExternalDocsLink>,
+      { container: root }
+    );
+
+    const link = getByRole('link', { name: 'External docs' });
+    fireEvent.click(link);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    const rememberToggle = screen.getByLabelText('Remember my choice');
+    fireEvent.click(rememberToggle);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open link' }));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const openedUrl = openSpy.mock.calls[0][0] as string;
+    expect(openedUrl).toContain('https://example.com/docs');
+    expect(openedUrl).toContain('utm_source=');
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+    expect(stored.domain['example.com']).toBe(true);
+
+    openSpy.mockClear();
+    fireEvent.click(link);
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('allows remembering a single URL and skips confirmation for subsequent visits', () => {
+    const href = 'https://docs.example.com/path?view=full';
+    const { getByRole } = render(
+      <ExternalDocsLink href={href}>Docs only</ExternalDocsLink>,
+      { container: root }
+    );
+
+    const link = getByRole('link', { name: 'Docs only' });
+    fireEvent.click(link);
+
+    const rememberToggle = screen.getByLabelText('Remember my choice');
+    fireEvent.click(rememberToggle);
+
+    const linkScope = screen.getByLabelText('Remember for this exact link');
+    fireEvent.click(linkScope);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open link' }));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const openedUrl = openSpy.mock.calls[0][0] as string;
+    expect(openedUrl).toContain('utm_campaign=');
+    expect(openedUrl).toContain('view=full');
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+    expect(stored.url[href]).toBe(true);
+    expect(stored.domain).toEqual({});
+
+    openSpy.mockClear();
+    fireEvent.click(link);
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -11,6 +11,14 @@ interface ModalProps {
      * Defaults to the Next.js root (`__next`).
      */
     overlayRoot?: string | HTMLElement;
+    /**
+     * ID of the element that labels the dialog. Useful for a11y.
+     */
+    ariaLabelledby?: string;
+    /**
+     * ID of the element that describes the dialog contents.
+     */
+    ariaDescribedby?: string;
 }
 
 const FOCUSABLE_SELECTORS = [
@@ -27,7 +35,14 @@ const FOCUSABLE_SELECTORS = [
     '[contenteditable]'
 ].join(',');
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot }) => {
+const Modal: React.FC<ModalProps> = ({
+    isOpen,
+    onClose,
+    children,
+    overlayRoot,
+    ariaLabelledby,
+    ariaDescribedby
+}) => {
     const modalRef = useRef<HTMLDivElement>(null);
     const triggerRef = useRef<HTMLElement | null>(null);
     const portalRef = useRef<HTMLDivElement | null>(null);
@@ -113,6 +128,8 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
         <div
             role="dialog"
             aria-modal="true"
+            aria-labelledby={ariaLabelledby}
+            aria-describedby={ariaDescribedby}
             ref={modalRef}
             onKeyDown={handleKeyDown}
             tabIndex={-1}

--- a/components/common/ExternalDocsLink.tsx
+++ b/components/common/ExternalDocsLink.tsx
@@ -1,0 +1,359 @@
+import React, {
+    AnchorHTMLAttributes,
+    forwardRef,
+    MouseEvent,
+    useCallback,
+    useId,
+    useMemo,
+    useState
+} from 'react';
+import Modal from '../base/Modal';
+
+type PreferenceScope = 'domain' | 'url';
+
+type PreferenceStore = {
+    domain: Record<string, boolean>;
+    url: Record<string, boolean>;
+};
+
+type UTMKeys =
+    | 'utm_source'
+    | 'utm_medium'
+    | 'utm_campaign'
+    | 'utm_content'
+    | 'utm_term';
+
+type UTMParams = Partial<Record<UTMKeys, string>>;
+
+interface ExternalDocsLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+    href: string;
+    /**
+     * Optional overrides for the tracking parameters appended to outbound links.
+     */
+    utmParams?: UTMParams;
+    /**
+     * Custom title displayed at the top of the confirmation dialog.
+     */
+    confirmTitle?: string;
+    /**
+     * Custom body copy for the confirmation dialog.
+     */
+    confirmBody?: string;
+    /**
+     * Initial preference scope when the remember toggle is activated.
+     */
+    defaultRememberScope?: PreferenceScope;
+}
+
+const STORAGE_KEY = 'external-docs:preferences';
+
+const DEFAULT_UTM: Record<UTMKeys, string> = {
+    utm_source: 'kali-portfolio',
+    utm_medium: 'external-link',
+    utm_campaign: 'documentation',
+    utm_content: 'external-link',
+    utm_term: 'navigation'
+};
+
+function createEmptyStore(): PreferenceStore {
+    return { domain: {}, url: {} };
+}
+
+function readStore(): PreferenceStore {
+    if (typeof window === 'undefined') {
+        return createEmptyStore();
+    }
+    try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (!raw) {
+            return createEmptyStore();
+        }
+        const parsed = JSON.parse(raw) as PreferenceStore;
+        return {
+            domain: parsed?.domain ? { ...parsed.domain } : {},
+            url: parsed?.url ? { ...parsed.url } : {}
+        };
+    } catch (error) {
+        console.warn('Failed to read external link preferences', error);
+        return createEmptyStore();
+    }
+}
+
+function writeStore(store: PreferenceStore): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+    try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+    } catch (error) {
+        console.warn('Failed to persist external link preference', error);
+    }
+}
+
+function markTrusted(scope: PreferenceScope, url: URL): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+    const store = readStore();
+    if (scope === 'domain') {
+        store.domain[url.host] = true;
+    } else {
+        store.url[url.href] = true;
+    }
+    writeStore(store);
+}
+
+function hasTrusted(url: URL): boolean {
+    if (typeof window === 'undefined') {
+        return false;
+    }
+    const store = readStore();
+    return Boolean(store.url[url.href] || store.domain[url.host]);
+}
+
+function isHttpUrl(url: URL): boolean {
+    return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
+function isExternal(url: URL): boolean {
+    if (!isHttpUrl(url)) {
+        return false;
+    }
+    if (typeof window === 'undefined') {
+        return true;
+    }
+    try {
+        return url.origin !== window.location.origin;
+    } catch {
+        return true;
+    }
+}
+
+function applyTrackingParams(url: URL, overrides?: UTMParams): string {
+    if (!isHttpUrl(url)) {
+        return url.toString();
+    }
+    const tracked = new URL(url.toString());
+    const params: Partial<Record<UTMKeys, string>> = { ...DEFAULT_UTM, ...overrides };
+    (Object.entries(params) as [UTMKeys, string | undefined][]).forEach(([key, value]) => {
+        if (!value) return;
+        tracked.searchParams.set(key, value);
+    });
+    return tracked.toString();
+}
+
+function mergeRel(rel?: string): string {
+    const required = ['noopener', 'noreferrer'];
+    const parts = new Set<string>();
+    if (rel) {
+        rel
+            .split(/\s+/)
+            .filter(Boolean)
+            .forEach((part) => parts.add(part));
+    }
+    required.forEach((item) => parts.add(item));
+    return Array.from(parts).join(' ');
+}
+
+const ExternalDocsLink = forwardRef<HTMLAnchorElement, ExternalDocsLinkProps>(
+    (
+        {
+            children,
+            href,
+            utmParams,
+            confirmTitle = 'Open external link?',
+            confirmBody,
+            defaultRememberScope = 'domain',
+            onClick,
+            rel,
+            target,
+            ...rest
+        },
+        ref
+    ) => {
+        const [dialogOpen, setDialogOpen] = useState(false);
+        const [pendingUrl, setPendingUrl] = useState<URL | null>(null);
+        const [rememberChoice, setRememberChoice] = useState(false);
+        const [rememberScope, setRememberScope] = useState<PreferenceScope>(defaultRememberScope);
+
+        const headingId = useId();
+        const descriptionId = useId();
+
+        const relValue = useMemo(() => mergeRel(rel), [rel]);
+        const targetValue = target ?? '_blank';
+        const scopeGroupName = useMemo(() => `${headingId}-scope`, [headingId]);
+        const rememberId = useMemo(() => `${headingId}-remember`, [headingId]);
+        const domainId = useMemo(() => `${headingId}-domain`, [headingId]);
+        const urlId = useMemo(() => `${headingId}-url`, [headingId]);
+
+        const domainLabel = useMemo(() => {
+            if (!pendingUrl) {
+                return '';
+            }
+            return pendingUrl.host;
+        }, [pendingUrl]);
+
+        const closeDialog = useCallback(() => {
+            setDialogOpen(false);
+            setPendingUrl(null);
+            setRememberChoice(false);
+            setRememberScope(defaultRememberScope);
+        }, [defaultRememberScope]);
+
+        const proceedToLink = useCallback(
+            (url: URL) => {
+                const destination = applyTrackingParams(url, utmParams);
+                window.open(destination, '_blank', 'noopener,noreferrer');
+            },
+            [utmParams]
+        );
+
+        const handleConfirm = useCallback(() => {
+            if (!pendingUrl) return;
+            if (rememberChoice) {
+                markTrusted(rememberScope, pendingUrl);
+            }
+            proceedToLink(pendingUrl);
+            closeDialog();
+        }, [pendingUrl, rememberChoice, rememberScope, proceedToLink, closeDialog]);
+
+        const handleCancel = useCallback(() => {
+            closeDialog();
+        }, [closeDialog]);
+
+        const handleInteraction = useCallback(
+            (event: MouseEvent<HTMLAnchorElement>) => {
+                onClick?.(event);
+                if (event.defaultPrevented) {
+                    return;
+                }
+                if (!href) {
+                    return;
+                }
+                if (typeof window === 'undefined') {
+                    return;
+                }
+                let url: URL;
+                try {
+                    url = new URL(href, window.location.href);
+                } catch {
+                    return;
+                }
+                if (!isExternal(url)) {
+                    return;
+                }
+                event.preventDefault();
+                if (hasTrusted(url)) {
+                    proceedToLink(url);
+                    return;
+                }
+                setPendingUrl(url);
+                setDialogOpen(true);
+            },
+            [href, onClick, proceedToLink]
+        );
+
+        const bodyText = useMemo(() => {
+            if (confirmBody) return confirmBody;
+            if (!pendingUrl) return 'This link will open in a new tab.';
+            return `You're about to open ${pendingUrl.host} in a new tab.`;
+        }, [confirmBody, pendingUrl]);
+
+        return (
+            <>
+                <a
+                    {...rest}
+                    href={href}
+                    ref={ref}
+                    rel={relValue}
+                    target={targetValue}
+                    onClick={handleInteraction}
+                >
+                    {children}
+                </a>
+                <Modal
+                    isOpen={dialogOpen}
+                    onClose={handleCancel}
+                    ariaLabelledby={headingId}
+                    ariaDescribedby={descriptionId}
+                >
+                    <div className="fixed inset-0 z-[1000] flex items-center justify-center">
+                        <div className="absolute inset-0 bg-black/60" aria-hidden="true" />
+                        <div className="relative z-10 w-full max-w-md rounded-lg bg-ubt-bg px-6 py-5 shadow-xl focus:outline-none">
+                            <h2 id={headingId} className="text-lg font-semibold text-ubt-off-white">
+                                {confirmTitle}
+                            </h2>
+                            <p id={descriptionId} className="mt-2 text-sm text-ubt-text">
+                                {bodyText}
+                            </p>
+                            <div className="mt-4 flex items-center gap-2 text-sm text-ubt-text">
+                                <input
+                                    id={rememberId}
+                                    type="checkbox"
+                                    className="h-4 w-4 accent-ub-orange"
+                                    checked={rememberChoice}
+                                    onChange={(event) => setRememberChoice(event.target.checked)}
+                                    aria-label="Remember my choice"
+                                />
+                                <label htmlFor={rememberId}>Remember my choice</label>
+                            </div>
+                            {rememberChoice ? (
+                                <fieldset className="mt-3 space-y-2 text-sm text-ubt-text">
+                                    <legend className="sr-only">Remember preference scope</legend>
+                                    <div className="flex items-center gap-2">
+                                        <input
+                                            id={domainId}
+                                            type="radio"
+                                            name={scopeGroupName}
+                                            value="domain"
+                                            checked={rememberScope === 'domain'}
+                                            onChange={() => setRememberScope('domain')}
+                                            className="h-4 w-4 accent-ub-orange"
+                                            aria-label="Remember for this domain"
+                                        />
+                                        <label htmlFor={domainId}>
+                                            Remember for this domain {domainLabel && `(${domainLabel})`}
+                                        </label>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <input
+                                            id={urlId}
+                                            type="radio"
+                                            name={scopeGroupName}
+                                            value="url"
+                                            checked={rememberScope === 'url'}
+                                            onChange={() => setRememberScope('url')}
+                                            className="h-4 w-4 accent-ub-orange"
+                                            aria-label="Remember for this exact link"
+                                        />
+                                        <label htmlFor={urlId}>Remember for this exact link</label>
+                                    </div>
+                                </fieldset>
+                            ) : null}
+                            <div className="mt-6 flex justify-end gap-3">
+                                <button
+                                    type="button"
+                                    className="rounded-md border border-ubt-cool-grey px-4 py-2 text-sm text-ubt-off-white transition hover:bg-ubt-cool-grey/30 focus:outline-none focus:ring-2 focus:ring-ub-orange"
+                                    onClick={handleCancel}
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    type="button"
+                                    className="rounded-md bg-ub-orange px-4 py-2 text-sm font-semibold text-black transition hover:bg-ub-orange/90 focus:outline-none focus:ring-2 focus:ring-ub-orange"
+                                    onClick={handleConfirm}
+                                >
+                                    Open link
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </Modal>
+            </>
+        );
+    }
+);
+
+ExternalDocsLink.displayName = 'ExternalDocsLink';
+
+export default ExternalDocsLink;


### PR DESCRIPTION
## Summary
- add an ExternalDocsLink component that confirms navigation, appends UTM parameters, and lets users remember trust per domain or per link
- extend the shared modal to expose aria-labelledby/aria-describedby hooks for accessible dialogs
- add unit tests to cover stored preferences and bypass logic for trusted external links

## Testing
- yarn lint
- yarn test externalDocsLink

------
https://chatgpt.com/codex/tasks/task_e_68dc624c5b608328a2f68c5a607744ba