### PR TITLE
[app] Classify error boundaries

### DIFF
--- a/__tests__/app-error-boundaries.test.tsx
+++ b/__tests__/app-error-boundaries.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import AppError from '../app/error';
+import GlobalError from '../app/global-error';
+import { reportClientError } from '../lib/client-error-reporter';
+import { NetworkError, ParseError, PermissionError } from '../lib/error-taxonomy';
+
+jest.mock('../lib/client-error-reporter', () => ({
+  reportClientError: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('Next.js app error boundary', () => {
+  const reset = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    reset.mockClear();
+  });
+
+  it('renders network guidance and retries without reload', async () => {
+    render(<AppError error={new NetworkError('Network offline')} reset={reset} />);
+
+    expect(screen.getByRole('heading', { name: /connection hiccup/i })).toBeInTheDocument();
+    const retryButton = screen.getByRole('button', { name: /retry request/i });
+    fireEvent.click(retryButton);
+    expect(reset).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(reportClientError).toHaveBeenCalledWith(expect.any(NetworkError), expect.objectContaining({
+        category: 'network',
+        retryable: true,
+      }));
+    });
+  });
+
+  it('offers parse recovery messaging', async () => {
+    render(<AppError error={new ParseError('Unexpected token at 1')} reset={reset} />);
+
+    expect(screen.getByRole('heading', { name: /data could not be processed/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /reset view/i }));
+    expect(reset).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(reportClientError).toHaveBeenCalledWith(expect.any(ParseError), expect.objectContaining({
+        category: 'parse',
+        retryable: true,
+      }));
+    });
+  });
+
+  it('surfaces permission guidance', async () => {
+    render(<AppError error={new PermissionError('Permission denied')} reset={reset} />);
+
+    expect(screen.getByRole('heading', { name: /permission required/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /retry with permissions/i }));
+    expect(reset).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(reportClientError).toHaveBeenCalledWith(expect.any(PermissionError), expect.objectContaining({
+        category: 'permission',
+        retryable: false,
+      }));
+    });
+  });
+});
+
+describe('Next.js global error boundary', () => {
+  const reset = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    reset.mockClear();
+  });
+
+  it('renders within the document shell and retries', async () => {
+    render(<GlobalError error={new NetworkError('Lost connection')} reset={reset} />);
+
+    expect(screen.getByRole('heading', { name: /connection hiccup/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /retry request/i }));
+    expect(reset).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(reportClientError).toHaveBeenCalledWith(expect.any(NetworkError), expect.objectContaining({
+        category: 'network',
+        retryable: true,
+      }));
+    });
+  });
+});

--- a/__tests__/error-taxonomy.test.ts
+++ b/__tests__/error-taxonomy.test.ts
@@ -1,0 +1,39 @@
+import { classifyError, getErrorPresentation, NetworkError, ParseError, PermissionError } from '../lib/error-taxonomy';
+
+describe('error taxonomy', () => {
+  it('classifies custom network errors', () => {
+    const result = classifyError(new NetworkError('Network unreachable'));
+    expect(result.category).toBe('network');
+    expect(result.retryable).toBe(true);
+  });
+
+  it('classifies fetch failures as network issues', () => {
+    const result = classifyError(new TypeError('Failed to fetch resource'));
+    expect(result.category).toBe('network');
+  });
+
+  it('classifies syntax errors as parse errors', () => {
+    const result = classifyError(new SyntaxError('Unexpected token < in JSON'));
+    expect(result.category).toBe('parse');
+    expect(result.retryable).toBe(true);
+  });
+
+  it('classifies permission denials', () => {
+    const result = classifyError(new PermissionError('Permission denied for camera'));
+    expect(result.category).toBe('permission');
+    expect(result.retryable).toBe(false);
+  });
+
+  it('falls back to unknown for other errors', () => {
+    const result = classifyError(new Error('totally unexpected'));
+    expect(result.category).toBe('unknown');
+    expect(result.retryable).toBe(false);
+  });
+
+  it('provides tailored presentations', () => {
+    expect(getErrorPresentation(classifyError(new NetworkError())).primaryActionLabel).toBe('Retry request');
+    expect(getErrorPresentation(classifyError(new ParseError())).primaryActionLabel).toBe('Reset view');
+    expect(getErrorPresentation(classifyError(new PermissionError())).primaryActionLabel).toBe('Retry with permissions');
+    expect(getErrorPresentation(classifyError(new Error())).primaryActionLabel).toBe('Try again');
+  });
+});

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,24 +1,63 @@
 
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { reportClientError } from '../lib/client-error-reporter';
+import { classifyError, getErrorPresentation } from '../lib/error-taxonomy';
 
 export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  const classification = useMemo(() => classifyError(error), [error]);
+  const presentation = useMemo(() => getErrorPresentation(classification), [classification]);
+
   useEffect(() => {
-    reportClientError(error, error.stack);
-  }, [error]);
+    reportClientError(classification.error, {
+      componentStack: error.stack,
+      category: classification.category,
+      diagnostics: classification.diagnostics,
+      retryable: classification.retryable,
+    });
+  }, [classification, error.stack]);
+
+  const handlePrimaryAction = () => {
+    reset();
+  };
+
+  const handleSecondaryAction = () => {
+    if (presentation.secondaryActionHref) {
+      window.open(presentation.secondaryActionHref, '_blank', 'noopener,noreferrer');
+    }
+  };
 
   return (
-    <div className="flex flex-col items-center justify-center gap-4 p-4">
-      <h2 className="text-xl font-semibold">Something went wrong!</h2>
-      <button
-        type="button"
-        onClick={() => reset()}
-        className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
-      >
-        Try again
-      </button>
+    <div className="flex flex-col items-center justify-center gap-4 p-4 text-center" role="alert" aria-live="assertive">
+      <h2 className="text-xl font-semibold">{presentation.title}</h2>
+      <p className="max-w-md text-sm text-slate-600 dark:text-slate-300">{presentation.message}</p>
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <button
+          type="button"
+          onClick={handlePrimaryAction}
+          className="rounded bg-slate-100 px-4 py-2 text-sm font-medium hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
+        >
+          {presentation.primaryActionLabel}
+        </button>
+        {presentation.secondaryActionLabel ? (
+          <button
+            type="button"
+            onClick={handleSecondaryAction}
+            className="rounded border border-slate-200 px-4 py-2 text-sm hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
+          >
+            {presentation.secondaryActionLabel}
+          </button>
+        ) : null}
+      </div>
+      {process.env.NODE_ENV === 'development' ? (
+        <details className="max-w-md text-left">
+          <summary className="cursor-pointer text-xs uppercase text-slate-400">Debug details</summary>
+          <pre className="mt-2 whitespace-pre-wrap break-words text-xs text-slate-500 dark:text-slate-400">
+            {classification.error.message}
+          </pre>
+        </details>
+      ) : null}
     </div>
   );
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { reportClientError } from '../lib/client-error-reporter';
+import { classifyError, getErrorPresentation } from '../lib/error-taxonomy';
 
 export default function GlobalError({
   error,
@@ -10,22 +11,60 @@ export default function GlobalError({
   error: Error;
   reset: () => void;
 }) {
+  const classification = useMemo(() => classifyError(error), [error]);
+  const presentation = useMemo(() => getErrorPresentation(classification), [classification]);
+
   useEffect(() => {
-    reportClientError(error, error.stack);
-  }, [error]);
+    reportClientError(classification.error, {
+      componentStack: error.stack,
+      category: classification.category,
+      diagnostics: classification.diagnostics,
+      retryable: classification.retryable,
+    });
+  }, [classification, error.stack]);
+
+  const handlePrimaryAction = () => {
+    reset();
+  };
+
+  const handleSecondaryAction = () => {
+    if (presentation.secondaryActionHref) {
+      window.open(presentation.secondaryActionHref, '_blank', 'noopener,noreferrer');
+    }
+  };
 
   return (
     <html>
       <body>
-        <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
-          <h2 className="text-xl font-semibold">Something went wrong!</h2>
-          <button
-            type="button"
-            onClick={() => reset()}
-            className="rounded bg-slate-100 px-4 py-2 text-sm hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
-          >
-            Try again
-          </button>
+        <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4 text-center" role="alert" aria-live="assertive">
+          <h2 className="text-xl font-semibold">{presentation.title}</h2>
+          <p className="max-w-lg text-sm text-slate-600 dark:text-slate-300">{presentation.message}</p>
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <button
+              type="button"
+              onClick={handlePrimaryAction}
+              className="rounded bg-slate-100 px-4 py-2 text-sm font-medium hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700"
+            >
+              {presentation.primaryActionLabel}
+            </button>
+            {presentation.secondaryActionLabel ? (
+              <button
+                type="button"
+                onClick={handleSecondaryAction}
+                className="rounded border border-slate-200 px-4 py-2 text-sm hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
+              >
+                {presentation.secondaryActionLabel}
+              </button>
+            ) : null}
+          </div>
+          {process.env.NODE_ENV === 'development' ? (
+            <details className="max-w-lg text-left">
+              <summary className="cursor-pointer text-xs uppercase text-slate-400">Debug details</summary>
+              <pre className="mt-2 whitespace-pre-wrap break-words text-xs text-slate-500 dark:text-slate-400">
+                {classification.error.message}
+              </pre>
+            </details>
+          ) : null}
         </div>
       </body>
     </html>

--- a/docs/error-taxonomy.md
+++ b/docs/error-taxonomy.md
@@ -1,0 +1,61 @@
+# Error taxonomy and boundary guidelines
+
+The desktop shell now exposes a shared error taxonomy so typed errors surface with
+contextual recovery hints inside Next.js error boundaries. This page documents
+how to throw and handle errors so the global and per-app boundaries can respond
+intelligently without forcing a full reload.
+
+## Categories
+
+| Category | When it is used | Preferred constructor |
+| --- | --- | --- |
+| `network` | Transport failures, offline mode, timeouts, or `fetch`/XHR issues. | `new NetworkError(message, { cause })` |
+| `parse` | Data could not be parsed (JSON, XML, binary decoders). | `new ParseError(message, { cause })` |
+| `permission` | Browser, OS, or API permission was denied (`NotAllowedError`, HTTP 401/403). | `new PermissionError(message, { cause })` |
+| `unknown` | Everything else that does not fall into the above buckets. | `new Error(message)` |
+
+`NetworkError`, `ParseError`, and `PermissionError` live in `lib/error-taxonomy.ts` and
+extend the built-in `Error`. They accept the same constructor options so you can
+preserve a `cause` for debugging.
+
+## Throwing typed errors
+
+1. Choose the category that best matches the failure so the UI can offer a
+   tailored message and action. For example, wrap low-level fetch errors in a
+   `NetworkError` before rethrowing them from services.
+2. Preserve the original error via the `cause` option when possible:
+
+   ```ts
+   try {
+     const response = await fetch(url);
+     if (!response.ok) {
+       throw new NetworkError(`Request failed with status ${response.status}`, { cause: new Error(response.statusText) });
+     }
+   } catch (error) {
+     throw new NetworkError('Unable to reach the API', { cause: error instanceof Error ? error : undefined });
+   }
+   ```
+
+3. Use `ParseError` for schema/format issues where a retry with fresh data could
+   recover.
+4. Use `PermissionError` when access is denied or the user must approve a
+   capability (camera, filesystem, clipboard, etc.).
+5. Fall back to a plain `Error` only when none of the typed categories apply.
+
+## Logging and privacy
+
+Error boundaries send diagnostics via `reportClientError`, which strips query
+strings from the URL and records only category, retryability, and lightweight
+metadata. Avoid embedding secrets or user content into error messages because
+those strings are forwarded for support triage.
+
+## Component guidance
+
+- Boundaries automatically present category-specific actions (`Retry request`,
+  `Reset view`, `Retry with permissions`, or `Try again`).
+- Recovery buttons call the local `reset` callback to reload the segment without
+  refreshing the entire desktop.
+- In development, expand the “Debug details” disclosure to view the raw message.
+
+Keep errors typed and descriptive to help support teams triage issues without
+collecting sensitive data from end users.

--- a/lib/client-error-reporter.ts
+++ b/lib/client-error-reporter.ts
@@ -1,22 +1,53 @@
+import type { ErrorCategory } from './error-taxonomy';
+
 export interface ClientErrorPayload {
   message: string;
+  name: string;
   stack?: string;
   componentStack?: string;
   url: string;
   segment: string;
+  category: ErrorCategory;
+  diagnostics: Record<string, string | number | boolean | null | undefined>;
+  retryable: boolean;
 }
 
-export async function reportClientError(error: Error, componentStack?: string) {
+export interface ClientErrorContext {
+  componentStack?: string;
+  category?: ErrorCategory;
+  diagnostics?: Record<string, string | number | boolean | null | undefined>;
+  retryable?: boolean;
+}
+
+function getSanitizedLocation() {
+  if (typeof window === 'undefined') {
+    return { url: '', segment: '' };
+  }
+
+  const { location } = window;
+  const base = `${location.origin}${location.pathname}`;
+  const hash = location.hash ? location.hash : '';
+  return { url: `${base}${hash}`, segment: location.pathname };
+}
+
+export async function reportClientError(error: Error, context: ClientErrorContext = {}) {
+  const { componentStack, category = 'unknown', diagnostics = {}, retryable = false } = context;
+  const { url, segment } = getSanitizedLocation();
+
   const payload: ClientErrorPayload = {
     message: error.message,
+    name: error.name,
     stack: error.stack,
     componentStack,
-    url: typeof window !== 'undefined' ? window.location.href : '',
-    segment: typeof window !== 'undefined' ? window.location.pathname : '',
+    url,
+    segment,
+    category,
+    diagnostics,
+    retryable,
   };
 
   if (process.env.NODE_ENV === 'development') {
-    console.error('[ClientError]', payload);
+    console.error(`[ClientError:${category}]`, payload);
     return;
   }
 

--- a/lib/error-taxonomy.ts
+++ b/lib/error-taxonomy.ts
@@ -1,0 +1,244 @@
+export type ErrorCategory = 'network' | 'parse' | 'permission' | 'unknown';
+
+export interface ClassifiedError {
+  category: ErrorCategory;
+  error: Error;
+  retryable: boolean;
+  diagnostics: Record<string, string | number | boolean | null | undefined>;
+}
+
+export class NetworkError extends Error {
+  constructor(message = 'Network request failed', options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'NetworkError';
+  }
+}
+
+export class ParseError extends Error {
+  constructor(message = 'Response could not be parsed', options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ParseError';
+  }
+}
+
+export class PermissionError extends Error {
+  constructor(message = 'Permission denied', options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'PermissionError';
+  }
+}
+
+const NETWORK_ERROR_NAMES = new Set([
+  'NetworkError',
+  'TypeError',
+  'FetchError',
+  'AxiosError',
+]);
+
+const PERMISSION_ERROR_NAMES = new Set([
+  'PermissionError',
+  'NotAllowedError',
+  'SecurityError',
+  'PermissionDeniedError',
+  'NotFoundError',
+]);
+
+const PARSE_ERROR_NAMES = new Set(['ParseError', 'SyntaxError', 'DOMException']);
+
+function normalizeError(input: unknown): Error {
+  if (input instanceof Error) {
+    return input;
+  }
+
+  if (typeof input === 'string') {
+    return new Error(input);
+  }
+
+  if (isPlainObject(input)) {
+    const { message, name } = input as { message?: unknown; name?: unknown };
+    const error = new Error(typeof message === 'string' ? message : 'Unexpected error');
+    if (typeof name === 'string') {
+      error.name = name;
+    }
+    return error;
+  }
+
+  return new Error('Unexpected error');
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function looksLikeNetworkError(error: Error): boolean {
+  if (error instanceof NetworkError) {
+    return true;
+  }
+
+  if (NETWORK_ERROR_NAMES.has(error.name)) {
+    const lowerMessage = error.message.toLowerCase();
+    return (
+      lowerMessage.includes('network') ||
+      lowerMessage.includes('failed to fetch') ||
+      lowerMessage.includes('load failed') ||
+      lowerMessage.includes('offline') ||
+      lowerMessage.includes('timeout')
+    );
+  }
+
+  if ('code' in error && typeof (error as { code?: unknown }).code === 'string') {
+    const code = ((error as { code?: string }).code ?? '').toUpperCase();
+    if (code.startsWith('ECONN') || code === 'ETIMEDOUT') {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function looksLikeParseError(error: Error): boolean {
+  if (error instanceof ParseError) {
+    return true;
+  }
+
+  if (PARSE_ERROR_NAMES.has(error.name)) {
+    return true;
+  }
+
+  const lowerMessage = error.message.toLowerCase();
+  return (
+    lowerMessage.includes('unexpected token') ||
+    lowerMessage.includes('parse') ||
+    lowerMessage.includes('json')
+  );
+}
+
+function looksLikePermissionError(error: Error): boolean {
+  if (error instanceof PermissionError) {
+    return true;
+  }
+
+  if (PERMISSION_ERROR_NAMES.has(error.name)) {
+    return true;
+  }
+
+  const lowerMessage = error.message.toLowerCase();
+  if (lowerMessage.includes('permission') || lowerMessage.includes('denied')) {
+    return true;
+  }
+
+  const status = (error as { status?: unknown }).status;
+  if (typeof status === 'number' && (status === 401 || status === 403)) {
+    return true;
+  }
+
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause instanceof Error) {
+    return looksLikePermissionError(cause);
+  }
+
+  return false;
+}
+
+function inferDiagnostics(error: Error): ClassifiedError['diagnostics'] {
+  const diagnostics: ClassifiedError['diagnostics'] = {
+    name: error.name,
+    hasStack: Boolean(error.stack),
+  };
+
+  if (typeof window !== 'undefined') {
+    diagnostics.online = window.navigator?.onLine;
+  }
+
+  const status = (error as { status?: unknown }).status;
+  if (typeof status === 'number') {
+    diagnostics.httpStatus = status;
+  }
+
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === 'string' || typeof code === 'number') {
+    diagnostics.code = code;
+  }
+
+  return diagnostics;
+}
+
+export function classifyError(input: unknown): ClassifiedError {
+  const error = normalizeError(input);
+
+  if (looksLikeNetworkError(error)) {
+    return {
+      category: 'network',
+      error,
+      retryable: true,
+      diagnostics: inferDiagnostics(error),
+    };
+  }
+
+  if (looksLikeParseError(error)) {
+    return {
+      category: 'parse',
+      error,
+      retryable: true,
+      diagnostics: inferDiagnostics(error),
+    };
+  }
+
+  if (looksLikePermissionError(error)) {
+    return {
+      category: 'permission',
+      error,
+      retryable: false,
+      diagnostics: inferDiagnostics(error),
+    };
+  }
+
+  return {
+    category: 'unknown',
+    error,
+    retryable: false,
+    diagnostics: inferDiagnostics(error),
+  };
+}
+
+export interface ErrorPresentation {
+  title: string;
+  message: string;
+  primaryActionLabel: string;
+  secondaryActionLabel?: string;
+  secondaryActionHref?: string;
+}
+
+export function getErrorPresentation(classification: ClassifiedError): ErrorPresentation {
+  switch (classification.category) {
+    case 'network':
+      return {
+        title: 'Connection hiccup',
+        message: 'We could not reach the service. Check your connection or VPN and then retry the operation.',
+        primaryActionLabel: 'Retry request',
+      };
+    case 'parse':
+      return {
+        title: 'Data could not be processed',
+        message: 'The response looked corrupted or outdated. Resetting will request fresh data without reloading the desktop.',
+        primaryActionLabel: 'Reset view',
+      };
+    case 'permission':
+      return {
+        title: 'Permission required',
+        message: 'The browser blocked an operation. Allow the permission in your browser or system settings, then retry.',
+        primaryActionLabel: 'Retry with permissions',
+      };
+    default:
+      return {
+        title: 'Unexpected error',
+        message: 'The app ran into something it did not expect. Retrying will attempt the operation again without a full reload.',
+        primaryActionLabel: 'Try again',
+      };
+  }
+}


### PR DESCRIPTION
## Summary
- classify global and segment error boundaries so they surface category-specific recovery guidance
- capture sanitized diagnostics via the client error reporter and expose a reusable error taxonomy
- document the taxonomy and cover boundaries with focused Jest tests

## Testing
- yarn test error-taxonomy app-error-boundaries

------
https://chatgpt.com/codex/tasks/task_e_68dc9372ae7c8328acd5861feda5219c