### PR TITLE
[ui] Improve loading accessibility feedback

### DIFF
--- a/__tests__/loadingComponents.test.tsx
+++ b/__tests__/loadingComponents.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import Skeleton from '@/components/ui/Skeleton';
+import Spinner from '@/components/ui/Spinner';
+import { announce, ANNOUNCER_EVENT, type AnnounceDetail } from '@/utils/liveAnnouncer';
+
+describe('loading components accessibility', () => {
+  it('marks parent containers busy while skeletons are mounted', () => {
+    const { rerender } = render(
+      <div data-testid="wrapper">
+        <Skeleton data-testid="skeleton" />
+      </div>,
+    );
+
+    expect(screen.getByTestId('wrapper')).toHaveAttribute('aria-busy', 'true');
+
+    rerender(<div data-testid="wrapper" />);
+
+    expect(screen.getByTestId('wrapper')).not.toHaveAttribute('aria-busy');
+  });
+
+  it('toggles aria-busy when spinner active state changes', () => {
+    const { rerender } = render(
+      <div data-testid="container">
+        <Spinner label="Loading content" />
+      </div>,
+    );
+
+    expect(screen.getByTestId('container')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    rerender(
+      <div data-testid="container">
+        <Spinner label="Loading content" active={false} />
+      </div>,
+    );
+
+    expect(screen.getByTestId('container')).not.toHaveAttribute('aria-busy');
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('dispatches announcer events with message detail', () => {
+    const handler = jest.fn((event: CustomEvent<AnnounceDetail>) => event.detail);
+    window.addEventListener(ANNOUNCER_EVENT, handler as EventListener);
+
+    announce('Data ready');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toMatchObject({ detail: { message: 'Data ready' } });
+
+    window.removeEventListener(ANNOUNCER_EVENT, handler as EventListener);
+  });
+});

--- a/apps/project-gallery/pages/index.tsx
+++ b/apps/project-gallery/pages/index.tsx
@@ -5,6 +5,9 @@ import type { TouchEvent } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import FilterChip from '../components/FilterChip';
+import Skeleton from '@/components/ui/Skeleton';
+import Spinner from '@/components/ui/Spinner';
+import { announce } from '@/utils/liveAnnouncer';
 
 const TagIcon = () => (
   <svg
@@ -323,6 +326,13 @@ export default function ProjectGalleryPage() {
   const [demoOnly, setDemoOnly] = usePersistentState<boolean>('pg-demo', false);
   const [compareSelection, setCompareSelection] = useState<Project[]>([]);
   const [activeSwipe, setActiveSwipe] = useState<number | null>(null);
+  const projectCount = projects.length;
+
+  useEffect(() => {
+    if (!loading) {
+      announce(`Project gallery loaded ${projectCount} projects`);
+    }
+  }, [loading, projectCount]);
 
   useEffect(() => {
     setLoading(true);
@@ -492,14 +502,15 @@ export default function ProjectGalleryPage() {
         ))}
       </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {loading && <Spinner className="sr-only" label="Loading projects" />}
         {loading
           ? Array.from({ length: 6 }).map((_, i) => (
               <div key={i} className="space-y-3 rounded-lg border p-4">
-                <div className="aspect-video w-full rounded-md bg-gray-200" />
+                <Skeleton className="aspect-video w-full bg-gray-200/60" />
                 <div className="space-y-2">
-                  <div className="h-4 w-3/4 rounded bg-gray-200" />
-                  <div className="h-3 w-2/3 rounded bg-gray-200" />
-                  <div className="h-3 w-1/2 rounded bg-gray-200" />
+                  <Skeleton className="h-4 w-3/4 bg-gray-200/60" />
+                  <Skeleton className="h-3 w-2/3 bg-gray-200/60" />
+                  <Skeleton className="h-3 w-1/2 bg-gray-200/60" />
                 </div>
               </div>
             ))

--- a/apps/x/index.tsx
+++ b/apps/x/index.tsx
@@ -14,6 +14,9 @@ import { useSettings } from '../../hooks/useSettings';
 import useScheduledTweets, {
   ScheduledTweet,
 } from './state/scheduled';
+import Skeleton from '@/components/ui/Skeleton';
+import Spinner from '@/components/ui/Spinner';
+import { announce } from '@/utils/liveAnnouncer';
 
 const IconRefresh = (
   props: SVGProps<SVGSVGElement>,
@@ -191,10 +194,12 @@ export default function XTimeline() {
       .then(() => {
         setTimelineLoaded(true);
         setLoading(false);
+        announce(`Timeline loaded for ${feed}`);
       })
       .catch(() => {
         setScriptError(true);
         setLoading(false);
+        announce('Timeline failed to load');
       });
   };
 
@@ -456,6 +461,11 @@ export default function XTimeline() {
           </button>
         ) : (
           <>
+            <Spinner
+              className="sr-only"
+              label="Loading timeline"
+              active={loading && !timelineLoaded && !scriptError}
+            />
             {loading && !timelineLoaded && !scriptError && (
               <ul className="tweet-feed space-y-1.5" aria-hidden="true">
                 {Array.from({ length: 3 }).map((_, i) => (
@@ -464,13 +474,13 @@ export default function XTimeline() {
                     className="flex gap-1.5 p-1.5 rounded-md border"
                   >
                     <div className="relative">
-                      <div className="w-12 h-12 rounded-full bg-[var(--color-muted)] animate-pulse" />
+                      <Skeleton className="w-12 h-12 rounded-full bg-[var(--color-muted)]" />
                       <IconBadge className="w-3 h-3 absolute bottom-0 right-0 text-[var(--color-muted)]" />
                     </div>
                     <div className="flex-1 space-y-1.5">
-                      <div className="h-3 bg-[var(--color-muted)] rounded animate-pulse w-3/4" />
-                      <div className="h-3 bg-[var(--color-muted)] rounded animate-pulse w-1/2" />
-                      <div className="h-3 bg-[var(--color-muted)] rounded animate-pulse w-full" />
+                      <Skeleton className="h-3 w-3/4 rounded bg-[var(--color-muted)]" />
+                      <Skeleton className="h-3 w-1/2 rounded bg-[var(--color-muted)]" />
+                      <Skeleton className="h-3 w-full rounded bg-[var(--color-muted)]" />
                     </div>
                     <IconShare className="w-5 h-5 text-[var(--color-muted)]" />
                   </li>

--- a/components/GitHubStars.js
+++ b/components/GitHubStars.js
@@ -1,5 +1,8 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import usePersistentState from '../hooks/usePersistentState';
+import Skeleton from './ui/Skeleton';
+import Spinner from './ui/Spinner';
+import { announce } from '../utils/liveAnnouncer';
 
 const GitHubStars = ({ user, repo }) => {
   const ref = useRef(null);
@@ -13,7 +16,9 @@ const GitHubStars = ({ user, repo }) => {
       const res = await fetch(`https://api.github.com/repos/${user}/${repo}`);
       if (!res.ok) throw new Error('Request failed');
       const data = await res.json();
-      setStars(data.stargazers_count || 0);
+      const count = data.stargazers_count || 0;
+      setStars(count);
+      announce(`${repo} star count loaded: ${count}`);
     } catch (e) {
       console.error('Failed to fetch star count', e);
     } finally {
@@ -46,7 +51,10 @@ const GitHubStars = ({ user, repo }) => {
   return (
     <div ref={ref} className="inline-flex items-center text-xs text-gray-300">
       {loading ? (
-        <div className="h-5 w-12 bg-gray-200 animate-pulse rounded" />
+        <>
+          <Skeleton className="h-5 w-12 bg-gray-200/70" />
+          <Spinner className="sr-only" label={`Loading star count for ${repo}`} />
+        </>
       ) : (
         <>
           <span>⭐ {stars}</span>

--- a/components/ui/Skeleton.tsx
+++ b/components/ui/Skeleton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import clsx from 'clsx';
+import { useBusyParent } from './useBusyIndicator';
+
+type SkeletonProps = React.HTMLAttributes<HTMLDivElement>;
+
+const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
+  ({ className, ...props }, ref) => {
+    const attachRef = useBusyParent<HTMLDivElement>(true, ref);
+    return (
+      <div
+        {...props}
+        ref={attachRef}
+        role="img"
+        aria-hidden="true"
+        className={clsx('animate-pulse rounded bg-white/10', className)}
+      />
+    );
+  },
+);
+
+Skeleton.displayName = 'Skeleton';
+
+export default Skeleton;

--- a/components/ui/Spinner.tsx
+++ b/components/ui/Spinner.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import clsx from 'clsx';
+import { useBusyParent } from './useBusyIndicator';
+
+interface SpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
+  label?: string;
+  active?: boolean;
+}
+
+const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
+  ({ className, children, label = 'Loading', active = true, ...props }, ref) => {
+    const attachRef = useBusyParent<HTMLDivElement>(active, ref);
+
+    if (!active) return null;
+
+    return (
+      <div
+        {...props}
+        ref={attachRef}
+        role="status"
+        aria-live="polite"
+        className={clsx('inline-flex items-center gap-2 text-sm text-white/80', className)}
+      >
+        <span
+          aria-hidden="true"
+          className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+        />
+        {children}
+        <span className="sr-only">{label}</span>
+      </div>
+    );
+  },
+);
+
+Spinner.displayName = 'Spinner';
+
+export default Spinner;

--- a/components/ui/useBusyIndicator.ts
+++ b/components/ui/useBusyIndicator.ts
@@ -1,0 +1,49 @@
+import { MutableRefObject, useCallback, useEffect, useState } from 'react';
+
+const BUSY_COUNT_ATTRIBUTE = 'data-busy-count';
+
+function updateRef<T>(ref: React.Ref<T> | undefined, value: T | null) {
+  if (!ref) return;
+  if (typeof ref === 'function') {
+    ref(value);
+  } else {
+    (ref as MutableRefObject<T | null>).current = value;
+  }
+}
+
+export function useBusyParent<T extends HTMLElement>(
+  active: boolean,
+  forwardedRef?: React.Ref<T>,
+) {
+  const [parent, setParent] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!parent || !active) return;
+
+    const currentAttr = parent.getAttribute(BUSY_COUNT_ATTRIBUTE);
+    const current = currentAttr ? Number.parseInt(currentAttr, 10) || 0 : 0;
+    const next = current + 1;
+    parent.setAttribute(BUSY_COUNT_ATTRIBUTE, String(next));
+    parent.setAttribute('aria-busy', 'true');
+
+    return () => {
+      const attr = parent.getAttribute(BUSY_COUNT_ATTRIBUTE);
+      const value = attr ? Number.parseInt(attr, 10) || 0 : 0;
+      const updated = Math.max(value - 1, 0);
+      if (updated === 0) {
+        parent.removeAttribute(BUSY_COUNT_ATTRIBUTE);
+        parent.removeAttribute('aria-busy');
+      } else {
+        parent.setAttribute(BUSY_COUNT_ATTRIBUTE, String(updated));
+      }
+    };
+  }, [active, parent]);
+
+  return useCallback(
+    (node: T | null) => {
+      setParent(node?.parentElement ?? null);
+      updateRef(forwardedRef, node);
+    },
+    [forwardedRef],
+  );
+}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -17,6 +17,7 @@ import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
+import { ANNOUNCER_EVENT } from '../utils/liveAnnouncer';
 
 import { Ubuntu } from 'next/font/google';
 
@@ -95,10 +96,17 @@ function MyApp(props) {
     const handleCopy = () => update('Copied to clipboard');
     const handleCut = () => update('Cut to clipboard');
     const handlePaste = () => update('Pasted from clipboard');
+    const handleAnnounce = (event) => {
+      const message = event?.detail?.message;
+      if (typeof message === 'string' && message.trim().length > 0) {
+        update(message);
+      }
+    };
 
     window.addEventListener('copy', handleCopy);
     window.addEventListener('cut', handleCut);
     window.addEventListener('paste', handlePaste);
+    window.addEventListener(ANNOUNCER_EVENT, handleAnnounce);
 
     const { clipboard } = navigator;
     const originalWrite = clipboard?.writeText?.bind(clipboard);
@@ -137,6 +145,7 @@ function MyApp(props) {
       window.removeEventListener('copy', handleCopy);
       window.removeEventListener('cut', handleCut);
       window.removeEventListener('paste', handlePaste);
+      window.removeEventListener(ANNOUNCER_EVENT, handleAnnounce);
       if (clipboard) {
         if (originalWrite) clipboard.writeText = originalWrite;
         if (originalRead) clipboard.readText = originalRead;

--- a/utils/liveAnnouncer.ts
+++ b/utils/liveAnnouncer.ts
@@ -1,0 +1,15 @@
+const ANNOUNCER_EVENT = 'app:announce';
+
+type AnnounceDetail = {
+  message: string;
+};
+
+export { ANNOUNCER_EVENT };
+
+export function announce(message: string) {
+  if (typeof window === 'undefined') return;
+  const detail: AnnounceDetail = { message };
+  window.dispatchEvent(new CustomEvent<AnnounceDetail>(ANNOUNCER_EVENT, { detail }));
+}
+
+export type { AnnounceDetail };


### PR DESCRIPTION
## Summary
- add reusable `Skeleton` and `Spinner` helpers that toggle `aria-busy` and hide placeholder content from screen readers
- update GitHub stars, project gallery, and X timeline loaders to announce completion via the shared live region
- listen for global announcer events in `_app` and cover loading utilities with unit tests

## Testing
- CI=1 yarn test __tests__/loadingComponents.test.tsx --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68dc625bd1588328bfda693a412b1f32