### PR TITLE
[config] Ensure worker DOM libs available

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,5 +5,6 @@ The project is a desktop-style portfolio built with Next.js.
 - **pages/** wraps applications using Next.js routing and dynamic imports.
 - **components/apps/** contains the individual app implementations.
 - **pages/api/** exposes serverless functions for backend features.
+- **workers/** houses browser and utility workers that rely on TypeScript's built-in DOM/WebWorker library definitions rather than custom shims.
 
 For setup instructions, see the [Getting Started](./getting-started.md) guide.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- include the DOM, DOM.Iterable, and WebWorker libs in the TypeScript client config so worker types resolve without custom shims
- note in the architecture guide that workers rely on TypeScript's built-in DOM/WebWorker libraries rather than local declarations

## Testing
- tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68ccbc414bf4832882b1e832868a1830