### PR TITLE
[apps] add shared run history with rerun support

### DIFF
--- a/__tests__/runHistory.test.ts
+++ b/__tests__/runHistory.test.ts
@@ -1,0 +1,67 @@
+import { performance } from 'perf_hooks';
+import {
+  addRunHistoryEntry,
+  filterHistoryEntries,
+  getLastRunForTool,
+  prepareHistoryEntries,
+  resetRunHistory,
+} from '../utils/runHistory';
+
+describe('run history utilities', () => {
+  beforeEach(() => {
+    resetRunHistory();
+  });
+
+  it('filters 500 entries in under 100ms with combined filters', () => {
+    const base = Date.now();
+    const entries = Array.from({ length: 500 }, (_, idx) => ({
+      id: `run-${idx}`,
+      tool: idx % 3 === 0 ? 'nmap' : idx % 3 === 1 ? 'hydra' : 'hashcat',
+      command: `command ${idx}`,
+      summary: `summary ${idx}`,
+      createdAt: base - idx * 1000,
+      tags: [`tag${idx % 10}`, idx % 2 === 0 ? 'fast' : 'slow'],
+      notes: idx % 7 === 0 ? 'important run' : '',
+      options: { index: idx },
+    }));
+
+    const prepared = prepareHistoryEntries(entries);
+
+    const start = performance.now();
+    const filtered = filterHistoryEntries(prepared, {
+      query: 'command',
+      tags: ['tag1'],
+      tool: 'hydra',
+      tools: undefined,
+    });
+    const duration = performance.now() - start;
+
+    expect(duration).toBeLessThan(100);
+    expect(filtered.every((entry) => entry.tool === 'hydra')).toBe(true);
+    expect(filtered.every((entry) => entry.searchText.includes('command'))).toBe(
+      true
+    );
+  });
+
+  it('returns the latest options snapshot for reruns', () => {
+    addRunHistoryEntry({
+      tool: 'hydra',
+      summary: 'Initial hydra run',
+      command: 'hydra -L users -P passes ssh://target',
+      createdAt: Date.now() - 5000,
+      tags: ['ssh'],
+      options: { target: 'first', service: 'ssh' },
+    });
+    const latest = addRunHistoryEntry({
+      tool: 'hydra',
+      summary: 'Hydra retry',
+      command: 'hydra -L better -P better ftp://internal',
+      tags: ['ftp'],
+      options: { target: 'internal', service: 'ftp', selectedUser: 'better' },
+    });
+
+    const run = getLastRunForTool('hydra');
+    expect(run?.id).toEqual(latest.id);
+    expect(run?.options).toEqual(latest.options);
+  });
+});

--- a/components/common/RunHistory.tsx
+++ b/components/common/RunHistory.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  RunHistoryEntry,
+  RunTool,
+  filterHistoryEntries,
+  prepareHistoryEntries,
+  subscribeRunHistory,
+} from '../../utils/runHistory';
+
+export interface RunHistoryProps {
+  tools?: RunTool[];
+  onRerun?: Partial<Record<RunTool, (entry: RunHistoryEntry) => void>>;
+  className?: string;
+  emptyMessage?: string;
+}
+
+const toolLabels: Record<RunTool, string> = {
+  nmap: 'Nmap',
+  hydra: 'Hydra',
+  hashcat: 'Hashcat',
+};
+
+const formatTimestamp = (timestamp: number) => {
+  const date = new Date(timestamp);
+  return `${date.toLocaleTimeString()} · ${date.toLocaleDateString()}`;
+};
+
+const RunHistory: React.FC<RunHistoryProps> = ({
+  tools,
+  onRerun = {},
+  className = '',
+  emptyMessage = 'No runs logged yet.',
+}) => {
+  const [entries, setEntries] = useState<RunHistoryEntry[]>([]);
+  const [query, setQuery] = useState('');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [toolFilter, setToolFilter] = useState<RunTool | 'all'>(
+    tools && tools.length === 1 ? tools[0] : 'all'
+  );
+  const searchId = useMemo(
+    () => `run-history-search-${Math.random().toString(36).slice(2, 9)}`,
+    []
+  );
+
+  useEffect(() => {
+    return subscribeRunHistory(setEntries);
+  }, []);
+
+  useEffect(() => {
+    if (tools && tools.length === 1) {
+      setToolFilter(tools[0]);
+    }
+  }, [tools]);
+
+  const prepared = useMemo(() => prepareHistoryEntries(entries), [entries]);
+
+  const availableTags = useMemo(() => {
+    const tagSet = new Set<string>();
+    prepared.forEach((entry) => {
+      entry.tags.forEach((tag) => tagSet.add(tag));
+    });
+    return Array.from(tagSet).sort((a, b) => a.localeCompare(b));
+  }, [prepared]);
+
+  const filtered = useMemo(
+    () =>
+      filterHistoryEntries(prepared, {
+        query,
+        tags: selectedTags,
+        tool: toolFilter,
+        tools,
+      }),
+    [prepared, query, selectedTags, toolFilter, tools]
+  );
+
+  const groupedByDay = useMemo(() => {
+    const grouped = new Map<string, typeof filtered>();
+    filtered.forEach((entry) => {
+      const key = new Date(entry.createdAt).toDateString();
+      if (!grouped.has(key)) {
+        grouped.set(key, []);
+      }
+      grouped.get(key)?.push(entry);
+    });
+    return grouped;
+  }, [filtered]);
+
+  const sortedDays = useMemo(
+    () =>
+      Array.from(groupedByDay.keys()).sort(
+        (a, b) => new Date(b).getTime() - new Date(a).getTime()
+      ),
+    [groupedByDay]
+  );
+
+  const toggleTag = (tag: string) => {
+    setSelectedTags((prev) =>
+      prev.includes(tag)
+        ? prev.filter((t) => t !== tag)
+        : [...prev, tag]
+    );
+  };
+
+  const handleRerun = (entry: RunHistoryEntry) => {
+    const rerun = onRerun[entry.tool];
+    if (rerun) {
+      rerun(entry);
+    }
+  };
+
+  return (
+    <div
+      className={`bg-gray-900 text-white border border-gray-700 rounded-md p-3 space-y-3 ${className}`.trim()}
+    >
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+        <label className="sr-only" htmlFor={searchId}>
+          Search run history
+        </label>
+        <input
+          id={searchId}
+          type="search"
+          placeholder="Search history"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label="Search run history"
+          className="flex-1 rounded bg-gray-800 border border-gray-700 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ub-yellow"
+        />
+        {(tools?.length || 0) !== 1 && (
+          <select
+            value={toolFilter}
+            onChange={(e) => setToolFilter(e.target.value as RunTool | 'all')}
+            aria-label="Filter history by tool"
+            className="rounded bg-gray-800 border border-gray-700 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ub-yellow"
+          >
+            <option value="all">All tools</option>
+            {(['nmap', 'hydra', 'hashcat'] as RunTool[])
+              .filter((tool) => !tools || tools.includes(tool))
+              .map((tool) => (
+                <option key={tool} value={tool}>
+                  {toolLabels[tool]}
+                </option>
+              ))}
+          </select>
+        )}
+      </div>
+      {availableTags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {availableTags.map((tag) => {
+            const active = selectedTags.includes(tag);
+            return (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => toggleTag(tag)}
+                className={`px-2 py-1 rounded-full text-xs transition-colors ${
+                  active
+                    ? 'bg-ub-yellow text-black'
+                    : 'bg-gray-800 border border-gray-700'
+                }`}
+              >
+                #{tag}
+              </button>
+            );
+          })}
+        </div>
+      )}
+      {filtered.length === 0 ? (
+        <p className="text-sm text-gray-400">{emptyMessage}</p>
+      ) : (
+        <div className="space-y-4 max-h-96 overflow-y-auto pr-1">
+          {sortedDays.map((day) => (
+            <div key={day} className="space-y-2">
+              <h3 className="text-xs uppercase tracking-wide text-gray-400">
+                {day}
+              </h3>
+              <ul className="space-y-2">
+                {(groupedByDay.get(day) || []).map((entry) => (
+                  <li
+                    key={entry.id}
+                    className="border border-gray-800 rounded-md p-3 bg-gray-950"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <div>
+                        <p className="text-sm font-semibold">
+                          {entry.summary || entry.command}
+                        </p>
+                        <p className="text-xs text-gray-400">
+                          {toolLabels[entry.tool]} · {formatTimestamp(entry.createdAt)}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleRerun(entry)}
+                        className="text-xs px-2 py-1 bg-ub-yellow text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+                      >
+                        Re-run
+                      </button>
+                    </div>
+                    <pre className="mt-2 text-xs bg-gray-900 p-2 rounded border border-gray-800 whitespace-pre-wrap break-words">
+                      {entry.command}
+                    </pre>
+                    {entry.notes && (
+                      <p className="mt-2 text-xs text-gray-300">{entry.notes}</p>
+                    )}
+                    {entry.tags.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-1">
+                        {entry.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="px-2 py-0.5 bg-gray-800 border border-gray-700 rounded-full text-[10px]"
+                          >
+                            #{tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RunHistory;

--- a/utils/runHistory.ts
+++ b/utils/runHistory.ts
@@ -1,0 +1,193 @@
+import { safeLocalStorage } from './safeStorage';
+
+export type RunTool = 'nmap' | 'hydra' | 'hashcat';
+
+export interface RunHistoryEntry {
+  id: string;
+  tool: RunTool;
+  command: string;
+  summary: string;
+  createdAt: number;
+  tags: string[];
+  notes?: string;
+  options: Record<string, unknown>;
+}
+
+const STORAGE_KEY = 'kali/run-history/v1';
+
+let cache: RunHistoryEntry[] = [];
+let loaded = false;
+const listeners = new Set<(entries: RunHistoryEntry[]) => void>();
+
+const createId = () => {
+  const cryptoApi =
+    typeof globalThis !== 'undefined' && 'crypto' in globalThis
+      ? (globalThis as typeof globalThis & {
+          crypto?: { randomUUID?: () => string };
+        }).crypto
+      : undefined;
+  if (cryptoApi && 'randomUUID' in cryptoApi) {
+    return cryptoApi.randomUUID();
+  }
+  return `run-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const normaliseTags = (tags?: string[]): string[] => {
+  if (!Array.isArray(tags)) return [];
+  const seen = new Set<string>();
+  const next: string[] = [];
+  tags.forEach((tag) => {
+    if (!tag) return;
+    const trimmed = tag.trim();
+    if (trimmed) {
+      const key = trimmed.toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
+        next.push(trimmed);
+      }
+    }
+  });
+  return next;
+};
+
+const normaliseEntry = (entry: Partial<RunHistoryEntry>): RunHistoryEntry => ({
+  id: entry.id || createId(),
+  tool: entry.tool || 'nmap',
+  command: entry.command || '',
+  summary: entry.summary || entry.command || 'Run',
+  createdAt: entry.createdAt || Date.now(),
+  tags: normaliseTags(entry.tags),
+  notes: entry.notes || '',
+  options: entry.options || {},
+});
+
+const ensureLoaded = () => {
+  if (loaded) return;
+  loaded = true;
+  if (!safeLocalStorage) {
+    cache = [];
+    return;
+  }
+  try {
+    const raw = safeLocalStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      cache = [];
+      return;
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      cache = [];
+      return;
+    }
+    cache = parsed
+      .map((entry) => normaliseEntry(entry))
+      .sort((a, b) => b.createdAt - a.createdAt);
+  } catch {
+    cache = [];
+  }
+};
+
+const persist = () => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+  } catch {
+    // ignore quota errors
+  }
+};
+
+const notify = () => {
+  const snapshot = cache.slice();
+  listeners.forEach((listener) => listener(snapshot));
+};
+
+export const getRunHistory = (): RunHistoryEntry[] => {
+  ensureLoaded();
+  return cache.slice();
+};
+
+export const addRunHistoryEntry = (
+  entry: Partial<RunHistoryEntry>
+): RunHistoryEntry => {
+  ensureLoaded();
+  const normalised = normaliseEntry(entry);
+  cache = [normalised, ...cache].sort((a, b) => b.createdAt - a.createdAt);
+  if (cache.length > 1000) {
+    cache = cache.slice(0, 1000);
+  }
+  persist();
+  notify();
+  return normalised;
+};
+
+export const subscribeRunHistory = (
+  listener: (entries: RunHistoryEntry[]) => void
+): (() => void) => {
+  ensureLoaded();
+  listeners.add(listener);
+  listener(cache.slice());
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const getLastRunForTool = (
+  tool: RunTool
+): RunHistoryEntry | undefined => {
+  ensureLoaded();
+  return cache.find((entry) => entry.tool === tool);
+};
+
+export const resetRunHistory = () => {
+  ensureLoaded();
+  cache = [];
+  persist();
+  notify();
+};
+
+export const prepareHistoryEntries = (
+  entries: RunHistoryEntry[]
+): Array<RunHistoryEntry & { searchText: string }> =>
+  entries.map((entry) => ({
+    ...entry,
+    searchText: [
+      entry.summary,
+      entry.command,
+      entry.tool,
+      entry.tags.join(' '),
+      entry.notes || '',
+    ]
+      .join(' ')
+      .toLowerCase(),
+  }));
+
+export interface HistoryFilterParams {
+  query: string;
+  tags: string[];
+  tool: RunTool | 'all';
+  tools?: RunTool[];
+}
+
+export const filterHistoryEntries = <T extends { searchText: string; tool: RunTool; tags: string[] }>(
+  entries: T[],
+  { query, tags, tool, tools }: HistoryFilterParams
+): T[] => {
+  const loweredQuery = query.trim().toLowerCase();
+  const tagSet = new Set(tags.map((t) => t.toLowerCase()));
+  return entries.filter((entry) => {
+    if (tools && tools.length && !tools.includes(entry.tool)) {
+      return false;
+    }
+    if (tool !== 'all' && entry.tool !== tool) {
+      return false;
+    }
+    if (tagSet.size > 0) {
+      const hasTag = entry.tags.some((tag) => tagSet.has(tag));
+      if (!hasTag) return false;
+    }
+    if (loweredQuery && !entry.searchText.includes(loweredQuery)) {
+      return false;
+    }
+    return true;
+  });
+};


### PR DESCRIPTION
## Summary
- introduce a shared run history store and reusable timeline component
- log Hydra, Hashcat, and Nmap runs with notes, tags, and rerun actions
- add unit coverage for filtering performance and rerun metadata restores

## Testing
- yarn lint
- yarn test runHistory

------
https://chatgpt.com/codex/tasks/task_e_68dc6272c3808328b9a93ec52ea0072e