### PR TITLE
desktop: add release notes modal

### DIFF
--- a/__tests__/ReleaseNotesModal.test.tsx
+++ b/__tests__/ReleaseNotesModal.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('marked', () => ({
+  marked: {
+    parseInline: (value: string) => value,
+  },
+}));
+
+jest.mock('dompurify', () => ({
+  __esModule: true,
+  default: { sanitize: (value: string) => value },
+  sanitize: (value: string) => value,
+}));
+
+import ReleaseNotesModal from '../components/common/ReleaseNotesModal';
+
+type ReleasePayload = {
+  generatedAt: string;
+  source: { changelog: string };
+  latest: {
+    version: string;
+    date: string;
+    url: string;
+    sections: { title: string; items: string[] }[];
+  } | null;
+  entries: unknown[];
+};
+
+const createPayload = (version: string): ReleasePayload => ({
+  generatedAt: '2024-01-01T00:00:00.000Z',
+  source: { changelog: 'https://example.com/changelog' },
+  latest: {
+    version,
+    date: '2024-12-11',
+    url: `https://example.com/${version}`,
+    sections: [
+      { title: 'Added', items: ['New feature [docs](https://example.com/feature)'] },
+      { title: 'Fixed', items: ['Stability improvements'] },
+    ],
+  },
+  entries: [],
+});
+
+describe('ReleaseNotesModal', () => {
+  let originalFetch: typeof fetch;
+  let fetchMock: jest.Mock;
+  let root: HTMLDivElement;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    fetchMock = jest.fn();
+    (global as any).fetch = fetchMock;
+    localStorage.clear();
+    root = document.createElement('div');
+    root.id = '__next';
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (root.parentNode) {
+      root.parentNode.removeChild(root);
+    }
+    if (originalFetch) {
+      (global as any).fetch = originalFetch;
+    } else {
+      delete (global as any).fetch;
+    }
+  });
+
+  const mockFetch = (data: ReleasePayload = createPayload('3.2.1')) => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => data,
+    } as unknown as Response);
+  };
+
+  const resetRoot = () => {
+    cleanup();
+    if (root.parentNode) {
+      root.parentNode.removeChild(root);
+    }
+    root = document.createElement('div');
+    root.id = '__next';
+    document.body.appendChild(root);
+  };
+
+  test('renders modal when latest version has not been seen', async () => {
+    const payload = createPayload('3.2.1');
+    mockFetch(payload);
+
+    render(<ReleaseNotesModal />, { container: root });
+
+    expect(fetchMock).toHaveBeenCalledWith('/release-notes.json', expect.any(Object));
+
+    const heading = await screen.findByRole('heading', { name: /3\.2\.1/ });
+    expect(heading).toBeInTheDocument();
+    expect(
+      screen.getByText('New feature [docs](https://example.com/feature)'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /View full changelog/i })).toHaveAttribute(
+      'href',
+      payload.latest?.url ?? payload.source.changelog,
+    );
+  });
+
+  test('persists mute preference per profile', async () => {
+    const profileKey = 'desktop:active-profile';
+    localStorage.setItem(profileKey, 'ops');
+
+    mockFetch(createPayload('3.2.1'));
+    const first = render(<ReleaseNotesModal />, { container: root });
+
+    const heading = await screen.findByRole('heading', { name: /3\.2\.1/ });
+    expect(heading).toBeInTheDocument();
+
+    const muteToggle = screen.getByLabelText(/Don't show again/i);
+    fireEvent.click(muteToggle);
+    expect(localStorage.getItem('release-notes:ops:muted')).toBe('true');
+
+    fireEvent.click(screen.getByRole('button', { name: /Close/i }));
+    await waitFor(() =>
+      expect(screen.queryByRole('heading', { name: /3\.2\.1/ })).not.toBeInTheDocument(),
+    );
+    expect(localStorage.getItem('release-notes:ops:last-seen')).toBe('3.2.1');
+
+    first.unmount();
+    resetRoot();
+
+    fetchMock.mockReset();
+    localStorage.setItem(profileKey, 'ops');
+    mockFetch(createPayload('4.0.0'));
+    const second = render(<ReleaseNotesModal />, { container: root });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.queryByRole('heading', { name: /4\.0\.0/ })).not.toBeInTheDocument(),
+    );
+    second.unmount();
+    resetRoot();
+
+    fetchMock.mockReset();
+    localStorage.setItem(profileKey, 'blue');
+    mockFetch(createPayload('4.0.0'));
+    render(<ReleaseNotesModal />, { container: root });
+    const newHeading = await screen.findByRole('heading', { name: /4\.0\.0/ });
+    expect(newHeading).toBeInTheDocument();
+  });
+});

--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -11,6 +11,10 @@ interface ModalProps {
      * Defaults to the Next.js root (`__next`).
      */
     overlayRoot?: string | HTMLElement;
+    className?: string;
+    ariaLabelledBy?: string;
+    ariaDescribedBy?: string;
+    ariaLabel?: string;
 }
 
 const FOCUSABLE_SELECTORS = [
@@ -27,7 +31,16 @@ const FOCUSABLE_SELECTORS = [
     '[contenteditable]'
 ].join(',');
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot }) => {
+const Modal: React.FC<ModalProps> = ({
+    isOpen,
+    onClose,
+    children,
+    overlayRoot,
+    className,
+    ariaLabelledBy,
+    ariaDescribedBy,
+    ariaLabel,
+}) => {
     const modalRef = useRef<HTMLDivElement>(null);
     const triggerRef = useRef<HTMLElement | null>(null);
     const portalRef = useRef<HTMLDivElement | null>(null);
@@ -116,6 +129,10 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
             ref={modalRef}
             onKeyDown={handleKeyDown}
             tabIndex={-1}
+            className={className}
+            {...(ariaLabelledBy ? { 'aria-labelledby': ariaLabelledBy } : {})}
+            {...(ariaDescribedBy ? { 'aria-describedby': ariaDescribedBy } : {})}
+            {...(ariaLabel ? { 'aria-label': ariaLabel } : {})}
         >
             {children}
         </div>,

--- a/components/common/ReleaseNotesModal.tsx
+++ b/components/common/ReleaseNotesModal.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
+import Modal from '../base/Modal';
+import { safeLocalStorage } from '../../utils/safeStorage';
+
+type ReleaseSection = {
+  title: string;
+  items?: string[];
+  description?: string;
+};
+
+type ReleaseEntry = {
+  version: string;
+  date?: string | null;
+  url?: string;
+  sections?: ReleaseSection[];
+};
+
+type ReleaseNotesPayload = {
+  generatedAt: string;
+  source?: {
+    changelog?: string;
+  };
+  latest?: ReleaseEntry;
+  entries: ReleaseEntry[];
+};
+
+const RELEASE_NOTES_PATH = '/release-notes.json';
+const DEFAULT_PROFILE_ID = 'default';
+const PROFILE_STORAGE_KEYS = ['desktop:active-profile', 'active-profile', 'profile:id'];
+
+const getActiveProfileId = (): string => {
+  if (typeof window === 'undefined') return DEFAULT_PROFILE_ID;
+  for (const key of PROFILE_STORAGE_KEYS) {
+    try {
+      const value = window.localStorage.getItem(key);
+      if (value) {
+        return value;
+      }
+    } catch {
+      // ignore storage errors
+    }
+  }
+  return DEFAULT_PROFILE_ID;
+};
+
+const scopedKey = (profileId: string, suffix: string) => `release-notes:${profileId}:${suffix}`;
+
+const readStorage = (key: string): string | null => {
+  try {
+    return safeLocalStorage?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const writeStorage = (key: string, value: string) => {
+  try {
+    safeLocalStorage?.setItem(key, value);
+  } catch {
+    // ignore storage errors
+  }
+};
+
+const sanitizeMarkdown = (markdown: string) =>
+  DOMPurify.sanitize(marked.parseInline(markdown) as string);
+
+const formatDate = (raw?: string | null): string | null => {
+  if (!raw) return null;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return raw;
+  }
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }).format(parsed);
+  } catch {
+    return raw;
+  }
+};
+
+const ReleaseNotesModal: React.FC = () => {
+  const [data, setData] = useState<ReleaseNotesPayload | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [profileId, setProfileId] = useState<string | null>(null);
+  const [muted, setMuted] = useState(false);
+  const [lastSeenVersion, setLastSeenVersion] = useState<string | null>(null);
+
+  const loadProfileState = useCallback((id: string) => {
+    const muteKey = scopedKey(id, 'muted');
+    const seenKey = scopedKey(id, 'last-seen');
+    setMuted(readStorage(muteKey) === 'true');
+    setLastSeenVersion(readStorage(seenKey));
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const activeId = getActiveProfileId();
+    setProfileId(activeId);
+    loadProfileState(activeId);
+  }, [loadProfileState]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    let cancelled = false;
+    const fetchNotes = async () => {
+      try {
+        const response = await fetch(RELEASE_NOTES_PATH, { cache: 'no-store' });
+        if (!response.ok) {
+          console.warn(`[release-notes] Failed to load release notes (status ${response.status})`);
+          return;
+        }
+        const payload = (await response.json()) as ReleaseNotesPayload;
+        if (!cancelled) {
+          setData(payload);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.warn('[release-notes] Failed to fetch release notes', error);
+        }
+      }
+    };
+    fetchNotes();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handleStorage = (event: StorageEvent) => {
+      if (!event.key) return;
+      if (PROFILE_STORAGE_KEYS.includes(event.key)) {
+        const activeId = getActiveProfileId();
+        setProfileId(activeId);
+        loadProfileState(activeId);
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [loadProfileState]);
+
+  useEffect(() => {
+    if (!data?.latest || profileId === null) return;
+    if (!muted && lastSeenVersion !== data.latest.version) {
+      setIsOpen(true);
+    }
+  }, [data, profileId, muted, lastSeenVersion]);
+
+  const handleClose = useCallback(() => {
+    if (profileId && data?.latest?.version) {
+      const seenKey = scopedKey(profileId, 'last-seen');
+      writeStorage(seenKey, data.latest.version);
+      setLastSeenVersion(data.latest.version);
+    }
+    setIsOpen(false);
+  }, [profileId, data]);
+
+  const handleMutedChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const nextValue = event.target.checked;
+      setMuted(nextValue);
+      if (profileId) {
+        const key = scopedKey(profileId, 'muted');
+        writeStorage(key, nextValue ? 'true' : 'false');
+      }
+    },
+    [profileId],
+  );
+
+  const latest = data?.latest;
+  const formattedDate = useMemo(() => formatDate(latest?.date ?? null), [latest?.date]);
+  const changelogUrl = latest?.url ?? data?.source?.changelog ?? null;
+
+  if (!latest) {
+    return null;
+  }
+
+  const modalTitleId = 'release-notes-title';
+  const modalDescriptionId = 'release-notes-description';
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      className="fixed inset-0 z-[1000] flex items-center justify-center p-4"
+      ariaLabelledBy={modalTitleId}
+      ariaDescribedBy={modalDescriptionId}
+    >
+      <div className="fixed inset-0 z-[1000] bg-black/60" aria-hidden="true" onClick={handleClose} />
+      <div className="relative z-[1001] w-full max-w-xl rounded-lg bg-ub-grey text-white shadow-xl">
+        <header className="flex items-start justify-between border-b border-white/10 p-4">
+          <div>
+            <h2 id={modalTitleId} className="text-xl font-semibold">
+              {`What's new in v${latest.version}`}
+            </h2>
+            {formattedDate && (
+              <p className="mt-1 text-sm text-ubt-grey">Released on {formattedDate}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded bg-white/10 px-2 py-1 text-sm font-medium text-white transition-colors hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ubb-orange focus-visible:ring-offset-2 focus-visible:ring-offset-ub-grey"
+          >
+            Close
+          </button>
+        </header>
+        <div id={modalDescriptionId} className="max-h-[60vh] space-y-4 overflow-y-auto p-4">
+          {(latest.sections ?? []).length === 0 ? (
+            <p>No release notes available for this version.</p>
+          ) : (
+            (latest.sections ?? []).map((section) => (
+              <section key={section.title} className="space-y-2">
+                <h3 className="text-lg font-semibold">{section.title}</h3>
+                {section.description && (
+                  <p
+                    className="text-sm text-ubt-grey"
+                    dangerouslySetInnerHTML={{ __html: sanitizeMarkdown(section.description) }}
+                  />
+                )}
+                {section.items && section.items.length > 0 && (
+                  <ul className="list-disc space-y-1 pl-5 text-sm">
+                    {section.items.map((item, index) => (
+                      <li
+                        key={`${section.title}-${index}`}
+                        dangerouslySetInnerHTML={{ __html: sanitizeMarkdown(item) }}
+                      />
+                    ))}
+                  </ul>
+                )}
+              </section>
+            ))
+          )}
+        </div>
+        <footer className="flex flex-col gap-4 border-t border-white/10 p-4 text-sm sm:flex-row sm:items-center sm:justify-between">
+          <label className="flex items-center gap-2">
+            <input type="checkbox" checked={muted} onChange={handleMutedChange} />
+            <span>Don&apos;t show again for this profile</span>
+          </label>
+          {changelogUrl && (
+            <a
+              href={changelogUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-ubt-blue underline transition-colors hover:text-ubb-orange"
+            >
+              View full changelog
+            </a>
+          )}
+        </footer>
+      </div>
+    </Modal>
+  );
+};
+
+export default ReleaseNotesModal;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://unnippillil.com/",
   "scripts": {
     "build:gamepad": "tsc -p tsconfig.gamepad.json",
-    "prebuild": "tsc -p tsconfig.gamepad.json",
+    "prebuild": "tsc -p tsconfig.gamepad.json && node scripts/generate-release-notes.mjs",
     "dev": "next dev",
     "build": "next build",
     "postbuild": "node scripts/safe-copy.mjs",

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -24,6 +24,17 @@ const InstallButton = dynamic(
     loading: () => <p>Loading install options...</p>,
   }
 );
+const ReleaseNotesModal = dynamic(
+  () =>
+    import('../components/common/ReleaseNotesModal').catch((err) => {
+      console.error('Failed to load ReleaseNotesModal component', err);
+      return { default: () => null };
+    }),
+  {
+    ssr: false,
+    loading: () => null,
+  }
+);
 
 /**
  * @returns {JSX.Element}
@@ -37,6 +48,7 @@ const App = () => (
     <Ubuntu />
     <BetaBadge />
     <InstallButton />
+    <ReleaseNotesModal />
   </>
 );
 

--- a/public/release-notes.json
+++ b/public/release-notes.json
@@ -1,0 +1,62 @@
+{
+  "generatedAt": "2025-09-19T05:27:05.451Z",
+  "source": {
+    "changelog": "https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/CHANGELOG.md"
+  },
+  "latest": {
+    "version": "2.1.0",
+    "date": "2025-09-03",
+    "url": "https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/CHANGELOG.md#210---2025-09-03",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "Added safe copy script and integrated into build process."
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Handle missing chat ID in chat module.",
+          "Pin Vercel runtime version to prevent deployment errors.",
+          "Update runtime mocks to resolve test issues."
+        ]
+      },
+      {
+        "title": "Upgrading",
+        "items": [
+          "No notable behavior changes."
+        ]
+      }
+    ]
+  },
+  "entries": [
+    {
+      "version": "2.1.0",
+      "date": "2025-09-03",
+      "url": "https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/CHANGELOG.md#210---2025-09-03",
+      "sections": [
+        {
+          "title": "Added",
+          "items": [
+            "Added safe copy script and integrated into build process."
+          ]
+        },
+        {
+          "title": "Fixed",
+          "items": [
+            "Handle missing chat ID in chat module.",
+            "Pin Vercel runtime version to prevent deployment errors.",
+            "Update runtime mocks to resolve test issues."
+          ]
+        },
+        {
+          "title": "Upgrading",
+          "items": [
+            "No notable behavior changes."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -1,0 +1,186 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const REPO_URL = 'https://github.com/Alex-Unnippillil/kali-linux-portfolio';
+const CHANGELOG_URL = `${REPO_URL}/blob/main/CHANGELOG.md`;
+const CHANGELOG_PATH = path.join(process.cwd(), 'CHANGELOG.md');
+const OUTPUT_PATH = path.join(process.cwd(), 'public', 'release-notes.json');
+
+const headingSlug = (version, date) => {
+  const heading = `[${version}]${date ? ` - ${date}` : ''}`;
+  return heading
+    .toLowerCase()
+    .replace(/[\[\]]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+};
+
+const createEntryUrl = (version, date) => `${CHANGELOG_URL}#${headingSlug(version, date)}`;
+
+const ensureSection = (entry, title = 'Changes') => {
+  if (!entry.currentSection) {
+    entry.currentSection = { title, items: [], description: '' };
+    entry.sections.push(entry.currentSection);
+  }
+  return entry.currentSection;
+};
+
+const pushEntry = (entries, entryState) => {
+  if (!entryState.currentEntry) return;
+
+  const sections = entryState.sections
+    .map((section) => {
+      const items = section.items
+        .map((item) => item.trim())
+        .filter(Boolean);
+      const description = section.description?.trim?.();
+      const result = {
+        title: section.title,
+        ...(items.length > 0 ? { items } : {}),
+        ...(description ? { description } : {}),
+      };
+      return result;
+    })
+    .filter((section) => (section.items && section.items.length > 0) || section.description);
+
+  const entry = {
+    version: entryState.currentEntry.version,
+    ...(entryState.currentEntry.date ? { date: entryState.currentEntry.date } : {}),
+    url: createEntryUrl(entryState.currentEntry.version, entryState.currentEntry.date),
+    sections,
+  };
+  entries.push(entry);
+  entryState.currentEntry = null;
+  entryState.sections = [];
+  entryState.currentSection = null;
+  entryState.currentItemIndex = -1;
+};
+
+const parseChangelog = (raw) => {
+  const lines = raw.split(/\r?\n/);
+  const entries = [];
+  const state = {
+    currentEntry: null,
+    sections: [],
+    currentSection: null,
+    currentItemIndex: -1,
+  };
+
+  for (const originalLine of lines) {
+    const line = originalLine.replace(/\r$/, '');
+    const trimmed = line.trim();
+
+    if (trimmed.length === 0) {
+      state.currentItemIndex = -1;
+      continue;
+    }
+
+    if (/^\[[^\]]+\]:/.test(trimmed)) {
+      continue;
+    }
+
+    if (/^---+$/.test(trimmed)) {
+      continue;
+    }
+
+    const entryMatch = trimmed.match(/^## \[(.+?)\](?: - ([^\]]+))?/);
+    if (entryMatch) {
+      pushEntry(entries, state);
+      const version = entryMatch[1].trim();
+      const date = entryMatch[2]?.trim() ?? null;
+      if (version.toLowerCase() === 'unreleased') {
+        state.currentEntry = null;
+        state.sections = [];
+        state.currentSection = null;
+        state.currentItemIndex = -1;
+        continue;
+      }
+      state.currentEntry = { version, date };
+      state.sections = [];
+      state.currentSection = null;
+      state.currentItemIndex = -1;
+      continue;
+    }
+
+    if (!state.currentEntry) {
+      continue;
+    }
+
+    const sectionMatch = trimmed.match(/^### (.+)$/);
+    if (sectionMatch) {
+      state.currentSection = {
+        title: sectionMatch[1].trim(),
+        items: [],
+        description: '',
+      };
+      state.sections.push(state.currentSection);
+      state.currentItemIndex = -1;
+      continue;
+    }
+
+    const bulletMatch = line.match(/^\s*[-*]\s+(.*)$/);
+    if (bulletMatch) {
+      const section = ensureSection(state, state.currentSection?.title ?? 'Changes');
+      const text = bulletMatch[1].trim();
+      section.items.push(text);
+      state.currentItemIndex = section.items.length - 1;
+      continue;
+    }
+
+    const continuationMatch = line.match(/^\s{2,}(.*)$/);
+    if (continuationMatch && state.currentSection && state.currentItemIndex >= 0) {
+      const addition = continuationMatch[1].trim();
+      if (addition) {
+        state.currentSection.items[state.currentItemIndex] += ` ${addition}`;
+      }
+      continue;
+    }
+
+    const section = ensureSection(state, state.currentSection?.title ?? 'Changes');
+    section.description = section.description
+      ? `${section.description} ${trimmed}`
+      : trimmed;
+    state.currentItemIndex = -1;
+  }
+
+  pushEntry(entries, state);
+  return entries;
+};
+
+const run = async () => {
+  let changelog;
+  try {
+    changelog = await fs.readFile(CHANGELOG_PATH, 'utf8');
+  } catch (error) {
+    throw new Error(`Failed to read CHANGELOG.md: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const entries = parseChangelog(changelog);
+
+  if (!entries.length) {
+    throw new Error('No release entries found in CHANGELOG.md');
+  }
+
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    source: {
+      changelog: CHANGELOG_URL,
+    },
+    latest: entries[0],
+    entries,
+  };
+
+  await fs.writeFile(OUTPUT_PATH, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+
+  console.log(
+    `[release-notes] Generated ${path.relative(process.cwd(), OUTPUT_PATH)} with ${entries.length} release${
+      entries.length === 1 ? '' : 's'
+    }.`,
+  );
+};
+
+run().catch((error) => {
+  console.error('[release-notes] Generation failed:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- generate `public/release-notes.json` from the changelog during the build pipeline
- surface a client release notes modal with focus management, profile-based mute persistence, and changelog links
- cover the modal behaviors with dedicated Jest tests

## Testing
- yarn lint *(fails: repository already contains numerous accessibility lint violations unrelated to this change)*
- yarn test __tests__/ReleaseNotesModal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cce5ca122883289e2ca1c2064bdc05