### PR TITLE
[fonts] add adaptive typography loader

### DIFF
--- a/__tests__/fontLoader.test.ts
+++ b/__tests__/fontLoader.test.ts
@@ -1,0 +1,19 @@
+import { detectFontGroups } from '../utils/fontLoader';
+
+describe('detectFontGroups', () => {
+  it('returns an empty array for latin-only content', () => {
+    expect(detectFontGroups('The quick brown fox jumps over the lazy dog.')).toEqual([]);
+  });
+
+  it('detects CJK characters', () => {
+    expect(detectFontGroups('你好，世界')).toEqual(['cjk']);
+    expect(detectFontGroups('カリ・リナックス')).toEqual(['cjk']);
+  });
+
+  it('detects RTL scripts and supports mixed content', () => {
+    expect(detectFontGroups('مرحبا بالعالم')).toEqual(['rtl']);
+    const mixed = detectFontGroups('Security 工具 مرحباً');
+    expect(mixed).toContain('cjk');
+    expect(mixed).toContain('rtl');
+  });
+});

--- a/docs/font-loading.md
+++ b/docs/font-loading.md
@@ -1,0 +1,33 @@
+# Font loading strategy
+
+This project renders a lot of multilingual security content, so the font stack has been updated to balance coverage, performance, and theming.
+
+## Baseline font stacks
+
+- `styles/typography.css` defines CSS custom properties for Latin, CJK, and RTL scripts. The defaults prioritise Ubuntu (to match the Kali look) and progressively fall back to platform UI fonts and the open Noto families. The same variables power `body`, language-specific selectors, and a shared `.font-root` class, so we do not get baseline jumps when theme switching.
+- Monospace selections use high-metric-compatible developer fonts (`JetBrains Mono`, `Fira Code`, `Source Code Pro`) before falling back to system monospace faces.
+
+## Lazy loading additional glyph coverage
+
+- `utils/fontLoader.ts` inspects visible text and only requests heavy font payloads when they are needed. The detector watches:
+  - CJK ranges (Han, Hiragana, Katakana, compatibility ideographs).
+  - RTL ranges for Hebrew and Arabic scripts.
+- When characters from those ranges appear, the loader injects a Google Fonts stylesheet for the relevant Noto font family. Requests are throttled to animation frames so rapid DOM mutations do not spam the network.
+- We preconnect to `fonts.gstatic.com` before requesting the stylesheet to avoid a separate TCP/TLS handshake when a new script is detected.
+
+## Caching behaviour
+
+- Loaded font groups are cached in `localStorage` (`kali-font-loader:v1`). On repeat visits we immediately rehydrate the same font groups so rerenders stay stable even before new content triggers detection.
+- The loader guards against unavailable APIs (e.g. older browsers without `MutationObserver`) and simply performs a best-effort scan of the initial DOM.
+
+## Performance considerations
+
+- Latin content continues to use the locally bundled Ubuntu subset, keeping the initial bundle lean.
+- Additional font CSS is only fetched when the page contains matching characters, cutting down on unused bytes for users who only browse English content.
+- Media swapping is handled by setting `link.media="print"` until the stylesheet finishes loading. This prevents blocking render.
+- The typography CSS relies on CSS variables so theme switches keep the same metrics regardless of which font is active.
+
+## Testing
+
+- Unit tests (`__tests__/fontLoader.test.ts`) verify the Unicode-range detection logic using sample CJK and RTL strings.
+- Manual checks should include loading content (e.g. Notes app, documents, or blog posts) with Chinese, Japanese, Arabic, and Hebrew strings to confirm the loader activates and the UI maintains its baseline alignment.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,7 @@ const compat = new FlatCompat();
 const config = [
   { ignores: ['components/apps/Chrome/index.tsx'] },
   {
+    files: ['**/*.{js,jsx,ts,tsx,mjs,cjs}'],
     plugins: {
       'no-top-level-window': noTopLevelWindow,
     },

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -6,6 +6,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import '../styles/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';
+import '../styles/typography.css';
 import '../styles/resume-print.css';
 import '../styles/print.css';
 import '@xterm/xterm/css/xterm.css';
@@ -15,14 +16,16 @@ import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import NotificationCenter from '../components/common/NotificationCenter';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
-import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { initFontLoader } from '../utils/fontLoader';
 
 import { Ubuntu } from 'next/font/google';
 
 const ubuntu = Ubuntu({
   subsets: ['latin'],
   weight: ['300', '400', '500', '700'],
+  variable: '--font-ubuntu',
+  display: 'swap',
 });
 
 
@@ -79,6 +82,10 @@ function MyApp(props) {
         console.error('Service worker setup failed', err);
       });
     }
+  }, []);
+
+  useEffect(() => {
+    initFontLoader();
   }, []);
 
   useEffect(() => {
@@ -149,8 +156,7 @@ function MyApp(props) {
 
   return (
     <ErrorBoundary>
-      <Script src="/a2hs.js" strategy="beforeInteractive" />
-      <div className={ubuntu.className}>
+      <div className={`${ubuntu.className} font-root`}>
         <a
           href="#app-grid"
           className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,4 +1,5 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import Script from 'next/script';
 
 class MyDocument extends Document {
   /**
@@ -18,7 +19,8 @@ class MyDocument extends Document {
           <link rel="icon" href="/favicon.ico" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#0f1317" />
-          <script nonce={nonce} src="/theme.js" />
+          <Script nonce={nonce} src="/theme.js" strategy="beforeInteractive" />
+          <Script nonce={nonce} src="/a2hs.js" strategy="beforeInteractive" />
         </Head>
         <body>
           <Main />

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -1,0 +1,54 @@
+:root {
+  --font-body-latin: var(--font-ubuntu, 'Ubuntu'), 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+  --font-body-cjk: 'Noto Sans CJK SC', 'Noto Sans CJK JP', 'Noto Sans CJK TC', 'PingFang SC', 'Hiragino Sans', 'Microsoft YaHei', 'Source Han Sans SC', 'Noto Sans', sans-serif;
+  --font-body-rtl: 'Noto Naskh Arabic', 'Noto Sans Arabic', 'Segoe UI', 'Tahoma', 'Noto Sans', sans-serif;
+  --font-body: var(--font-body-latin);
+  --font-monospace: 'JetBrains Mono', 'Fira Code', 'Fira Mono', 'Source Code Pro', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+html[dir='rtl'] {
+  --font-body: var(--font-body-rtl);
+}
+
+html:lang(zh),
+html:lang(ja),
+html:lang(ko),
+body:lang(zh),
+body:lang(ja),
+body:lang(ko) {
+  --font-body: var(--font-body-cjk);
+}
+
+body {
+  font-family: var(--font-body);
+  font-feature-settings: 'kern' 1, 'liga' 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  line-height: 1.6;
+}
+
+.font-root {
+  font-family: var(--font-body);
+}
+
+code,
+pre,
+kbd,
+samp {
+  font-family: var(--font-monospace);
+}
+
+[lang='ar'],
+[lang='fa'],
+[lang='ur'],
+[lang='ps'],
+[lang='he'] {
+  font-family: var(--font-body-rtl);
+}
+
+[lang='zh'],
+[lang='ja'],
+[lang='ko'] {
+  font-family: var(--font-body-cjk);
+}

--- a/utils/fontLoader.ts
+++ b/utils/fontLoader.ts
@@ -1,0 +1,207 @@
+const STORAGE_KEY = 'kali-font-loader:v1';
+
+type FontGroupKey = 'cjk' | 'rtl';
+
+type FontGroup = {
+  key: FontGroupKey;
+  regex: RegExp;
+  href: string;
+  preloadHosts?: string[];
+};
+
+const FONT_GROUPS: FontGroup[] = [
+  {
+    key: 'cjk',
+    regex: /[\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9fff\u{20000}-\u{2cea1}\u{f900}-\u{faff}]/u,
+    href: 'https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700&display=swap',
+    preloadHosts: ['https://fonts.gstatic.com'],
+  },
+  {
+    key: 'rtl',
+    regex: /[\u0590-\u05ff\u0600-\u06ff\u0750-\u077f\u08a0-\u08ff]/u,
+    href: 'https://fonts.googleapis.com/css2?family=Noto+Naskh+Arabic:wght@400;500;700&display=swap',
+    preloadHosts: ['https://fonts.gstatic.com'],
+  },
+];
+
+const memoryLoaded = new Set<FontGroupKey>();
+
+const getPersisted = (): Set<FontGroupKey> => {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return new Set();
+  }
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) return new Set();
+    const parsed = JSON.parse(stored) as FontGroupKey[];
+    return new Set(parsed);
+  } catch (error) {
+    console.warn('Font loader cache read failed', error);
+    return new Set();
+  }
+};
+
+const persistLoaded = () => {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(memoryLoaded)));
+  } catch (error) {
+    console.warn('Font loader cache write failed', error);
+  }
+};
+
+const ensurePreconnect = (url: string) => {
+  if (typeof document === 'undefined') return;
+  const existing = document.head?.querySelector(`link[rel="preconnect"][href="${url}"]`);
+  if (existing) return;
+
+  const link = document.createElement('link');
+  link.rel = 'preconnect';
+  link.href = url;
+  link.crossOrigin = 'anonymous';
+  document.head?.appendChild(link);
+};
+
+const injectStylesheet = (group: FontGroup) => {
+  if (typeof document === 'undefined') return;
+  const stylesheetId = `font-loader-${group.key}`;
+  if (document.getElementById(stylesheetId)) {
+    return;
+  }
+
+  group.preloadHosts?.forEach((host) => ensurePreconnect(host));
+
+  const link = document.createElement('link');
+  link.id = stylesheetId;
+  link.rel = 'stylesheet';
+  link.href = group.href;
+  link.media = 'print';
+  link.onload = () => {
+    link.media = 'all';
+  };
+  document.head?.appendChild(link);
+};
+
+export const detectFontGroups = (text: string): FontGroupKey[] => {
+  if (!text) return [];
+
+  const matches: FontGroupKey[] = [];
+  for (const group of FONT_GROUPS) {
+    if (group.regex.test(text)) {
+      matches.push(group.key);
+    }
+  }
+  return matches;
+};
+
+const maybeLoadGroups = (keys: FontGroupKey[]) => {
+  if (typeof document === 'undefined') return;
+
+  let didPersist = false;
+
+  keys.forEach((key) => {
+    if (memoryLoaded.has(key)) return;
+
+    const group = FONT_GROUPS.find((candidate) => candidate.key === key);
+    if (!group) return;
+
+    memoryLoaded.add(key);
+    injectStylesheet(group);
+    didPersist = true;
+  });
+
+  if (didPersist) {
+    persistLoaded();
+  }
+};
+
+const extractText = (node: Node): string => {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent ?? '';
+  }
+
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    return (node as Element).textContent ?? '';
+  }
+
+  return '';
+};
+
+export const initFontLoader = () => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+
+  const persisted = getPersisted();
+  if (persisted.size) {
+    maybeLoadGroups(Array.from(persisted));
+  }
+
+  const scheduleLoad = (() => {
+    let buffer = '';
+    let rafId: number | null = null;
+
+    const flush = () => {
+      const text = buffer;
+      buffer = '';
+      rafId = null;
+      if (text) {
+        const detected = detectFontGroups(text);
+        if (detected.length) {
+          maybeLoadGroups(detected);
+        }
+      }
+    };
+
+    return (text: string) => {
+      if (!text) return;
+      buffer += text;
+      if (rafId != null) return;
+      rafId = window.requestAnimationFrame(flush);
+    };
+  })();
+
+  const initialText = document.body?.innerText ?? '';
+  if (initialText) {
+    scheduleLoad(initialText);
+  }
+
+  if (!('MutationObserver' in window) || !document.body) {
+    return;
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    let aggregated = '';
+    for (const mutation of mutations) {
+      if (mutation.type === 'characterData') {
+        aggregated += (mutation.target?.textContent ?? '') as string;
+      }
+      mutation.addedNodes.forEach((node) => {
+        aggregated += extractText(node);
+      });
+    }
+
+    if (aggregated) {
+      scheduleLoad(aggregated);
+    }
+  });
+
+  observer.observe(document.body, {
+    characterData: true,
+    childList: true,
+    subtree: true,
+  });
+
+  window.addEventListener('languagechange', () => {
+    const text = document.body?.innerText ?? '';
+    if (text) {
+      scheduleLoad(text);
+    }
+  });
+};
+
+export const __FONT_GROUPS__ = FONT_GROUPS;


### PR DESCRIPTION
## Summary
- add typography.css with global font variables covering Latin, CJK, and RTL scripts
- introduce a cached font loader that lazy-loads Noto fonts when matching characters appear
- update app shell and document to use the new stack and document the strategy

## Testing
- yarn lint
- yarn test __tests__/fontLoader.test.ts --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68dc625663308328896ea80205e29103