### PR TITLE
[settings] add data retention controls and purge scheduler

### DIFF
--- a/__tests__/DataRetentionPanel.test.tsx
+++ b/__tests__/DataRetentionPanel.test.tsx
@@ -1,0 +1,75 @@
+import { RenderResult, act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import DataRetentionPanel from '../components/common/DataRetentionPanel';
+import TasksManagerProvider from '../components/common/TasksManager';
+import DataRetentionProvider from '../components/common/DataRetentionProvider';
+import { DAY_MS } from '../utils/dataRetention';
+
+describe('DataRetentionPanel', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  const renderPanel = async (): Promise<RenderResult> => {
+    let rendered: RenderResult | null = null;
+    await act(async () => {
+      rendered = render(
+        <TasksManagerProvider>
+          <DataRetentionProvider>
+            <DataRetentionPanel />
+          </DataRetentionProvider>
+        </TasksManagerProvider>,
+      );
+    });
+    return rendered!;
+  };
+
+  test('manual purge removes expired trash and supports undo', async () => {
+    const now = Date.now();
+    const stale = { id: 'old', title: 'Old', closedAt: now - 20 * DAY_MS };
+    const fresh = { id: 'new', title: 'New', closedAt: now - 2 * DAY_MS };
+    localStorage.setItem('window-trash', JSON.stringify([stale, fresh]));
+
+    await renderPanel();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    const select = await screen.findByLabelText('Retention TTL for Trash Bin');
+    act(() => {
+      fireEvent.change(select, { target: { value: String(7 * DAY_MS) } });
+    });
+
+    const purgeButton = screen.getByRole('button', { name: /Run purge now/i });
+    act(() => {
+      fireEvent.click(purgeButton);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Last purge/)).toBeInTheDocument();
+    });
+
+    const remaining = JSON.parse(localStorage.getItem('window-trash') || '[]');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe('new');
+
+    const undoButton = screen.getByRole('button', { name: /Undo purge/i });
+    act(() => {
+      fireEvent.click(undoButton);
+    });
+
+    await waitFor(() => {
+      const restored = JSON.parse(localStorage.getItem('window-trash') || '[]');
+      expect(restored).toHaveLength(2);
+    });
+
+    expect(screen.getByText(/Recent retention activity/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/dataRetention.test.ts
+++ b/__tests__/dataRetention.test.ts
@@ -1,0 +1,53 @@
+import { DAY_MS, purgeArtifacts, restoreArtifacts, retentionDefaults } from '../utils/dataRetention';
+
+describe('data retention utilities', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('purgeArtifacts removes expired trash items', () => {
+    const now = Date.now();
+    const oldItem = { id: 'one', title: 'Old', closedAt: now - 40 * DAY_MS };
+    const freshItem = { id: 'two', title: 'New', closedAt: now - 5 * DAY_MS };
+    localStorage.setItem('window-trash', JSON.stringify([oldItem, freshItem]));
+
+    const settings = {
+      ...retentionDefaults,
+      trash: 30 * DAY_MS,
+      trashHistory: 0,
+      scheduledTweets: 0,
+      networkHistory: 0,
+    };
+
+    const results = purgeArtifacts(settings, now);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ type: 'trash', removed: 1 });
+
+    const remaining = JSON.parse(localStorage.getItem('window-trash') || '[]');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe('two');
+  });
+
+  test('restoreArtifacts reinstates purged trash', () => {
+    const now = Date.now();
+    const oldItem = { id: 'one', title: 'Old', closedAt: now - 40 * DAY_MS };
+    const freshItem = { id: 'two', title: 'New', closedAt: now - 5 * DAY_MS };
+    localStorage.setItem('window-trash', JSON.stringify([oldItem, freshItem]));
+
+    const settings = {
+      ...retentionDefaults,
+      trash: 30 * DAY_MS,
+      trashHistory: 0,
+      scheduledTweets: 0,
+      networkHistory: 0,
+    };
+
+    const results = purgeArtifacts(settings, now);
+    expect(JSON.parse(localStorage.getItem('window-trash') || '[]')).toHaveLength(1);
+
+    restoreArtifacts({ trash: results[0]?.removedItems ?? [] });
+    const restored = JSON.parse(localStorage.getItem('window-trash') || '[]');
+    expect(restored).toHaveLength(2);
+    expect(restored.find((item: any) => item.id === 'one')).toBeTruthy();
+  });
+});

--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -17,13 +17,22 @@ const formatBytes = (bytes?: number) =>
 
 export default function NetworkInsights() {
   const [active, setActive] = useState<FetchEntry[]>(getActiveFetches());
-  const [history, setHistory] = usePersistentState<FetchEntry[]>(HISTORY_KEY, []);
+  const [history, setHistory] = usePersistentState<(FetchEntry & { recordedAt?: number })[]>(
+    HISTORY_KEY,
+    [],
+  );
 
   useEffect(() => {
     const unsubStart = onFetchProxy('start', () => setActive(getActiveFetches()));
     const unsubEnd = onFetchProxy('end', (e: CustomEvent<FetchEntry>) => {
       setActive(getActiveFetches());
-      setHistory((h) => [...h, e.detail]);
+      setHistory((h) => [
+        ...h,
+        {
+          ...e.detail,
+          recordedAt: Date.now(),
+        },
+      ]);
     });
     return () => {
       unsubStart();

--- a/apps/resource-monitor/components/TaskActivity.tsx
+++ b/apps/resource-monitor/components/TaskActivity.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React from 'react';
+import useTasksManager from '../../../hooks/useTasksManager';
+
+const formatTime = (timestamp: number) =>
+  new Date(timestamp).toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+
+const TaskActivity: React.FC = () => {
+  const { tasks } = useTasksManager();
+
+  const statusColor: Record<string, string> = {
+    info: 'text-blue-300',
+    success: 'text-green-300',
+    warning: 'text-yellow-300',
+    error: 'text-red-300',
+  };
+
+  return (
+    <div className="p-2 text-xs text-white bg-[var(--kali-bg)]">
+      <h2 className="font-bold mb-1">Tasks Manager</h2>
+      <ul className="divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
+        {tasks.length === 0 && (
+          <li className="p-2 text-gray-400">No background tasks recorded</li>
+        )}
+        {tasks.map(task => (
+          <li key={task.id} className="p-2">
+            <div className="flex justify-between">
+              <span className="font-medium text-white">{task.message}</span>
+              <span className="text-gray-400">{formatTime(task.timestamp)}</span>
+            </div>
+            <div className={`uppercase tracking-wide text-[11px] ${statusColor[task.status] ?? 'text-gray-300'}`}>
+              {task.status}
+            </div>
+            <div className="text-gray-300">Source: {task.source}</div>
+            {task.detail && (
+              <div className="text-gray-400 text-[11px] mt-1">{task.detail}</div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TaskActivity;

--- a/apps/resource-monitor/index.tsx
+++ b/apps/resource-monitor/index.tsx
@@ -2,11 +2,15 @@
 
 import React from 'react';
 import NetworkInsights from './components/NetworkInsights';
+import TaskActivity from './components/TaskActivity';
 
 export default function ResourceMonitorApp() {
   return (
     <div className="h-full w-full bg-ub-cool-grey overflow-auto">
-      <NetworkInsights />
+      <div className="grid gap-2 lg:grid-cols-2">
+        <NetworkInsights />
+        <TaskActivity />
+      </div>
     </div>
   );
 }

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -13,6 +13,7 @@ import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
 import KaliWallpaper from "../../components/util-components/kali-wallpaper";
+import DataRetentionPanel from "../../components/common/DataRetentionPanel";
 
 export default function Settings() {
   const {
@@ -305,9 +306,10 @@ export default function Settings() {
               onClick={() => fileInputRef.current?.click()}
               className="px-4 py-2 rounded bg-ub-orange text-white"
             >
-              Import Settings
+            Import Settings
             </button>
           </div>
+          <DataRetentionPanel />
         </>
       )}
         <input

--- a/apps/trash/state.ts
+++ b/apps/trash/state.ts
@@ -1,5 +1,6 @@
 import { useEffect, useCallback } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
+import { parseTrashPurgeSetting } from '../../utils/dataRetention';
 
 export interface TrashItem {
   id: string;
@@ -18,10 +19,10 @@ export default function useTrashState() {
   const [history, setHistory] = usePersistentState<TrashItem[]>(HISTORY_KEY, []);
 
   useEffect(() => {
-    const purgeDays = parseInt(
-      window.localStorage.getItem('trash-purge-days') || '30',
-      10,
+    const purgeDays = parseTrashPurgeSetting(
+      window.localStorage.getItem('trash-purge-days'),
     );
+    if (!Number.isFinite(purgeDays)) return;
     const ms = purgeDays * 24 * 60 * 60 * 1000;
     const now = Date.now();
     setItems(prev => prev.filter(item => now - item.closedAt <= ms));

--- a/components/common/DataRetentionPanel.tsx
+++ b/components/common/DataRetentionPanel.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from 'react';
+import useDataRetention from '../../hooks/useDataRetention';
+import { ArtifactType, formatTtl, retentionArtifacts } from '../../utils/dataRetention';
+
+const formatTimestamp = (timestamp: number) =>
+  new Date(timestamp).toLocaleString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+  });
+
+const formatUndoCountdown = (expiresAt: number, now: number) => {
+  const diff = Math.max(0, expiresAt - now);
+  const seconds = Math.ceil(diff / 1000);
+  return `${seconds}s`;
+};
+
+const DataRetentionPanel: React.FC = () => {
+  const {
+    settings,
+    updateSetting,
+    purgeAll,
+    purgeType,
+    lastRun,
+    undo,
+    undoExpiresAt,
+    isPurging,
+    logs,
+    retentionOptions,
+  } = useDataRetention();
+  const [now, setNow] = useState(Date.now());
+
+  const orderedArtifacts = useMemo(() => (
+    Object.entries(retentionArtifacts) as Array<[
+      ArtifactType,
+      (typeof retentionArtifacts)[ArtifactType],
+    ]>
+  ), []);
+
+  useEffect(() => {
+    if (!undoExpiresAt) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [undoExpiresAt]);
+
+  return (
+    <section className="mx-auto my-6 w-full max-w-3xl rounded-lg border border-gray-800 bg-black bg-opacity-40 p-4 text-sm text-white">
+      <header className="mb-4">
+        <h2 className="text-lg font-semibold">Data Retention</h2>
+        <p className="text-xs text-gray-300">
+          Configure how long artifacts are kept on this device. Purges run automatically and can be undone briefly.
+        </p>
+      </header>
+      <div className="space-y-3">
+        {orderedArtifacts.map(([type, meta]) => {
+          const ttl = settings[type];
+          const hasOption = retentionOptions.some(option => option.value === ttl);
+          const selectValue = hasOption ? String(ttl) : 'custom';
+          const fallbackOption = retentionOptions[0];
+          return (
+            <div
+              key={type}
+              className="flex flex-col gap-2 rounded-md border border-gray-800 bg-black/30 p-3 md:flex-row md:items-center"
+            >
+              <div className="flex-1">
+                <p className="font-medium">{meta.label}</p>
+                <p className="text-xs text-gray-400">{meta.description}</p>
+              </div>
+              <div className="flex flex-col items-stretch gap-2 md:w-64">
+                <label className="text-xs text-gray-400" htmlFor={`ttl-${type}`}>
+                  Time to keep
+                </label>
+                <select
+                  id={`ttl-${type}`}
+                  className="rounded border border-gray-700 bg-black/40 px-2 py-1 text-sm focus:border-ub-orange focus:outline-none"
+                  value={selectValue}
+                  onChange={event => {
+                    const value = event.target.value;
+                    const option = retentionOptions.find(o => `${o.value}` === value);
+                    if (option) {
+                      updateSetting(type, option.value);
+                      return;
+                    }
+                    // fallback to default option when unknown
+                    if (fallbackOption) {
+                      updateSetting(type, fallbackOption.value);
+                    }
+                  }}
+                  aria-label={`Retention TTL for ${meta.label}`}
+                >
+                  {retentionOptions.map(option => (
+                    <option key={option.value} value={String(option.value)}>
+                      {option.label}
+                    </option>
+                  ))}
+                  {!hasOption && (
+                    <option value="custom" disabled>
+                      {formatTtl(ttl)}
+                    </option>
+                  )}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => purgeType(type)}
+                  disabled={isPurging}
+                  className="rounded border border-gray-700 bg-black/40 px-2 py-1 text-sm transition hover:border-ub-orange disabled:opacity-50"
+                >
+                  Purge expired now
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="mt-4 flex flex-col gap-2 md:flex-row md:items-center">
+        <button
+          type="button"
+          onClick={() => purgeAll('manual')}
+          disabled={isPurging}
+          className="w-full rounded bg-ub-orange px-3 py-2 text-sm font-semibold text-white transition hover:bg-orange-500 disabled:opacity-60 md:w-auto"
+        >
+          {isPurging ? 'Purging…' : 'Run purge now'}
+        </button>
+        {undoExpiresAt && (
+          <button
+            type="button"
+            onClick={() => undo()}
+            className="w-full rounded border border-yellow-500/70 px-3 py-2 text-sm text-yellow-300 transition hover:bg-yellow-500/10 md:w-auto"
+          >
+            Undo purge ({formatUndoCountdown(undoExpiresAt, now)})
+          </button>
+        )}
+        {lastRun && (
+          <p className="text-xs text-gray-300 md:ml-auto">
+            Last purge ({lastRun.trigger}): {lastRun.removedTotal}{' '}
+            item{lastRun.removedTotal === 1 ? '' : 's'} at {formatTimestamp(lastRun.timestamp)}
+          </p>
+        )}
+      </div>
+      <div className="mt-4">
+        <h3 className="text-sm font-semibold text-gray-200">Recent retention activity</h3>
+        <ul className="mt-2 space-y-1">
+          {logs.length === 0 && (
+            <li className="rounded border border-gray-800 bg-black/30 px-3 py-2 text-xs text-gray-400">
+              No retention actions recorded yet.
+            </li>
+          )}
+          {logs.slice(0, 5).map(log => (
+            <li
+              key={log.id}
+              className="rounded border border-gray-800 bg-black/30 px-3 py-2 text-xs text-gray-200"
+            >
+              <div className="flex flex-col md:flex-row md:items-center md:justify-between">
+                <span className="font-medium text-gray-100">{log.summary}</span>
+                <span className="text-[11px] text-gray-400">{formatTimestamp(log.timestamp)}</span>
+              </div>
+              {log.details.length > 0 && (
+                <div className="mt-1 text-[11px] text-gray-300">
+                  {log.details
+                    .map(detail => `${retentionArtifacts[detail.type].label}: ${detail.removed}`)
+                    .join(', ')}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default DataRetentionPanel;

--- a/components/common/DataRetentionProvider.tsx
+++ b/components/common/DataRetentionProvider.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  ArtifactSnapshot,
+  ArtifactType,
+  RETENTION_OPTIONS,
+  RetentionLog,
+  RetentionSettings,
+  appendRetentionLog,
+  buildLogEntry,
+  loadRetentionLog,
+  loadRetentionSettings,
+  purgeArtifactType,
+  purgeArtifacts,
+  restoreArtifacts,
+  retentionArtifacts,
+  saveRetentionSettings,
+} from '../../utils/dataRetention';
+import useTasksManager from '../../hooks/useTasksManager';
+
+export interface LastRunSummary {
+  timestamp: number;
+  removedTotal: number;
+  trigger: RetentionLog['trigger'];
+  details: RetentionLog['details'];
+}
+
+interface UndoState {
+  snapshot: ArtifactSnapshot;
+  expiresAt: number;
+  reason: RetentionLog['trigger'];
+}
+
+interface DataRetentionContextValue {
+  settings: RetentionSettings;
+  updateSetting: (type: ArtifactType, ttl: number) => void;
+  purgeAll: (trigger?: RetentionLog['trigger']) => Promise<RetentionLog | null>;
+  purgeType: (type: ArtifactType) => Promise<RetentionLog | null>;
+  lastRun: LastRunSummary | null;
+  undo: () => Promise<boolean>;
+  undoExpiresAt: number | null;
+  isPurging: boolean;
+  logs: RetentionLog[];
+  retentionOptions: typeof RETENTION_OPTIONS;
+}
+
+const UNDO_WINDOW_MS = 30_000;
+const SCHEDULE_INTERVAL_MS = 5 * 60 * 1000;
+
+export const DataRetentionContext = createContext<DataRetentionContextValue | null>(null);
+
+const buildSnapshot = (results: ReturnType<typeof purgeArtifacts>) => {
+  const snapshot: ArtifactSnapshot = {};
+  results.forEach(result => {
+    if (result.removed > 0) {
+      snapshot[result.type] = result.removedItems;
+    }
+  });
+  return snapshot;
+};
+
+const computeTotalRemoved = (results: ReturnType<typeof purgeArtifacts>) =>
+  results.reduce((sum, result) => sum + result.removed, 0);
+
+const updateTrashCompatibility = (ttl: number) => {
+  if (typeof window === 'undefined') return;
+  try {
+    if (ttl <= 0) {
+      window.localStorage.setItem('trash-purge-days', '0');
+      return;
+    }
+    const days = Math.max(1, Math.round(ttl / (24 * 60 * 60 * 1000)));
+    window.localStorage.setItem('trash-purge-days', String(days));
+  } catch {
+    // ignore storage write errors
+  }
+};
+
+export const DataRetentionProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const [settings, setSettings] = useState<RetentionSettings>(() => loadRetentionSettings());
+  const [logs, setLogs] = useState<RetentionLog[]>(() => loadRetentionLog());
+  const [lastRun, setLastRun] = useState<LastRunSummary | null>(null);
+  const [undoState, setUndoState] = useState<UndoState | null>(null);
+  const [isPurging, setIsPurging] = useState(false);
+  const scheduleRef = useRef<number | null>(null);
+  const { logTask } = useTasksManager();
+
+  const applySettings = useCallback((next: RetentionSettings) => {
+    setSettings(next);
+    saveRetentionSettings(next);
+    updateTrashCompatibility(next.trash);
+  }, []);
+
+  useEffect(() => {
+    updateTrashCompatibility(settings.trash);
+  }, [settings.trash]);
+
+  const updateSetting = useCallback(
+    (type: ArtifactType, ttl: number) => {
+      applySettings({ ...settings, [type]: ttl });
+    },
+    [applySettings, settings],
+  );
+
+  const recordLog = useCallback((entry: RetentionLog) => {
+    const next = appendRetentionLog(entry);
+    setLogs(next);
+  }, []);
+
+  const handleResults = useCallback(
+    (trigger: RetentionLog['trigger'], results: ReturnType<typeof purgeArtifacts>) => {
+      if (results.length === 0) {
+        const logEntry = buildLogEntry(trigger, results);
+        recordLog(logEntry);
+        logTask({
+          source: 'data-retention',
+          message: logEntry.summary,
+          status: 'info',
+        });
+        setLastRun({
+          timestamp: logEntry.timestamp,
+          removedTotal: 0,
+          trigger,
+          details: logEntry.details,
+        });
+        return logEntry;
+      }
+
+      const logEntry = buildLogEntry(trigger, results);
+      recordLog(logEntry);
+      logTask({
+        source: 'data-retention',
+        message: logEntry.summary,
+        status: 'success',
+        detail: logEntry.details
+          .map(detail => `${retentionArtifacts[detail.type].label}: ${detail.removed}`)
+          .join(', '),
+      });
+      setLastRun({
+        timestamp: logEntry.timestamp,
+        removedTotal: computeTotalRemoved(results),
+        trigger,
+        details: logEntry.details,
+      });
+      setUndoState({
+        snapshot: buildSnapshot(results),
+        expiresAt: Date.now() + UNDO_WINDOW_MS,
+        reason: trigger,
+      });
+      return logEntry;
+    },
+    [logTask, recordLog],
+  );
+
+  const purge = useCallback(
+    async (trigger: RetentionLog['trigger'], type?: ArtifactType) => {
+      if (typeof window === 'undefined') return null;
+      setIsPurging(true);
+      try {
+        const now = Date.now();
+        const results = type
+          ? (() => {
+              const result = purgeArtifactType(type, settings, now);
+              return result ? [result] : [];
+            })()
+          : purgeArtifacts(settings, now);
+        const logEntry = handleResults(trigger, results);
+        if (!results.length) {
+          setUndoState(null);
+        }
+        return logEntry;
+      } finally {
+        setIsPurging(false);
+      }
+    },
+    [handleResults, settings],
+  );
+
+  const purgeAll = useCallback(
+    (trigger: RetentionLog['trigger'] = 'manual') => purge(trigger),
+    [purge],
+  );
+
+  const purgeType = useCallback(
+    (type: ArtifactType) => purge('manual', type),
+    [purge],
+  );
+
+  const undo = useCallback(async () => {
+    if (!undoState) return false;
+    if (undoState.expiresAt < Date.now()) {
+      setUndoState(null);
+      return false;
+    }
+    restoreArtifacts(undoState.snapshot);
+    logTask({
+      source: 'data-retention',
+      message: 'Undo applied: restored last purge snapshot',
+      status: 'warning',
+    });
+    setUndoState(null);
+    return true;
+  }, [logTask, undoState]);
+
+  useEffect(() => {
+    if (!undoState) return;
+    const remaining = undoState.expiresAt - Date.now();
+    if (remaining <= 0) {
+      setUndoState(null);
+      return;
+    }
+    const timeout = window.setTimeout(() => setUndoState(null), remaining);
+    return () => window.clearTimeout(timeout);
+  }, [undoState]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    purge('startup');
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (scheduleRef.current) {
+      window.clearInterval(scheduleRef.current);
+    }
+    const interval = window.setInterval(() => {
+      if (undoState) return;
+      purge('scheduled');
+    }, SCHEDULE_INTERVAL_MS);
+    scheduleRef.current = interval;
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [purge, undoState]);
+
+  useEffect(() => () => {
+    if (scheduleRef.current) {
+      window.clearInterval(scheduleRef.current);
+    }
+  }, []);
+
+  const value = useMemo<DataRetentionContextValue>(() => ({
+    settings,
+    updateSetting,
+    purgeAll,
+    purgeType,
+    lastRun,
+    undo,
+    undoExpiresAt: undoState?.expiresAt ?? null,
+    isPurging,
+    logs,
+    retentionOptions: RETENTION_OPTIONS,
+  }), [
+    isPurging,
+    lastRun,
+    logs,
+    purgeAll,
+    purgeType,
+    settings,
+    undo,
+    undoState?.expiresAt,
+    updateSetting,
+  ]);
+
+  return (
+    <DataRetentionContext.Provider value={value}>
+      {children}
+    </DataRetentionContext.Provider>
+  );
+};
+
+export default DataRetentionProvider;

--- a/components/common/TasksManager.tsx
+++ b/components/common/TasksManager.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import React, { createContext, useCallback, useMemo } from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+
+export type TaskStatus = 'info' | 'success' | 'warning' | 'error';
+
+export interface TaskActivity {
+  id: string;
+  source: string;
+  message: string;
+  status: TaskStatus;
+  timestamp: number;
+  detail?: string;
+}
+
+interface TasksManagerContextValue {
+  tasks: TaskActivity[];
+  logTask: (
+    input: Omit<TaskActivity, 'id' | 'timestamp'> & { id?: string; timestamp?: number },
+  ) => string;
+  clearTasks: () => void;
+}
+
+const TASK_LOG_KEY = 'tasks-manager-log';
+const TASK_LIMIT = 50;
+
+const isTaskActivityArray = (value: unknown): value is TaskActivity[] =>
+  Array.isArray(value) &&
+  value.every(
+    item =>
+      item &&
+      typeof item === 'object' &&
+      typeof item.id === 'string' &&
+      typeof item.source === 'string' &&
+      typeof item.message === 'string' &&
+      typeof item.status === 'string' &&
+      typeof item.timestamp === 'number',
+  );
+
+export const TasksManagerContext = createContext<TasksManagerContextValue | null>(null);
+
+export const TasksManagerProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const [tasks, setTasks] = usePersistentState<TaskActivity[]>(
+    TASK_LOG_KEY,
+    () => [],
+    isTaskActivityArray,
+  );
+
+  const logTask = useCallback<
+    TasksManagerContextValue['logTask']
+  >((input) => {
+    const entry: TaskActivity = {
+      id: input.id ?? `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      timestamp: input.timestamp ?? Date.now(),
+      source: input.source,
+      message: input.message,
+      status: input.status,
+      detail: input.detail,
+    };
+    setTasks(prev => {
+      const next = [entry, ...prev];
+      return next.slice(0, TASK_LIMIT);
+    });
+    return entry.id;
+  }, [setTasks]);
+
+  const clearTasks = useCallback(() => {
+    setTasks([]);
+  }, [setTasks]);
+
+  const value = useMemo<TasksManagerContextValue>(() => ({
+    tasks,
+    logTask,
+    clearTasks,
+  }), [tasks, logTask, clearTasks]);
+
+  return (
+    <TasksManagerContext.Provider value={value}>
+      {children}
+    </TasksManagerContext.Provider>
+  );
+};
+
+export default TasksManagerProvider;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1550,12 +1550,21 @@ export class Desktop extends Component {
 
         // persist in trash with autopurge
         const appMeta = apps.find(a => a.id === objId) || {};
-        const purgeDays = parseInt(safeLocalStorage?.getItem('trash-purge-days') || '30', 10);
-        const ms = purgeDays * 24 * 60 * 60 * 1000;
+        const rawPurgeDays = safeLocalStorage?.getItem('trash-purge-days');
+        let purgeDays;
+        if (rawPurgeDays === '0') {
+            purgeDays = Number.POSITIVE_INFINITY;
+        } else {
+            const parsed = parseInt(rawPurgeDays || '30', 10);
+            purgeDays = Number.isNaN(parsed) || parsed < 0 ? 30 : parsed;
+        }
+        const ms = Number.isFinite(purgeDays) ? purgeDays * 24 * 60 * 60 * 1000 : Number.POSITIVE_INFINITY;
         const now = Date.now();
         let trash = [];
         try { trash = JSON.parse(safeLocalStorage?.getItem('window-trash') || '[]'); } catch (e) { trash = []; }
-        trash = trash.filter(item => now - item.closedAt <= ms);
+        if (Number.isFinite(ms)) {
+            trash = trash.filter(item => now - item.closedAt <= ms);
+        }
         trash.push({
             id: objId,
             title: appMeta.title || objId,

--- a/hooks/useDataRetention.ts
+++ b/hooks/useDataRetention.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { DataRetentionContext } from '../components/common/DataRetentionProvider';
+
+export const useDataRetention = () => {
+  const ctx = useContext(DataRetentionContext);
+  if (!ctx) {
+    throw new Error('useDataRetention must be used within DataRetentionProvider');
+  }
+  return ctx;
+};
+
+export default useDataRetention;

--- a/hooks/useTasksManager.ts
+++ b/hooks/useTasksManager.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { TasksManagerContext } from '../components/common/TasksManager';
+
+export const useTasksManager = () => {
+  const ctx = useContext(TasksManagerContext);
+  if (!ctx) {
+    throw new Error('useTasksManager must be used within TasksManagerProvider');
+  }
+  return ctx;
+};
+
+export default useTasksManager;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -14,6 +14,8 @@ import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
 import NotificationCenter from '../components/common/NotificationCenter';
 import PipPortalProvider from '../components/common/PipPortal';
+import TasksManagerProvider from '../components/common/TasksManager';
+import DataRetentionProvider from '../components/common/DataRetentionProvider';
 import ErrorBoundary from '../components/core/ErrorBoundary';
 import Script from 'next/script';
 import { reportWebVitals as reportWebVitalsUtil } from '../utils/reportWebVitals';
@@ -158,11 +160,13 @@ function MyApp(props) {
           Skip to app grid
         </a>
         <SettingsProvider>
-          <NotificationCenter>
-            <PipPortalProvider>
-              <div aria-live="polite" id="live-region" />
-              <Component {...pageProps} />
-              <ShortcutOverlay />
+          <TasksManagerProvider>
+            <DataRetentionProvider>
+              <NotificationCenter>
+                <PipPortalProvider>
+                  <div aria-live="polite" id="live-region" />
+                  <Component {...pageProps} />
+                  <ShortcutOverlay />
               <Analytics
                 beforeSend={(e) => {
                   if (e.url.includes('/admin') || e.url.includes('/private')) return null;
@@ -172,9 +176,11 @@ function MyApp(props) {
                 }}
               />
 
-              {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
-            </PipPortalProvider>
-          </NotificationCenter>
+                {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+              </PipPortalProvider>
+            </NotificationCenter>
+          </DataRetentionProvider>
+        </TasksManagerProvider>
         </SettingsProvider>
       </div>
     </ErrorBoundary>

--- a/utils/dataRetention.ts
+++ b/utils/dataRetention.ts
@@ -1,0 +1,349 @@
+import type { TrashItem } from '../apps/trash/state';
+import type { ScheduledTweet } from '../apps/x/state/scheduled';
+import type { FetchEntry } from '../lib/fetchProxy';
+
+const STORAGE_KEY = 'data-retention-settings';
+const LOG_STORAGE_KEY = 'data-retention-log';
+
+export const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type ArtifactType = 'trash' | 'trashHistory' | 'scheduledTweets' | 'networkHistory';
+
+export interface RetentionSettings {
+  trash: number;
+  trashHistory: number;
+  scheduledTweets: number;
+  networkHistory: number;
+}
+
+export type RetentionLog = {
+  id: string;
+  timestamp: number;
+  trigger: 'manual' | 'scheduled' | 'startup';
+  summary: string;
+  details: Array<{
+    type: ArtifactType;
+    removed: number;
+  }>;
+};
+
+export interface PurgeResult<T = unknown> {
+  type: ArtifactType;
+  removed: number;
+  removedItems: T[];
+}
+
+export type ArtifactSnapshot = Partial<Record<ArtifactType, unknown[]>>;
+
+type LoggedFetchEntry = FetchEntry & { recordedAt?: number };
+
+const TRASH_KEY = 'window-trash';
+const TRASH_HISTORY_KEY = 'window-trash-history';
+const SCHEDULED_TWEETS_KEY = 'x-scheduled-tweets';
+const NETWORK_HISTORY_KEY = 'network-insights-history';
+
+const MAX_LOG_ENTRIES = 50;
+
+const defaultSettings: RetentionSettings = {
+  trash: 30 * DAY_MS,
+  trashHistory: 14 * DAY_MS,
+  scheduledTweets: 14 * DAY_MS,
+  networkHistory: 7 * DAY_MS,
+};
+
+const isNumberRecord = (value: unknown): value is Record<string, number> =>
+  Boolean(
+    value &&
+      typeof value === 'object' &&
+      Object.values(value as Record<string, unknown>).every(v => typeof v === 'number'),
+  );
+
+const isRetentionSettings = (value: unknown): value is RetentionSettings => {
+  if (!isNumberRecord(value)) return false;
+  const record = value as Record<string, number>;
+  return (
+    ['trash', 'trashHistory', 'scheduledTweets', 'networkHistory'] as ArtifactType[]
+  ).every(key => typeof record[key] === 'number');
+};
+
+const isRetentionLog = (value: unknown): value is RetentionLog[] =>
+  Array.isArray(value) &&
+  value.every(
+    entry =>
+      entry &&
+      typeof entry === 'object' &&
+      typeof entry.id === 'string' &&
+      typeof entry.timestamp === 'number' &&
+      (entry.trigger === 'manual' || entry.trigger === 'scheduled' || entry.trigger === 'startup') &&
+      typeof entry.summary === 'string' &&
+      Array.isArray(entry.details) &&
+      entry.details.every(
+        detail =>
+          detail &&
+          typeof detail === 'object' &&
+          typeof detail.type === 'string' &&
+          typeof detail.removed === 'number',
+      ),
+  );
+
+const readJson = <T>(key: string): T | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+};
+
+const writeJson = (key: string, value: unknown) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore storage failures
+  }
+};
+
+const partition = <T>(items: T[], predicate: (item: T) => boolean): { keep: T[]; removed: T[] } => {
+  const keep: T[] = [];
+  const removed: T[] = [];
+  items.forEach(item => {
+    if (predicate(item)) keep.push(item);
+    else removed.push(item);
+  });
+  return { keep, removed };
+};
+
+export const parseTrashPurgeSetting = (value: string | null): number => {
+  if (!value) return 30;
+  if (value === '0') return Number.POSITIVE_INFINITY;
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 0) return 30;
+  return parsed;
+};
+
+export const loadRetentionSettings = (): RetentionSettings => {
+  const stored = readJson<RetentionSettings>(STORAGE_KEY);
+  if (stored && isRetentionSettings(stored)) {
+    return { ...defaultSettings, ...stored };
+  }
+  const settings = { ...defaultSettings };
+  if (typeof window !== 'undefined') {
+    const trashDays = parseTrashPurgeSetting(window.localStorage.getItem('trash-purge-days'));
+    settings.trash = !Number.isFinite(trashDays) ? 0 : trashDays * DAY_MS;
+  }
+  return settings;
+};
+
+export const saveRetentionSettings = (settings: RetentionSettings) => {
+  writeJson(STORAGE_KEY, settings);
+};
+
+export const loadRetentionLog = (): RetentionLog[] => {
+  const stored = readJson<RetentionLog[]>(LOG_STORAGE_KEY);
+  if (stored && isRetentionLog(stored)) {
+    return stored.slice(0, MAX_LOG_ENTRIES);
+  }
+  return [];
+};
+
+export const appendRetentionLog = (entry: RetentionLog) => {
+  const current = loadRetentionLog();
+  const next = [entry, ...current].slice(0, MAX_LOG_ENTRIES);
+  writeJson(LOG_STORAGE_KEY, next);
+  return next;
+};
+
+const saveTrash = (items: TrashItem[]) => writeJson(TRASH_KEY, items);
+const saveTrashHistory = (items: TrashItem[]) => writeJson(TRASH_HISTORY_KEY, items);
+const saveScheduledTweets = (items: ScheduledTweet[]) => writeJson(SCHEDULED_TWEETS_KEY, items);
+const saveNetworkHistory = (items: LoggedFetchEntry[]) => writeJson(NETWORK_HISTORY_KEY, items);
+
+const readTrash = () => (readJson<TrashItem[]>(TRASH_KEY) || []).filter(Boolean);
+const readTrashHistory = () => (readJson<TrashItem[]>(TRASH_HISTORY_KEY) || []).filter(Boolean);
+const readScheduledTweets = () => (readJson<ScheduledTweet[]>(SCHEDULED_TWEETS_KEY) || []).filter(Boolean);
+const readNetworkHistory = () => (readJson<LoggedFetchEntry[]>(NETWORK_HISTORY_KEY) || []).filter(Boolean);
+
+const shouldKeepByTimestamp = (timestamp: number | undefined, threshold: number) => {
+  if (threshold <= 0) return true;
+  if (typeof timestamp !== 'number') return true;
+  return timestamp >= threshold;
+};
+
+export const purgeArtifacts = (settings: RetentionSettings, now = Date.now()): PurgeResult[] => {
+  if (typeof window === 'undefined') return [];
+
+  const results: PurgeResult[] = [];
+
+  const handleResult = <T>(type: ArtifactType, removed: T[], save: (items: T[]) => void, keep: T[]) => {
+    if (removed.length > 0) {
+      save(keep);
+      results.push({ type, removed: removed.length, removedItems: removed });
+    }
+  };
+
+  // trash
+  const trashTtl = settings.trash;
+  if (trashTtl > 0) {
+    const trash = readTrash();
+    const threshold = now - trashTtl;
+    const { keep, removed } = partition(trash, item => shouldKeepByTimestamp(item?.closedAt, threshold));
+    handleResult('trash', removed, items => {
+      saveTrash(items);
+      window.dispatchEvent(new Event('trash-change'));
+    }, keep);
+  }
+
+  // trash history
+  const trashHistoryTtl = settings.trashHistory;
+  if (trashHistoryTtl > 0) {
+    const history = readTrashHistory();
+    const threshold = now - trashHistoryTtl;
+    const { keep, removed } = partition(history, item => shouldKeepByTimestamp(item?.closedAt, threshold));
+    handleResult('trashHistory', removed, saveTrashHistory, keep);
+  }
+
+  // scheduled tweets
+  const scheduledTtl = settings.scheduledTweets;
+  if (scheduledTtl > 0) {
+    const scheduled = readScheduledTweets();
+    const threshold = now - scheduledTtl;
+    const { keep, removed } = partition(
+      scheduled,
+      item => shouldKeepByTimestamp(item?.time, threshold),
+    );
+    handleResult('scheduledTweets', removed, saveScheduledTweets, keep);
+  }
+
+  // network history
+  const networkTtl = settings.networkHistory;
+  if (networkTtl > 0) {
+    const history = readNetworkHistory();
+    const threshold = now - networkTtl;
+    const { keep, removed } = partition(history, item => shouldKeepByTimestamp(item?.recordedAt, threshold));
+    handleResult('networkHistory', removed, saveNetworkHistory, keep);
+  }
+
+  return results;
+};
+
+export const purgeArtifactType = (
+  type: ArtifactType,
+  settings: RetentionSettings,
+  now = Date.now(),
+): PurgeResult | null => {
+  const scoped: RetentionSettings = {
+    trash: type === 'trash' ? settings.trash : 0,
+    trashHistory: type === 'trashHistory' ? settings.trashHistory : 0,
+    scheduledTweets:
+      type === 'scheduledTweets' ? settings.scheduledTweets : 0,
+    networkHistory: type === 'networkHistory' ? settings.networkHistory : 0,
+  };
+  const [result] = purgeArtifacts(scoped, now);
+  return result ?? null;
+};
+
+const mergeTrash = (current: TrashItem[], restored: TrashItem[]) => {
+  const combined = [...current, ...restored];
+  combined.sort((a, b) => (a.closedAt || 0) - (b.closedAt || 0));
+  return combined;
+};
+
+const mergeScheduledTweets = (current: ScheduledTweet[], restored: ScheduledTweet[]) => {
+  const map = new Map<string, ScheduledTweet>();
+  [...current, ...restored].forEach(item => {
+    if (item && item.id) {
+      map.set(item.id, item);
+    }
+  });
+  return Array.from(map.values()).sort((a, b) => (a.time || 0) - (b.time || 0));
+};
+
+const mergeNetworkHistory = (current: LoggedFetchEntry[], restored: LoggedFetchEntry[]) => {
+  const combined = [...current, ...restored];
+  combined.sort((a, b) => (a.recordedAt || 0) - (b.recordedAt || 0));
+  return combined;
+};
+
+export const restoreArtifacts = (snapshot: ArtifactSnapshot) => {
+  if (typeof window === 'undefined') return;
+  if (snapshot.trash && snapshot.trash.length) {
+    const current = readTrash();
+    saveTrash(mergeTrash(current, snapshot.trash as TrashItem[]));
+    window.dispatchEvent(new Event('trash-change'));
+  }
+  if (snapshot.trashHistory && snapshot.trashHistory.length) {
+    const current = readTrashHistory();
+    saveTrashHistory(mergeTrash(current, snapshot.trashHistory as TrashItem[]));
+  }
+  if (snapshot.scheduledTweets && snapshot.scheduledTweets.length) {
+    const current = readScheduledTweets();
+    saveScheduledTweets(mergeScheduledTweets(current, snapshot.scheduledTweets as ScheduledTweet[]));
+  }
+  if (snapshot.networkHistory && snapshot.networkHistory.length) {
+    const current = readNetworkHistory();
+    saveNetworkHistory(mergeNetworkHistory(current, snapshot.networkHistory as LoggedFetchEntry[]));
+  }
+};
+
+export const retentionArtifacts: Record<ArtifactType, { label: string; description: string }> = {
+  trash: {
+    label: 'Trash Bin',
+    description: 'Closed windows kept for quick restore.',
+  },
+  trashHistory: {
+    label: 'Trash History',
+    description: 'Recently purged windows available for restore.',
+  },
+  scheduledTweets: {
+    label: 'Scheduled Posts',
+    description: 'Pending social posts and reminders.',
+  },
+  networkHistory: {
+    label: 'Network History',
+    description: 'Saved fetch logs from Resource Monitor.',
+  },
+};
+
+export const RETENTION_OPTIONS: Array<{ label: string; value: number }> = [
+  { label: '24 hours', value: DAY_MS },
+  { label: '7 days', value: 7 * DAY_MS },
+  { label: '30 days', value: 30 * DAY_MS },
+  { label: '90 days', value: 90 * DAY_MS },
+  { label: 'Keep forever', value: 0 },
+];
+
+export const formatTtl = (ttl: number): string => {
+  if (ttl <= 0) return 'Keep forever';
+  if (ttl % DAY_MS === 0) {
+    const days = Math.round(ttl / DAY_MS);
+    return `${days} day${days === 1 ? '' : 's'}`;
+  }
+  return `${Math.round(ttl / (60 * 60 * 1000))} hours`;
+};
+
+export const buildLogEntry = (
+  trigger: RetentionLog['trigger'],
+  results: PurgeResult[],
+): RetentionLog => {
+  const totalRemoved = results.reduce((sum, result) => sum + result.removed, 0);
+  const summary =
+    totalRemoved > 0
+      ? `Purged ${totalRemoved} item${totalRemoved === 1 ? '' : 's'} across ${results.length} artifact${
+          results.length === 1 ? '' : 's'
+        }`
+      : 'No expired artifacts to purge';
+  return {
+    id: `ret-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    timestamp: Date.now(),
+    trigger,
+    summary,
+    details: results.map(result => ({ type: result.type, removed: result.removed })),
+  };
+};
+
+export const retentionDefaults = defaultSettings;
+export const retentionSettingsKey = STORAGE_KEY;
+export const retentionLogKey = LOG_STORAGE_KEY;


### PR DESCRIPTION
## Summary
- add a reusable data retention provider with scheduled purge and undo support
- surface retention controls in Settings and Task Manager activity feed in Resource Monitor
- log purge activity, store retention settings, and update trash auto-purge handling

## Testing
- yarn test __tests__/dataRetention.test.ts --watchAll=false
- yarn test __tests__/DataRetentionPanel.test.tsx --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68dc626ac9cc83288fe394d78797dfca