### PR TITLE
[serial-terminal] add configurable presets

### DIFF
--- a/__tests__/serialTerminal.test.tsx
+++ b/__tests__/serialTerminal.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import SerialTerminalApp from '../components/apps/serial-terminal';
+
+const STORAGE_KEY = 'serial-terminal-presets';
+
+describe('Serial terminal presets', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('saves the current configuration as a preset', () => {
+    render(<SerialTerminalApp />);
+
+    fireEvent.change(screen.getByLabelText('Baud Rate'), { target: { value: '115200' } });
+    fireEvent.change(screen.getByLabelText('Data Bits'), { target: { value: '7' } });
+    fireEvent.change(screen.getByLabelText('Parity'), { target: { value: 'even' } });
+    fireEvent.change(screen.getByLabelText('Stop Bits'), { target: { value: '2' } });
+    fireEvent.change(screen.getByLabelText('Flow Control'), { target: { value: 'hardware' } });
+    fireEvent.change(screen.getByLabelText('Preset Name'), { target: { value: 'My Preset' } });
+
+    fireEvent.click(screen.getByText('Save Preset'));
+
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    expect(stored).toBeTruthy();
+    expect(JSON.parse(stored as string)).toEqual([
+      {
+        name: 'My Preset',
+        config: {
+          baudRate: 115200,
+          dataBits: 7,
+          parity: 'even',
+          stopBits: 2,
+          flowControl: 'hardware',
+        },
+      },
+    ]);
+  });
+
+  test('loads presets from storage and applies the selected preset', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        {
+          name: 'Slow Device',
+          config: {
+            baudRate: 4800,
+            dataBits: 7,
+            parity: 'odd',
+            stopBits: 2,
+            flowControl: 'none',
+          },
+        },
+      ]),
+    );
+
+    render(<SerialTerminalApp />);
+
+    await waitFor(() => expect(screen.getByLabelText('Presets')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('Presets'), { target: { value: 'Slow Device' } });
+
+    expect((screen.getByLabelText('Baud Rate') as HTMLInputElement).value).toBe('4800');
+    expect((screen.getByLabelText('Data Bits') as HTMLSelectElement).value).toBe('7');
+    expect((screen.getByLabelText('Parity') as HTMLSelectElement).value).toBe('odd');
+    expect((screen.getByLabelText('Stop Bits') as HTMLSelectElement).value).toBe('2');
+    expect((screen.getByLabelText('Flow Control') as HTMLSelectElement).value).toBe('none');
+  });
+});

--- a/components/apps/serial-terminal.tsx
+++ b/components/apps/serial-terminal.tsx
@@ -1,9 +1,20 @@
 import React, { useEffect, useState, useRef } from 'react';
 import FormError from '../ui/FormError';
 
+type SerialParity = 'none' | 'even' | 'odd';
+type SerialFlowControl = 'none' | 'hardware';
+
+interface SerialOptions {
+  baudRate: number;
+  dataBits?: number;
+  parity?: SerialParity;
+  stopBits?: number;
+  flowControl?: SerialFlowControl;
+}
+
 interface SerialPort {
   readonly readable: ReadableStream<Uint8Array> | null;
-  open(options: { baudRate: number }): Promise<void>;
+  open(options: SerialOptions): Promise<void>;
   close(): Promise<void>;
 }
 
@@ -15,11 +26,39 @@ interface Serial {
 
 type NavigatorSerial = Navigator & { serial: Serial };
 
+interface SerialConfig {
+  baudRate: number;
+  dataBits: number;
+  parity: SerialParity;
+  stopBits: number;
+  flowControl: SerialFlowControl;
+}
+
+interface SerialPreset {
+  name: string;
+  config: SerialConfig;
+}
+
+const DEFAULT_CONFIG: SerialConfig = {
+  baudRate: 9600,
+  dataBits: 8,
+  parity: 'none',
+  stopBits: 1,
+  flowControl: 'none',
+};
+
+const STORAGE_KEY = 'serial-terminal-presets';
+
 const SerialTerminalApp: React.FC = () => {
   const supported = typeof navigator !== 'undefined' && 'serial' in navigator;
   const [port, setPort] = useState<SerialPort | null>(null);
   const [logs, setLogs] = useState('');
   const [error, setError] = useState('');
+  const [config, setConfig] = useState<SerialConfig>(DEFAULT_CONFIG);
+  const [activeConfig, setActiveConfig] = useState<SerialConfig | null>(null);
+  const [presetName, setPresetName] = useState('');
+  const [selectedPreset, setSelectedPreset] = useState('');
+  const [presets, setPresets] = useState<SerialPreset[]>([]);
   const readerRef = useRef<ReadableStreamDefaultReader<string> | null>(null);
 
   useEffect(() => {
@@ -36,6 +75,59 @@ const SerialTerminalApp: React.FC = () => {
       nav.serial.removeEventListener('disconnect', handleDisconnect);
     };
   }, [supported, port]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (!stored) return;
+      const parsed: unknown = JSON.parse(stored);
+      if (!Array.isArray(parsed)) return;
+      const validPresets: SerialPreset[] = parsed
+        .filter((item): item is SerialPreset => {
+          if (!item || typeof item !== 'object') return false;
+          const candidate = item as Partial<SerialPreset>;
+          const cfg = candidate.config as Partial<SerialConfig> | undefined;
+          return (
+            typeof candidate.name === 'string' &&
+            cfg !== undefined &&
+            typeof cfg.baudRate === 'number' &&
+            typeof cfg.dataBits === 'number' &&
+            typeof cfg.parity === 'string' &&
+            typeof cfg.stopBits === 'number' &&
+            typeof cfg.flowControl === 'string'
+          );
+        })
+        .map((item) => ({
+          name: item.name,
+          config: {
+            baudRate: item.config.baudRate,
+            dataBits: item.config.dataBits,
+            parity: item.config.parity as SerialParity,
+            stopBits: item.config.stopBits,
+            flowControl: item.config.flowControl as SerialFlowControl,
+          },
+        }));
+      if (validPresets.length) {
+        setPresets(validPresets);
+      }
+    } catch {
+      // ignore malformed storage
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      if (presets.length) {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(presets));
+      } else {
+        window.localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch {
+      // ignore write errors
+    }
+  }, [presets]);
 
   const readLoop = async (p: SerialPort) => {
     const textDecoder = new TextDecoderStream();
@@ -61,8 +153,16 @@ const SerialTerminalApp: React.FC = () => {
     setError('');
     try {
       const p = await (navigator as NavigatorSerial).serial.requestPort();
-      await p.open({ baudRate: 9600 });
+      const configToUse = { ...config };
+      await p.open({
+        baudRate: configToUse.baudRate,
+        dataBits: configToUse.dataBits,
+        parity: configToUse.parity,
+        stopBits: configToUse.stopBits,
+        flowControl: configToUse.flowControl,
+      });
       setPort(p);
+      setActiveConfig(configToUse);
       readLoop(p);
     } catch (err) {
       const e = err as DOMException;
@@ -84,12 +184,53 @@ const SerialTerminalApp: React.FC = () => {
       // ignore
     } finally {
       setPort(null);
+      setActiveConfig(null);
     }
   };
 
+  const updateConfigField = <K extends keyof SerialConfig>(key: K, value: SerialConfig[K]) => {
+    setConfig((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const savePreset = () => {
+    const trimmed = presetName.trim();
+    if (!trimmed) {
+      setError('Preset name is required.');
+      return;
+    }
+    setPresetName(trimmed);
+    setError('');
+    setPresets((prev) => {
+      const existingIndex = prev.findIndex((preset) => preset.name === trimmed);
+      const updatedPreset: SerialPreset = {
+        name: trimmed,
+        config: { ...config },
+      };
+      if (existingIndex >= 0) {
+        const copy = [...prev];
+        copy[existingIndex] = updatedPreset;
+        return copy;
+      }
+      return [...prev, updatedPreset];
+    });
+    setSelectedPreset(trimmed);
+  };
+
+  const handlePresetSelect = (value: string) => {
+    setSelectedPreset(value);
+    const preset = presets.find((item) => item.name === value);
+    if (preset) {
+      setConfig({ ...preset.config });
+      setError('');
+    }
+  };
+
+  const describeConfig = (cfg: SerialConfig) =>
+    `Baud ${cfg.baudRate}, Data ${cfg.dataBits}, Parity ${cfg.parity}, Stop ${cfg.stopBits}, Flow ${cfg.flowControl}`;
+
   return (
     <div className="relative h-full w-full bg-black p-4 text-green-400 font-mono">
-      <div className="mb-4 flex gap-2">
+      <div className="mb-4 flex flex-wrap items-end gap-3">
         {!port ? (
           <button
             onClick={connect}
@@ -106,6 +247,39 @@ const SerialTerminalApp: React.FC = () => {
             Disconnect
           </button>
         )}
+        <div className="flex flex-col text-xs text-gray-200">
+          <label htmlFor="serial-preset-name">Preset Name</label>
+          <input
+            id="serial-preset-name"
+            value={presetName}
+            onChange={(e) => setPresetName(e.target.value)}
+            className="mt-1 rounded bg-gray-800 px-2 py-1 text-sm text-white placeholder:text-gray-500"
+            placeholder="My Device"
+            aria-label="Preset Name"
+          />
+        </div>
+        <button onClick={savePreset} className="rounded bg-blue-700 px-2 py-1 text-white">
+          Save Preset
+        </button>
+        {presets.length > 0 && (
+          <div className="flex flex-col text-xs text-gray-200">
+            <label htmlFor="serial-preset-select">Presets</label>
+            <select
+              id="serial-preset-select"
+              value={selectedPreset}
+              onChange={(e) => handlePresetSelect(e.target.value)}
+              className="mt-1 rounded bg-gray-800 px-2 py-1 text-sm text-white"
+              aria-label="Presets"
+            >
+              <option value="">Select a preset</option>
+              {presets.map((preset) => (
+                <option key={preset.name} value={preset.name}>
+                  {preset.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
       </div>
       {!supported && (
         <p className="mb-2 text-sm text-yellow-400">
@@ -113,6 +287,88 @@ const SerialTerminalApp: React.FC = () => {
         </p>
       )}
       {error && <FormError className="mb-2 mt-0">{error}</FormError>}
+      <div className="mb-3 grid gap-3 sm:grid-cols-2 md:grid-cols-3">
+        <div className="flex flex-col text-xs text-gray-200">
+          <label htmlFor="serial-baud-rate">Baud Rate</label>
+          <input
+            id="serial-baud-rate"
+            type="number"
+            min={110}
+            max={921600}
+            value={config.baudRate}
+            onChange={(e) => updateConfigField('baudRate', Number.parseInt(e.target.value, 10) || DEFAULT_CONFIG.baudRate)}
+            className="mt-1 rounded bg-gray-800 px-2 py-1 text-sm text-white"
+            aria-label="Baud Rate"
+          />
+        </div>
+        <div className="flex flex-col text-xs text-gray-200">
+          <label htmlFor="serial-data-bits">Data Bits</label>
+          <select
+            id="serial-data-bits"
+            value={config.dataBits}
+            onChange={(e) => updateConfigField('dataBits', Number.parseInt(e.target.value, 10) as SerialConfig['dataBits'])}
+            className="mt-1 rounded bg-gray-800 px-2 py-1 text-sm text-white"
+            aria-label="Data Bits"
+          >
+            {[5, 6, 7, 8].map((bits) => (
+              <option key={bits} value={bits}>
+                {bits}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex flex-col text-xs text-gray-200">
+          <label htmlFor="serial-parity">Parity</label>
+          <select
+            id="serial-parity"
+            value={config.parity}
+            onChange={(e) => updateConfigField('parity', e.target.value as SerialParity)}
+            className="mt-1 rounded bg-gray-800 px-2 py-1 text-sm text-white"
+            aria-label="Parity"
+          >
+            {(['none', 'even', 'odd'] as SerialParity[]).map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex flex-col text-xs text-gray-200">
+          <label htmlFor="serial-stop-bits">Stop Bits</label>
+          <select
+            id="serial-stop-bits"
+            value={config.stopBits}
+            onChange={(e) => updateConfigField('stopBits', Number.parseInt(e.target.value, 10) as SerialConfig['stopBits'])}
+            className="mt-1 rounded bg-gray-800 px-2 py-1 text-sm text-white"
+            aria-label="Stop Bits"
+          >
+            {[1, 2].map((bits) => (
+              <option key={bits} value={bits}>
+                {bits}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex flex-col text-xs text-gray-200">
+          <label htmlFor="serial-flow-control">Flow Control</label>
+          <select
+            id="serial-flow-control"
+            value={config.flowControl}
+            onChange={(e) => updateConfigField('flowControl', e.target.value as SerialFlowControl)}
+            className="mt-1 rounded bg-gray-800 px-2 py-1 text-sm text-white"
+            aria-label="Flow Control"
+          >
+            {['none', 'hardware'].map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      {port && activeConfig && (
+        <p className="mb-2 text-sm text-green-300">{`Connected with ${describeConfig(activeConfig)}`}</p>
+      )}
       <pre className="h-[calc(100%-4rem)] overflow-auto whitespace-pre-wrap break-words">
         {logs || 'No data'}
       </pre>


### PR DESCRIPTION
## Summary
- extend the serial terminal UI with controls for baud rate, data bits, parity, stop bits, and flow control
- persist named connection presets in localStorage and surface the active configuration while connected
- add unit coverage to verify preset persistence and selection

## Testing
- yarn test __tests__/serialTerminal.test.tsx --runTestsByPath
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc2684e8348328ac67848c348db140