### PR TITLE
fix: handle undefined frequency data in visualizer

### DIFF
--- a/apps/spotify/Visualizer.tsx
+++ b/apps/spotify/Visualizer.tsx
@@ -24,7 +24,9 @@ export default function Visualizer({ analyser }: Props) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       const barWidth = canvas.width / bufferLength;
       for (let i = 0; i < bufferLength; i++) {
-        const value = dataArray[i];
+        // Default to 0 when no frequency data is available to satisfy
+        // TypeScript's `noUncheckedIndexedAccess` setting.
+        const value = dataArray[i] ?? 0;
         const barHeight = (value / 255) * canvas.height;
         ctx.fillStyle = `rgb(${value}, 100, 150)`;
         ctx.fillRect(i * barWidth, canvas.height - barHeight, barWidth - 1, barHeight);


### PR DESCRIPTION
## Summary
- guard against undefined audio frequency values in Spotify Visualizer to satisfy noUncheckedIndexedAccess

## Testing
- `yarn typecheck` *(fails: Type '{ file?: string; ... }' is not assignable to type 'AutostartEntry', etc.)*
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cf6f69f48328a4a9263bef35eee4