### PR TITLE
[i18n] Adopt ICU message formatting

### DIFF
--- a/__tests__/__snapshots__/i18n.message.test.ts.snap
+++ b/__tests__/__snapshots__/i18n.message.test.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ICU message formatting formats pluralised trash day strings across locales 1`] = `
+{
+  "en": [
+    "0 days left",
+    "1 day left",
+    "2 days left",
+    "5 days left",
+  ],
+  "es": [
+    "Quedan 0 días",
+    "Queda 1 día",
+    "Quedan 2 días",
+    "Quedan 5 días",
+  ],
+  "fr": [
+    "0 days left",
+    "1 day left",
+    "2 days left",
+    "5 days left",
+  ],
+}
+`;
+
+exports[`ICU message formatting supports gender aware selections 1`] = `
+{
+  "enFemale": "Riley deleted her file",
+  "enMale": "Alex deleted his files",
+  "enNeutral": "Sam deleted their files",
+  "esNeutral": "Mar eliminó sus archivos",
+}
+`;

--- a/__tests__/i18n.message.test.ts
+++ b/__tests__/i18n.message.test.ts
@@ -1,0 +1,68 @@
+import {
+  FALLBACK_LOCALE,
+  createMessageFormatter,
+  defaultCatalogs,
+  getMessageFormatter,
+} from '../i18n/message';
+
+describe('ICU message formatting', () => {
+  it('formats pluralised trash day strings across locales', () => {
+    const counts = [0, 1, 2, 5];
+    const locales = ['en', 'es', 'fr'];
+    const formatted = Object.fromEntries(
+      locales.map((locale) => {
+        const formatter = createMessageFormatter({
+          locale,
+          fallbackLocale: FALLBACK_LOCALE,
+          catalogs: defaultCatalogs,
+        });
+        return [
+          locale,
+          counts.map((count) =>
+            formatter.format('trash.daysRemaining', { count }),
+          ),
+        ];
+      }),
+    );
+
+    expect(formatted).toMatchSnapshot();
+  });
+
+  it('supports gender aware selections', () => {
+    const english = getMessageFormatter('en');
+    const spanish = getMessageFormatter('es');
+
+    const samples = {
+      enMale: english.format('trash.genderedActor', {
+        gender: 'male',
+        name: 'Alex',
+        count: 2,
+      }),
+      enFemale: english.format('trash.genderedActor', {
+        gender: 'female',
+        name: 'Riley',
+        count: 1,
+      }),
+      enNeutral: english.format('trash.genderedActor', {
+        gender: 'other',
+        name: 'Sam',
+        count: 3,
+      }),
+      esNeutral: spanish.format('trash.genderedActor', {
+        gender: 'other',
+        name: 'Mar',
+        count: 4,
+      }),
+    };
+
+    expect(samples).toMatchSnapshot();
+  });
+
+  it('falls back to the default locale for missing translations', () => {
+    const formatter = getMessageFormatter('fr');
+    expect(formatter.resolvedLocale).toBe('en');
+    expect(
+      formatter.format('youtube.playlistCount', { count: 3 })
+    ).toBe('3 playlists');
+  });
+});

--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { getMessageFormatter } from '../../i18n/message';
 import useTrashState from './state';
 import HistoryList from './components/HistoryList';
 
@@ -21,6 +22,7 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
   const [purgeDays, setPurgeDays] = useState(30);
   const [emptyCountdown, setEmptyCountdown] = useState<number | null>(null);
   const [, setTick] = useState(0);
+  const messageFormatter = useMemo(() => getMessageFormatter(), []);
   const daysLeft = useCallback(
     (closedAt: number) =>
       Math.max(
@@ -191,13 +193,15 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
         </div>
         {items.length > 0 && (
           <ul className="p-2 space-y-1.5 mt-4">
-            {items.map((item, idx) => (
-              <li
-                key={item.closedAt}
-                tabIndex={0}
-                onClick={() => setSelected(idx)}
-                className={`flex items-center h-9 px-1 cursor-pointer ${selected === idx ? 'bg-ub-drk-abrgn' : ''}`}
-              >
+            {items.map((item, idx) => {
+              const remaining = daysLeft(item.closedAt);
+              return (
+                <li
+                  key={item.closedAt}
+                  tabIndex={0}
+                  onClick={() => setSelected(idx)}
+                  className={`flex items-center h-9 px-1 cursor-pointer ${selected === idx ? 'bg-ub-drk-abrgn' : ''}`}
+                >
                 <img
                   src={item.icon || DEFAULT_ICON}
                   alt=""
@@ -206,18 +210,20 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
                 <span className="truncate font-mono" title={item.title}>
                   {item.title}
                 </span>
-                <span
-                  className="ml-auto text-xs opacity-70"
-                  aria-label={`Purges in ${daysLeft(item.closedAt)} day${
-                    daysLeft(item.closedAt) === 1 ? '' : 's'
-                  }`}
-                >
-                  {`${daysLeft(item.closedAt)} day${
-                    daysLeft(item.closedAt) === 1 ? '' : 's'
-                  } left`}
-                </span>
-              </li>
-            ))}
+                  <span
+                    className="ml-auto text-xs opacity-70"
+                    aria-label={messageFormatter.format(
+                      'trash.daysRemaining.aria',
+                      { count: remaining },
+                    )}
+                  >
+                    {messageFormatter.format('trash.daysRemaining', {
+                      count: remaining,
+                    })}
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/components/apps/project-gallery.tsx
+++ b/components/apps/project-gallery.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import projectsData from '../../data/projects.json';
+import { getMessageFormatter } from '../../i18n/message';
 
 interface Project {
   id: number;
@@ -35,6 +36,7 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
   const [tags, setTags] = useState<string[]>([]);
   const [ariaMessage, setAriaMessage] = useState('');
   const [selected, setSelected] = useState<Project[]>([]);
+  const messageFormatter = useMemo(() => getMessageFormatter(), []);
 
   const readFilters = async () => {
     try {
@@ -88,9 +90,14 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
       setYear(data.year || '');
       setType(data.type || '');
       setTags(data.tags || []);
-      setAriaMessage(`Showing ${projects.length} projects`);
+      setAriaMessage(
+        messageFormatter.format('projectGallery.filteredCount', {
+          count: projects.length,
+          filters: '',
+        }),
+      );
     });
-  }, [projects.length]);
+  }, [messageFormatter, projects.length]);
 
   const stacks = useMemo(
     () => Array.from(new Set(projects.flatMap((p) => p.stack))),
@@ -129,10 +136,50 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
   }, [search, stack, year, type, tags]);
 
   useEffect(() => {
+    const filterSegments: string[] = [];
+    if (stack) {
+      filterSegments.push(
+        messageFormatter.format('projectGallery.filters.stack', { stack }),
+      );
+    }
+    if (tags.length) {
+      filterSegments.push(
+        messageFormatter.format('projectGallery.filters.tags', {
+          tags: tags.join(', '),
+        }),
+      );
+    }
+    if (year) {
+      filterSegments.push(
+        messageFormatter.format('projectGallery.filters.year', { year }),
+      );
+    }
+    if (type) {
+      filterSegments.push(
+        messageFormatter.format('projectGallery.filters.type', { type }),
+      );
+    }
+    if (search) {
+      filterSegments.push(
+        messageFormatter.format('projectGallery.filters.search', { search }),
+      );
+    }
+
     setAriaMessage(
-      `Showing ${filtered.length} project${filtered.length === 1 ? '' : 's'}${stack ? ` filtered by ${stack}` : ''}${tags.length ? ` with tags ${tags.join(', ')}` : ''}${year ? ` in ${year}` : ''}${type ? ` of type ${type}` : ''}${search ? ` matching "${search}"` : ''}`
+      messageFormatter.format('projectGallery.filteredCount', {
+        count: filtered.length,
+        filters: filterSegments.join(''),
+      }),
     );
-  }, [filtered.length, stack, year, type, tags, search]);
+  }, [
+    filtered.length,
+    messageFormatter,
+    search,
+    stack,
+    tags,
+    type,
+    year,
+  ]);
 
   const openInFirefox = (url: string) => {
     try {

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { getMessageFormatter } from '../../../i18n/message';
 
 interface Playlist {
   id: string;
@@ -316,6 +317,7 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [lastQuery, setLastQuery] = useState<string>('');
   const [showMobileFilters, setShowMobileFilters] = useState(false);
+  const messageFormatter = useMemo(() => getMessageFormatter(), []);
 
   useEffect(() => {
     setPlaylists(normalizedInitial);
@@ -657,7 +659,9 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
                   <div className="mb-3 flex items-center justify-between">
                     <h2 className="text-lg font-semibold text-white">{group.title}</h2>
                     <span className="rounded-full bg-black/30 px-3 py-1 text-xs text-ubt-grey">
-                      {group.items.length} playlist{group.items.length === 1 ? '' : 's'}
+                      {messageFormatter.format('youtube.playlistCount', {
+                        count: group.items.length,
+                      })}
                     </span>
                   </div>
                   <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">

--- a/docs/i18n-icu.md
+++ b/docs/i18n-icu.md
@@ -1,0 +1,40 @@
+# ICU Message Formatting Guidelines
+
+This project uses [ICU MessageFormat](https://unicode-org.github.io/icu/userguide/format_parse/messages/) strings to provide
+locale-aware pluralisation, gender selection, and runtime interpolation. The i18n runtime is defined in `i18n/message.ts` and
+ships with default English (`en`) and Spanish (`es`) catalogues located in `i18n/locales/`.
+
+## Adding or Updating Messages
+
+1. **Edit the catalogues** – Each locale catalogue is a flat JSON map. Keys use dot notation to match feature areas (for
+   example `trash.daysRemaining`). Values must be ICU-formatted strings. Keep leading spaces in the ICU text if the segment is
+   meant to be concatenated with other segments, as seen in the project gallery filters.
+2. **Plural rules** – Use the `{count, plural, one {...} other {...}}` pattern. If you need language-specific rules add extra
+   selectors such as `=0` or `few`.
+3. **Gender-aware messaging** – Use `{gender, select, male {...} female {...} other {...}}` to ensure inclusive phrasing. The
+   runtime passes through unknown options to the `other` branch.
+4. **Fallbacks** – When a message is missing from the requested locale the formatter automatically falls back to the default
+   locale (`en`). Always keep the English catalogue complete so translators have a reference.
+5. **Testing** – Add or update Jest snapshots in `__tests__/i18n.message.test.ts` whenever you change plural or gender rules. Run
+   `yarn test i18n.message.test.ts --updateSnapshot` to refresh the reference output.
+
+## Using the Formatter in Code
+
+```ts
+import { getMessageFormatter } from '@/i18n/message';
+
+const formatter = getMessageFormatter('es'); // Defaults to English when omitted
+const label = formatter.format('youtube.playlistCount', { count: playlists.length });
+```
+
+* Call `getMessageFormatter(locale)` from React hooks (for example inside `useMemo`) to avoid recalculating instances.
+* If you need to detect the browser locale, use `detectLocale()` and pass the result into `getMessageFormatter()` so server and
+  client renders stay consistent.
+* Never manually assemble plural suffixes (`count === 1 ? '' : 's'`) – always go through the formatter so languages with
+  non-English plural rules render correctly.
+
+## Translator Tips
+
+* Keep placeholders such as `{count}` or `{name}` intact. You can reposition them to match the grammar of the target language.
+* Retain quotation marks around interpolated search terms (`"{search}"`) so UI copy stays consistent.
+* When in doubt, check the existing English string and the snapshot tests to see how the message is rendered with real values.

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1,0 +1,12 @@
+{
+  "trash.daysRemaining": "{count, plural, one {{count} day left} other {{count} days left}}",
+  "trash.daysRemaining.aria": "Purges in {count, plural, one {{count} day} other {{count} days}}",
+  "trash.genderedActor": "{gender, select, male {{name} deleted {count, plural, one {his file} other {his files}}} female {{name} deleted {count, plural, one {her file} other {her files}}} other {{name} deleted {count, plural, one {their file} other {their files}}}}",
+  "projectGallery.filteredCount": "Showing {count, plural, one {# project} other {# projects}}{filters}",
+  "projectGallery.filters.stack": " filtered by {stack}",
+  "projectGallery.filters.tags": " with tags {tags}",
+  "projectGallery.filters.year": " in {year}",
+  "projectGallery.filters.type": " of type {type}",
+  "projectGallery.filters.search": " matching \"{search}\"",
+  "youtube.playlistCount": "{count, plural, one {# playlist} other {# playlists}}"
+}

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1,0 +1,12 @@
+{
+  "trash.daysRemaining": "{count, plural, one {Queda {count} día} other {Quedan {count} días}}",
+  "trash.daysRemaining.aria": "Se vacía en {count, plural, one {{count} día} other {{count} días}}",
+  "trash.genderedActor": "{gender, select, male {{name} eliminó {count, plural, one {su archivo} other {sus archivos}}} female {{name} eliminó {count, plural, one {su archivo} other {sus archivos}}} other {{name} eliminó {count, plural, one {su archivo} other {sus archivos}}}}",
+  "projectGallery.filteredCount": "Mostrando {count, plural, one {# proyecto} other {# proyectos}}{filters}",
+  "projectGallery.filters.stack": " filtrado por {stack}",
+  "projectGallery.filters.tags": " con etiquetas {tags}",
+  "projectGallery.filters.year": " en {year}",
+  "projectGallery.filters.type": " de tipo {type}",
+  "projectGallery.filters.search": " que coincide con \"{search}\"",
+  "youtube.playlistCount": "{count, plural, one {# lista de reproducción} other {# listas de reproducción}}"
+}

--- a/i18n/message.ts
+++ b/i18n/message.ts
@@ -1,0 +1,179 @@
+import IntlMessageFormat from 'intl-messageformat';
+import en from './locales/en.json';
+import es from './locales/es.json';
+
+export type MessageValues = Record<string, unknown>;
+export type MessageCatalog = Record<string, string>;
+export type CatalogMap = Record<string, MessageCatalog>;
+
+export const defaultCatalogs: CatalogMap = {
+  en,
+  es,
+};
+
+export type SupportedLocale = keyof typeof defaultCatalogs;
+
+export const FALLBACK_LOCALE: SupportedLocale = 'en';
+
+export interface MessageFormatter {
+  format: (key: string, values?: MessageValues) => string;
+  has: (key: string) => boolean;
+  readonly resolvedLocale: string;
+  readonly resolvedFallbackLocale: string;
+}
+
+export interface CreateMessageFormatterOptions {
+  locale: string;
+  fallbackLocale?: string;
+  catalogs?: CatalogMap;
+}
+
+const formatterCache = new Map<string, IntlMessageFormat>();
+
+function normalizeLocale(
+  locale: string | undefined,
+  catalogs: CatalogMap,
+  fallbackLocale: string,
+): string {
+  if (!locale) return fallbackLocale;
+  const lower = locale.toLowerCase();
+  if (lower in catalogs) return lower;
+  const [base] = lower.split(/[\-_]/);
+  if (base && base in catalogs) return base;
+  return fallbackLocale;
+}
+
+function getMessage(
+  catalogs: CatalogMap,
+  locale: string,
+  key: string,
+): string | undefined {
+  return catalogs[locale]?.[key];
+}
+
+function getIntlFormatter(locale: string, key: string, message: string) {
+  const cacheKey = `${locale}|${key}|${message}`;
+  let formatter = formatterCache.get(cacheKey);
+  if (!formatter) {
+    formatter = new IntlMessageFormat(message, locale);
+    formatterCache.set(cacheKey, formatter);
+  }
+  return formatter;
+}
+
+export function createMessageFormatter({
+  locale,
+  fallbackLocale = FALLBACK_LOCALE,
+  catalogs = defaultCatalogs,
+}: CreateMessageFormatterOptions): MessageFormatter {
+  const normalizedFallback = normalizeLocale(
+    fallbackLocale,
+    catalogs,
+    FALLBACK_LOCALE,
+  );
+  const normalizedLocale = normalizeLocale(
+    locale,
+    catalogs,
+    normalizedFallback,
+  );
+
+  return {
+    get resolvedLocale() {
+      return normalizedLocale;
+    },
+    get resolvedFallbackLocale() {
+      return normalizedFallback;
+    },
+    format(key: string, values?: MessageValues) {
+      const directMessage = getMessage(catalogs, normalizedLocale, key);
+      if (directMessage) {
+        return String(
+          getIntlFormatter(normalizedLocale, key, directMessage).format(values),
+        );
+      }
+      if (normalizedFallback !== normalizedLocale) {
+        const fallbackMessage = getMessage(
+          catalogs,
+          normalizedFallback,
+          key,
+        );
+        if (fallbackMessage) {
+          return String(
+            getIntlFormatter(
+              normalizedFallback,
+              key,
+              fallbackMessage,
+            ).format(values),
+          );
+        }
+      }
+      return key;
+    },
+    has(key: string) {
+      return (
+        getMessage(catalogs, normalizedLocale, key) !== undefined ||
+        getMessage(catalogs, normalizedFallback, key) !== undefined
+      );
+    },
+  };
+}
+
+const runtimeCache = new Map<string, MessageFormatter>();
+
+export function getMessageFormatter(
+  locale?: string,
+  fallbackLocale: string = FALLBACK_LOCALE,
+): MessageFormatter {
+  const normalizedFallback = normalizeLocale(
+    fallbackLocale,
+    defaultCatalogs,
+    FALLBACK_LOCALE,
+  );
+  const normalizedLocale = normalizeLocale(
+    locale,
+    defaultCatalogs,
+    normalizedFallback,
+  );
+  const cacheKey = `${normalizedLocale}|${normalizedFallback}`;
+  let formatter = runtimeCache.get(cacheKey);
+  if (!formatter) {
+    formatter = createMessageFormatter({
+      locale: normalizedLocale,
+      fallbackLocale: normalizedFallback,
+      catalogs: defaultCatalogs,
+    });
+    runtimeCache.set(cacheKey, formatter);
+  }
+  return formatter;
+}
+
+export function formatMessage(
+  key: string,
+  values?: MessageValues,
+  options?: { locale?: string; fallbackLocale?: string },
+): string {
+  const formatter = getMessageFormatter(
+    options?.locale,
+    options?.fallbackLocale ?? FALLBACK_LOCALE,
+  );
+  return formatter.format(key, values);
+}
+
+export function detectLocale(defaultLocale: string = FALLBACK_LOCALE): string {
+  if (typeof navigator !== 'undefined') {
+    const nav = navigator as Navigator & { languages?: string[] };
+    if (nav.languages?.length) {
+      return nav.languages[0];
+    }
+    if (nav.language) {
+      return nav.language;
+    }
+  }
+  if (typeof Intl !== 'undefined' && typeof Intl.DateTimeFormat === 'function') {
+    const resolved = new Intl.DateTimeFormat().resolvedOptions().locale;
+    if (resolved) {
+      return resolved;
+    }
+  }
+  return defaultLocale;
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "html2canvas": "^1.4.1",
     "idb": "7.1.1",
     "idb-keyval": "^6.2.1",
+    "intl-messageformat": "^10.7.16",
     "jspdf": "^3.0.2",
     "kaitai-struct": "^0.10.0",
     "leaflet": "^1.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1692,6 +1692,57 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@formatjs/ecma402-abstract@npm:2.3.4":
+  version: 2.3.4
+  resolution: "@formatjs/ecma402-abstract@npm:2.3.4"
+  dependencies:
+    "@formatjs/fast-memoize": "npm:2.2.7"
+    "@formatjs/intl-localematcher": "npm:0.6.1"
+    decimal.js: "npm:^10.4.3"
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/2644bc618a34dc610ef9691281eeb45ae6175e6982cf19f1bd140672fc95c748747ce3c85b934649ea7e4a304f7ae0060625fd53d5df76f92ca3acf743e1eb0a
+  languageName: node
+  linkType: hard
+
+"@formatjs/fast-memoize@npm:2.2.7":
+  version: 2.2.7
+  resolution: "@formatjs/fast-memoize@npm:2.2.7"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/f5eabb0e4ab7162297df8252b4cfde194b23248120d9df267592eae2be2d2f7c4f670b5a70523d91b4ecdc35d40e65823bb8eeba8dd79fbf8601a972bf3b8866
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-messageformat-parser@npm:2.11.2":
+  version: 2.11.2
+  resolution: "@formatjs/icu-messageformat-parser@npm:2.11.2"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.4"
+    "@formatjs/icu-skeleton-parser": "npm:1.8.14"
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/a121f2d2c6b36a1632ffd64c3545e2500c8ee0f7fee5db090318c035d635c430ab123faedb5d000f18d9423a7b55fbf670b84e2e2dd72cc307a38aed61d3b2e0
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-skeleton-parser@npm:1.8.14":
+  version: 1.8.14
+  resolution: "@formatjs/icu-skeleton-parser@npm:1.8.14"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.4"
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/a1807ed6e90b8a2e8d0e5b5125e6f9a2c057d3cff377fb031d2333af7cfaa6de4ed3a15c23da7294d4c3557f8b28b2163246434a19720f26b5db0497d97e9b58
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl-localematcher@npm:0.6.1":
+  version: 0.6.1
+  resolution: "@formatjs/intl-localematcher@npm:0.6.1"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/bacbedd508519c1bb5ca2620e89dc38f12101be59439aa14aa472b222915b462cb7d679726640f6dcf52a05dd218b5aa27ccd60f2e5010bb96f1d4929848cde0
+  languageName: node
+  linkType: hard
+
 "@hapi/hoek@npm:^9.0.0, @hapi/hoek@npm:^9.3.0":
   version: 9.3.0
   resolution: "@hapi/hoek@npm:9.3.0"
@@ -8156,6 +8207,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"intl-messageformat@npm:^10.7.16":
+  version: 10.7.16
+  resolution: "intl-messageformat@npm:10.7.16"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.4"
+    "@formatjs/fast-memoize": "npm:2.2.7"
+    "@formatjs/icu-messageformat-parser": "npm:2.11.2"
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/537735bf6439f0560f132895d117df6839957ac04cdd58d861f6da86803d40bfc19059e3d341ddb8de87214b73a6329b57f9acdb512bb0f745dcf08729507b9b
+  languageName: node
+  linkType: hard
+
 "invariant@npm:^2.2.4":
   version: 2.2.4
   resolution: "invariant@npm:2.2.4"
@@ -13917,6 +13980,7 @@ __metadata:
     html2canvas: "npm:^1.4.1"
     idb: "npm:7.1.1"
     idb-keyval: "npm:^6.2.1"
+    intl-messageformat: "npm:^10.7.16"
     jest: "npm:30.0.5"
     jest-environment-jsdom: "npm:30.0.5"
     jspdf: "npm:^3.0.2"


### PR DESCRIPTION
## Summary
- add an ICU-powered message formatter with locale fallbacks and shared catalogs
- switch Trash, Project Gallery, and YouTube plural strings to the formatter
- add localization guidelines and snapshot coverage for plural and gender cases

## Testing
- yarn test i18n.message.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc62542b588328be43bad11a1bb96e