### PR TITLE
[security] Sandbox external embeds and tighten messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,22 @@ Defined in `next.config.js`. See [CSP External Domains](#csp-external-domains) f
 - `Permissions-Policy: camera=(), microphone=(), geolocation=()`
 - `X-Frame-Options: SAMEORIGIN`
 
+### Sandboxed embeds
+
+- External or user-provided documents (Firefox simulator, VSCode/StackBlitz, Spotify, YouTube fallbacks, React docs, Nikto
+  previews) now render inside sandboxed iframes with the minimum capabilities needed for interaction. Examples:
+  - Firefox browser: `allow-forms allow-popups allow-scripts allow-top-navigation-by-user-activation`.
+  - StackBlitz/VScode wrapper: `allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation` with
+    clipboard access only.
+  - Spotify embeds: `allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation` plus a feature `allow`
+    list limited to playback controls.
+- Each sandbox sets `referrerPolicy="no-referrer"` to avoid leaking workspace URLs and strips unnecessary `allow` permissions
+  (camera/microphone/etc.).
+- Parent ↔ iframe messaging validates origins (`https://open.spotify.com` for embeds, `origin === 'null'` for generated plugin
+  sandboxes) before acting, preventing hostile frames from invoking privileged UI flows.
+- Because of the sandbox, cross-origin scripts cannot access the main window or cookies. Some embeds may lose features that require
+  elevated permissions (e.g., persistent logins).
+
 ### CSP External Domains
 
 These external domains are whitelisted in the default CSP. Update this list whenever `next.config.js` changes.

--- a/__tests__/firefox.test.tsx
+++ b/__tests__/firefox.test.tsx
@@ -29,6 +29,11 @@ describe('Firefox app', () => {
     await user.click(screen.getByRole('button', { name: 'Go' }));
     const frame = await screen.findByTitle('Firefox');
     expect(frame).toHaveAttribute('src', 'https://example.com/');
+    expect(frame).toHaveAttribute(
+      'sandbox',
+      'allow-forms allow-popups allow-scripts allow-top-navigation-by-user-activation',
+    );
+    expect(frame).toHaveAttribute('referrerpolicy', 'no-referrer');
     expect(localStorage.getItem('firefox:last-url')).toBe('https://example.com/');
   });
 

--- a/__tests__/moodTuner.test.tsx
+++ b/__tests__/moodTuner.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MoodTuner from '../apps/spotify/components/MoodTuner';
+
+describe('MoodTuner sandboxing', () => {
+  const playlists = { chill: 'playlist-id' };
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    const fetchMock = jest.fn(async (url: RequestInfo | URL) => {
+      if (typeof url === 'string' && url.startsWith('/spotify-playlists.json')) {
+        return {
+          json: async () => playlists,
+        } as unknown as Response;
+      }
+      throw new Error(`Unexpected fetch: ${String(url)}`);
+    }) as unknown as typeof fetch;
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      // @ts-expect-error restore undefined fetch
+      delete global.fetch;
+    }
+  });
+
+  it('renders the Spotify embed inside a sandboxed iframe', async () => {
+    render(<MoodTuner />);
+    const frame = await screen.findByTitle('chill');
+    expect(frame).toHaveAttribute(
+      'sandbox',
+      'allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation',
+    );
+    expect(frame).toHaveAttribute('referrerpolicy', 'no-referrer');
+  });
+
+  it('sends commands to the Spotify origin and ignores other messages', async () => {
+    const user = userEvent.setup();
+    render(<MoodTuner />);
+    const frame = await screen.findByTitle('chill');
+    const frameWindow = { postMessage: jest.fn() } as Window;
+    Object.defineProperty(frame, 'contentWindow', {
+      value: frameWindow,
+      configurable: true,
+    });
+
+    const playButton = await screen.findByTitle('Play/Pause (Space)');
+    await user.click(playButton);
+    expect(frameWindow.postMessage).toHaveBeenCalledWith(
+      { command: 'play' },
+      'https://open.spotify.com',
+    );
+    expect(playButton).toHaveTextContent('⏸');
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: 'https://evil.example',
+          data: ['playback_update', { is_paused: true }],
+          source: frameWindow,
+        }),
+      );
+    });
+    expect(playButton).toHaveTextContent('⏸');
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: 'https://open.spotify.com',
+          data: ['playback_update', { is_paused: true }],
+          source: frameWindow,
+        }),
+      );
+    });
+    expect(playButton).toHaveTextContent('▶');
+  });
+});
+

--- a/apps/spotify/components/MoodTuner.tsx
+++ b/apps/spotify/components/MoodTuner.tsx
@@ -5,6 +5,8 @@ interface Playlists {
   [mood: string]: string;
 }
 
+const SPOTIFY_ORIGIN = "https://open.spotify.com";
+
 const MoodTuner = () => {
   const [playlists, setPlaylists] = useState<Playlists>({});
   const [mood, setMood] = usePersistentState<string>("spotify-mood", "");
@@ -35,7 +37,9 @@ const MoodTuner = () => {
   }, [playlists, mood, setMood]);
 
   const post = useCallback((cmd: string) => {
-    iframeRef.current?.contentWindow?.postMessage({ command: cmd }, "*");
+    const targetWindow = iframeRef.current?.contentWindow;
+    if (!targetWindow) return;
+    targetWindow.postMessage({ command: cmd }, SPOTIFY_ORIGIN);
   }, []);
 
   const togglePlay = useCallback(() => {
@@ -51,7 +55,7 @@ const MoodTuner = () => {
   // Update play state from Spotify messages
   useEffect(() => {
     const handleMessage = (e: MessageEvent) => {
-      if (!e.origin.includes("spotify")) return;
+      if (e.origin !== SPOTIFY_ORIGIN) return;
       const data = e.data;
       if (Array.isArray(data) && data[0] === "playback_update") {
         setIsPlaying(!data[1]?.is_paused);
@@ -102,7 +106,9 @@ const MoodTuner = () => {
             width="100%"
             height="152"
             frameBorder="0"
-            allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+            sandbox="allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation"
+            allow="autoplay; encrypted-media; fullscreen; picture-in-picture"
+            referrerPolicy="no-referrer"
             loading="lazy"
           />
           <div className="flex justify-center space-x-4 p-2 bg-black bg-opacity-30">

--- a/components/ExternalFrame.js
+++ b/components/ExternalFrame.js
@@ -63,8 +63,8 @@ export default function ExternalFrame({ src, title, prefetch = false, onLoad: on
           <iframe
             src={src}
             title={title}
-            sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; geolocation; gyroscope; picture-in-picture; microphone; camera"
+            sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation"
+            allow="clipboard-write"
             referrerPolicy="no-referrer"
             onLoad={(e) => {
               setLoaded(true);

--- a/components/apps/firefox/index.tsx
+++ b/components/apps/firefox/index.tsx
@@ -130,8 +130,8 @@ const Firefox: React.FC = () => {
             title="Firefox"
             src={address}
             className="h-full w-full border-0"
-            sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            sandbox="allow-forms allow-popups allow-scripts allow-top-navigation-by-user-activation"
+            referrerPolicy="no-referrer"
           />
         )}
       </div>

--- a/components/apps/nikto/index.js
+++ b/components/apps/nikto/index.js
@@ -288,6 +288,8 @@ const NiktoApp = () => {
         <iframe
           title="Nikto HTML Report"
           srcDoc={htmlReport}
+          sandbox=""
+          referrerPolicy="no-referrer"
           className="w-full h-64 bg-white"
         />
       </div>

--- a/components/apps/plugin-manager/index.tsx
+++ b/components/apps/plugin-manager/index.tsx
@@ -91,9 +91,13 @@ export default function PluginManager() {
       const url = URL.createObjectURL(blob);
       const iframe = document.createElement('iframe');
       iframe.sandbox.add('allow-scripts');
+      iframe.referrerPolicy = 'no-referrer';
       const listener = (e: MessageEvent) => {
-        if (e.source === iframe.contentWindow) {
-          output.push(String(e.data));
+        if (e.origin !== 'null' || e.source !== iframe.contentWindow) {
+          return;
+        }
+        if (typeof e.data === 'string') {
+          output.push(e.data);
         }
       };
       window.addEventListener('message', listener);

--- a/pages/hook-flow.tsx
+++ b/pages/hook-flow.tsx
@@ -35,7 +35,8 @@ const HookFlow: React.FC = () => {
       <iframe
         title="React Hooks Documentation"
         src="https://react.dev/learn/hooks"
-        sandbox="allow-scripts allow-same-origin"
+        sandbox="allow-popups allow-scripts"
+        referrerPolicy="no-referrer"
         className="w-full h-96 border"
       />
     </main>


### PR DESCRIPTION
## Summary
- sandbox the Firefox browser sim, VSCode shell, Spotify embed, and other iframe previews with minimal permissions and `no-referrer`
- harden iframe <-> parent messaging by validating origins for Spotify and plugin sandboxes
- document the isolation model and add focused tests covering sandbox attributes and bridge filtering

## Testing
- [x] `npx jest __tests__/pluginManager.test.tsx --runTestsByPath`
- [x] `npx jest __tests__/moodTuner.test.tsx --runTestsByPath`
- [x] `npx jest __tests__/firefox.test.tsx --runTestsByPath`
- [ ] `yarn test` *(fails: pre-existing suites outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9369cffc83288e78865ff87c895c