### PR TITLE
chore: remove Vercel analytics

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,7 +1,5 @@
 import { useEffect } from 'react';
 import ReactGA from 'react-ga4';
-import { Analytics, type BeforeSendEvent } from '@vercel/analytics/next';
-import { SpeedInsights } from '@vercel/speed-insights/next';
 import 'tailwindcss/tailwind.css';
 import '../styles/globals.css';
 import '../styles/index.css';
@@ -128,15 +126,7 @@ function MyApp({ Component, pageProps }) {
         <div aria-live="polite" id="live-region" />
         <Component {...pageProps} />
         <ShortcutOverlay />
-        <Analytics
-          beforeSend={(e: BeforeSendEvent) => {
-            if (e.url.includes('/admin') || e.url.includes('/private')) return null;
-            if (e.metadata?.email) delete e.metadata.email;
-            return e;
-          }}
-        />
-
-        {process.env.NEXT_PUBLIC_STATIC_EXPORT !== 'true' && <SpeedInsights />}
+        {/* analytics removed */}
       </PipPortalProvider>
     </SettingsProvider>
   );


### PR DESCRIPTION
## Summary
- remove Vercel analytics and Speed Insights integrations from custom App
- leave placeholder comment to preserve layout

## Testing
- `npx eslint --ext .jsx pages/_app.jsx`
- `yarn test pages/_app.jsx --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b261144d948328b9151855a4f38463