### PR TITLE
[security] tighten permissions policy enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Defined in `next.config.js`. See [CSP External Domains](#csp-external-domains) f
 - **Content-Security-Policy (CSP)** (string built from `ContentSecurityPolicy[]`; see [CSP External Domains](#csp-external-domains))
 - `X-Content-Type-Options: nosniff`
 - `Referrer-Policy: strict-origin-when-cross-origin`
-- `Permissions-Policy: camera=(), microphone=(), geolocation=()`
+- `Permissions-Policy: camera=(), microphone=(), geolocation=()` (see [`docs/permissions-policy.md`](docs/permissions-policy.md) for approved overrides)
 - `X-Frame-Options: SAMEORIGIN`
 
 ### CSP External Domains

--- a/__tests__/permissions-policy.test.ts
+++ b/__tests__/permissions-policy.test.ts
@@ -1,0 +1,38 @@
+/** @jest-environment node */
+
+import { webcrypto } from 'crypto';
+import { NextRequest } from 'next/server';
+
+import { middleware } from '../middleware';
+import {
+  DEFAULT_PERMISSIONS_POLICY,
+  PERMISSIONS_POLICY_OVERRIDES,
+  getPermissionsPolicy,
+} from '../lib/security/permissionsPolicy';
+
+describe('permissions policy configuration', () => {
+  beforeAll(() => {
+    if (!globalThis.crypto) {
+      // @ts-expect-error - Jest's node environment lacks a webcrypto implementation
+      globalThis.crypto = webcrypto;
+    }
+  });
+
+  it('returns the default policy for unrelated paths', () => {
+    expect(getPermissionsPolicy('/')).toBe(DEFAULT_PERMISSIONS_POLICY);
+    expect(getPermissionsPolicy('/apps/weather')).toBe(DEFAULT_PERMISSIONS_POLICY);
+  });
+
+  it('applies overrides for approved routes', () => {
+    const qrOverride = PERMISSIONS_POLICY_OVERRIDES.find((entry) => entry.id === 'qr-scanner-camera');
+    expect(qrOverride).toBeDefined();
+    expect(getPermissionsPolicy('/apps/qr')).toBe(qrOverride?.policy);
+    expect(getPermissionsPolicy('/apps/qr/scan')).toBe(qrOverride?.policy);
+  });
+
+  it('middleware attaches the resolved policy to responses', () => {
+    const request = new NextRequest('https://example.com/apps/qr');
+    const response = middleware(request);
+    expect(response.headers.get('Permissions-Policy')).toBe(getPermissionsPolicy('/apps/qr'));
+  });
+});

--- a/docs/permissions-policy.md
+++ b/docs/permissions-policy.md
@@ -1,0 +1,50 @@
+# Permissions-Policy hardening
+
+The portfolio denies access to high-risk browser capabilities by default using the
+[`Permissions-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy)
+header. Only vetted routes that need camera, microphone, or geolocation access may
+request exceptions.
+
+## Default policy
+
+The base header is defined in `lib/security/permissions-policy.js` and applied by both
+Next.js middleware and the production server configuration:
+
+```
+camera=(), microphone=(), geolocation=()
+```
+
+All routes inherit this restriction unless explicitly listed in the override table
+below. Middleware also injects the header during development so the behaviour stays
+consistent across environments.
+
+## Approved overrides
+
+| Route pattern | Granted policy | Reason |
+| --- | --- | --- |
+| `/apps/qr/:path*` | `camera=(self), microphone=(), geolocation=()` | QR code scanner demo needs camera access for live preview. |
+
+Overrides live in `lib/security/permissions-policy.js`. Each entry documents why the
+exception exists so reviewers can confirm it remains justified.
+
+## Requesting a new exception
+
+1. **Document the need.** Open an issue describing the user journey and why the
+   capability is essential. Include screenshots or recordings if it touches the UI.
+2. **Propose mitigations.** Outline how the feature avoids storing raw media, how the
+   UI warns users, and any fallbacks when permission is denied.
+3. **Update the configuration.** Add a new override in
+   `lib/security/permissions-policy.js`, ensuring the `source` matches the route and
+   the `matcher` RegExp mirrors it for middleware. Extend the automated tests in
+   `__tests__/permissions-policy.test.ts` to cover the new route.
+4. **Refresh documentation.** Update this file and any affected app docs to call out
+   the new capability requirement.
+5. **Run audits.** Execute the security and performance checks that validate headers
+   are emitted, for example `yarn lint`, `yarn test`, and the Lighthouse stage in
+   `yarn verify`. Capture Lighthouse (or other security scanner) reports showing the
+   permissions policy passes with the new override in place.
+6. **Submit for review.** Reference the audit artefacts and test output in the pull
+   request so reviewers can verify compliance quickly.
+
+Routes without an explicit override will continue to receive the locked-down default
+policy, preventing regressions if new pages are added without an explicit decision.

--- a/lib/security/permissions-policy.js
+++ b/lib/security/permissions-policy.js
@@ -1,0 +1,32 @@
+const DEFAULT_PERMISSIONS_POLICY = 'camera=(), microphone=(), geolocation=()';
+
+const PERMISSIONS_POLICY_OVERRIDES = [
+  {
+    id: 'qr-scanner-camera',
+    description: 'Allow camera access for the QR code scanner demo.',
+    policy: 'camera=(self), microphone=(), geolocation=()',
+    matcher: /^\/apps\/qr(?:\/|$)/,
+    source: '/apps/qr/:path*',
+  },
+];
+
+function normalizePathname(pathname) {
+  if (!pathname) return '/';
+  const [rawPath] = pathname.split('?');
+  if (!rawPath) return '/';
+  if (rawPath === '/') return rawPath;
+  return rawPath.endsWith('/') ? rawPath.slice(0, -1) : rawPath;
+}
+
+function getPermissionsPolicy(pathname) {
+  const normalized = normalizePathname(pathname);
+  const override = PERMISSIONS_POLICY_OVERRIDES.find(({ matcher }) => matcher.test(normalized));
+  return override ? override.policy : DEFAULT_PERMISSIONS_POLICY;
+}
+
+module.exports = {
+  DEFAULT_PERMISSIONS_POLICY,
+  PERMISSIONS_POLICY_OVERRIDES,
+  getPermissionsPolicy,
+  normalizePathname,
+};

--- a/lib/security/permissionsPolicy.ts
+++ b/lib/security/permissionsPolicy.ts
@@ -1,0 +1,38 @@
+import type { IncomingHttpHeaders } from 'http';
+
+interface PermissionsPolicyModule {
+  DEFAULT_PERMISSIONS_POLICY: string;
+  PERMISSIONS_POLICY_OVERRIDES: PermissionsPolicyOverride[];
+  getPermissionsPolicy: (pathname: string) => string;
+}
+
+export interface PermissionsPolicyOverride {
+  id: string;
+  description: string;
+  policy: string;
+  matcher: RegExp;
+  source: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- shared configuration lives in a CommonJS module for Next.js
+const permissionsPolicy = require('./permissions-policy') as PermissionsPolicyModule;
+
+export const DEFAULT_PERMISSIONS_POLICY = permissionsPolicy.DEFAULT_PERMISSIONS_POLICY;
+export const PERMISSIONS_POLICY_OVERRIDES = permissionsPolicy.PERMISSIONS_POLICY_OVERRIDES;
+
+export function getPermissionsPolicy(pathname: string): string {
+  return permissionsPolicy.getPermissionsPolicy(pathname);
+}
+
+export function applyPermissionsPolicy(headers: Headers | IncomingHttpHeaders, pathname: string): void {
+  const policy = getPermissionsPolicy(pathname);
+
+  if (headers instanceof Headers) {
+    headers.set('Permissions-Policy', policy);
+    return;
+  }
+
+  // Node.js response headers object - mutate in place
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (headers as any)['Permissions-Policy'] = policy;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
+import { getPermissionsPolicy } from './lib/security/permissionsPolicy';
+
 function nonce() {
   const arr = new Uint8Array(16);
   crypto.getRandomValues(arr);
@@ -42,5 +44,6 @@ export function middleware(req: NextRequest) {
   const res = NextResponse.next();
   res.headers.set('x-csp-nonce', n);
   res.headers.set('Content-Security-Policy', csp);
+  res.headers.set('Permissions-Policy', getPermissionsPolicy(req.nextUrl.pathname));
   return res;
 }

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,10 @@
 // Update README (section "CSP External Domains") when editing domains below.
 
 const { validateServerEnv: validateEnv } = require('./lib/validate.js');
+const {
+  DEFAULT_PERMISSIONS_POLICY,
+  PERMISSIONS_POLICY_OVERRIDES,
+} = require('./lib/security/permissions-policy');
 
 const ContentSecurityPolicy = [
   "default-src 'self'",
@@ -48,7 +52,7 @@ const securityHeaders = [
   },
   {
     key: 'Permissions-Policy',
-    value: 'camera=(), microphone=(), geolocation=*',
+    value: DEFAULT_PERMISSIONS_POLICY,
   },
   {
     // Allow same-origin framing so the PDF resume renders in an <object>
@@ -56,6 +60,15 @@ const securityHeaders = [
     value: 'SAMEORIGIN',
   },
 ];
+
+const permissionsPolicyOverrides = PERMISSIONS_POLICY_OVERRIDES.map((override) => ({
+  source: override.source,
+  headers: securityHeaders.map((header) =>
+    header.key === 'Permissions-Policy'
+      ? { ...header, value: override.policy }
+      : header,
+  ),
+}));
 
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
@@ -235,6 +248,7 @@ module.exports = withBundleAnalyzer(
       : {
           async headers() {
             return [
+              ...permissionsPolicyOverrides,
               {
                 source: '/(.*)',
                 headers: securityHeaders,


### PR DESCRIPTION
## Summary
- centralize the permissions policy configuration so only the QR scanner route can request camera access
- apply the permissions policy header from middleware and the production headers configuration for consistent coverage
- document the exception approval process and add regression tests for the policy resolver

## Testing
- yarn test permissions-policy

------
https://chatgpt.com/codex/tasks/task_e_68dc936c3d6083289504d670914a5176