### PR TITLE
[redaction] Guard exports before download

### DIFF
--- a/__tests__/utils/redact.test.ts
+++ b/__tests__/utils/redact.test.ts
@@ -1,0 +1,115 @@
+import { buildPreview, guardTextDownload, redactText, scanText } from '../../utils/redact';
+import rules from '../../utils/redact/rules';
+
+const harmlessCorpus = [
+  'The quick brown fox jumps over the lazy dog.',
+  'Version 1.2.3 release notes.',
+  'Contact us at example@example.com for assistance.',
+  'SHA256: deadbeefcafebabe but trimmed.',
+  'Latitude 47.6062, Longitude -122.3321.',
+  'Invoice total: 1234.56 USD.',
+  'Usernames: alice, bob, carol.',
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+  'Phone number: (206) 555-0100.',
+  'Random words: nebula, synthesis, cascade.',
+  'Meeting scheduled for 2024-03-01 at 10:00.',
+  'UUID example: 123e4567-e89b-12d3-a456-426614174000.',
+  'Discuss OIDC scopes and OAuth flows (no secrets here).',
+  'Base64 sample: ZmFrZXNhbXBsZQ== (safe).',
+  'Configuration uses placeholders like ${TOKEN} and ${SECRET}.',
+  'Paths: /usr/local/bin, C:\\Program Files\\App.',
+  'Database DSN: postgres://user@localhost:5432/dbname.',
+  'Public SSH key header: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD only stub.',
+  'An empty string should be ignored.',
+  'Numbers 1111-2222-3333-444 without proper checksum should not match.',
+];
+
+describe('redaction rules', () => {
+  it('detects known credentials and redacts them', () => {
+    const sample = `AWS key AKIAIOSFODNN7EXAMPLE with aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`;
+    const { matches, redactedText } = redactText(sample);
+    const matchIds = matches.map((m) => m.rule.id);
+    expect(matchIds).toContain('aws-access-key-id');
+    expect(matchIds).toContain('aws-secret-access-key');
+    expect(redactedText).not.toContain('AKIAIOSFODNN7EXAMPLE');
+    expect(redactedText).toContain('«redacted:aws-secret-access-key»');
+  });
+
+  it('builds previews with contextual snippets', () => {
+    const sample = 'Token ghp_abcd1234abcd1234abcd1234abcd1234abcd leaks in logs.';
+    const matches = scanText(sample);
+    const preview = buildPreview(sample, matches, { contextRadius: 8 });
+    expect(preview).toMatch(/GitHub personal access token/);
+    expect(preview).toMatch(/«redacted:github-token»/);
+  });
+
+  it('checksums potential card numbers to avoid false positives', () => {
+    const maybeCard = 'Card 4242 4242 4242 4242 is a Stripe test number';
+    const matches = scanText(maybeCard);
+    expect(matches.some((m) => m.rule.id === 'card-number')).toBe(true);
+
+    const fake = 'Digits 1234 5678 9012 3456 should fail the Luhn check.';
+    const fakeMatches = scanText(fake);
+    expect(fakeMatches.some((m) => m.rule.id === 'card-number')).toBe(false);
+  });
+
+  it('limits false positives on benign corpus', () => {
+    const flagged = harmlessCorpus.filter((entry) => scanText(entry).length > 0);
+    const rate = flagged.length / harmlessCorpus.length;
+    expect(rate).toBeLessThan(0.05);
+  });
+});
+
+describe('guardTextDownload', () => {
+  const originalConfirm = window.confirm;
+
+  afterEach(() => {
+    window.confirm = originalConfirm;
+    jest.restoreAllMocks();
+  });
+
+  it('returns redacted content when user accepts redaction', () => {
+    const confirmMock = jest.spyOn(window, 'confirm');
+    confirmMock.mockImplementationOnce(() => true);
+
+    const githubToken = 'ghp_' + 'a'.repeat(36);
+    const decision = guardTextDownload(`Token ${githubToken}`, {
+      filename: 'report.txt',
+    });
+
+    expect(decision.redacted).toBe(true);
+    expect(decision.aborted).toBe(false);
+    expect(decision.content).not.toContain(githubToken);
+    expect(confirmMock).toHaveBeenCalled();
+  });
+
+  it('allows override when user declines redaction but accepts override', () => {
+    const confirmMock = jest.spyOn(window, 'confirm');
+    confirmMock.mockImplementationOnce(() => false);
+    confirmMock.mockImplementationOnce(() => true);
+
+    const decision = guardTextDownload('Authorization: Basic QWxhZGRpbjpPcGVuU2VzYW1l', {
+      filename: 'headers.txt',
+    });
+
+    expect(decision.redacted).toBe(false);
+    expect(decision.aborted).toBe(false);
+    expect(decision.content).toContain('QWxhZGRpbjpPcGVuU2VzYW1l');
+    expect(confirmMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts when user cancels both prompts', () => {
+    const confirmMock = jest.spyOn(window, 'confirm').mockImplementation(() => false);
+    const decision = guardTextDownload('AKIAIOSFODNN7EXAMPLE', { filename: 'keys.txt' });
+    expect(decision.aborted).toBe(true);
+    expect(decision.redacted).toBe(false);
+    expect(confirmMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('rule catalogue', () => {
+  it('exposes a stable set of rules', () => {
+    expect(Array.isArray(rules)).toBe(true);
+    expect(rules.length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/apps/resource-monitor/export.ts
+++ b/apps/resource-monitor/export.ts
@@ -1,11 +1,16 @@
 import { FetchEntry } from '../../lib/fetchProxy';
+import { guardTextDownload } from '../../utils/redact';
 
 export function serializeMetrics(entries: FetchEntry[]): string {
   return JSON.stringify(entries, null, 2);
 }
 
 export function exportMetrics(entries: FetchEntry[], filename = 'network-insights.json'): void {
-  const blob = new Blob([serializeMetrics(entries)], { type: 'application/json' });
+  const serialized = serializeMetrics(entries);
+  const decision = guardTextDownload(serialized, { filename });
+  if (decision.aborted) return;
+
+  const blob = new Blob([decision.content], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;

--- a/components/apps/Games/common/share/share.ts
+++ b/components/apps/Games/common/share/share.ts
@@ -1,5 +1,23 @@
+import { guardTextDownload } from '../../../../../utils/redact';
+
+const TEXTUAL_MIME = /^(text\/|application\/(?:json|xml|csv|x-yaml|javascript))/i;
+
+const shouldScanBlob = (blob: Blob): boolean => {
+  if (!blob.type) return blob.size <= 512 * 1024; // assume small unknown blobs are textual
+  return TEXTUAL_MIME.test(blob.type);
+};
+
 export async function shareBlob(blob: Blob, fileName: string): Promise<void> {
-  const file = new File([blob], fileName, { type: blob.type });
+  let workingBlob = blob;
+
+  if (shouldScanBlob(blob)) {
+    const text = await blob.text();
+    const decision = guardTextDownload(text, { filename: fileName });
+    if (decision.aborted) return;
+    workingBlob = new Blob([decision.content], { type: blob.type || 'text/plain' });
+  }
+
+  const file = new File([workingBlob], fileName, { type: workingBlob.type });
   const shareData: ShareData = { files: [file] };
 
   if (navigator.share && navigator.canShare && navigator.canShare(shareData)) {
@@ -11,7 +29,7 @@ export async function shareBlob(blob: Blob, fileName: string): Promise<void> {
     }
   }
 
-  const url = URL.createObjectURL(blob);
+  const url = URL.createObjectURL(workingBlob);
   const link = document.createElement('a');
   link.href = url;
   link.download = fileName;

--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -1,0 +1,39 @@
+# Redaction and export safety
+
+The redaction scanner runs before export and download flows that deal with textual data. It is designed to reduce the risk of accidentally sharing credentials or other sensitive tokens while still keeping the demo experience lightweight.
+
+## What gets flagged
+
+The scanner currently ships with the following high-confidence rules:
+
+- AWS access key identifiers and associated secret access keys.
+- GitHub personal access tokens (prefixes `ghp_`, `gho_`, `ghs_`, `ghu_`, `ghr_`).
+- Google Cloud API keys (`AIza…`).
+- Slack bot/user tokens (`xox…`).
+- Stripe live secret keys (`sk_live_…`).
+- PEM-encoded private key blocks.
+- JSON Web Tokens that parse into valid headers.
+- Payment card numbers that satisfy the Luhn checksum.
+- HTTP `Authorization: Basic …` headers with decodable username/password pairs.
+
+Each finding is replaced with a `«redacted:<rule-id>»` placeholder by default. When a match is discovered the user is shown a preview that includes a short description and a snippet of the redacted output. From there they can either:
+
+1. Accept the redacted version (default),
+2. Cancel the download altogether, or
+3. Override the redaction and export the original content.
+
+## Limitations
+
+- Only textual blobs (`text/*`, `application/json`, `application/xml`, `application/csv`, `application/x-yaml`, `application/javascript`) are scanned today. Binary exports fall back to the original behaviour.
+- Patterns are tuned to minimise false positives (<5% against the demo corpus), which means the scanner intentionally avoids very generic entropy checks. Extremely novel or proprietary token formats may slip through.
+- JWT detection only verifies the structure of the header and payload; encrypted (JWE) tokens are not flagged.
+- Secrets embedded inside compressed archives are not detected.
+
+## Messaging guidelines
+
+- Use action-driven phrasing: “Potential secrets found in <filename>. Download a redacted copy?”
+- Always present the number of matches, their type, and a preview of the redacted output.
+- Clearly label overrides as riskier choices. For example: “Download original unredacted content? Choosing Cancel keeps the download cancelled.”
+- When surfacing hints or rule descriptions, prefer short, recognisable identifiers (e.g. “AWS access key id”).
+
+These rules are defined in `utils/redact/rules.ts` and can be extended when new demo flows need extra coverage.

--- a/utils/redact/index.ts
+++ b/utils/redact/index.ts
@@ -1,0 +1,197 @@
+import rules, { RedactionRule, RedactionSeverity } from './rules';
+
+export interface RedactionMatch {
+  rule: RedactionRule;
+  match: string;
+  start: number;
+  end: number;
+  replacement: string;
+}
+
+export interface RedactionResult {
+  matches: RedactionMatch[];
+  redactedText: string;
+}
+
+export interface RedactOptions {
+  maskWith?: string;
+}
+
+const ensureGlobal = (pattern: RegExp): RegExp => {
+  if (pattern.flags.includes('g')) return pattern;
+  return new RegExp(pattern.source, pattern.flags + 'g');
+};
+
+const defaultReplacement = (rule: RedactionRule) => `«redacted:${rule.id}»`;
+
+const buildMatch = (
+  text: string,
+  rule: RedactionRule,
+  exec: RegExpExecArray,
+): RedactionMatch => {
+  const match = exec[0];
+  const start = exec.index;
+  const end = start + match.length;
+  const replacement = rule.replacement?.(match) ?? defaultReplacement(rule);
+  return { rule, match, start, end, replacement };
+};
+
+const dedupeOverlaps = (matches: RedactionMatch[]): RedactionMatch[] => {
+  const sorted = [...matches].sort((a, b) => a.start - b.start || b.end - a.end);
+  const result: RedactionMatch[] = [];
+  let cursor = -1;
+  for (const match of sorted) {
+    if (match.start >= cursor) {
+      result.push(match);
+      cursor = match.end;
+    }
+  }
+  return result;
+};
+
+export const scanText = (text: string): RedactionMatch[] => {
+  if (!text) return [];
+  const matches: RedactionMatch[] = [];
+  for (const rule of rules) {
+    const regex = ensureGlobal(rule.pattern);
+    regex.lastIndex = 0;
+    let exec: RegExpExecArray | null;
+    while ((exec = regex.exec(text)) !== null) {
+      const candidate = exec[0];
+      if (!candidate) {
+        // Avoid zero-length match infinite loops
+        regex.lastIndex += 1;
+        continue;
+      }
+      if (rule.validator && !rule.validator(candidate, exec, text)) {
+        continue;
+      }
+      matches.push(buildMatch(text, rule, exec));
+    }
+  }
+  return dedupeOverlaps(matches);
+};
+
+export const applyRedactions = (text: string, matches: RedactionMatch[]): string => {
+  if (!matches.length) return text;
+  const ordered = [...matches].sort((a, b) => a.start - b.start);
+  let cursor = 0;
+  let result = '';
+  for (const match of ordered) {
+    result += text.slice(cursor, match.start) + match.replacement;
+    cursor = match.end;
+  }
+  result += text.slice(cursor);
+  return result;
+};
+
+export const redactText = (text: string, options?: RedactOptions): RedactionResult => {
+  const matches = scanText(text);
+  if (!matches.length) {
+    return { matches, redactedText: text };
+  }
+  const withMask = options?.maskWith
+    ? matches.map((m) => ({ ...m, replacement: options.maskWith!.repeat(Math.max(4, Math.min(12, m.match.length))) }))
+    : matches;
+  return {
+    matches: withMask,
+    redactedText: applyRedactions(text, withMask),
+  };
+};
+
+export interface PreviewOptions {
+  contextRadius?: number;
+  maxExamples?: number;
+}
+
+export const buildPreview = (
+  text: string,
+  matches: RedactionMatch[],
+  options: PreviewOptions = {},
+): string => {
+  const radius = options.contextRadius ?? 16;
+  const limit = options.maxExamples ?? 3;
+  const snippets = matches.slice(0, limit).map((match) => {
+    const start = Math.max(0, match.start - radius);
+    const end = Math.min(text.length, match.end + radius);
+    const before = text.slice(start, match.start);
+    const after = text.slice(match.end, end);
+    return `• ${match.rule.description}: …${before}${match.replacement}${after}…`;
+  });
+  return snippets.join('\n');
+};
+
+export interface GuardDecision {
+  content: string;
+  matches: RedactionMatch[];
+  redacted: boolean;
+  aborted: boolean;
+  severity?: RedactionSeverity;
+}
+
+export interface GuardOptions extends PreviewOptions {
+  filename?: string;
+  onOverride?: (matches: RedactionMatch[]) => void;
+}
+
+const highestSeverity = (matches: RedactionMatch[]): RedactionSeverity => {
+  if (!matches.length) return 'low';
+  if (matches.some((m) => m.rule.severity === 'high')) return 'high';
+  if (matches.some((m) => m.rule.severity === 'medium')) return 'medium';
+  return 'low';
+};
+
+export const guardTextDownload = (text: string, options: GuardOptions = {}): GuardDecision => {
+  const { matches, redactedText } = redactText(text);
+  if (matches.length === 0 || typeof window === 'undefined') {
+    return {
+      content: text,
+      matches,
+      redacted: false,
+      aborted: false,
+      severity: highestSeverity(matches),
+    };
+  }
+
+  const preview = buildPreview(text, matches, options);
+  const summary = `${matches.length} potential secret${matches.length === 1 ? '' : 's'} found`;
+  const label = options.filename ? ` in ${options.filename}` : '';
+  const message = `${summary}${label}.\n\n${preview}\n\nPress OK to download a redacted copy. Cancel to review override options.`;
+
+  const proceed = window.confirm(message);
+  if (proceed) {
+    return {
+      content: redactedText,
+      matches,
+      redacted: true,
+      aborted: false,
+      severity: highestSeverity(matches),
+    };
+  }
+
+  const override = window.confirm(
+    'Download original unredacted content? Choosing Cancel keeps the download cancelled.',
+  );
+
+  if (!override) {
+    return {
+      content: text,
+      matches,
+      redacted: false,
+      aborted: true,
+      severity: highestSeverity(matches),
+    };
+  }
+
+  options.onOverride?.(matches);
+
+  return {
+    content: text,
+    matches,
+    redacted: false,
+    aborted: false,
+    severity: highestSeverity(matches),
+  };
+};
+
+export type { RedactionRule } from './rules';

--- a/utils/redact/rules.ts
+++ b/utils/redact/rules.ts
@@ -1,0 +1,211 @@
+export type RedactionSeverity = 'low' | 'medium' | 'high';
+
+export interface RedactionRule {
+  /**
+   * Unique identifier for the rule. Use kebab-case so the id can double
+   * as a placeholder label inside redacted content.
+   */
+  id: string;
+  /**
+   * Short human readable description used inside logs and previews.
+   */
+  description: string;
+  /**
+   * Regular expression that surfaces candidate strings to validate.
+   *
+   * The scanner will always execute this regex with the global flag so
+   * callers do not need to worry about stateful `lastIndex` behaviour.
+   */
+  pattern: RegExp;
+  /**
+   * Optional validator used to refine matches surfaced by the regex.
+   * Validators are useful for checksum validation or entropy checks and
+   * return true when the match should be considered sensitive.
+   */
+  validator?: (match: string, exec: RegExpExecArray, source: string) => boolean;
+  /**
+   * Optional helper to format replacement text. Defaults to a
+   * `«redacted:<id>»` placeholder when omitted.
+   */
+  replacement?: (match: string) => string;
+  /**
+   * Severity guides the user messaging when multiple matches are found.
+   */
+  severity: RedactionSeverity;
+  /**
+   * Optional hint surfaced alongside previews.
+   */
+  hint?: string;
+}
+
+const awsAccessKeyPrefixes = ['AKIA', 'ASIA', 'AGPA', 'AIDA', 'ANPA', 'AROA'];
+
+const isLikelyAwsAccessKey = (candidate: string): boolean =>
+  awsAccessKeyPrefixes.some((prefix) => candidate.startsWith(prefix));
+
+const luhnCheck = (candidate: string): boolean => {
+  let sum = 0;
+  let shouldDouble = false;
+  for (let i = candidate.length - 1; i >= 0; i -= 1) {
+    const digit = parseInt(candidate[i]!, 10);
+    if (Number.isNaN(digit)) return false;
+    let value = digit;
+    if (shouldDouble) {
+      value *= 2;
+      if (value > 9) value -= 9;
+    }
+    sum += value;
+    shouldDouble = !shouldDouble;
+  }
+  return sum % 10 === 0;
+};
+
+const decodeBase64 = (value: string): string | null => {
+  const globalAny = globalThis as {
+    atob?: (data: string) => string;
+    Buffer?: { from(data: string, encoding: string): { toString(encoding: string): string } };
+  };
+
+  if (typeof globalAny.atob === 'function') {
+    try {
+      return globalAny.atob(value);
+    } catch {
+      // ignore failures and fall back to Buffer branch
+    }
+  }
+
+  if (globalAny.Buffer) {
+    try {
+      return globalAny.Buffer.from(value, 'base64').toString('utf8');
+    } catch {
+      // ignore decode errors
+    }
+  }
+
+  return null;
+};
+
+const isBase64 = (value: string): boolean => {
+  if (value.length % 4 !== 0) return false;
+  return /^[A-Za-z0-9+/=]+$/.test(value);
+};
+
+const decodeBase64Url = (value: string): string | null => {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const paddingNeeded = (4 - (normalized.length % 4 || 4)) % 4;
+  const padded = normalized.padEnd(normalized.length + paddingNeeded, '=');
+  return decodeBase64(padded);
+};
+
+const isJwt = (token: string): boolean => {
+  const parts = token.split('.');
+  if (parts.length !== 3) return false;
+  const [header, payload] = parts;
+  if (!/^[A-Za-z0-9_-]+$/.test(header) || !/^[A-Za-z0-9_-]+$/.test(payload)) return false;
+  const decodedHeader = decodeBase64Url(header);
+  if (!decodedHeader) return false;
+  try {
+    const json = JSON.parse(decodedHeader);
+    return typeof json === 'object' && json !== null;
+  } catch {
+    return false;
+  }
+};
+
+const rules: RedactionRule[] = [
+  {
+    id: 'aws-access-key-id',
+    description: 'AWS access key id',
+    pattern: /\b[A-Z0-9]{20}\b/g,
+    validator: (match) => match.length === 20 && isLikelyAwsAccessKey(match),
+    replacement: () => '«redacted:aws-access-key-id»',
+    severity: 'high',
+    hint: 'Matches 20 character AWS style credential prefixes.',
+  },
+  {
+    id: 'aws-secret-access-key',
+    description: 'AWS secret access key',
+    pattern: /(?<=aws[_-]secret[_-]access[_-]key\s*[:=]\s*)[A-Za-z0-9\/+=]{40}/gi,
+    validator: (match) => match.length === 40,
+    replacement: () => '«redacted:aws-secret-access-key»',
+    severity: 'high',
+    hint: 'Triggered when inline configuration exposes long AWS secrets.',
+  },
+  {
+    id: 'github-token',
+    description: 'GitHub personal access token',
+    pattern: /\bgh[pousr]_[A-Za-z0-9]{36}\b/g,
+    severity: 'high',
+    replacement: () => '«redacted:github-token»',
+    hint: 'GitHub tokens start with ghp_, gho_, ghs_, ghu_, or ghr_.',
+  },
+  {
+    id: 'google-api-key',
+    description: 'Google API key',
+    pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g,
+    severity: 'high',
+    replacement: () => '«redacted:google-api-key»',
+  },
+  {
+    id: 'slack-token',
+    description: 'Slack bot or user token',
+    pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,48}\b/g,
+    severity: 'high',
+    replacement: () => '«redacted:slack-token»',
+  },
+  {
+    id: 'stripe-secret-key',
+    description: 'Stripe secret key',
+    pattern: /\bsk_live_[0-9a-zA-Z]{24}\b/g,
+    severity: 'high',
+    replacement: () => '«redacted:stripe-secret-key»',
+  },
+  {
+    id: 'private-key-block',
+    description: 'Embedded private key block',
+    pattern:
+      /-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----[\s\S]+?-----END (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/g,
+    severity: 'high',
+    replacement: () => '«redacted:private-key»',
+    hint: 'Looks for PEM encoded private key material.',
+  },
+  {
+    id: 'json-web-token',
+    description: 'JSON Web Token',
+    pattern: /\b[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g,
+    validator: (match) => match.length > 40 && isJwt(match),
+    replacement: () => '«redacted:jwt»',
+    severity: 'medium',
+    hint: 'JWTs are redacted because they often embed bearer credentials.',
+  },
+  {
+    id: 'card-number',
+    description: 'Payment card number',
+    pattern: /\b(?:\d[ -]*?){13,19}\b/g,
+    validator: (match) => {
+      const digits = match.replace(/\D/g, '');
+      if (digits.length < 13 || digits.length > 19) return false;
+      return luhnCheck(digits);
+    },
+    replacement: () => '«redacted:card-number»',
+    severity: 'high',
+    hint: 'Uses a Luhn checksum to avoid false positives on random numbers.',
+  },
+  {
+    id: 'basic-auth-header',
+    description: 'Authorization header with Basic credentials',
+    pattern: /Authorization:\s*Basic\s+([A-Za-z0-9+/=]{8,})/gi,
+    validator: (match, exec) => {
+      const raw = exec[1];
+      if (!raw || raw.length < 8) return false;
+      if (!isBase64(raw)) return false;
+      const decoded = decodeBase64(raw);
+      if (!decoded) return false;
+      return decoded.includes(':');
+    },
+    replacement: () => 'Authorization: Basic «redacted:credentials»',
+    severity: 'medium',
+  },
+];
+
+export default rules;


### PR DESCRIPTION
## Summary
- add reusable scanning utilities with regex- and checksum-backed rules for common secrets
- integrate the guard into text-based export/share flows and document the preview + override behaviour
- cover the scanner with targeted unit tests and a benign corpus false-positive check

## Testing
- yarn test utils/redact.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc936ca86c8328a3e586fe5c612fb8