### PR TITLE
[file-explorer] add recycle bin with undo support

### DIFF
--- a/__tests__/fileExplorer.recycle.test.ts
+++ b/__tests__/fileExplorer.recycle.test.ts
@@ -1,0 +1,192 @@
+import {
+  persistSoftDelete,
+  restoreEntry,
+  purgeExpiredEntries,
+  loadBinEntries,
+} from '../components/apps/file-explorer/recycleBin';
+
+const BIN_STORE = 'bin';
+
+class FakeFile {
+  private content: string;
+  size: number;
+
+  constructor(content: string) {
+    this.content = content;
+    this.size = new TextEncoder().encode(content).length;
+  }
+
+  async text() {
+    return this.content;
+  }
+}
+
+async function toStringValue(input: any): Promise<string> {
+  if (typeof input === 'string') return input;
+  if (input instanceof ArrayBuffer) return new TextDecoder().decode(input);
+  if (ArrayBuffer.isView(input)) return new TextDecoder().decode(input);
+  if (input && typeof input.text === 'function') return input.text();
+  if (input instanceof Blob) return input.text();
+  return String(input ?? '');
+}
+
+class FakeFileHandle {
+  name: string;
+  private content: string;
+
+  constructor(name: string, initialContent: string) {
+    this.name = name;
+    this.content = initialContent;
+  }
+
+  async getFile() {
+    return new FakeFile(this.content);
+  }
+
+  async createWritable() {
+    return {
+      write: async (input: any) => {
+        this.content = await toStringValue(input);
+      },
+      close: async () => {},
+    };
+  }
+}
+
+class FakeDirectoryHandle {
+  name: string;
+  files: Map<string, FakeFileHandle> = new Map();
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  async getFileHandle(name: string, options: { create?: boolean } = {}) {
+    if (this.files.has(name)) return this.files.get(name)!;
+    if (options.create) {
+      const handle = new FakeFileHandle(name, '');
+      this.files.set(name, handle);
+      return handle;
+    }
+    throw new Error(`File ${name} not found`);
+  }
+
+  async removeEntry(name: string) {
+    if (!this.files.delete(name)) {
+      throw new Error(`File ${name} not found`);
+    }
+  }
+
+  async requestPermission() {
+    return 'granted';
+  }
+}
+
+function createDb(initial: any[] = []) {
+  const store = new Map(initial.map((entry) => [entry.id, entry]));
+  return {
+    async getAll(name: string) {
+      if (name !== BIN_STORE) throw new Error('Unexpected store');
+      return Array.from(store.values());
+    },
+    async put(name: string, value: any) {
+      if (name !== BIN_STORE) throw new Error('Unexpected store');
+      store.set(value.id, value);
+    },
+    async delete(name: string, key: string) {
+      if (name !== BIN_STORE) throw new Error('Unexpected store');
+      store.delete(key);
+    },
+  };
+}
+
+describe('recycle bin operations', () => {
+  it('soft deletes files into recycle bin and records metadata', async () => {
+    const directory = new FakeDirectoryHandle('root');
+    const original = new FakeFileHandle('notes.txt', 'hello world');
+    directory.files.set('notes.txt', original);
+    const recycleDir = new FakeDirectoryHandle('bin');
+    const db = createDb();
+
+    const entry = await persistSoftDelete({
+      fileEntry: { name: 'notes.txt', handle: original },
+      directoryHandle: directory as any,
+      recycleDir: recycleDir as any,
+      dbPromise: Promise.resolve(db as any),
+      pathSegments: ['root'],
+      now: 1234,
+      makeId: () => 'entry-1',
+    });
+
+    expect(entry).toMatchObject({
+      id: 'entry-1',
+      name: 'notes.txt',
+      originalPath: 'root/notes.txt',
+      deletedAt: 1234,
+    });
+    expect(entry.size).toBe((await original.getFile()).size);
+    expect(directory.files.has('notes.txt')).toBe(false);
+    expect(recycleDir.files.has('entry-1-notes.txt')).toBe(true);
+
+    const stored = await loadBinEntries(Promise.resolve(db as any));
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe('entry-1');
+  });
+
+  it('restores soft deleted entries to original directory', async () => {
+    const directory = new FakeDirectoryHandle('docs');
+    const original = new FakeFileHandle('report.md', 'draft');
+    directory.files.set('report.md', original);
+    const recycleDir = new FakeDirectoryHandle('bin');
+    const db = createDb();
+
+    const entry = await persistSoftDelete({
+      fileEntry: { name: 'report.md', handle: original },
+      directoryHandle: directory as any,
+      recycleDir: recycleDir as any,
+      dbPromise: Promise.resolve(db as any),
+      pathSegments: ['docs'],
+      now: 2000,
+      makeId: () => 'entry-2',
+    });
+
+    await restoreEntry(entry, { recycleDir: recycleDir as any, dbPromise: Promise.resolve(db as any) });
+
+    const restoredHandle = await directory.getFileHandle('report.md');
+    expect(await (await restoredHandle.getFile()).text()).toBe('draft');
+    expect(recycleDir.files.has('entry-2-report.md')).toBe(false);
+    const stored = await loadBinEntries(Promise.resolve(db as any));
+    expect(stored).toHaveLength(0);
+  });
+
+  it('purges entries past retention period', async () => {
+    const recycleDir = new FakeDirectoryHandle('bin');
+    recycleDir.files.set('old-file', new FakeFileHandle('old-file', 'old'));
+    recycleDir.files.set('recent-file', new FakeFileHandle('recent-file', 'new'));
+    const oldEntry = {
+      id: 'old',
+      name: 'old.txt',
+      binFileName: 'old-file',
+      deletedAt: 0,
+    };
+    const recentEntry = {
+      id: 'recent',
+      name: 'recent.txt',
+      binFileName: 'recent-file',
+      deletedAt: Date.now(),
+    };
+    const db = createDb([oldEntry, recentEntry]);
+
+    const { purged, remaining } = await purgeExpiredEntries({
+      recycleDir: recycleDir as any,
+      dbPromise: Promise.resolve(db as any),
+      retentionMs: 100,
+      now: 200,
+    });
+
+    expect(purged.map((entry) => entry.id)).toEqual(['old']);
+    expect(remaining.map((entry) => entry.id)).toEqual(['recent']);
+    expect(recycleDir.files.has('old-file')).toBe(false);
+    expect(recycleDir.files.has('recent-file')).toBe(true);
+  });
+});

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -1,9 +1,19 @@
 "use client";
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 import { getDb } from '../../utils/safeIDB';
 import Breadcrumbs from '../ui/Breadcrumbs';
+import { formatBytes } from './converter/format';
+import {
+  loadBinEntries,
+  persistSoftDelete,
+  restoreEntry,
+  removeEntry,
+  emptyBin,
+  purgeExpiredEntries,
+  BIN_STORE,
+} from './file-explorer/recycleBin';
 
 export async function openFileDialog(options = {}) {
   if (typeof window !== 'undefined' && window.showOpenFilePicker) {
@@ -61,11 +71,18 @@ export async function saveFileDialog(options = {}) {
 
 const DB_NAME = 'file-explorer';
 const STORE_NAME = 'recent';
+const BIN_RETENTION_KEY = 'trash-purge-days';
+const DEFAULT_RETENTION_DAYS = 30;
 
 function openDB() {
-  return getDb(DB_NAME, 1, {
-    upgrade(db) {
-      db.createObjectStore(STORE_NAME, { autoIncrement: true });
+  return getDb(DB_NAME, 2, {
+    upgrade(db, oldVersion) {
+      if (oldVersion < 1 && !db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { autoIncrement: true });
+      }
+      if (!db.objectStoreNames.contains(BIN_STORE)) {
+        db.createObjectStore(BIN_STORE, { keyPath: 'id' });
+      }
     },
   });
 }
@@ -105,6 +122,11 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
   const workerRef = useRef(null);
   const fallbackInputRef = useRef(null);
   const [locationError, setLocationError] = useState(null);
+  const [recycleDir, setRecycleDir] = useState(null);
+  const [binItems, setBinItems] = useState([]);
+  const [showBin, setShowBin] = useState(false);
+  const undoTimeoutRef = useRef(null);
+  const [undoEntry, setUndoEntry] = useState(null);
 
   const hasWorker = typeof Worker !== 'undefined';
   const {
@@ -116,6 +138,19 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
     deleteFile: opfsDelete,
   } = useOPFS();
   const [unsavedDir, setUnsavedDir] = useState(null);
+  const dbPromiseRef = useRef(null);
+
+  if (!dbPromiseRef.current) {
+    dbPromiseRef.current = openDB();
+  }
+
+  const dbPromise = dbPromiseRef.current;
+
+  const binSummary = useMemo(() => {
+    const count = binItems.length;
+    const totalSize = binItems.reduce((sum, item) => sum + (item.size || 0), 0);
+    return { count, totalSize };
+  }, [binItems]);
 
   useEffect(() => {
     const ok = !!window.showDirectoryPicker;
@@ -130,8 +165,51 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
       setDirHandle(root);
       setPath([{ name: root.name || '/', handle: root }]);
       await readDir(root);
+      setRecycleDir(await getDir('recycle-bin'));
     })();
-  }, [opfsSupported, root, getDir]);
+  }, [opfsSupported, root, getDir, readDir]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!dbPromise) return;
+    (async () => {
+      const entries = await loadBinEntries(dbPromise);
+      if (!cancelled) setBinItems(entries);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [dbPromise]);
+
+  const purgeBin = useCallback(async () => {
+    if (!dbPromise) return;
+    const retentionDays = parseInt(
+      (typeof window !== 'undefined' && window.localStorage?.getItem(BIN_RETENTION_KEY)) ||
+        `${DEFAULT_RETENTION_DAYS}`,
+      10,
+    );
+    const retentionMs = retentionDays * 24 * 60 * 60 * 1000;
+    const { remaining } = await purgeExpiredEntries({
+      recycleDir,
+      dbPromise,
+      retentionMs,
+    });
+    setBinItems(remaining);
+    if (undoEntry && !remaining.some((item) => item.id === undoEntry.id)) {
+      if (undoTimeoutRef.current) {
+        clearTimeout(undoTimeoutRef.current);
+        undoTimeoutRef.current = null;
+      }
+      setUndoEntry(null);
+    }
+  }, [dbPromise, recycleDir, undoEntry]);
+
+  useEffect(() => {
+    if (!dbPromise) return;
+    purgeBin();
+    const interval = setInterval(purgeBin, 60 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [dbPromise, purgeBin]);
 
   const saveBuffer = async (name, data) => {
     if (unsavedDir) await opfsWrite(name, data, unsavedDir);
@@ -145,6 +223,12 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
   const removeBuffer = async (name) => {
     if (unsavedDir) await opfsDelete(name, unsavedDir);
   };
+
+  const refreshBin = useCallback(async () => {
+    if (!dbPromise) return;
+    const entries = await loadBinEntries(dbPromise);
+    setBinItems(entries);
+  }, [dbPromise]);
 
   const openFallback = async (e) => {
     const file = e.target.files[0];
@@ -310,12 +394,140 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
     }
   };
 
+  const handleSoftDelete = async (file) => {
+    if (!dirHandle || !recycleDir) return;
+    if (!dbPromise) {
+      setLocationError('Recycle bin storage is unavailable.');
+      return;
+    }
+    try {
+      if (dirHandle.requestPermission) {
+        const perm = await dirHandle.requestPermission({ mode: 'readwrite' });
+        if (perm !== 'granted') {
+          setLocationError('Permission denied for deleting files.');
+          return;
+        }
+      }
+      const entry = await persistSoftDelete({
+        fileEntry: file,
+        directoryHandle: dirHandle,
+        recycleDir,
+        dbPromise,
+        pathSegments: path.map((p) => (p.name === '/' ? '' : p.name)),
+      });
+      setFiles((prev) => prev.filter((f) => f.name !== file.name));
+      setBinItems((prev) => [entry, ...prev]);
+      if (currentFile?.name === file.name) {
+        setCurrentFile(null);
+        setContent('');
+      }
+      if (opfsSupported) await removeBuffer(file.name);
+      if (undoTimeoutRef.current) clearTimeout(undoTimeoutRef.current);
+      setUndoEntry(entry);
+      undoTimeoutRef.current = setTimeout(() => {
+        setUndoEntry(null);
+        undoTimeoutRef.current = null;
+      }, 10000);
+    } catch (err) {
+      setLocationError(`Unable to delete ${file.name}`);
+      await refreshBin();
+    }
+  };
+
+  const handleRestore = async (entry) => {
+    if (!entry || !dbPromise) return;
+    try {
+      await restoreEntry(entry, { recycleDir, dbPromise });
+      if (undoEntry?.id === entry.id) {
+        clearTimeout(undoTimeoutRef.current);
+        undoTimeoutRef.current = null;
+        setUndoEntry(null);
+      }
+      setBinItems((prev) => prev.filter((item) => item.id !== entry.id));
+      if (dirHandle && entry.directoryHandle === dirHandle) {
+        await readDir(dirHandle);
+      }
+    } catch (err) {
+      setLocationError(`Unable to restore ${entry.name}`);
+      await refreshBin();
+    }
+  };
+
+  const handlePermanentDelete = async (entry) => {
+    if (!entry || !dbPromise) return;
+    try {
+      await removeEntry(entry, { recycleDir, dbPromise });
+      setBinItems((prev) => prev.filter((item) => item.id !== entry.id));
+      if (undoEntry?.id === entry.id && undoTimeoutRef.current) {
+        clearTimeout(undoTimeoutRef.current);
+        undoTimeoutRef.current = null;
+        setUndoEntry(null);
+      }
+    } catch {
+      setLocationError(`Unable to remove ${entry.name} permanently`);
+      await refreshBin();
+    }
+  };
+
+  const handleEmptyBin = async () => {
+    if (!binItems.length) return;
+    if (typeof window !== 'undefined' && !window.confirm('Permanently delete all items in the recycle bin?')) {
+      return;
+    }
+    if (!dbPromise) return;
+    try {
+      await emptyBin({ recycleDir, dbPromise });
+      setBinItems([]);
+      if (undoTimeoutRef.current) {
+        clearTimeout(undoTimeoutRef.current);
+        undoTimeoutRef.current = null;
+      }
+      setUndoEntry(null);
+    } catch {
+      setLocationError('Unable to empty recycle bin');
+      await refreshBin();
+    }
+  };
+
+  const undoDelete = async () => {
+    if (!undoEntry || !dbPromise) return;
+    try {
+      await restoreEntry(undoEntry, { recycleDir, dbPromise });
+      if (undoTimeoutRef.current) {
+        clearTimeout(undoTimeoutRef.current);
+        undoTimeoutRef.current = null;
+      }
+      setUndoEntry(null);
+      setBinItems((prev) => prev.filter((item) => item.id !== undoEntry.id));
+      if (dirHandle && undoEntry.directoryHandle === dirHandle) {
+        await readDir(dirHandle);
+      }
+    } catch {
+      setLocationError(`Unable to undo delete for ${undoEntry.name}`);
+      await refreshBin();
+    }
+  };
+
+  useEffect(
+    () => () => {
+      if (undoTimeoutRef.current) clearTimeout(undoTimeoutRef.current);
+    },
+    [],
+  );
+
   useEffect(() => () => workerRef.current?.terminate(), []);
 
   if (!supported) {
     return (
       <div className="p-4 flex flex-col h-full">
-        <input ref={fallbackInputRef} type="file" onChange={openFallback} className="hidden" />
+        <input
+          ref={fallbackInputRef}
+          type="file"
+          onChange={openFallback}
+          className="hidden"
+          aria-hidden="true"
+          tabIndex={-1}
+        />
         {!currentFile && (
           <button
             onClick={() => fallbackInputRef.current?.click()}
@@ -330,6 +542,7 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
               className="flex-1 mt-2 p-2 bg-ub-cool-grey outline-none"
               value={content}
               onChange={onChange}
+              aria-label="File contents"
             />
             <button
               onClick={async () => {
@@ -360,6 +573,12 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
           </button>
         )}
         <Breadcrumbs path={path} onNavigate={navigateTo} />
+        <button
+          onClick={() => setShowBin((prev) => !prev)}
+          className="px-2 py-1 bg-black bg-opacity-50 rounded"
+        >
+          {showBin ? 'Close Bin' : `Recycle Bin (${binSummary.count})`}
+        </button>
         {locationError && (
           <div className="text-xs text-red-300" role="status">
             {locationError}
@@ -372,62 +591,138 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
         )}
       </div>
       <div className="flex flex-1 overflow-hidden">
-        <div className="w-40 overflow-auto border-r border-gray-600">
-          <div className="p-2 font-bold">Recent</div>
-          {recent.map((r, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openRecent(r)}
-            >
-              {r.name}
+        {!showBin && (
+          <>
+            <div className="w-40 overflow-auto border-r border-gray-600">
+              <div className="p-2 font-bold">Recent</div>
+              {recent.map((r, i) => (
+                <div
+                  key={i}
+                  className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
+                  onClick={() => openRecent(r)}
+                >
+                  {r.name}
+                </div>
+              ))}
+              <div className="p-2 font-bold">Directories</div>
+              {dirs.map((d, i) => (
+                <div
+                  key={i}
+                  className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
+                  onClick={() => openDir(d)}
+                >
+                  {d.name}
+                </div>
+              ))}
+              <div className="p-2 font-bold">Files</div>
+              {files.map((f, i) => (
+                <div
+                  key={i}
+                  className="px-2 py-1 flex items-center justify-between hover:bg-black hover:bg-opacity-30"
+                >
+                  <span className="flex-1 cursor-pointer" onClick={() => openFile(f)}>
+                    {f.name}
+                  </span>
+                  <button
+                    onClick={() => handleSoftDelete(f)}
+                    className="ml-2 px-1 py-0.5 text-xs bg-red-600 bg-opacity-70 rounded"
+                  >
+                    Delete
+                  </button>
+                </div>
+              ))}
             </div>
-          ))}
-          <div className="p-2 font-bold">Directories</div>
-          {dirs.map((d, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openDir(d)}
-            >
-              {d.name}
+            <div className="flex-1 flex flex-col">
+              {currentFile && (
+                <textarea
+                  className="flex-1 p-2 bg-ub-cool-grey outline-none"
+                  value={content}
+                  onChange={onChange}
+                  aria-label="Editor contents"
+                />
+              )}
+              <div className="p-2 border-t border-gray-600">
+                <input
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Find in files"
+                  className="px-1 py-0.5 text-black"
+                  aria-label="Search within files"
+                />
+                <button onClick={runSearch} className="ml-2 px-2 py-1 bg-black bg-opacity-50 rounded">
+                  Search
+                </button>
+                <div className="max-h-40 overflow-auto mt-2">
+                  {results.map((r, i) => (
+                    <div key={i}>
+                      <span className="font-bold">{r.file}:{r.line}</span> {r.text}
+                    </div>
+                  ))}
+                </div>
+              </div>
             </div>
-          ))}
-          <div className="p-2 font-bold">Files</div>
-          {files.map((f, i) => (
-            <div
-              key={i}
-              className="px-2 cursor-pointer hover:bg-black hover:bg-opacity-30"
-              onClick={() => openFile(f)}
-            >
-              {f.name}
+          </>
+        )}
+        {showBin && (
+          <div className="flex-1 flex flex-col overflow-hidden">
+            <div className="p-2 border-b border-gray-600 flex items-center justify-between">
+              <div>
+                <div className="font-semibold">Recycle Bin</div>
+                <div className="text-xs text-gray-300">
+                  {binSummary.count} item{binSummary.count === 1 ? '' : 's'} · {formatBytes(binSummary.totalSize || 0)}
+                </div>
+              </div>
+              <button
+                onClick={handleEmptyBin}
+                className="px-2 py-1 bg-black bg-opacity-50 rounded disabled:opacity-50"
+                disabled={!binItems.length}
+              >
+                Empty Bin
+              </button>
             </div>
-          ))}
-        </div>
-        <div className="flex-1 flex flex-col">
-          {currentFile && (
-            <textarea className="flex-1 p-2 bg-ub-cool-grey outline-none" value={content} onChange={onChange} />
-          )}
-          <div className="p-2 border-t border-gray-600">
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Find in files"
-              className="px-1 py-0.5 text-black"
-            />
-            <button onClick={runSearch} className="ml-2 px-2 py-1 bg-black bg-opacity-50 rounded">
-              Search
-            </button>
-            <div className="max-h-40 overflow-auto mt-2">
-              {results.map((r, i) => (
-                <div key={i}>
-                  <span className="font-bold">{r.file}:{r.line}</span> {r.text}
+            <div className="flex-1 overflow-auto p-2 space-y-2">
+              {!binItems.length && (
+                <div className="text-center text-gray-300">No items in recycle bin.</div>
+              )}
+              {binItems.map((item) => (
+                <div key={item.id} className="bg-black bg-opacity-40 p-2 rounded flex items-center justify-between">
+                  <div>
+                    <div className="font-semibold">{item.name}</div>
+                    <div className="text-xs text-gray-300">
+                      {item.originalPath || item.name} · Deleted {new Date(item.deletedAt).toLocaleString()}
+                    </div>
+                    <div className="text-xs text-gray-400">{formatBytes(item.size || 0)}</div>
+                  </div>
+                  <div className="space-x-2">
+                    <button
+                      onClick={() => handleRestore(item)}
+                      className="px-2 py-1 bg-green-600 bg-opacity-70 rounded"
+                    >
+                      Restore
+                    </button>
+                    <button
+                      onClick={() => handlePermanentDelete(item)}
+                      className="px-2 py-1 bg-red-600 bg-opacity-70 rounded"
+                    >
+                      Delete
+                    </button>
+                  </div>
                 </div>
               ))}
             </div>
           </div>
-        </div>
+        )}
       </div>
+      {undoEntry && (
+        <div className="p-2 bg-black bg-opacity-60 flex items-center justify-between text-xs">
+          <span>
+            {undoEntry.name} moved to recycle bin. Undo available for 10 seconds.
+          </span>
+          <button onClick={undoDelete} className="px-2 py-1 bg-green-600 bg-opacity-70 rounded">
+            Undo
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/apps/file-explorer/recycleBin.js
+++ b/components/apps/file-explorer/recycleBin.js
@@ -1,0 +1,117 @@
+export const BIN_STORE = 'bin';
+
+function sortEntries(entries = []) {
+  return [...entries].sort((a, b) => (b.deletedAt || 0) - (a.deletedAt || 0));
+}
+
+export async function loadBinEntries(dbPromise) {
+  if (!dbPromise) return [];
+  try {
+    const db = await dbPromise;
+    const entries = await db.getAll(BIN_STORE);
+    return sortEntries(entries || []);
+  } catch {
+    return [];
+  }
+}
+
+async function writeToHandle(handle, data) {
+  const writable = await handle.createWritable();
+  await writable.write(data);
+  await writable.close();
+}
+
+export async function persistSoftDelete({
+  fileEntry,
+  directoryHandle,
+  recycleDir,
+  dbPromise,
+  pathSegments = [],
+  now = Date.now(),
+  makeId = () => (globalThis.crypto?.randomUUID ? globalThis.crypto.randomUUID() : `${now}-${Math.random()}`),
+}) {
+  if (!fileEntry?.handle || !directoryHandle || !recycleDir || !dbPromise) {
+    throw new Error('Recycle bin unavailable');
+  }
+  const db = await dbPromise;
+  const sourceFile = await fileEntry.handle.getFile();
+  const id = makeId();
+  const binFileName = `${id}-${fileEntry.name}`;
+  const binHandle = await recycleDir.getFileHandle(binFileName, { create: true });
+  await writeToHandle(binHandle, sourceFile);
+  try {
+    await directoryHandle.removeEntry(fileEntry.name);
+  } catch (err) {
+    await recycleDir.removeEntry(binFileName).catch(() => {});
+    throw err;
+  }
+  const path = [...pathSegments.filter(Boolean), fileEntry.name].join('/');
+  const entry = {
+    id,
+    name: fileEntry.name,
+    originalPath: path,
+    directoryHandle,
+    deletedAt: now,
+    size: sourceFile.size || 0,
+    binFileName,
+  };
+  await db.put(BIN_STORE, entry);
+  return entry;
+}
+
+export async function restoreEntry(entry, { recycleDir, dbPromise }) {
+  if (!entry || !recycleDir || !dbPromise) throw new Error('Recycle bin unavailable');
+  const db = await dbPromise;
+  const targetDir = entry.directoryHandle;
+  if (!targetDir) throw new Error('Missing original directory');
+  if (targetDir.requestPermission) {
+    const perm = await targetDir.requestPermission({ mode: 'readwrite' });
+    if (perm !== 'granted') throw new Error('Permission denied');
+  }
+  const binHandle = await recycleDir.getFileHandle(entry.binFileName);
+  const data = await binHandle.getFile();
+  const destHandle = await targetDir.getFileHandle(entry.name, { create: true });
+  await writeToHandle(destHandle, data);
+  await recycleDir.removeEntry(entry.binFileName).catch(() => {});
+  await db.delete(BIN_STORE, entry.id);
+  return true;
+}
+
+export async function removeEntry(entry, { recycleDir, dbPromise }) {
+  if (!entry || !recycleDir || !dbPromise) throw new Error('Recycle bin unavailable');
+  const db = await dbPromise;
+  await recycleDir.removeEntry(entry.binFileName).catch(() => {});
+  await db.delete(BIN_STORE, entry.id);
+  return true;
+}
+
+export async function emptyBin({ recycleDir, dbPromise }) {
+  if (!recycleDir || !dbPromise) throw new Error('Recycle bin unavailable');
+  const db = await dbPromise;
+  const entries = await db.getAll(BIN_STORE);
+  await Promise.all(
+    (entries || []).map(async (entry) => {
+      await recycleDir.removeEntry(entry.binFileName).catch(() => {});
+      await db.delete(BIN_STORE, entry.id);
+    }),
+  );
+  return true;
+}
+
+export async function purgeExpiredEntries({ recycleDir, dbPromise, retentionMs, now = Date.now() }) {
+  if (!dbPromise) return { purged: [], remaining: [] };
+  const db = await dbPromise;
+  const entries = (await db.getAll(BIN_STORE)) || [];
+  if (!entries.length) return { purged: [], remaining: [] };
+  const expired = entries.filter((entry) => now - (entry.deletedAt || 0) > retentionMs);
+  await Promise.all(
+    expired.map(async (entry) => {
+      if (recycleDir) {
+        await recycleDir.removeEntry(entry.binFileName).catch(() => {});
+      }
+      await db.delete(BIN_STORE, entry.id);
+    }),
+  );
+  const remaining = entries.filter((entry) => !expired.includes(entry));
+  return { purged: expired, remaining: sortEntries(remaining) };
+}


### PR DESCRIPTION
## Summary
- add an OPFS-backed recycle bin workflow with retention-aware auto purge and undo support in the file explorer
- surface a recycle bin view that reports item counts/size and allows restore or permanent deletion
- cover recycle bin soft delete, restore, and purge logic with unit tests

## Testing
- yarn lint
- yarn test fileExplorer.recycle


------
https://chatgpt.com/codex/tasks/task_e_68dc6273bac48328b52c64f3601c17e3