### PR TITLE
[utils] Add deterministic serializer for stable caches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,7 @@ Use these step‑by‑step guides to avoid breaking conventions.
 * [ ] Screenshots or short clip added for UI changes
 * [ ] Docs updated if you added a flag or app
 * [ ] PR reviewed on both serverful and static builds if the feature touches `/api/*`
+* [ ] Snapshot-sensitive caches or diffs use the deterministic serializer from `utils/serdes.ts`
 
 ```
 

--- a/__tests__/__snapshots__/serdes.test.ts.snap
+++ b/__tests__/__snapshots__/serdes.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`deterministicStringify produces identical output for equivalent permutations 1`] = `"{"a":1,"z":{"x":{"a":null,"c":true},"y":[3,2,1]}}"`;

--- a/__tests__/serdes.test.ts
+++ b/__tests__/serdes.test.ts
@@ -1,0 +1,66 @@
+import {
+  deterministicStringify,
+  deterministicEquals,
+  parseDeterministicJSON,
+} from '../utils/serdes';
+
+describe('deterministicStringify', () => {
+  it('sorts keys at every depth', () => {
+    const payload = { b: 1, a: { d: 2, c: 3 } };
+    expect(deterministicStringify(payload)).toBe('{"a":{"c":3,"d":2},"b":1}');
+  });
+
+  it('produces identical output for equivalent permutations', () => {
+    const first = { a: 1, z: { y: [3, 2, 1], x: { c: true, a: null } } };
+    const second = { z: { x: { a: null, c: true }, y: [3, 2, 1] }, a: 1 };
+
+    const serializedFirst = deterministicStringify(first);
+    const serializedSecond = deterministicStringify(second);
+
+    expect(serializedFirst).toBe(serializedSecond);
+    expect(serializedFirst).toMatchSnapshot();
+  });
+
+  it('remains compatible with vanilla JSON consumers', () => {
+    const data = {
+      title: 'Snapshot',
+      nested: { values: [1, 2, { note: 'same data' }] },
+      flag: true,
+    };
+
+    const deterministic = deterministicStringify(data);
+    const vanilla = JSON.stringify(data);
+
+    expect(deterministic).not.toBeUndefined();
+    expect(JSON.parse(deterministic!)).toEqual(JSON.parse(vanilla!));
+  });
+
+  it('serializes bigint values without throwing', () => {
+    const serialized = deterministicStringify({ value: 123n });
+    expect(serialized).toBe('{"value":{"$$deterministicType":"bigint","value":"123"}}');
+
+    const revived = parseDeterministicJSON(serialized!);
+    expect(revived).toEqual({ value: 123n });
+  });
+
+  it('serializes dates using ISO strings', () => {
+    const date = new Date('2020-01-01T00:00:00.000Z');
+    expect(deterministicStringify({ date })).toBe('{"date":"2020-01-01T00:00:00.000Z"}');
+  });
+});
+
+describe('deterministicEquals', () => {
+  it('ignores insertion order differences', () => {
+    const a = { alpha: 1, nested: { z: 0, y: [1, 2, 3] } };
+    const b = { nested: { y: [1, 2, 3], z: 0 }, alpha: 1 };
+
+    expect(deterministicEquals(a, b)).toBe(true);
+  });
+
+  it('detects meaningful changes', () => {
+    const baseline = { value: 1 };
+    const mutated = { value: 2 };
+
+    expect(deterministicEquals(baseline, mutated)).toBe(false);
+  });
+});

--- a/components/apps/car-racer.js
+++ b/components/apps/car-racer.js
@@ -2,6 +2,7 @@ import React, { useRef, useEffect, useState } from 'react';
 import useCanvasResize from '../../hooks/useCanvasResize';
 import { CAR_SKINS, loadSkinAssets } from '../../apps/games/car-racer/customization';
 import { hasOffscreenCanvas } from '../../utils/feature';
+import { deterministicEquals } from '../../utils/serdes';
 
 // Canvas dimensions
 const WIDTH = 300;
@@ -269,7 +270,7 @@ const CarRacer = () => {
         const diff = {};
         const lastState = lastRenderRef.current;
         Object.keys(state).forEach((k) => {
-          if (JSON.stringify(state[k]) !== JSON.stringify(lastState[k])) {
+          if (!deterministicEquals(state[k], lastState[k])) {
             diff[k] = state[k];
           }
         });

--- a/docs/deterministic-serialization.md
+++ b/docs/deterministic-serialization.md
@@ -1,0 +1,46 @@
+# Deterministic serialization helpers
+
+`utils/serdes.ts` exposes utilities for producing a canonical JSON payload. They exist to keep
+cache keys, snapshot exports, and diff calculations stable even when key insertion order varies.
+
+## When to reach for `deterministicStringify`
+
+Use the deterministic serializer whenever a string representation is used to:
+
+- Generate cache keys or memoization maps.
+- Compare complex structures for equality (for example, diffing UI state before syncing to a worker).
+- Persist snapshots that should remain identical across runs even if object key order changes.
+
+It mirrors `JSON.stringify` for supported inputs but sorts object keys and normalizes specific
+primitives so the output is consistent. The helper returns `undefined` when the source value would be
+omitted by `JSON.stringify` (for example a top-level `undefined`). Handle that case before storing
+results.
+
+## Primitive handling
+
+- **BigInt** values are supported. They are converted to the tagged structure
+  `{ "$$deterministicType": "bigint", "value": "<digits>" }` to keep intent explicit. Parse the
+  string with `parseDeterministicJSON` to recover real `bigint` values if needed.
+- **Dates** serialize to ISO-8601 strings using the existing `toJSON` behaviour.
+- **Non-finite numbers** (`NaN`, `Infinity`, `-Infinity`) collapse to `null`, matching vanilla JSON.
+- **Typed arrays** are converted to plain arrays so their contents remain ordered and comparable.
+
+## Companion helpers
+
+- `deterministicEquals(a, b)` reuses the serializer to perform stable structural comparisons.
+- `parseDeterministicJSON(serialized)` revives deterministic output (including `bigint` tags) back to
+  runtime values.
+
+## Pitfalls and guidance
+
+- The serializer intentionally throws on circular references to mirror `JSON.stringify`. Break
+  cycles before calling it.
+- The canonical output may differ from the default JSON order. Consumers that diff raw strings should
+  switch to the deterministic helper at the same time to avoid false positives.
+- Keep snapshots human-readable by formatting after serialization if needed (e.g. wrap in
+  `JSON.stringify(JSON.parse(deterministicStringify(obj)!), null, 2)`).
+- Do not feed untrusted deterministic payloads directly into `JSON.parse` if you need `bigint`
+  recovery—use `parseDeterministicJSON` so the tagged values revive correctly.
+
+Adopting these helpers on snapshot-sensitive code paths ensures order-only changes no longer evict
+caches or churn diffs.

--- a/utils/gameSettings.ts
+++ b/utils/gameSettings.ts
@@ -1,3 +1,5 @@
+import { deterministicStringify } from './serdes';
+
 export function exportGameSettings(game: string): string {
   if (typeof window === 'undefined') return '{}';
   const data: Record<string, unknown> = {};
@@ -12,7 +14,7 @@ export function exportGameSettings(game: string): string {
       }
     }
   }
-  return JSON.stringify(data);
+  return deterministicStringify(data) ?? '{}';
 }
 
 export function importGameSettings(game: string, json: string): void {

--- a/utils/serdes.ts
+++ b/utils/serdes.ts
@@ -1,0 +1,150 @@
+export type DeterministicJSONValue =
+  | null
+  | boolean
+  | number
+  | string
+  | DeterministicJSONValue[]
+  | { [key: string]: DeterministicJSONValue };
+
+const TYPE_TAG = '$$deterministicType';
+const VALUE_TAG = 'value';
+
+type CanonicalValue = DeterministicJSONValue | undefined;
+
+type SeenSet = WeakSet<object>;
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (value === null || typeof value !== 'object') return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+};
+
+const createTaggedValue = (type: string, value: string): Record<string, DeterministicJSONValue> => ({
+  [TYPE_TAG]: type,
+  [VALUE_TAG]: value,
+});
+
+const normalizeNumber = (value: number): number | null =>
+  Number.isFinite(value) ? value : null;
+
+const normalizeArrayBufferView = (value: ArrayBufferView, seen: SeenSet): DeterministicJSONValue => {
+  const view = value as unknown as { readonly length: number; readonly [index: number]: number };
+  const result: DeterministicJSONValue[] = [];
+  for (let i = 0; i < view.length; i += 1) {
+    result.push(normalizeValue(view[i], seen, true) as DeterministicJSONValue);
+  }
+  return result;
+};
+
+function normalizeValue(value: unknown, seen: SeenSet, inArray: boolean): CanonicalValue {
+  if (value === null) return null;
+  const valueType = typeof value;
+
+  if (valueType === 'string' || valueType === 'boolean') {
+    return value as string | boolean;
+  }
+
+  if (valueType === 'number') {
+    return normalizeNumber(value as number);
+  }
+
+  if (valueType === 'bigint') {
+    return createTaggedValue('bigint', (value as bigint).toString());
+  }
+
+  if (valueType === 'undefined' || valueType === 'function' || valueType === 'symbol') {
+    return inArray ? null : undefined;
+  }
+
+  if (value instanceof Date) {
+    return value.toJSON();
+  }
+
+  if (Array.isArray(value)) {
+    return (value as unknown[]).map(item => normalizeValue(item, seen, true)) as DeterministicJSONValue[];
+  }
+
+  if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+    return normalizeArrayBufferView(value as ArrayBufferView, seen);
+  }
+
+  if (valueType === 'object' && value !== null) {
+    if (seen.has(value as object)) {
+      throw new TypeError('Converting circular structure to JSON');
+    }
+    seen.add(value as object);
+
+    try {
+      const maybeToJSON = (value as { toJSON?: () => unknown }).toJSON;
+      if (typeof maybeToJSON === 'function') {
+        const jsonValue = maybeToJSON.call(value);
+        return normalizeValue(jsonValue, seen, inArray);
+      }
+
+      if (!isPlainObject(value)) {
+        const entries = Object.entries(value as Record<string | symbol, unknown>)
+          .filter(([key]) => typeof key === 'string')
+          .map(([key, v]) => [key, normalizeValue(v, seen, false)] as const)
+          .filter(([, v]) => v !== undefined)
+          .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+        return entries.reduce<Record<string, DeterministicJSONValue>>((acc, [key, v]) => {
+          acc[key] = v as DeterministicJSONValue;
+          return acc;
+        }, {});
+      }
+
+      const keys = Object.keys(value as Record<string, unknown>).sort();
+      const result: Record<string, DeterministicJSONValue> = {};
+
+      for (const key of keys) {
+        const normalized = normalizeValue((value as Record<string, unknown>)[key], seen, false);
+        if (normalized !== undefined) {
+          result[key] = normalized as DeterministicJSONValue;
+        }
+      }
+
+      return result;
+    } finally {
+      seen.delete(value as object);
+    }
+  }
+
+  return undefined;
+}
+
+export const deterministicStringify = (value: unknown): string | undefined => {
+  const normalized = normalizeValue(value, new WeakSet(), false);
+  if (normalized === undefined) {
+    return undefined;
+  }
+  return JSON.stringify(normalized);
+};
+
+export const deterministicEquals = (a: unknown, b: unknown): boolean =>
+  deterministicStringify(a) === deterministicStringify(b);
+
+export const parseDeterministicJSON = (json: string): unknown => {
+  const revive = (input: unknown): unknown => {
+    if (input === null || typeof input !== 'object') return input;
+    if (Array.isArray(input)) {
+      return input.map(revive);
+    }
+    const record = input as Record<string, unknown>;
+    if (record[TYPE_TAG] === 'bigint' && typeof record[VALUE_TAG] === 'string') {
+      try {
+        return BigInt(record[VALUE_TAG]);
+      } catch {
+        return record[VALUE_TAG];
+      }
+    }
+    return Object.keys(record).reduce<Record<string, unknown>>((acc, key) => {
+      acc[key] = revive(record[key]);
+      return acc;
+    }, {});
+  };
+
+  return revive(JSON.parse(json));
+};
+
+export default deterministicStringify;


### PR DESCRIPTION
## Summary
- add a deterministic serialization helper that sorts keys and revives bigint tags
- switch snapshot-sensitive cache and diff flows to the deterministic helpers
- document serializer usage and extend the checklist to cover deterministic caching

## Testing
- yarn test serdes

------
https://chatgpt.com/codex/tasks/task_e_68dc9359de888328a8ee5ab1f94ae187