### PR TITLE
[accessibility] Add global announcer context

### DIFF
--- a/__tests__/liveRegion.test.tsx
+++ b/__tests__/liveRegion.test.tsx
@@ -1,19 +1,94 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
+import React, { useEffect, useState } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import Announcer from '../components/common/Announcer';
 import Toast from '../components/ui/Toast';
 import FormError from '../components/ui/FormError';
+import { useAnnounce } from '../hooks/useAnnounce';
 
-describe('live region components', () => {
-  it('Toast uses polite live region', () => {
-    const { unmount } = render(<Toast message="Saved" />);
-    const region = screen.getByRole('status');
-    expect(region).toHaveAttribute('aria-live', 'polite');
-    unmount();
+describe('global live announcer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
   });
 
-  it('FormError announces politely', () => {
-    render(<FormError>Required field</FormError>);
-    const region = screen.getByRole('status');
-    expect(region).toHaveAttribute('aria-live', 'polite');
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('announces toast messages politely and clears after delay', async () => {
+    render(
+      <Announcer>
+        <Toast message="Saved" />
+      </Announcer>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent('Saved'),
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('');
+  });
+
+  it('announces form errors assertively', async () => {
+    render(
+      <Announcer>
+        <FormError>Required field</FormError>
+      </Announcer>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Required field'),
+    );
+  });
+
+  it('deduplicates identical messages until cleared', async () => {
+    const Trigger: React.FC = () => {
+      const { announcePolite } = useAnnounce();
+      const [result, setResult] = useState<string>('idle');
+
+      useEffect(() => {
+        const initial = announcePolite('Process finished');
+        setResult(initial ? 'announced' : 'skipped');
+      }, [announcePolite]);
+
+      return (
+        <button
+          type="button"
+          data-testid="repeat"
+          onClick={() =>
+            setResult(announcePolite('Process finished') ? 'announced' : 'skipped')
+          }
+        >
+          {result}
+        </button>
+      );
+    };
+
+    render(
+      <Announcer>
+        <Trigger />
+      </Announcer>,
+    );
+
+    const button = screen.getByTestId('repeat');
+    expect(button).toHaveTextContent('announced');
+
+    fireEvent.click(button);
+    expect(button).toHaveTextContent('skipped');
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('');
+
+    fireEvent.click(button);
+    expect(button).toHaveTextContent('announced');
   });
 });

--- a/components/FixturesLoader.tsx
+++ b/components/FixturesLoader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from 'react';
+import useAnnounce from '../hooks/useAnnounce';
 
 interface LoaderProps {
   onData: (rows: any[]) => void;
@@ -9,6 +10,7 @@ interface LoaderProps {
 export default function FixturesLoader({ onData }: LoaderProps) {
   const [progress, setProgress] = useState(0);
   const [worker, setWorker] = useState<Worker | null>(null);
+  const { announceProgress, announceTask } = useAnnounce();
 
   useEffect(() => {
     const w = new Worker(new URL('../workers/fixturesParser.ts', import.meta.url));
@@ -45,6 +47,15 @@ export default function FixturesLoader({ onData }: LoaderProps) {
   };
 
   const cancel = () => worker?.postMessage({ type: 'cancel' });
+
+  useEffect(() => {
+    if (progress <= 0) return;
+    if (progress >= 100) {
+      announceTask({ taskName: 'Fixture import', status: 'completed' });
+      return;
+    }
+    announceProgress({ label: 'Fixture import', value: progress, total: 100 });
+  }, [progress, announceProgress, announceTask]);
 
   return (
     <div className="text-xs" aria-label="fixtures loader">

--- a/components/apps/project-gallery.tsx
+++ b/components/apps/project-gallery.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import projectsData from '../../data/projects.json';
+import useAnnounce from '../../hooks/useAnnounce';
 
 interface Project {
   id: number;
@@ -35,6 +36,7 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
   const [tags, setTags] = useState<string[]>([]);
   const [ariaMessage, setAriaMessage] = useState('');
   const [selected, setSelected] = useState<Project[]>([]);
+  const { announcePolite } = useAnnounce();
 
   const readFilters = async () => {
     try {
@@ -88,9 +90,11 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
       setYear(data.year || '');
       setType(data.type || '');
       setTags(data.tags || []);
-      setAriaMessage(`Showing ${projects.length} projects`);
+      const initialMessage = `Showing ${projects.length} projects`;
+      setAriaMessage(initialMessage);
+      announcePolite(initialMessage);
     });
-  }, [projects.length]);
+  }, [projects.length, announcePolite]);
 
   const stacks = useMemo(
     () => Array.from(new Set(projects.flatMap((p) => p.stack))),
@@ -129,10 +133,16 @@ const ProjectGallery: React.FC<Props> = ({ openApp }) => {
   }, [search, stack, year, type, tags]);
 
   useEffect(() => {
-    setAriaMessage(
-      `Showing ${filtered.length} project${filtered.length === 1 ? '' : 's'}${stack ? ` filtered by ${stack}` : ''}${tags.length ? ` with tags ${tags.join(', ')}` : ''}${year ? ` in ${year}` : ''}${type ? ` of type ${type}` : ''}${search ? ` matching "${search}"` : ''}`
-    );
-  }, [filtered.length, stack, year, type, tags, search]);
+    const message = `Showing ${
+      filtered.length
+    } project${filtered.length === 1 ? '' : 's'}${stack ? ` filtered by ${stack}` : ''}${
+      tags.length ? ` with tags ${tags.join(', ')}` : ''
+    }${year ? ` in ${year}` : ''}${type ? ` of type ${type}` : ''}${
+      search ? ` matching "${search}"` : ''
+    }`;
+    setAriaMessage(message);
+    announcePolite(message);
+  }, [announcePolite, filtered.length, stack, year, type, tags, search]);
 
   const openInFirefox = (url: string) => {
     try {

--- a/components/common/Announcer.tsx
+++ b/components/common/Announcer.tsx
@@ -1,0 +1,137 @@
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+export type LiveRegionChannel = 'polite' | 'assertive';
+
+export interface AnnouncerContextValue {
+  announce: (message: string, channel?: LiveRegionChannel) => boolean;
+  announcePolite: (message: string) => boolean;
+  announceAssertive: (message: string) => boolean;
+  clear: (channel?: LiveRegionChannel) => void;
+}
+
+const CLEAR_DELAY = 2000;
+
+export const AnnouncerContext = createContext<AnnouncerContextValue | null>(null);
+
+type TimerMap = Record<LiveRegionChannel, ReturnType<typeof setTimeout> | null>;
+type MessageMap = Record<LiveRegionChannel, string>;
+
+const resetTimers = (timers: TimerMap, channel: LiveRegionChannel) => {
+  const timer = timers[channel];
+  if (timer) {
+    clearTimeout(timer);
+    timers[channel] = null;
+  }
+};
+
+const Announcer: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const [politeMessage, setPoliteMessage] = useState('');
+  const [assertiveMessage, setAssertiveMessage] = useState('');
+  const timersRef = useRef<TimerMap>({ polite: null, assertive: null });
+  const lastMessageRef = useRef<MessageMap>({ polite: '', assertive: '' });
+
+  const clearChannel = useCallback((channel: LiveRegionChannel) => {
+    resetTimers(timersRef.current, channel);
+    if (channel === 'polite') {
+      setPoliteMessage('');
+    } else {
+      setAssertiveMessage('');
+    }
+    lastMessageRef.current[channel] = '';
+  }, []);
+
+  const clear = useCallback(
+    (channel?: LiveRegionChannel) => {
+      if (channel) {
+        clearChannel(channel);
+        return;
+      }
+      clearChannel('polite');
+      clearChannel('assertive');
+    },
+    [clearChannel],
+  );
+
+  const setMessage = useCallback((channel: LiveRegionChannel, message: string) => {
+    const trimmed = message.trim();
+    if (!trimmed) return false;
+    if (lastMessageRef.current[channel] === trimmed) return false;
+
+    lastMessageRef.current[channel] = trimmed;
+    if (channel === 'polite') setPoliteMessage(trimmed);
+    else setAssertiveMessage(trimmed);
+
+    resetTimers(timersRef.current, channel);
+    timersRef.current[channel] = setTimeout(() => {
+      if (channel === 'polite') setPoliteMessage('');
+      else setAssertiveMessage('');
+      lastMessageRef.current[channel] = '';
+      timersRef.current[channel] = null;
+    }, CLEAR_DELAY);
+
+    return true;
+  }, []);
+
+  const announcePolite = useCallback(
+    (message: string) => setMessage('polite', message),
+    [setMessage],
+  );
+
+  const announceAssertive = useCallback(
+    (message: string) => setMessage('assertive', message),
+    [setMessage],
+  );
+
+  const announce = useCallback(
+    (message: string, channel: LiveRegionChannel = 'polite') =>
+      channel === 'assertive'
+        ? setMessage('assertive', message)
+        : setMessage('polite', message),
+    [setMessage],
+  );
+
+  useEffect(() => () => clear(), [clear]);
+
+  const value = useMemo(
+    () => ({
+      announce,
+      announcePolite,
+      announceAssertive,
+      clear,
+    }),
+    [announce, announcePolite, announceAssertive, clear],
+  );
+
+  return (
+    <AnnouncerContext.Provider value={value}>
+      {children}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+        data-testid="announcer-polite"
+      >
+        {politeMessage}
+      </div>
+      <div
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+        className="sr-only"
+        data-testid="announcer-assertive"
+      >
+        {assertiveMessage}
+      </div>
+    </AnnouncerContext.Provider>
+  );
+};
+
+export default Announcer;

--- a/components/ui/FormError.tsx
+++ b/components/ui/FormError.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
+import useAnnounce from '../../hooks/useAnnounce';
 
 interface FormErrorProps {
   id?: string;
@@ -6,15 +7,29 @@ interface FormErrorProps {
   children: React.ReactNode;
 }
 
-const FormError = ({ id, className = '', children }: FormErrorProps) => (
-  <p
-    id={id}
-    role="status"
-    aria-live="polite"
-    className={`text-red-600 text-sm mt-2 ${className}`.trim()}
-  >
-    {children}
-  </p>
-);
+const flattenText = (node: React.ReactNode): string => {
+  if (node === null || node === undefined || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(flattenText).join(' ');
+  if (React.isValidElement(node)) return flattenText(node.props.children);
+  return '';
+};
+
+const FormError = ({ id, className = '', children }: FormErrorProps) => {
+  const { announceAssertive } = useAnnounce();
+  const textContent = useMemo(() => flattenText(children).trim(), [children]);
+
+  useEffect(() => {
+    if (textContent) {
+      announceAssertive(textContent);
+    }
+  }, [announceAssertive, textContent]);
+
+  return (
+    <p id={id} className={`text-red-600 text-sm mt-2 ${className}`.trim()}>
+      {children}
+    </p>
+  );
+};
 
 export default FormError;

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import useAnnounce from '../../hooks/useAnnounce';
 
 interface ToastProps {
   message: string;
@@ -16,22 +17,24 @@ const Toast: React.FC<ToastProps> = ({
   duration = 6000,
 }) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const { announceToast } = useAnnounce();
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
     setVisible(true);
+    if (message) {
+      announceToast(message);
+    }
     timeoutRef.current = setTimeout(() => {
       onClose && onClose();
     }, duration);
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-  }, [duration, onClose]);
+  }, [announceToast, message, duration, onClose]);
 
   return (
     <div
-      role="status"
-      aria-live="polite"
       className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
       <span>{message}</span>

--- a/hooks/useAnnounce.ts
+++ b/hooks/useAnnounce.ts
@@ -1,0 +1,112 @@
+import { useCallback, useContext, useMemo } from 'react';
+import { AnnouncerContext, AnnouncerContextValue } from '../components/common/Announcer';
+
+export type { LiveRegionChannel } from '../components/common/Announcer';
+
+export interface ProgressAnnouncement {
+  label: string;
+  value: number;
+  total?: number;
+}
+
+export interface TaskAnnouncement {
+  taskName: string;
+  status: 'started' | 'completed' | 'failed' | 'progress' | string;
+  detail?: string;
+  progress?: number;
+  total?: number;
+}
+
+const clampPercent = (value: number) => {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 100) return 100;
+  return Math.round(value);
+};
+
+const normaliseProgress = (value: number, total?: number) => {
+  if (typeof total === 'number' && total > 0) {
+    return clampPercent((value / total) * 100);
+  }
+  if (value <= 1) {
+    return clampPercent(value * 100);
+  }
+  return clampPercent(value);
+};
+
+export interface UseAnnounceResult extends AnnouncerContextValue {
+  announceToast: (message: string) => boolean;
+  announceProgress: (announcement: ProgressAnnouncement) => boolean;
+  announceTask: (announcement: TaskAnnouncement) => boolean;
+}
+
+export const useAnnounce = (): UseAnnounceResult => {
+  const context = useContext(AnnouncerContext);
+  if (!context) {
+    throw new Error('useAnnounce must be used within an Announcer');
+  }
+
+  const { announcePolite, announceAssertive } = context;
+
+  const announceToast = useCallback(
+    (message: string) => announcePolite(message),
+    [announcePolite],
+  );
+
+  const announceProgress = useCallback(
+    ({ label, value, total }: ProgressAnnouncement) => {
+      if (!label) return false;
+      const percent = normaliseProgress(value, total);
+      return announcePolite(`${label} ${percent}% complete`);
+    },
+    [announcePolite],
+  );
+
+  const announceTask = useCallback(
+    ({ taskName, status, detail, progress, total }: TaskAnnouncement) => {
+      if (!taskName || !status) return false;
+      const normalizedStatus = status.toLowerCase();
+      const parts: string[] = [taskName];
+      if (normalizedStatus === 'completed' || normalizedStatus === 'complete') {
+        parts.push('completed');
+      } else if (normalizedStatus === 'failed' || normalizedStatus === 'error') {
+        parts.push('failed');
+      } else if (normalizedStatus === 'started' || normalizedStatus === 'start') {
+        parts.push('started');
+      } else if (normalizedStatus === 'progress') {
+        parts.push('progress update');
+      } else {
+        parts.push(status);
+      }
+
+      if (typeof progress === 'number') {
+        const percent = normaliseProgress(progress, total);
+        parts.push(`${percent}%`);
+      }
+
+      if (detail) {
+        parts.push(detail);
+      }
+
+      const message = parts.join(' ').replace(/\s+/g, ' ').trim();
+      const announceFn =
+        normalizedStatus === 'failed' || normalizedStatus === 'error'
+          ? announceAssertive
+          : announcePolite;
+      return announceFn(message);
+    },
+    [announceAssertive, announcePolite],
+  );
+
+  return useMemo(
+    () => ({
+      ...context,
+      announceToast,
+      announceProgress,
+      announceTask,
+    }),
+    [context, announceToast, announceProgress, announceTask],
+  );
+};
+
+export default useAnnounce;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,6 +14,7 @@ import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import NotificationCenter from '../components/common/NotificationCenter';
 import PipPortalProvider from '../components/common/PipPortal';
+import Announcer from '../components/common/Announcer';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
@@ -149,34 +150,35 @@ function MyApp(props) {
 
   return (
     <ErrorBoundary>
-      <Script src="/a2hs.js" strategy="beforeInteractive" />
-      <div className={ubuntu.className}>
-        <a
-          href="#app-grid"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
-        >
-          Skip to app grid
-        </a>
-        <SettingsProvider>
-          <NotificationCenter>
-            <PipPortalProvider>
-              <div aria-live="polite" id="live-region" />
-              <Component {...pageProps} />
-              <ShortcutOverlay />
-              <Analytics
-                beforeSend={(e) => {
-                  if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-                  const evt = e;
-                  if (evt.metadata?.email) delete evt.metadata.email;
-                  return e;
-                }}
-              />
+      <Announcer>
+        <Script src="/a2hs.js" strategy="beforeInteractive" />
+        <div className={ubuntu.className}>
+          <a
+            href="#app-grid"
+            className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-50 focus:p-2 focus:bg-white focus:text-black"
+          >
+            Skip to app grid
+          </a>
+          <SettingsProvider>
+            <NotificationCenter>
+              <PipPortalProvider>
+                <Component {...pageProps} />
+                <ShortcutOverlay />
+                <Analytics
+                  beforeSend={(e) => {
+                    if (e.url.includes('/admin') || e.url.includes('/private')) return null;
+                    const evt = e;
+                    if (evt.metadata?.email) delete evt.metadata.email;
+                    return e;
+                  }}
+                />
 
-              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-            </PipPortalProvider>
-          </NotificationCenter>
-        </SettingsProvider>
-      </div>
+                {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+              </PipPortalProvider>
+            </NotificationCenter>
+          </SettingsProvider>
+        </div>
+      </Announcer>
     </ErrorBoundary>
 
 


### PR DESCRIPTION
## Summary
- add a global announcer provider that exposes polite and assertive live regions with deduplication helpers
- create a reusable `useAnnounce` hook for toasts, task updates, and progress events
- integrate announcements into common flows and add unit tests covering updates and deduplication

## Testing
- yarn test liveRegion.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc625941648328b885b3b6fcacbc2a