### PR TITLE
[settings] add undoable clear data flow

### DIFF
--- a/__tests__/settings.clear-data.test.tsx
+++ b/__tests__/settings.clear-data.test.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import ClearDataSection from '../apps/settings/components/ClearDataSection';
+import { SettingsContext } from '../hooks/useSettings';
+import { defaults } from '../utils/settingsStore';
+import { set as setKeyval } from 'idb-keyval';
+import { logEvent } from '../utils/analytics';
+
+jest.mock('../utils/analytics', () => ({
+  logEvent: jest.fn(),
+}));
+
+type ContextOverrides = Partial<React.ContextType<typeof SettingsContext>>;
+
+const createContextValue = (overrides: ContextOverrides = {}) => ({
+  accent: defaults.accent,
+  wallpaper: defaults.wallpaper,
+  bgImageName: defaults.wallpaper,
+  useKaliWallpaper: defaults.useKaliWallpaper,
+  density: defaults.density as 'regular',
+  reducedMotion: defaults.reducedMotion,
+  fontScale: defaults.fontScale,
+  highContrast: defaults.highContrast,
+  largeHitAreas: defaults.largeHitAreas,
+  pongSpin: defaults.pongSpin,
+  allowNetwork: defaults.allowNetwork,
+  haptics: defaults.haptics,
+  theme: 'default',
+  setAccent: jest.fn(),
+  setWallpaper: jest.fn(),
+  setUseKaliWallpaper: jest.fn(),
+  setDensity: jest.fn(),
+  setReducedMotion: jest.fn(),
+  setFontScale: jest.fn(),
+  setHighContrast: jest.fn(),
+  setLargeHitAreas: jest.fn(),
+  setPongSpin: jest.fn(),
+  setAllowNetwork: jest.fn(),
+  setHaptics: jest.fn(),
+  setTheme: jest.fn(),
+  ...overrides,
+});
+
+const deleteDatabase = async (name: string) => {
+  await new Promise<void>((resolve) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+    request.onsuccess = () => resolve();
+  });
+};
+
+let usingFakeTimers = false;
+
+afterEach(async () => {
+  jest.clearAllMocks();
+  if (usingFakeTimers) {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    usingFakeTimers = false;
+  } else {
+    jest.useRealTimers();
+  }
+  await deleteDatabase('keyval-store');
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+describe('ClearDataSection', () => {
+  it('requires the confirmation phrase before enabling the clear button', () => {
+    const contextValue = createContextValue();
+    const { unmount } = render(
+      <SettingsContext.Provider value={contextValue}>
+        <ClearDataSection />
+      </SettingsContext.Provider>,
+    );
+
+    const button = screen.getByRole('button', { name: /clear all data/i });
+    const input = screen.getByLabelText(/type clear all data/i);
+
+    expect(button).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: 'clear now' } });
+    expect(button).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: 'CLEAR ALL DATA' } });
+    expect(button).toBeEnabled();
+
+    unmount();
+  });
+
+  it('restores data when undo is triggered within the grace period', async () => {
+    jest.useFakeTimers();
+    usingFakeTimers = true;
+
+    await deleteDatabase('keyval-store');
+    await setKeyval('accent', '#123456');
+    await setKeyval('bg-image', 'wall-5');
+
+    window.localStorage.setItem('app:theme', 'neon');
+    window.localStorage.setItem('density', 'compact');
+    window.localStorage.setItem('use-kali-wallpaper', 'true');
+    window.localStorage.setItem('reduced-motion', 'true');
+    window.localStorage.setItem('font-scale', '1.25');
+    window.localStorage.setItem('high-contrast', 'true');
+    window.localStorage.setItem('large-hit-areas', 'true');
+    window.localStorage.setItem('pong-spin', 'false');
+    window.localStorage.setItem('allow-network', 'true');
+    window.localStorage.setItem('haptics', 'false');
+    window.sessionStorage.setItem('session-flag', 'persist');
+
+    const contextValue = createContextValue();
+    const { unmount } = render(
+      <SettingsContext.Provider value={contextValue}>
+        <ClearDataSection />
+      </SettingsContext.Provider>,
+    );
+
+    const input = screen.getByLabelText(/type clear all data/i);
+    const clearButton = screen.getByRole('button', { name: /clear all data/i });
+
+    fireEvent.change(input, { target: { value: 'CLEAR ALL DATA' } });
+
+    await act(async () => {
+      fireEvent.click(clearButton);
+    });
+
+    await waitFor(() =>
+      expect(logEvent).toHaveBeenCalledWith({ category: 'settings', action: 'clear_all_data' }),
+    );
+    expect(window.localStorage.getItem('app:theme')).toBeNull();
+    expect(window.sessionStorage.getItem('session-flag')).toBeNull();
+
+    const undoButton = screen.getByRole('button', { name: /undo/i });
+
+    await act(async () => {
+      fireEvent.click(undoButton);
+    });
+
+    await waitFor(() =>
+      expect(logEvent).toHaveBeenCalledWith({ category: 'settings', action: 'clear_all_data_undo' }),
+    );
+
+    expect(window.localStorage.getItem('app:theme')).toBe('neon');
+    expect(window.localStorage.getItem('density')).toBe('compact');
+    expect(window.localStorage.getItem('use-kali-wallpaper')).toBe('true');
+    expect(window.localStorage.getItem('high-contrast')).toBe('true');
+    expect(window.sessionStorage.getItem('session-flag')).toBe('persist');
+
+    await waitFor(() => expect(contextValue.setAccent).toHaveBeenLastCalledWith('#123456'));
+    expect(contextValue.setWallpaper).toHaveBeenLastCalledWith('wall-5');
+    expect(contextValue.setUseKaliWallpaper).toHaveBeenLastCalledWith(true);
+    expect(contextValue.setDensity).toHaveBeenLastCalledWith('compact');
+    expect(contextValue.setReducedMotion).toHaveBeenLastCalledWith(true);
+    expect(contextValue.setFontScale).toHaveBeenLastCalledWith(1.25);
+    expect(contextValue.setHighContrast).toHaveBeenLastCalledWith(true);
+    expect(contextValue.setLargeHitAreas).toHaveBeenLastCalledWith(true);
+    expect(contextValue.setPongSpin).toHaveBeenLastCalledWith(false);
+    expect(contextValue.setAllowNetwork).toHaveBeenLastCalledWith(true);
+    expect(contextValue.setHaptics).toHaveBeenLastCalledWith(false);
+    expect(contextValue.setTheme).toHaveBeenLastCalledWith('neon');
+
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+
+    unmount();
+  });
+});

--- a/apps/settings/components/ClearDataSection.tsx
+++ b/apps/settings/components/ClearDataSection.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSettings } from '../../../hooks/useSettings';
+import {
+  defaults,
+  getAccent as loadAccent,
+  getWallpaper as loadWallpaper,
+  getUseKaliWallpaper as loadUseKaliWallpaper,
+  getDensity as loadDensity,
+  getReducedMotion as loadReducedMotion,
+  getFontScale as loadFontScale,
+  getHighContrast as loadHighContrast,
+  getLargeHitAreas as loadLargeHitAreas,
+  getPongSpin as loadPongSpin,
+  getAllowNetwork as loadAllowNetwork,
+  getHaptics as loadHaptics,
+} from '../../../utils/settingsStore';
+import { getTheme as loadTheme } from '../../../utils/theme';
+import {
+  captureDataSnapshot,
+  clearClientData,
+  restoreDataSnapshot,
+  DataSnapshot,
+} from '../../../utils/dataReset';
+import { logEvent } from '../../../utils/analytics';
+import logger from '../../../utils/logger';
+
+const CONFIRMATION_PHRASE = 'CLEAR ALL DATA';
+const UNDO_DURATION_MS = 10_000;
+
+const summaryItems = [
+  'Desktop personalization (theme, wallpaper, density, accents).',
+  'Saved games, replays, keyboard shortcuts, and high scores stored offline.',
+  'Recent apps, installed plug-ins, lab mode flags, and cached tool data.',
+  'Any other settings saved to this browser via localStorage or IndexedDB.',
+];
+
+const formatSeconds = (msRemaining: number): number => {
+  const seconds = Math.ceil(msRemaining / 1000);
+  return seconds > 0 ? seconds : 0;
+};
+
+export default function ClearDataSection() {
+  const {
+    setAccent,
+    setWallpaper,
+    setUseKaliWallpaper,
+    setDensity,
+    setReducedMotion,
+    setFontScale,
+    setHighContrast,
+    setLargeHitAreas,
+    setPongSpin,
+    setAllowNetwork,
+    setHaptics,
+    setTheme,
+  } = useSettings();
+
+  const [inputValue, setInputValue] = useState('');
+  const [status, setStatus] = useState<'idle' | 'clearing' | 'undoing'>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [undoDeadline, setUndoDeadline] = useState<number | null>(null);
+  const [undoSeconds, setUndoSeconds] = useState<number>(0);
+
+  const snapshotRef = useRef<DataSnapshot | null>(null);
+  const reloadTimeoutRef = useRef<number | null>(null);
+
+  const confirmationMatches = useMemo(
+    () => inputValue.trim().toUpperCase() === CONFIRMATION_PHRASE,
+    [inputValue],
+  );
+
+  useEffect(
+    () => () => {
+      if (typeof window === 'undefined') return;
+      if (reloadTimeoutRef.current !== null) {
+        window.clearTimeout(reloadTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (undoDeadline === null) {
+      setUndoSeconds(0);
+      return;
+    }
+
+    const updateCountdown = () => {
+      const remaining = undoDeadline - Date.now();
+      if (remaining <= 0) {
+        snapshotRef.current = null;
+        setUndoDeadline(null);
+        setUndoSeconds(0);
+        return;
+      }
+      setUndoSeconds(formatSeconds(remaining));
+    };
+
+    updateCountdown();
+    const interval = window.setInterval(updateCountdown, 250);
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [undoDeadline]);
+
+  const applyDefaults = () => {
+    setAccent(defaults.accent);
+    setWallpaper(defaults.wallpaper);
+    setUseKaliWallpaper(defaults.useKaliWallpaper);
+    setDensity(defaults.density as any);
+    setReducedMotion(defaults.reducedMotion);
+    setFontScale(defaults.fontScale);
+    setHighContrast(defaults.highContrast);
+    setLargeHitAreas(defaults.largeHitAreas);
+    setPongSpin(defaults.pongSpin);
+    setAllowNetwork(defaults.allowNetwork);
+    setHaptics(defaults.haptics);
+    setTheme('default');
+  };
+
+  const hydrateFromStorage = async () => {
+    try {
+      const [
+        accent,
+        wallpaper,
+        useKaliWallpaper,
+        density,
+        reducedMotion,
+        fontScale,
+        highContrast,
+        largeHitAreas,
+        pongSpin,
+        allowNetwork,
+        haptics,
+      ] = await Promise.all([
+        loadAccent(),
+        loadWallpaper(),
+        loadUseKaliWallpaper(),
+        loadDensity(),
+        loadReducedMotion(),
+        loadFontScale(),
+        loadHighContrast(),
+        loadLargeHitAreas(),
+        loadPongSpin(),
+        loadAllowNetwork(),
+        loadHaptics(),
+      ]);
+
+      setAccent(accent);
+      setWallpaper(wallpaper);
+      setUseKaliWallpaper(useKaliWallpaper);
+      setDensity(density as any);
+      setReducedMotion(reducedMotion);
+      setFontScale(fontScale);
+      setHighContrast(highContrast);
+      setLargeHitAreas(largeHitAreas);
+      setPongSpin(pongSpin);
+      setAllowNetwork(allowNetwork);
+      setHaptics(haptics);
+      setTheme(loadTheme());
+    } catch (err) {
+      logger.error('Failed to hydrate settings after undo', err);
+    }
+  };
+
+  const scheduleReload = () => {
+    if (typeof window === 'undefined') return;
+    if (reloadTimeoutRef.current !== null) {
+      window.clearTimeout(reloadTimeoutRef.current);
+    }
+    reloadTimeoutRef.current = window.setTimeout(() => {
+      try {
+        window.location.reload();
+      } catch {
+        // ignore reload failures in non-browser environments
+      }
+    }, UNDO_DURATION_MS);
+  };
+
+  const handleClear = async () => {
+    if (!confirmationMatches || status !== 'idle' || undoDeadline !== null) return;
+    setStatus('clearing');
+    setError(null);
+
+    let snapshot: DataSnapshot | null = null;
+
+    try {
+      snapshot = await captureDataSnapshot();
+      snapshotRef.current = snapshot;
+      await clearClientData(snapshot);
+      applyDefaults();
+      setInputValue('');
+      setUndoDeadline(Date.now() + UNDO_DURATION_MS);
+      setUndoSeconds(formatSeconds(UNDO_DURATION_MS));
+      scheduleReload();
+      logEvent({ category: 'settings', action: 'clear_all_data' });
+    } catch (err) {
+      logger.error('Failed to clear stored data', err);
+      setError('Unable to clear data. Please try again.');
+      if (snapshot) {
+        try {
+          await restoreDataSnapshot(snapshot);
+        } catch (restoreErr) {
+          logger.error('Failed to restore snapshot after clear failure', restoreErr);
+        }
+      }
+      snapshotRef.current = null;
+    } finally {
+      setStatus('idle');
+    }
+  };
+
+  const handleUndo = async () => {
+    const snapshot = snapshotRef.current;
+    if (!snapshot || status !== 'idle') return;
+
+    setStatus('undoing');
+    setError(null);
+    try {
+      await restoreDataSnapshot(snapshot);
+      await hydrateFromStorage();
+      logEvent({ category: 'settings', action: 'clear_all_data_undo' });
+    } catch (err) {
+      logger.error('Failed to undo data clear', err);
+      setError('Undo failed. Your data may already be gone.');
+    } finally {
+      snapshotRef.current = null;
+      setUndoDeadline(null);
+      setUndoSeconds(0);
+      if (typeof window !== 'undefined' && reloadTimeoutRef.current !== null) {
+        window.clearTimeout(reloadTimeoutRef.current);
+        reloadTimeoutRef.current = null;
+      }
+      setStatus('idle');
+    }
+  };
+
+  const disableClearButton =
+    !confirmationMatches || status !== 'idle' || undoDeadline !== null;
+
+  return (
+    <section className="mt-6 border-t border-gray-900 pt-6 text-ubt-grey">
+      <h3 className="text-lg font-semibold">Clear all data</h3>
+      <p className="mt-2 text-sm text-ubt-grey/80">
+        This will erase everything saved locally in this browser and return the desktop to
+        its initial state. The following data will be removed:
+      </p>
+      <ul className="mt-3 list-disc space-y-1 pl-6 text-sm text-ubt-grey/80">
+        {summaryItems.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+      <label htmlFor="clear-data-confirm" className="mt-4 block text-sm font-medium">
+        Type <span className="font-semibold">{CONFIRMATION_PHRASE}</span> to confirm.
+      </label>
+        <input
+          id="clear-data-confirm"
+          type="text"
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+          className="mt-2 w-full rounded border border-ubt-cool-grey bg-ub-cool-grey px-3 py-2 text-sm text-white focus:border-ub-orange focus:outline-none"
+          placeholder={CONFIRMATION_PHRASE}
+          aria-describedby="clear-data-helper"
+          aria-label="Confirmation phrase"
+        />
+      <p id="clear-data-helper" className="mt-2 text-xs text-ubt-grey/60">
+        A 10 second undo window will be shown after you clear everything.
+      </p>
+      {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
+      <button
+        type="button"
+        onClick={handleClear}
+        disabled={disableClearButton}
+        className="mt-4 rounded bg-ub-orange px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-ubt-grey"
+      >
+        {status === 'clearing' ? 'Clearing…' : 'Clear all data'}
+      </button>
+      {undoDeadline !== null && snapshotRef.current && (
+        <div className="mt-4 flex flex-col gap-2 rounded border border-ubt-cool-grey bg-black/30 p-4 text-sm">
+          <p>
+            Local data deleted. You have <strong>{undoSeconds}</strong> second
+            {undoSeconds === 1 ? '' : 's'} to undo.
+          </p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleUndo}
+              disabled={status !== 'idle'}
+              className="rounded bg-white/10 px-3 py-2 font-medium text-white disabled:cursor-not-allowed disabled:bg-white/5"
+            >
+              {status === 'undoing' ? 'Restoring…' : 'Undo'}
+            </button>
+            <span className="self-center text-xs text-ubt-grey/70">
+              The desktop will reload automatically when the timer expires.
+            </span>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -4,8 +4,6 @@ import { useState, useRef } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
-  resetSettings,
-  defaults,
   exportSettings as exportSettingsData,
   importSettings as importSettingsData,
 } from "../../utils/settingsStore";
@@ -13,6 +11,7 @@ import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
 import KaliWallpaper from "../../components/util-components/kali-wallpaper";
+import ClearDataSection from "./components/ClearDataSection";
 
 export default function Settings() {
   const {
@@ -89,24 +88,6 @@ export default function Settings() {
     }
   };
 
-  const handleReset = async () => {
-    if (
-      !window.confirm(
-        "Reset desktop to default settings? This will clear all saved data."
-      )
-    )
-      return;
-    await resetSettings();
-    window.localStorage.clear();
-    setAccent(defaults.accent);
-    setWallpaper(defaults.wallpaper);
-    setDensity(defaults.density as any);
-    setReducedMotion(defaults.reducedMotion);
-    setFontScale(defaults.fontScale);
-    setHighContrast(defaults.highContrast);
-    setTheme("default");
-  };
-
   const [showKeymap, setShowKeymap] = useState(false);
 
   return (
@@ -157,16 +138,17 @@ export default function Settings() {
             </div>
           </div>
           <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey flex items-center">
-              <input
-                type="checkbox"
-                checked={useKaliWallpaper}
-                onChange={(e) => setUseKaliWallpaper(e.target.checked)}
-                className="mr-2"
-              />
-              Kali Gradient Wallpaper
-            </label>
-          </div>
+              <label className="mr-2 text-ubt-grey flex items-center">
+                <input
+                  type="checkbox"
+                  checked={useKaliWallpaper}
+                  onChange={(e) => setUseKaliWallpaper(e.target.checked)}
+                  className="mr-2"
+                  aria-label="Use Kali gradient wallpaper"
+                />
+                Kali Gradient Wallpaper
+              </label>
+            </div>
           {useKaliWallpaper && (
             <p className="text-center text-xs text-ubt-grey/70 px-6 -mt-2 mb-4">
               Your previous wallpaper selection is preserved for when you turn this off.
@@ -220,14 +202,6 @@ export default function Settings() {
                 }}
               ></div>
             ))}
-          </div>
-          <div className="border-t border-gray-900 mt-4 pt-4 px-4 flex justify-center">
-            <button
-              onClick={handleReset}
-              className="px-4 py-2 rounded bg-ub-orange text-white"
-            >
-              Reset Desktop
-            </button>
           </div>
         </>
       )}
@@ -308,6 +282,7 @@ export default function Settings() {
               Import Settings
             </button>
           </div>
+          <ClearDataSection />
         </>
       )}
         <input

--- a/utils/dataReset.ts
+++ b/utils/dataReset.ts
@@ -1,0 +1,285 @@
+'use client';
+
+import { entries, setMany } from 'idb-keyval';
+
+type StorageSnapshot = Record<string, string>;
+
+type IDBRecord = {
+  key: IDBValidKey;
+  value: unknown;
+};
+
+export interface IDBStoreSnapshot {
+  name: string;
+  records: IDBRecord[];
+}
+
+export interface IndexedDBSnapshot {
+  name: string;
+  version?: number;
+  stores: IDBStoreSnapshot[];
+}
+
+export interface DataSnapshot {
+  localStorage: StorageSnapshot;
+  sessionStorage: StorageSnapshot;
+  keyvalEntries: [IDBValidKey, unknown][];
+  indexedDBs: IndexedDBSnapshot[];
+}
+
+const KEYVAL_DB_NAME = 'keyval-store';
+
+const readStorage = (storage: Storage | undefined | null): StorageSnapshot => {
+  const snapshot: StorageSnapshot = {};
+  if (!storage) return snapshot;
+  try {
+    for (let i = 0; i < storage.length; i += 1) {
+      const key = storage.key(i);
+      if (!key) continue;
+      const value = storage.getItem(key);
+      if (typeof value === 'string') {
+        snapshot[key] = value;
+      }
+    }
+  } catch {
+    // Ignore storage read failures (e.g., security errors)
+  }
+  return snapshot;
+};
+
+const captureKeyvalEntries = async (): Promise<[IDBValidKey, unknown][]> => {
+  if (typeof indexedDB === 'undefined') return [];
+  try {
+    return await entries();
+  } catch {
+    return [];
+  }
+};
+
+const captureIndexedDBs = async (): Promise<IndexedDBSnapshot[]> => {
+  if (typeof indexedDB === 'undefined') return [];
+  const getDatabases = (indexedDB as any).databases?.bind(indexedDB);
+  if (typeof getDatabases !== 'function') return [];
+
+  try {
+    const dbs = await getDatabases();
+    const snapshots: IndexedDBSnapshot[] = [];
+
+    for (const info of dbs) {
+      const name = info?.name;
+      if (!name || name === KEYVAL_DB_NAME) continue;
+
+      const snapshot = await new Promise<IndexedDBSnapshot | null>((resolve) => {
+        try {
+          const request = info?.version
+            ? indexedDB.open(name, info.version)
+            : indexedDB.open(name);
+
+          request.onerror = () => resolve(null);
+          request.onblocked = () => resolve(null);
+          request.onsuccess = () => {
+            const db = request.result;
+            const storeNames = Array.from(db.objectStoreNames);
+            const stores: IDBStoreSnapshot[] = [];
+            if (storeNames.length === 0) {
+              db.close();
+              resolve({ name, version: info?.version, stores });
+              return;
+            }
+
+            const transaction = db.transaction(storeNames, 'readonly');
+            storeNames.forEach((storeName) => {
+              const storeSnapshot: IDBStoreSnapshot = {
+                name: storeName,
+                records: [],
+              };
+              stores.push(storeSnapshot);
+
+              const objectStore = transaction.objectStore(storeName);
+              const cursorRequest = objectStore.openCursor();
+              cursorRequest.onerror = () => {
+                // Ignore cursor errors for individual stores
+              };
+              cursorRequest.onsuccess = (event) => {
+                const cursor = event.target?.result as IDBCursorWithValue | null;
+                if (!cursor) return;
+                try {
+                  storeSnapshot.records.push({ key: cursor.key, value: cursor.value });
+                } catch {
+                  // Ignore serialization issues for problematic records
+                }
+                cursor.continue();
+              };
+            });
+
+            transaction.oncomplete = () => {
+              db.close();
+              resolve({ name, version: info?.version, stores });
+            };
+            transaction.onerror = () => {
+              db.close();
+              resolve({ name, version: info?.version, stores });
+            };
+          };
+        } catch {
+          resolve(null);
+        }
+      });
+
+      if (snapshot) snapshots.push(snapshot);
+    }
+
+    return snapshots;
+  } catch {
+    return [];
+  }
+};
+
+const deleteDatabase = async (name: string): Promise<void> => {
+  if (!name || typeof indexedDB === 'undefined') return;
+  await new Promise<void>((resolve) => {
+    try {
+      const request = indexedDB.deleteDatabase(name);
+      request.onerror = () => resolve();
+      request.onblocked = () => resolve();
+      request.onsuccess = () => resolve();
+    } catch {
+      resolve();
+    }
+  });
+};
+
+const restoreDatabase = async (snapshot: IndexedDBSnapshot): Promise<void> => {
+  if (typeof indexedDB === 'undefined') return;
+  await new Promise<void>((resolve) => {
+    try {
+      const request = snapshot.version
+        ? indexedDB.open(snapshot.name, snapshot.version)
+        : indexedDB.open(snapshot.name);
+
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        try {
+          const existingStores = Array.from(db.objectStoreNames);
+          existingStores.forEach((storeName) => {
+            if (!snapshot.stores.some((store) => store.name === storeName)) {
+              db.deleteObjectStore(storeName);
+            }
+          });
+          snapshot.stores.forEach((store) => {
+            if (!db.objectStoreNames.contains(store.name)) {
+              db.createObjectStore(store.name);
+            }
+          });
+        } catch {
+          // Ignore schema reconstruction errors
+        }
+      };
+
+      request.onerror = () => resolve();
+      request.onblocked = () => resolve();
+      request.onsuccess = () => {
+        const db = request.result;
+        const writeRecords = async () => {
+          for (const store of snapshot.stores) {
+            if (!db.objectStoreNames.contains(store.name)) continue;
+            await new Promise<void>((storeResolve) => {
+              try {
+                const tx = db.transaction(store.name, 'readwrite');
+                const objectStore = tx.objectStore(store.name);
+                store.records.forEach((record) => {
+                  try {
+                    objectStore.put(record.value, record.key);
+                  } catch {
+                    // Ignore put failures for individual records
+                  }
+                });
+                tx.oncomplete = () => storeResolve();
+                tx.onerror = () => storeResolve();
+              } catch {
+                storeResolve();
+              }
+            });
+          }
+        };
+
+        writeRecords().finally(() => {
+          db.close();
+          resolve();
+        });
+      };
+    } catch {
+      resolve();
+    }
+  });
+};
+
+export const captureDataSnapshot = async (): Promise<DataSnapshot> => {
+  const [keyvalEntries, indexedDBs] = await Promise.all([
+    captureKeyvalEntries(),
+    captureIndexedDBs(),
+  ]);
+
+  return {
+    localStorage: typeof window === 'undefined' ? {} : readStorage(window.localStorage),
+    sessionStorage:
+      typeof window === 'undefined' ? {} : readStorage(window.sessionStorage),
+    keyvalEntries,
+    indexedDBs,
+  };
+};
+
+export const clearClientData = async (snapshot: DataSnapshot): Promise<void> => {
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.clear();
+    } catch {
+      // ignore
+    }
+    try {
+      window.sessionStorage.clear();
+    } catch {
+      // ignore
+    }
+  }
+
+  const names = new Set<string>();
+  snapshot.indexedDBs.forEach((db) => names.add(db.name));
+  names.add(KEYVAL_DB_NAME);
+
+  await Promise.all(Array.from(names).map((name) => deleteDatabase(name)));
+};
+
+export const restoreDataSnapshot = async (snapshot: DataSnapshot): Promise<void> => {
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.clear();
+      Object.entries(snapshot.localStorage).forEach(([key, value]) => {
+        window.localStorage.setItem(key, value);
+      });
+    } catch {
+      // ignore failures when restoring localStorage
+    }
+
+    try {
+      window.sessionStorage.clear();
+      Object.entries(snapshot.sessionStorage).forEach(([key, value]) => {
+        window.sessionStorage.setItem(key, value);
+      });
+    } catch {
+      // ignore failures when restoring sessionStorage
+    }
+  }
+
+  if (snapshot.keyvalEntries.length > 0) {
+    try {
+      await setMany(snapshot.keyvalEntries as [IDBValidKey, unknown][]);
+    } catch {
+      // ignore failures when restoring keyval entries
+    }
+  }
+
+  for (const dbSnapshot of snapshot.indexedDBs) {
+    await restoreDatabase(dbSnapshot);
+  }
+};


### PR DESCRIPTION
## Summary
- add a dedicated ClearDataSection with confirmation prompt, countdown undo banner, and reload scheduling for the new "Clear all data" action
- create a dataReset helper to snapshot local/session storage plus IndexedDB entries before purge and restore them on undo
- surface the clear-all action in the privacy tab, improve checkbox labelling, and add Jest coverage for confirmation and undo logic

## Testing
- yarn lint
- yarn test settings.clear-data.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc626b9978832892d2c40c3403071a