### PR TITLE
Remove unused analytics import

### DIFF
--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -1,7 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { randomBytes } from 'crypto';
-import trackServerEvent from '@/lib/analytics-server';
-import { reportValue, beta } from '@/flags';
 import { contactSchema } from '../../utils/contactSchema';
 import { validateServerEnv } from '../../lib/validate';
 import { getServiceSupabase } from '../../lib/supabase';


### PR DESCRIPTION
## Summary
- remove unused analytics import from contact API handler

## Testing
- `npx eslint pages/api/contact.ts`
- `yarn lint pages/api/contact.ts` *(fails: 40 problems (6 errors, 34 warnings))*
- `yarn test pages/api/contact.ts` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b261153da48328a8ad3be454c73443