### PR TITLE
[wasm] add runtime harness with fallbacks

### DIFF
--- a/__tests__/wasmRuntime.test.ts
+++ b/__tests__/wasmRuntime.test.ts
@@ -1,0 +1,49 @@
+import { createHashAccelerator } from '../wasm/hashModule';
+import { loadWasmModule, resetWasmRuntimeState } from '../wasm/runtime';
+
+describe('WASM runtime', () => {
+  beforeEach(() => {
+    resetWasmRuntimeState();
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_ENABLE_WASM_RUNTIME;
+    delete process.env.ENABLE_WASM_RUNTIME;
+    const globalObject = globalThis as {
+      __KALI_FEATURES__?: unknown;
+    };
+    delete globalObject.__KALI_FEATURES__;
+    resetWasmRuntimeState();
+  });
+
+  it('falls back to the JS implementation when the feature flag disables WASM', async () => {
+    process.env.NEXT_PUBLIC_ENABLE_WASM_RUNTIME = 'disabled';
+    const accelerator = await createHashAccelerator();
+    expect(accelerator.wasWasmUsed).toBe(false);
+    expect(accelerator.hash('abc')).toBe(294);
+    accelerator.release();
+  });
+
+  it('loads the WASM module and produces deterministic hashes when enabled', async () => {
+    const accelerator = await createHashAccelerator();
+    expect(accelerator.wasWasmUsed).toBe(true);
+    expect(accelerator.hash('abc')).toBe(294);
+    expect(accelerator.hash(new Uint8Array([1, 2, 3]))).toBe(6);
+    accelerator.release();
+  });
+
+  it('gracefully falls back if instantiation fails', async () => {
+    const handle = await loadWasmModule<{ ok: boolean }>({
+      name: 'broken-module',
+      moduleBytes: new Uint8Array([0, 1, 2, 3]),
+      fallback: () => ({ ok: true }),
+      setup() {
+        throw new Error('Should not run');
+      },
+    });
+
+    expect(handle.wasWasmUsed).toBe(false);
+    expect(handle.exports).toEqual({ ok: true });
+    handle.release();
+  });
+});

--- a/docs/wasm-runtime.md
+++ b/docs/wasm-runtime.md
@@ -1,0 +1,88 @@
+# WASM Runtime Harness
+
+This project ships a lightweight WebAssembly runtime wrapper that standardises how
+modules are fetched, instantiated, pooled, and sandboxed. Use it to integrate
+new compute-heavy helpers while keeping the UI responsive and fallbacks safe.
+
+## Feature flagging
+
+WebAssembly paths are disabled whenever the runtime cannot probe the necessary
+capabilities **or** when a feature flag requests a fallback. The runtime looks at
+these flags in order:
+
+1. `NEXT_PUBLIC_ENABLE_WASM_RUNTIME`
+2. `ENABLE_WASM_RUNTIME`
+3. `globalThis.__KALI_FEATURES__?.wasmRuntime`
+
+Accepted values (case insensitive) are `enabled`, `disabled`, `true`, `false`,
+`on`, `off`, `1`, or `0`. When no overrides are present the runtime uses the
+feature whenever `WebAssembly` is available in the current environment.
+
+## Loading modules
+
+Use `loadWasmModule` from `wasm/runtime.ts` to bootstrap a module. The helper:
+
+- Reuses `WebAssembly.Memory` objects via opt-in pools so several modules can
+  share the same backing store.
+- Configures imports (providing a default `env.memory` binding when needed).
+- Times out fetch/instantiation attempts so failures do not hang the UI.
+- Falls back to the supplied JS implementation on errors, disabled flags, or
+  environments without WASM support.
+- Optionally spins up a dedicated worker. The inline worker is limited to
+  modules without custom imports—provide a `WorkerFactory` if you need a custom
+  script.
+
+```ts
+const handle = await loadWasmModule<MyExports>({
+  name: 'demo-module',
+  moduleUrl: '/modules/demo.wasm',
+  memory: { initial: 2, maximum: 4, shared: true, pool: 'demo-pool' },
+  importObject: ({ capabilities }) => ({
+    env: {
+      abort: () => console.warn('abort from demo-module'),
+      supportsThreads: capabilities.threads,
+    },
+  }),
+  fallback: () => ({ /* JS implementation */ }),
+});
+
+// Use the exports
+handle.exports.doWork();
+
+// Release when done to decrement the memory pool reference count
+handle.release();
+```
+
+Call `resetWasmRuntimeState()` in tests to clear caches and memory pools.
+
+## Sample module: hash accelerator
+
+`wasm/hashModule.ts` demonstrates the runtime with a tiny WASM module that sums
+bytes for a lightweight hashing helper. The helper automatically falls back to a
+JS implementation when WASM is unavailable:
+
+```ts
+const accelerator = await createHashAccelerator();
+const digest = accelerator.hash('hello world');
+accelerator.release();
+```
+
+## Onboarding checklist for new modules
+
+1. **Decide on the entry point.** Create a helper similar to
+   `wasm/hashModule.ts` that wraps WASM exports in a friendly API and provides a
+   JS fallback.
+2. **Use memory pools.** Declare a `memory.pool` key when multiple modules can
+   reuse the same configuration. This avoids redundant allocations.
+3. **Limit capabilities.** Keep imports explicit and lean. Probe optional
+   features via the `capabilities` field instead of assuming availability.
+4. **Add tests.** Cover both the WASM and fallback paths. Tests should call
+   `resetWasmRuntimeState()` between runs to avoid shared state.
+5. **Document flags.** Note any new feature toggles in this file or the relevant
+   app README.
+6. **Review worker needs.** If a module must run off the main thread and
+   requires custom imports, provide a bespoke `WorkerFactory` so the runtime can
+   load the correct script.
+
+Following this checklist keeps new modules sandboxed, debuggable, and easy to
+ship across environments that may lack WebAssembly.

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "playwright-core": "^1.55.0",
     "test-exclude": "7.0.1",
     "typescript": "5.8.2",
+    "wabt": "^1.0.37",
     "wait-on": "^8.0.4",
     "webpack": "^5.92.0",
     "workbox-build": "7.1.1",

--- a/wasm/hashModule.ts
+++ b/wasm/hashModule.ts
@@ -1,0 +1,94 @@
+import { loadWasmModule, WasmModuleHandle } from './runtime';
+
+const WASM_HASH_BYTES = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 7, 1, 96, 2, 127, 127, 1, 127, 3, 2, 1, 0,
+  5, 3, 1, 0, 1, 7, 17, 2, 6, 109, 101, 109, 111, 114, 121, 2, 0, 4, 104, 97,
+  115, 104, 0, 0, 10, 48, 1, 46, 1, 2, 127, 32, 0, 32, 1, 106, 33, 2, 3, 64,
+  32, 0, 32, 2, 79, 4, 64, 32, 3, 15, 11, 32, 3, 32, 0, 45, 0, 0, 106, 33, 3,
+  32, 0, 65, 1, 106, 33, 0, 12, 0, 11, 32, 3, 11, 0, 31, 4, 110, 97, 109, 101,
+  2, 24, 1, 0, 4, 0, 3, 112, 116, 114, 1, 3, 108, 101, 110, 2, 3, 101, 110,
+  100, 3, 4, 104, 97, 115, 104,
+]);
+
+export interface HashAccelerator {
+  hash(input: Uint8Array | string): number;
+  release(): void;
+  wasWasmUsed: boolean;
+}
+
+interface NativeHashExports {
+  memory: WebAssembly.Memory;
+  hash(ptr: number, len: number): number;
+}
+
+interface HashModuleExports {
+  hashBytes(buffer: Uint8Array): number;
+}
+
+function ensureCapacity(memory: WebAssembly.Memory, length: number): Uint8Array {
+  const pageSize = 65_536;
+  if (memory.buffer.byteLength < length) {
+    const additional = Math.ceil(
+      (length - memory.buffer.byteLength) / pageSize,
+    );
+    memory.grow(additional);
+  }
+  return new Uint8Array(memory.buffer, 0, length);
+}
+
+function toBytes(input: Uint8Array | string): Uint8Array {
+  if (typeof input === 'string') {
+    return new TextEncoder().encode(input);
+  }
+  return input;
+}
+
+function createJsFallback(): HashModuleExports {
+  return {
+    hashBytes(buffer: Uint8Array) {
+      let sum = 0;
+      for (let i = 0; i < buffer.length; i += 1) {
+        sum = (sum + buffer[i]) >>> 0;
+      }
+      return sum;
+    },
+  };
+}
+
+async function createNativeHasher(): Promise<WasmModuleHandle<HashModuleExports>> {
+  return loadWasmModule<HashModuleExports>({
+    name: 'hash-accelerator',
+    moduleBytes: WASM_HASH_BYTES,
+    memory: {
+      initial: 1,
+      pool: 'hash-accelerator',
+    },
+    fallback: createJsFallback,
+    setup(instance) {
+      const exports = instance.exports as unknown as NativeHashExports;
+      const memory = exports.memory;
+      return {
+        hashBytes(buffer: Uint8Array) {
+          const view = ensureCapacity(memory, buffer.length);
+          view.set(buffer);
+          const result = exports.hash(0, buffer.length);
+          return result >>> 0;
+        },
+      };
+    },
+  });
+}
+
+export async function createHashAccelerator(): Promise<HashAccelerator> {
+  const handle = await createNativeHasher();
+  return {
+    hash(input: Uint8Array | string) {
+      const bytes = toBytes(input);
+      return handle.exports.hashBytes(bytes);
+    },
+    release() {
+      handle.release();
+    },
+    wasWasmUsed: handle.wasWasmUsed,
+  };
+}

--- a/wasm/runtime.ts
+++ b/wasm/runtime.ts
@@ -1,0 +1,585 @@
+import { createLogger } from '../lib/logger';
+
+const logger = createLogger('wasm-runtime');
+
+export interface WasmCapabilityReport {
+  supported: boolean;
+  sharedMemory: boolean;
+  threads: boolean;
+  bulkMemory: boolean;
+}
+
+export interface MemoryPoolConfig {
+  initial: number;
+  maximum?: number;
+  shared?: boolean;
+  /**
+   * Optional pool identifier used to reuse a memory instance across modules
+   * that can safely share the same backing store.
+   */
+  pool?: string;
+}
+
+export interface WasmRuntimeContext {
+  memory?: WebAssembly.Memory;
+  capabilities: WasmCapabilityReport;
+}
+
+export interface WorkerProxy {
+  invoke<T = unknown>(exportName: string, ...args: unknown[]): Promise<T>;
+  terminate(): void;
+  worker: Worker;
+}
+
+export interface WasmModuleHandle<TExports> {
+  name: string;
+  exports: TExports;
+  memory?: WebAssembly.Memory;
+  release(): void;
+  /**
+   * Indicates whether the WebAssembly path was used instead of the fallback.
+   */
+  wasWasmUsed: boolean;
+  /**
+   * Provides the detected capabilities that were used to decide between WASM
+   * and the fallback implementation.
+   */
+  capabilities: WasmCapabilityReport;
+  workerProxy?: WorkerProxy;
+}
+
+export type ImportObjectFactory = (
+  context: WasmRuntimeContext,
+) => WebAssembly.Imports;
+
+export type WorkerFactory = () => Worker;
+
+export interface WasmModuleConfig<TExports> {
+  name: string;
+  moduleUrl?: string;
+  moduleBytes?: ArrayBuffer | ArrayBufferView;
+  cacheKey?: string;
+  importObject?: WebAssembly.Imports | ImportObjectFactory;
+  memory?: MemoryPoolConfig;
+  fallback: () => Promise<TExports> | TExports;
+  setup?: (
+    instance: WebAssembly.Instance,
+    context: WasmRuntimeContext,
+  ) => Promise<TExports> | TExports;
+  timeoutMs?: number;
+  useWorker?: boolean | WorkerFactory;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const moduleCache = new Map<string, WebAssembly.Module>();
+
+type MemoryPool = {
+  memory: WebAssembly.Memory;
+  refCount: number;
+  descriptor: WebAssembly.MemoryDescriptor;
+};
+
+const memoryPools = new Map<string, MemoryPool>();
+let cachedCapabilities: WasmCapabilityReport | null = null;
+
+function parseBooleanFlag(value: unknown): boolean | null {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['1', 'true', 'enabled', 'on', 'yes'].includes(normalized)) {
+      return true;
+    }
+    if (['0', 'false', 'disabled', 'off', 'no'].includes(normalized)) {
+      return false;
+    }
+  }
+  return null;
+}
+
+function resolveFeatureFlag(defaultValue: boolean): boolean {
+  const envFlag =
+    parseBooleanFlag(process.env.NEXT_PUBLIC_ENABLE_WASM_RUNTIME) ??
+    parseBooleanFlag(process.env.ENABLE_WASM_RUNTIME);
+  if (envFlag !== null) {
+    return envFlag;
+  }
+
+  if (typeof globalThis === 'object') {
+    const globalFlag = parseBooleanFlag(
+      (globalThis as any).__KALI_FEATURES__?.wasmRuntime,
+    );
+    if (globalFlag !== null) {
+      return globalFlag;
+    }
+  }
+
+  return defaultValue;
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  errorMessage: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    promise.finally(() => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }),
+    new Promise<T>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error(errorMessage));
+      }, timeoutMs);
+    }),
+  ]);
+}
+
+function detectSharedMemorySupport(): boolean {
+  try {
+    if (typeof SharedArrayBuffer === 'undefined') {
+      return false;
+    }
+    const memory = new WebAssembly.Memory({
+      initial: 1,
+      maximum: 1,
+      shared: true,
+    });
+    // Trigger usage of the memory so engines allocate it eagerly.
+    const view = new Uint8Array(memory.buffer);
+    view[0] = view[0];
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function detectBulkMemorySupport(): boolean {
+  return typeof WebAssembly === 'object' && 'Memory' in WebAssembly;
+}
+
+export function detectWasmCapabilities(): WasmCapabilityReport {
+  if (cachedCapabilities) {
+    return cachedCapabilities;
+  }
+
+  const supported = typeof WebAssembly !== 'undefined';
+
+  const sharedMemory = supported && detectSharedMemorySupport();
+  const threads = sharedMemory && typeof Atomics !== 'undefined';
+  const bulkMemory = supported && detectBulkMemorySupport();
+
+  cachedCapabilities = { supported, sharedMemory, threads, bulkMemory };
+  return cachedCapabilities;
+}
+
+async function fetchModuleBytes(
+  config: WasmModuleConfig<unknown>,
+): Promise<ArrayBuffer> {
+  if (config.moduleBytes) {
+    if (config.moduleBytes instanceof ArrayBuffer) {
+      return config.moduleBytes;
+    }
+    const view = config.moduleBytes as ArrayBufferView;
+    return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength);
+  }
+
+  if (!config.moduleUrl) {
+    throw new Error(`Module "${config.name}" did not provide bytes or a URL.`);
+  }
+
+  const response = await fetch(config.moduleUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch WASM module at ${config.moduleUrl}: ${response.status}`,
+    );
+  }
+  return response.arrayBuffer();
+}
+
+function getMemoryPoolKey(
+  config: MemoryPoolConfig,
+  shared: boolean,
+): string {
+  const maximumPart =
+    typeof config.maximum === 'number' ? `:${config.maximum}` : ':none';
+  const poolId = config.pool ?? `${config.initial}${maximumPart}`;
+  return `${poolId}:${shared ? 'shared' : 'private'}`;
+}
+
+function acquireMemory(
+  config: MemoryPoolConfig | undefined,
+  capabilities: WasmCapabilityReport,
+): { memory?: WebAssembly.Memory; poolKey?: string } {
+  if (!config) {
+    return {};
+  }
+
+  const sharedRequested = Boolean(config.shared);
+  const sharedAvailable = sharedRequested && capabilities.sharedMemory;
+  const poolKey = getMemoryPoolKey(config, sharedAvailable);
+  let pool = memoryPools.get(poolKey);
+  if (!pool) {
+    const descriptor: WebAssembly.MemoryDescriptor = {
+      initial: config.initial,
+    };
+    if (typeof config.maximum === 'number') {
+      descriptor.maximum = config.maximum;
+    }
+    if (sharedAvailable) {
+      descriptor.shared = true;
+    } else if (sharedRequested && !capabilities.sharedMemory) {
+      logger.warn('Shared memory requested but not supported; falling back.', {
+        pool: config.pool ?? config.initial,
+      });
+    }
+
+    pool = {
+      memory: new WebAssembly.Memory(descriptor),
+      refCount: 0,
+      descriptor,
+    };
+    memoryPools.set(poolKey, pool);
+  }
+  pool.refCount += 1;
+  return { memory: pool.memory, poolKey };
+}
+
+function releaseMemory(poolKey?: string): void {
+  if (!poolKey) {
+    return;
+  }
+  const pool = memoryPools.get(poolKey);
+  if (!pool) {
+    return;
+  }
+  pool.refCount -= 1;
+  if (pool.refCount <= 0) {
+    memoryPools.delete(poolKey);
+  }
+}
+
+async function compileModule(
+  config: WasmModuleConfig<unknown>,
+  bytes: ArrayBuffer,
+): Promise<WebAssembly.Module> {
+  const cacheKey = config.cacheKey ?? config.moduleUrl ?? config.name;
+  const cached = moduleCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const compiledModule = await WebAssembly.compile(bytes);
+  moduleCache.set(cacheKey, compiledModule);
+  return compiledModule;
+}
+
+function ensureEnvImport(importObject: WebAssembly.Imports, memory?: WebAssembly.Memory) {
+  if (!memory) {
+    return importObject;
+  }
+  const normalized = { ...importObject } as Record<string, Record<string, any>>;
+  normalized.env = {
+    ...(normalized.env ?? {}),
+    memory,
+  };
+  return normalized;
+}
+
+function getWorkerFactory(useWorker: boolean | WorkerFactory | undefined):
+  | WorkerFactory
+  | null {
+  if (!useWorker) {
+    return null;
+  }
+  if (typeof Worker === 'undefined') {
+    return null;
+  }
+  if (typeof useWorker === 'function') {
+    return useWorker;
+  }
+  return createInlineWorker;
+}
+
+function createInlineWorker(): Worker {
+  const source = `
+    let instance = null;
+    let memory = null;
+
+    async function init(config) {
+      try {
+        if (config.memoryDescriptor) {
+          memory = new WebAssembly.Memory(config.memoryDescriptor);
+        }
+        const imports = {};
+        if (memory) {
+          imports.env = { memory };
+        }
+        const module = await WebAssembly.instantiate(config.moduleBytes, imports);
+        instance = module.instance;
+        self.postMessage({ type: 'ready' });
+      } catch (error) {
+        self.postMessage({ type: 'error', message: error?.message || String(error) });
+      }
+    }
+
+    function handleCall(message) {
+      if (!instance) {
+        self.postMessage({ type: 'error', callId: message.callId, message: 'Instance not ready' });
+        return;
+      }
+      try {
+        const result = instance.exports[message.exportName](...(message.args || []));
+        self.postMessage({ type: 'result', callId: message.callId, result });
+      } catch (error) {
+        self.postMessage({ type: 'error', callId: message.callId, message: error?.message || String(error) });
+      }
+    }
+
+    self.onmessage = (event) => {
+      const message = event.data || {};
+      switch (message.type) {
+        case 'init':
+          init(message.config);
+          break;
+        case 'call':
+          handleCall(message);
+          break;
+        case 'terminate':
+          self.close();
+          break;
+        default:
+          break;
+      }
+    };
+  `;
+  const blob = new Blob([source], { type: 'application/javascript' });
+  const workerUrl = URL.createObjectURL(blob);
+  const worker = new Worker(workerUrl);
+  URL.revokeObjectURL(workerUrl);
+  return worker;
+}
+
+function buildWorkerProxy(
+  factory: WorkerFactory,
+  moduleBytes: ArrayBuffer,
+  memoryDescriptor?: WebAssembly.MemoryDescriptor,
+  timeoutMs: number,
+): Promise<WorkerProxy> {
+  return new Promise((resolve, reject) => {
+    const worker = factory();
+    const timer = setTimeout(() => {
+      worker.terminate();
+      reject(new Error('Timed out initialising WASM worker.'));
+    }, timeoutMs);
+
+    const pending = new Map<number, { resolve: (value: any) => void; reject: (reason?: any) => void }>();
+    let nextCallId = 0;
+
+    worker.onmessage = (event: MessageEvent) => {
+      const data = event.data || {};
+      switch (data.type) {
+        case 'ready':
+          clearTimeout(timer);
+          resolve({
+            worker,
+            invoke(exportName: string, ...args: unknown[]) {
+              const callId = nextCallId += 1;
+              return new Promise((callResolve, callReject) => {
+                pending.set(callId, { resolve: callResolve, reject: callReject });
+                worker.postMessage({ type: 'call', exportName, args, callId });
+              });
+            },
+            terminate() {
+              worker.postMessage({ type: 'terminate' });
+              worker.terminate();
+              pending.forEach(({ reject: callReject }) =>
+                callReject(new Error('Worker terminated.')),
+              );
+              pending.clear();
+            },
+          });
+          break;
+        case 'result': {
+          const entry = pending.get(data.callId);
+          if (entry) {
+            entry.resolve(data.result);
+            pending.delete(data.callId);
+          }
+          break;
+        }
+        case 'error': {
+          const entry = pending.get(data.callId);
+          if (entry) {
+            entry.reject(new Error(data.message));
+            pending.delete(data.callId);
+          } else {
+            clearTimeout(timer);
+            worker.terminate();
+            reject(new Error(data.message));
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    };
+
+    worker.postMessage(
+      {
+        type: 'init',
+        config: {
+          moduleBytes,
+          memoryDescriptor,
+        },
+      },
+      [moduleBytes],
+    );
+  });
+}
+
+function shouldUseWasm(capabilities: WasmCapabilityReport): boolean {
+  return resolveFeatureFlag(capabilities.supported);
+}
+
+async function instantiateModule<TExports>(
+  config: WasmModuleConfig<TExports>,
+  capabilities: WasmCapabilityReport,
+  bytes: ArrayBuffer,
+  memory: WebAssembly.Memory | undefined,
+  timeoutMs: number,
+): Promise<WasmModuleHandle<TExports>> {
+  const workerFactory = getWorkerFactory(config.useWorker);
+  if (workerFactory && config.importObject) {
+    logger.warn(
+      'Worker integration does not support custom imports; falling back to main thread.',
+      { name: config.name },
+    );
+  }
+
+  if (workerFactory && !config.importObject) {
+    const memoryDescriptor = memory
+      ? {
+          initial: memory.buffer.byteLength / 65_536,
+          maximum: undefined,
+          shared: false,
+        }
+      : undefined;
+
+    try {
+      const proxy = await buildWorkerProxy(
+        workerFactory,
+        bytes.slice(0),
+        memoryDescriptor,
+        timeoutMs,
+      );
+      return {
+        name: config.name,
+        exports: ({} as unknown) as TExports,
+        release() {
+          proxy.terminate();
+        },
+        wasWasmUsed: true,
+        capabilities,
+        workerProxy: proxy,
+      };
+    } catch (error) {
+      logger.warn('Worker initialisation failed; falling back to main thread.', {
+        name: config.name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const compiledModule = await compileModule(config, bytes);
+  const imports =
+    typeof config.importObject === 'function'
+      ? config.importObject({ memory, capabilities })
+      : config.importObject ?? {};
+  const normalizedImports = ensureEnvImport(imports, memory);
+
+  const instance = await WebAssembly.instantiate(
+    compiledModule,
+    normalizedImports,
+  );
+  const exports = config.setup
+    ? await config.setup(instance, { memory, capabilities })
+    : ((instance.exports as unknown) as TExports);
+
+  return {
+    name: config.name,
+    exports,
+    memory,
+    release() {
+      // Nothing to dispose besides releasing pooled memory in the caller.
+    },
+    wasWasmUsed: true,
+    capabilities,
+  };
+}
+
+async function loadFallback<TExports>(
+  config: WasmModuleConfig<TExports>,
+  capabilities: WasmCapabilityReport,
+): Promise<WasmModuleHandle<TExports>> {
+  const exports = await config.fallback();
+  return {
+    name: config.name,
+    exports,
+    release() {},
+    wasWasmUsed: false,
+    capabilities,
+  };
+}
+
+export async function loadWasmModule<TExports>(
+  config: WasmModuleConfig<TExports>,
+): Promise<WasmModuleHandle<TExports>> {
+  const capabilities = detectWasmCapabilities();
+  if (!capabilities.supported || !shouldUseWasm(capabilities)) {
+    return loadFallback(config, capabilities);
+  }
+
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const { memory, poolKey } = acquireMemory(config.memory, capabilities);
+
+  try {
+    const bytes = await withTimeout(
+      fetchModuleBytes(config),
+      timeoutMs,
+      `Timed out fetching WASM module ${config.name}.`,
+    );
+
+    const handle = await withTimeout(
+      instantiateModule(config, capabilities, bytes, memory, timeoutMs),
+      timeoutMs,
+      `Timed out instantiating WASM module ${config.name}.`,
+    );
+
+    const originalRelease = handle.release.bind(handle);
+    handle.release = () => {
+      try {
+        originalRelease();
+      } finally {
+        releaseMemory(poolKey);
+      }
+    };
+
+    return handle;
+  } catch (error) {
+    logger.warn('WASM module failed; using fallback.', {
+      name: config.name,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    releaseMemory(poolKey);
+    return loadFallback(config, capabilities);
+  }
+}
+
+export function resetWasmRuntimeState(): void {
+  moduleCache.clear();
+  memoryPools.clear();
+  cachedCapabilities = null;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13963,6 +13963,7 @@ __metadata:
     three: "npm:^0.179.1"
     turndown: "npm:^7.2.1"
     typescript: "npm:5.8.2"
+    wabt: "npm:^1.0.37"
     wait-on: "npm:^8.0.4"
     webpack: "npm:^5.92.0"
     workbox-build: "npm:7.1.1"
@@ -14119,6 +14120,23 @@ __metadata:
   dependencies:
     xml-name-validator: "npm:^5.0.0"
   checksum: 10c0/8712774c1aeb62dec22928bf1cdfd11426c2c9383a1a63f2bcae18db87ca574165a0fbe96b312b73652149167ac6c7f4cf5409f2eb101d9c805efe0e4bae798b
+  languageName: node
+  linkType: hard
+
+"wabt@npm:^1.0.37":
+  version: 1.0.37
+  resolution: "wabt@npm:1.0.37"
+  bin:
+    wasm-decompile: bin/wasm-decompile
+    wasm-interp: bin/wasm-interp
+    wasm-objdump: bin/wasm-objdump
+    wasm-stats: bin/wasm-stats
+    wasm-strip: bin/wasm-strip
+    wasm-validate: bin/wasm-validate
+    wasm2c: bin/wasm2c
+    wasm2wat: bin/wasm2wat
+    wat2wasm: bin/wat2wasm
+  checksum: 10c0/d0a43755986baffc9ee3b321eed3913bc1c4abd9dd8e63b8a27d261159c0e3536db176a995ee15f9db44206fcf54c7ccadf1ee412522dce44ea09c40095185eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add a shared WASM runtime harness with feature flags, memory pooling, worker hooks, and fallback handling
- ship a hash accelerator example plus onboarding docs for future WebAssembly helpers
- cover both the wasm and JS fallback paths with automated tests

## Testing
- yarn lint
- yarn test wasmRuntime

------
https://chatgpt.com/codex/tasks/task_e_68dc93586c288328a01ef0f376b85ec0