### PR TITLE
[hashcat] add contextual strategy advisor

### DIFF
--- a/__tests__/hashcat-advisor.test.tsx
+++ b/__tests__/hashcat-advisor.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HashcatAdvisor, {
+  advisorRules,
+  type AdvisorContext,
+} from '../components/apps/hashcat/Advisor';
+
+jest.mock('@/lib/analytics-client', () => ({
+  trackEvent: jest.fn(),
+}));
+
+const trackEvent = require('@/lib/analytics-client').trackEvent as jest.Mock;
+
+const baseContext: AdvisorContext = {
+  hashTypeId: '0',
+  attackMode: '0',
+  ruleSet: 'none',
+  mask: '',
+  maskStats: { count: 0, time: 0 },
+  wordlist: 'rockyou',
+  pattern: '',
+  maskModeActive: false,
+};
+
+describe('HashcatAdvisor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_ENABLE_ANALYTICS = 'true';
+  });
+
+  afterAll(() => {
+    delete process.env.NEXT_PUBLIC_ENABLE_ANALYTICS;
+  });
+
+  it('renders bcrypt guidance when bcrypt is selected', () => {
+    render(<HashcatAdvisor {...baseContext} hashTypeId="3200" />);
+    expect(
+      screen.getByText(/bcrypt hashes are intentionally slow/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows fallback copy when no rules apply', () => {
+    render(<HashcatAdvisor {...baseContext} />);
+    expect(
+      screen.getByText(/This advisor surfaces general guidance/i),
+    ).toBeInTheDocument();
+  });
+
+  it('encourages providing a mask when brute-force mode is active without one', () => {
+    render(
+      <HashcatAdvisor
+        {...baseContext}
+        attackMode="3"
+        maskModeActive
+      />,
+    );
+    expect(screen.getByTestId('advisor-tip-mask-required')).toBeInTheDocument();
+  });
+
+  it('tracks analytics when tips are visible and analytics are enabled', () => {
+    render(<HashcatAdvisor {...baseContext} hashTypeId="3200" />);
+    expect(trackEvent).toHaveBeenCalledWith(
+      'hashcat_tip_impression',
+      expect.objectContaining({ rules: expect.stringContaining('hash-type-bcrypt') }),
+    );
+  });
+
+  it('covers every rule with an explicit context', () => {
+    const contexts: Record<string, AdvisorContext> = {
+      'hash-type-bcrypt': { ...baseContext, hashTypeId: '3200' },
+      'mask-required': { ...baseContext, attackMode: '3', maskModeActive: true },
+      'mask-large-space': {
+        ...baseContext,
+        mask: '?d?d?d',
+        maskModeActive: true,
+        maskStats: { count: 1_000_000_001, time: 0 },
+      },
+      'rules-enabled': { ...baseContext, ruleSet: 'best64' },
+      'wordlist-missing': { ...baseContext, wordlist: '' },
+      'pattern-present': { ...baseContext, pattern: 'abc' },
+    };
+
+    advisorRules.forEach((rule) => {
+      const context = contexts[rule.id];
+      expect(context).toBeDefined();
+      expect(rule.test(context)).toBe(true);
+    });
+  });
+});

--- a/components/apps/hashcat/Advisor.tsx
+++ b/components/apps/hashcat/Advisor.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import React, { useEffect, useMemo } from 'react';
+import { trackEvent } from '@/lib/analytics-client';
+
+export type AdvisorContext = {
+  hashTypeId: string;
+  attackMode: string;
+  ruleSet: string;
+  mask: string;
+  maskStats: {
+    count: number;
+    time: number;
+  };
+  wordlist: string;
+  pattern: string;
+  maskModeActive: boolean;
+};
+
+export type AdvisorMessage = {
+  id: string;
+  defaultMessage: string;
+};
+
+export type AdvisorRule = {
+  id: string;
+  message: AdvisorMessage;
+  tone: 'info' | 'caution';
+  test: (context: AdvisorContext) => boolean;
+};
+
+export const advisorRules: readonly AdvisorRule[] = [
+  {
+    id: 'hash-type-bcrypt',
+    tone: 'info',
+    message: {
+      id: 'hashcat.tip.bcryptSlow',
+      defaultMessage:
+        'bcrypt hashes are intentionally slow. Training against them highlights how adaptive hashing increases verification cost.',
+    },
+    test: (context) => context.hashTypeId === '3200',
+  },
+  {
+    id: 'mask-required',
+    tone: 'caution',
+    message: {
+      id: 'hashcat.tip.maskRequired',
+      defaultMessage:
+        'Brute-force style modes need a mask to stay within a safe demo space. Add tokens like ?l or ?d to focus the simulation.',
+    },
+    test: (context) => context.maskModeActive && !context.mask,
+  },
+  {
+    id: 'mask-large-space',
+    tone: 'caution',
+    message: {
+      id: 'hashcat.tip.maskLargeSpace',
+      defaultMessage:
+        'This mask opens a very large candidate space. Use the estimate to discuss why narrowing patterns keeps demos responsible.',
+    },
+    test: (context) => context.maskStats.count > 100_000_000,
+  },
+  {
+    id: 'rules-enabled',
+    tone: 'info',
+    message: {
+      id: 'hashcat.tip.rulesEnabled',
+      defaultMessage:
+        'Rule files mutate dictionary entries for experimentation. Review the sample rules to explain each transformation step.',
+    },
+    test: (context) => context.ruleSet !== 'none',
+  },
+  {
+    id: 'wordlist-missing',
+    tone: 'info',
+    message: {
+      id: 'hashcat.tip.wordlistMissing',
+      defaultMessage:
+        'Straight mode demonstrates best when paired with a curated wordlist. The demo includes safe stand-ins like rockyou.txt.',
+    },
+    test: (context) => context.attackMode === '0' && !context.wordlist,
+  },
+  {
+    id: 'pattern-present',
+    tone: 'info',
+    message: {
+      id: 'hashcat.tip.patternPresent',
+      defaultMessage:
+        'Generated wordlists stay in-browser. Short patterns keep downloads quick and reinforce how pattern design shapes results.',
+    },
+    test: (context) => Boolean(context.pattern.trim()),
+  },
+] as const;
+
+export type HashcatAdvisorProps = AdvisorContext;
+
+const toneStyles: Record<AdvisorRule['tone'], string> = {
+  info: 'border-sky-500/40 bg-sky-500/5 text-sky-100',
+  caution: 'border-amber-400/50 bg-amber-500/10 text-amber-100',
+};
+
+const HashcatAdvisor: React.FC<HashcatAdvisorProps> = (props) => {
+  const {
+    hashTypeId,
+    attackMode,
+    ruleSet,
+    mask,
+    maskStats,
+    wordlist,
+    pattern,
+    maskModeActive,
+  } = props;
+
+  const context = useMemo(
+    () => ({
+      hashTypeId,
+      attackMode,
+      ruleSet,
+      mask,
+      maskStats: {
+        count: maskStats.count,
+        time: maskStats.time,
+      },
+      wordlist,
+      pattern,
+      maskModeActive,
+    }),
+    [
+      hashTypeId,
+      attackMode,
+      ruleSet,
+      mask,
+      maskStats.count,
+      maskStats.time,
+      wordlist,
+      pattern,
+      maskModeActive,
+    ],
+  );
+
+  const tips = useMemo(
+    () =>
+      advisorRules.filter((rule) => rule.test(context)).map((rule) => ({
+        id: rule.id,
+        tone: rule.tone,
+        message: rule.message,
+      })),
+    [context],
+  );
+
+  useEffect(() => {
+    const analyticsEnabled =
+      typeof process !== 'undefined' &&
+      process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === 'true';
+    if (!tips.length || !analyticsEnabled) {
+      return;
+    }
+    trackEvent('hashcat_tip_impression', {
+      rules: tips.map((tip) => tip.id).join(','),
+      mask: context.mask ? 'present' : 'absent',
+    });
+  }, [tips, context.mask]);
+
+  return (
+    <section
+      aria-label="Hashcat advisor"
+      className="w-full max-w-md rounded border border-white/10 bg-black/40 p-4 text-xs text-white/90"
+    >
+      <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-white/70">
+        Strategy Advisor
+      </h2>
+      <div aria-live="polite" role="status" className="space-y-2">
+        {tips.length ? (
+          tips.map((tip) => (
+            <p
+              key={tip.id}
+              className={`rounded border px-3 py-2 leading-relaxed ${toneStyles[tip.tone]}`}
+              data-testid={`advisor-tip-${tip.id}`}
+            >
+              {tip.message.defaultMessage}
+            </p>
+          ))
+        ) : (
+          <p className="rounded border border-white/10 bg-white/5 px-3 py-2 text-white/80">
+            This advisor surfaces general guidance for the training lab. Adjust the
+            options above to explore how strategy notes change without leaving the
+            safe simulation.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default HashcatAdvisor;

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import progressInfo from './progress.json';
 import StatsChart from '../../StatsChart';
+import HashcatAdvisor from './Advisor';
 
 export const hashTypes = [
   {
@@ -444,6 +445,16 @@ function HashcatApp() {
           {rulePreview || '(no rules)'}
         </pre>
       </div>
+      <HashcatAdvisor
+        hashTypeId={hashType}
+        attackMode={attackMode}
+        ruleSet={ruleSet}
+        mask={mask}
+        maskStats={maskStats}
+        wordlist={wordlist}
+        pattern={pattern}
+        maskModeActive={showMask}
+      />
       <div>Detected: {selectedHash}</div>
       <div>Summary: {selected.summary}</div>
       <div>Example hash: {selected.example}</div>

--- a/docs/hashcat-advisor.md
+++ b/docs/hashcat-advisor.md
@@ -1,0 +1,23 @@
+# Hashcat Advisor Guidelines
+
+The Hashcat simulation now includes a strategy advisor that reacts to user input without offering operational instructions. This note explains how to extend the tips safely.
+
+## Adding a new tip
+
+1. Open `components/apps/hashcat/Advisor.tsx`.
+2. Add a new entry to the exported `advisorRules` array.
+   - Give it a unique `id`.
+   - Provide localization-ready copy via the `message` object (`id` and `defaultMessage`).
+   - Set `tone` to either `info` or `caution` to pick the badge style.
+   - Supply a `test` function that inspects the `AdvisorContext` and returns `true` when the tip should appear.
+3. Update `__tests__/hashcat-advisor.test.tsx` with a matching context in the `rule coverage` test so every rule stays exercised.
+4. Run `yarn test hashcat-advisor` to confirm the advisor suite passes.
+
+## Guard rails
+
+- Keep every tip non-prescriptive. Focus on what the simulation is demonstrating (e.g., why adaptive hashes are slow) rather than how to run a live attack.
+- Do not link to tooling that enables offensive action. Point to existing documentation that is already surfaced in the UI if needed.
+- Avoid suggesting targets, infrastructure, or evasion strategies.
+- If you add analytics tracking properties, stick to high-level metadata (like which rule fired) so no sensitive input leaves the browser.
+
+Following these guard rails keeps the demo aligned with the project’s "education only" policy while still giving visitors useful talking points.

--- a/lib/analytics-client.ts
+++ b/lib/analytics-client.ts
@@ -4,7 +4,8 @@ export type EventName =
   | 'contact_submit'
   | 'contact_submit_error'
   | 'outbound_link_click'
-  | 'download_click';
+  | 'download_click'
+  | 'hashcat_tip_impression';
 
 export function trackEvent(
   name: EventName,


### PR DESCRIPTION
## Summary
- add a localized-ready Hashcat advisor with contextual rules and analytics tracking
- integrate the advisor into the simulator UI and extend the analytics event types
- document tip authoring guard rails and add focused unit tests for rule coverage

## Testing
- yarn test hashcat-advisor
- yarn test hashcat.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc937e72208328b5b6542e54d771a0