### PR TITLE
[ci] Add preview deployments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,133 @@
+# This workflow is mirrored in ci/preview.yml to make the configuration discoverable by
+# contributors who expect CI definitions outside of .github/workflows/.
+# Keep both files in sync when editing preview automation.
+name: Preview Deployments
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    name: Build and deploy preview
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      NODE_ENV: production
+      NEXT_PUBLIC_ENABLE_ANALYTICS: 'false'
+      FEATURE_TOOL_APIS: disabled
+      NEXT_PUBLIC_BASE_PATH: ''
+      NEXT_PUBLIC_SUPABASE_URL: ''
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ''
+      SUPABASE_URL: ''
+      SUPABASE_SERVICE_ROLE_KEY: ''
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        id: next-cache
+        with:
+          path: |
+            .next/cache
+            .vercel/output
+          key: preview-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ github.ref }}
+          restore-keys: |
+            preview-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-
+            preview-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Pull Vercel environment
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          yarn dlx vercel@latest pull --yes --environment=preview --token "$VERCEL_TOKEN"
+
+      - name: Build preview (with bundle analysis)
+        env:
+          ANALYZE: 'true'
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          yarn dlx vercel@latest build --token "$VERCEL_TOKEN"
+
+      - name: Upload bundle report
+        id: upload-report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle-report-${{ github.run_id }}
+          path: |
+            .next/analyze
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Deploy preview
+        id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          preview_url=$(yarn dlx vercel@latest deploy --prebuilt --token "$VERCEL_TOKEN" \
+            | grep -Eo 'https://[^ ]+' \
+            | tail -n1 \
+            | tr -d '\n')
+          if [ -z "$preview_url" ]; then
+            echo "Preview URL not detected" >&2
+            exit 1
+          fi
+          echo "url=$preview_url" >> "$GITHUB_OUTPUT"
+
+      - name: Publish preview comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          identifier: preview-ci
+          body: |
+            ### 🚀 Preview build ready
+            - Preview URL: [${{ steps.deploy.outputs.url }}](${{ steps.deploy.outputs.url }})
+            - Bundle report: [Download artifact](${{ steps.upload-report.outputs.artifact-url }})
+            - Build cache restored: `${{ steps.next-cache.outputs.cache-hit }}`
+
+            _Previews run with analytics disabled and sensitive integrations in demo mode._
+
+      - name: Publish failure notice
+        if: failure() && github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          identifier: preview-ci-failure
+          body: |
+            ### ⚠️ Preview deployment failed
+            The automated preview could not be published. Please review the workflow logs and fall back to the local production build:
+            ```bash
+            yarn install
+            yarn build
+            yarn start
+            ```
+            Bundle reports (if any) remain available under the workflow run's artifacts.

--- a/ci/preview.yml
+++ b/ci/preview.yml
@@ -1,0 +1,130 @@
+name: Preview Deployments
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    name: Build and deploy preview
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      NODE_ENV: production
+      NEXT_PUBLIC_ENABLE_ANALYTICS: 'false'
+      FEATURE_TOOL_APIS: disabled
+      NEXT_PUBLIC_BASE_PATH: ''
+      NEXT_PUBLIC_SUPABASE_URL: ''
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ''
+      SUPABASE_URL: ''
+      SUPABASE_SERVICE_ROLE_KEY: ''
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        id: next-cache
+        with:
+          path: |
+            .next/cache
+            .vercel/output
+          key: preview-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ github.ref }}
+          restore-keys: |
+            preview-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-
+            preview-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Pull Vercel environment
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          yarn dlx vercel@latest pull --yes --environment=preview --token "$VERCEL_TOKEN"
+
+      - name: Build preview (with bundle analysis)
+        env:
+          ANALYZE: 'true'
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          yarn dlx vercel@latest build --token "$VERCEL_TOKEN"
+
+      - name: Upload bundle report
+        id: upload-report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle-report-${{ github.run_id }}
+          path: |
+            .next/analyze
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Deploy preview
+        id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          preview_url=$(yarn dlx vercel@latest deploy --prebuilt --token "$VERCEL_TOKEN" \
+            | grep -Eo 'https://[^ ]+' \
+            | tail -n1 \
+            | tr -d '\n')
+          if [ -z "$preview_url" ]; then
+            echo "Preview URL not detected" >&2
+            exit 1
+          fi
+          echo "url=$preview_url" >> "$GITHUB_OUTPUT"
+
+      - name: Publish preview comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          identifier: preview-ci
+          body: |
+            ### 🚀 Preview build ready
+            - Preview URL: [${{ steps.deploy.outputs.url }}](${{ steps.deploy.outputs.url }})
+            - Bundle report: [Download artifact](${{ steps.upload-report.outputs.artifact-url }})
+            - Build cache restored: `${{ steps.next-cache.outputs.cache-hit }}`
+
+            _Previews run with analytics disabled and sensitive integrations in demo mode._
+
+      - name: Publish failure notice
+        if: failure() && github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          identifier: preview-ci-failure
+          body: |
+            ### ⚠️ Preview deployment failed
+            The automated preview could not be published. Please review the workflow logs and fall back to the local production build:
+            ```bash
+            yarn install
+            yarn build
+            yarn start
+            ```
+            Bundle reports (if any) remain available under the workflow run's artifacts.

--- a/docs/preview-reviewer-guide.md
+++ b/docs/preview-reviewer-guide.md
@@ -1,0 +1,45 @@
+# Preview deployment reviewer guide
+
+This repository now publishes per-PR preview builds via the `Preview Deployments` workflow (`ci/preview.yml`). The workflow posts a status comment on each pull request with a link to the deployed Vercel preview as well as a downloadable bundle analysis report.
+
+## Accessing the preview
+
+1. Open the pull request.
+2. Locate the automated comment titled “🚀 Preview build ready.”
+3. Follow the **Preview URL** link to view the live deployment. Previews run with analytics disabled and simulated tool APIs so you can safely explore features without requiring privileged credentials.
+
+> **Note:** Vercel deploys behind GitHub authentication for private repositories. If prompted, log in with your GitHub account that has access to this repository.
+
+## Reviewing the bundle report
+
+1. In the same comment, use the **Bundle report** link to download the `bundle-report-<run-id>.zip` artifact.
+2. Extract the archive locally. The `.next/analyze` directory contains:
+   - `client.html` – client bundle breakdown.
+   - `server.html` – server bundle breakdown.
+3. Open the HTML files in your browser to inspect bundle sizes, added modules, and potential regressions.
+
+## When a preview fails
+
+If the workflow cannot deploy:
+
+- A “⚠️ Preview deployment failed” comment is posted with a reminder to run the production build locally.
+- Follow the fallback recipe:
+  ```bash
+  yarn install
+  yarn build
+  yarn start
+  ```
+- Bundle reports may still be attached to the workflow run. Navigate to **Checks → Preview Deployments → Artifacts** to download them.
+
+## Environment safeguards
+
+Previews automatically set the following environment variables to ensure sensitive integrations stay disabled:
+
+- `NEXT_PUBLIC_ENABLE_ANALYTICS=false`
+- `FEATURE_TOOL_APIS=disabled`
+- `NEXT_PUBLIC_SUPABASE_URL=` (empty)
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY=` (empty)
+- `SUPABASE_URL=` (empty)
+- `SUPABASE_SERVICE_ROLE_KEY=` (empty)
+
+This keeps analytics, Supabase features, and other remote integrations inactive during reviewer testing.


### PR DESCRIPTION
## Summary
- add a reusable preview workflow under `ci/preview.yml` and mirror it in `.github/workflows/preview.yml`
- deploy Vercel previews with cached installs, bundle reports, and automated PR comments
- document reviewer access, artifacts, and fallback instructions for preview builds

## Testing
- not run (workflow only)


------
https://chatgpt.com/codex/tasks/task_e_68dc9362b5f08328ae81105ed25adb83