### PR TITLE
[accessibility] Batch terminal SR announcements

### DIFF
--- a/__tests__/TerminalOutput.test.tsx
+++ b/__tests__/TerminalOutput.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TerminalOutput from '../components/TerminalOutput';
+
+describe('TerminalOutput accessibility', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('restores persisted screen reader mode', () => {
+    window.localStorage.setItem('terminal-output-sr-mode', 'on');
+    render(<TerminalOutput text="line one" ariaLabel="terminal output" />);
+    const checkbox = screen.getByRole('checkbox', {
+      name: /screen reader announcements/i,
+    });
+    expect(checkbox).toBeChecked();
+  });
+
+  it('announces batched updates when enabled', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const { rerender } = render(<TerminalOutput text="hello" ariaLabel="terminal output" />);
+    const checkbox = screen.getByRole('checkbox', {
+      name: /screen reader announcements/i,
+    });
+
+    await user.click(checkbox);
+    rerender(<TerminalOutput text={`hello\nworld`} ariaLabel="terminal output" />);
+    expect(screen.getByRole('status')).toHaveTextContent('');
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('world');
+  });
+
+  it('announces focus instructions when focused with screen reader mode on', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<TerminalOutput text="ready" ariaLabel="terminal output" />);
+    const checkbox = screen.getByRole('checkbox', {
+      name: /screen reader announcements/i,
+    });
+    await user.click(checkbox);
+    const focusable = screen.getByLabelText('terminal output');
+    fireEvent.focus(focusable);
+    expect(screen.getByRole('status').textContent).toContain('Screen reader mode is on');
+  });
+});

--- a/components/TerminalOutput.tsx
+++ b/components/TerminalOutput.tsx
@@ -1,12 +1,98 @@
-import React from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 
 interface TerminalOutputProps {
   text: string;
   ariaLabel?: string;
+  className?: string;
 }
 
-export default function TerminalOutput({ text, ariaLabel }: TerminalOutputProps) {
-  const lines = text.split('\n');
+const SR_MODE_STORAGE_KEY = 'terminal-output-sr-mode';
+const BATCH_DELAY = 400;
+const FOCUS_MESSAGE =
+  'Screen reader mode is on. New terminal output will be announced as grouped updates.';
+
+export default function TerminalOutput({
+  text,
+  ariaLabel,
+  className = '',
+}: TerminalOutputProps) {
+  const instructionsId = useId();
+  const [showInstructions, setShowInstructions] = useState(false);
+  const [srEnabled, setSrEnabled] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem(SR_MODE_STORAGE_KEY) === 'on';
+  });
+  const [liveMessage, setLiveMessage] = useState('');
+  const previousTextRef = useRef(text);
+  const pendingAnnouncementRef = useRef('');
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const lines = React.useMemo(() => text.split('\n'), [text]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(SR_MODE_STORAGE_KEY, srEnabled ? 'on' : 'off');
+  }, [srEnabled]);
+
+  useEffect(() => {
+    const prevText = previousTextRef.current;
+
+    if (!srEnabled) {
+      previousTextRef.current = text;
+      pendingAnnouncementRef.current = '';
+      if (flushTimerRef.current) {
+        clearTimeout(flushTimerRef.current);
+        flushTimerRef.current = null;
+      }
+      setLiveMessage('');
+      return;
+    }
+
+    let delta = '';
+    if (text.length >= prevText.length && text.startsWith(prevText)) {
+      delta = text.slice(prevText.length);
+    } else {
+      delta = text;
+    }
+
+    previousTextRef.current = text;
+
+    const cleanedDelta = delta
+      .split('\n')
+      .map((segment) => segment.trim())
+      .filter(Boolean)
+      .join('\n');
+
+    if (!cleanedDelta) {
+      return;
+    }
+
+    if (pendingAnnouncementRef.current) {
+      pendingAnnouncementRef.current += '\n';
+    }
+    pendingAnnouncementRef.current += cleanedDelta;
+
+    if (!flushTimerRef.current) {
+      flushTimerRef.current = setTimeout(() => {
+        setLiveMessage((prev) => {
+          const nextMessage = pendingAnnouncementRef.current;
+          pendingAnnouncementRef.current = '';
+          flushTimerRef.current = null;
+          if (!nextMessage) return prev;
+          return nextMessage;
+        });
+      }, BATCH_DELAY);
+    }
+  }, [text, srEnabled]);
+
+  useEffect(() => {
+    return () => {
+      if (flushTimerRef.current) {
+        clearTimeout(flushTimerRef.current);
+      }
+    };
+  }, []);
+
   const copyLine = async (line: string) => {
     try {
       await navigator.clipboard.writeText(line);
@@ -14,23 +100,78 @@ export default function TerminalOutput({ text, ariaLabel }: TerminalOutputProps)
       // ignore
     }
   };
+
+  const handleFocus = () => {
+    if (!srEnabled) return;
+    setLiveMessage((prev) => {
+      if (prev.startsWith(FOCUS_MESSAGE)) {
+        return `${FOCUS_MESSAGE} `;
+      }
+      return FOCUS_MESSAGE;
+    });
+  };
+
   return (
-    <div
-      className="bg-black text-green-400 font-mono text-xs p-2 rounded"
-      aria-label={ariaLabel}
-    >
-      {lines.map((line, idx) => (
-        <div key={idx} className="flex items-start">
-          <span className="flex-1 whitespace-pre-wrap">{line}</span>
-          <button
-            className="ml-2 text-gray-400 hover:text-white"
-            onClick={() => copyLine(line)}
-            aria-label="copy line"
-          >
-            📋
-          </button>
+    <div className={`space-y-2 ${className}`}>
+      <div className="flex flex-wrap items-center gap-2 text-[11px] text-green-200">
+        <button
+          type="button"
+          onClick={() => setShowInstructions((value) => !value)}
+          className="rounded border border-green-500 px-2 py-1 text-xs text-green-100 hover:bg-green-800/40 focus:outline-none focus:ring-2 focus:ring-green-400"
+          aria-expanded={showInstructions}
+          aria-controls={instructionsId}
+        >
+          {showInstructions ? 'Hide screen reader help' : 'Show screen reader help'}
+        </button>
+        <label className="inline-flex items-center gap-1">
+          <input
+            type="checkbox"
+            className="h-3 w-3 accent-green-500"
+            checked={srEnabled}
+            onChange={(event) => setSrEnabled(event.target.checked)}
+          />
+          <span>Enable screen reader announcements</span>
+        </label>
+      </div>
+      {showInstructions && (
+        <div
+          id={instructionsId}
+          className="rounded border border-green-600 bg-black/60 p-2 text-[11px] text-green-100"
+        >
+          <p className="mb-1">
+            Enable the announcements toggle to hear batched terminal updates. Focus this
+            area with Tab or by clicking so your screen reader receives new output.
+          </p>
+          <p className="mb-0">
+            Use the copy button after each line to copy command output without leaving the
+            terminal window.
+          </p>
         </div>
-      ))}
+      )}
+      <div
+        className="bg-black text-green-400 font-mono text-xs p-2 rounded"
+        aria-label={ariaLabel}
+        aria-describedby={showInstructions ? instructionsId : undefined}
+        tabIndex={0}
+        onFocus={handleFocus}
+      >
+        {lines.map((line, idx) => (
+          <div key={`${idx}-${line}`} className="flex items-start">
+            <span className="flex-1 whitespace-pre-wrap">{line}</span>
+            <button
+              className="ml-2 text-gray-400 hover:text-white focus:text-white focus:outline-none"
+              onClick={() => copyLine(line)}
+              aria-label={`Copy line ${idx + 1}`}
+              type="button"
+            >
+              📋
+            </button>
+          </div>
+        ))}
+        <div role="status" aria-live="polite" className="sr-only">
+          {liveMessage}
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/apps/serial-terminal.tsx
+++ b/components/apps/serial-terminal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import FormError from '../ui/FormError';
+import TerminalOutput from '../TerminalOutput';
 
 interface SerialPort {
   readonly readable: ReadableStream<Uint8Array> | null;
@@ -113,9 +114,13 @@ const SerialTerminalApp: React.FC = () => {
         </p>
       )}
       {error && <FormError className="mb-2 mt-0">{error}</FormError>}
-      <pre className="h-[calc(100%-4rem)] overflow-auto whitespace-pre-wrap break-words">
-        {logs || 'No data'}
-      </pre>
+      <div className="h-[calc(100%-4rem)] overflow-auto pr-1">
+        <TerminalOutput
+          text={logs || 'No data'}
+          ariaLabel="Serial terminal output"
+          className="h-full"
+        />
+      </div>
     </div>
   );
 };

--- a/tests/manual/screen-reader-terminal.md
+++ b/tests/manual/screen-reader-terminal.md
@@ -1,0 +1,11 @@
+# Screen reader announcement QA
+
+These steps verify the new terminal output batching experience.
+
+1. Launch the portfolio locally with `yarn dev` and open `/apps/serial-terminal`.
+2. Locate the "Enable screen reader announcements" checkbox under the terminal header.
+3. Toggle the checkbox on and press <kbd>Tab</kbd> until the terminal body gains focus. A polite live region should announce that screen reader mode is active.
+4. Trigger incoming data by connecting a demo device or using the built-in fixtures so the terminal receives multiple characters. Listen for a single grouped announcement instead of character-by-character output.
+5. Toggle the checkbox off and ensure no further announcements are read even as new data arrives.
+6. Refresh the page and confirm the checkbox state persists.
+7. Toggle the "Show screen reader help" button and read the guidance with the screen reader to validate instructions can be surfaced on demand.


### PR DESCRIPTION
## Summary
- add a persisted screen reader mode toggle and instructions to `TerminalOutput` with batched live region updates
- wire the serial terminal app to the enhanced terminal output while keeping copy affordances
- add unit coverage and a manual QA script for screen reader announcement behavior

## Testing
- yarn test TerminalOutput

------
https://chatgpt.com/codex/tasks/task_e_68dc625b60d88328898f8e4492700b33