### PR TITLE
[launcher] add metadata and keyboard shortcuts

### DIFF
--- a/__tests__/WhiskerMenu.test.tsx
+++ b/__tests__/WhiskerMenu.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import WhiskerMenu from '../components/menu/WhiskerMenu';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+
+describe('WhiskerMenu keyboard shortcuts', () => {
+  let dispatchSpy: jest.SpyInstance<boolean, [event: Event]>;
+
+  const openMenuAndSearch = async (term: string) => {
+    render(<WhiskerMenu />);
+    fireEvent.click(screen.getByRole('button', { name: /applications/i }));
+    const input = await screen.findByPlaceholderText(/search/i);
+    fireEvent.change(input, { target: { value: term } });
+    return input;
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+  });
+
+  afterEach(() => {
+    dispatchSpy.mockRestore();
+  });
+
+  it('dispatches an open-app event when Enter is pressed', async () => {
+    await openMenuAndSearch('Calculator');
+    await screen.findByText('Calculator');
+    dispatchSpy.mockClear();
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+
+    const events = dispatchSpy.mock.calls.filter(([evt]) => evt.type === 'open-app');
+    expect(events).toHaveLength(1);
+    const event = events[0][0] as CustomEvent<{ id: string; spawnNew: boolean }>;
+    expect(event.detail).toEqual({ id: 'calculator', spawnNew: false });
+  });
+
+  it('dispatches an open-app event requesting a new window on Alt+Enter', async () => {
+    await openMenuAndSearch('Terminal');
+    await screen.findByText('Terminal');
+    dispatchSpy.mockClear();
+
+    fireEvent.keyDown(window, { key: 'Enter', altKey: true });
+
+    const events = dispatchSpy.mock.calls.filter(([evt]) => evt.type === 'open-app');
+    expect(events).toHaveLength(1);
+    const event = events[0][0] as CustomEvent<{ id: string; spawnNew: boolean }>;
+    expect(event.detail).toEqual({ id: 'terminal', spawnNew: true });
+  });
+
+  it('announces keyboard shortcuts in the aria-label', async () => {
+    await openMenuAndSearch('Calculator');
+    const appButton = await screen.findByRole('button', {
+      name: /calculator.*press enter to open/i,
+    });
+    const aria = appButton.getAttribute('aria-label') || '';
+    expect(aria).toContain('Press Enter to open');
+    expect(aria).toMatch(/Alt\+Enter/i);
+  });
+});

--- a/apps.config.js
+++ b/apps.config.js
@@ -269,7 +269,7 @@ const utilityList = [
   },
 ];
 
-export const utilities = utilityList;
+
 
 // Default window sizing for games to prevent oversized frames
 export const gameDefaults = {
@@ -592,9 +592,7 @@ const gameList = [
   },
 ];
 
-export const games = gameList.map((game) => ({ ...gameDefaults, ...game }));
-
-const apps = [
+const appList = [
   {
     id: 'chrome',
     title: 'Google Chrome',
@@ -1051,10 +1049,74 @@ const apps = [
     desktop_shortcut: false,
     screen: displaySecurityTools,
   },
-  // Utilities are grouped separately
-  ...utilities,
-  // Games are included so they appear alongside apps
-  ...games,
 ];
+
+const DEFAULT_RECENT_APP_IDS = ['plugin-manager', 'kismet', 'evidence-vault'];
+
+const APP_CATEGORIES = new Map();
+const assignCategory = (category, ids) => {
+  ids.forEach((id) => APP_CATEGORIES.set(id, category));
+};
+
+assignCategory('Utility', [
+  'calculator',
+  'converter',
+  'resource-monitor',
+  'screen-recorder',
+  'weather',
+  'weather-widget',
+]);
+assignCategory('Game', gameList.map((item) => item.id));
+assignCategory('Utility', utilityList.map((item) => item.id));
+assignCategory('Browser', ['chrome']);
+assignCategory('Development', ['terminal', 'vscode', 'html-rewriter']);
+assignCategory('Social', ['x']);
+assignCategory('Media', ['spotify', 'youtube']);
+assignCategory('Security', [
+  'beef',
+  'metasploit',
+  'wireshark',
+  'ettercap',
+  'nikto',
+  'reaver',
+  'nessus',
+  'hydra',
+  'nmap-nse',
+  'mimikatz',
+  'mimikatz/offline',
+  'hashcat',
+  'msf-post',
+  'dsniff',
+  'john',
+  'openvas',
+  'recon-ng',
+  'security-tools',
+  'kismet',
+]);
+assignCategory('System', ['about', 'settings', 'files', 'plugin-manager', 'trash']);
+assignCategory('Productivity', ['todoist', 'sticky_notes']);
+assignCategory('Communication', ['gedit', 'contact']);
+assignCategory('Hardware', ['ble-sensor', 'serial-terminal']);
+assignCategory('Reverse Engineering', ['ghidra', 'radare2']);
+assignCategory('Forensics', ['autopsy', 'volatility', 'evidence-vault']);
+assignCategory('Networking', ['ssh', 'http']);
+
+const RECENT_APP_IDS = new Set(DEFAULT_RECENT_APP_IDS);
+
+const withMetadata = (entry) => ({
+  ...entry,
+  category: entry.category ?? APP_CATEGORIES.get(entry.id) ?? 'Application',
+  recent: entry.recent ?? RECENT_APP_IDS.has(entry.id),
+});
+
+export const utilities = utilityList.map((item) => withMetadata(item));
+
+export const games = gameList.map((game) =>
+  withMetadata({ ...gameDefaults, ...game })
+);
+
+const apps = [...appList.map(withMetadata), ...utilities, ...games];
+
+export const defaultRecentAppIds = [...DEFAULT_RECENT_APP_IDS];
 
 export default apps;

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -1,15 +1,22 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useMemo,
+  useCallback,
+} from 'react';
 import Image from 'next/image';
-import UbuntuApp from '../base/ubuntu_app';
 import apps, { utilities, games } from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 
-type AppMeta = {
+type LauncherApp = {
   id: string;
   title: string;
   icon: string;
   disabled?: boolean;
   favourite?: boolean;
+  category: string;
+  recent?: boolean;
 };
 
 const CATEGORIES = [
@@ -17,8 +24,20 @@ const CATEGORIES = [
   { id: 'favorites', label: 'Favorites' },
   { id: 'recent', label: 'Recent' },
   { id: 'utilities', label: 'Utilities' },
-  { id: 'games', label: 'Games' }
+  { id: 'games', label: 'Games' },
 ];
+
+const buildAriaLabel = (app: LauncherApp) => {
+  const segments = [
+    app.title,
+    app.category ? `Category: ${app.category}` : undefined,
+    app.recent ? 'Recent app' : undefined,
+    'Press Enter to open',
+    'Press Alt plus Enter (Alt+Enter) to open a new window',
+  ].filter(Boolean) as string[];
+
+  return `${segments.join('. ')}.`;
+};
 
 const WhiskerMenu: React.FC = () => {
   const [open, setOpen] = useState(false);
@@ -27,22 +46,43 @@ const WhiskerMenu: React.FC = () => {
   const [highlight, setHighlight] = useState(0);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
-  const allApps: AppMeta[] = apps as any;
-  const favoriteApps = useMemo(() => allApps.filter(a => a.favourite), [allApps]);
+  const allApps = apps as LauncherApp[];
+  const favoriteApps = useMemo(
+    () => allApps.filter((app) => app.favourite),
+    [allApps, open]
+  );
+
+  const metadataRecentApps = useMemo(
+    () => allApps.filter((app) => app.recent),
+    [allApps, open]
+  );
+
   const recentApps = useMemo(() => {
+    let ids: string[] = [];
     try {
-      const ids: string[] = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]');
-      return ids.map(id => allApps.find(a => a.id === id)).filter(Boolean) as AppMeta[];
+      ids = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]');
     } catch {
-      return [];
+      ids = [];
     }
-  }, [allApps, open]);
-  const utilityApps: AppMeta[] = utilities as any;
-  const gameApps: AppMeta[] = games as any;
+    if (!ids.length) {
+      return metadataRecentApps;
+    }
+    const resolved = ids
+      .map((id) => allApps.find((app) => app.id === id))
+      .filter(Boolean) as LauncherApp[];
+    const fallback = metadataRecentApps.filter(
+      (app) => !resolved.some((item) => item.id === app.id)
+    );
+    return [...resolved, ...fallback];
+  }, [allApps, metadataRecentApps, open]);
+
+  const utilityApps = utilities as LauncherApp[];
+  const gameApps = games as LauncherApp[];
 
   const currentApps = useMemo(() => {
-    let list: AppMeta[];
+    let list: LauncherApp[];
     switch (category) {
       case 'favorites':
         list = favoriteApps;
@@ -59,28 +99,49 @@ const WhiskerMenu: React.FC = () => {
       default:
         list = allApps;
     }
-    if (query) {
-      const q = query.toLowerCase();
-      list = list.filter(a => a.title.toLowerCase().includes(q));
+    const q = query.trim().toLowerCase();
+    if (q) {
+      list = list.filter((app) => app.title.toLowerCase().includes(q));
     }
     return list;
-  }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps]);
+  }, [category, query, allApps, favoriteApps, recentApps, utilityApps, gameApps, open]);
 
   useEffect(() => {
     if (!open) return;
     setHighlight(0);
   }, [open, category, query]);
 
-  const openSelectedApp = (id: string) => {
-    window.dispatchEvent(new CustomEvent('open-app', { detail: id }));
-    setOpen(false);
-  };
+  useEffect(() => {
+    if (!open) return;
+    if (!currentApps.length) {
+      setHighlight(0);
+      return;
+    }
+    setHighlight((value) => Math.min(value, currentApps.length - 1));
+  }, [currentApps, open]);
+
+  useEffect(() => {
+    itemRefs.current = itemRefs.current.slice(0, currentApps.length);
+  }, [currentApps.length]);
+
+  const openSelectedApp = useCallback(
+    (app: LauncherApp | undefined, options?: { spawnNew?: boolean }) => {
+      if (!app || app.disabled) return;
+      window.dispatchEvent(
+        new CustomEvent('open-app', {
+          detail: { id: app.id, spawnNew: !!options?.spawnNew },
+        })
+      );
+      setOpen(false);
+    },
+    []
+  );
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Meta' && !e.ctrlKey && !e.shiftKey && !e.altKey) {
         e.preventDefault();
-        setOpen(o => !o);
+        setOpen((o) => !o);
         return;
       }
       if (!open) return;
@@ -88,19 +149,19 @@ const WhiskerMenu: React.FC = () => {
         setOpen(false);
       } else if (e.key === 'ArrowDown') {
         e.preventDefault();
-        setHighlight(h => Math.min(h + 1, currentApps.length - 1));
+        setHighlight((value) => Math.min(value + 1, currentApps.length - 1));
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
-        setHighlight(h => Math.max(h - 1, 0));
+        setHighlight((value) => Math.max(value - 1, 0));
       } else if (e.key === 'Enter') {
         e.preventDefault();
         const app = currentApps[highlight];
-        if (app) openSelectedApp(app.id);
+        openSelectedApp(app, { spawnNew: e.altKey });
       }
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [open, currentApps, highlight]);
+  }, [open, currentApps, highlight, openSelectedApp]);
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
@@ -114,12 +175,20 @@ const WhiskerMenu: React.FC = () => {
     return () => document.removeEventListener('mousedown', handleClick);
   }, [open]);
 
+  useEffect(() => {
+    if (!open) return;
+    const node = itemRefs.current[highlight];
+    if (node?.scrollIntoView) {
+      node.scrollIntoView({ block: 'nearest' });
+    }
+  }, [highlight, open, currentApps.length]);
+
   return (
     <div className="relative">
       <button
         ref={buttonRef}
         type="button"
-        onClick={() => setOpen(o => !o)}
+        onClick={() => setOpen((o) => !o)}
         className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
       >
         <Image
@@ -143,37 +212,108 @@ const WhiskerMenu: React.FC = () => {
           }}
         >
           <div className="flex flex-col bg-gray-800 p-2">
-            {CATEGORIES.map(cat => (
+            {CATEGORIES.map((cat) => (
               <button
                 key={cat.id}
-                className={`text-left px-2 py-1 rounded mb-1 ${category === cat.id ? 'bg-gray-700' : ''}`}
-                onClick={() => setCategory(cat.id)}
+                type="button"
+                aria-pressed={category === cat.id}
+                className={`text-left px-2 py-1 rounded mb-1 transition ${
+                  category === cat.id ? 'bg-gray-700' : 'hover:bg-gray-700'
+                }`}
+                onClick={() => {
+                  setCategory(cat.id);
+                  setHighlight(0);
+                }}
               >
                 {cat.label}
               </button>
             ))}
           </div>
-          <div className="p-3">
+          <div className="p-3 w-80">
             <input
-              className="mb-3 w-64 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+              className="mb-3 w-full px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
               placeholder="Search"
               value={query}
-              onChange={e => setQuery(e.target.value)}
+              onChange={(e) => setQuery(e.target.value)}
               autoFocus
             />
-            <div className="grid grid-cols-3 gap-2 max-h-64 overflow-y-auto">
-              {currentApps.map((app, idx) => (
-                <div key={app.id} className={idx === highlight ? 'ring-2 ring-ubb-orange' : ''}>
-                  <UbuntuApp
-                    id={app.id}
-                    icon={app.icon}
-                    name={app.title}
-                    openApp={() => openSelectedApp(app.id)}
-                    disabled={app.disabled}
-                  />
-                </div>
-              ))}
-            </div>
+            {currentApps.length === 0 ? (
+              <p className="text-sm text-gray-300">No applications match your search.</p>
+            ) : (
+              <ul
+                role="listbox"
+                aria-label="Application results"
+                className="max-h-64 overflow-y-auto space-y-2 pr-1"
+              >
+                {currentApps.map((app, idx) => {
+                  const isHighlighted = idx === highlight;
+                  const iconSrc = app.icon.replace('./', '/');
+                  const className = `group w-full text-left rounded-md border border-transparent px-3 py-2 transition ${
+                    isHighlighted
+                      ? 'bg-gray-700 border-gray-500 ring-2 ring-orange-400'
+                      : 'hover:bg-gray-700 focus-visible:ring-2 focus-visible:ring-orange-400'
+                  } ${app.disabled ? 'opacity-50 cursor-not-allowed' : ''}`;
+
+                  return (
+                    <li key={app.id}>
+                      <button
+                        ref={(node) => {
+                          itemRefs.current[idx] = node;
+                        }}
+                        type="button"
+                        className={className}
+                        aria-label={buildAriaLabel(app)}
+                        aria-keyshortcuts="Enter Alt+Enter"
+                        aria-selected={isHighlighted}
+                        onMouseEnter={() => setHighlight(idx)}
+                        onFocus={() => setHighlight(idx)}
+                        onClick={() => openSelectedApp(app)}
+                        disabled={app.disabled}
+                      >
+                        <div className="flex items-start gap-3">
+                          <div className="relative flex-shrink-0">
+                            <Image
+                              src={iconSrc}
+                              alt={`${app.title} icon`}
+                              width={40}
+                              height={40}
+                              className="h-10 w-10"
+                            />
+                          </div>
+                          <div className="flex-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className="text-sm font-medium text-white">{app.title}</span>
+                              {app.recent && (
+                                <span
+                                  aria-hidden
+                                  className="inline-flex items-center rounded bg-orange-400 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-black"
+                                >
+                                  Recent
+                                </span>
+                              )}
+                            </div>
+                            <div className="text-xs text-gray-300">{app.category}</div>
+                            <div
+                              aria-hidden
+                              className={`mt-2 flex flex-wrap gap-2 text-[10px] text-gray-200 ${
+                                isHighlighted ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                              }`}
+                            >
+                              <span className="rounded border border-gray-600 bg-black bg-opacity-40 px-1.5 py-0.5">
+                                Enter
+                              </span>
+                              <span className="rounded border border-gray-600 bg-black bg-opacity-40 px-1.5 py-0.5">
+                                Alt + Enter
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
           </div>
         </div>
       )}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -8,7 +8,7 @@ const BackgroundImage = dynamic(
     { ssr: false }
 );
 import SideBar from './side_bar';
-import apps, { games } from '../../apps.config';
+import apps, { games, defaultRecentAppIds } from '../../apps.config';
 import Window from '../base/window';
 import UbuntuApp from '../base/ubuntu_app';
 import AllApplications from '../screen/all-applications'
@@ -342,6 +342,14 @@ export class Desktop extends Component {
         }
     }
 
+    updateRecentMetadata = (ids = []) => {
+        const recentSet = new Set(defaultRecentAppIds);
+        ids.forEach((id) => recentSet.add(id));
+        apps.forEach((app) => {
+            app.recent = recentSet.has(app.id);
+        });
+    }
+
     fetchAppsData = (callback) => {
         let pinnedApps = safeLocalStorage?.getItem('pinnedApps');
         if (pinnedApps) {
@@ -350,6 +358,16 @@ export class Desktop extends Component {
         } else {
             pinnedApps = apps.filter(app => app.favourite).map(app => app.id);
             safeLocalStorage?.setItem('pinnedApps', JSON.stringify(pinnedApps));
+        }
+        const storedRecent = safeLocalStorage?.getItem('recentApps');
+        if (storedRecent) {
+            try {
+                this.updateRecentMetadata(JSON.parse(storedRecent));
+            } catch (e) {
+                this.updateRecentMetadata([]);
+            }
+        } else {
+            this.updateRecentMetadata([]);
         }
         let focused_windows = {}, closed_windows = {}, disabled_apps = {}, favourite_apps = {}, overlapped_windows = {}, minimized_windows = {};
         let desktop_apps = [];
@@ -577,13 +595,20 @@ export class Desktop extends Component {
     }
 
     handleOpenAppEvent = (e) => {
-        const id = e.detail;
-        if (id) {
-            this.openApp(id);
+        const detail = e.detail;
+        if (!detail) return;
+        if (typeof detail === 'string') {
+            this.openApp(detail);
+            return;
+        }
+        if (typeof detail === 'object' && detail.id) {
+            this.openApp(detail.id, { spawnNew: !!detail.spawnNew });
         }
     }
 
-    openApp = (objId) => {
+    openApp = (objId, options = {}) => {
+
+        const { spawnNew = false } = options || {};
 
         // google analytics
         ReactGA.event({
@@ -594,13 +619,17 @@ export class Desktop extends Component {
         // if the app is disabled
         if (this.state.disabled_apps[objId]) return;
 
+        const wasOpen = this.state.closed_windows[objId] === false;
+
         // if app is already open, focus it instead of spawning a new window
-        if (this.state.closed_windows[objId] === false) {
+        if (wasOpen && !spawnNew) {
             // if it's minimised, restore its last position
             if (this.state.minimized_windows[objId]) {
                 this.focus(objId);
                 var r = document.querySelector("#" + objId);
-                r.style.transform = `translate(${r.style.getPropertyValue("--window-transform-x")},${r.style.getPropertyValue("--window-transform-y")}) scale(1)`;
+                if (r) {
+                    r.style.transform = `translate(${r.style.getPropertyValue("--window-transform-x")},${r.style.getPropertyValue("--window-transform-y")}) scale(1)`;
+                }
                 let minimized_windows = this.state.minimized_windows;
                 minimized_windows[objId] = false;
                 this.setState({ minimized_windows: minimized_windows }, this.saveSession);
@@ -609,51 +638,62 @@ export class Desktop extends Component {
                 this.saveSession();
             }
             return;
-        } else {
-            let closed_windows = this.state.closed_windows;
-            let favourite_apps = this.state.favourite_apps;
-            let frequentApps = [];
-            try { frequentApps = JSON.parse(safeLocalStorage?.getItem('frequentApps') || '[]'); } catch (e) { frequentApps = []; }
-            var currentApp = frequentApps.find(app => app.id === objId);
-            if (currentApp) {
-                frequentApps.forEach((app) => {
-                    if (app.id === currentApp.id) {
-                        app.frequency += 1; // increase the frequency if app is found 
-                    }
-                });
-            } else {
-                frequentApps.push({ id: objId, frequency: 1 }); // new app opened
-            }
-
-            frequentApps.sort((a, b) => {
-                if (a.frequency < b.frequency) {
-                    return 1;
-                }
-                if (a.frequency > b.frequency) {
-                    return -1;
-                }
-                return 0; // sort according to decreasing frequencies
-            });
-
-            safeLocalStorage?.setItem('frequentApps', JSON.stringify(frequentApps));
-
-            let recentApps = [];
-            try { recentApps = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]'); } catch (e) { recentApps = []; }
-            recentApps = recentApps.filter(id => id !== objId);
-            recentApps.unshift(objId);
-            recentApps = recentApps.slice(0, 10);
-            safeLocalStorage?.setItem('recentApps', JSON.stringify(recentApps));
-
-            setTimeout(() => {
-                favourite_apps[objId] = true; // adds opened app to sideBar
-                closed_windows[objId] = false; // openes app's window
-                this.setState({ closed_windows, favourite_apps, allAppsView: false }, () => {
-                    this.focus(objId);
-                    this.saveSession();
-                });
-                this.app_stack.push(objId);
-            }, 200);
         }
+
+        let closed_windows = this.state.closed_windows;
+        let favourite_apps = this.state.favourite_apps;
+        let minimized_windows = this.state.minimized_windows;
+        let frequentApps = [];
+        try { frequentApps = JSON.parse(safeLocalStorage?.getItem('frequentApps') || '[]'); } catch (e) { frequentApps = []; }
+        var currentApp = frequentApps.find(app => app.id === objId);
+        if (currentApp) {
+            frequentApps.forEach((app) => {
+                if (app.id === currentApp.id) {
+                    app.frequency += 1; // increase the frequency if app is found
+                }
+            });
+        } else {
+            frequentApps.push({ id: objId, frequency: 1 }); // new app opened
+        }
+
+        frequentApps.sort((a, b) => {
+            if (a.frequency < b.frequency) {
+                return 1;
+            }
+            if (a.frequency > b.frequency) {
+                return -1;
+            }
+            return 0; // sort according to decreasing frequencies
+        });
+
+        safeLocalStorage?.setItem('frequentApps', JSON.stringify(frequentApps));
+
+        let recentApps = [];
+        try { recentApps = JSON.parse(safeLocalStorage?.getItem('recentApps') || '[]'); } catch (e) { recentApps = []; }
+        recentApps = recentApps.filter(id => id !== objId);
+        recentApps.unshift(objId);
+        recentApps = recentApps.slice(0, 10);
+        safeLocalStorage?.setItem('recentApps', JSON.stringify(recentApps));
+        this.updateRecentMetadata(recentApps);
+
+        setTimeout(() => {
+            favourite_apps[objId] = true; // adds opened app to sideBar
+            closed_windows[objId] = false; // openes app's window
+            if (wasOpen) {
+                minimized_windows[objId] = false;
+            }
+            const nextState = wasOpen
+                ? { closed_windows, favourite_apps, minimized_windows, allAppsView: false }
+                : { closed_windows, favourite_apps, allAppsView: false };
+            this.setState(nextState, () => {
+                this.focus(objId);
+                this.saveSession();
+            });
+            if (wasOpen) {
+                this.app_stack = this.app_stack.filter(id => id !== objId);
+            }
+            this.app_stack.push(objId);
+        }, 200);
     }
 
     closeApp = async (objId) => {


### PR DESCRIPTION
## Summary
- add app metadata helpers for categories and default recent flags
- update the Whisker menu to surface categories, recent badges, and Enter/Alt+Enter shortcuts with improved aria labels
- ensure desktop event handling respects spawnNew requests and keeps recent metadata in sync

## Testing
- yarn lint *(fails: existing accessibility rules trip on legacy app inputs)*
- yarn test WhiskerMenu

------
https://chatgpt.com/codex/tasks/task_e_68cc6fd9906c83288fbd094aef331c0a