### PR TITLE
[ui] Ensure 44px minimum tap targets

### DIFF
--- a/components/apps/evidence-vault/index.js
+++ b/components/apps/evidence-vault/index.js
@@ -37,7 +37,7 @@ const TagTreeNode = ({ name, node, onSelect }) => {
           {node.items.length > 0 && (
             <button
               onClick={() => onSelect(node)}
-              className="ml-2 text-xs text-blue-400 hover:underline"
+              className="ml-2 inline-flex min-h-[44px] items-center rounded px-3 py-2 text-xs text-blue-400 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400"
             >
               View items
             </button>
@@ -105,23 +105,23 @@ const EvidenceVaultApp = () => {
       <div className="w-1/3 border-r border-gray-700 pr-2 overflow-auto">
         <button
           onClick={() => setSelectedNode(null)}
-          className="text-sm text-blue-400 hover:underline mb-2"
+          className="mb-2 inline-flex min-h-[44px] items-center rounded px-4 py-2 text-sm text-blue-400 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400"
         >
           All Items
         </button>
         <TagTree data={treeData} onSelect={setSelectedNode} />
       </div>
       <div className="flex-1 pl-4 flex flex-col">
-        <div className="mb-2 space-x-2">
+        <div className="mb-2 flex flex-wrap gap-2">
           <button
             onClick={addNote}
-            className="px-2 py-1 bg-blue-600 rounded"
+            className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded bg-blue-600 px-4 py-2 text-sm font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-300"
           >
             Add Note
           </button>
           <button
             onClick={() => fileInputRef.current?.click()}
-            className="px-2 py-1 bg-blue-600 rounded"
+            className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded bg-blue-600 px-4 py-2 text-sm font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-300"
           >
             Add File
           </button>
@@ -129,12 +129,14 @@ const EvidenceVaultApp = () => {
             ref={fileInputRef}
             type="file"
             className="hidden"
+            aria-hidden="true"
+            tabIndex={-1}
             onChange={handleFileChange}
           />
         </div>
         <ul className="flex-1 overflow-auto space-y-2">
           {displayItems.map((item) => (
-            <li key={item.id} className="p-2 bg-gray-800 rounded">
+            <li key={item.id} className="rounded bg-gray-800 p-2">
               {item.type === 'note' ? (
                 <div>
                   <h4 className="font-semibold">{item.title}</h4>

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -110,7 +110,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
             item.onSelect();
             setOpen(false);
           }}
-          className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+          className="w-full text-left cursor-default mb-1.5 flex min-h-[44px] items-center rounded px-3 py-2 hover:bg-gray-700"
         >
           {item.label}
         </button>

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -35,9 +35,9 @@ function AppMenu(props) {
                 onClick={handlePin}
                 role="menuitem"
                 aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full text-left cursor-default mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-gray-700"
             >
-                <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
+                <span className="ml-2">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
             </button>
         </div>
     )

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -30,9 +30,9 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Linkedin"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full block cursor-default mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-gray-700"
             >
-                <span className="ml-5">🙋‍♂️</span> <span className="ml-2">Follow on <strong>Linkedin</strong></span>
+                <span className="ml-2">🙋‍♂️</span> <span className="ml-2">Follow on <strong>Linkedin</strong></span>
             </a>
             <a
                 rel="noopener noreferrer"
@@ -40,9 +40,9 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Follow on Github"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full block cursor-default mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-gray-700"
             >
-                <span className="ml-5">🤝</span> <span className="ml-2">Follow on <strong>Github</strong></span>
+                <span className="ml-2">🤝</span> <span className="ml-2">Follow on <strong>Github</strong></span>
             </a>
             <a
                 rel="noopener noreferrer"
@@ -50,9 +50,9 @@ function DefaultMenu(props) {
                 target="_blank"
                 role="menuitem"
                 aria-label="Contact Me"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full block cursor-default mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-gray-700"
             >
-                <span className="ml-5">📥</span> <span className="ml-2">Contact Me</span>
+                <span className="ml-2">📥</span> <span className="ml-2">Contact Me</span>
             </a>
             <Devider />
             <button
@@ -60,9 +60,9 @@ function DefaultMenu(props) {
                 onClick={() => { localStorage.clear(); window.location.reload() }}
                 role="menuitem"
                 aria-label="Reset Kali Linux"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full text-left cursor-default mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-gray-700"
             >
-                <span className="ml-5">🧹</span> <span className="ml-2">Reset Kali Linux</span>
+                <span className="ml-2">🧹</span> <span className="ml-2">Reset Kali Linux</span>
             </button>
         </div>
     )

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -55,35 +55,35 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="New Folder"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-ub-warm-grey hover:bg-opacity-20"
             >
-                <span className="ml-5">New Folder</span>
+                <span className="ml-2">New Folder</span>
             </button>
             <button
                 onClick={props.openShortcutSelector}
                 type="button"
                 role="menuitem"
                 aria-label="Create Shortcut"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-ub-warm-grey hover:bg-opacity-20"
             >
-                <span className="ml-5">Create Shortcut...</span>
+                <span className="ml-2">Create Shortcut...</span>
             </button>
             <Devider />
-            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Paste</span>
+            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 text-gray-400 hover:bg-ub-warm-grey hover:bg-opacity-20">
+                <span className="ml-2">Paste</span>
             </div>
             <Devider />
-            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Show Desktop in Files</span>
+            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 text-gray-400 hover:bg-ub-warm-grey hover:bg-opacity-20">
+                <span className="ml-2">Show Desktop in Files</span>
             </div>
             <button
                 onClick={openTerminal}
                 type="button"
                 role="menuitem"
                 aria-label="Open in Terminal"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-ub-warm-grey hover:bg-opacity-20"
             >
-                <span className="ml-5">Open in Terminal</span>
+                <span className="ml-2">Open in Terminal</span>
             </button>
             <Devider />
             <button
@@ -91,22 +91,22 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Change Background"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-ub-warm-grey hover:bg-opacity-20"
             >
-                <span className="ml-5">Change Background...</span>
+                <span className="ml-2">Change Background...</span>
             </button>
             <Devider />
-            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Display Settings</span>
+            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 text-gray-400 hover:bg-ub-warm-grey hover:bg-opacity-20">
+                <span className="ml-2">Display Settings</span>
             </div>
             <button
                 onClick={openSettings}
                 type="button"
                 role="menuitem"
                 aria-label="Settings"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-ub-warm-grey hover:bg-opacity-20"
             >
-                <span className="ml-5">Settings</span>
+                <span className="ml-2">Settings</span>
             </button>
             <Devider />
             <button
@@ -114,9 +114,9 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-ub-warm-grey hover:bg-opacity-20"
             >
-                <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
+                <span className="ml-2">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
             </button>
             <Devider />
             <button
@@ -124,9 +124,9 @@ function DesktopMenu(props) {
                 type="button"
                 role="menuitem"
                 aria-label="Clear Session"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+                className="w-full text-left mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-ub-warm-grey hover:bg-opacity-20"
             >
-                <span className="ml-5">Clear Session</span>
+                <span className="ml-2">Clear Session</span>
             </button>
         </div>
     )

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -37,18 +37,18 @@ function TaskbarMenu(props) {
                 onClick={handleMinimize}
                 role="menuitem"
                 aria-label={props.minimized ? 'Restore Window' : 'Minimize Window'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full text-left cursor-default mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-gray-700"
             >
-                <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
+                <span className="ml-2">{props.minimized ? 'Restore' : 'Minimize'}</span>
             </button>
             <button
                 type="button"
                 onClick={handleClose}
                 role="menuitem"
                 aria-label="Close Window"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+                className="w-full text-left cursor-default mb-1.5 flex min-h-[44px] items-center rounded px-4 py-2 hover:bg-gray-700"
             >
-                <span className="ml-5">Close</span>
+                <span className="ml-2">Close</span>
             </button>
         </div>
     );

--- a/components/menu/ApplicationsMenu.tsx
+++ b/components/menu/ApplicationsMenu.tsx
@@ -97,11 +97,11 @@ const ApplicationsMenu: React.FC<ApplicationsMenuProps> = ({ activeCategory, onS
               <button
                 type="button"
                 onClick={() => onSelect(category.id)}
-                className={`flex w-full items-center gap-3 rounded px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
-                  isActive ? 'bg-gray-700 text-white' : 'bg-transparent hover:bg-gray-700/60'
-                }`}
-                aria-pressed={isActive}
-              >
+              className={`flex w-full items-center gap-3 rounded px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-sky-400 min-h-[44px] ${
+                isActive ? 'bg-gray-700 text-white' : 'bg-transparent hover:bg-gray-700/60'
+              }`}
+              aria-pressed={isActive}
+            >
                 <CategoryIcon categoryId={category.id} label={category.label} />
                 <span className="text-sm font-medium">{category.label}</span>
               </button>

--- a/components/menu/PlacesMenu.tsx
+++ b/components/menu/PlacesMenu.tsx
@@ -63,7 +63,7 @@ const PlacesMenu: React.FC<PlacesMenuProps> = ({ heading = 'Places', items }) =>
               <button
                 type="button"
                 onClick={handleClick}
-                className="flex w-full items-center gap-3 rounded px-3 py-2 text-left transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-ubb-orange"
+                className="flex w-full items-center gap-3 rounded px-3 py-2 text-left transition hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-ubb-orange min-h-[44px]"
               >
                 <img
                   src={src}

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -243,7 +243,7 @@ const NotificationBell: React.FC = () => {
         aria-expanded={isOpen}
         aria-controls={panelId}
         onClick={togglePanel}
-        className="relative mx-1 flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey transition focus:border-ubb-orange focus:outline-none focus:ring-0 hover:bg-white hover:bg-opacity-10"
+        className="relative mx-1 flex h-11 w-11 items-center justify-center rounded-md border border-transparent bg-transparent text-ubt-grey transition focus:border-ubb-orange focus:outline-none focus:ring-0 hover:bg-white hover:bg-opacity-10"
       >
         <svg
           aria-hidden="true"
@@ -256,7 +256,7 @@ const NotificationBell: React.FC = () => {
           <path d="M7 12a3 3 0 006 0H7z" />
         </svg>
         {unreadCount > 0 && (
-          <span className="absolute -top-1.5 -right-1.5 min-w-[1.5rem] rounded-full bg-ubb-orange px-1 text-center text-[0.65rem] font-semibold leading-5 text-white">
+          <span className="absolute -right-1.5 -top-1.5 min-w-[1.5rem] rounded-full bg-ubb-orange px-1 text-center text-[0.65rem] font-semibold leading-5 text-white">
             {unreadCount > 99 ? '99+' : unreadCount}
           </span>
         )}

--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -386,7 +386,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
             <button
               type="button"
               ref={moreButtonRef}
-              className="px-2 py-1 bg-gray-800 hover:bg-gray-700 focus:outline-none"
+              className="inline-flex min-h-[44px] items-center justify-center rounded bg-gray-800 px-3 py-2 text-sm font-medium hover:bg-gray-700 focus:outline-none"
               onClick={() => setMoreMenuOpen((open) => !open)}
               aria-haspopup="menu"
               aria-expanded={moreMenuOpen}
@@ -404,7 +404,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
                     key={tab.id}
                     type="button"
                     role="menuitem"
-                    className="flex w-full items-center justify-between px-3 py-1 text-left hover:bg-gray-700"
+                    className="flex w-full items-center justify-between rounded px-3 py-2 text-left hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-ubb-orange"
                     onClick={() => handleMoreSelect(tab.id)}
                   >
                     <span className="truncate">{tab.title}</span>
@@ -417,7 +417,7 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
         )}
         {onNewTab && (
           <button
-            className="px-2 py-1 bg-gray-800 hover:bg-gray-700"
+            className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded bg-gray-800 px-3 py-2 text-sm font-medium hover:bg-gray-700"
             onClick={addTab}
             aria-label="New Tab"
           >

--- a/components/util-components/clock.js
+++ b/components/util-components/clock.js
@@ -423,7 +423,7 @@ const Clock = ({ onlyDay = false, onlyTime = false, showCalendar = false, hour12
                     <button
                         type="button"
                         onClick={() => handleMonthChange(-1)}
-                        className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/10 bg-slate-900/60 text-lg text-white/80 transition-colors hover:border-white/30 hover:bg-slate-800 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+                        className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/10 bg-slate-900/60 text-lg text-white/80 transition-colors hover:border-white/30 hover:bg-slate-800 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
                         aria-label="Previous month"
                     >
                         ‹
@@ -431,7 +431,7 @@ const Clock = ({ onlyDay = false, onlyTime = false, showCalendar = false, hour12
                     <button
                         type="button"
                         onClick={() => handleMonthChange(1)}
-                        className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/10 bg-slate-900/60 text-lg text-white/80 transition-colors hover:border-white/30 hover:bg-slate-800 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+                        className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/10 bg-slate-900/60 text-lg text-white/80 transition-colors hover:border-white/30 hover:bg-slate-800 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
                         aria-label="Next month"
                     >
                         ›
@@ -469,13 +469,13 @@ const Clock = ({ onlyDay = false, onlyTime = false, showCalendar = false, hour12
                                         key={date.toISOString()}
                                         role="gridcell"
                                         aria-selected={isFocused}
-                                        className="p-1"
+                                        className="p-1.5"
                                     >
                                         <button
                                             type="button"
                                             onClick={handleDayClick}
                                             onKeyDown={(event) => handleDayKeyDown(event, date)}
-                                            className={`flex h-9 w-9 items-center justify-center rounded-2xl text-sm font-medium transition duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
+                                            className={`flex h-11 w-11 items-center justify-center rounded-2xl text-sm font-medium transition duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
                                                 inCurrentMonth ? 'text-white' : 'text-white/35'
                                             } ${
                                                 isToday

--- a/docs/touch-gestures.md
+++ b/docs/touch-gestures.md
@@ -7,6 +7,7 @@ The desktop shell now exposes responsive breakpoints and gesture affordances so 
 - The new `components/desktop/Layout.tsx` component defines CSS custom properties for taskbar height, padding, and desktop icon sizing.
 - Breakpoints progressively scale hit targets from 40px to 60px+ widths, and `(pointer: coarse)` media queries ensure touch-first devices immediately receive larger dimensions.
 - `UbuntuApp` tiles, the dock/taskbar, and window chrome consume these variables so every interactive surface respects the same sizing rules.
+- Shared components (menu items, icon buttons, inventory controls) must expose at least a **44×44px** hit target. Use utility classes like `min-h-[44px] min-w-[44px]` or dedicated wrappers so keyboard, mouse, and touch users receive consistent affordances.
 
 ## Panel defaults on tablets
 


### PR DESCRIPTION
## Summary
- enlarge evidence vault inventory actions and shared context menu items to respect the 44px minimum tap target
- expand icon-based controls (notification bell, tab overflow, calendar) to meet the same sizing while maintaining layout balance
- document the tap target requirement in the touch gestures guide for future component work

## Testing
- yarn lint
- npx pa11y-ci *(fails: missing libatk in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc62595f6c8328b7766f7020a4a2cc