### PR TITLE
[feedback] add diagnostics-enabled dialog

### DIFF
--- a/__tests__/FeedbackDialog.test.tsx
+++ b/__tests__/FeedbackDialog.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import FeedbackDialog from '../components/common/FeedbackDialog';
+import { logEvent } from '../utils/analytics';
+import { trackEvent } from '../lib/analytics-client';
+import { redactText } from '../utils/redaction';
+
+jest.mock('../utils/analytics', () => ({
+  logEvent: jest.fn(),
+}));
+
+jest.mock('../lib/analytics-client', () => ({
+  trackEvent: jest.fn(),
+}));
+
+describe('FeedbackDialog', () => {
+  const originalUserAgent = navigator.userAgent;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '<div id="__next"></div>';
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: originalUserAgent,
+      configurable: true,
+    });
+  });
+
+  it('validates required fields before submitting', async () => {
+    const submitFeedback = jest.fn().mockResolvedValue(undefined);
+    render(
+      <FeedbackDialog
+        isOpen
+        onClose={() => {}}
+        submitFeedback={submitFeedback}
+      />,
+    );
+
+    const submitButton = screen.getByRole('button', { name: /send report/i });
+    fireEvent.click(submitButton);
+
+    expect(await screen.findByText(/provide a short summary/i)).toBeInTheDocument();
+    expect(submitFeedback).not.toHaveBeenCalled();
+  });
+
+  it('packages diagnostics with consent and redaction', async () => {
+    const submitFeedback = jest.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'Mozilla/5.0 user@example.com',
+      configurable: true,
+    });
+
+    const getStateSnapshot = () => ({
+      path: '/apps',
+      token: 'token=abc123abc123abc123abc123',
+      contact: 'user@example.com',
+    });
+
+    const hashString = (input: string) => {
+      let hash = 0;
+      for (let i = 0; i < input.length; i += 1) {
+        hash = (hash * 31 + input.charCodeAt(i)) >>> 0;
+      }
+      return hash.toString(16);
+    };
+
+    const sanitizedState = {
+      path: '/apps',
+      token: 'token= [redacted-token]',
+      contact: '[redacted-email]',
+    };
+    const expectedHash = hashString(JSON.stringify(sanitizedState));
+
+    render(
+      <FeedbackDialog
+        isOpen
+        onClose={() => {}}
+        submitFeedback={submitFeedback}
+        getStateSnapshot={getStateSnapshot}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/summary/i), {
+      target: { value: 'App issue from user@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/details/i), {
+      target: {
+        value: 'Steps to reproduce token=abc123abc123abc123abc123 and bearer ABC123ABC123',
+      },
+    });
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: /send report/i }));
+
+    await waitFor(() => expect(submitFeedback).toHaveBeenCalled());
+
+    const payload = submitFeedback.mock.calls[0][0];
+    expect(payload.summary).not.toContain('user@example.com');
+    expect(payload.summary).toContain('[redacted-email]');
+    expect(payload.description).toContain('[redacted-token]');
+    expect(payload.includeDiagnostics).toBe(true);
+    expect(payload.diagnostics).toBeTruthy();
+    expect(payload.diagnostics?.stateHash).toBe(expectedHash);
+    expect(payload.diagnostics?.vitals.userAgent).toBe(redactText('Mozilla/5.0 user@example.com'));
+
+    expect((logEvent as jest.Mock).mock.calls[0][0]).toEqual({
+      category: 'feedback',
+      action: 'submit',
+      label: 'with_diagnostics',
+    });
+    expect(trackEvent).toHaveBeenCalledWith('feedback_submit', { includeDiagnostics: true });
+
+  });
+});

--- a/components/common/FeedbackDialog.tsx
+++ b/components/common/FeedbackDialog.tsx
@@ -1,0 +1,408 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import Modal from '../base/Modal';
+import { logEvent } from '../../utils/analytics';
+import { trackEvent } from '../../lib/analytics-client';
+import { redactDiagnostics, redactText, redactValue } from '../../utils/redaction';
+import type { DiagnosticsBundle, FeedbackSubmission } from '../../types/feedback';
+
+interface FeedbackDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  submitFeedback?: (payload: FeedbackSubmission) => Promise<void>;
+  getStateSnapshot?: () => unknown;
+  onSubmitted?: () => void;
+}
+
+type FormErrors = {
+  summary?: string;
+  description?: string;
+};
+
+const hashString = (input: string): string => {
+  let hash = 0;
+  for (let index = 0; index < input.length; index += 1) {
+    hash = (hash * 31 + input.charCodeAt(index)) >>> 0;
+  }
+  return hash.toString(16);
+};
+
+const defaultCollectState = (): unknown => {
+  if (typeof window === 'undefined') {
+    return { environment: 'server' };
+  }
+
+  const snapshot: Record<string, unknown> = {
+    path: window.location?.pathname,
+    hash: window.location?.hash,
+    theme: document.documentElement?.className,
+  };
+
+  try {
+    const keys: string[] = [];
+    for (let index = 0; index < window.localStorage.length; index += 1) {
+      const key = window.localStorage.key(index);
+      if (key) keys.push(redactText(key));
+    }
+    if (keys.length > 0) {
+      snapshot.localStorageKeys = keys;
+    }
+  } catch {
+    snapshot.localStorageKeys = ['unavailable'];
+  }
+
+  const workspaceState = (window as any).__WORKSPACE_STATE__;
+  if (workspaceState) {
+    snapshot.workspace = redactValue(workspaceState);
+  }
+
+  return snapshot;
+};
+
+const collectVitals = (): DiagnosticsBundle['vitals'] => {
+  const timestamp = new Date().toISOString();
+  if (typeof window === 'undefined') {
+    return { timestamp };
+  }
+
+  const nav = navigator as Navigator & { connection?: { effectiveType?: string }; deviceMemory?: number };
+  const perf = performance as Performance & { memory?: { jsHeapSizeLimit: number; totalJSHeapSize: number; usedJSHeapSize: number } };
+
+  const vitals: DiagnosticsBundle['vitals'] = {
+    timestamp,
+    userAgent: nav?.userAgent,
+    language: nav?.language,
+    platform: nav?.platform,
+    online: typeof nav?.onLine === 'boolean' ? nav.onLine : undefined,
+    connectionType: nav?.connection?.effectiveType,
+    viewport: typeof window !== 'undefined' ? { width: window.innerWidth, height: window.innerHeight } : undefined,
+  };
+
+  if (perf?.memory) {
+    vitals.memory = {
+      jsHeapSizeLimit: perf.memory.jsHeapSizeLimit,
+      totalJSHeapSize: perf.memory.totalJSHeapSize,
+      usedJSHeapSize: perf.memory.usedJSHeapSize,
+      deviceMemory: nav?.deviceMemory,
+    };
+  } else if (typeof nav?.deviceMemory === 'number') {
+    vitals.memory = {
+      deviceMemory: nav.deviceMemory,
+    };
+  }
+
+  return vitals;
+};
+
+const buildDiagnostics = (getStateSnapshot: () => unknown): DiagnosticsBundle => {
+  const stateSnapshot = redactValue(getStateSnapshot());
+  const serialized = JSON.stringify(stateSnapshot ?? {});
+  const stateHash = hashString(serialized);
+  const vitals = redactValue(collectVitals());
+  return redactDiagnostics({ stateHash, vitals });
+};
+
+const postJson = async (url: string, payload: FeedbackSubmission) => {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);
+  }
+};
+
+const defaultSubmitFeedback = async (payload: FeedbackSubmission) => {
+  try {
+    await postJson('/api/support/report', payload);
+    return;
+  } catch {
+    // fall through to fallback
+  }
+
+  try {
+    await postJson('/api/dummy', payload);
+  } catch (error) {
+    console.info('[feedback:fallback]', payload);
+    throw error;
+  }
+};
+
+const FeedbackDialog: React.FC<FeedbackDialogProps> = ({
+  isOpen,
+  onClose,
+  submitFeedback = defaultSubmitFeedback,
+  getStateSnapshot = defaultCollectState,
+  onSubmitted,
+}) => {
+  const [summary, setSummary] = useState('');
+  const [description, setDescription] = useState('');
+  const [includeDiagnostics, setIncludeDiagnostics] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSummary('');
+      setDescription('');
+      setIncludeDiagnostics(false);
+      setStatus('idle');
+      setErrors({});
+    }
+  }, [isOpen]);
+
+  const disableSubmit = status === 'submitting';
+
+  const handleClose = useCallback(() => {
+    if (disableSubmit) return;
+    onClose();
+  }, [disableSubmit, onClose]);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (status === 'submitting') return;
+
+      const trimmedSummary = summary.trim();
+      const trimmedDescription = description.trim();
+
+      const nextErrors: FormErrors = {};
+      if (trimmedSummary.length < 5) {
+        nextErrors.summary = 'Please provide a short summary.';
+      }
+      if (trimmedDescription.length < 10) {
+        nextErrors.description = 'Describe the issue or request in more detail.';
+      }
+
+      if (Object.keys(nextErrors).length > 0) {
+        setErrors(nextErrors);
+        return;
+      }
+
+      setErrors({});
+      setStatus('submitting');
+
+      const sanitizedSummary = redactText(trimmedSummary);
+      const sanitizedDescription = redactText(trimmedDescription);
+
+      let diagnostics: DiagnosticsBundle | null = null;
+      if (includeDiagnostics) {
+        diagnostics = buildDiagnostics(getStateSnapshot);
+      }
+
+      const payload: FeedbackSubmission = {
+        summary: sanitizedSummary,
+        description: sanitizedDescription,
+        includeDiagnostics,
+        diagnostics,
+        timestamp: new Date().toISOString(),
+        channel: 'desktop-feedback',
+      };
+
+      try {
+        await submitFeedback(payload);
+        logEvent({
+          category: 'feedback',
+          action: 'submit',
+          label: includeDiagnostics ? 'with_diagnostics' : 'without_diagnostics',
+        });
+        trackEvent('feedback_submit', { includeDiagnostics });
+        setStatus('success');
+        onSubmitted?.();
+      } catch (error) {
+        console.error('Failed to submit feedback', error);
+        setStatus('error');
+        trackEvent('feedback_submit_error', { includeDiagnostics });
+      }
+    },
+    [description, getStateSnapshot, includeDiagnostics, status, submitFeedback, summary, onSubmitted],
+  );
+
+  const statusMessage = useMemo(() => {
+    if (status === 'success') {
+      return {
+        tone: 'success' as const,
+        text: 'Thanks! Your report was sent to the support queue.',
+      };
+    }
+    if (status === 'error') {
+      return {
+        tone: 'error' as const,
+        text: 'We could not reach the support endpoint. Please try again later.',
+      };
+    }
+    return null;
+  }, [status]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <div className="fixed inset-0 z-[1000] flex items-center justify-center p-4">
+        <div
+          className="absolute inset-0 bg-slate-950/80"
+          aria-hidden="true"
+          onClick={handleClose}
+        />
+        <div
+          role="document"
+          aria-labelledby="feedback-dialog-title"
+          className="relative z-10 w-full max-w-xl rounded-xl border border-white/10 bg-slate-900/95 text-white shadow-2xl"
+        >
+          <div className="flex items-start justify-between border-b border-white/10 px-6 py-4">
+            <div>
+              <h2 id="feedback-dialog-title" className="text-lg font-semibold">
+                Send feedback
+              </h2>
+              <p className="mt-1 text-sm text-slate-300">
+                Share a bug report, feature idea, or general comment.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleClose}
+              className="rounded-full bg-white/10 p-1 text-slate-200 transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+              aria-label="Close feedback dialog"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+          <form onSubmit={handleSubmit} className="space-y-4 px-6 py-5">
+            <div>
+              <label htmlFor="feedback-summary" className="mb-1 block text-sm font-medium text-slate-200">
+                Summary
+              </label>
+              <input
+                id="feedback-summary"
+                name="summary"
+                value={summary}
+                onChange={event => setSummary(event.target.value)}
+                className={`w-full rounded border px-3 py-2 text-sm text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 ${
+                  errors.summary ? 'border-red-500' : 'border-transparent'
+                }`}
+                maxLength={120}
+                aria-invalid={Boolean(errors.summary)}
+                aria-describedby={errors.summary ? 'feedback-summary-error' : undefined}
+                aria-label="Feedback summary"
+                placeholder="Quick headline (e.g. VPN window won't open)"
+              />
+              {errors.summary && (
+                <p id="feedback-summary-error" className="mt-1 text-xs text-red-400">
+                  {errors.summary}
+                </p>
+              )}
+            </div>
+            <div>
+              <label htmlFor="feedback-description" className="mb-1 block text-sm font-medium text-slate-200">
+                Details
+              </label>
+              <textarea
+                id="feedback-description"
+                name="description"
+                value={description}
+                onChange={event => setDescription(event.target.value)}
+                className={`min-h-[120px] w-full rounded border px-3 py-2 text-sm text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 ${
+                  errors.description ? 'border-red-500' : 'border-transparent'
+                }`}
+                maxLength={2000}
+                aria-invalid={Boolean(errors.description)}
+                aria-describedby={errors.description ? 'feedback-description-error' : undefined}
+                aria-label="Feedback details"
+                placeholder="What happened? Include steps, expected results, or environment notes."
+              />
+              {errors.description && (
+                <p id="feedback-description-error" className="mt-1 text-xs text-red-400">
+                  {errors.description}
+                </p>
+              )}
+            </div>
+            <fieldset className="rounded-lg border border-white/10 bg-white/5 px-4 py-3">
+              <legend className="px-1 text-sm font-medium text-slate-200">Diagnostics</legend>
+              <div className="flex items-start gap-3 text-sm text-slate-200">
+                <input
+                  id="feedback-include-diagnostics"
+                  type="checkbox"
+                  checked={includeDiagnostics}
+                  onChange={event => setIncludeDiagnostics(event.target.checked)}
+                  className="mt-1 h-4 w-4 rounded border-slate-500 bg-slate-800 text-cyan-400 focus:ring-cyan-400"
+                  aria-describedby="feedback-include-diagnostics-description"
+                  aria-labelledby="feedback-include-diagnostics-label"
+                />
+                <label
+                  id="feedback-include-diagnostics-label"
+                  htmlFor="feedback-include-diagnostics"
+                  className="flex-1"
+                >
+                  Attach a sanitized diagnostics bundle (state hash + vitals snapshot). I consent to share this anonymized data to
+                  help troubleshoot issues.
+                  <span id="feedback-include-diagnostics-description" className="mt-1 block text-xs text-slate-400">
+                    We never include raw logs or credentials, and we redact obvious secrets automatically.
+                  </span>
+                </label>
+              </div>
+            </fieldset>
+            {statusMessage && (
+              <div
+                role="status"
+                className={`rounded-md border px-3 py-2 text-sm ${
+                  statusMessage.tone === 'success'
+                    ? 'border-green-600 bg-green-900/40 text-green-200'
+                    : 'border-red-600 bg-red-900/40 text-red-200'
+                }`}
+              >
+                {statusMessage.text}
+              </div>
+            )}
+            <div className="flex items-center justify-end gap-3 pt-2">
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded-full px-4 py-2 text-sm font-medium text-slate-300 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+                disabled={disableSubmit}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="flex items-center gap-2 rounded-full bg-cyan-500 px-5 py-2 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-cyan-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 disabled:cursor-not-allowed disabled:opacity-70"
+                disabled={disableSubmit}
+              >
+                {status === 'submitting' && (
+                  <svg
+                    className="h-4 w-4 animate-spin"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <circle cx="12" cy="12" r="10" opacity="0.25" />
+                    <path d="M22 12a10 10 0 0 0-10-10" />
+                  </svg>
+                )}
+                <span>{status === 'submitting' ? 'Sending…' : 'Send report'}</span>
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default FeedbackDialog;

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import apps from '../../apps.config';
 import { safeLocalStorage } from '../../utils/safeStorage';
 
@@ -470,16 +471,36 @@ const WhiskerMenu: React.FC = () => {
                 </button>
               ))}
             </div>
-            <div className="border-t border-[#1d2a3c] px-4 py-3 text-sm text-gray-400">
-              <div className="flex items-center gap-2">
-                <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#142132] text-sm font-semibold uppercase text-[#53b9ff]">k</span>
-                <div>
-                  <p className="text-sm font-semibold text-white">kali</p>
-                  <p className="text-xs uppercase tracking-[0.3em] text-gray-500">User Session</p>
-                </div>
+          <div className="border-t border-[#1d2a3c] px-4 py-3 text-sm text-gray-400">
+            <div className="flex items-center gap-2">
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#142132] text-sm font-semibold uppercase text-[#53b9ff]">k</span>
+              <div>
+                <p className="text-sm font-semibold text-white">kali</p>
+                <p className="text-xs uppercase tracking-[0.3em] text-gray-500">User Session</p>
               </div>
             </div>
+            <Link
+              href="/docs/feedback"
+              className="mt-3 inline-flex items-center gap-2 rounded-lg bg-[#17273d] px-3 py-2 text-xs font-medium text-[#8bc9ff] transition hover:bg-[#1e3350] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#53b9ff] focus-visible:ring-offset-2 focus-visible:ring-offset-[#111c2b]"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M12 20h9" />
+                <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4Z" />
+              </svg>
+              <span>Feedback workflow</span>
+            </Link>
           </div>
+        </div>
           <div className="flex max-h-[44vh] flex-1 flex-col bg-[#0f1a29] sm:max-h-full">
             <div className="border-b border-[#1d2a3c] px-4 py-4 sm:px-5">
               <div className="relative mb-4">

--- a/docs/feedback-workflow.md
+++ b/docs/feedback-workflow.md
@@ -1,0 +1,42 @@
+# Feedback workflow
+
+The desktop shell now includes a feedback dialog for reporting bugs, feature requests, and general comments. This document
+covers how the flow works so maintainers can test or extend it.
+
+## Entry points
+
+- Any component can render `<FeedbackDialog />`. The dialog requires `isOpen` and `onClose` props and automatically handles
+  focus trapping via the shared `Modal` utility.
+- The Whisker application menu exposes a "Feedback workflow" link that opens `/docs/feedback` for quick guidance.
+
+## Submission lifecycle
+
+1. Users supply a summary (5+ characters) and detailed description (10+ characters).
+2. They can optionally consent to attach a diagnostic bundle by checking the consent box.
+3. On submit we redact the summary/description, build the bundle if consented, and emit analytics events.
+4. Payloads are posted to `/api/support/report` when available. We fall back to `/api/dummy` during local development.
+
+## Diagnostic bundle contents
+
+| Field              | Description                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| `stateHash`        | Deterministic hash of a sanitized snapshot (location, theme, workspace hints, storage keys) |
+| `vitals.timestamp` | ISO timestamp when the bundle was generated.                                               |
+| `vitals.userAgent` | Redacted UA string from `navigator.userAgent`.                                             |
+| `vitals.memory`    | Optional heap/device-memory stats from the performance API.                                |
+| `vitals.viewport`  | `window.innerWidth`/`window.innerHeight` to help reproduce layout issues.                  |
+
+The snapshot is sanitized before hashing via the utilities in `utils/redaction.ts`. Obvious tokens, emails, and long
+hex strings are replaced with placeholders.
+
+## Testing checklist
+
+- `yarn test FeedbackDialog` verifies validation, redaction, and packaging.
+- Mock `submitFeedback` to capture outbound payloads when wiring a new endpoint.
+- Confirm analytics fire by asserting `logEvent`/`trackEvent` in Jest or by inspecting GA in preview.
+
+## Extending the flow
+
+- Provide a custom `getStateSnapshot` prop if an app has richer state to hash.
+- Override `submitFeedback` in integration tests to avoid hitting network stubs.
+- Update `types/feedback.ts` if you need to add new diagnostic fields so the redaction helper picks them up automatically.

--- a/lib/analytics-client.ts
+++ b/lib/analytics-client.ts
@@ -4,7 +4,9 @@ export type EventName =
   | 'contact_submit'
   | 'contact_submit_error'
   | 'outbound_link_click'
-  | 'download_click';
+  | 'download_click'
+  | 'feedback_submit'
+  | 'feedback_submit_error';
 
 export function trackEvent(
   name: EventName,
@@ -12,7 +14,6 @@ export function trackEvent(
 ) {
   try {
     // Dynamically require to avoid ESM issues in test environment
-    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
     const { track } = require('@vercel/analytics');
     track(name, props);
   } catch {

--- a/pages/docs/feedback.tsx
+++ b/pages/docs/feedback.tsx
@@ -1,0 +1,49 @@
+import Head from 'next/head';
+
+const FeedbackDocs = () => (
+  <>
+    <Head>
+      <title>Feedback workflow</title>
+    </Head>
+    <main className="mx-auto max-w-3xl px-6 py-10 text-slate-100">
+      <h1 className="text-3xl font-semibold">Feedback workflow</h1>
+      <p className="mt-4 text-slate-300">
+        Use the desktop feedback dialog to report bugs, request features, or attach diagnostics that help the maintainer triage
+        issues quickly.
+      </p>
+
+      <section className="mt-8 space-y-3">
+        <h2 className="text-2xl font-semibold">How to submit</h2>
+        <ol className="ml-5 list-decimal space-y-2 text-slate-200">
+          <li>Open the Whisker menu and choose an app or press the feedback shortcut to open the dialog.</li>
+          <li>Describe the problem in the summary and details fields. The more context you add, the faster we can reproduce it.</li>
+          <li>
+            Tick the diagnostics checkbox if you consent to share an anonymized bundle that includes a state hash and vitals
+            snapshot.
+          </li>
+          <li>Press “Send report”. You will see a confirmation message when the submission succeeds.</li>
+        </ol>
+      </section>
+
+      <section className="mt-8 space-y-3">
+        <h2 className="text-2xl font-semibold">What diagnostics include</h2>
+        <p className="text-slate-300">
+          Diagnostics never contain raw logs or credentials. We hash a sanitized version of the active desktop state and capture a
+          lightweight vitals snapshot (user agent, viewport, memory stats, and timestamp). Redaction utilities replace obvious
+          emails, tokens, and keys before hashing or sending.
+        </p>
+      </section>
+
+      <section className="mt-8 space-y-3">
+        <h2 className="text-2xl font-semibold">Privacy and support endpoints</h2>
+        <p className="text-slate-300">
+          Reports are posted to the support endpoint when available. In local or offline builds we fall back to the simulated
+          `/api/dummy` route so you can still test the flow without leaking data. Analytics events emit only if tracking is
+          enabled in your environment.
+        </p>
+      </section>
+    </main>
+  </>
+);
+
+export default FeedbackDocs;

--- a/types/feedback.ts
+++ b/types/feedback.ts
@@ -1,0 +1,29 @@
+export interface VitalsSnapshot {
+  timestamp: string;
+  userAgent?: string;
+  language?: string;
+  platform?: string;
+  online?: boolean;
+  connectionType?: string;
+  viewport?: { width?: number; height?: number };
+  memory?: {
+    jsHeapSizeLimit?: number;
+    totalJSHeapSize?: number;
+    usedJSHeapSize?: number;
+    deviceMemory?: number;
+  };
+}
+
+export interface DiagnosticsBundle {
+  stateHash: string;
+  vitals: VitalsSnapshot;
+}
+
+export interface FeedbackSubmission {
+  summary: string;
+  description: string;
+  includeDiagnostics: boolean;
+  diagnostics?: DiagnosticsBundle | null;
+  timestamp: string;
+  channel: 'desktop-feedback';
+}

--- a/utils/redaction.ts
+++ b/utils/redaction.ts
@@ -1,0 +1,55 @@
+import type { DiagnosticsBundle } from '../types/feedback';
+
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const TOKEN_PATTERN = /(bearer\s+|api[_-]?key\s*=|token\s*=|secret\s*=)([A-Z0-9._-]+)/gi;
+const LONG_HEX_PATTERN = /\b(?:0x)?[A-F0-9]{16,}\b/gi;
+const AWS_KEY_PATTERN = /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g;
+
+const REPLACEMENTS: Array<[RegExp, string | ((substring: string, ...groups: string[]) => string)]> = [
+  [EMAIL_PATTERN, '[redacted-email]'],
+  [
+    TOKEN_PATTERN,
+    (_match, prefix) => `${prefix.trimEnd()} [redacted-token]`,
+  ],
+  [LONG_HEX_PATTERN, '[redacted-sequence]'],
+  [AWS_KEY_PATTERN, '[redacted-key]'],
+];
+
+export const redactText = (value: string): string => {
+  return REPLACEMENTS.reduce((acc, [pattern, replacement]) => acc.replace(pattern, replacement as any), value);
+};
+
+export const redactValue = <T>(value: T): T => {
+  if (typeof value === 'string') {
+    return redactText(value) as unknown as T;
+  }
+
+  if (value instanceof Date) {
+    return redactText(value.toISOString()) as unknown as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => redactValue(item)) as unknown as T;
+  }
+
+  if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    Object.entries(value as Record<string, unknown>).forEach(([key, entry]) => {
+      result[key] = redactValue(entry);
+    });
+    return result as T;
+  }
+
+  return value;
+};
+
+export const redactDiagnostics = (bundle: DiagnosticsBundle): DiagnosticsBundle => {
+  const sanitizedVitals = redactValue(bundle.vitals);
+  return {
+    ...bundle,
+    stateHash: redactText(bundle.stateHash),
+    vitals: sanitizedVitals,
+  };
+};
+
+export default redactValue;


### PR DESCRIPTION
## Summary
- add a reusable FeedbackDialog that optionally bundles sanitized diagnostics before submitting
- introduce shared redaction helpers and feedback types plus Jest coverage for validation and packaging
- document the workflow, expose a public guide, and surface the link from the Whisker menu while extending analytics events

## Testing
- yarn lint
- yarn test FeedbackDialog

------
https://chatgpt.com/codex/tasks/task_e_68dc93755990832883b776593229ebf3