### PR TITLE
[resource-monitor] Add scheduling controls and CPU simulation

### DIFF
--- a/__tests__/resourceMonitor.test.tsx
+++ b/__tests__/resourceMonitor.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import ResourceMonitorApp from '../apps/resource-monitor';
+
+describe('Resource monitor controls', () => {
+  class MockWorker {
+    public listeners = new Map<string, Set<(event: MessageEvent<any>) => void>>();
+
+    public messages: any[] = [];
+
+    postMessage = jest.fn((message: any) => {
+      this.messages.push(message);
+    });
+
+    addEventListener = (type: string, handler: (event: MessageEvent<any>) => void) => {
+      if (!this.listeners.has(type)) {
+        this.listeners.set(type, new Set());
+      }
+      this.listeners.get(type)!.add(handler);
+    };
+
+    removeEventListener = (type: string, handler: (event: MessageEvent<any>) => void) => {
+      this.listeners.get(type)?.delete(handler);
+    };
+
+    terminate = jest.fn();
+
+    emit(data: any) {
+      const handlers = this.listeners.get('message');
+      handlers?.forEach((handler) => handler({ data } as MessageEvent<any>));
+    }
+  }
+
+  let workerInstance: MockWorker;
+  let workerFactory: jest.Mock;
+  let randomSpy: jest.SpyInstance<number, []>;
+  const originalWorker = global.Worker;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.3);
+    workerFactory = jest.fn(() => {
+      workerInstance = new MockWorker();
+      return workerInstance as unknown as Worker;
+    });
+    // @ts-ignore override global Worker
+    global.Worker = workerFactory;
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    randomSpy.mockRestore();
+    workerFactory.mockReset();
+    global.Worker = originalWorker;
+  });
+
+  it('keeps controls responsive while jobs queue under load', async () => {
+    render(<ResourceMonitorApp />);
+
+    const slider = await screen.findByLabelText(/parallelism limit/i);
+    expect(slider).toBeEnabled();
+
+    act(() => {
+      workerInstance.emit({ type: 'metrics', cpu: 55 });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+      workerInstance.emit({ type: 'metrics', cpu: 62 });
+    });
+
+    fireEvent.change(slider, { target: { value: '4' } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/limit:\s*4/i)).toBeInTheDocument();
+    });
+    expect(slider).toBeEnabled();
+
+    const runningCount = Number(screen.getByTestId('running-count').textContent);
+    expect(runningCount).toBeLessThanOrEqual(4);
+  });
+
+  it('engages backpressure when CPU usage exceeds the threshold', async () => {
+    render(<ResourceMonitorApp />);
+
+    const slider = await screen.findByLabelText(/parallelism limit/i);
+    fireEvent.change(slider, { target: { value: '1' } });
+    await waitFor(() => expect(screen.getByText(/limit:\s*1/i)).toBeInTheDocument());
+
+    act(() => {
+      workerInstance.emit({ type: 'metrics', cpu: 90 });
+    });
+
+    expect(await screen.findByText(/backpressure engaged/i)).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(3500);
+    });
+
+    const runningCount = Number(screen.getByTestId('running-count').textContent);
+    expect(runningCount).toBeLessThanOrEqual(1);
+
+    const resumeButton = screen.getByRole('button', { name: /resume/i });
+    expect(resumeButton).toBeDisabled();
+
+    act(() => {
+      workerInstance.emit({ type: 'metrics', cpu: 45 });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/backpressure engaged/i)).not.toBeInTheDocument();
+    });
+
+    expect(resumeButton).not.toBeDisabled();
+  });
+});

--- a/apps/resource-monitor/components/NetworkInsights.tsx
+++ b/apps/resource-monitor/components/NetworkInsights.tsx
@@ -9,6 +9,8 @@ import {
 } from '../../../lib/fetchProxy';
 import { exportMetrics } from '../export';
 import RequestChart from './RequestChart';
+import ResourceHeader from './ResourceHeader';
+import useResourceManager from '../hooks/useResourceManager';
 
 const HISTORY_KEY = 'network-insights-history';
 
@@ -18,6 +20,7 @@ const formatBytes = (bytes?: number) =>
 export default function NetworkInsights() {
   const [active, setActive] = useState<FetchEntry[]>(getActiveFetches());
   const [history, setHistory] = usePersistentState<FetchEntry[]>(HISTORY_KEY, []);
+  const { state: resourceState, controls, autoPauseReason } = useResourceManager();
 
   useEffect(() => {
     const unsubStart = onFetchProxy('start', () => setActive(getActiveFetches()));
@@ -33,6 +36,19 @@ export default function NetworkInsights() {
 
   return (
     <div className="p-2 text-xs text-white bg-[var(--kali-bg)]">
+      <ResourceHeader
+        cpuUsage={resourceState.cpuUsage}
+        queued={resourceState.queued}
+        running={resourceState.running}
+        completed={resourceState.completed}
+        maxParallel={resourceState.maxParallel}
+        userPaused={resourceState.userPaused}
+        autoPaused={resourceState.autoPaused}
+        autoPauseReason={autoPauseReason}
+        onParallelismChange={controls.setParallelism}
+        onPause={controls.pause}
+        onResume={controls.resume}
+      />
       <h2 className="font-bold mb-1">Active Fetches</h2>
       <ul className="mb-2 divide-y divide-gray-700 border border-gray-700 rounded bg-[var(--kali-panel)]">
         {active.length === 0 && <li className="p-1 text-gray-400">None</li>}

--- a/apps/resource-monitor/components/ResourceHeader.tsx
+++ b/apps/resource-monitor/components/ResourceHeader.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import React from 'react';
+import { AutoPauseReason } from '../scheduler';
+
+interface ResourceHeaderProps {
+  cpuUsage: number;
+  queued: number;
+  running: number;
+  completed: number;
+  maxParallel: number;
+  userPaused: boolean;
+  autoPaused: boolean;
+  autoPauseReason: AutoPauseReason;
+  onParallelismChange: (value: number) => void;
+  onPause: () => void;
+  onResume: () => void;
+}
+
+const formatUsage = (value: number) => `${value.toFixed(1)}%`;
+
+const clampPercent = (value: number) => Math.min(100, Math.max(0, value));
+
+const BackpressureNotice = ({ reason }: { reason: AutoPauseReason }) => {
+  if (!reason) return null;
+  if (reason.type === 'cpu') {
+    return (
+      <p
+        className="mt-2 rounded border border-yellow-500/60 bg-yellow-900/40 px-2 py-1 text-xs text-yellow-200"
+        role="status"
+        aria-live="polite"
+      >
+        Backpressure engaged: CPU usage {formatUsage(reason.usage)} exceeded the
+        {` ${reason.threshold}%`} safety budget. New jobs will queue until usage
+        falls below the resume threshold.
+      </p>
+    );
+  }
+  return null;
+};
+
+const StatBlock = ({
+  label,
+  value,
+  testId,
+}: {
+  label: string;
+  value: number;
+  testId: string;
+}) => (
+  <div className="flex flex-col rounded border border-[var(--kali-border)] bg-[var(--kali-panel)] px-2 py-1">
+    <span className="text-[10px] uppercase tracking-wide text-gray-300">{label}</span>
+    <span
+      className="font-mono text-lg"
+      data-testid={testId}
+      aria-label={label}
+    >
+      {value}
+    </span>
+  </div>
+);
+
+export default function ResourceHeader({
+  cpuUsage,
+  queued,
+  running,
+  completed,
+  maxParallel,
+  userPaused,
+  autoPaused,
+  autoPauseReason,
+  onParallelismChange,
+  onPause,
+  onResume,
+}: ResourceHeaderProps) {
+  const isUserPaused = userPaused;
+  const isAutoPaused = autoPaused && !userPaused;
+  const sliderId = 'resource-monitor-parallelism';
+  const limitLabel = `Limit: ${maxParallel}`;
+
+  const usageClass =
+    cpuUsage < 60 ? 'bg-green-500' : cpuUsage < 80 ? 'bg-yellow-400' : 'bg-red-500';
+
+  return (
+    <header className="mb-3 rounded-lg border border-[var(--kali-border)] bg-[var(--kali-panel)] p-3 text-xs text-white">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="min-w-[140px] flex-1">
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] uppercase tracking-wide text-gray-300">
+              CPU usage
+            </span>
+            <span className="font-mono text-sm" aria-live="polite">
+              {formatUsage(cpuUsage)}
+            </span>
+          </div>
+          <div className="mt-1 h-2 w-full overflow-hidden rounded bg-gray-700">
+            <div
+              className={`h-full transition-all duration-500 ${usageClass}`}
+              style={{ width: `${clampPercent(cpuUsage)}%` }}
+              role="presentation"
+            />
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <StatBlock label="Queued" value={queued} testId="queued-count" />
+          <StatBlock label="Running" value={running} testId="running-count" />
+          <StatBlock label="Completed" value={completed} testId="completed-count" />
+        </div>
+        <div className="ml-auto flex flex-col gap-1">
+          <label htmlFor={sliderId} className="text-[10px] uppercase tracking-wide text-gray-300">
+            Parallelism limit
+          </label>
+          <div className="flex items-center gap-2">
+            <input
+              id={sliderId}
+              type="range"
+              min={1}
+              max={8}
+              value={maxParallel}
+              onChange={(event) => onParallelismChange(Number(event.target.value))}
+              aria-valuemin={1}
+              aria-valuemax={8}
+              aria-valuenow={maxParallel}
+              aria-label="Parallelism limit"
+              className="h-2 w-36 cursor-pointer appearance-none rounded bg-gray-700 accent-green-400"
+            />
+            <span className="font-mono text-sm" aria-live="polite">
+              {limitLabel}
+            </span>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onPause}
+            className="rounded bg-gray-800 px-3 py-1 text-xs font-semibold hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={isUserPaused}
+          >
+            Pause
+          </button>
+          <button
+            type="button"
+            onClick={onResume}
+            className="rounded bg-green-700 px-3 py-1 text-xs font-semibold text-black hover:bg-green-600 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={isAutoPaused}
+          >
+            Resume
+          </button>
+        </div>
+      </div>
+      {isUserPaused && (
+        <p className="mt-2 rounded border border-blue-400/40 bg-blue-900/30 px-2 py-1 text-xs text-blue-100" role="status">
+          Simulation paused manually. Resume to allow new jobs to start.
+        </p>
+      )}
+      {!isUserPaused && <BackpressureNotice reason={autoPauseReason} />}
+    </header>
+  );
+}

--- a/apps/resource-monitor/hooks/useResourceManager.ts
+++ b/apps/resource-monitor/hooks/useResourceManager.ts
@@ -1,0 +1,183 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
+import {
+  AutoPauseReason,
+  SchedulerSnapshot,
+  createJobScheduler,
+  JobScheduler,
+} from '../scheduler';
+
+interface ResourceState extends SchedulerSnapshot {
+  cpuUsage: number;
+}
+
+interface ResourceControls {
+  setParallelism: (value: number) => void;
+  pause: () => void;
+  resume: () => void;
+}
+
+interface CpuWorker {
+  postMessage: (message: any) => void;
+  addEventListener: typeof Worker.prototype.addEventListener;
+  removeEventListener: typeof Worker.prototype.removeEventListener;
+  terminate: () => void;
+}
+
+type Action =
+  | { type: 'snapshot'; snapshot: SchedulerSnapshot }
+  | { type: 'cpu'; value: number };
+
+const initialState: ResourceState = {
+  queued: 0,
+  running: 0,
+  completed: 0,
+  maxParallel: 3,
+  userPaused: false,
+  autoPaused: false,
+  autoPauseReason: null,
+  cpuUsage: 18,
+};
+
+const reducer = (state: ResourceState, action: Action): ResourceState => {
+  switch (action.type) {
+    case 'snapshot':
+      return {
+        ...state,
+        ...action.snapshot,
+      };
+    case 'cpu':
+      return {
+        ...state,
+        cpuUsage: action.value,
+      };
+    default:
+      return state;
+  }
+};
+
+const CPU_THRESHOLD = 82;
+const RESUME_THRESHOLD = 58;
+const JOB_INJECTION_INTERVAL = 1400;
+
+export interface ResourceManagerHook {
+  state: ResourceState;
+  controls: ResourceControls;
+  autoPauseReason: AutoPauseReason;
+}
+
+export const useResourceManager = (): ResourceManagerHook => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const schedulerRef = useRef<JobScheduler | null>(null);
+  const workerRef = useRef<CpuWorker | null>(null);
+  const queueIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return () => {};
+
+    const scheduler = createJobScheduler({
+      maxParallel: initialState.maxParallel,
+      cpuThreshold: CPU_THRESHOLD,
+      resumeThreshold: RESUME_THRESHOLD,
+      onStateChange: (snapshot) => {
+        dispatch({ type: 'snapshot', snapshot });
+        workerRef.current?.postMessage({
+          type: 'updateLoad',
+          running: snapshot.running,
+          maxParallel: snapshot.maxParallel,
+        });
+      },
+    });
+    schedulerRef.current = scheduler;
+    dispatch({ type: 'snapshot', snapshot: scheduler.getState() });
+
+    if (typeof Worker !== 'undefined') {
+      const worker = new Worker(
+        new URL('../../../workers/resourceCpu.worker.ts', import.meta.url)
+      ) as unknown as CpuWorker;
+      workerRef.current = worker;
+      const handleMessage = (event: MessageEvent<{ type: string; cpu?: number }>) => {
+        if (!event.data || event.data.type !== 'metrics') return;
+        const cpu = typeof event.data.cpu === 'number' ? event.data.cpu : 0;
+        scheduler.updateCpuUsage(cpu);
+        dispatch({ type: 'cpu', value: cpu });
+      };
+      worker.addEventListener('message', handleMessage);
+      const snapshot = scheduler.getState();
+      worker.postMessage({
+        type: 'updateLoad',
+        running: snapshot.running,
+        maxParallel: snapshot.maxParallel,
+      });
+      worker.postMessage({ type: 'start', interval: 900 });
+
+      const cleanupWorker = () => {
+        worker?.postMessage({ type: 'stop' });
+        worker?.removeEventListener('message', handleMessage);
+        worker?.terminate();
+      };
+
+      queueIntervalRef.current = setInterval(() => {
+        const burst = Math.random() < 0.3 ? 3 : 1;
+        scheduler.enqueueJobs(burst);
+      }, JOB_INJECTION_INTERVAL);
+
+      return () => {
+        cleanupWorker();
+        if (queueIntervalRef.current) {
+          clearInterval(queueIntervalRef.current);
+          queueIntervalRef.current = null;
+        }
+        scheduler.dispose();
+        schedulerRef.current = null;
+        workerRef.current = null;
+      };
+    }
+
+    // Fallback if Worker is unavailable (unlikely in browser, but useful for SSR/tests)
+    let fallbackCpu = initialState.cpuUsage;
+    const fallbackInterval = setInterval(() => {
+      fallbackCpu = Math.min(95, Math.max(5, fallbackCpu + (Math.random() - 0.4) * 6));
+      scheduler.updateCpuUsage(fallbackCpu);
+      dispatch({ type: 'cpu', value: fallbackCpu });
+    }, 1000);
+
+    queueIntervalRef.current = setInterval(() => {
+      scheduler.enqueueJobs(Math.random() < 0.3 ? 3 : 1);
+    }, JOB_INJECTION_INTERVAL);
+
+    return () => {
+      clearInterval(fallbackInterval);
+      if (queueIntervalRef.current) {
+        clearInterval(queueIntervalRef.current);
+        queueIntervalRef.current = null;
+      }
+      scheduler.dispose();
+      schedulerRef.current = null;
+    };
+  }, []);
+
+  const setParallelism = useCallback((value: number) => {
+    schedulerRef.current?.setMaxParallel(value);
+  }, []);
+
+  const pause = useCallback(() => {
+    schedulerRef.current?.pauseUser();
+  }, []);
+
+  const resume = useCallback(() => {
+    schedulerRef.current?.resumeUser();
+  }, []);
+
+  return useMemo(
+    () => ({
+      state,
+      controls: { setParallelism, pause, resume },
+      autoPauseReason: state.autoPauseReason,
+    }),
+    [state, setParallelism, pause, resume]
+  );
+};
+
+export default useResourceManager;

--- a/apps/resource-monitor/scheduler.ts
+++ b/apps/resource-monitor/scheduler.ts
@@ -1,0 +1,188 @@
+export type AutoPauseReason =
+  | null
+  | {
+      type: 'cpu';
+      usage: number;
+      threshold: number;
+    };
+
+export interface SchedulerSnapshot {
+  queued: number;
+  running: number;
+  completed: number;
+  maxParallel: number;
+  userPaused: boolean;
+  autoPaused: boolean;
+  autoPauseReason: AutoPauseReason;
+}
+
+interface SchedulerOptions {
+  maxParallel: number;
+  cpuThreshold: number;
+  resumeThreshold?: number;
+  onStateChange: (snapshot: SchedulerSnapshot) => void;
+}
+
+interface Job {
+  id: number;
+  duration: number;
+  timeout?: ReturnType<typeof setTimeout>;
+}
+
+const DEFAULT_RESUME_HYSTERESIS = 20;
+
+export class JobScheduler {
+  private queue: Job[] = [];
+  private running = new Map<number, Job>();
+  private completed = 0;
+  private jobCounter = 0;
+  private maxParallel: number;
+  private userPaused = false;
+  private autoPauseReason: AutoPauseReason = null;
+  private readonly cpuThreshold: number;
+  private readonly resumeThreshold: number;
+  private readonly onStateChange: (snapshot: SchedulerSnapshot) => void;
+  private disposed = false;
+
+  constructor({
+    maxParallel,
+    cpuThreshold,
+    resumeThreshold,
+    onStateChange,
+  }: SchedulerOptions) {
+    this.maxParallel = Math.max(1, maxParallel);
+    this.cpuThreshold = cpuThreshold;
+    this.resumeThreshold =
+      typeof resumeThreshold === 'number'
+        ? resumeThreshold
+        : Math.max(10, cpuThreshold - DEFAULT_RESUME_HYSTERESIS);
+    this.onStateChange = onStateChange;
+    this.emit();
+  }
+
+  enqueueJobs(count: number) {
+    for (let i = 0; i < count; i += 1) {
+      const job: Job = {
+        id: ++this.jobCounter,
+        duration: 800 + Math.floor(Math.random() * 2200),
+      };
+      this.queue.push(job);
+    }
+    this.emit();
+    this.tryStartJobs();
+  }
+
+  setMaxParallel(limit: number) {
+    const clamped = Math.max(1, Math.round(limit));
+    if (clamped === this.maxParallel) return;
+    this.maxParallel = clamped;
+    this.emit();
+    this.tryStartJobs();
+  }
+
+  pauseUser() {
+    if (this.userPaused) return;
+    this.userPaused = true;
+    this.emit();
+  }
+
+  resumeUser() {
+    if (!this.userPaused) return;
+    this.userPaused = false;
+    this.emit();
+    this.tryStartJobs();
+  }
+
+  updateCpuUsage(usage: number) {
+    if (Number.isNaN(usage)) return;
+    if (usage >= this.cpuThreshold) {
+      this.setAutoPause({ type: 'cpu', usage, threshold: this.cpuThreshold });
+    } else if (this.autoPauseReason && usage <= this.resumeThreshold) {
+      this.setAutoPause(null);
+    } else if (this.autoPauseReason?.type === 'cpu') {
+      // Update the usage shown in the reason to provide fresh context.
+      this.autoPauseReason = {
+        type: 'cpu',
+        usage,
+        threshold: this.autoPauseReason.threshold,
+      };
+      this.emit();
+    }
+  }
+
+  dispose() {
+    this.disposed = true;
+    this.running.forEach((job) => {
+      if (job.timeout) clearTimeout(job.timeout);
+    });
+    this.queue.forEach((job) => {
+      if (job.timeout) clearTimeout(job.timeout);
+    });
+    this.running.clear();
+    this.queue = [];
+  }
+
+  getState(): SchedulerSnapshot {
+    return {
+      queued: this.queue.length,
+      running: this.running.size,
+      completed: this.completed,
+      maxParallel: this.maxParallel,
+      userPaused: this.userPaused,
+      autoPaused: !!this.autoPauseReason,
+      autoPauseReason: this.autoPauseReason,
+    };
+  }
+
+  private setAutoPause(reason: AutoPauseReason) {
+    const previouslyPaused = !!this.autoPauseReason;
+    this.autoPauseReason = reason;
+    if (!reason && previouslyPaused) {
+      this.emit();
+      this.tryStartJobs();
+    } else if (reason) {
+      this.emit();
+    }
+  }
+
+  private tryStartJobs() {
+    if (this.disposed) return;
+    while (
+      !this.isPaused() &&
+      this.running.size < this.maxParallel &&
+      this.queue.length > 0
+    ) {
+      const job = this.queue.shift();
+      if (!job) break;
+      this.startJob(job);
+    }
+  }
+
+  private startJob(job: Job) {
+    this.running.set(job.id, job);
+    this.emit();
+    job.timeout = setTimeout(() => {
+      this.finishJob(job.id);
+    }, job.duration);
+  }
+
+  private finishJob(id: number) {
+    const job = this.running.get(id);
+    if (!job) return;
+    this.running.delete(id);
+    this.completed += 1;
+    this.emit();
+    this.tryStartJobs();
+  }
+
+  private isPaused() {
+    return this.userPaused || !!this.autoPauseReason;
+  }
+
+  private emit() {
+    this.onStateChange(this.getState());
+  }
+}
+
+export const createJobScheduler = (options: SchedulerOptions) =>
+  new JobScheduler(options);

--- a/docs/resource-monitor-best-practices.md
+++ b/docs/resource-monitor-best-practices.md
@@ -1,0 +1,38 @@
+# Resource monitor simulation best practices
+
+The resource monitor app now simulates CPU pressure and job orchestration to
+illustrate how tooling should back off when hosts are saturated. Follow these
+patterns when extending the simulation or building new demos:
+
+## Scheduler hygiene
+
+- Keep the scheduler educational. Each job is a mock task; never trigger real
+  workloads or background scans. The queue should represent theoretical work.
+- Respect the parallelism guard rail exposed to the learner. The job scheduler
+  should never spin up more running jobs than the configured limit.
+- Use backpressure to prevent runaway simulations. When CPU usage exceeds the
+  threshold, pause starting new jobs and surface a clear explanation in the UI.
+- Resume automatically only after metrics drop below the resume threshold. This
+  mirrors production systems where hysteresis prevents thrashing.
+
+## CPU metrics simulation
+
+- Metrics are produced inside a dedicated worker so UI updates stay smooth. The
+  worker accepts load hints (running jobs and limits) and returns smoothed usage
+  samples.
+- Keep the worker deterministic. Avoid API calls, and clamp values to a
+  realistic range so the gauge does not jitter wildly.
+- When adjusting worker logic, update the Jest worker mock in
+  `__tests__/resourceMonitor.test.tsx` to keep the tests deterministic.
+
+## UI responsibilities
+
+- Expose control over the parallelism limit, plus explicit pause/resume buttons
+  so visitors can experiment with resource policies.
+- Surface job counters (queued, running, completed) alongside CPU usage to
+  reinforce the relationship between work and system pressure.
+- Use `aria-live` regions for alerts so assistive technology announces
+  backpressure state changes.
+
+These guidelines keep the app firmly in "safe simulation" territory while
+teaching operational guard rails.

--- a/workers/resourceCpu.worker.ts
+++ b/workers/resourceCpu.worker.ts
@@ -1,0 +1,85 @@
+const ctx: DedicatedWorkerGlobalScope = self as any;
+
+interface UpdateLoadMessage {
+  type: 'updateLoad';
+  running: number;
+  maxParallel: number;
+}
+
+interface StartMessage {
+  type: 'start';
+  interval?: number;
+}
+
+interface StopMessage {
+  type: 'stop';
+}
+
+type IncomingMessage = UpdateLoadMessage | StartMessage | StopMessage;
+
+type MetricsMessage = {
+  type: 'metrics';
+  cpu: number;
+};
+
+let runningJobs = 0;
+let maxParallel = 1;
+let currentUsage = 18;
+let targetUsage = 18;
+let timer: ReturnType<typeof setInterval> | null = null;
+let intervalMs = 1000;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+const computeTarget = () => {
+  const loadRatio = maxParallel > 0 ? runningJobs / maxParallel : runningJobs > 0 ? 1 : 0;
+  const base = 18 + loadRatio * 65;
+  const noise = (Math.random() - 0.5) * 12;
+  targetUsage = clamp(base + noise, 8, 97);
+};
+
+const tick = () => {
+  const delta = targetUsage - currentUsage;
+  currentUsage = clamp(currentUsage + delta * 0.25 + (Math.random() - 0.5) * 2.5, 0, 99);
+  const payload: MetricsMessage = {
+    type: 'metrics',
+    cpu: Number(currentUsage.toFixed(1)),
+  };
+  ctx.postMessage(payload);
+};
+
+const start = () => {
+  if (timer) return;
+  timer = setInterval(tick, intervalMs);
+};
+
+const stop = () => {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+};
+
+ctx.addEventListener('message', (event: MessageEvent<IncomingMessage>) => {
+  const data = event.data;
+  if (!data) return;
+  switch (data.type) {
+    case 'start':
+      intervalMs = typeof data.interval === 'number' ? data.interval : 1000;
+      start();
+      break;
+    case 'stop':
+      stop();
+      break;
+    case 'updateLoad':
+      runningJobs = data.running;
+      maxParallel = Math.max(1, data.maxParallel);
+      computeTarget();
+      break;
+    default:
+      break;
+  }
+});
+
+export {};


### PR DESCRIPTION
## Summary
- add a resource monitor header with CPU usage gauge, job counters, and manual parallelism controls
- integrate a job scheduler with CPU-driven backpressure plus a dedicated worker that simulates usage metrics
- document simulation guard rails and add Jest tests covering responsiveness and user limit enforcement

## Testing
- yarn lint
- yarn test resourceMonitor

------
https://chatgpt.com/codex/tasks/task_e_68dc937d47c88328bad180f68bc48239