### PR TITLE
Relax environment variable validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Copy `.env.local.example` to `.env.local` and fill in required API keys:
 
 - `NEXT_PUBLIC_ENABLE_ANALYTICS` – enable client-side analytics when set to `true`.
 - `FEATURE_TOOL_APIS` – toggle simulated tool APIs (`enabled` or `disabled`).
-- `RECAPTCHA_SECRET` and related `NEXT_PUBLIC_RECAPTCHA_*` keys for contact form spam protection.
-- `RATE_LIMIT_SECRET` – secret used to sign rate limit cookies. Define this as a project environment variable in Vercel; no secret is referenced in `vercel.json`.
-- `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` – Supabase credentials. When unset, Supabase-backed APIs and features are disabled.
+- `RECAPTCHA_SECRET` and related `NEXT_PUBLIC_RECAPTCHA_*` keys – optional, required only for contact form spam protection.
+- `RATE_LIMIT_SECRET` – optional secret used to sign rate limit cookies. Define this as a project environment variable in Vercel; no secret is referenced in `vercel.json`.
+- `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` – optional Supabase credentials. When unset, Supabase-backed APIs and features are disabled.
 - `NODE_OPTIONS` – override Node.js memory limits. The build script sets `NODE_OPTIONS="--max-old-space-size=4096"` automatically when `CI` is detected to avoid out-of-memory errors in constrained environments.
 
 See `.env.local.example` for the full list.

--- a/__tests__/validateServerEnv.test.ts
+++ b/__tests__/validateServerEnv.test.ts
@@ -2,24 +2,7 @@
 const { validateServerEnv } = require('../lib/validate');
 
 describe('validateServerEnv', () => {
-  const baseEnv = {
-    NEXT_PUBLIC_SUPABASE_URL: 'url',
-    NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon',
-    SUPABASE_URL: 'url',
-    SUPABASE_ANON_KEY: 'anon',
-    SUPABASE_SERVICE_ROLE_KEY: 'service',
-    RATE_LIMIT_SECRET: 'rate',
-    FLAGS_SECRET: 'flags',
-    RECAPTCHA_SECRET: 'recaptcha',
-  };
-
-  it('does not throw when all required vars are present', () => {
-    expect(() => validateServerEnv(baseEnv)).not.toThrow();
-  });
-
-  it('throws when required vars are missing', () => {
-    const { RATE_LIMIT_SECRET, RECAPTCHA_SECRET, ...env } = baseEnv;
-    expect(() => validateServerEnv(env)).toThrow(/RATE_LIMIT_SECRET/);
-    expect(() => validateServerEnv(env)).toThrow(/RECAPTCHA_SECRET/);
+  it('does not throw when environment variables are absent', () => {
+    expect(() => validateServerEnv({})).not.toThrow();
   });
 });

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -3,22 +3,8 @@
  * @param {NodeJS.ProcessEnv} env
  * @throws {Error} If any required variable is missing.
  */
-function validateServerEnv(env) {
-  const required = [
-    'NEXT_PUBLIC_SUPABASE_URL',
-    'NEXT_PUBLIC_SUPABASE_ANON_KEY',
-    'SUPABASE_URL',
-    'SUPABASE_ANON_KEY',
-    'SUPABASE_SERVICE_ROLE_KEY',
-    'RATE_LIMIT_SECRET',
-    'FLAGS_SECRET',
-    'RECAPTCHA_SECRET',
-  ];
-
-  const missing = required.filter((name) => !env?.[name]);
-  if (missing.length > 0) {
-    throw new Error(`Missing environment variables: ${missing.join(', ')}`);
-  }
+function validateServerEnv() {
+  // All server environment variables are optional.
 }
 
 module.exports = { validateServerEnv };


### PR DESCRIPTION
## Summary
- make server environment validation a no-op so builds don't fail when variables are missing
- clarify optional environment variables in README
- update validation tests accordingly

## Testing
- `yarn lint` *(fails: A control must be associated with a text label)*
- `yarn test` *(fails: Unable to find role="alert"; Missing environment variables: RATE_LIMIT_SECRET, FLAGS_SECRET)*
- `yarn test __tests__/validateServerEnv.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68be1ff9cb948328b6760aaec010fe85