### PR TITLE
[common] Add permissions management panel

### DIFF
--- a/__tests__/usePermissions.test.tsx
+++ b/__tests__/usePermissions.test.tsx
@@ -1,0 +1,210 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import usePermissions from '../hooks/usePermissions';
+import { NotificationsContext } from '../components/common/NotificationCenter';
+
+class MockPermissionStatus implements PermissionStatus {
+  state: PermissionState;
+
+  name?: string | undefined;
+
+  onchange: ((this: PermissionStatus, ev: Event) => any) | null = null;
+
+  private listeners = new Set<(event: Event) => void>();
+
+  private listenerMap = new Map<EventListenerOrEventListenerObject, (event: Event) => void>();
+
+  constructor(initialState: PermissionState) {
+    this.state = initialState;
+  }
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
+    if (type !== 'change' || !listener) return;
+    const callback =
+      typeof listener === 'function'
+        ? listener
+        : (event: Event) => listener.handleEvent?.(event);
+    if (!callback) return;
+    this.listeners.add(callback);
+    this.listenerMap.set(listener, callback);
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
+    if (type !== 'change' || !listener) return;
+    const callback = this.listenerMap.get(listener);
+    if (!callback) return;
+    this.listeners.delete(callback);
+    this.listenerMap.delete(listener);
+  }
+
+  dispatch(newState: PermissionState) {
+    this.state = newState;
+    const event = new Event('change');
+    this.listeners.forEach(listener => listener(event));
+    this.onchange?.call(this, event);
+  }
+}
+
+const createWrapper = (pushNotification = jest.fn()) => {
+  const value = {
+    notificationsByApp: {},
+    notifications: [],
+    unreadCount: 0,
+    pushNotification,
+    dismissNotification: jest.fn(),
+    clearNotifications: jest.fn(),
+    markAllRead: jest.fn(),
+  };
+
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <NotificationsContext.Provider value={value}>{children}</NotificationsContext.Provider>
+  );
+
+  return { Wrapper, pushNotification };
+};
+
+describe('usePermissions', () => {
+  const mediaStream = {
+    getTracks: () => [
+      {
+        stop: jest.fn(),
+      },
+    ],
+  } as unknown as MediaStream;
+
+  let permissionStatuses: Record<string, MockPermissionStatus>;
+
+  const createStatuses = () => ({
+    camera: new MockPermissionStatus('prompt'),
+    microphone: new MockPermissionStatus('denied'),
+    serial: new MockPermissionStatus('prompt'),
+    'persistent-storage': new MockPermissionStatus('prompt'),
+  });
+
+  const installNavigatorMocks = () => {
+    const permissions = {
+      query: jest.fn(async (descriptor: PermissionDescriptor) => {
+        const name = (descriptor as PermissionDescriptor & { name: string }).name;
+        return permissionStatuses[name] ?? null;
+      }),
+      revoke: jest.fn(async (descriptor: PermissionDescriptor) => {
+        const name = (descriptor as PermissionDescriptor & { name: string }).name;
+        const status = permissionStatuses[name];
+        status?.dispatch('prompt');
+        return status;
+      }),
+    };
+
+    Object.assign(navigator, {
+      permissions,
+      mediaDevices: {
+        getUserMedia: jest.fn(async () => {
+          permissionStatuses.camera.dispatch('granted');
+          return mediaStream;
+        }),
+      },
+      serial: {
+        requestPort: jest.fn(async () => {
+          permissionStatuses.serial.dispatch('granted');
+          return {
+            close: jest.fn(),
+          };
+        }),
+      },
+      storage: {
+        persist: jest.fn(async () => {
+          permissionStatuses['persistent-storage'].dispatch('granted');
+          return true;
+        }),
+      },
+    } as Navigator);
+
+    return permissions;
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    permissionStatuses = createStatuses();
+    installNavigatorMocks();
+  });
+
+  test('reads initial permission states and reacts to change events', async () => {
+    const { Wrapper, pushNotification } = createWrapper();
+    const { result } = renderHook(() => usePermissions(), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      const camera = result.current.permissions.find(item => item.key === 'camera');
+      expect(camera?.state).toBe('prompt');
+    });
+
+    act(() => {
+      permissionStatuses.camera.dispatch('granted');
+    });
+
+    await waitFor(() => {
+      const camera = result.current.permissions.find(item => item.key === 'camera');
+      expect(camera?.state).toBe('granted');
+    });
+
+    expect(pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: 'system-permissions',
+        title: expect.stringContaining('Camera'),
+      }),
+    );
+  });
+
+  test('request and revoke actions update state snapshots', async () => {
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePermissions(), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.permissions.every(entry => entry.state !== 'unknown')).toBe(true);
+    });
+
+    const getPermission = (key: string) =>
+      result.current.permissions.find(permission => permission.key === key)!;
+
+    await act(async () => {
+      await getPermission('camera').request();
+    });
+
+    await waitFor(() => {
+      expect(getPermission('camera').state).toBe('granted');
+    });
+
+    await act(async () => {
+      await getPermission('camera').revoke();
+    });
+
+    await waitFor(() => {
+      expect(getPermission('camera').state).toBe('prompt');
+    });
+
+    await act(async () => {
+      await getPermission('filesystem').request();
+    });
+
+    await waitFor(() => {
+      expect(getPermission('filesystem').state).toBe('granted');
+    });
+  });
+
+  test('disables unsupported APIs gracefully', async () => {
+    const permissions = installNavigatorMocks();
+    delete (navigator as any).serial;
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePermissions(), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.permissions.length).toBeGreaterThan(0);
+    });
+
+    const serialPermission = result.current.permissions.find(permission => permission.key === 'serial');
+    expect(serialPermission?.supported).toBe(false);
+    expect(serialPermission?.canRequest).toBe(false);
+    expect(permissions.query).toHaveBeenCalled();
+  });
+});
+

--- a/components/common/PermissionsPanel.tsx
+++ b/components/common/PermissionsPanel.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import usePermissions, {
+  PermissionDetail,
+  PermissionStateValue,
+} from '../../hooks/usePermissions';
+
+const STATUS_LABELS: Record<PermissionStateValue, string> = {
+  granted: 'Granted',
+  denied: 'Blocked',
+  prompt: 'Prompt',
+  unknown: 'Unknown',
+};
+
+const STATUS_CLASSES: Record<PermissionStateValue, string> = {
+  granted: 'bg-emerald-500/80 text-emerald-100',
+  denied: 'bg-red-600/80 text-red-100',
+  prompt: 'bg-amber-500/80 text-amber-100',
+  unknown: 'bg-slate-600/80 text-slate-200',
+};
+
+const ActionButton: React.FC<{
+  disabled?: boolean;
+  busy?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}> = ({ disabled, busy, onClick, children }) => (
+  <button
+    type="button"
+    className="px-3 py-1 rounded bg-ubt-blue text-white text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+    disabled={disabled || busy}
+    onClick={() => {
+      if (!disabled && !busy) onClick();
+    }}
+  >
+    {busy ? 'Working…' : children}
+  </button>
+);
+
+const PermissionCard: React.FC<{ permission: PermissionDetail }> = ({ permission }) => {
+  const status = permission.supported ? permission.state : 'unknown';
+  const statusLabel = STATUS_LABELS[status];
+  const statusClass = STATUS_CLASSES[status];
+
+  const unsupportedMessage =
+    'This browser does not expose the necessary APIs. Buttons are disabled to avoid inconsistent behaviour.';
+
+  return (
+    <li className="rounded-lg border border-white/10 bg-black/30 p-4 space-y-3" data-permission={permission.key}>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold text-white">{permission.label}</h3>
+          <p className="text-sm text-slate-200/80 max-w-xl">{permission.description}</p>
+        </div>
+        <span className={`px-2 py-1 rounded text-xs font-semibold uppercase tracking-wide ${statusClass}`}>
+          {statusLabel}
+        </span>
+      </div>
+      <p className="text-xs text-slate-200/80">
+        {permission.supported ? 'Need details?' : unsupportedMessage}{' '}
+        <a
+          href={permission.docUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="text-ubt-blue underline"
+        >
+          Read the docs
+        </a>
+      </p>
+      <div className="flex flex-wrap gap-2">
+        <ActionButton
+          disabled={!permission.canRequest || !permission.supported}
+          busy={permission.requesting}
+          onClick={() => {
+            void permission.request();
+          }}
+        >
+          Request access
+        </ActionButton>
+        <ActionButton
+          disabled={!permission.canRevoke || !permission.supported}
+          busy={permission.revoking}
+          onClick={() => {
+            void permission.revoke();
+          }}
+        >
+          Revoke
+        </ActionButton>
+      </div>
+      {permission.error ? <p className="text-xs text-red-300">{permission.error}</p> : null}
+    </li>
+  );
+};
+
+const PermissionsPanel: React.FC = () => {
+  const { permissions } = usePermissions();
+
+  return (
+    <section
+      aria-labelledby="permissions-panel-heading"
+      className="space-y-4 rounded-xl border border-white/10 bg-ub-grey p-5 text-white"
+    >
+      <div className="space-y-2">
+        <h2 id="permissions-panel-heading" className="text-lg font-semibold">
+          Device permissions
+        </h2>
+        <p className="text-sm text-slate-100/80">
+          Check browser support, view current permission states, and quickly toggle access for hardware integrations. We send a
+          desktop-style notification whenever states change so you have an audit trail.
+        </p>
+      </div>
+      <ul className="space-y-4">
+        {permissions.map(permission => (
+          <PermissionCard key={permission.key} permission={permission} />
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default PermissionsPanel;

--- a/hooks/usePermissions.ts
+++ b/hooks/usePermissions.ts
@@ -1,0 +1,484 @@
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { NotificationsContext } from '../components/common/NotificationCenter';
+
+export type PermissionKey = 'camera' | 'microphone' | 'serial' | 'filesystem';
+
+export type PermissionStateValue = PermissionState | 'unknown';
+
+export interface PermissionActionResult {
+  ok: boolean;
+  error?: string;
+  state?: PermissionStateValue;
+}
+
+export interface PermissionDetail {
+  key: PermissionKey;
+  label: string;
+  description: string;
+  docUrl: string;
+  supported: boolean;
+  state: PermissionStateValue;
+  error: string | null;
+  canRequest: boolean;
+  canRevoke: boolean;
+  requesting: boolean;
+  revoking: boolean;
+  request: () => Promise<PermissionActionResult>;
+  revoke: () => Promise<PermissionActionResult>;
+}
+
+interface PermissionConfig {
+  label: string;
+  description: string;
+  docUrl: string;
+  permissionName: string;
+  request?: () => Promise<void>;
+  revoke?: () => Promise<void>;
+  isSupported: () => boolean;
+}
+
+interface PermissionEntryState {
+  supported: boolean;
+  state: PermissionStateValue;
+  error: string | null;
+}
+
+interface PermissionActionState {
+  requesting: boolean;
+  revoking: boolean;
+  error: string | null;
+}
+
+const PERMISSION_KEYS: PermissionKey[] = ['camera', 'microphone', 'serial', 'filesystem'];
+
+const getNavigator = () => (typeof navigator !== 'undefined' ? navigator : undefined);
+
+const stopTracks = (stream: MediaStream | null | undefined) => {
+  if (!stream) return;
+  try {
+    stream.getTracks().forEach(track => {
+      try {
+        track.stop();
+      } catch {}
+    });
+  } catch {}
+};
+
+const PERMISSION_CONFIG: Record<PermissionKey, PermissionConfig> = {
+  camera: {
+    label: 'Camera',
+    description:
+      'Used for barcode scanners and video capture demos. Media streams are immediately released after the check.',
+    docUrl: 'https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia',
+    permissionName: 'camera',
+    request: async () => {
+      const nav = getNavigator();
+      if (!nav?.mediaDevices?.getUserMedia) {
+        throw new Error('MediaDevices.getUserMedia is not available in this browser.');
+      }
+      const stream = await nav.mediaDevices.getUserMedia({ video: true });
+      stopTracks(stream);
+    },
+    isSupported: () => {
+      const nav = getNavigator();
+      return !!nav?.mediaDevices?.getUserMedia;
+    },
+  },
+  microphone: {
+    label: 'Microphone',
+    description:
+      'Enables simulated VoIP calls and audio spectrum visualisers. Audio streams are closed immediately after requesting access.',
+    docUrl: 'https://developer.mozilla.org/docs/Web/API/MediaDevices/getUserMedia',
+    permissionName: 'microphone',
+    request: async () => {
+      const nav = getNavigator();
+      if (!nav?.mediaDevices?.getUserMedia) {
+        throw new Error('MediaDevices.getUserMedia is not available in this browser.');
+      }
+      const stream = await nav.mediaDevices.getUserMedia({ audio: true });
+      stopTracks(stream);
+    },
+    isSupported: () => {
+      const nav = getNavigator();
+      return !!nav?.mediaDevices?.getUserMedia;
+    },
+  },
+  serial: {
+    label: 'Serial',
+    description:
+      'Allows connecting to USB serial devices for hardware lab walkthroughs. Ports are closed as soon as the permission flow completes.',
+    docUrl: 'https://developer.mozilla.org/docs/Web/API/Serial',
+    permissionName: 'serial',
+    request: async () => {
+      const nav = getNavigator() as Navigator & { serial?: { requestPort: () => Promise<any> } };
+      const serial = nav?.serial;
+      if (!serial?.requestPort) {
+        throw new Error('Web Serial API is not available in this browser.');
+      }
+      const port = await serial.requestPort();
+      try {
+        await port.close?.();
+      } catch {}
+    },
+    isSupported: () => {
+      const nav = getNavigator() as Navigator & { serial?: unknown };
+      return !!nav?.serial;
+    },
+  },
+  filesystem: {
+    label: 'Persistent storage',
+    description:
+      'Persists emulator save files and OPFS data so they survive reloads. Requests StorageManager.persist under the hood.',
+    docUrl: 'https://developer.mozilla.org/docs/Web/API/StorageManager/persist',
+    permissionName: 'persistent-storage',
+    request: async () => {
+      const nav = getNavigator();
+      if (!nav?.storage?.persist) {
+        throw new Error('Persistent storage is not available in this browser.');
+      }
+      const granted = await nav.storage.persist();
+      if (!granted) {
+        throw new Error('Persistent storage request was dismissed.');
+      }
+    },
+    isSupported: () => {
+      const nav = getNavigator();
+      return !!nav?.storage?.persist;
+    },
+  },
+};
+
+const createInitialState = (): Record<PermissionKey, PermissionEntryState> => {
+  const state: Record<PermissionKey, PermissionEntryState> = {
+    camera: { supported: PERMISSION_CONFIG.camera.isSupported(), state: 'unknown', error: null },
+    microphone: {
+      supported: PERMISSION_CONFIG.microphone.isSupported(),
+      state: 'unknown',
+      error: null,
+    },
+    serial: { supported: PERMISSION_CONFIG.serial.isSupported(), state: 'unknown', error: null },
+    filesystem: {
+      supported: PERMISSION_CONFIG.filesystem.isSupported(),
+      state: 'unknown',
+      error: null,
+    },
+  };
+  return state;
+};
+
+const createInitialActionState = (): Record<PermissionKey, PermissionActionState> => ({
+  camera: { requesting: false, revoking: false, error: null },
+  microphone: { requesting: false, revoking: false, error: null },
+  serial: { requesting: false, revoking: false, error: null },
+  filesystem: { requesting: false, revoking: false, error: null },
+});
+
+const describeState = (state: PermissionStateValue): string => {
+  switch (state) {
+    case 'granted':
+      return 'granted';
+    case 'denied':
+      return 'denied';
+    case 'prompt':
+      return 'pending';
+    default:
+      return 'updated';
+  }
+};
+
+export interface UsePermissionsResult {
+  permissions: PermissionDetail[];
+  requestPermission: (key: PermissionKey) => Promise<PermissionActionResult>;
+  revokePermission: (key: PermissionKey) => Promise<PermissionActionResult>;
+  refreshPermissions: (key?: PermissionKey) => Promise<void>;
+}
+
+export const usePermissions = (): UsePermissionsResult => {
+  const notifications = useContext(NotificationsContext);
+
+  const [entries, setEntries] = useState<Record<PermissionKey, PermissionEntryState>>(createInitialState);
+  const [actions, setActions] = useState<Record<PermissionKey, PermissionActionState>>(createInitialActionState);
+
+  const navigatorInstance = getNavigator();
+  const permissionsApi = navigatorInstance?.permissions;
+  const canRevokeViaApi = !!permissionsApi?.revoke;
+
+  const detachRef = useRef<Partial<Record<PermissionKey, () => void>>>({});
+  const prevStatesRef = useRef<Record<PermissionKey, PermissionStateValue>>({
+    camera: 'unknown',
+    microphone: 'unknown',
+    serial: 'unknown',
+    filesystem: 'unknown',
+  });
+  const initializedRef = useRef(false);
+
+  const updateEntry = useCallback(
+    (key: PermissionKey, patch: Partial<PermissionEntryState>) => {
+      setEntries(prev => ({
+        ...prev,
+        [key]: {
+          ...prev[key],
+          ...patch,
+        },
+      }));
+    },
+    [],
+  );
+
+  const updateFromStatus = useCallback(
+    (key: PermissionKey, status: PermissionStatus) => {
+      updateEntry(key, {
+        supported: true,
+        state: status.state,
+        error: null,
+      });
+    },
+    [updateEntry],
+  );
+
+  const attachStatusListener = useCallback(
+    (key: PermissionKey, status: PermissionStatus) => {
+      detachRef.current[key]?.();
+
+      const handler = () => {
+        updateFromStatus(key, status);
+      };
+
+      if (typeof status.addEventListener === 'function') {
+        status.addEventListener('change', handler);
+        detachRef.current[key] = () => {
+          status.removeEventListener('change', handler);
+        };
+      } else {
+        const bound = () => handler();
+        Reflect.set(status, 'onchange', bound);
+        detachRef.current[key] = () => {
+          const current = Reflect.get(status, 'onchange');
+          if (current === bound) {
+            Reflect.set(status, 'onchange', null);
+          }
+        };
+      }
+    },
+    [updateFromStatus],
+  );
+
+  const refreshPermissionInternal = useCallback(
+    async (key: PermissionKey): Promise<PermissionStatus | null> => {
+      const config = PERMISSION_CONFIG[key];
+      const supported = config.isSupported();
+      updateEntry(key, { supported });
+
+      if (!permissionsApi?.query || !supported) {
+        if (!supported) {
+          updateEntry(key, { state: 'unknown', error: null });
+        }
+        return null;
+      }
+
+      try {
+        const descriptor = { name: config.permissionName } as PermissionDescriptor;
+        const status = await permissionsApi.query(descriptor);
+        updateFromStatus(key, status);
+        attachStatusListener(key, status);
+        return status;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unable to read permission status';
+        updateEntry(key, { state: 'unknown', error: message });
+        return null;
+      }
+    },
+    [attachStatusListener, permissionsApi, updateEntry, updateFromStatus],
+  );
+
+  useEffect(() => {
+    if (!navigatorInstance) {
+      initializedRef.current = true;
+      return () => {};
+    }
+
+    let cancelled = false;
+    const detachHandles = detachRef.current;
+
+    const run = async () => {
+      for (const key of PERMISSION_KEYS) {
+        if (cancelled) break;
+        await refreshPermissionInternal(key);
+      }
+      if (!cancelled) {
+        initializedRef.current = true;
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+      PERMISSION_KEYS.forEach(key => {
+        detachHandles[key]?.();
+        detachHandles[key] = undefined;
+      });
+    };
+  }, [navigatorInstance, refreshPermissionInternal]);
+
+  useEffect(() => {
+    const notificationApi = notifications?.pushNotification;
+    const nextStates: Partial<Record<PermissionKey, PermissionStateValue>> = {};
+
+    const changed: Array<{ key: PermissionKey; state: PermissionStateValue }> = [];
+    PERMISSION_KEYS.forEach(key => {
+      const currentState = entries[key].state;
+      const previous = prevStatesRef.current[key];
+      nextStates[key] = currentState;
+      if (previous !== currentState) {
+        changed.push({ key, state: currentState });
+      }
+    });
+
+    prevStatesRef.current = {
+      camera: nextStates.camera ?? 'unknown',
+      microphone: nextStates.microphone ?? 'unknown',
+      serial: nextStates.serial ?? 'unknown',
+      filesystem: nextStates.filesystem ?? 'unknown',
+    };
+
+    if (!notificationApi || !initializedRef.current) {
+      return;
+    }
+
+    changed
+      .filter(({ state }) => state !== 'unknown')
+      .forEach(({ key, state }) => {
+        const config = PERMISSION_CONFIG[key];
+        const statusDescription = describeState(state);
+        notificationApi({
+          appId: 'system-permissions',
+          title: `${config.label} permission ${statusDescription}`,
+          body: `Status is now “${state}”. Read why we ask: ${config.docUrl}`,
+          hints: {
+            source: 'permissions-panel',
+            permission: key,
+            state,
+          },
+        });
+      });
+  }, [entries, notifications]);
+
+  const setActionState = useCallback(
+    (key: PermissionKey, patch: Partial<PermissionActionState>) => {
+      setActions(prev => ({
+        ...prev,
+        [key]: {
+          ...prev[key],
+          ...patch,
+        },
+      }));
+    },
+    [],
+  );
+
+  const requestPermission = useCallback(
+    async (key: PermissionKey): Promise<PermissionActionResult> => {
+      const config = PERMISSION_CONFIG[key];
+      if (!config.request) {
+        const error = 'Requesting this permission is not supported on this browser.';
+        setActionState(key, { error });
+        return { ok: false, error };
+      }
+
+      setActionState(key, { requesting: true, error: null });
+      try {
+        await config.request();
+        const status = await refreshPermissionInternal(key);
+        const state = status?.state ?? entries[key].state;
+        return { ok: true, state };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Permission request failed.';
+        setActionState(key, { error: message });
+        return { ok: false, error: message };
+      } finally {
+        setActionState(key, { requesting: false });
+      }
+    },
+    [entries, refreshPermissionInternal, setActionState],
+  );
+
+  const revokePermission = useCallback(
+    async (key: PermissionKey): Promise<PermissionActionResult> => {
+      const config = PERMISSION_CONFIG[key];
+      const hasCustomRevoke = !!config.revoke;
+      if (!hasCustomRevoke && !canRevokeViaApi) {
+        const error = 'Revoking this permission is not supported on this browser.';
+        setActionState(key, { error });
+        return { ok: false, error };
+      }
+
+      setActionState(key, { revoking: true, error: null });
+      try {
+        if (config.revoke) {
+          await config.revoke();
+        } else if (permissionsApi?.revoke) {
+          const descriptor = { name: config.permissionName } as PermissionDescriptor;
+          await permissionsApi.revoke(descriptor);
+        }
+        const status = await refreshPermissionInternal(key);
+        const state = status?.state ?? entries[key].state;
+        return { ok: true, state };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to revoke permission.';
+        setActionState(key, { error: message });
+        return { ok: false, error: message };
+      } finally {
+        setActionState(key, { revoking: false });
+      }
+    },
+    [canRevokeViaApi, entries, permissionsApi, refreshPermissionInternal, setActionState],
+  );
+
+  const refreshPermissions = useCallback(
+    async (key?: PermissionKey) => {
+      if (key) {
+        await refreshPermissionInternal(key);
+        return;
+      }
+      await Promise.all(PERMISSION_KEYS.map(permission => refreshPermissionInternal(permission)));
+    },
+    [refreshPermissionInternal],
+  );
+
+  const permissions = useMemo<PermissionDetail[]>(() => {
+    return PERMISSION_KEYS.map(key => {
+      const config = PERMISSION_CONFIG[key];
+      const entry = entries[key];
+      const actionState = actions[key];
+      const canRequest = !!config.request && entry.supported;
+      const canRevoke = (config.revoke ? true : canRevokeViaApi) && entry.supported;
+      const error = actionState.error ?? entry.error;
+
+      return {
+        key,
+        label: config.label,
+        description: config.description,
+        docUrl: config.docUrl,
+        supported: entry.supported,
+        state: entry.state,
+        error,
+        canRequest,
+        canRevoke,
+        requesting: actionState.requesting,
+        revoking: actionState.revoking,
+        request: () => requestPermission(key),
+        revoke: () => revokePermission(key),
+      } satisfies PermissionDetail;
+    });
+  }, [actions, canRevokeViaApi, entries, requestPermission, revokePermission]);
+
+  return {
+    permissions,
+    requestPermission,
+    revokePermission,
+    refreshPermissions,
+  };
+};
+
+export default usePermissions;


### PR DESCRIPTION
## Summary
- add a usePermissions hook that normalises camera, microphone, serial, and persistent storage states with notification updates
- build a desktop-style permissions panel with quick actions and doc links for each capability
- cover permission flows with unit tests that stub the browser Permissions API

## Testing
- yarn lint
- yarn test __tests__/usePermissions.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc625cc85c8328a963a5ffa8ac6800