### PR TITLE
[desktop] add data backup bundle

### DIFF
--- a/__tests__/dataBundle.test.ts
+++ b/__tests__/dataBundle.test.ts
@@ -1,0 +1,129 @@
+import {
+  applyDataBundle,
+  createDataBundle,
+  estimateBundleSize,
+  formatBundleSize,
+  parseDataBundle,
+  serializeDataBundle,
+} from '../utils/dataBundle';
+import { RECENT_STORAGE_KEY } from '../utils/recentStorage';
+import { exportSettings, importSettings } from '../utils/settingsStore';
+
+jest.mock('../utils/settingsStore', () => ({
+  exportSettings: jest.fn(),
+  importSettings: jest.fn(),
+}));
+
+describe('dataBundle utilities', () => {
+  const mockedExportSettings = exportSettings as unknown as jest.MockedFunction<() => Promise<string>>;
+  const mockedImportSettings = importSettings as unknown as jest.MockedFunction<(input: unknown) => Promise<void>>;
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-02T03:04:05Z'));
+    localStorage.clear();
+    mockedExportSettings.mockReset();
+    mockedImportSettings.mockReset();
+    mockedExportSettings.mockResolvedValue(JSON.stringify({ accent: '#123456', theme: 'dark' }));
+    mockedImportSettings.mockResolvedValue();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    localStorage.clear();
+  });
+
+  it('collects configured storage keys and estimates bundle size', async () => {
+    localStorage.setItem('launcherFavorites', JSON.stringify(['nessus']));
+    localStorage.setItem('recentApps', JSON.stringify(['hydra']));
+    localStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(['wireshark']));
+    localStorage.setItem('snap-enabled', JSON.stringify(true));
+    localStorage.setItem('app:theme', 'matrix');
+    localStorage.setItem('reconng-report-template', 'audit');
+    localStorage.setItem('portfolio-tasks', JSON.stringify([{ id: 't1' }]));
+    localStorage.setItem('qrLastGeneration', 'payload');
+
+    const bundle = await createDataBundle();
+
+    expect(bundle.version).toBe(1);
+    expect(bundle.createdAt).toBe('2024-01-02T03:04:05.000Z');
+    expect(bundle.settings).toEqual({ accent: '#123456', theme: 'dark' });
+    expect(bundle.storage.launcher).toMatchObject({
+      launcherFavorites: ['nessus'],
+      [RECENT_STORAGE_KEY]: ['wireshark'],
+      recentApps: ['hydra'],
+    });
+    expect(bundle.storage.preferences).toMatchObject({
+      'snap-enabled': true,
+      'app:theme': 'matrix',
+    });
+    expect(bundle.storage.templates).toMatchObject({
+      'reconng-report-template': 'audit',
+    });
+    expect(bundle.storage.workspace).toMatchObject({
+      'portfolio-tasks': [{ id: 't1' }],
+    });
+    expect(bundle.storage.qr).toMatchObject({
+      qrLastGeneration: 'payload',
+    });
+
+    const serialized = serializeDataBundle(bundle);
+    expect(serialized).toContain('"version": 1');
+
+    const size = estimateBundleSize(serialized);
+    expect(size).toBeGreaterThan(serialized.length - 10);
+    expect(formatBundleSize(size)).toMatch(/\b(?:B|KB|MB)\b/);
+  });
+
+  it('performs a round-trip export and import', async () => {
+    localStorage.setItem('launcherFavorites', JSON.stringify(['nessus']));
+    localStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(['wireshark']));
+    localStorage.setItem('snap-enabled', JSON.stringify(false));
+    localStorage.setItem('app:theme', 'neon');
+
+    const bundle = await createDataBundle();
+    const serialized = serializeDataBundle(bundle);
+    const parsed = parseDataBundle(serialized);
+
+    localStorage.clear();
+
+    await applyDataBundle(parsed);
+
+    expect(mockedImportSettings).toHaveBeenCalledWith(parsed.settings);
+    expect(JSON.parse(localStorage.getItem('launcherFavorites') || '[]')).toEqual(['nessus']);
+    expect(JSON.parse(localStorage.getItem(RECENT_STORAGE_KEY) || '[]')).toEqual(['wireshark']);
+    expect(localStorage.getItem('snap-enabled')).toBe('false');
+    expect(localStorage.getItem('app:theme')).toBe('neon');
+  });
+
+  it('rejects unsupported bundle versions', () => {
+    const invalid = JSON.stringify({
+      version: 2,
+      createdAt: '2024-01-02T03:04:05.000Z',
+      settings: {},
+      storage: {},
+    });
+    expect(() => parseDataBundle(invalid)).toThrow('Unsupported bundle version');
+  });
+
+  it('sanitises unknown storage categories and keys', () => {
+    const json = JSON.stringify({
+      version: 1,
+      createdAt: '2024-01-02T03:04:05.000Z',
+      settings: {},
+      storage: {
+        launcher: {
+          launcherFavorites: ['hydra'],
+          extraneous: 'value',
+        },
+        rogue: {
+          foo: 'bar',
+        },
+      },
+    });
+
+    const parsed = parseDataBundle(json);
+
+    expect(parsed.storage.launcher).toEqual({ launcherFavorites: ['hydra'] });
+    expect(parsed.storage).not.toHaveProperty('rogue');
+  });
+});

--- a/components/common/DataExport.tsx
+++ b/components/common/DataExport.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  applyDataBundle,
+  createDataBundle,
+  estimateBundleSize,
+  formatBundleSize,
+  parseDataBundle,
+  serializeDataBundle,
+  type DataBundle,
+} from '../../utils/dataBundle';
+
+interface PreparedBundle {
+  bundle: DataBundle;
+  serialized: string;
+  size: number;
+}
+
+const formatPreparedAt = (bundle: PreparedBundle | null): string => {
+  if (!bundle) return '—';
+  const date = new Date(bundle.bundle.createdAt);
+  if (Number.isNaN(date.getTime())) return bundle.bundle.createdAt;
+  return date.toLocaleString();
+};
+
+const buildFileName = (bundle: DataBundle): string => {
+  const safeTimestamp = bundle.createdAt.replace(/[:.]/g, '-');
+  return `kali-portfolio-backup-${safeTimestamp}.json`;
+};
+
+const DataExport: React.FC = () => {
+  const [prepared, setPrepared] = useState<PreparedBundle | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const preparedRef = useRef<PreparedBundle | null>(null);
+  const busyRef = useRef(false);
+
+  const refreshBundle = useCallback(async (): Promise<PreparedBundle | null> => {
+    if (busyRef.current) {
+      return preparedRef.current;
+    }
+    busyRef.current = true;
+    setIsBusy(true);
+    setError(null);
+    try {
+      const bundle = await createDataBundle();
+      const serialized = serializeDataBundle(bundle);
+      const size = estimateBundleSize(serialized);
+      const next: PreparedBundle = { bundle, serialized, size };
+      preparedRef.current = next;
+      setPrepared(next);
+      setStatus(`Bundle prepared ${formatPreparedAt(next)}.`);
+      return next;
+    } catch (err) {
+      console.error('Failed to prepare export bundle', err);
+      setError('Unable to prepare export bundle. Try again in a moment.');
+      return null;
+    } finally {
+      busyRef.current = false;
+      setIsBusy(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshBundle();
+  }, [refreshBundle]);
+
+  const sizeLabel = useMemo(() => {
+    if (!prepared) return 'Calculating…';
+    return formatBundleSize(prepared.size);
+  }, [prepared]);
+
+  const handleDownload = useCallback(async () => {
+    setError(null);
+    let current = prepared;
+    if (!current) {
+      current = await refreshBundle();
+    }
+    if (!current) return;
+
+    try {
+      const blob = new Blob([current.serialized], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = buildFileName(current.bundle);
+      anchor.rel = 'noopener';
+      anchor.click();
+      URL.revokeObjectURL(url);
+      setStatus('Download started. Store the backup safely to restore later.');
+    } catch (err) {
+      console.error('Failed to trigger download', err);
+      setError('Unable to start download. Your browser may block automatic downloads.');
+    }
+  }, [prepared, refreshBundle]);
+
+  const handleFilePicker = useCallback(() => {
+    setError(null);
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleImport = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+
+      setIsBusy(true);
+      setError(null);
+      setStatus(null);
+      try {
+        const text = await file.text();
+        const bundle = parseDataBundle(text);
+        await applyDataBundle(bundle);
+        setStatus('Backup restored. Reload open apps to see updated data.');
+        await refreshBundle();
+      } catch (err) {
+        console.error('Failed to import bundle', err);
+        setError('The selected file is not a recognised backup bundle.');
+      } finally {
+        setIsBusy(false);
+        busyRef.current = false;
+        event.target.value = '';
+      }
+    },
+    [refreshBundle],
+  );
+
+  return (
+    <section className="rounded-lg border border-white/10 bg-black/40 p-4 text-sm text-white shadow-lg">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Data backup &amp; restore</h2>
+          <p className="mt-1 text-white/70">
+            Export desktop settings, launcher favourites, templates, recents, and workspace data into a
+            single JSON bundle.
+          </p>
+        </div>
+        <div className="text-right text-xs uppercase tracking-wide text-white/60">
+          <p>Estimated size</p>
+          <p className="text-base font-semibold text-white">{sizeLabel}</p>
+          <p className="mt-1">Prepared: {formatPreparedAt(prepared)}</p>
+        </div>
+      </div>
+
+      <ul className="mt-4 list-disc space-y-1 pl-5 text-xs text-white/60 sm:text-sm">
+        <li>Desktop appearance and accessibility settings</li>
+        <li>Launcher favourites, recent apps, and snap preferences</li>
+        <li>Templates for Recon-ng, Sokoban packs, scanner schedules, and Hydra sessions</li>
+        <li>Workspace data including portfolio tasks, plugin states, and QR history</li>
+      </ul>
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => void refreshBundle()}
+          disabled={isBusy}
+          className="rounded bg-white/10 px-4 py-2 text-sm font-medium transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Refresh estimate
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleDownload()}
+          disabled={isBusy}
+          className="rounded bg-ub-orange px-4 py-2 text-sm font-semibold text-black transition hover:bg-ub-orange/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Download backup
+        </button>
+        <button
+          type="button"
+          onClick={handleFilePicker}
+          disabled={isBusy}
+          className="rounded border border-white/30 px-4 py-2 text-sm font-medium transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Restore from file
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json"
+          className="hidden"
+          aria-label="Import data bundle"
+          onChange={handleImport}
+        />
+      </div>
+
+      <div className="mt-4 space-y-2 text-xs sm:text-sm" aria-live="polite">
+        {status && <p className="text-emerald-300" role="status">{status}</p>}
+        {error && <p className="text-red-400" role="alert">{error}</p>}
+      </div>
+    </section>
+  );
+};
+
+export default DataExport;

--- a/utils/dataBundle.ts
+++ b/utils/dataBundle.ts
@@ -1,0 +1,243 @@
+import { RECENT_STORAGE_KEY } from './recentStorage';
+import { safeLocalStorage } from './safeStorage';
+import { exportSettings, importSettings } from './settingsStore';
+
+export const BUNDLE_VERSION = 1;
+
+type StorageEncoding = 'json' | 'string';
+
+interface StorageKeyDefinition {
+  key: string;
+  encoding: StorageEncoding;
+}
+
+const STORAGE_SCHEMA = {
+  launcher: [
+    { key: 'launcherFavorites', encoding: 'json' },
+    { key: RECENT_STORAGE_KEY, encoding: 'json' },
+    { key: 'recentApps', encoding: 'json' },
+    { key: 'whisker-menu-category', encoding: 'string' },
+  ],
+  preferences: [
+    { key: 'snap-enabled', encoding: 'json' },
+    { key: 'app:theme', encoding: 'string' },
+  ],
+  templates: [
+    { key: 'reconng-report-template', encoding: 'string' },
+    { key: 'project-gallery-filters', encoding: 'json' },
+    { key: 'sokoban_packs', encoding: 'json' },
+  ],
+  workspace: [
+    { key: 'portfolio-tasks', encoding: 'json' },
+    { key: 'todoist-column-order', encoding: 'json' },
+    { key: 'installedPlugins', encoding: 'json' },
+    { key: 'lastPluginRun', encoding: 'json' },
+  ],
+  schedules: [
+    { key: 'scanSchedules', encoding: 'json' },
+  ],
+  hydra: [
+    { key: 'hydraUserLists', encoding: 'json' },
+    { key: 'hydraPassLists', encoding: 'json' },
+    { key: 'hydra/session', encoding: 'json' },
+    { key: 'hydra/config', encoding: 'json' },
+  ],
+  qr: [
+    { key: 'qrScans', encoding: 'json' },
+    { key: 'qrLastScan', encoding: 'string' },
+    { key: 'qrLastGeneration', encoding: 'string' },
+  ],
+} as const satisfies Record<string, readonly StorageKeyDefinition[]>;
+
+type StorageCategory = keyof typeof STORAGE_SCHEMA;
+
+type StorageData = Partial<Record<StorageCategory, Record<string, unknown>>>;
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readLocalStorageValue = (
+  storage: Storage,
+  definition: StorageKeyDefinition,
+): unknown | undefined => {
+  const raw = storage.getItem(definition.key);
+  if (raw === null) return undefined;
+  if (definition.encoding === 'string') {
+    return raw;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+};
+
+const writeLocalStorageValue = (
+  storage: Storage,
+  definition: StorageKeyDefinition,
+  value: unknown,
+): void => {
+  if (value === undefined) return;
+  if (value === null) {
+    try {
+      storage.removeItem(definition.key);
+    } catch {
+      /* ignore */
+    }
+    return;
+  }
+
+  try {
+    if (definition.encoding === 'string') {
+      storage.setItem(definition.key, String(value));
+    } else {
+      storage.setItem(definition.key, JSON.stringify(value));
+    }
+  } catch {
+    /* ignore quota or serialization errors */
+  }
+};
+
+export interface DataBundle {
+  version: typeof BUNDLE_VERSION;
+  createdAt: string;
+  settings: Record<string, unknown>;
+  storage: StorageData;
+}
+
+export const serializeDataBundle = (bundle: DataBundle): string =>
+  JSON.stringify(bundle, null, 2);
+
+export const estimateBundleSize = (serialized: string): number => {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(serialized).length;
+  }
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.byteLength(serialized, 'utf-8');
+  }
+  return serialized.length;
+};
+
+export const createDataBundle = async (): Promise<DataBundle> => {
+  let settings: Record<string, unknown> = {};
+  try {
+    const exported = await exportSettings();
+    settings = JSON.parse(exported);
+  } catch {
+    settings = {};
+  }
+
+  const storage = safeLocalStorage;
+  const storageData: StorageData = {};
+  if (storage) {
+    (Object.keys(STORAGE_SCHEMA) as StorageCategory[]).forEach(category => {
+      const entries: Record<string, unknown> = {};
+      STORAGE_SCHEMA[category].forEach(definition => {
+        const value = readLocalStorageValue(storage, definition);
+        if (value !== undefined) {
+          entries[definition.key] = value;
+        }
+      });
+      if (Object.keys(entries).length > 0) {
+        storageData[category] = entries;
+      }
+    });
+  }
+
+  return {
+    version: BUNDLE_VERSION,
+    createdAt: new Date().toISOString(),
+    settings,
+    storage: storageData,
+  };
+};
+
+export const parseDataBundle = (json: string): DataBundle => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (error) {
+    throw new Error('Invalid bundle: unreadable JSON');
+  }
+
+  if (!isPlainObject(parsed)) {
+    throw new Error('Invalid bundle: expected object');
+  }
+
+  const { version, createdAt, settings, storage } = parsed;
+  if (version !== BUNDLE_VERSION) {
+    throw new Error('Unsupported bundle version');
+  }
+  if (typeof createdAt !== 'string') {
+    throw new Error('Invalid bundle: missing timestamp');
+  }
+  if (!isPlainObject(settings)) {
+    throw new Error('Invalid bundle: settings section missing');
+  }
+
+  const sanitizedStorage: StorageData = {};
+  if (isPlainObject(storage)) {
+    Object.entries(storage).forEach(([categoryKey, value]) => {
+      if (!Object.prototype.hasOwnProperty.call(STORAGE_SCHEMA, categoryKey)) {
+        return;
+      }
+      if (!isPlainObject(value)) {
+        return;
+      }
+      const allowedDefinitions = STORAGE_SCHEMA[categoryKey as StorageCategory];
+      const allowedKeys = new Set(allowedDefinitions.map(def => def.key));
+      const cleaned: Record<string, unknown> = {};
+      Object.entries(value).forEach(([key, entryValue]) => {
+        if (allowedKeys.has(key)) {
+          cleaned[key] = entryValue;
+        }
+      });
+      if (Object.keys(cleaned).length > 0) {
+        sanitizedStorage[categoryKey as StorageCategory] = cleaned;
+      }
+    });
+  }
+
+  return {
+    version: BUNDLE_VERSION,
+    createdAt,
+    settings,
+    storage: sanitizedStorage,
+  };
+};
+
+export const applyDataBundle = async (bundle: DataBundle): Promise<void> => {
+  await importSettings(bundle.settings);
+  const storage = safeLocalStorage;
+  if (!storage || !bundle.storage) return;
+
+  (Object.keys(bundle.storage) as StorageCategory[]).forEach(category => {
+    const data = bundle.storage?.[category];
+    if (!data) return;
+    const definitions = STORAGE_SCHEMA[category];
+    definitions.forEach(definition => {
+      if (Object.prototype.hasOwnProperty.call(data, definition.key)) {
+        writeLocalStorageValue(storage, definition, data[definition.key]);
+      }
+    });
+  });
+};
+
+export const formatBundleSize = (bytes: number): string => {
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return '0 B';
+  }
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const units = ['KB', 'MB', 'GB'];
+  let size = bytes / 1024;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+  return `${size.toFixed(1)} ${units[unitIndex]}`;
+};
+
+export type { StorageCategory };


### PR DESCRIPTION
## Summary
- add a reusable DataExport component that surfaces bundle size and download/import controls for user data
- implement dataBundle utility to collect settings, launcher, templates, workspace data and restore with validation
- cover bundle creation and round-trip import with dedicated Jest tests

## Testing
- yarn lint
- yarn test __tests__/dataBundle.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc626be188832896af6a38ff7b92b7