### PR TITLE
[audit] add local audit log storage and viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ See `.env.local.example` for the full list.
 - Run `yarn lint` and `yarn test` before committing changes.
 - For manual smoke tests, start `yarn dev` and in another terminal run `yarn smoke` to visit every `/apps/*` route.
 
+## Audit Logging (Local Only)
+
+- Users can opt into audit logging from **Settings → Enable Audit Logging**. Logging is disabled by default to honor privacy.
+- When enabled, events are written to the browser&apos;s Origin Private File System (OPFS) where available, or IndexedDB as a
+  fallback. No audit data leaves the device.
+- The **Audit Log Viewer** utility lists recorded events, verifies payload hashes, and supports export/import of integrity-
+  checked bundles so analysts can back up or restore their local trail.
+- Exported bundles include SHA-256 digests for each entry and for the bundle manifest; imports are rejected if verification
+  fails.
+
 ---
 
 ## Speed Insights

--- a/__tests__/auditLog.test.ts
+++ b/__tests__/auditLog.test.ts
@@ -1,0 +1,95 @@
+import {
+  appendAuditEvent,
+  clearAuditLog,
+  exportAuditLog,
+  getAuditLog,
+  importAuditLog,
+  verifyAuditLog,
+} from '../utils/auditLog';
+import {
+  getAuditLogOptIn,
+  setAuditLogOptIn,
+} from '../utils/settingsStore';
+
+describe('audit log utilities', () => {
+  beforeEach(async () => {
+    await clearAuditLog();
+    localStorage.clear();
+  });
+
+  it('respects opt-in state before recording', async () => {
+    const initialOptIn = await getAuditLogOptIn();
+    expect(initialOptIn).toBe(false);
+
+    const noEntry = await appendAuditEvent({
+      actor: 'tester',
+      action: 'no-log',
+      payload: { ok: true },
+    });
+    expect(noEntry).toBeNull();
+
+    await setAuditLogOptIn(true);
+    const entry = await appendAuditEvent({
+      actor: 'tester',
+      action: 'record',
+      payload: { ok: true },
+    });
+    expect(entry).not.toBeNull();
+
+    const storedOptIn = await getAuditLogOptIn();
+    expect(storedOptIn).toBe(true);
+
+    const log = await getAuditLog();
+    expect(log).toHaveLength(1);
+    expect(log[0]?.payloadHash).toBeTruthy();
+  });
+
+  it('detects tampering via integrity report', async () => {
+    await setAuditLogOptIn(true);
+    await appendAuditEvent({
+      actor: 'analyst',
+      action: 'simulate-action',
+      payload: { target: 'lab', status: 'ok' },
+    });
+    const log = await getAuditLog();
+    const report = await verifyAuditLog(log);
+    expect(report.valid).toBe(true);
+
+    const tampered = log.map((entry, index) =>
+      index === 0
+        ? { ...entry, payload: { ...entry.payload, status: 'tampered' } }
+        : entry,
+    );
+    const tamperedReport = await verifyAuditLog(tampered);
+    expect(tamperedReport.valid).toBe(false);
+    expect(tamperedReport.issues[0]?.reason).toMatch(/hash/i);
+  });
+
+  it('round-trips through export and import with integrity preserved', async () => {
+    await setAuditLogOptIn(true);
+    await appendAuditEvent({
+      actor: 'analyst',
+      action: 'first',
+      payload: { detail: 1 },
+    });
+    await appendAuditEvent({
+      actor: 'analyst',
+      action: 'second',
+      payload: { detail: 2 },
+    });
+
+    const exported = await exportAuditLog();
+    await clearAuditLog();
+
+    const result = await importAuditLog(exported);
+    expect(result.success).toBe(true);
+    expect(result.importedCount).toBe(2);
+    expect(result.report.valid).toBe(true);
+
+    const importedLog = await getAuditLog();
+    expect(importedLog).toHaveLength(2);
+    const verifyResult = await verifyAuditLog(importedLog);
+    expect(verifyResult.valid).toBe(true);
+  });
+});
+

--- a/apps.config.js
+++ b/apps.config.js
@@ -92,6 +92,7 @@ const KismetApp = createDynamicApp('kismet.jsx', 'Kismet');
 const HashcatApp = createDynamicApp('hashcat', 'Hashcat');
 const MsfPostApp = createDynamicApp('msf-post', 'Metasploit Post');
 const EvidenceVaultApp = createDynamicApp('evidence-vault', 'Evidence Vault');
+const AuditLogViewerApp = createDynamicApp('audit-log', 'Audit Log Viewer');
 const MimikatzApp = createDynamicApp('mimikatz', 'Mimikatz');
 const MimikatzOfflineApp = createDynamicApp('mimikatz/offline', 'Mimikatz Offline');
 const EttercapApp = createDynamicApp('ettercap', 'Ettercap');
@@ -178,6 +179,7 @@ const displayVolatility = createDisplay(VolatilityApp);
 
 const displayMsfPost = createDisplay(MsfPostApp);
 const displayEvidenceVault = createDisplay(EvidenceVaultApp);
+const displayAuditLogViewer = createDisplay(AuditLogViewerApp);
 const displayMimikatz = createDisplay(MimikatzApp);
 const displayMimikatzOffline = createDisplay(MimikatzOfflineApp);
 const displayEttercap = createDisplay(EttercapApp);
@@ -1013,6 +1015,15 @@ const apps = [
     favourite: false,
     desktop_shortcut: false,
     screen: displayEvidenceVault,
+  },
+  {
+    id: 'audit-log',
+    title: 'Audit Log Viewer',
+    icon: '/themes/Yaru/apps/project-gallery.svg',
+    disabled: false,
+    favourite: false,
+    desktop_shortcut: false,
+    screen: displayAuditLogViewer,
   },
   {
     id: 'dsniff',

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -9,7 +9,14 @@ interface Props {
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
-  const { accent, setAccent, theme, setTheme } = useSettings();
+  const {
+    accent,
+    setAccent,
+    theme,
+    setTheme,
+    auditLogEnabled,
+    setAuditLogEnabled,
+  } = useSettings();
 
   return (
     <div>
@@ -51,6 +58,22 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
                 />
               ))}
             </div>
+          </label>
+          <label className="mt-4 block">
+            <span className="font-semibold block">Audit log</span>
+            <div className="mt-1 flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={auditLogEnabled}
+                onChange={(e) => setAuditLogEnabled(e.target.checked)}
+                aria-label="Enable audit logging"
+              />
+              <span>Store local-only audit events</span>
+            </div>
+            <p className="mt-1 text-xs text-gray-300">
+              Events are saved to your browser&apos;s private storage (OPFS/IndexedDB)
+              and never leave this device.
+            </p>
           </label>
         </div>
       )}

--- a/components/apps/audit-log/index.tsx
+++ b/components/apps/audit-log/index.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  getAuditLog,
+  exportAuditLog,
+  importAuditLog,
+  verifyAuditLog,
+  AuditLogEntry,
+  AuditIntegrityReport,
+} from '../../../utils/auditLog';
+import { useSettings } from '../../../hooks/useSettings';
+
+const formatTimestamp = (value: string) => {
+  try {
+    const date = new Date(value);
+    return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+  } catch {
+    return value;
+  }
+};
+
+const AuditLogViewer: React.FC = () => {
+  const { auditLogEnabled, setAuditLogEnabled } = useSettings();
+  const [entries, setEntries] = useState<AuditLogEntry[]>([]);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [report, setReport] = useState<AuditIntegrityReport | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    setStatus(null);
+    setReport(null);
+    const log = await getAuditLog();
+    const sorted = [...log].sort(
+      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    );
+    setEntries(sorted);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleExport = useCallback(async () => {
+    try {
+      const data = await exportAuditLog();
+      const blob = new Blob([data], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `audit-log-${new Date().toISOString()}.json`;
+      link.click();
+      URL.revokeObjectURL(url);
+      setStatus('Audit log exported. Keep the file secure.');
+      setError(null);
+    } catch (err) {
+      setError('Unable to export audit log.');
+      console.error(err);
+    }
+  }, []);
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImport = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+      try {
+        const text = await file.text();
+        const result = await importAuditLog(text);
+        if (result.success) {
+          setStatus(`Imported ${result.importedCount} entries.`);
+          setError(null);
+          setReport(result.report);
+          await refresh();
+        } else {
+          setStatus(null);
+          setReport(result.report);
+          setError(result.error || 'Import failed.');
+        }
+      } catch (err) {
+        setStatus(null);
+        setError('Import failed.');
+        console.error(err);
+      } finally {
+        event.target.value = '';
+      }
+    },
+    [refresh],
+  );
+
+  const handleVerify = useCallback(async () => {
+    const result = await verifyAuditLog();
+    setReport(result);
+    if (result.valid) {
+      setStatus('Integrity check passed.');
+      setError(null);
+    } else {
+      setStatus(null);
+      setError('Integrity issues detected. Review the entries below.');
+    }
+  }, []);
+
+  return (
+    <div className="flex h-full flex-col bg-ub-dark text-white">
+      <div className="border-b border-black/40 p-4">
+        <h1 className="text-lg font-semibold">Audit Log Viewer</h1>
+        <p className="mt-1 text-xs text-ubt-grey">
+          Audit events remain local to this device. Enable logging to record actions, export for offline backup, and import
+          verified bundles when restoring.
+        </p>
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+          <button
+            onClick={() => setAuditLogEnabled(!auditLogEnabled)}
+            className={`rounded px-2 py-1 ${
+              auditLogEnabled ? 'bg-ub-green text-black' : 'bg-ub-cool-grey text-white'
+            }`}
+          >
+            {auditLogEnabled ? 'Logging enabled' : 'Enable logging'}
+          </button>
+          <button onClick={refresh} className="rounded bg-ub-cool-grey px-2 py-1 text-white">
+            Refresh
+          </button>
+          <button onClick={handleVerify} className="rounded bg-ub-orange px-2 py-1 text-black">
+            Verify integrity
+          </button>
+          <button onClick={handleExport} className="rounded bg-ub-orange px-2 py-1 text-black">
+            Export
+          </button>
+          <button onClick={handleImportClick} className="rounded bg-ub-cool-grey px-2 py-1 text-white">
+            Import
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json"
+            className="hidden"
+            aria-label="Import audit log file"
+            onChange={handleImport}
+          />
+        </div>
+        <div className="mt-2 space-y-1 text-xs">
+          <p className="text-ubt-grey">
+            Status: {auditLogEnabled ? 'opt-in active' : 'logging disabled'} · {entries.length} entries recorded
+          </p>
+          {status && <p className="text-ub-green">{status}</p>}
+          {error && <p className="text-red-400">{error}</p>}
+          {report && (
+            <p className={report.valid ? 'text-ub-green' : 'text-red-400'}>
+              {report.valid
+                ? 'Log integrity verified.'
+                : `Found ${report.issues.length} issue${report.issues.length === 1 ? '' : 's'}.`}
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="flex-1 overflow-auto p-4">
+        {entries.length === 0 ? (
+          <p className="text-sm text-ubt-grey">
+            No audit entries yet. Logging begins after you opt in. Actions from utilities and simulations can record context for
+            your own lab notes.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {entries.map((entry) => (
+              <li key={entry.id} className="rounded border border-black/30 bg-ub-cool-grey p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-ubt-grey">
+                  <span>{formatTimestamp(entry.timestamp)}</span>
+                  <span className="font-semibold text-white">{entry.actor}</span>
+                  <span className="text-ub-yellow">{entry.action}</span>
+                  <span className="break-all text-[10px] text-ub-green">
+                    hash: {entry.payloadHash}
+                  </span>
+                </div>
+                <pre className="mt-2 max-h-32 overflow-auto rounded bg-black/60 p-2 text-xs text-ubt-grey">
+                  {JSON.stringify(entry.payload, null, 2)}
+                </pre>
+              </li>
+            ))}
+          </ul>
+        )}
+        {report && !report.valid && report.issues.length > 0 && (
+          <div className="mt-4 rounded border border-red-500/40 bg-red-500/10 p-3 text-xs text-red-200">
+            <h2 className="mb-2 text-sm font-semibold text-red-300">Integrity issues</h2>
+            <ul className="space-y-1">
+              {report.issues.map((issue, idx) => (
+                <li key={`${issue.index}-${idx}`}>
+                  Entry {issue.index + 1}: {issue.reason}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AuditLogViewer;
+

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -4,7 +4,7 @@ import { resetSettings, defaults, exportSettings as exportSettingsData, importSe
 import KaliWallpaper from '../util-components/kali-wallpaper';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, auditLogEnabled, setAuditLogEnabled, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -89,6 +89,7 @@ export function Settings() {
                         checked={useKaliWallpaper}
                         onChange={(e) => setUseKaliWallpaper(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle Kali gradient wallpaper"
                     />
                     Kali Gradient Wallpaper
                 </label>
@@ -135,6 +136,7 @@ export function Settings() {
                     value={fontScale}
                     onChange={(e) => setFontScale(parseFloat(e.target.value))}
                     className="ubuntu-slider"
+                    aria-label="Adjust font scale"
                 />
             </div>
             <div className="flex justify-center my-4">
@@ -144,6 +146,7 @@ export function Settings() {
                         checked={reducedMotion}
                         onChange={(e) => setReducedMotion(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle reduced motion"
                     />
                     Reduced Motion
                 </label>
@@ -155,6 +158,7 @@ export function Settings() {
                         checked={largeHitAreas}
                         onChange={(e) => setLargeHitAreas(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle large hit areas"
                     />
                     Large Hit Areas
                 </label>
@@ -166,6 +170,7 @@ export function Settings() {
                         checked={highContrast}
                         onChange={(e) => setHighContrast(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle high contrast mode"
                     />
                     High Contrast
                 </label>
@@ -177,6 +182,7 @@ export function Settings() {
                         checked={allowNetwork}
                         onChange={(e) => setAllowNetwork(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle network requests"
                     />
                     Allow Network Requests
                 </label>
@@ -185,9 +191,32 @@ export function Settings() {
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
                         type="checkbox"
+                        checked={auditLogEnabled}
+                        onChange={(e) => setAuditLogEnabled(e.target.checked)}
+                        className="mr-2"
+                        aria-label="Toggle audit logging"
+                    />
+                    Enable Audit Logging
+                </label>
+            </div>
+            {auditLogEnabled ? (
+                <p className="text-center text-xs text-ubt-grey/70 px-6 -mt-2 mb-4">
+                    Audit entries are stored only in this browser using OPFS/IndexedDB. Use the Audit Log Viewer utility to
+                    export or import verified bundles when you need a backup.
+                </p>
+            ) : (
+                <p className="text-center text-xs text-ubt-grey/70 px-6 -mt-2 mb-4">
+                    Opt in to keep a local-only audit trail. Nothing is recorded until you enable logging.
+                </p>
+            )}
+            <div className="flex justify-center my-4">
+                <label className="mr-2 text-ubt-grey flex items-center">
+                    <input
+                        type="checkbox"
                         checked={haptics}
                         onChange={(e) => setHaptics(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle haptics"
                     />
                     Haptics
                 </label>
@@ -199,6 +228,7 @@ export function Settings() {
                         checked={pongSpin}
                         onChange={(e) => setPongSpin(e.target.checked)}
                         className="mr-2"
+                        aria-label="Toggle pong spin"
                     />
                     Pong Spin
                 </label>
@@ -288,6 +318,7 @@ export function Settings() {
                 type="file"
                 accept="application/json"
                 ref={fileInput}
+                aria-label="Import settings file"
                 onChange={async (e) => {
                     const file = e.target.files && e.target.files[0];
                     if (!file) return;

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -22,6 +22,8 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getAuditLogOptIn as loadAuditLogOptIn,
+  setAuditLogOptIn as saveAuditLogOptIn,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
@@ -66,6 +68,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  auditLogEnabled: boolean;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -78,6 +81,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setAuditLogEnabled: (value: boolean) => void;
   setTheme: (value: string) => void;
 }
 
@@ -94,6 +98,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  auditLogEnabled: defaults.auditLogEnabled,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -106,6 +111,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setAuditLogEnabled: () => {},
   setTheme: () => {},
 });
 
@@ -121,6 +127,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [auditLogEnabled, setAuditLogEnabled] = useState<boolean>(
+    defaults.auditLogEnabled,
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -137,6 +146,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setAuditLogEnabled(await loadAuditLogOptIn());
       setTheme(loadTheme());
     })();
   }, []);
@@ -250,6 +260,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    saveAuditLogOptIn(auditLogEnabled);
+  }, [auditLogEnabled]);
+
   const bgImageName = useKaliWallpaper ? 'kali-gradient' : wallpaper;
 
   return (
@@ -267,6 +281,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        auditLogEnabled,
         theme,
         setAccent,
         setWallpaper,
@@ -279,6 +294,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setAuditLogEnabled,
         setTheme,
       }}
     >

--- a/utils/auditLog.ts
+++ b/utils/auditLog.ts
@@ -1,0 +1,444 @@
+import { isBrowser, hasIndexedDB } from './isBrowser';
+import { getDb } from './safeIDB';
+
+export const AUDIT_LOG_ENABLED_KEY = 'audit-log-enabled';
+
+const AUDIT_FILE_NAME = 'audit-log.json';
+const AUDIT_DB_NAME = 'kali-audit-log';
+const AUDIT_STORE_NAME = 'audit';
+const AUDIT_STORE_KEY = 'entries';
+const AUDIT_LOG_VERSION = 1;
+
+const textEncoder = new TextEncoder();
+
+interface AuditLogFile {
+  version: number;
+  entries: AuditLogEntry[];
+}
+
+export interface AuditEventInput {
+  actor: string;
+  action: string;
+  payload?: unknown;
+}
+
+export interface AuditLogEntry {
+  id: string;
+  timestamp: string;
+  actor: string;
+  action: string;
+  payload: unknown;
+  payloadHash: string;
+}
+
+export interface AuditIntegrityIssue {
+  index: number;
+  reason: string;
+  entry: AuditLogEntry | null;
+}
+
+export interface AuditIntegrityReport {
+  valid: boolean;
+  issues: AuditIntegrityIssue[];
+}
+
+export interface AuditImportResult {
+  success: boolean;
+  importedCount: number;
+  report: AuditIntegrityReport;
+  error?: string;
+}
+
+let cachedState: AuditLogFile | null = null;
+let idbPromise: ReturnType<typeof getDb> | null = null;
+
+const memoryState: AuditLogFile = { version: AUDIT_LOG_VERSION, entries: [] };
+
+function openAuditDb() {
+  if (!idbPromise) {
+    idbPromise = getDb(AUDIT_DB_NAME, 1, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(AUDIT_STORE_NAME)) {
+          db.createObjectStore(AUDIT_STORE_NAME);
+        }
+      },
+    });
+  }
+  return idbPromise;
+}
+
+function hasOpfs() {
+  return (
+    isBrowser &&
+    typeof navigator.storage !== 'undefined' &&
+    typeof navigator.storage.getDirectory === 'function'
+  );
+}
+
+function createId() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `audit-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+function sanitizePayload(payload: unknown): unknown {
+  if (payload === undefined) return null;
+  try {
+    return JSON.parse(JSON.stringify(payload));
+  } catch {
+    return { message: 'Non-serializable payload', value: String(payload) };
+  }
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function digestString(value: string): Promise<string> {
+  if (typeof crypto !== 'undefined' && crypto.subtle) {
+    const hash = await crypto.subtle.digest('SHA-256', textEncoder.encode(value));
+    return toHex(hash);
+  }
+  try {
+    const { createHash } = await import('crypto');
+    return createHash('sha256').update(value).digest('hex');
+  } catch {
+    return value;
+  }
+}
+
+async function hashPayload(payload: unknown): Promise<string> {
+  return digestString(JSON.stringify(payload));
+}
+
+async function readFromOpfs(): Promise<AuditLogFile | null> {
+  if (!hasOpfs()) return null;
+  try {
+    const root = await navigator.storage.getDirectory();
+    const handle = await root.getFileHandle(AUDIT_FILE_NAME);
+    const file = await handle.getFile();
+    const parsed = JSON.parse(await file.text());
+    if (parsed && typeof parsed === 'object') {
+      return normalizeFile(parsed);
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+async function writeToOpfs(state: AuditLogFile): Promise<boolean> {
+  if (!hasOpfs()) return false;
+  try {
+    const root = await navigator.storage.getDirectory();
+    const handle = await root.getFileHandle(AUDIT_FILE_NAME, { create: true });
+    const writable = await handle.createWritable();
+    await writable.write(JSON.stringify(state));
+    await writable.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readFromIdb(): Promise<AuditLogFile | null> {
+  if (!hasIndexedDB) return null;
+  const dbp = openAuditDb();
+  if (!dbp) return null;
+  try {
+    const db = await dbp;
+    const stored = await db.get(AUDIT_STORE_NAME, AUDIT_STORE_KEY);
+    if (!stored) return null;
+    return normalizeFile(stored);
+  } catch {
+    return null;
+  }
+}
+
+async function writeToIdb(state: AuditLogFile): Promise<boolean> {
+  if (!hasIndexedDB) return false;
+  const dbp = openAuditDb();
+  if (!dbp) return false;
+  try {
+    const db = await dbp;
+    await db.put(AUDIT_STORE_NAME, state, AUDIT_STORE_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeFile(raw: any): AuditLogFile {
+  if (!raw || typeof raw !== 'object') {
+    return { version: AUDIT_LOG_VERSION, entries: [] };
+  }
+  const version =
+    typeof raw.version === 'number' ? raw.version : AUDIT_LOG_VERSION;
+  const entries = Array.isArray(raw.entries) ? raw.entries : [];
+  return { version, entries };
+}
+
+async function loadState(): Promise<AuditLogFile> {
+  if (cachedState) return cachedState;
+  const fromOpfs = await readFromOpfs();
+  if (fromOpfs) {
+    cachedState = { ...fromOpfs, entries: [...fromOpfs.entries] };
+    memoryState.entries = [...cachedState.entries];
+    return cachedState;
+  }
+  const fromIdb = await readFromIdb();
+  if (fromIdb) {
+    cachedState = { ...fromIdb, entries: [...fromIdb.entries] };
+    memoryState.entries = [...cachedState.entries];
+    return cachedState;
+  }
+  cachedState = { ...memoryState, entries: [...memoryState.entries] };
+  return cachedState;
+}
+
+async function persistState(state: AuditLogFile): Promise<void> {
+  cachedState = { version: state.version, entries: [...state.entries] };
+  memoryState.entries = [...state.entries];
+  if (!(await writeToOpfs(state))) {
+    await writeToIdb(state);
+  } else {
+    await writeToIdb(state);
+  }
+}
+
+function isLoggingEnabled(): boolean {
+  if (isBrowser) {
+    try {
+      return localStorage.getItem(AUDIT_LOG_ENABLED_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+function validateStringField(
+  value: unknown,
+  field: 'actor' | 'action',
+  index: number,
+  issues: AuditIntegrityIssue[],
+): string {
+  if (typeof value === 'string' && value.trim()) return value;
+  issues.push({
+    index,
+    reason: `${field} missing`,
+    entry: null,
+  });
+  return '';
+}
+
+function validateTimestamp(
+  value: unknown,
+  index: number,
+  issues: AuditIntegrityIssue[],
+): string {
+  if (typeof value === 'string' && !Number.isNaN(Date.parse(value))) {
+    return value;
+  }
+  issues.push({ index, reason: 'invalid timestamp', entry: null });
+  return new Date(0).toISOString();
+}
+
+async function inspectEntry(
+  raw: any,
+  index: number,
+): Promise<{ entry: AuditLogEntry; issues: AuditIntegrityIssue[] }> {
+  const issues: AuditIntegrityIssue[] = [];
+  if (!raw || typeof raw !== 'object') {
+    return {
+      entry: {
+        id: createId(),
+        actor: '',
+        action: '',
+        timestamp: new Date(0).toISOString(),
+        payload: null,
+        payloadHash: '',
+      },
+      issues: [
+        {
+          index,
+          reason: 'entry is not an object',
+          entry: null,
+        },
+      ],
+    };
+  }
+  const actor = validateStringField(raw.actor, 'actor', index, issues);
+  const action = validateStringField(raw.action, 'action', index, issues);
+  const timestamp = validateTimestamp(raw.timestamp, index, issues);
+  const payload = sanitizePayload(raw.payload);
+  const payloadHash = typeof raw.payloadHash === 'string' ? raw.payloadHash : '';
+  if (!payloadHash) {
+    issues.push({ index, reason: 'payload hash missing', entry: null });
+  } else {
+    const computed = await hashPayload(payload);
+    if (computed !== payloadHash) {
+      issues.push({ index, reason: 'payload hash mismatch', entry: null });
+    }
+  }
+  const entry: AuditLogEntry = {
+    id:
+      typeof raw.id === 'string' && raw.id.trim()
+        ? raw.id
+        : createId(),
+    actor,
+    action,
+    timestamp,
+    payload,
+    payloadHash,
+  };
+  return { entry, issues };
+}
+
+export async function appendAuditEvent(
+  event: AuditEventInput,
+): Promise<AuditLogEntry | null> {
+  if (!isLoggingEnabled()) return null;
+  const { actor, action } = event;
+  if (!actor || !action) return null;
+  const state = await loadState();
+  const payload = sanitizePayload(event.payload);
+  const payloadHash = await hashPayload(payload);
+  const entry: AuditLogEntry = {
+    id: createId(),
+    actor,
+    action,
+    timestamp: new Date().toISOString(),
+    payload,
+    payloadHash,
+  };
+  state.entries.push(entry);
+  await persistState(state);
+  return entry;
+}
+
+export async function getAuditLog(): Promise<AuditLogEntry[]> {
+  const state = await loadState();
+  return [...state.entries];
+}
+
+export async function clearAuditLog(): Promise<void> {
+  const empty: AuditLogFile = { version: AUDIT_LOG_VERSION, entries: [] };
+  await persistState(empty);
+  if (hasOpfs()) {
+    try {
+      const root = await navigator.storage.getDirectory();
+      await root.removeEntry(AUDIT_FILE_NAME);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export async function verifyAuditLog(
+  entries?: AuditLogEntry[],
+): Promise<AuditIntegrityReport> {
+  const data = entries ?? (await getAuditLog());
+  const issues: AuditIntegrityIssue[] = [];
+  await Promise.all(
+    data.map(async (entry, index) => {
+      const { issues: entryIssues } = await inspectEntry(entry, index);
+      issues.push(
+        ...entryIssues.map((issue) => ({
+          ...issue,
+          entry,
+        })),
+      );
+    }),
+  );
+  return { valid: issues.length === 0, issues };
+}
+
+export async function exportAuditLog(): Promise<string> {
+  const state = await loadState();
+  const payload = {
+    version: state.version,
+    exportedAt: new Date().toISOString(),
+    entries: state.entries,
+  };
+  const integrity = await digestString(JSON.stringify(payload.entries));
+  return JSON.stringify({ ...payload, integrity }, null, 2);
+}
+
+export async function importAuditLog(
+  raw: string | object,
+): Promise<AuditImportResult> {
+  let parsed: any;
+  try {
+    parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  } catch (error) {
+    return {
+      success: false,
+      importedCount: 0,
+      error: 'Invalid JSON',
+      report: { valid: false, issues: [] },
+    };
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return {
+      success: false,
+      importedCount: 0,
+      error: 'Invalid export format',
+      report: { valid: false, issues: [] },
+    };
+  }
+  const { entries, integrity } = parsed;
+  if (!Array.isArray(entries)) {
+    return {
+      success: false,
+      importedCount: 0,
+      error: 'Missing entries array',
+      report: { valid: false, issues: [] },
+    };
+  }
+  const expectedIntegrity = await digestString(JSON.stringify(entries));
+  if (expectedIntegrity !== integrity) {
+    return {
+      success: false,
+      importedCount: 0,
+      error: 'Integrity check failed',
+      report: { valid: false, issues: [] },
+    };
+  }
+  const normalized: AuditLogEntry[] = [];
+  const issues: AuditIntegrityIssue[] = [];
+  for (let i = 0; i < entries.length; i += 1) {
+    const { entry, issues: entryIssues } = await inspectEntry(entries[i], i);
+    if (entryIssues.length > 0) {
+      issues.push(
+        ...entryIssues.map((issue) => ({
+          ...issue,
+          entry,
+        })),
+      );
+    }
+    normalized.push(entry);
+  }
+  const report: AuditIntegrityReport = {
+    valid: issues.length === 0,
+    issues,
+  };
+  if (!report.valid) {
+    return {
+      success: false,
+      importedCount: 0,
+      error: 'Log entries failed integrity validation',
+      report,
+    };
+  }
+  await persistState({ version: AUDIT_LOG_VERSION, entries: normalized });
+  return { success: true, importedCount: normalized.length, report };
+}
+
+export function isAuditLoggingEnabled(): boolean {
+  return isLoggingEnabled();
+}
+

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -15,6 +15,16 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  auditLogEnabled: false,
+};
+
+const getLocalStorageSafe = () => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
 };
 
 export async function getAccent() {
@@ -38,29 +48,34 @@ export async function setWallpaper(wallpaper) {
 }
 
 export async function getUseKaliWallpaper() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.useKaliWallpaper;
-  const stored = window.localStorage.getItem('use-kali-wallpaper');
+  const storage = getLocalStorageSafe();
+  if (!storage) return DEFAULT_SETTINGS.useKaliWallpaper;
+  const stored = storage.getItem('use-kali-wallpaper');
   return stored === null ? DEFAULT_SETTINGS.useKaliWallpaper : stored === 'true';
 }
 
 export async function setUseKaliWallpaper(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('use-kali-wallpaper', value ? 'true' : 'false');
+  const storage = getLocalStorageSafe();
+  if (!storage) return;
+  storage.setItem('use-kali-wallpaper', value ? 'true' : 'false');
 }
 
 export async function getDensity() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
-  return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
+  const storage = getLocalStorageSafe();
+  if (!storage) return DEFAULT_SETTINGS.density;
+  return storage.getItem('density') || DEFAULT_SETTINGS.density;
 }
 
 export async function setDensity(density) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('density', density);
+  const storage = getLocalStorageSafe();
+  if (!storage) return;
+  storage.setItem('density', density);
 }
 
 export async function getReducedMotion() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
-  const stored = window.localStorage.getItem('reduced-motion');
+  const storage = getLocalStorageSafe();
+  if (!storage) return DEFAULT_SETTINGS.reducedMotion;
+  const stored = storage.getItem('reduced-motion');
   if (stored !== null) {
     return stored === 'true';
   }
@@ -68,88 +83,115 @@ export async function getReducedMotion() {
 }
 
 export async function setReducedMotion(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
+  const storage = getLocalStorageSafe();
+  if (!storage) return;
+  storage.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
-  const stored = window.localStorage.getItem('font-scale');
+  const storage = getLocalStorageSafe();
+  if (!storage) return DEFAULT_SETTINGS.fontScale;
+  const stored = storage.getItem('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('font-scale', String(scale));
+  const storage = getLocalStorageSafe();
+  if (!storage) return;
+  storage.setItem('font-scale', String(scale));
 }
 
 export async function getHighContrast() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
-  return window.localStorage.getItem('high-contrast') === 'true';
+  const storage = getLocalStorageSafe();
+  if (!storage) return DEFAULT_SETTINGS.highContrast;
+  return storage.getItem('high-contrast') === 'true';
 }
 
 export async function setHighContrast(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
+  const storage = getLocalStorageSafe();
+  if (!storage) return;
+  storage.setItem('high-contrast', value ? 'true' : 'false');
 }
 
 export async function getLargeHitAreas() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
-  return window.localStorage.getItem('large-hit-areas') === 'true';
+  const storage = getLocalStorageSafe();
+  if (!storage) return DEFAULT_SETTINGS.largeHitAreas;
+  return storage.getItem('large-hit-areas') === 'true';
 }
 
 export async function setLargeHitAreas(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
+  const storage = getLocalStorageSafe();
+  if (!storage) return;
+  storage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
 export async function getHaptics() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
-  const val = window.localStorage.getItem('haptics');
+  const storage = getLocalStorageSafe();
+  if (!storage) return DEFAULT_SETTINGS.haptics;
+  const val = storage.getItem('haptics');
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
 export async function setHaptics(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('haptics', value ? 'true' : 'false');
+  const storage = getLocalStorageSafe();
+  if (!storage) return;
+  storage.setItem('haptics', value ? 'true' : 'false');
 }
 
 export async function getPongSpin() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
-  const val = window.localStorage.getItem('pong-spin');
+  const storage = getLocalStorageSafe();
+  if (!storage) return DEFAULT_SETTINGS.pongSpin;
+  const val = storage.getItem('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
 export async function setPongSpin(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
+  const storage = getLocalStorageSafe();
+  if (!storage) return;
+  storage.setItem('pong-spin', value ? 'true' : 'false');
 }
 
 export async function getAllowNetwork() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
-  return window.localStorage.getItem('allow-network') === 'true';
+  const storage = getLocalStorageSafe();
+  if (!storage) return DEFAULT_SETTINGS.allowNetwork;
+  return storage.getItem('allow-network') === 'true';
 }
 
 export async function setAllowNetwork(value) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem('allow-network', value ? 'true' : 'false');
+  const storage = getLocalStorageSafe();
+  if (!storage) return;
+  storage.setItem('allow-network', value ? 'true' : 'false');
+}
+
+export async function getAuditLogOptIn() {
+  const storage = getLocalStorageSafe();
+  if (!storage) return DEFAULT_SETTINGS.auditLogEnabled;
+  return storage.getItem('audit-log-enabled') === 'true';
+}
+
+export async function setAuditLogOptIn(value) {
+  const storage = getLocalStorageSafe();
+  if (!storage) return;
+  storage.setItem('audit-log-enabled', value ? 'true' : 'false');
 }
 
 export async function resetSettings() {
-  if (typeof window === 'undefined') return;
+  const storage = getLocalStorageSafe();
+  if (!storage) return;
   await Promise.all([
     del('accent'),
     del('bg-image'),
   ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
-  window.localStorage.removeItem('use-kali-wallpaper');
+  storage.removeItem('density');
+  storage.removeItem('reduced-motion');
+  storage.removeItem('font-scale');
+  storage.removeItem('high-contrast');
+  storage.removeItem('large-hit-areas');
+  storage.removeItem('pong-spin');
+  storage.removeItem('allow-network');
+  storage.removeItem('haptics');
+  storage.removeItem('use-kali-wallpaper');
+  storage.removeItem('audit-log-enabled');
 }
 
 export async function exportSettings() {
@@ -165,6 +207,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    auditLogEnabled,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -177,6 +220,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getAuditLogOptIn(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -190,6 +234,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    auditLogEnabled,
     useKaliWallpaper,
     theme,
   });
@@ -217,6 +262,7 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    auditLogEnabled,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -230,6 +276,7 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (auditLogEnabled !== undefined) await setAuditLogOptIn(auditLogEnabled);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- implement an OPFS/IndexedDB backed audit log utility with per-entry hashing plus export/import verification helpers
- add an Audit Log Viewer app with import/export UI and integrity checks, and expose the opt-in toggle in the desktop settings
- persist the audit log preference alongside other settings and document the local-only logging workflow

## Testing
- yarn lint
- yarn test auditLog.test.ts
- yarn test --runTestsByPath __tests__/reconng.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68dc936d497883288a6209519b954b53