### PR TITLE
[settings] add language switcher with live i18n updates

### DIFF
--- a/__tests__/languageSwitcher.test.tsx
+++ b/__tests__/languageSwitcher.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LanguageSwitcher from '../components/common/LanguageSwitcher';
+import { SettingsProvider } from '../hooks/useSettings';
+import { __resetForTests, useI18n } from '../hooks/useI18n';
+
+const TestConsumer = () => {
+  const { t } = useI18n();
+  return <div data-testid="locale-text">{t('settings.language.instructions')}</div>;
+};
+
+beforeEach(() => {
+  const store: Record<string, string> = {};
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => {
+        store[key] = String(value);
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        Object.keys(store).forEach((key) => delete store[key]);
+      },
+    } as Storage,
+  });
+  window.localStorage.clear();
+  __resetForTests();
+});
+
+test('changing the language updates translations and persists the selection', async () => {
+  const user = userEvent.setup();
+
+  render(
+    <SettingsProvider>
+      <LanguageSwitcher />
+      <TestConsumer />
+    </SettingsProvider>,
+  );
+
+  const localeText = await screen.findByTestId('locale-text');
+  expect(localeText).toHaveTextContent('Choose the language for your desktop.');
+
+  await waitFor(() => expect(window.localStorage.getItem('locale')).toBe('en'));
+  const spanishOption = screen.getByRole('radio', { name: /español/i });
+  await user.click(spanishOption);
+
+  await waitFor(() => expect(window.localStorage.getItem('locale')).toBe('es'));
+  await waitFor(() =>
+    expect(screen.getByTestId('locale-text')).toHaveTextContent(
+      'Elige el idioma de tu escritorio.',
+    ),
+  );
+  expect(window.localStorage.getItem('locale')).toBe('es');
+});
+
+test('stored locale is applied on mount without user interaction', async () => {
+  const user = userEvent.setup();
+
+  const { unmount } = render(
+    <SettingsProvider>
+      <LanguageSwitcher />
+      <TestConsumer />
+    </SettingsProvider>,
+  );
+
+  const frenchOption = await screen.findByRole('radio', { name: /français/i });
+  await user.click(frenchOption);
+
+  await waitFor(() => expect(window.localStorage.getItem('locale')).toBe('fr'));
+  await waitFor(() =>
+    expect(screen.getByTestId('locale-text')).toHaveTextContent(
+      'Choisissez la langue de votre bureau.',
+    ),
+  );
+
+  unmount();
+
+  render(
+    <SettingsProvider>
+      <TestConsumer />
+    </SettingsProvider>,
+  );
+
+  await waitFor(() =>
+    expect(screen.getByTestId('locale-text')).toHaveTextContent(
+      'Choisissez la langue de votre bureau.',
+    ),
+  );
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
@@ -13,6 +13,10 @@ import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
 import KaliWallpaper from "../../components/util-components/kali-wallpaper";
+import LanguageSwitcher from "../../components/common/LanguageSwitcher";
+import { useI18n } from "../../hooks/useI18n";
+
+type TabId = "appearance" | "accessibility" | "privacy";
 
 export default function Settings() {
   const {
@@ -35,14 +39,17 @@ export default function Settings() {
     theme,
     setTheme,
   } = useSettings();
+  const { t } = useI18n();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const tabs = [
-    { id: "appearance", label: "Appearance" },
-    { id: "accessibility", label: "Accessibility" },
-    { id: "privacy", label: "Privacy" },
-  ] as const;
-  type TabId = (typeof tabs)[number]["id"];
+  const tabs = useMemo(
+    () => [
+      { id: "appearance" as TabId, label: t("settings.tabs.appearance") },
+      { id: "accessibility" as TabId, label: t("settings.tabs.accessibility") },
+      { id: "privacy" as TabId, label: t("settings.tabs.privacy") },
+    ],
+    [t],
+  );
   const [activeTab, setActiveTab] = useState<TabId>("appearance");
 
   const wallpapers = [
@@ -140,6 +147,9 @@ export default function Settings() {
               <option value="matrix">Matrix</option>
             </select>
           </div>
+          <div className="my-6 flex justify-center px-6">
+            <LanguageSwitcher />
+          </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Accent:</label>
             <div aria-label="Accent color picker" role="radiogroup" className="flex gap-2">
@@ -163,6 +173,7 @@ export default function Settings() {
                 checked={useKaliWallpaper}
                 onChange={(e) => setUseKaliWallpaper(e.target.checked)}
                 className="mr-2"
+                aria-label="Use Kali gradient wallpaper"
               />
               Kali Gradient Wallpaper
             </label>

--- a/components/common/LanguageSwitcher.tsx
+++ b/components/common/LanguageSwitcher.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useMemo } from 'react';
+import { getLocaleLabel } from '../../utils/i18nConfig';
+import { useI18n } from '../../hooks/useI18n';
+import { useSettings } from '../../hooks/useSettings';
+
+const badgeClass =
+  'rounded-md bg-white/5 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide';
+
+const LanguageSwitcher = () => {
+  const { locale, setLocale } = useSettings();
+  const { detectedLocale, t, availableLocales } = useI18n();
+
+  const detectedLabel = useMemo(
+    () => getLocaleLabel(detectedLocale),
+    [detectedLocale],
+  );
+
+  return (
+    <fieldset className="w-full max-w-xl rounded-lg border border-[#1b2638] bg-[#0f1724]/60 p-4 text-ubt-grey shadow-lg">
+      <legend className="px-2 text-xs font-semibold uppercase tracking-[0.2em] text-ubt-green">
+        {t('settings.language.label')}
+      </legend>
+      <p className="text-sm text-ubt-grey/80">
+        {t('settings.language.instructions')}
+      </p>
+      <p className="mt-3 text-[11px] uppercase tracking-[0.2em] text-ubt-green/80">
+        {t('settings.language.detectedMessage', {
+          values: { locale: detectedLabel },
+        })}
+      </p>
+      <div
+        role="radiogroup"
+        aria-label={t('settings.language.ariaLabel')}
+        className="mt-4 grid gap-3 sm:grid-cols-2"
+      >
+        {availableLocales.map((item) => {
+          const isActive = item.code === locale;
+          const isDetected = item.code === detectedLocale;
+          return (
+            <label
+              key={item.code}
+              className={`flex cursor-pointer items-center justify-between rounded-lg border px-4 py-3 text-sm transition focus-within:outline-none focus-within:ring-2 focus-within:ring-ubt-green/70 ${
+                isActive
+                  ? 'border-ubt-green/70 bg-ubt-green/10'
+                  : 'border-white/10 bg-white/[0.03] hover:border-ubt-green/40'
+              }`}
+            >
+              <span className="flex flex-col text-white">
+                <span className="font-medium">{item.nativeLabel || item.label}</span>
+                {item.nativeLabel && item.nativeLabel !== item.label && (
+                  <span className="text-xs text-ubt-grey/70">{item.label}</span>
+                )}
+              </span>
+              <span className="flex items-center gap-2">
+                {isDetected && (
+                  <span className={`${badgeClass} text-ubt-green/80`}>
+                    {t('settings.language.detectedBadge')}
+                  </span>
+                )}
+                {isActive && (
+                  <span className={`${badgeClass} text-[#7db3ff]`}>
+                    {t('settings.language.currentBadge')}
+                  </span>
+                )}
+                <input
+                  type="radio"
+                  name="language"
+                  value={item.code}
+                  checked={isActive}
+                  onChange={() => setLocale(item.code)}
+                  className="h-4 w-4 accent-[#1793d1]"
+                  aria-label={t('settings.language.select', {
+                    values: { locale: item.nativeLabel || item.label },
+                  })}
+                />
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+};
+
+export default LanguageSwitcher;

--- a/data/i18n/messages.ts
+++ b/data/i18n/messages.ts
@@ -1,0 +1,61 @@
+export type MessageValue = string | MessageDictionary;
+export interface MessageDictionary {
+  [key: string]: MessageValue;
+}
+
+export const MESSAGES: Record<string, MessageDictionary> = {
+  en: {
+    settings: {
+      tabs: {
+        appearance: 'Appearance',
+        accessibility: 'Accessibility',
+        privacy: 'Privacy',
+      },
+      language: {
+        label: 'Language',
+        ariaLabel: 'Language selection',
+        instructions: 'Choose the language for your desktop.',
+        detectedBadge: 'Suggested',
+        currentBadge: 'Current',
+        detectedMessage: 'Suggested for you: {locale}',
+        select: 'Select {locale}',
+      },
+    },
+  },
+  es: {
+    settings: {
+      tabs: {
+        appearance: 'Apariencia',
+        accessibility: 'Accesibilidad',
+        privacy: 'Privacidad',
+      },
+      language: {
+        label: 'Idioma',
+        ariaLabel: 'Selección de idioma',
+        instructions: 'Elige el idioma de tu escritorio.',
+        detectedBadge: 'Sugerido',
+        currentBadge: 'Actual',
+        detectedMessage: 'Sugerido para ti: {locale}',
+        select: 'Selecciona {locale}',
+      },
+    },
+  },
+  fr: {
+    settings: {
+      tabs: {
+        appearance: 'Apparence',
+        accessibility: 'Accessibilité',
+        privacy: 'Confidentialité',
+      },
+      language: {
+        label: 'Langue',
+        ariaLabel: 'Sélection de la langue',
+        instructions: 'Choisissez la langue de votre bureau.',
+        detectedBadge: 'Suggéré',
+        currentBadge: 'Actuel',
+        detectedMessage: 'Suggéré pour vous : {locale}',
+        select: 'Sélectionner {locale}',
+      },
+    },
+  },
+};

--- a/hooks/useI18n.ts
+++ b/hooks/useI18n.ts
@@ -1,0 +1,167 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  AVAILABLE_LOCALES,
+  FALLBACK_LOCALE,
+  detectLocale,
+  matchLocale,
+} from '../utils/i18nConfig';
+import { publish, subscribe } from '../utils/pubsub';
+import { getLocale as loadLocale, setLocale as persistLocale } from '../utils/settingsStore';
+import { MESSAGES, MessageDictionary } from '../data/i18n/messages';
+
+const LOCALE_TOPIC = 'i18n:locale-change';
+
+export interface TranslateOptions {
+  fallback?: string;
+  values?: Record<string, string | number>;
+}
+
+interface I18nState {
+  locale: string;
+  detectedLocale: string;
+  messages: MessageDictionary;
+}
+
+const resolveMessages = (locale: string): MessageDictionary =>
+  MESSAGES[locale] ?? MESSAGES[FALLBACK_LOCALE] ?? {};
+
+let state: I18nState = {
+  locale: FALLBACK_LOCALE,
+  detectedLocale: detectLocale(),
+  messages: resolveMessages(FALLBACK_LOCALE),
+};
+
+let hydrated = false;
+
+function emit() {
+  publish(LOCALE_TOPIC, { ...state });
+}
+
+async function hydrateFromStorage() {
+  if (hydrated) return;
+  hydrated = true;
+  try {
+    const stored = await loadLocale();
+    const matched = matchLocale(stored);
+    state = {
+      ...state,
+      locale: matched,
+      messages: resolveMessages(matched),
+    };
+  } catch {
+    // ignore storage errors
+  }
+  emit();
+}
+
+export function setI18nLocale(
+  locale: string,
+  options: { persist?: boolean } = {},
+) {
+  const matched = matchLocale(locale);
+  if (matched === state.locale && options.persist !== false) {
+    // still persist to keep storage in sync but avoid duplicate emissions
+    persistLocale(matched);
+    return;
+  }
+  state = {
+    ...state,
+    locale: matched,
+    messages: resolveMessages(matched),
+  };
+  emit();
+  if (options.persist !== false) {
+    persistLocale(matched);
+  }
+}
+
+export function getCurrentLocale() {
+  return state.locale;
+}
+
+export function subscribeToLocaleChanges(cb: (next: I18nState) => void) {
+  const handler = (next: unknown) => {
+    if (typeof next === 'object' && next !== null) {
+      cb(next as I18nState);
+    }
+  };
+  return subscribe(LOCALE_TOPIC, handler);
+}
+
+const lookupMessage = (
+  key: string,
+  dictionary: MessageDictionary,
+): string | undefined =>
+  key.split('.').reduce<any>((acc, part) => {
+    if (acc && typeof acc === 'object') {
+      return acc[part];
+    }
+    return undefined;
+  }, dictionary) as string | undefined;
+
+const formatMessage = (
+  template: string,
+  values?: Record<string, string | number>,
+) => {
+  if (!values) return template;
+  return template.replace(/\{([^}]+)\}/g, (match, token) => {
+    const key = String(token).trim();
+    const value = values[key];
+    return value === undefined ? match : String(value);
+  });
+};
+
+export interface UseI18nValue {
+  locale: string;
+  detectedLocale: string;
+  availableLocales: typeof AVAILABLE_LOCALES;
+  t: (key: string, options?: TranslateOptions) => string;
+}
+
+export function useI18n(): UseI18nValue {
+  const [localState, setLocalState] = useState<I18nState>({ ...state });
+
+  useEffect(() => {
+    const unsubscribe = subscribe(LOCALE_TOPIC, (next) => {
+      if (typeof next === 'object' && next !== null) {
+        setLocalState(next as I18nState);
+      }
+    });
+    hydrateFromStorage().then(() => {
+      setLocalState({ ...state });
+    });
+    return unsubscribe;
+  }, []);
+
+  const t = useCallback(
+    (key: string, options: TranslateOptions = {}) => {
+      const raw = lookupMessage(key, localState.messages);
+      const fallback = options.fallback ?? key;
+      const template = typeof raw === 'string' ? raw : fallback;
+      return formatMessage(template, options.values);
+    },
+    [localState.messages],
+  );
+
+  return useMemo(
+    () => ({
+      locale: localState.locale,
+      detectedLocale: localState.detectedLocale,
+      availableLocales: AVAILABLE_LOCALES,
+      t,
+    }),
+    [localState.locale, localState.detectedLocale, t],
+  );
+}
+
+export function __resetForTests() {
+  hydrated = false;
+  state = {
+    locale: FALLBACK_LOCALE,
+    detectedLocale: detectLocale(),
+    messages: resolveMessages(FALLBACK_LOCALE),
+  };
+  emit();
+}

--- a/utils/i18nConfig.js
+++ b/utils/i18nConfig.js
@@ -1,0 +1,58 @@
+export const AVAILABLE_LOCALES = [
+  {
+    code: 'en',
+    label: 'English',
+    nativeLabel: 'English',
+  },
+  {
+    code: 'es',
+    label: 'Spanish',
+    nativeLabel: 'Español',
+  },
+  {
+    code: 'fr',
+    label: 'French',
+    nativeLabel: 'Français',
+  },
+];
+
+export const FALLBACK_LOCALE = 'en';
+
+const normalize = (locale) =>
+  (locale || '')
+    .toLowerCase()
+    .replace('_', '-')
+    .trim();
+
+export function matchLocale(locale) {
+  const normalized = normalize(locale);
+  if (!normalized) return FALLBACK_LOCALE;
+  const exact = AVAILABLE_LOCALES.find(
+    (item) => normalize(item.code) === normalized,
+  );
+  if (exact) return exact.code;
+  const prefix = normalized.split('-')[0];
+  const prefixMatch = AVAILABLE_LOCALES.find((item) =>
+    normalize(item.code).startsWith(prefix),
+  );
+  return prefixMatch ? prefixMatch.code : FALLBACK_LOCALE;
+}
+
+export function detectLocale() {
+  if (typeof navigator === 'undefined') return FALLBACK_LOCALE;
+  const preferences = Array.isArray(navigator.languages)
+    ? navigator.languages
+    : [navigator.language];
+  for (const preference of preferences) {
+    if (!preference) continue;
+    const matched = matchLocale(preference);
+    if (matched) return matched;
+  }
+  return FALLBACK_LOCALE;
+}
+
+export function getLocaleLabel(locale) {
+  const normalized = matchLocale(locale);
+  const meta = AVAILABLE_LOCALES.find((item) => item.code === normalized);
+  return meta?.nativeLabel || meta?.label || normalized;
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -3,6 +3,8 @@
 import { get, set, del } from 'idb-keyval';
 import { getTheme, setTheme } from './theme';
 
+import { detectLocale, matchLocale } from './i18nConfig';
+
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
   wallpaper: 'wall-2',
@@ -15,6 +17,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  locale: 'en',
 };
 
 export async function getAccent() {
@@ -114,6 +117,24 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+export async function getLocale() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.locale;
+  const stored = window.localStorage.getItem('locale');
+  if (stored) {
+    const normalized = matchLocale(stored);
+    if (normalized) return normalized;
+  }
+  const detected = detectLocale();
+  window.localStorage.setItem('locale', detected);
+  return detected;
+}
+
+export async function setLocale(locale) {
+  if (typeof window === 'undefined') return;
+  const normalized = matchLocale(locale);
+  window.localStorage.setItem('locale', normalized);
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -150,6 +171,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
   window.localStorage.removeItem('use-kali-wallpaper');
+  window.localStorage.removeItem('locale');
 }
 
 export async function exportSettings() {
@@ -165,6 +187,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    locale,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -177,6 +200,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getLocale(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -192,6 +216,7 @@ export async function exportSettings() {
     haptics,
     useKaliWallpaper,
     theme,
+    locale,
   });
 }
 
@@ -217,6 +242,7 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    locale,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -230,6 +256,7 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (locale !== undefined) await setLocale(locale);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add a reusable i18n hook backed by a locale store and pubsub updates
- create a settings LanguageSwitcher component that highlights detected locales and persists selections
- expand the settings app to surface translated tab labels and ship tests covering locale persistence and live updates

## Testing
- yarn lint
- yarn test languageSwitcher.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc6250277c832899a5a3c5e69e7bb6