### PR TITLE
fix: ensure script entries exist

### DIFF
--- a/apps/terminal/components/Scripts.tsx
+++ b/apps/terminal/components/Scripts.tsx
@@ -145,8 +145,7 @@ const Scripts = ({ runCommand }: ScriptsProps) => {
         )}
       </div>
       <ul className="space-y-1">
-        {Object.keys(scripts).map((n) => {
-          const entry = scripts[n];
+        {Object.entries(scripts).map(([n, entry]) => {
           const data: ScriptEntry =
             typeof entry === 'string' ? { code: entry } : entry;
           const presets = data.presets || {};


### PR DESCRIPTION
## Summary
- prevent undefined script entries in terminal scripts component by iterating over Object.entries

## Testing
- `yarn typecheck` *(fails: Type 'undefined' cannot be used as an index type, missing env variables, etc.)*
- `yarn test` *(fails: missing env variables, displayYouTube reference errors, Playwright browser missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c20afee0f083289ad520fde8042e16