### PR TITLE
chore: remove analytics from install button

### DIFF
--- a/components/InstallButton.tsx
+++ b/components/InstallButton.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { trackEvent } from '@/lib/analytics-client';
 
 interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[];
@@ -23,7 +22,7 @@ const InstallButton: React.FC = () => {
     if (!prompt) return;
     await prompt.prompt();
     await prompt.userChoice;
-    trackEvent('cta_click', { location: 'install_button' });
+    // analytics removed
     setPrompt(null);
   };
 


### PR DESCRIPTION
## Summary
- remove analytics tracking from InstallButton

## Testing
- `yarn lint` *(fails: 6 errors, 34 warnings)*
- `yarn test` *(fails: ReferenceError: handlePresetSelect is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2611374c883288c2c64f64c03242f