### PR TITLE
[settings] Add telemetry privacy controls

### DIFF
--- a/__tests__/telemetry.test.ts
+++ b/__tests__/telemetry.test.ts
@@ -1,0 +1,58 @@
+import {
+  __resetTelemetryStateForTests,
+  buildSampleTelemetryPayload,
+  enqueueTelemetry,
+  flushTelemetryQueue,
+  updateTelemetryConsent,
+} from '../utils/telemetry';
+
+describe('telemetry consent pipeline', () => {
+  beforeEach(() => {
+    __resetTelemetryStateForTests();
+    (global as any).fetch = jest.fn().mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    delete (global as any).fetch;
+  });
+
+  it('sends events only when consented', async () => {
+    updateTelemetryConsent({ performance: false, errors: false, features: false });
+    enqueueTelemetry('performance', { frameTime: 16, sessionId: 'abc123' });
+    await flushTelemetryQueue();
+    expect((global.fetch as jest.Mock)).not.toHaveBeenCalled();
+
+    updateTelemetryConsent({ performance: true, errors: false, features: false });
+    enqueueTelemetry('performance', { frameTime: 18, sessionId: 'def456' });
+    await flushTelemetryQueue();
+
+    expect((global.fetch as jest.Mock)).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(((global.fetch as jest.Mock).mock.calls[0][1]!.body as string) ?? '{}');
+    expect(body.category).toBe('performance');
+    expect(body.payload.sessionId).toBe('[redacted]');
+  });
+
+  it('clears queued events when consent is revoked', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('network down'));
+    updateTelemetryConsent({ performance: true, errors: false, features: false });
+    enqueueTelemetry('performance', { frameTime: 20, sessionId: 'ghi789' });
+    await flushTelemetryQueue();
+
+    expect((global.fetch as jest.Mock)).toHaveBeenCalledTimes(1);
+
+    updateTelemetryConsent({ performance: false, errors: false, features: false });
+    (global.fetch as jest.Mock).mockClear().mockResolvedValue({ ok: true });
+    await flushTelemetryQueue();
+
+    expect((global.fetch as jest.Mock)).not.toHaveBeenCalled();
+  });
+});
+
+describe('telemetry preview', () => {
+  it('redacts sensitive fields in sample payloads', () => {
+    const sample = buildSampleTelemetryPayload('errors');
+    expect(sample.payload.sessionId).toBe('[redacted]');
+    expect(sample.payload.userEmail).toBe('[redacted]');
+    expect(JSON.stringify(sample)).not.toContain('operator@example.com');
+  });
+});

--- a/pages/api/telemetry.ts
+++ b/pages/api/telemetry.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type TelemetryResponse = {
+  status: 'ok';
+  received: string | null;
+  accepted: boolean;
+};
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<TelemetryResponse | { status: 'method_not_allowed' }>,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ status: 'method_not_allowed' });
+    return;
+  }
+
+  const category = typeof req.body?.category === 'string' ? req.body.category : null;
+
+  res.status(200).json({ status: 'ok', received: category, accepted: true });
+}

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,20 +1,41 @@
+import { enqueueTelemetry } from './telemetry'
+
 const loggedMessages = new Set()
 
-const formatKey = (args) => args
-  .map(a => {
-    if (a instanceof Error) {
-      return a.stack || a.message
-    }
-    if (typeof a === 'object') {
-      try {
-        return JSON.stringify(a)
-      } catch {
-        return String(a)
+const formatKey = (args) =>
+  args
+    .map((a) => {
+      if (a instanceof Error) {
+        return a.stack || a.message
       }
+      if (typeof a === 'object') {
+        try {
+          return JSON.stringify(a)
+        } catch {
+          return String(a)
+        }
+      }
+      return String(a)
+    })
+    .join(' ')
+
+const normalizeArg = (arg) => {
+  if (arg instanceof Error) {
+    return {
+      name: arg.name,
+      message: arg.message,
+      stack: typeof arg.stack === 'string' ? arg.stack.split('\n').slice(0, 5) : [],
     }
-    return String(a)
-  })
-  .join(' ')
+  }
+  if (typeof arg === 'object' && arg !== null) {
+    try {
+      return JSON.parse(JSON.stringify(arg))
+    } catch {
+      return { summary: String(arg) }
+    }
+  }
+  return arg
+}
 
 const logger = {
   error: (...args) => {
@@ -22,7 +43,13 @@ const logger = {
     if (loggedMessages.has(key)) return
     loggedMessages.add(key)
     console.error(...args)
-  }
+    if (typeof window !== 'undefined') {
+      enqueueTelemetry('errors', {
+        message: args.map((arg) => (arg instanceof Error ? arg.message : String(arg))).join(' '),
+        arguments: args.map(normalizeArg),
+      })
+    }
+  },
 }
 
 export default logger

--- a/utils/reportWebVitals.ts
+++ b/utils/reportWebVitals.ts
@@ -1,4 +1,5 @@
 import ReactGA from 'react-ga4';
+import { enqueueTelemetry } from './telemetry';
 
 interface WebVitalMetric {
   id: string;
@@ -16,6 +17,7 @@ export const reportWebVitals = ({ id, name, value }: WebVitalMetric): void => {
   if (name !== 'LCP' && name !== 'INP') return;
 
   const rounded = Math.round(value);
+  const threshold = thresholds[name];
 
   ReactGA.event({
     category: 'Web Vitals',
@@ -25,7 +27,13 @@ export const reportWebVitals = ({ id, name, value }: WebVitalMetric): void => {
     nonInteraction: true,
   });
 
-  const threshold = thresholds[name];
+  enqueueTelemetry('performance', {
+    metric: name,
+    value: rounded,
+    metricId: id,
+    threshold,
+    aboveThreshold: threshold !== undefined ? value > threshold : false,
+  });
   if (threshold !== undefined && value > threshold) {
     ReactGA.event({
       category: 'Performance Alert',

--- a/utils/telemetry.ts
+++ b/utils/telemetry.ts
@@ -1,0 +1,254 @@
+import { defaultTelemetry } from './settingsStore';
+
+type TelemetryCategory = 'performance' | 'errors' | 'features';
+
+type TelemetryConsent = Record<TelemetryCategory, boolean>;
+
+type TelemetryPayload = Record<string, unknown>;
+
+interface TelemetryEvent {
+  category: TelemetryCategory;
+  timestamp: string;
+  context: {
+    route: string;
+    locale: string;
+    appVersion: string;
+  };
+  payload: TelemetryPayload;
+}
+
+interface SampleDefinition {
+  title: string;
+  description: string;
+  payload: TelemetryPayload;
+}
+
+const REDACTED_VALUE = '[redacted]';
+
+const SENSITIVE_KEYS = new Set([
+  'sessionid',
+  'userid',
+  'useremail',
+  'email',
+  'userhandle',
+  'accountid',
+  'deviceid',
+  'auth',
+  'token',
+  'apikey',
+]);
+
+const SAMPLE_DEFINITIONS: Record<TelemetryCategory, SampleDefinition> = {
+  performance: {
+    title: 'Performance diagnostics',
+    description:
+      'Frame timings and resource counts help highlight slow screens without storing personal data.',
+    payload: {
+      sessionId: '1a2b3c',
+      route: '/apps/terminal',
+      lcp: 2130,
+      hydrationDurationMs: 420,
+      assetCount: 37,
+      deviceProfile: 'desktop',
+    },
+  },
+  errors: {
+    title: 'Crash reports',
+    description:
+      'Redacted stack traces capture the origin of a failure so we can fix it quickly.',
+    payload: {
+      sessionId: '1a2b3c',
+      userEmail: 'operator@example.com',
+      message: 'Cannot read properties of undefined',
+      componentStack: ['Desktop', 'WindowManager', 'TerminalApp'],
+      stack:
+        'TypeError: Cannot read properties of undefined\n    at Terminal.js:42:12\n    at commitHookEffectListMount',
+    },
+  },
+  features: {
+    title: 'Feature adoption',
+    description:
+      'Counts how often core tools are used so we focus on the right improvements.',
+    payload: {
+      sessionId: '1a2b3c',
+      userHandle: '@operator',
+      feature: 'launcher.open',
+      intent: 'launch-app',
+      surface: 'dock',
+    },
+  },
+};
+
+const DEFAULT_CONSENT: TelemetryConsent = { ...defaultTelemetry };
+
+let consentState: TelemetryConsent = { ...DEFAULT_CONSENT };
+let queue: TelemetryEvent[] = [];
+let flushing = false;
+
+const listeners = new Set<(consent: TelemetryConsent) => void>();
+
+const getGlobalFetch = (): typeof fetch | null => {
+  if (typeof fetch === 'function') return fetch;
+  if (typeof globalThis !== 'undefined' && typeof (globalThis as any).fetch === 'function') {
+    return (globalThis as any).fetch;
+  }
+  return null;
+};
+
+const shouldRedactKey = (key: string): boolean => {
+  if (!key) return false;
+  const normalized = key.toLowerCase();
+  if (SENSITIVE_KEYS.has(normalized)) return true;
+  return normalized.includes('session') || normalized.includes('user');
+};
+
+const sanitizeValue = (value: unknown, key: string): unknown => {
+  if (value == null) return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item, key));
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).map(([entryKey, entryValue]) => [
+      entryKey,
+      sanitizeValue(entryValue, entryKey),
+    ]);
+    return Object.fromEntries(entries);
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    if (shouldRedactKey(key) || (typeof value === 'string' && value.includes('@'))) {
+      return REDACTED_VALUE;
+    }
+  }
+  return value;
+};
+
+export const sanitizeTelemetryPayload = (payload: TelemetryPayload): TelemetryPayload => {
+  const entries = Object.entries(payload).map(([key, value]) => [key, sanitizeValue(value, key)]);
+  return Object.fromEntries(entries);
+};
+
+const getContext = () => {
+  if (typeof window === 'undefined') {
+    return {
+      route: '/server',
+      locale: 'en-US',
+      appVersion: 'desktop-sim',
+    };
+  }
+  const route = window.location?.pathname || '/';
+  const locale = navigator?.language || 'en-US';
+  return {
+    route,
+    locale,
+    appVersion: 'desktop-sim',
+  };
+};
+
+const createEvent = (
+  category: TelemetryCategory,
+  payload: TelemetryPayload,
+): TelemetryEvent => ({
+  category,
+  timestamp: new Date().toISOString(),
+  context: getContext(),
+  payload: sanitizeTelemetryPayload(payload),
+});
+
+const processQueue = async () => {
+  if (flushing) return;
+  flushing = true;
+  try {
+    const transport = getGlobalFetch();
+    if (!transport) {
+      queue = [];
+      return;
+    }
+    while (queue.length > 0) {
+      const event = queue.shift()!;
+      if (!consentState[event.category]) {
+        continue;
+      }
+      try {
+        await transport('/api/telemetry', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(event),
+          keepalive: true,
+        });
+      } catch (error) {
+        queue.unshift(event);
+        if (typeof console !== 'undefined') {
+          console.debug('Telemetry send failed, will retry later', error);
+        }
+        break;
+      }
+    }
+  } finally {
+    flushing = false;
+  }
+};
+
+export const enqueueTelemetry = (
+  category: TelemetryCategory,
+  payload: TelemetryPayload,
+): void => {
+  if (typeof window === 'undefined') return;
+  queue.push(createEvent(category, payload));
+  void processQueue();
+};
+
+export const updateTelemetryConsent = (nextConsent: TelemetryConsent): void => {
+  consentState = { ...nextConsent };
+  queue = queue.filter((event) => consentState[event.category]);
+  listeners.forEach((listener) => listener(consentState));
+  void processQueue();
+};
+
+export const getTelemetryConsent = (): TelemetryConsent => ({ ...consentState });
+
+export const subscribeToTelemetryConsent = (
+  listener: (consent: TelemetryConsent) => void,
+): (() => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+export const flushTelemetryQueue = async (): Promise<void> => {
+  await processQueue();
+};
+
+export const buildSampleTelemetryPayload = (
+  category: TelemetryCategory,
+): TelemetryEvent => {
+  const sample = SAMPLE_DEFINITIONS[category];
+  return createEvent(category, sample.payload);
+};
+
+export const TELEMETRY_CATEGORY_INFO: Record<
+  TelemetryCategory,
+  { title: string; description: string }
+> = Object.fromEntries(
+  (Object.entries(SAMPLE_DEFINITIONS) as [TelemetryCategory, SampleDefinition][]).map(
+    ([category, definition]) => [
+      category,
+      {
+        title: definition.title,
+        description: definition.description,
+      },
+    ],
+  ),
+) as Record<TelemetryCategory, { title: string; description: string }>;
+
+export const recordFeatureUsage = (feature: string, extra: TelemetryPayload = {}) => {
+  enqueueTelemetry('features', { feature, ...extra });
+};
+
+export const __resetTelemetryStateForTests = () => {
+  consentState = { ...DEFAULT_CONSENT };
+  queue = [];
+  flushing = false;
+};
+
+export type { TelemetryCategory, TelemetryConsent, TelemetryEvent };


### PR DESCRIPTION
## Summary
- add telemetry consent toggles with redacted preview to the Settings privacy tab
- persist telemetry preferences, update the telemetry pipeline, and hook it into web vitals and error logging
- add an API stub plus unit tests covering consent handling and sample payload redaction

## Testing
- yarn lint
- yarn test telemetry

------
https://chatgpt.com/codex/tasks/task_e_68dc626cc3e4832884f97e67a5d23139