### PR TITLE
fix: handle optional alias names

### DIFF
--- a/apps/terminal/commands/index.ts
+++ b/apps/terminal/commands/index.ts
@@ -29,12 +29,13 @@ function alias(args: string, ctx: CommandContext) {
     Object.entries(ctx.aliases).forEach(([k, v]) => ctx.writeLine(`${k}='${v}'`));
     return;
   }
-  const [name, value] = args.split('=');
+  const [name = '', value] = args.split('=');
+  const trimmedName = name.trim();
   if (value) {
-    ctx.setAlias(name.trim(), value.trim());
+    ctx.setAlias(trimmedName, value.trim());
   } else {
-    const existing = ctx.aliases[name.trim()];
-    if (existing) ctx.writeLine(`${name}='${existing}'`);
+    const existing = ctx.aliases[trimmedName];
+    if (existing) ctx.writeLine(`${trimmedName}='${existing}'`);
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent alias command from using undefined name

## Testing
- `yarn eslint apps/terminal/commands/index.ts`
- `yarn typecheck` *(fails: Property 'X-GNOME-Autostart-Delay' does not exist on type...)*
- `yarn test apps/terminal/commands/index.test.ts` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c206fd77c083289299517f96d5d24e