### PR TITLE
[docs] Add anchored headings to docs viewer

### DIFF
--- a/__tests__/DocsRenderer.test.tsx
+++ b/__tests__/DocsRenderer.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import DocsRenderer from "@/components/apps/docs/DocsRenderer";
+
+describe("DocsRenderer", () => {
+  test("generates unique slugified anchors and exposes copy controls", async () => {
+    const onAnchorClick = jest.fn();
+    const onAnchorsRendered = jest.fn();
+
+    const html = `
+      <h2>Getting Started</h2>
+      <h2>Getting Started</h2>
+      <h3>Ümlaut & Stuff!</h3>
+    `;
+
+    render(
+      <DocsRenderer
+        html={html}
+        onAnchorClick={onAnchorClick}
+        onAnchorsRendered={onAnchorsRendered}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button", { name: /copy link to/i })
+      ).toHaveLength(3);
+    });
+
+    const headings = Array.from(
+      document.querySelectorAll<HTMLHeadingElement>("h2, h3")
+    );
+
+    expect(headings[0].id).toBe("getting-started");
+    expect(headings[1].id).toBe("getting-started-2");
+    expect(headings[2].id).toBe("umlaut-stuff");
+
+    const anchors = screen.getAllByRole("button", {
+      name: /copy link to/i,
+    });
+
+    expect(anchors[0]).toHaveAttribute("data-docs-anchor", "getting-started");
+
+    const user = userEvent.setup();
+    await user.click(anchors[0]);
+    expect(onAnchorClick).toHaveBeenCalledWith("getting-started");
+
+    expect(onAnchorsRendered).toHaveBeenCalledWith([
+      "getting-started",
+      "getting-started-2",
+      "umlaut-stuff",
+    ]);
+  });
+});

--- a/__tests__/DocsViewer.test.tsx
+++ b/__tests__/DocsViewer.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("marked", () => ({
+  marked: {
+    parse: (markdown: string) =>
+      markdown
+        .split(/\n{2,}/)
+        .map((block) => {
+          const match = block.trim().match(/^(#{1,6})\s+(.*)$/);
+          if (match) {
+            const level = match[1].length;
+            const text = match[2].trim();
+            return `<h${level}>${text}</h${level}>`;
+          }
+          const trimmed = block.trim();
+          return trimmed ? `<p>${trimmed}</p>` : "";
+        })
+        .join(""),
+  },
+}));
+
+import DocsViewer from "@/components/apps/docs/DocsViewer";
+
+describe("DocsViewer", () => {
+  const originalScrollIntoView = Element.prototype.scrollIntoView;
+  const originalClipboard = Object.getOwnPropertyDescriptor(
+    navigator,
+    "clipboard"
+  );
+  let scrollMock: jest.Mock;
+  let clipboardWriteMock: jest.Mock;
+
+  beforeEach(() => {
+    scrollMock = jest.fn();
+    Element.prototype.scrollIntoView = scrollMock;
+    window.location.hash = "";
+
+    clipboardWriteMock = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: clipboardWriteMock,
+      },
+    });
+  });
+
+  afterEach(() => {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      delete (navigator as Navigator & { clipboard?: Clipboard }).clipboard;
+    }
+    window.location.hash = "";
+  });
+
+  test("scrolls to an anchor when the initial hash is present", async () => {
+    window.location.hash = "#initial-section";
+
+    render(<DocsViewer markdown="## Initial Section" />);
+
+    await waitFor(() => {
+      expect(scrollMock).toHaveBeenCalled();
+    });
+
+    expect(scrollMock.mock.calls[0][0]).toEqual({ behavior: "smooth", block: "start" });
+  });
+
+  test("copies the heading link, updates the hash, and scrolls on icon click", async () => {
+    const replaceStateSpy = jest.spyOn(window.history, "replaceState");
+
+    render(<DocsViewer markdown="## Copy Target" />);
+
+    const control = await screen.findByRole("button", {
+      name: "Copy link to Copy Target",
+    });
+
+    fireEvent.click(control);
+
+    await waitFor(() => {
+      expect(replaceStateSpy).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(window.location.hash).toBe("#copy-target");
+    });
+
+    await waitFor(() => {
+      expect(clipboardWriteMock).toHaveBeenCalled();
+    });
+
+    expect(clipboardWriteMock).toHaveBeenCalledWith(
+      "http://localhost/#copy-target"
+    );
+    expect(window.location.hash).toBe("#copy-target");
+    expect(scrollMock).toHaveBeenCalled();
+
+    replaceStateSpy.mockRestore();
+  });
+});

--- a/components/apps/docs/DocsRenderer.tsx
+++ b/components/apps/docs/DocsRenderer.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const COPY_ICON_SVG =
+  '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" class="h-4 w-4" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M3 5a2 2 0 0 1 2-2h7a1 1 0 1 1 0 2H5v12h7a1 1 0 1 1 0 2H5a2 2 0 0 1-2-2zm7-1a2 2 0 0 1 2-2h7a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2h-7a2 2 0 0 1-2-2zm2 0v12h7V4z"/></svg>';
+
+const slugify = (value: string) => {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+};
+
+const FALLBACK_SLUG = "section";
+
+export interface DocsRendererProps {
+  html: string;
+  onAnchorClick?: (slug: string) => void;
+  onAnchorsRendered?: (slugs: string[]) => void;
+}
+
+export default function DocsRenderer({
+  html,
+  onAnchorClick,
+  onAnchorsRendered,
+}: DocsRendererProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const cleanupHandlers: Array<() => void> = [];
+    const slugCounts = new Map<string, number>();
+    const renderedAnchors: string[] = [];
+
+    const headings = Array.from(
+      container.querySelectorAll<HTMLElement>("h1, h2, h3, h4, h5, h6")
+    );
+
+    headings.forEach((heading) => {
+      const existingButton = heading.querySelector<HTMLButtonElement>(
+        "button[data-docs-anchor]"
+      );
+      if (existingButton) {
+        existingButton.remove();
+      }
+
+      const textContent = heading.textContent?.trim() ?? "";
+      if (!textContent) {
+        return;
+      }
+
+      const baseSlug = slugify(textContent) || FALLBACK_SLUG;
+      const duplicateCount = slugCounts.get(baseSlug) ?? 0;
+      const slug = duplicateCount === 0 ? baseSlug : `${baseSlug}-${duplicateCount + 1}`;
+      slugCounts.set(baseSlug, duplicateCount + 1);
+      heading.id = slug;
+      heading.classList.add("group", "relative");
+      renderedAnchors.push(slug);
+
+      const button = document.createElement("button");
+      button.type = "button";
+      button.setAttribute("data-docs-anchor", slug);
+      button.setAttribute("aria-label", `Copy link to ${textContent}`);
+      button.setAttribute(
+        "class",
+        "ml-2 inline-flex items-center rounded p-1 text-slate-400 transition-opacity focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-slate-900 group-hover:opacity-100 hover:text-slate-200 opacity-0 focus:opacity-100"
+      );
+      button.innerHTML = COPY_ICON_SVG;
+
+      const handleClick = (event: MouseEvent) => {
+        event.preventDefault();
+        event.stopPropagation();
+        onAnchorClick?.(slug);
+      };
+
+      button.addEventListener("click", handleClick);
+      cleanupHandlers.push(() => {
+        button.removeEventListener("click", handleClick);
+      });
+
+      heading.appendChild(button);
+    });
+
+    onAnchorsRendered?.(renderedAnchors);
+
+    return () => {
+      cleanupHandlers.forEach((cleanup) => cleanup());
+    };
+  }, [html, onAnchorClick, onAnchorsRendered]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="docs-renderer prose prose-invert max-w-none"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/components/apps/docs/DocsViewer.tsx
+++ b/components/apps/docs/DocsViewer.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useCallback, useEffect, useMemo } from "react";
+import DOMPurify from "dompurify";
+import { marked } from "marked";
+
+import DocsRenderer from "./DocsRenderer";
+
+interface DocsViewerProps {
+  markdown: string;
+  className?: string;
+}
+
+const fallbackCopy = (value: string) => {
+  if (typeof document === "undefined") return;
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "absolute";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    if (typeof document.execCommand === "function") {
+      document.execCommand("copy");
+    }
+  } catch (error) {
+    // Ignore failures; clipboard access is best-effort.
+  } finally {
+    document.body.removeChild(textarea);
+  }
+};
+
+const buildUrlWithHash = (slug: string) => {
+  if (typeof window === "undefined") {
+    return `#${slug}`;
+  }
+  return `${window.location.origin}${window.location.pathname}#${slug}`;
+};
+
+const scrollToAnchor = (target: string) => {
+  if (typeof document === "undefined") return;
+  const id = target.startsWith("#") ? target.slice(1) : target;
+  if (!id) return;
+  const element = document.getElementById(id);
+  if (element) {
+    element.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+};
+
+export default function DocsViewer({ markdown, className }: DocsViewerProps) {
+  const html = useMemo(() => {
+    const parsed = marked.parse(markdown) as string;
+    return DOMPurify.sanitize(parsed);
+  }, [markdown]);
+
+  const handleAnchorClick = useCallback((slug: string) => {
+    const url = buildUrlWithHash(slug);
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(url).catch(() => fallbackCopy(url));
+    } else {
+      fallbackCopy(url);
+    }
+
+    if (typeof window !== "undefined") {
+      const hashValue = `#${slug}`;
+      if (typeof history !== "undefined") {
+        try {
+          history.replaceState(null, "", `${window.location.pathname}${hashValue}`);
+        } catch (error) {
+          window.location.hash = hashValue;
+        }
+      } else {
+        window.location.hash = hashValue;
+      }
+
+      if (window.location.hash !== hashValue) {
+        window.location.hash = hashValue;
+      }
+    }
+
+    scrollToAnchor(slug);
+  }, []);
+
+  const handleAnchorsRendered = useCallback((slugs: string[]) => {
+    if (typeof window === "undefined") return;
+    const currentHash = window.location.hash.slice(1);
+    if (!currentHash) return;
+    if (slugs.includes(currentHash)) {
+      scrollToAnchor(currentHash);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onHashChange = () => {
+      if (window.location.hash) {
+        scrollToAnchor(window.location.hash);
+      }
+    };
+    window.addEventListener("hashchange", onHashChange);
+    return () => {
+      window.removeEventListener("hashchange", onHashChange);
+    };
+  }, []);
+
+  return (
+    <div className={`docs-viewer overflow-y-auto p-4 ${className ?? ""}`.trim()}>
+      <DocsRenderer
+        html={html}
+        onAnchorClick={handleAnchorClick}
+        onAnchorsRendered={handleAnchorsRendered}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a docs renderer that injects slugged heading anchors with hover copy buttons
- scroll the docs viewer to hashed headings and copy shareable URLs
- add unit tests covering anchor generation and hash-based navigation

## Testing
- yarn test DocsViewer DocsRenderer

------
https://chatgpt.com/codex/tasks/task_e_68dc624ce5008328a02701169a2d8016