### PR TITLE
feat: add redaction preview for exports

### DIFF
--- a/__tests__/RedactionPreview.test.tsx
+++ b/__tests__/RedactionPreview.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import RedactionPreview from '../components/common/RedactionPreview';
+import { getPlaceholder } from '../utils/redaction';
+import { clearAuditTrail, getAuditTrail } from '../utils/auditLog';
+
+describe('RedactionPreview', () => {
+  let confirmSpy: jest.SpyInstance;
+  let infoSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    clearAuditTrail();
+    confirmSpy = jest.spyOn(window, 'confirm').mockImplementation(() => true);
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    confirmSpy.mockRestore();
+    infoSpy.mockRestore();
+  });
+
+  it('redacts content and emits changes', async () => {
+    const handleChange = jest.fn();
+    render(
+      <RedactionPreview
+        content={'admin@example.com 10.0.0.1 example.org'}
+        onChange={handleChange}
+        context="test"
+      />,
+    );
+    await waitFor(() => expect(handleChange).toHaveBeenCalled());
+    const lastCall = handleChange.mock.calls.at(-1);
+    expect(lastCall?.[0]).toContain(getPlaceholder('email'));
+    expect(lastCall?.[0]).toContain(getPlaceholder('ip'));
+    expect(lastCall?.[0]).toContain(getPlaceholder('domain'));
+  });
+
+  it('allows revealing categories with confirmation', async () => {
+    const handleChange = jest.fn();
+    render(
+      <RedactionPreview
+        content={'admin@example.com 10.0.0.1 example.org'}
+        onChange={handleChange}
+        context="test"
+      />,
+    );
+
+    const emailToggle = screen.getByLabelText('Redact Email Addresses') as HTMLInputElement;
+    expect(emailToggle.checked).toBe(true);
+    fireEvent.click(emailToggle);
+
+    await waitFor(() => {
+      const lastCall = handleChange.mock.calls.at(-1);
+      expect(lastCall?.[0]).toContain('admin@example.com');
+    });
+
+    const auditEvents = getAuditTrail().filter((event) => event.category === 'email');
+    expect(auditEvents.some((event) => event.action === 'reveal')).toBe(true);
+  });
+
+  it('supports reveal once flow', async () => {
+    render(
+      <RedactionPreview
+        content={'admin@example.com 10.0.0.1 example.org'}
+        context="test"
+      />,
+    );
+
+    const revealOnce = screen.getByRole('button', { name: /Reveal Email Addresses once/i });
+    fireEvent.click(revealOnce);
+
+    const status = await screen.findByRole('status');
+    expect(within(status).getByText('admin@example.com')).toBeInTheDocument();
+
+    const auditEvents = getAuditTrail().filter((event) => event.category === 'email');
+    expect(auditEvents.some((event) => event.action === 'peek')).toBe(true);
+  });
+});

--- a/__tests__/ReportExport.test.tsx
+++ b/__tests__/ReportExport.test.tsx
@@ -27,10 +27,13 @@ describe('ReportExport', () => {
         ]}
       />
     );
+    await screen.findByLabelText('Redaction preview');
     fireEvent.click(screen.getByText('Copy HTML Report'));
     await waitFor(() =>
       expect(navigator.clipboard.writeText).toHaveBeenCalled()
     );
-    expect((navigator.clipboard.writeText as jest.Mock).mock.calls[0][0]).toContain('<!DOCTYPE html>');
+    const payload = (navigator.clipboard.writeText as jest.Mock).mock.calls[0][0];
+    expect(payload).toContain('<!DOCTYPE html>');
+    expect(payload).toContain('demo Report');
   });
 });

--- a/__tests__/redaction.test.ts
+++ b/__tests__/redaction.test.ts
@@ -1,0 +1,33 @@
+import { applyRedactions, getPlaceholder, scanSensitiveMatches } from '../utils/redaction';
+
+describe('redaction utils', () => {
+  const sample = 'Contact admin@example.com at 192.168.10.5 or visit internal.example.org.';
+
+  it('identifies sensitive values', () => {
+    const matches = scanSensitiveMatches(sample);
+    expect(matches.map((match) => ({ category: match.category, value: match.value }))).toEqual([
+      { category: 'email', value: 'admin@example.com' },
+      { category: 'ip', value: '192.168.10.5' },
+      { category: 'domain', value: 'internal.example.org' },
+    ]);
+  });
+
+  it('redacts configured categories', () => {
+    const matches = scanSensitiveMatches(sample);
+    const result = applyRedactions(sample, ['email', 'domain', 'ip'], matches);
+    expect(result.text).not.toContain('admin@example.com');
+    expect(result.text).not.toContain('192.168.10.5');
+    expect(result.text).not.toContain('internal.example.org');
+    expect(result.text).toContain(getPlaceholder('email'));
+    expect(result.text).toContain(getPlaceholder('ip'));
+    expect(result.text).toContain(getPlaceholder('domain'));
+  });
+
+  it('respects category toggles', () => {
+    const matches = scanSensitiveMatches(sample);
+    const result = applyRedactions(sample, ['email'], matches);
+    expect(result.text).toContain(getPlaceholder('email'));
+    expect(result.text).toContain('192.168.10.5');
+    expect(result.text).toContain('internal.example.org');
+  });
+});

--- a/apps/autopsy/components/ReportExport.tsx
+++ b/apps/autopsy/components/ReportExport.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import copyToClipboard from '../../../utils/clipboard';
+import RedactionPreview from '../../../components/common/RedactionPreview';
 
 interface Artifact {
   name: string;
@@ -34,8 +35,14 @@ const ReportExport: React.FC<ReportExportProps> = ({ caseName = 'case', artifact
     return `<!DOCTYPE html><html><head><meta charset="utf-8"/><title>${escapeHtml(caseName)} Report</title></head><body><h1>${escapeHtml(caseName)}</h1><table border="1"><tr><th>Name</th><th>Type</th><th>Description</th><th>Size</th><th>Plugin</th><th>Timestamp</th></tr>${rows}</table></body></html>`;
   }, [artifacts, caseName]);
 
+  const [redactedHtml, setRedactedHtml] = useState(htmlReport);
+
+  useEffect(() => {
+    setRedactedHtml(htmlReport);
+  }, [htmlReport]);
+
   const exportReport = () => {
-    const blob = new Blob([htmlReport], { type: 'text/html' });
+    const blob = new Blob([redactedHtml], { type: 'text/html' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -47,23 +54,30 @@ const ReportExport: React.FC<ReportExportProps> = ({ caseName = 'case', artifact
   };
 
   const copyReport = () => {
-    copyToClipboard(htmlReport);
+    copyToClipboard(redactedHtml);
   };
 
   return (
-    <div className="flex gap-2">
-      <button
-        onClick={copyReport}
-        className="bg-ub-gray px-3 py-1 rounded text-sm text-black"
-      >
-        Copy HTML Report
-      </button>
-      <button
-        onClick={exportReport}
-        className="bg-ub-orange px-3 py-1 rounded text-sm text-black"
-      >
-        Download HTML Report
-      </button>
+    <div className="space-y-3">
+      <RedactionPreview
+        content={htmlReport}
+        context="autopsy-report-export"
+        onChange={(value) => setRedactedHtml(value)}
+      />
+      <div className="flex gap-2">
+        <button
+          onClick={copyReport}
+          className="bg-ub-gray px-3 py-1 rounded text-sm text-black"
+        >
+          Copy HTML Report
+        </button>
+        <button
+          onClick={exportReport}
+          className="bg-ub-orange px-3 py-1 rounded text-sm text-black"
+        >
+          Download HTML Report
+        </button>
+      </div>
     </div>
   );
 };

--- a/components/apps/reconng/components/ReportTemplates.tsx
+++ b/components/apps/reconng/components/ReportTemplates.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import usePersistentState from '../../../../hooks/usePersistentState';
 import defaultTemplates from '../../../../templates/export/report-templates.json';
+import RedactionPreview from '../../../../components/common/RedactionPreview';
 
 interface Finding {
   title: string;
@@ -55,8 +56,14 @@ export default function ReportTemplates() {
     [templateKey, templateData],
   );
 
+  const [redactedReport, setRedactedReport] = useState(report);
+
+  useEffect(() => {
+    setRedactedReport(report);
+  }, [report]);
+
   const exportReport = () => {
-    const blob = new Blob([report], { type: 'text/plain' });
+    const blob = new Blob([redactedReport], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -124,19 +131,29 @@ export default function ReportTemplates() {
           Import/Share
         </button>
       </div>
-      <pre className="flex-1 bg-black p-2 overflow-auto whitespace-pre-wrap text-sm">
-        {report}
-      </pre>
+      <div className="flex-1 overflow-auto pr-1">
+        <RedactionPreview
+          content={report}
+          context="recon-report-export"
+          onChange={(value) => setRedactedReport(value)}
+        />
+      </div>
       {showDialog && (
-        <dialog open className="p-4 bg-gray-800 text-white rounded max-w-md">
-          <p className="mb-2">Import templates (JSON)</p>
-          <input type="file" accept="application/json" onChange={handleImport} />
-          <p className="mt-4 mb-2">Share templates</p>
-          <textarea
-            readOnly
-            value={shareJson}
-            className="w-full h-40 p-1 text-black"
-          />
+          <dialog open className="p-4 bg-gray-800 text-white rounded max-w-md">
+            <p className="mb-2">Import templates (JSON)</p>
+            <input
+              type="file"
+              accept="application/json"
+              onChange={handleImport}
+              aria-label="Import report templates JSON"
+            />
+            <p className="mt-4 mb-2">Share templates</p>
+            <textarea
+              readOnly
+              value={shareJson}
+              className="w-full h-40 p-1 text-black"
+              aria-label="Shareable templates JSON"
+            />
           <div className="flex gap-2 mt-2">
             <button
               type="button"

--- a/components/common/RedactionPreview.tsx
+++ b/components/common/RedactionPreview.tsx
@@ -1,0 +1,261 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  applyRedactions,
+  buildPlaceholderRegex,
+  CATEGORY_DEFINITIONS,
+  getCategoryDefinition,
+  getPlaceholder,
+  scanSensitiveMatches,
+  type RedactionCategory,
+  type RedactionMatch,
+} from '../../utils/redaction';
+import { logRedactionAudit } from '../../utils/auditLog';
+
+const DEFAULT_CATEGORY_IDS = CATEGORY_DEFINITIONS.map(
+  (definition) => definition.id,
+);
+
+interface RedactionPreviewProps {
+  content: string;
+  categories?: RedactionCategory[];
+  context?: string;
+  onChange?: (redacted: string, activeCategories: RedactionCategory[]) => void;
+}
+
+interface Segment {
+  text: string;
+  highlight?: boolean;
+  category?: RedactionCategory;
+}
+
+const createSegments = (text: string, matches: RedactionMatch[]): Segment[] => {
+  if (!matches.length) return [{ text }];
+  const segments: Segment[] = [];
+  let cursor = 0;
+  matches.forEach((match) => {
+    if (cursor < match.start) {
+      segments.push({ text: text.slice(cursor, match.start) });
+    }
+    segments.push({
+      text: text.slice(match.start, match.end),
+      highlight: true,
+      category: match.category,
+    });
+    cursor = match.end;
+  });
+  if (cursor < text.length) {
+    segments.push({ text: text.slice(cursor) });
+  }
+  return segments;
+};
+
+const createRedactedSegments = (
+  text: string,
+  categories: RedactionCategory[],
+): Segment[] => {
+  if (!text) return [{ text: '' }];
+  const regex = buildPlaceholderRegex(categories);
+  if (!regex.source || regex.source === '$^') return [{ text }];
+  const segments: Segment[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text))) {
+    const value = match[0];
+    const offset = match.index ?? 0;
+    if (offset > lastIndex) {
+      segments.push({ text: text.slice(lastIndex, offset) });
+    }
+    const category = categories.find(
+      (candidate) => getPlaceholder(candidate) === value,
+    );
+    segments.push({ text: value, highlight: true, category });
+    lastIndex = offset + value.length;
+  }
+  if (lastIndex < text.length) {
+    segments.push({ text: text.slice(lastIndex) });
+  }
+  return segments;
+};
+
+const CATEGORY_COLORS: Record<RedactionCategory, string> = {
+  ip: 'bg-purple-700/60',
+  email: 'bg-emerald-700/60',
+  domain: 'bg-blue-700/60',
+};
+
+const RedactionPreview: React.FC<RedactionPreviewProps> = ({
+  content,
+  categories = DEFAULT_CATEGORY_IDS,
+  context = 'export',
+  onChange,
+}) => {
+  const categoryList = useMemo(
+    () => CATEGORY_DEFINITIONS.filter((definition) => categories.includes(definition.id)),
+    [categories],
+  );
+
+  const [active, setActive] = useState<Set<RedactionCategory>>(
+    () => new Set(categoryList.map((definition) => definition.id)),
+  );
+  const [peekCategory, setPeekCategory] = useState<RedactionCategory | null>(null);
+
+  const categoryKey = useMemo(
+    () => categoryList.map((definition) => definition.id).join('|'),
+    [categoryList],
+  );
+
+  useEffect(() => {
+    setActive(new Set(categoryList.map((definition) => definition.id)));
+  }, [categoryKey, categoryList]);
+
+  const matches = useMemo(() => scanSensitiveMatches(content), [content]);
+
+  const activeCategories = useMemo(
+    () => categoryList.map((definition) => definition.id).filter((id) => active.has(id)),
+    [active, categoryList],
+  );
+
+  const redactedResult = useMemo(
+    () => applyRedactions(content, activeCategories, matches),
+    [content, activeCategories, matches],
+  );
+
+  useEffect(() => {
+    onChange?.(redactedResult.text, activeCategories);
+  }, [redactedResult.text, activeCategories, onChange]);
+
+  const toggleCategory = (category: RedactionCategory, shouldRedact: boolean) => {
+    setActive((prev) => {
+      const next = new Set(prev);
+      if (shouldRedact) {
+        next.add(category);
+        logRedactionAudit({ type: 'redaction', category, action: 'redact', context });
+        return next;
+      }
+      const confirmed = typeof window !== 'undefined'
+        ? window.confirm(
+            `Reveal ${getCategoryDefinition(category).label}? This exposes sensitive data until re-enabled.`,
+          )
+        : true;
+      if (!confirmed) return prev;
+      next.delete(category);
+      logRedactionAudit({ type: 'redaction', category, action: 'reveal', context });
+      return next;
+    });
+  };
+
+  const handleRevealOnce = (category: RedactionCategory) => {
+    const confirmed = typeof window !== 'undefined'
+      ? window.confirm(
+          `Reveal ${getCategoryDefinition(category).label} for a short time?`,
+        )
+      : true;
+    if (!confirmed) return;
+    setPeekCategory(category);
+    logRedactionAudit({ type: 'redaction', category, action: 'peek', context });
+  };
+
+  const originalSegments = useMemo(() => createSegments(content, matches), [content, matches]);
+  const redactedSegments = useMemo(
+    () => createRedactedSegments(redactedResult.text, Array.from(new Set(activeCategories))),
+    [redactedResult.text, activeCategories],
+  );
+
+  const peekValues = useMemo(() => {
+    if (!peekCategory) return [] as string[];
+    return matches
+      .filter((match) => match.category === peekCategory)
+      .map((match) => match.value)
+      .filter((value, index, array) => array.indexOf(value) === index);
+  }, [matches, peekCategory]);
+
+  return (
+    <section className="space-y-3" aria-label="Redaction preview">
+      <div className="space-y-2">
+        {categoryList.map((definition) => {
+          const matchCount = matches.filter((match) => match.category === definition.id).length;
+          const isChecked = active.has(definition.id);
+          const hasMatches = matchCount > 0;
+          return (
+            <div key={definition.id} className="flex flex-wrap items-center gap-2 text-sm">
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={isChecked}
+                  onChange={(event) => toggleCategory(definition.id, event.target.checked)}
+                  aria-label={`Toggle redaction for ${definition.label}`}
+                />
+                <span>{`Redact ${definition.label}`}</span>
+              </label>
+              <span className="text-xs text-gray-400">
+                {hasMatches ? `${matchCount} match${matchCount === 1 ? '' : 'es'}` : 'No matches'}
+              </span>
+              <button
+                type="button"
+                className="px-2 py-1 text-xs rounded bg-gray-700 disabled:opacity-40"
+                onClick={() => handleRevealOnce(definition.id)}
+                disabled={!hasMatches}
+                aria-label={`Reveal ${definition.label} once`}
+              >
+                Reveal once
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      {peekCategory && peekValues.length > 0 && (
+        <div className="rounded border border-yellow-500/60 bg-yellow-900/40 p-3" role="status">
+          <div className="flex items-center justify-between gap-2">
+            <p className="font-semibold text-sm">
+              Revealed {getCategoryDefinition(peekCategory).label}
+            </p>
+            <button
+              type="button"
+              onClick={() => setPeekCategory(null)}
+              className="text-xs underline"
+            >
+              Dismiss
+            </button>
+          </div>
+          <ul className="mt-2 text-xs space-y-1">
+            {peekValues.map((value) => (
+              <li key={value} className="break-all">
+                {value}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div className="grid gap-3 md:grid-cols-2">
+        <div>
+          <h3 className="text-sm font-semibold mb-1">Original</h3>
+          <pre className="max-h-60 overflow-auto whitespace-pre-wrap rounded border border-gray-700 bg-black/60 p-3 text-xs">
+            {originalSegments.map((segment, index) => (
+              <span
+                key={`orig-${index}`}
+                className={segment.highlight && segment.category ? CATEGORY_COLORS[segment.category] : undefined}
+              >
+                {segment.text}
+              </span>
+            ))}
+          </pre>
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold mb-1">Redacted preview</h3>
+          <pre className="max-h-60 overflow-auto whitespace-pre-wrap rounded border border-gray-700 bg-black/60 p-3 text-xs">
+            {redactedSegments.map((segment, index) => (
+              <span
+                key={`red-${index}`}
+                className={segment.highlight && segment.category ? CATEGORY_COLORS[segment.category] : undefined}
+              >
+                {segment.text}
+              </span>
+            ))}
+          </pre>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default RedactionPreview;

--- a/utils/auditLog.ts
+++ b/utils/auditLog.ts
@@ -1,0 +1,33 @@
+import type { RedactionCategory } from './redaction';
+
+export type RedactionAuditAction = 'redact' | 'reveal' | 'peek';
+
+export interface RedactionAuditEvent {
+  type: 'redaction';
+  category: RedactionCategory;
+  action: RedactionAuditAction;
+  context: string;
+  timestamp: string;
+}
+
+const auditTrail: RedactionAuditEvent[] = [];
+
+export const logRedactionAudit = (
+  event: Omit<RedactionAuditEvent, 'timestamp'>,
+): RedactionAuditEvent => {
+  const entry: RedactionAuditEvent = {
+    ...event,
+    timestamp: new Date().toISOString(),
+  };
+  auditTrail.push(entry);
+  if (typeof console !== 'undefined' && typeof console.info === 'function') {
+    console.info('[audit]', entry);
+  }
+  return entry;
+};
+
+export const getAuditTrail = (): RedactionAuditEvent[] => [...auditTrail];
+
+export const clearAuditTrail = (): void => {
+  auditTrail.length = 0;
+};

--- a/utils/redaction.ts
+++ b/utils/redaction.ts
@@ -1,0 +1,122 @@
+export type RedactionCategory = 'ip' | 'email' | 'domain';
+
+export interface RedactionMatch {
+  start: number;
+  end: number;
+  value: string;
+  category: RedactionCategory;
+}
+
+interface RedactionRule {
+  category: RedactionCategory;
+  pattern: RegExp;
+}
+
+export interface RedactedResult {
+  text: string;
+  matches: RedactionMatch[];
+}
+
+export interface CategoryDefinition {
+  id: RedactionCategory;
+  label: string;
+  placeholder: string;
+  description: string;
+}
+
+export const CATEGORY_DEFINITIONS: CategoryDefinition[] = [
+  {
+    id: 'ip',
+    label: 'IP Addresses',
+    placeholder: '⟦REDACTED:IP⟧',
+    description: 'Masks IPv4 and IPv6 addresses in exported content.',
+  },
+  {
+    id: 'email',
+    label: 'Email Addresses',
+    placeholder: '⟦REDACTED:EMAIL⟧',
+    description: 'Masks email addresses in exported content.',
+  },
+  {
+    id: 'domain',
+    label: 'Domains',
+    placeholder: '⟦REDACTED:DOMAIN⟧',
+    description: 'Masks fully qualified domain names in exported content.',
+  },
+];
+
+const placeholderMap = CATEGORY_DEFINITIONS.reduce<Record<RedactionCategory, string>>(
+  (acc, def) => ({ ...acc, [def.id]: def.placeholder }),
+  { ip: '⟦REDACTED:IP⟧', email: '⟦REDACTED:EMAIL⟧', domain: '⟦REDACTED:DOMAIN⟧' }
+);
+
+const escapeRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const getPlaceholder = (category: RedactionCategory): string => placeholderMap[category];
+
+const ipv4Segment = '(?:25[0-5]|2[0-4]\\d|1?\\d{1,2})';
+const ipv4Pattern = new RegExp(`\\b(?:${ipv4Segment}\\.){3}${ipv4Segment}\\b`, 'g');
+// IPv6 pattern covers full and shorthand notations (simplified for mock data)
+const ipv6Pattern = /\b(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}\b/gi;
+const emailPattern = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,63}\b/gi;
+const domainPattern = /\b(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+[A-Z]{2,63}\b/gi;
+
+const RULES: RedactionRule[] = [
+  { category: 'email', pattern: emailPattern },
+  { category: 'ip', pattern: ipv4Pattern },
+  { category: 'ip', pattern: ipv6Pattern },
+  { category: 'domain', pattern: domainPattern },
+];
+
+const overlaps = (a: { start: number; end: number }, b: { start: number; end: number }) =>
+  a.start < b.end && b.start < a.end;
+
+export const scanSensitiveMatches = (text: string): RedactionMatch[] => {
+  const matches: RedactionMatch[] = [];
+  const occupied: Array<{ start: number; end: number }> = [];
+
+  RULES.forEach(({ category, pattern }) => {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(text))) {
+      const value = match[0];
+      const start = match.index ?? 0;
+      const end = start + value.length;
+      if (occupied.some((range) => overlaps(range, { start, end }))) continue;
+      matches.push({ category, start, end, value });
+      occupied.push({ start, end });
+    }
+  });
+
+  matches.sort((a, b) => a.start - b.start);
+  return matches;
+};
+
+export const applyRedactions = (
+  text: string,
+  categories: RedactionCategory[],
+  cachedMatches?: RedactionMatch[],
+): RedactedResult => {
+  const matches = cachedMatches ?? scanSensitiveMatches(text);
+  const targets = matches.filter((match) => categories.includes(match.category));
+  if (targets.length === 0) return { text, matches };
+
+  let output = text;
+  [...targets]
+    .sort((a, b) => b.start - a.start)
+    .forEach((match) => {
+      const placeholder = getPlaceholder(match.category);
+      output = `${output.slice(0, match.start)}${placeholder}${output.slice(match.end)}`;
+    });
+
+  return { text: output, matches };
+};
+
+export const buildPlaceholderRegex = (categories: RedactionCategory[]): RegExp => {
+  const tokens = categories.map((category) => escapeRegex(getPlaceholder(category)));
+  if (tokens.length === 0) return /$^/;
+  return new RegExp(`(${tokens.join('|')})`, 'g');
+};
+
+export const getCategoryDefinition = (category: RedactionCategory): CategoryDefinition =>
+  CATEGORY_DEFINITIONS.find((def) => def.id === category) ?? CATEGORY_DEFINITIONS[0];


### PR DESCRIPTION
## Summary
- add shared redaction utilities and audit logging for export flows
- create a reusable redaction preview with per-category controls and reveal confirmation, and wire it into the Autopsy and ReconNG exports
- add unit coverage for redaction behaviour alongside the updated export test harness

## Testing
- yarn lint
- CI=1 npx jest __tests__/redaction.test.ts __tests__/RedactionPreview.test.tsx --runInBand --detectOpenHandles
- CI=1 npx jest __tests__/ReportExport.test.tsx --runInBand --detectOpenHandles

------
https://chatgpt.com/codex/tasks/task_e_68dc62691eec8328814f979a60e34f62