### PR TITLE
[accessibility] unify focus ring styling

### DIFF
--- a/__tests__/popularModules.test.tsx
+++ b/__tests__/popularModules.test.tsx
@@ -5,6 +5,9 @@ import PopularModules from '../components/PopularModules';
 describe('PopularModules', () => {
   it('filters modules and displays logs and table when selected', () => {
     render(<PopularModules />);
+    expect(
+      screen.getByRole('button', { name: /update modules/i })
+    ).toHaveClass('focus-ring');
     fireEvent.click(screen.getByRole('button', { name: 'scanner' }));
     expect(screen.getByRole('button', { name: /Port Scanner/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Brute Force/i })).not.toBeInTheDocument();

--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -55,7 +55,7 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
         aria-label="Help"
         aria-expanded={open}
         onClick={toggle}
-        className="fixed top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+        className="fixed top-2 right-2 z-40 bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus-ring focus-ring-strong"
       >
         ?
       </button>

--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -33,7 +33,7 @@ export default function ModuleCard({
   return (
     <button
       onClick={() => onSelect(module)}
-      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
+      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none focus-ring ${
         selected ? 'bg-gray-100' : ''
       }`}
     >

--- a/components/NetworkAttackStepper.tsx
+++ b/components/NetworkAttackStepper.tsx
@@ -98,7 +98,7 @@ const NetworkAttackStepper: React.FC = () => {
                       type="button"
                       onClick={() => setStep(index)}
                       aria-current={isActive ? 'step' : undefined}
-                      className={`group relative flex w-full items-center gap-4 rounded-lg border border-transparent px-1 py-3 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue ${
+                      className={`group relative flex w-full items-center gap-4 rounded-lg border border-transparent px-1 py-3 text-left transition focus:outline-none focus-ring focus-ring-surface ${
                         isActive ? 'bg-slate-800/80' : 'hover:bg-slate-800/60'
                       }`}
                     >

--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -188,7 +188,7 @@ const PopularModules: React.FC = () => {
       <div className="flex items-center gap-2">
         <button
           onClick={handleUpdate}
-          className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus-ring focus-ring-surface"
         >
           Update Modules
         </button>
@@ -203,12 +203,13 @@ const PopularModules: React.FC = () => {
         placeholder="Search modules"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
+        aria-label="Search modules"
         className="w-full p-2 text-black rounded"
       />
       <div className="flex flex-wrap gap-2">
         <button
           onClick={() => setFilter('')}
-          className={`px-2 py-1 text-sm rounded focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+          className={`px-2 py-1 text-sm rounded focus:outline-none focus-ring focus-ring-surface ${
             filter === '' ? 'bg-blue-600' : 'bg-gray-700'
           }`}
         >
@@ -218,7 +219,7 @@ const PopularModules: React.FC = () => {
           <button
             key={t}
             onClick={() => setFilter(t)}
-            className={`px-2 py-1 text-sm rounded focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+            className={`px-2 py-1 text-sm rounded focus:outline-none focus-ring focus-ring-surface ${
               filter === t ? 'bg-blue-600' : 'bg-gray-700'
             }`}
           >
@@ -231,7 +232,7 @@ const PopularModules: React.FC = () => {
           <button
             key={m.id}
             onClick={() => handleSelect(m)}
-            className="p-3 text-left bg-ub-grey rounded border border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            className="p-3 text-left bg-ub-grey rounded border border-gray-700 focus:outline-none focus-ring focus-ring-surface"
           >
             <h3 className="font-semibold">{m.name}</h3>
             <p className="text-sm text-gray-300">{m.description}</p>
@@ -276,26 +277,28 @@ const PopularModules: React.FC = () => {
             <button
               type="button"
               onClick={copyCommand}
-              className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus-ring focus-ring-surface"
             >
               Copy
             </button>
           </div>
           <div className="space-y-1">
-            <label className="block text-sm">
+            <label className="block text-sm" htmlFor="module-log-filter">
               Filter logs
               <input
+                id="module-log-filter"
                 placeholder="Filter logs"
                 type="text"
                 value={logFilter}
                 onChange={(e) => setLogFilter(e.target.value)}
+                aria-label="Filter logs"
                 className="w-full p-1 mt-1 text-black rounded"
               />
             </label>
             <button
               type="button"
               onClick={copyLogs}
-              className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className="px-2 py-1 text-sm rounded bg-gray-700 focus:outline-none focus-ring focus-ring-surface"
             >
               Copy Logs
             </button>

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -28,7 +28,7 @@ export default function Tabs<T extends string>({
           aria-selected={active === t.id}
           tabIndex={active === t.id ? 0 : -1}
           onClick={() => onChange(t.id)}
-          className={`px-4 py-2 focus:outline-none ${
+          className={`px-4 py-2 focus:outline-none focus-ring ${
             active === t.id ? "bg-ub-orange text-white" : "text-ubt-grey"
           }`}
         >

--- a/components/ToggleSwitch.tsx
+++ b/components/ToggleSwitch.tsx
@@ -20,7 +20,7 @@ export default function ToggleSwitch({
       aria-checked={checked}
       aria-label={ariaLabel}
       onClick={() => onChange(!checked)}
-      className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none ${
+      className={`relative inline-flex w-10 h-5 rounded-full transition-colors focus:outline-none focus-ring ${
         checked ? "bg-ub-orange" : "bg-ubt-cool-grey"
       } ${className}`.trim()}
     >

--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -222,7 +222,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           <button
             type="button"
             onClick={resume}
-            className="px-4 py-2 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className="px-4 py-2 bg-gray-700 text-white rounded focus:outline-none focus-ring focus-ring-strong"
             autoFocus
           >
             Resume
@@ -233,28 +233,28 @@ const GameLayout: React.FC<GameLayoutProps> = ({
         <button
           type="button"
           onClick={() => setPaused((p) => !p)}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus-ring focus-ring-strong"
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
         <button
           type="button"
           onClick={snapshot}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus-ring focus-ring-strong"
         >
           Snapshot
         </button>
         <button
           type="button"
           onClick={replay}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus-ring focus-ring-strong"
         >
           Replay
         </button>
         <button
           type="button"
           onClick={shareApp}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus-ring focus-ring-strong"
         >
           Share
         </button>
@@ -262,7 +262,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           <button
             type="button"
             onClick={shareScore}
-            className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus-ring focus-ring-strong"
           >
             Share Score
           </button>
@@ -272,7 +272,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           aria-label="Help"
           aria-expanded={showHelp}
           onClick={toggle}
-          className="bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus:ring"
+          className="bg-gray-700 text-white rounded-full w-8 h-8 flex items-center justify-center focus:outline-none focus-ring focus-ring-strong"
         >
           ?
         </button>

--- a/components/apps/Games/common/input-remap/InputRemap.tsx
+++ b/components/apps/Games/common/input-remap/InputRemap.tsx
@@ -32,7 +32,7 @@ const InputRemap: React.FC<Props> = ({ mapping, setKey, actions }) => {
           <button
             type="button"
             onClick={() => capture(action)}
-            className="px-2 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+            className="px-2 py-1 bg-gray-700 rounded focus:outline-none focus-ring focus-ring-strong"
           >
             {waiting === action ? 'Press key...' : mapping[action]}
           </button>

--- a/components/apps/HelpOverlay.tsx
+++ b/components/apps/HelpOverlay.tsx
@@ -244,7 +244,7 @@ const HelpOverlay: React.FC<HelpOverlayProps> = ({ gameId, onClose }) => {
         )}
         <button
           onClick={onClose}
-          className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus:ring"
+          className="mt-4 px-3 py-1 bg-gray-700 rounded focus:outline-none focus-ring focus-ring-strong"
         >
           Close
         </button>

--- a/components/apps/checkers/index.tsx
+++ b/components/apps/checkers/index.tsx
@@ -458,7 +458,7 @@ const Checkers = () => {
                 {...pointerHandlers(() =>
                   selected ? tryMove(r, c) : selectPiece(r, c)
                 )}
-                className={`w-12 h-12 md:w-14 md:h-14 flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-white ${
+                className={`w-12 h-12 md:w-14 md:h-14 flex items-center justify-center focus:outline-none focus-ring focus-ring-strong focus-ring-contrast ${
                   isDark ? 'bg-gray-700' : 'bg-gray-400'
                 } ${
                   showMove

--- a/components/apps/contact/index.tsx
+++ b/components/apps/contact/index.tsx
@@ -299,11 +299,12 @@ const ContactApp: React.FC = () => {
         </p>
       )}
       <form onSubmit={handleSubmit} className="space-y-6 max-w-md">
-        <div className="relative">
-          <input
-            id="contact-name"
-            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
-            value={name}
+          <div className="relative">
+            <input
+              id="contact-name"
+              aria-label="Name"
+              className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus-ring focus-ring-inset focus-ring-strong"
+              value={name}
             onChange={(e) => setName(e.target.value)}
             required
             placeholder=" "
@@ -316,10 +317,11 @@ const ContactApp: React.FC = () => {
           </label>
         </div>
         <div className="relative">
-          <input
-            id="contact-email"
-            type="email"
-            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+            <input
+              id="contact-email"
+              type="email"
+              aria-label="Email"
+              className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus-ring focus-ring-inset focus-ring-strong"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
@@ -340,9 +342,10 @@ const ContactApp: React.FC = () => {
           )}
         </div>
         <div className="relative">
-          <textarea
-            id="contact-message"
-            className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+            <textarea
+              id="contact-message"
+              aria-label="Message"
+              className="peer w-full rounded border border-gray-700 bg-gray-800 px-3 py-3 text-white focus:outline-none focus-ring focus-ring-inset focus-ring-strong"
             rows={4}
             value={message}
             onChange={(e) => setMessage(e.target.value)}
@@ -374,14 +377,16 @@ const ContactApp: React.FC = () => {
             setAttachments((prev) => prev.filter((_, idx) => idx !== i))
           }
         />
-        <input
-          type="text"
-          value={honeypot}
-          onChange={(e) => setHoneypot(e.target.value)}
-          className="hidden"
-          tabIndex={-1}
-          autoComplete="off"
-        />
+          <input
+            type="text"
+            value={honeypot}
+            onChange={(e) => setHoneypot(e.target.value)}
+            className="hidden"
+            tabIndex={-1}
+            autoComplete="off"
+            aria-hidden="true"
+            aria-label="Do not fill"
+          />
         {error && <FormError className="mt-3">{error}</FormError>}
         <button
           type="submit"

--- a/components/apps/firefox/index.tsx
+++ b/components/apps/firefox/index.tsx
@@ -100,11 +100,12 @@ const Firefox: React.FC = () => {
           value={inputValue}
           onChange={(event) => setInputValue(event.target.value)}
           placeholder="Enter a URL"
-          className="flex-1 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-400 focus:border-blue-500 focus:outline-none"
+          aria-label="Address bar"
+          className="flex-1 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus-ring focus-ring-inset"
         />
         <button
           type="submit"
-          className="rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
+          className="rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-400 focus:outline-none focus-ring focus-ring-strong"
         >
           Go
         </button>
@@ -115,7 +116,7 @@ const Firefox: React.FC = () => {
             key={bookmark.url}
             type="button"
             onClick={() => updateAddress(bookmark.url)}
-            className="rounded bg-gray-800 px-3 py-1 font-medium text-gray-200 transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            className="rounded bg-gray-800 px-3 py-1 font-medium text-gray-200 transition hover:bg-gray-700 focus:outline-none focus-ring"
           >
             {bookmark.label}
           </button>

--- a/components/apps/firefox/simulations.tsx
+++ b/components/apps/firefox/simulations.tsx
@@ -537,7 +537,7 @@ export const FirefoxSimulationView: React.FC<{ simulation: FirefoxSimulation }> 
         href={simulation.externalUrl}
         target="_blank"
         rel="noreferrer"
-        className="mt-4 inline-flex items-center gap-2 rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
+        className="mt-4 inline-flex items-center gap-2 rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-400 focus:outline-none focus-ring focus-ring-strong"
       >
         {simulation.ctaLabel ?? 'Open official site'}
         <span aria-hidden="true" className="text-xs">↗</span>
@@ -557,7 +557,7 @@ export const FirefoxSimulationView: React.FC<{ simulation: FirefoxSimulation }> 
                       href={link.href}
                       target="_blank"
                       rel="noreferrer"
-                      className="font-medium text-blue-300 hover:text-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
+                      className="font-medium text-blue-300 hover:text-blue-200 focus:outline-none focus-ring"
                     >
                       {link.label}
                     </a>

--- a/components/apps/solitaire/index.tsx
+++ b/components/apps/solitaire/index.tsx
@@ -671,7 +671,7 @@ const Solitaire = () => {
           <button
             type="button"
             onClick={resume}
-            className="px-4 py-2 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className="px-4 py-2 bg-gray-700 text-white rounded focus:outline-none focus-ring focus-ring-strong"
             autoFocus
           >
             Resume
@@ -782,14 +782,15 @@ const Solitaire = () => {
         >
           Passes {passLimit === Infinity ? '∞' : passLimit}
         </button>
-        <label className="flex items-center space-x-1">
-          <input
-            type="checkbox"
-            checked={winnableOnly}
-            onChange={(e) => setWinnableOnly(e.target.checked)}
-          />
-          <span className="select-none">Winnable Only</span>
-        </label>
+          <label className="flex items-center space-x-1">
+            <input
+              type="checkbox"
+              checked={winnableOnly}
+              aria-label="Winnable only"
+              onChange={(e) => setWinnableOnly(e.target.checked)}
+            />
+            <span className="select-none">Winnable Only</span>
+          </label>
       </div>
       <div className="flex space-x-4 mb-4">
         <div className="w-16 h-24 min-w-[24px] min-h-[24px]" onClick={draw}>

--- a/components/apps/trash/index.tsx
+++ b/components/apps/trash/index.tsx
@@ -106,28 +106,28 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
           <button
             onClick={restore}
             disabled={selected === null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus-ring focus-ring-strong disabled:opacity-50"
           >
             Restore
           </button>
           <button
             onClick={restoreAll}
             disabled={items.length === 0}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus-ring focus-ring-strong disabled:opacity-50"
           >
             Restore All
           </button>
           <button
             onClick={remove}
             disabled={selected === null}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus-ring focus-ring-strong disabled:opacity-50"
           >
             Delete
           </button>
           <button
             onClick={empty}
             disabled={items.length === 0}
-            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange disabled:opacity-50"
+            className="border border-black bg-black bg-opacity-50 px-3 py-1 my-1 mx-1 rounded hover:bg-opacity-80 focus:outline-none focus-ring focus-ring-strong disabled:opacity-50"
           >
             Empty
           </button>

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -463,7 +463,7 @@ export default function YouTubeApp({ initialResults = [] }: Props) {
                 if (error) setError(null);
               }}
               placeholder="Search for playlists by topic, creator, or mood…"
-              className="w-full rounded-md border border-white/10 bg-black/40 px-4 py-3 text-sm text-white placeholder:text-ubt-grey focus:border-ubt-green focus:outline-none focus:ring-2 focus:ring-ubt-green/40"
+              className="w-full rounded-md border border-white/10 bg-black/40 px-4 py-3 text-sm text-white placeholder:text-ubt-grey focus:border-ubt-green focus:outline-none focus-ring focus-ring-inset focus-ring-strong"
             />
           </div>
           <button

--- a/components/menu/ApplicationsMenu.tsx
+++ b/components/menu/ApplicationsMenu.tsx
@@ -97,7 +97,7 @@ const ApplicationsMenu: React.FC<ApplicationsMenuProps> = ({ activeCategory, onS
               <button
                 type="button"
                 onClick={() => onSelect(category.id)}
-                className={`flex w-full items-center gap-3 rounded px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
+                className={`flex w-full items-center gap-3 rounded px-3 py-2 text-left transition focus:outline-none focus-ring focus-ring-surface ${
                   isActive ? 'bg-gray-700 text-white' : 'bg-transparent hover:bg-gray-700/60'
                 }`}
                 aria-pressed={isActive}

--- a/components/menu/PlacesMenu.tsx
+++ b/components/menu/PlacesMenu.tsx
@@ -63,7 +63,7 @@ const PlacesMenu: React.FC<PlacesMenuProps> = ({ heading = 'Places', items }) =>
               <button
                 type="button"
                 onClick={handleClick}
-                className="flex w-full items-center gap-3 rounded px-3 py-2 text-left transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-ubb-orange"
+                className="flex w-full items-center gap-3 rounded px-3 py-2 text-left transition hover:bg-gray-700 focus:outline-none focus-ring focus-ring-surface"
               >
                 <img
                   src={src}

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -443,7 +443,7 @@ const WhiskerMenu: React.FC = () => {
                     categoryButtonRefs.current[index] = el;
                   }}
                   type="button"
-                  className={`group flex min-h-[44px] items-center gap-3 rounded-lg px-3 py-3 text-left text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1724] ${
+                  className={`group flex min-h-[44px] items-center gap-3 rounded-lg px-3 py-3 text-left text-sm transition focus:outline-none focus-ring focus-ring-surface ${
                     category === cat.id
                       ? 'bg-[#162236] text-white shadow-[inset_2px_0_0_#53b9ff]'
                       : 'text-gray-300 hover:bg-[#152133] hover:text-white'
@@ -507,7 +507,7 @@ const WhiskerMenu: React.FC = () => {
                     key={app.id}
                     type="button"
                     onClick={() => openSelectedApp(app.id)}
-                    className="flex h-11 w-11 items-center justify-center rounded-lg bg-[#122136] text-white transition hover:-translate-y-0.5 hover:bg-[#1b2d46] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1a29]"
+                    className="flex h-11 w-11 items-center justify-center rounded-lg bg-[#122136] text-white transition hover:-translate-y-0.5 hover:bg-[#1b2d46] focus:outline-none focus-ring focus-ring-surface"
                     aria-label={`Open ${app.title}`}
                   >
                     <Image
@@ -550,7 +550,7 @@ const WhiskerMenu: React.FC = () => {
                     <li key={app.id}>
                       <button
                         type="button"
-                        className={`flex w-full min-h-[44px] items-center justify-between gap-4 rounded-xl px-4 py-3 text-left text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1a29] ${
+                        className={`flex w-full min-h-[44px] items-center justify-between gap-4 rounded-xl px-4 py-3 text-left text-sm transition focus:outline-none focus-ring focus-ring-surface ${
                           idx === highlight
                             ? 'bg-[#162438] text-white shadow-[0_0_0_1px_rgba(83,185,255,0.35)]'
                             : 'text-gray-200 hover:bg-[#142132]'

--- a/components/panel/WorkspaceSwitcher.tsx
+++ b/components/panel/WorkspaceSwitcher.tsx
@@ -48,7 +48,7 @@ export default function WorkspaceSwitcher({
             aria-pressed={isActive}
             aria-label={formatAriaLabel(workspace)}
             onClick={() => onSelect(workspace.id)}
-            className={`relative flex h-8 min-w-[2.25rem] items-center justify-center px-3 text-xs font-medium text-white/70 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kali-blue)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#161b25] ${
+            className={`relative flex h-8 min-w-[2.25rem] items-center justify-center px-3 text-xs font-medium text-white/70 transition-colors focus:outline-none focus-ring focus-ring-surface ${
               index > 0 ? "border-l border-white/10" : ""
             } ${isActive ? "text-white" : "hover:text-white"}`}
           >

--- a/components/ui/BatteryIndicator.tsx
+++ b/components/ui/BatteryIndicator.tsx
@@ -179,7 +179,7 @@ const BatteryIndicator: FC<BatteryIndicatorProps> = ({ className = "" }) => {
     <div ref={rootRef} className={`relative flex items-center ${className}`.trim()}>
       <button
         type="button"
-        className="flex h-6 w-6 items-center justify-center rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+        className="flex h-6 w-6 items-center justify-center rounded focus:outline-none focus-ring focus-ring-strong"
         aria-label={tooltip}
         aria-haspopup="true"
         aria-expanded={open}

--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -17,7 +17,7 @@ const Breadcrumbs: React.FC<Props> = ({ path, onNavigate }) => {
           <button
             type="button"
             onClick={() => onNavigate(idx)}
-            className="hover:underline focus:outline-none"
+            className="hover:underline focus:outline-none focus-ring"
           >
             {seg.name || '/'}
           </button>

--- a/components/ui/NetworkIndicator.tsx
+++ b/components/ui/NetworkIndicator.tsx
@@ -559,7 +559,7 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
     <div ref={rootRef} className={classNames("relative flex items-center", className)}>
       <button
         type="button"
-        className="flex h-6 w-6 items-center justify-center rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+        className="flex h-6 w-6 items-center justify-center rounded focus:outline-none focus-ring focus-ring-strong"
         aria-label={summary.tooltip}
         aria-haspopup="true"
         aria-expanded={open}

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -243,7 +243,7 @@ const NotificationBell: React.FC = () => {
         aria-expanded={isOpen}
         aria-controls={panelId}
         onClick={togglePanel}
-        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey transition focus:border-ubb-orange focus:outline-none focus:ring-0 hover:bg-white hover:bg-opacity-10"
+        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey transition focus:border-ubb-orange focus:outline-none focus-ring focus-ring-strong focus-ring-surface hover:bg-white hover:bg-opacity-10"
       >
         <svg
           aria-hidden="true"
@@ -302,7 +302,7 @@ const NotificationBell: React.FC = () => {
                         onClick={() => toggleGroup(group.priority)}
                         aria-expanded={!collapsed}
                         aria-controls={contentId}
-                        className="flex w-full items-center justify-between px-4 py-2 text-left text-sm font-semibold text-white transition hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-ubb-orange"
+                        className="flex w-full items-center justify-between px-4 py-2 text-left text-sm font-semibold text-white transition hover:bg-white/5 focus:outline-none focus-ring focus-ring-surface"
                       >
                         <span className="flex items-center gap-2">
                           {group.metadata.label}

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -312,7 +312,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
         {canScrollLeft && (
           <button
             type="button"
-            className="px-2 py-1 h-full bg-gray-800 hover:bg-gray-700 focus:outline-none"
+            className="px-2 py-1 h-full bg-gray-800 hover:bg-gray-700 focus:outline-none focus-ring"
             onClick={() => scrollByAmount('left')}
             aria-label="Scroll tabs left"
           >
@@ -374,7 +374,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
         {canScrollRight && (
           <button
             type="button"
-            className="px-2 py-1 h-full bg-gray-800 hover:bg-gray-700 focus:outline-none"
+            className="px-2 py-1 h-full bg-gray-800 hover:bg-gray-700 focus:outline-none focus-ring"
             onClick={() => scrollByAmount('right')}
             aria-label="Scroll tabs right"
           >
@@ -386,7 +386,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
             <button
               type="button"
               ref={moreButtonRef}
-              className="px-2 py-1 bg-gray-800 hover:bg-gray-700 focus:outline-none"
+              className="px-2 py-1 bg-gray-800 hover:bg-gray-700 focus:outline-none focus-ring"
               onClick={() => setMoreMenuOpen((open) => !open)}
               aria-haspopup="menu"
               aria-expanded={moreMenuOpen}

--- a/components/ui/VolumeControl.tsx
+++ b/components/ui/VolumeControl.tsx
@@ -108,7 +108,7 @@ const VolumeControl: React.FC<VolumeControlProps> = ({ className = "" }) => {
     >
       <button
         type="button"
-        className="flex h-6 w-6 items-center justify-center rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
+        className="flex h-6 w-6 items-center justify-center rounded focus:outline-none focus-ring focus-ring-strong"
         aria-label={`Volume ${formatPercent(volume)}`}
         aria-haspopup="true"
         aria-expanded={open}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,7 +17,6 @@
   --color-border: #2a2e36; /* subtle borders */
   --color-terminal: #00ff00; /* terminal green */
   --color-dark: #0c0f12; /* card back */
-  --color-focus-ring: var(--color-accent);
   --color-selection: var(--color-accent);
   --color-control-accent: var(--color-accent);
   --kali-text: #f5f5f5;
@@ -81,8 +80,61 @@ html[data-theme='matrix'] {
 }
 
 *:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+  box-shadow: 0 0 0 var(--focus-ring-offset) var(--focus-ring-offset-color);
+  --tw-ring-color: var(--focus-ring-color) !important;
+  --tw-ring-offset-width: var(--focus-ring-offset);
+  --tw-ring-offset-color: var(--focus-ring-offset-color);
+}
+
+.focus-ring {
+  outline: none;
+  transition: outline-color var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease;
+}
+
+.focus-ring:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+  box-shadow: 0 0 0 var(--focus-ring-offset) var(--focus-ring-offset-color);
+}
+
+.focus-ring-strong:focus-visible {
+  outline-width: var(--focus-ring-width-strong);
+  box-shadow: 0 0 0 var(--focus-ring-offset) var(--focus-ring-offset-color);
+}
+
+.focus-ring-inset {
+  outline: none;
+}
+
+.focus-ring-inset:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 var(--focus-ring-width) var(--focus-ring-color);
+}
+
+.focus-ring-inset.focus-ring-strong:focus-visible {
+  box-shadow: inset 0 0 0 var(--focus-ring-width-strong)
+      var(--focus-ring-color);
+}
+
+.focus-ring-contrast {
+  --focus-ring-color: var(--focus-ring-contrast-color);
+  --focus-ring-offset-color: var(--focus-ring-contrast-offset-color);
+}
+
+.focus-ring-offset-none {
+  --focus-ring-offset: 0px;
+  --focus-ring-offset-color: transparent;
+}
+
+.focus-ring-surface {
+  --focus-ring-offset-color: color-mix(
+    in srgb,
+    var(--color-bg) 82%,
+    transparent 18%
+  );
 }
 
 html {

--- a/styles/index.css
+++ b/styles/index.css
@@ -75,8 +75,9 @@ button, [role="button"], input[type="button"], input[type="submit"], input[type=
 
 a:focus-visible,
 button:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color) !important;
-    outline-offset: 2px;
+    outline: var(--focus-ring-width) solid var(--focus-ring-color) !important;
+    outline-offset: var(--focus-ring-offset);
+    box-shadow: 0 0 0 var(--focus-ring-offset) var(--focus-ring-offset-color);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -569,8 +570,9 @@ pre {
 /* Visible focus rings for copy buttons and text areas */
 button:focus-visible,
 textarea:focus-visible {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color);
-    outline-offset: 2px;
+    outline: var(--focus-ring-width) solid var(--focus-ring-color);
+    outline-offset: var(--focus-ring-offset);
+    box-shadow: 0 0 0 var(--focus-ring-offset) var(--focus-ring-offset-color);
 }
 
 /* Enable scroll snapping for gallery containers */

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -84,9 +84,42 @@
   --font-multiplier: 1;
   /* Minimum interactive target size */
   --hit-area: 32px;
-  /* Focus outline */
-  --focus-outline-color: var(--color-ubt-blue);
-  --focus-outline-width: 2px;
+  /* Focus rings */
+  --focus-ring-width: 2px;
+  --focus-ring-width-strong: 3px;
+  --focus-ring-offset: 2px;
+  --focus-ring-offset-wide: 3px;
+  --color-focus-ring: var(--color-accent);
+  --focus-ring-color: color-mix(in srgb, var(--color-focus-ring) 85%, white 15%);
+  --focus-ring-color-strong: var(--color-focus-ring);
+  --focus-ring-contrast-color: #ffffff;
+  --focus-ring-offset-color: color-mix(
+    in srgb,
+    var(--focus-ring-color) 25%,
+    transparent 75%
+  );
+  --focus-ring-contrast-offset-color: rgba(255, 255, 255, 0.35);
+}
+
+html.dark,
+html[data-theme='dark'],
+html[data-theme='neon'],
+html[data-theme='matrix'] {
+  --focus-ring-color: color-mix(in srgb, var(--color-focus-ring) 88%, white 12%);
+  --focus-ring-offset-color: color-mix(
+    in srgb,
+    var(--focus-ring-color) 32%,
+    transparent 68%
+  );
+}
+
+html[data-theme='light'] {
+  --focus-ring-color: color-mix(in srgb, var(--color-focus-ring) 75%, black 25%);
+  --focus-ring-offset-color: color-mix(
+    in srgb,
+    var(--focus-ring-color) 28%,
+    transparent 72%
+  );
 }
 
 /* High contrast theme */
@@ -104,6 +137,8 @@
   --game-color-success: #00ffff;
   --game-color-warning: #ff00ff;
   --game-color-danger: #ff0000;
+  --focus-ring-color: var(--focus-ring-contrast-color);
+  --focus-ring-offset-color: var(--focus-ring-contrast-offset-color);
 }
 
 /* Dyslexia-friendly fonts */

--- a/tests/focus-rings.spec.ts
+++ b/tests/focus-rings.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+
+const getActiveSummary = () =>
+  document.activeElement
+    ? `${
+        (document.activeElement as HTMLElement).ariaLabel ?? ''
+      }|${document.activeElement.textContent?.trim() ?? ''}`
+    : '';
+
+test.describe('Focus ring styling', () => {
+  test('keyboard navigation shows focus ring on popular modules controls', async ({ page }) => {
+    await page.goto('/popular-modules');
+
+    // Move focus through the page until the "Update Modules" button is active.
+    for (let i = 0; i < 15; i += 1) {
+      await page.keyboard.press('Tab');
+      const summary = await page.evaluate(getActiveSummary);
+      if (summary.toLowerCase().includes('update modules')) {
+        break;
+      }
+    }
+
+    const metrics = await page.evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      if (!el) {
+        throw new Error('No focused element');
+      }
+      const style = getComputedStyle(el);
+      return {
+        outlineColor: style.outlineColor,
+        outlineWidth: style.outlineWidth,
+        boxShadow: style.boxShadow,
+      };
+    });
+
+    expect(metrics.outlineWidth).toBe('2px');
+    expect(metrics.outlineColor).not.toBe('rgba(0, 0, 0, 0)');
+    expect(metrics.boxShadow).toContain('rgb');
+  });
+
+  test('focus ring tokens respond to high contrast mode', async ({ page }) => {
+    await page.goto('/');
+
+    const defaultColor = await page.evaluate(() =>
+      getComputedStyle(document.documentElement)
+        .getPropertyValue('--focus-ring-color')
+        .trim()
+    );
+
+    await page.evaluate(() => {
+      document.documentElement.classList.add('high-contrast');
+    });
+
+    const highContrastColor = await page.evaluate(() =>
+      getComputedStyle(document.documentElement)
+        .getPropertyValue('--focus-ring-color')
+        .trim()
+    );
+
+    expect(defaultColor).not.toEqual('');
+    expect(highContrastColor).not.toEqual('');
+    expect(defaultColor).not.toEqual(highContrastColor);
+  });
+});


### PR DESCRIPTION
## Summary
- add focus ring design tokens and utility utility classes for light, dark, and high-contrast themes
- refactor common interactive components to rely on the shared focus-ring helpers
- add Playwright coverage to snapshot focus ring metrics in UI and high-contrast mode

## Testing
- yarn lint
- yarn test popularModules.test.tsx --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dc6258535c8328b9d18a5d00d4df0d