### PR TITLE
[settings] unify unit preferences across apps

### DIFF
--- a/__tests__/unitPreferences.test.tsx
+++ b/__tests__/unitPreferences.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import Forecast from '../apps/weather/components/Forecast';
+import UnitsPanel from '../components/apps/settings/UnitsPanel';
+import Clock from '../components/util-components/clock';
+import { SettingsProvider } from '../hooks/useSettings';
+
+const renderWithSettings = (ui: React.ReactNode) =>
+  render(<SettingsProvider>{ui}</SettingsProvider>);
+
+describe('unit preference propagation', () => {
+  beforeAll(() => {
+    // Ensure worker-based timers fall back to setInterval in tests
+    // @ts-ignore
+    global.Worker = undefined;
+    const storage: Record<string, string> = {};
+    Object.defineProperty(window, 'localStorage', {
+      writable: true,
+      value: {
+        getItem: (key: string) => (key in storage ? storage[key] : null),
+        setItem: (key: string, value: string) => {
+          storage[key] = value;
+        },
+        removeItem: (key: string) => {
+          delete storage[key];
+        },
+        clear: () => {
+          Object.keys(storage).forEach((k) => delete storage[k]);
+        },
+        key: (index: number) => Object.keys(storage)[index] ?? null,
+        get length() {
+          return Object.keys(storage).length;
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('forecast updates when switching measurement system', async () => {
+    renderWithSettings(
+      <>
+        <UnitsPanel />
+        <Forecast
+          days={[
+            { date: '2024-01-01', temp: 10, condition: 0 },
+            { date: '2024-01-02', temp: 8, condition: 0 },
+          ]}
+        />
+      </>,
+    );
+
+    expect(await screen.findByText('10°C')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/Imperial/i));
+
+    await waitFor(() => {
+      expect(screen.getByText('50°F')).toBeInTheDocument();
+    });
+  });
+
+  test('clock follows selected time format', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-01T13:30:00'));
+
+    renderWithSettings(
+      <>
+        <UnitsPanel />
+        <Clock onlyTime={true} />
+      </>,
+    );
+
+    expect(await screen.findByText(/13:30/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/12-hour clock/i));
+
+    await waitFor(() => {
+      const twelveHour = screen.getByText((content) => /1:?30/i.test(content));
+      expect(/pm/i.test(twelveHour.textContent || '')).toBe(true);
+    });
+  });
+});

--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -9,15 +9,15 @@ import {
 } from '../../../lib/fetchProxy';
 import { exportMetrics } from '../export';
 import RequestChart from './RequestChart';
+import { useUnitPreferences } from '../../../hooks/useSettings';
+import { formatDataSize } from '../../../utils/unitFormat';
 
 const HISTORY_KEY = 'network-insights-history';
-
-const formatBytes = (bytes?: number) =>
-  typeof bytes === 'number' ? `${(bytes / 1024).toFixed(1)} kB` : '—';
 
 export default function NetworkInsights() {
   const [active, setActive] = useState<FetchEntry[]>(getActiveFetches());
   const [history, setHistory] = usePersistentState<FetchEntry[]>(HISTORY_KEY, []);
+  const { measurementSystem } = useUnitPreferences();
 
   useEffect(() => {
     const unsubStart = onFetchProxy('start', () => setActive(getActiveFetches()));
@@ -67,7 +67,7 @@ export default function NetworkInsights() {
               )}
             </div>
             <div className="text-gray-400">
-              {f.duration ? `${f.duration.toFixed(0)}ms` : ''} · req {formatBytes(f.requestSize)} · res {formatBytes(f.responseSize)}
+              {f.duration ? `${f.duration.toFixed(0)}ms` : ''} · req {formatDataSize(f.requestSize, measurementSystem)} · res {formatDataSize(f.responseSize, measurementSystem)}
             </div>
           </li>
         ))}

--- a/apps/weather/components/Forecast.tsx
+++ b/apps/weather/components/Forecast.tsx
@@ -1,9 +1,13 @@
+
 'use client';
 
 import WeatherIcon from './WeatherIcon';
 import { ForecastDay } from '../state';
+import { useUnitPreferences } from '../../../hooks/useSettings';
+import { formatTemperature } from '../../../utils/unitFormat';
 
 export default function Forecast({ days }: { days: ForecastDay[] }) {
+  const { measurementSystem } = useUnitPreferences();
   return (
     <div className="flex gap-1.5">
       {days.map((d) => (
@@ -12,7 +16,9 @@ export default function Forecast({ days }: { days: ForecastDay[] }) {
           className="flex flex-col items-center p-1.5 bg-white/10 rounded"
         >
           <WeatherIcon code={d.condition} />
-          <div className="text-sm mt-1">{Math.round(d.temp)}°</div>
+          <div className="text-sm mt-1">
+            {formatTemperature(d.temp, measurementSystem)}
+          </div>
         </div>
       ))}
     </div>

--- a/apps/weather/index.tsx
+++ b/apps/weather/index.tsx
@@ -9,6 +9,8 @@ import useWeatherState, {
 } from './state';
 import Forecast from './components/Forecast';
 import CityDetail from './components/CityDetail';
+import { useUnitPreferences } from '../../hooks/useSettings';
+import { formatTemperature } from '../../utils/unitFormat';
 
 interface ReadingUpdate {
   temp: number;
@@ -17,11 +19,16 @@ interface ReadingUpdate {
 }
 
 function CityTile({ city }: { city: City }) {
+  const { measurementSystem } = useUnitPreferences();
+  const formattedTemp = city.lastReading
+    ? formatTemperature(city.lastReading.temp, measurementSystem)
+    : null;
+
   return (
     <div>
       <div className="font-bold mb-1.5">{city.name}</div>
-      {city.lastReading ? (
-        <div className="mb-1.5">{Math.round(city.lastReading.temp)}°C</div>
+      {formattedTemp ? (
+        <div className="mb-1.5">{formattedTemp}</div>
       ) : (
         <div className="opacity-70 mb-1.5">No data</div>
       )}

--- a/components/apps/autopsy/index.js
+++ b/components/apps/autopsy/index.js
@@ -5,6 +5,8 @@ import KeywordSearchPanel from './KeywordSearchPanel';
 import demoArtifacts from './data/sample-artifacts.json';
 import ReportExport from '../../../apps/autopsy/components/ReportExport';
 import demoCase from '../../../apps/autopsy/data/case.json';
+import { useUnitPreferences } from '../../../hooks/useSettings';
+import { formatTimelineTick } from '../../../utils/unitFormat';
 
 const escapeFilename = (str = '') =>
   str
@@ -28,6 +30,7 @@ function Timeline({ events, onSelect }) {
   const [zoomAnnouncement, setZoomAnnouncement] = useState('');
   const [sliderIndex, setSliderIndex] = useState(0);
   const [hoverIndex, setHoverIndex] = useState(null);
+  const { timeFormat } = useUnitPreferences();
   const dayMarkers = useMemo(() => {
     const days = [];
     const seen = new Set();
@@ -135,17 +138,7 @@ function Timeline({ events, onSelect }) {
         const x = ((t - min) / 60000) * zoom;
         ctx.fillRect(x, height / 2 + 10, 1, 10);
         const date = new Date(t);
-        let label;
-        if (tickMinutes >= 1440) {
-          label = date.toLocaleDateString();
-        } else if (tickMinutes >= 60) {
-          label = date.toLocaleTimeString([], { hour: '2-digit' });
-        } else {
-          label = date.toLocaleTimeString([], {
-            hour: '2-digit',
-            minute: '2-digit',
-          });
-        }
+        const label = formatTimelineTick(date, tickMinutes, timeFormat);
         ctx.fillText(label, x + 2, height / 2 + 25);
       }
 
@@ -193,7 +186,7 @@ function Timeline({ events, onSelect }) {
     } else {
       requestAnimationFrame(render);
     }
-  }, [sorted, zoom]);
+  }, [sorted, zoom, timeFormat]);
 
   useEffect(() => {
     const canvas = canvasRef.current;

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import UnitsPanel from './settings/UnitsPanel';
 import KaliWallpaper from '../util-components/kali-wallpaper';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme, setMeasurementSystem, setTimeFormat } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -125,6 +126,7 @@ export function Settings() {
                     <option value="compact">Compact</option>
                 </select>
             </div>
+            <UnitsPanel />
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey">Font Size:</label>
                 <input
@@ -277,6 +279,8 @@ export function Settings() {
                         setLargeHitAreas(defaults.largeHitAreas);
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
+                        setMeasurementSystem(defaults.measurementSystem);
+                        setTimeFormat(defaults.timeFormat);
                         setTheme('default');
                     }}
                     className="px-4 py-2 rounded bg-ub-orange text-white"
@@ -301,6 +305,8 @@ export function Settings() {
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
+                        if (parsed.measurementSystem !== undefined) setMeasurementSystem(parsed.measurementSystem);
+                        if (parsed.timeFormat !== undefined) setTimeFormat(parsed.timeFormat);
                         if (parsed.theme !== undefined) { setTheme(parsed.theme); }
                     } catch (err) {
                         console.error('Invalid settings', err);

--- a/components/apps/settings/UnitsPanel.tsx
+++ b/components/apps/settings/UnitsPanel.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useUnitPreferences } from '../../../hooks/useSettings';
+import { getTemperatureUnit } from '../../../utils/unitFormat';
+
+const measurementOptions = [
+  { value: 'metric' as const, label: 'Metric', description: '°C, meters, kB' },
+  { value: 'imperial' as const, label: 'Imperial', description: '°F, miles, KiB' },
+];
+
+const timeOptions = [
+  { value: '24h' as const, label: '24-hour clock' },
+  { value: '12h' as const, label: '12-hour clock' },
+];
+
+export default function UnitsPanel() {
+  const {
+    measurementSystem,
+    setMeasurementSystem,
+    timeFormat,
+    setTimeFormat,
+  } = useUnitPreferences();
+
+  return (
+    <section className="my-4 flex flex-col items-center text-ubt-grey">
+      <fieldset className="w-full max-w-md rounded-lg border border-ubt-cool-grey/60 bg-ub-cool-grey/40 p-4">
+        <legend className="px-2 text-sm font-semibold uppercase tracking-wide text-ubt-grey/80">
+          Units &amp; time
+        </legend>
+        <div className="mb-4">
+          <div className="mb-2 text-xs uppercase tracking-wide text-ubt-grey/70">
+            Measurement system
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            {measurementOptions.map((option) => (
+              <label
+                key={option.value}
+                className={`flex flex-1 cursor-pointer items-center gap-2 rounded border px-3 py-2 text-sm transition-colors ${
+                  measurementSystem === option.value
+                    ? 'border-ub-orange bg-ub-orange/10 text-white'
+                    : 'border-transparent bg-black/20 hover:border-ubt-cool-grey/60'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="measurement-system"
+                  value={option.value}
+                  checked={measurementSystem === option.value}
+                  onChange={() => setMeasurementSystem(option.value)}
+                  className="h-4 w-4 accent-ub-orange"
+                />
+                <span>
+                  <span className="block font-semibold">{option.label}</span>
+                  <span className="block text-xs text-ubt-grey/70">{option.description}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+          <p className="mt-2 text-xs text-ubt-grey/70">
+            Weather and analytics widgets immediately reflect your choice. Current display:{' '}
+            <strong>
+              {measurementSystem === 'imperial' ? 'Imperial' : 'Metric'}{' '}
+              ({getTemperatureUnit(measurementSystem)})
+            </strong>
+            .
+          </p>
+        </div>
+        <div>
+          <div className="mb-2 text-xs uppercase tracking-wide text-ubt-grey/70">Clock format</div>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            {timeOptions.map((option) => (
+              <label
+                key={option.value}
+                className={`flex flex-1 cursor-pointer items-center gap-2 rounded border px-3 py-2 text-sm transition-colors ${
+                  timeFormat === option.value
+                    ? 'border-ub-orange bg-ub-orange/10 text-white'
+                    : 'border-transparent bg-black/20 hover:border-ubt-cool-grey/60'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="time-format"
+                  value={option.value}
+                  checked={timeFormat === option.value}
+                  onChange={() => setTimeFormat(option.value)}
+                  className="h-4 w-4 accent-ub-orange"
+                />
+                <span className="font-semibold">{option.label}</span>
+              </label>
+            ))}
+          </div>
+          <p className="mt-2 text-xs text-ubt-grey/70">
+            Dock clocks, charts, and sunrise/sunset displays follow this preference instantly.
+          </p>
+        </div>
+      </fieldset>
+    </section>
+  );
+}

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -104,7 +104,7 @@ export default class Navbar extends PureComponent {
                                                         'rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/90 shadow-sm backdrop-blur transition duration-150 ease-in-out hover:border-white/30 hover:bg-white/10'
                                                 }
                                         >
-                                                <Clock onlyTime={true} showCalendar={true} hour12={false} />
+                                                <Clock onlyTime={true} showCalendar={true} />
                                         </div>
                                         <button
                                                 type="button"

--- a/components/util-components/clock.js
+++ b/components/util-components/clock.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { useUnitPreferences } from '../../hooks/useSettings'
 
 const MONTHS = [
     "Jan",
@@ -119,7 +120,7 @@ const formatDisplayTime = ({ currentTime, onlyDay, onlyTime, timeFormatter }) =>
     return `${dayString} ${timeString}`
 }
 
-const Clock = ({ onlyDay = false, onlyTime = false, showCalendar = false, hour12 = true }) => {
+const Clock = ({ onlyDay = false, onlyTime = false, showCalendar = false, hour12 }) => {
     const [currentTime, setCurrentTime] = useState(null)
     const [isOpen, setIsOpen] = useState(false)
     const [viewDate, setViewDate] = useState(() => new Date())
@@ -133,6 +134,8 @@ const Clock = ({ onlyDay = false, onlyTime = false, showCalendar = false, hour12
     const popoverId = `${headingId}-popover`
     const [canUsePortal, setCanUsePortal] = useState(false)
     const [popoverStyles, setPopoverStyles] = useState({})
+    const { timeFormat } = useUnitPreferences()
+    const resolvedHour12 = typeof hour12 === 'boolean' ? hour12 : timeFormat === '12h'
 
     useEffect(() => {
         const update = () => setCurrentTime(new Date())
@@ -294,9 +297,9 @@ const Clock = ({ onlyDay = false, onlyTime = false, showCalendar = false, hour12
             new Intl.DateTimeFormat(undefined, {
                 hour: '2-digit',
                 minute: '2-digit',
-                hour12
+                hour12: resolvedHour12
             }),
-        [hour12]
+        [resolvedHour12]
     )
 
     const timeFormatter = useMemo(
@@ -304,9 +307,9 @@ const Clock = ({ onlyDay = false, onlyTime = false, showCalendar = false, hour12
             new Intl.DateTimeFormat(undefined, {
                 hour: '2-digit',
                 minute: '2-digit',
-                hour12
+                hour12: resolvedHour12
             }),
-        [hour12]
+        [resolvedHour12]
     )
 
     const handleToggle = useCallback(() => {

--- a/pages/apps/weather_widget.jsx
+++ b/pages/apps/weather_widget.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
+import { useUnitPreferences } from '../../hooks/useSettings';
+import { getTemperatureUnit } from '../../utils/unitFormat';
 
 const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
   ssr: false,
@@ -8,19 +10,11 @@ const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
 
 // Display stored unit preference and the browser's location consent status.
 export default function WeatherWidgetPage() {
-  const [unit, setUnit] = useState('metric');
   const [locationConsent, setLocationConsent] = useState('unknown');
+  const { measurementSystem, timeFormat } = useUnitPreferences();
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-
-    // Load persisted unit preference if available
-    try {
-      const stored = localStorage.getItem('weatherUnit');
-      if (stored) setUnit(stored);
-    } catch {
-      // ignore storage errors
-    }
 
     // Query geolocation permission state
     if (navigator?.permissions?.query) {
@@ -37,7 +31,10 @@ export default function WeatherWidgetPage() {
   return (
     <div>
       <div className="mb-2 text-sm">
-        Unit preference: {unit === 'imperial' ? 'Fahrenheit' : 'Celsius'}
+        Unit preference: {measurementSystem === 'imperial' ? 'Imperial' : 'Metric'} ({getTemperatureUnit(measurementSystem)})
+      </div>
+      <div className="mb-2 text-sm">
+        Clock format: {timeFormat === '12h' ? '12-hour' : '24-hour'}
       </div>
       <div className="mb-4 text-sm">
         Location consent: {locationConsent}

--- a/types/preferences.ts
+++ b/types/preferences.ts
@@ -1,0 +1,8 @@
+export type MeasurementSystem = 'metric' | 'imperial';
+export type TimeFormat = '12h' | '24h';
+
+export const normalizeMeasurementSystem = (value: unknown): MeasurementSystem =>
+  value === 'imperial' ? 'imperial' : 'metric';
+
+export const normalizeTimeFormat = (value: unknown): TimeFormat =>
+  value === '12h' ? '12h' : '24h';

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -15,6 +15,8 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  measurementSystem: 'metric',
+  timeFormat: '24h',
 };
 
 export async function getAccent() {
@@ -135,6 +137,30 @@ export async function setAllowNetwork(value) {
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
+export async function getMeasurementSystem() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.measurementSystem;
+  const stored = window.localStorage.getItem('measurement-system');
+  return stored === 'imperial' ? 'imperial' : DEFAULT_SETTINGS.measurementSystem;
+}
+
+export async function setMeasurementSystem(value) {
+  if (typeof window === 'undefined') return;
+  const normalized = value === 'imperial' ? 'imperial' : 'metric';
+  window.localStorage.setItem('measurement-system', normalized);
+}
+
+export async function getTimeFormat() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.timeFormat;
+  const stored = window.localStorage.getItem('time-format');
+  return stored === '12h' ? '12h' : DEFAULT_SETTINGS.timeFormat;
+}
+
+export async function setTimeFormat(value) {
+  if (typeof window === 'undefined') return;
+  const normalized = value === '12h' ? '12h' : '24h';
+  window.localStorage.setItem('time-format', normalized);
+}
+
 export async function resetSettings() {
   if (typeof window === 'undefined') return;
   await Promise.all([
@@ -150,6 +176,8 @@ export async function resetSettings() {
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
   window.localStorage.removeItem('use-kali-wallpaper');
+  window.localStorage.removeItem('measurement-system');
+  window.localStorage.removeItem('time-format');
 }
 
 export async function exportSettings() {
@@ -165,6 +193,8 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    measurementSystem,
+    timeFormat,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -177,6 +207,8 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getMeasurementSystem(),
+    getTimeFormat(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -192,6 +224,8 @@ export async function exportSettings() {
     haptics,
     useKaliWallpaper,
     theme,
+    measurementSystem,
+    timeFormat,
   });
 }
 
@@ -217,6 +251,8 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    measurementSystem,
+    timeFormat,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -230,6 +266,8 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (measurementSystem !== undefined) await setMeasurementSystem(measurementSystem);
+  if (timeFormat !== undefined) await setTimeFormat(timeFormat);
 }
 
 export const defaults = DEFAULT_SETTINGS;

--- a/utils/unitFormat.ts
+++ b/utils/unitFormat.ts
@@ -1,0 +1,94 @@
+import type { MeasurementSystem, TimeFormat } from '../types/preferences';
+import { normalizeMeasurementSystem, normalizeTimeFormat } from '../types/preferences';
+
+export const getTemperatureUnit = (system: MeasurementSystem): '°C' | '°F' =>
+  system === 'imperial' ? '°F' : '°C';
+
+export const convertTemperatureValue = (
+  value: number,
+  system: MeasurementSystem,
+): number => {
+  const normalized = normalizeMeasurementSystem(system);
+  if (!Number.isFinite(value)) return value;
+  return normalized === 'imperial' ? (value * 9) / 5 + 32 : value;
+};
+
+export const convertTemperatureSeries = (
+  values: number[],
+  system: MeasurementSystem,
+): number[] => values.map((value) => convertTemperatureValue(value, system));
+
+interface FormatTemperatureOptions {
+  maximumFractionDigits?: number;
+}
+
+export const formatTemperature = (
+  celsiusValue: number | null | undefined,
+  system: MeasurementSystem,
+  { maximumFractionDigits = 0 }: FormatTemperatureOptions = {},
+): string => {
+  if (typeof celsiusValue !== 'number' || Number.isNaN(celsiusValue)) {
+    return '—';
+  }
+  const normalized = normalizeMeasurementSystem(system);
+  const converted = convertTemperatureValue(celsiusValue, normalized);
+  const formatter = new Intl.NumberFormat(undefined, {
+    maximumFractionDigits,
+    minimumFractionDigits: maximumFractionDigits,
+  });
+  return `${formatter.format(converted)}${getTemperatureUnit(normalized)}`;
+};
+
+export const formatDataSize = (
+  bytes?: number,
+  system?: MeasurementSystem,
+): string => {
+  if (typeof bytes !== 'number' || Number.isNaN(bytes)) return '—';
+  const normalized = normalizeMeasurementSystem(system ?? 'metric');
+  const base = normalized === 'imperial' ? 1024 : 1000;
+  const units = normalized === 'imperial'
+    ? ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']
+    : ['B', 'kB', 'MB', 'GB', 'TB', 'PB'];
+  const sign = bytes < 0 ? -1 : 1;
+  let value = Math.abs(bytes);
+  let unitIndex = 0;
+  while (value >= base && unitIndex < units.length - 1) {
+    value /= base;
+    unitIndex += 1;
+  }
+  const formatter = new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: value < 10 && unitIndex > 0 ? 1 : 0,
+  });
+  const formattedValue = formatter.format(value * sign);
+  return `${formattedValue} ${units[unitIndex]}`;
+};
+
+export const formatTimeOfDay = (
+  date: Date,
+  timeFormat: TimeFormat,
+  options: Intl.DateTimeFormatOptions = {},
+): string => {
+  const normalized = normalizeTimeFormat(timeFormat);
+  return date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: normalized === '12h',
+    ...options,
+  });
+};
+
+export const formatTimelineTick = (
+  date: Date,
+  tickMinutes: number,
+  timeFormat: TimeFormat,
+): string => {
+  if (tickMinutes >= 1440) {
+    return date.toLocaleDateString();
+  }
+  if (tickMinutes >= 60) {
+    return formatTimeOfDay(date, timeFormat, { minute: undefined });
+  }
+  return formatTimeOfDay(date, timeFormat);
+};
+
+export { normalizeMeasurementSystem, normalizeTimeFormat };


### PR DESCRIPTION
## Summary
- add measurement/time preference persistence in the settings store and expose unit helpers
- surface a Units panel in the desktop settings UI and wire it into reset/import flows
- update weather, timeline, clock, and network insights views to respect the shared unit preferences

## Testing
- `yarn test unitPreferences`


------
https://chatgpt.com/codex/tasks/task_e_68dc62532770832888ec198597060375