### PR TITLE
[build] add bundle regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,90 @@ jobs:
       - run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - run: npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+
+  bundle-report:
+    runs-on: ubuntu-latest
+    needs: install
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
+      - run: yarn dedupe --check
+      - run: yarn build
+      - name: Compare bundle to baseline
+        id: bundle_report
+        run: node scripts/bundle-report.mjs --output bundle-report.json
+        continue-on-error: true
+      - name: Comment bundle regressions
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- bundle-report -->';
+            if (!fs.existsSync('bundle-report.json')) {
+              return;
+            }
+            const report = JSON.parse(fs.readFileSync('bundle-report.json', 'utf8'));
+            const offenders = report.offenders ?? [];
+            const formatBytes = (bytes) => {
+              if (!Number.isFinite(bytes)) return `${bytes}`;
+              const absolute = Math.abs(bytes);
+              if (absolute >= 1024 * 1024) {
+                return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+              }
+              if (absolute >= 1024) {
+                return `${(bytes / 1024).toFixed(1)} kB`;
+              }
+              return `${bytes} B`;
+            };
+            const issueNumber = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const previous = comments.find((comment) => comment.body?.includes(marker));
+            if (!offenders.length) {
+              if (previous) {
+                await github.rest.issues.deleteComment({
+                  ...context.repo,
+                  comment_id: previous.id,
+                });
+              }
+              return;
+            }
+            const lines = [
+              marker,
+              '### ⚠️ Bundle size regression detected',
+              '',
+              `The following routes grew by more than **${formatBytes(report.thresholdBytes)}** compared to the stored baseline.`,
+              '',
+              offenders
+                .map((entry) => `- \`${entry.route}\`: +${formatBytes(entry.delta)} (now ${formatBytes(entry.current)})`)
+                .join('\n'),
+              '',
+              'Review these routes and run `yarn bundle:baseline` after accepting intentional increases.',
+            ];
+            const body = lines.join('\n');
+            if (previous) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issueNumber,
+                body,
+              });
+            }
+      - name: Fail on regressions
+        if: steps.bundle_report.outcome == 'failure'
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ See `.env.local.example` for the full list.
 - `yarn test` – run the test suite.
 - `yarn lint` – check code for linting issues.
 - `yarn export` – generate a static export in the `out/` directory.
+- `yarn bundle:budget` – compare the latest build output against the stored bundle baseline (run after `yarn build`).
+- `yarn bundle:baseline` – update `data/bundle-baseline.json` after approving an intentional bundle size increase.
 
 ---
 
@@ -99,6 +101,16 @@ See `.env.local.example` for the full list.
 
 - Run `yarn lint` and `yarn test` before committing changes.
 - For manual smoke tests, start `yarn dev` and in another terminal run `yarn smoke` to visit every `/apps/*` route.
+- Run `yarn build` followed by `yarn bundle:budget` to surface any routes that exceed the 30 kB regression threshold locally.
+
+---
+
+## Bundle size monitoring
+
+- The bundle baseline lives in [`data/bundle-baseline.json`](./data/bundle-baseline.json). It records the byte size of each statically generated route.
+- Continuous integration rebuilds the site and runs `yarn bundle:budget`. Routes that grow by more than **30 kB** trigger a failing job and a pull request comment listing the affected routes.
+- When a bundle increase is expected, run `yarn build && yarn bundle:baseline`, review the diff for reasonableness, and commit the updated baseline file.
+- The [`scripts/bundle-report.mjs`](./scripts/bundle-report.mjs) helper also powers the CI comment and can write machine-readable JSON via `--output` when needed.
 
 ---
 

--- a/__tests__/bundle-report.test.ts
+++ b/__tests__/bundle-report.test.ts
@@ -1,0 +1,96 @@
+/** @jest-environment node */
+
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+describe('bundle-report utilities', () => {
+  let bundleReport: typeof import('../scripts/bundle-report.mjs');
+
+  beforeAll(async () => {
+    // @ts-expect-error -- importing ESM module from CommonJS context
+    bundleReport = await import('../scripts/bundle-report.mjs');
+  });
+
+  describe('computeRouteSizes', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bundle-report-'));
+      await fs.mkdir(path.join(tempDir, 'static', 'chunks'), { recursive: true });
+    });
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('sums unique asset sizes per route', async () => {
+      const chunkDir = path.join(tempDir, 'static', 'chunks');
+      await fs.writeFile(path.join(chunkDir, 'shared.js'), 'a'.repeat(1024));
+      await fs.writeFile(path.join(chunkDir, 'route-a.js'), 'a'.repeat(2048));
+      await fs.writeFile(path.join(chunkDir, 'route-b.js'), 'a'.repeat(512));
+
+      const manifest = {
+        pages: {
+          '/a': ['static/chunks/shared.js', 'static/chunks/route-a.js', 'static/chunks/shared.js'],
+          '/b': ['static/chunks/shared.js', 'static/chunks/route-b.js'],
+          '/_app': ['static/chunks/ignore.js'],
+        },
+      };
+
+      const sizes = await bundleReport.computeRouteSizes(manifest, { distDir: tempDir });
+
+      expect(sizes.get('/a')).toEqual({
+        size: 1024 + 2048,
+        files: [
+          { file: 'static/chunks/route-a.js', size: 2048 },
+          { file: 'static/chunks/shared.js', size: 1024 },
+        ],
+      });
+      expect(sizes.get('/b')).toEqual({
+        size: 1024 + 512,
+        files: [
+          { file: 'static/chunks/shared.js', size: 1024 },
+          { file: 'static/chunks/route-b.js', size: 512 },
+        ],
+      });
+      expect(sizes.has('/_app')).toBe(false);
+    });
+  });
+
+  describe('diffRoutes & findOffenders', () => {
+    it('marks new routes and filters increases above the threshold', () => {
+      const current = new Map([
+        ['/unchanged', { size: 10, files: [] }],
+        ['/new', { size: 40000, files: [{ file: 'chunk.js', size: 40000 }] }],
+        ['/small', { size: 5000, files: [{ file: 'chunk.js', size: 5000 }] }],
+      ]);
+      const baseline = {
+        '/unchanged': { size: 10 },
+        '/small': { size: 4000 },
+      };
+
+      const diffs = bundleReport.diffRoutes(baseline, current);
+      const offenders = bundleReport.findOffenders(diffs, 30 * 1024);
+
+      const newRoute = diffs.find((entry) => entry.route === '/new');
+      expect(newRoute?.status).toBe('added');
+      expect(newRoute?.baseline).toBe(0);
+      expect(newRoute?.delta).toBe(40000);
+
+      const smallRoute = diffs.find((entry) => entry.route === '/small');
+      expect(smallRoute?.delta).toBe(1000);
+
+      expect(offenders).toHaveLength(1);
+      expect(offenders[0]?.route).toBe('/new');
+    });
+  });
+
+  describe('formatBytes', () => {
+    it('formats kilobyte and megabyte values', () => {
+      expect(bundleReport.formatBytes(1024)).toBe('1.0 kB');
+      expect(bundleReport.formatBytes(2 * 1024 * 1024)).toBe('2.0 MB');
+      expect(bundleReport.formatBytes(512)).toBe('512 B');
+    });
+  });
+});

--- a/data/bundle-baseline.json
+++ b/data/bundle-baseline.json
@@ -1,0 +1,230 @@
+{
+  "generatedAt": "2025-10-01T02:43:06.901Z",
+  "routes": {
+    "/": {
+      "size": 349698
+    },
+    "/admin/messages": {
+      "size": 342593
+    },
+    "/apps": {
+      "size": 364284
+    },
+    "/apps/2048": {
+      "size": 346049
+    },
+    "/apps/ascii-art": {
+      "size": 346106
+    },
+    "/apps/autopsy": {
+      "size": 346091
+    },
+    "/apps/beef": {
+      "size": 346112
+    },
+    "/apps/blackjack": {
+      "size": 346122
+    },
+    "/apps/calculator": {
+      "size": 378509
+    },
+    "/apps/checkers": {
+      "size": 346134
+    },
+    "/apps/connect-four": {
+      "size": 346097
+    },
+    "/apps/contact": {
+      "size": 346130
+    },
+    "/apps/converter": {
+      "size": 346097
+    },
+    "/apps/figlet": {
+      "size": 346083
+    },
+    "/apps/firefox": {
+      "size": 346082
+    },
+    "/apps/http": {
+      "size": 346092
+    },
+    "/apps/input-lab": {
+      "size": 346071
+    },
+    "/apps/john": {
+      "size": 346092
+    },
+    "/apps/kismet": {
+      "size": 346089
+    },
+    "/apps/metasploit": {
+      "size": 346133
+    },
+    "/apps/metasploit-post": {
+      "size": 346103
+    },
+    "/apps/mimikatz/offline": {
+      "size": 346104
+    },
+    "/apps/minesweeper": {
+      "size": 346142
+    },
+    "/apps/nmap-nse": {
+      "size": 346096
+    },
+    "/apps/password_generator": {
+      "size": 350402
+    },
+    "/apps/phaser_matter": {
+      "size": 350417
+    },
+    "/apps/pinball": {
+      "size": 346084
+    },
+    "/apps/project-gallery": {
+      "size": 346063
+    },
+    "/apps/qr": {
+      "size": 346115
+    },
+    "/apps/settings": {
+      "size": 346067
+    },
+    "/apps/simon": {
+      "size": 346136
+    },
+    "/apps/sokoban": {
+      "size": 350377
+    },
+    "/apps/solitaire": {
+      "size": 346086
+    },
+    "/apps/spotify": {
+      "size": 346059
+    },
+    "/apps/ssh": {
+      "size": 346091
+    },
+    "/apps/sticky_notes": {
+      "size": 346100
+    },
+    "/apps/subnet-calculator": {
+      "size": 346103
+    },
+    "/apps/timer_stopwatch": {
+      "size": 346101
+    },
+    "/apps/tower-defense": {
+      "size": 346097
+    },
+    "/apps/volatility": {
+      "size": 346098
+    },
+    "/apps/vscode": {
+      "size": 346119
+    },
+    "/apps/weather": {
+      "size": 346125
+    },
+    "/apps/weather_widget": {
+      "size": 346686
+    },
+    "/apps/wireshark": {
+      "size": 346097
+    },
+    "/apps/word_search": {
+      "size": 350446
+    },
+    "/apps/x": {
+      "size": 346076
+    },
+    "/daily-quote": {
+      "size": 412736
+    },
+    "/dummy-form": {
+      "size": 344526
+    },
+    "/gamepad-calibration": {
+      "size": 346333
+    },
+    "/games/blackjack": {
+      "size": 346122
+    },
+    "/games/blackjack/trainer": {
+      "size": 346104
+    },
+    "/games/breakout/editor": {
+      "size": 346104
+    },
+    "/hook-flow": {
+      "size": 353303
+    },
+    "/hydra-preview": {
+      "size": 344283
+    },
+    "/input-hub": {
+      "size": 346431
+    },
+    "/keyboard-reference": {
+      "size": 343414
+    },
+    "/module-workspace": {
+      "size": 347309
+    },
+    "/nessus-dashboard": {
+      "size": 422703
+    },
+    "/nessus-report": {
+      "size": 348654
+    },
+    "/network-topology": {
+      "size": 347482
+    },
+    "/nikto-report": {
+      "size": 346319
+    },
+    "/notes": {
+      "size": 462793
+    },
+    "/popular-modules": {
+      "size": 350890
+    },
+    "/post_exploitation": {
+      "size": 396345
+    },
+    "/profile": {
+      "size": 345773
+    },
+    "/qr": {
+      "size": 826393
+    },
+    "/qr/vcard": {
+      "size": 378687
+    },
+    "/recon/graph": {
+      "size": 347173
+    },
+    "/security-education": {
+      "size": 406301
+    },
+    "/sekurlsa_logonpasswords": {
+      "size": 347262
+    },
+    "/share-target": {
+      "size": 342460
+    },
+    "/spoofing": {
+      "size": 348004
+    },
+    "/ui/settings/theme": {
+      "size": 345050
+    },
+    "/video-gallery": {
+      "size": 354397
+    },
+    "/wps-attack": {
+      "size": 348104
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "analyze": "ANALYZE=true yarn build",
     "preinstall": "corepack enable && corepack prepare yarn@4.9.2 --activate",
     "verify:all": "node scripts/verify.mjs",
-    "dedupe:fix": "yarn dedupe"
+    "dedupe:fix": "yarn dedupe",
+    "bundle:budget": "node scripts/bundle-report.mjs",
+    "bundle:report": "yarn bundle:budget",
+    "bundle:baseline": "node scripts/bundle-report.mjs --update-baseline"
   },
   "engines": {
     "node": "20"

--- a/scripts/bundle-report.mjs
+++ b/scripts/bundle-report.mjs
@@ -1,0 +1,323 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const scriptFilename = fileURLToPath(import.meta.url);
+const scriptDir = path.dirname(scriptFilename);
+
+const DEFAULT_MANIFEST_PATH = path.join(scriptDir, '..', '.next', 'build-manifest.json');
+const DEFAULT_BASELINE_PATH = path.join(scriptDir, '..', 'data', 'bundle-baseline.json');
+const DEFAULT_THRESHOLD_BYTES = 30 * 1024;
+
+function toArray(value) {
+  if (Array.isArray(value)) return value;
+  if (!value && value !== 0) return [];
+  return [value];
+}
+
+export function formatBytes(bytes) {
+  if (!Number.isFinite(bytes)) return '0 B';
+  const absolute = Math.abs(bytes);
+  if (absolute >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (absolute >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} kB`;
+  }
+  return `${bytes} B`;
+}
+
+export function collectRouteFiles(buildManifest = {}) {
+  const pages = buildManifest.pages ?? {};
+  const routes = new Map();
+  for (const [route, files] of Object.entries(pages)) {
+    if (!route.startsWith('/')) continue;
+    if (route === '/_app' || route === '/_error' || route === '/_document') continue;
+    if (route.startsWith('/_next') || route.startsWith('/__')) continue;
+    const uniqueFiles = Array.from(new Set(toArray(files).flat()));
+    routes.set(route, uniqueFiles);
+  }
+  return routes;
+}
+
+export async function computeRouteSizes(manifest, { distDir }) {
+  const routes = collectRouteFiles(manifest);
+  const results = new Map();
+  for (const [route, files] of routes.entries()) {
+    const contributions = [];
+    let total = 0;
+    for (const relativePath of files) {
+      const absolutePath = path.join(distDir, relativePath);
+      try {
+        const stat = await fs.stat(absolutePath);
+        const size = stat.size;
+        total += size;
+        contributions.push({ file: relativePath, size });
+      } catch (error) {
+        if (error && error.code === 'ENOENT') {
+          throw new Error(`Missing asset for route ${route}: ${relativePath}`);
+        }
+        throw error;
+      }
+    }
+    contributions.sort((a, b) => b.size - a.size);
+    results.set(route, { size: total, files: contributions });
+  }
+  return results;
+}
+
+export function diffRoutes(baselineRoutes = {}, currentRoutes) {
+  const current = new Map(currentRoutes);
+  const diffs = [];
+  const baseline = new Map(Object.entries(baselineRoutes));
+
+  for (const [route, currentEntry] of current.entries()) {
+    const baselineEntry = baseline.get(route);
+    const baselineSize = baselineEntry?.size ?? 0;
+    const delta = currentEntry.size - baselineSize;
+    diffs.push({
+      route,
+      baseline: baselineSize,
+      current: currentEntry.size,
+      delta,
+      files: currentEntry.files,
+      status: baselineEntry ? 'updated' : 'added',
+    });
+  }
+
+  for (const [route, baselineEntry] of baseline.entries()) {
+    if (!current.has(route)) {
+      diffs.push({
+        route,
+        baseline: baselineEntry.size,
+        current: 0,
+        delta: -baselineEntry.size,
+        files: [],
+        status: 'removed',
+      });
+    }
+  }
+
+  diffs.sort((a, b) => {
+    if (Math.abs(b.delta) === Math.abs(a.delta)) {
+      return a.route.localeCompare(b.route);
+    }
+    return Math.abs(b.delta) - Math.abs(a.delta);
+  });
+
+  return diffs;
+}
+
+export function findOffenders(diffs, thresholdBytes) {
+  return diffs.filter((entry) => entry.delta > thresholdBytes);
+}
+
+async function readJson(filePath) {
+  const raw = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function loadManifest(manifestPath) {
+  try {
+    return await readJson(manifestPath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      throw new Error(`Build manifest not found at ${manifestPath}. Run \`next build\` first.`);
+    }
+    throw error;
+  }
+}
+
+async function loadBaseline(baselinePath) {
+  try {
+    return await readJson(baselinePath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function writeBaseline(baselinePath, routes) {
+  const sortedEntries = Array.from(routes.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    routes: Object.fromEntries(sortedEntries.map(([route, value]) => [route, { size: value.size }])),
+  };
+  await fs.mkdir(path.dirname(baselinePath), { recursive: true });
+  await fs.writeFile(baselinePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return payload;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('-')) continue;
+    if (token.startsWith('--')) {
+      const [rawKey, rawValue] = token.split('=', 2);
+      const key = rawKey.slice(2);
+      if (rawValue !== undefined) {
+        args[key] = rawValue;
+        continue;
+      }
+      const next = argv[i + 1];
+      if (next && !next.startsWith('-')) {
+        args[key] = next;
+        i += 1;
+      } else {
+        args[key] = true;
+      }
+    } else {
+      const key = token.slice(1);
+      const next = argv[i + 1];
+      if (next && !next.startsWith('-')) {
+        args[key] = next;
+        i += 1;
+      } else {
+        args[key] = true;
+      }
+    }
+  }
+  return args;
+}
+
+function resolveThreshold(rawValue) {
+  if (rawValue === undefined || rawValue === null || rawValue === '') {
+    return DEFAULT_THRESHOLD_BYTES;
+  }
+  if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+    return Math.round(rawValue * 1024);
+  }
+  if (typeof rawValue !== 'string') {
+    throw new Error(`Invalid threshold: ${rawValue}`);
+  }
+  const normalized = rawValue.trim().toLowerCase();
+  if (!normalized) {
+    return DEFAULT_THRESHOLD_BYTES;
+  }
+  const match = normalized.match(/^([0-9]+(?:\.[0-9]+)?)\s*(kb|k|mb|m|b)?$/);
+  if (!match) {
+    throw new Error(`Invalid threshold: ${rawValue}`);
+  }
+  const value = Number.parseFloat(match[1]);
+  const unit = match[2] ?? 'kb';
+  if (Number.isNaN(value)) {
+    throw new Error(`Invalid threshold: ${rawValue}`);
+  }
+  switch (unit) {
+    case 'mb':
+    case 'm':
+      return Math.round(value * 1024 * 1024);
+    case 'b':
+      return Math.round(value);
+    case 'kb':
+    case 'k':
+    default:
+      return Math.round(value * 1024);
+  }
+}
+
+function renderSummary(diffs, offenders, thresholdBytes) {
+  const lines = [];
+  lines.push(`Threshold: ${formatBytes(thresholdBytes)} per route`);
+  if (!diffs.length) {
+    lines.push('No routes discovered in build manifest.');
+    return lines.join('\n');
+  }
+  const increases = diffs.filter((entry) => entry.delta > 0);
+  if (increases.length) {
+    lines.push('Route deltas:');
+    for (const entry of increases.slice(0, 20)) {
+      const deltaLabel = entry.delta === 0 ? '±0 B' : `${entry.delta > 0 ? '+' : ''}${formatBytes(entry.delta)}`;
+      lines.push(`  • ${entry.route}: ${deltaLabel} (now ${formatBytes(entry.current)})`);
+    }
+    if (increases.length > 20) {
+      lines.push(`  … ${increases.length - 20} additional routes unchanged or decreased.`);
+    }
+  } else {
+    lines.push('All tracked routes decreased or stayed flat.');
+  }
+  if (offenders.length) {
+    lines.push('\nRoutes above threshold:');
+    for (const offender of offenders) {
+      lines.push(`  ✖ ${offender.route}: +${formatBytes(offender.delta)} (now ${formatBytes(offender.current)})`);
+      const topFiles = offender.files.slice(0, 3);
+      for (const file of topFiles) {
+        lines.push(`      - ${file.file} (${formatBytes(file.size)})`);
+      }
+      if (offender.files.length > topFiles.length) {
+        lines.push(`      - … ${offender.files.length - topFiles.length} more chunks`);
+      }
+    }
+  } else {
+    lines.push('\n✅ No routes exceeded the threshold.');
+  }
+  return lines.join('\n');
+}
+
+async function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  const manifestPath = path.resolve(args.manifest ?? DEFAULT_MANIFEST_PATH);
+  const distDir = path.resolve(args.dist ?? path.dirname(manifestPath));
+  const baselinePath = path.resolve(args.baseline ?? DEFAULT_BASELINE_PATH);
+  const thresholdBytes = args['threshold-bytes']
+    ? Number.parseInt(args['threshold-bytes'], 10)
+    : resolveThreshold(args.threshold);
+  const outputPath = args.output ? path.resolve(args.output) : null;
+  const shouldUpdateBaseline = Boolean(args['update-baseline'] ?? args.updateBaseline ?? args.update);
+
+  const manifest = await loadManifest(manifestPath);
+  const currentRoutes = await computeRouteSizes(manifest, { distDir });
+  const baselineData = await loadBaseline(baselinePath);
+  const baselineRoutes = baselineData?.routes ?? {};
+  const diffs = diffRoutes(baselineRoutes, currentRoutes);
+  const offenders = findOffenders(diffs, thresholdBytes);
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    manifestPath,
+    baselinePath,
+    thresholdBytes,
+    offenders: offenders.map((entry) => ({
+      route: entry.route,
+      delta: entry.delta,
+      current: entry.current,
+      baseline: entry.baseline,
+      files: entry.files,
+    })),
+    routes: diffs.map((entry) => ({
+      route: entry.route,
+      delta: entry.delta,
+      current: entry.current,
+      baseline: entry.baseline,
+      status: entry.status,
+    })),
+  };
+
+  if (outputPath) {
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  }
+
+  if (shouldUpdateBaseline) {
+    await writeBaseline(baselinePath, currentRoutes);
+    console.log(`Baseline updated at ${baselinePath}`);
+    return;
+  }
+
+  console.log(renderSummary(diffs, offenders, thresholdBytes));
+
+  if (offenders.length) {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  runCli().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}
+


### PR DESCRIPTION
## Summary
- add a bundle-report script that compares the current build manifest to a stored baseline and expose bundle:budget/bundle:baseline yarn tasks
- store the initial route-size baseline and document the workflow for refreshing it when bundle growth is intentional
- wire the script into CI to fail on >30 kB route regressions and leave a pull request comment with the offending routes, plus add unit tests for the utilities

## Testing
- yarn lint
- yarn test __tests__/bundle-report.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc936792a08328af16812678b980f4