### PR TITLE
[radare2] add inline annotations workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,8 +462,19 @@ play/pause and track controls include keyboard hotkeys.
 - **`hooks/usePersistentState.ts`** - localStorage-backed state with validation + reset helper.
 - **`hooks/useSettings.tsx`** - global settings context exposing theme, accent, wallpaper and other preferences with persistence.
 - **`components/apps/GameLayout.tsx`** - standardized layout and help toggle for games.
-- **`components/apps/radare2`** - dual hex/disassembly panes with seek/find/xref; graph mode from JSON fixtures; per-file notes and bookmarks.
+- **`components/apps/radare2`** - dual hex/disassembly panes with seek/find/xref; graph mode from JSON fixtures; per-file notes, bookmarks, and inline annotations with undo/redo and export support.
 - **`components/common/PipPortal.tsx`** - renders arbitrary UI inside a Document Picture-in-Picture window. See [`docs/pip-portal.md`](./docs/pip-portal.md).
+
+## Radare2 annotations
+
+The Radare2 simulation includes an annotation workflow to keep analysis notes alongside the bundled disassembly:
+
+- **Inline editing.** Use the **Rename** and **Comment** controls next to each instruction to assign a symbol or remark. Edits are stored per file and can be undone/redone from the toolbar.
+- **Annotation manager.** Select **Manage Annotations** to review all labels/comments, resolve duplicate labels, or bulk-clear entries without leaving the code pane.
+- **Persistence.** Annotations persist in `localStorage` under `r2-annotations-<file>` and a richer snapshot (`r2-annotation-snapshot-<file>`) that records the annotated instructions plus metadata. The viewer reloads from these snapshots automatically when the file is reopened.
+- **Exports.** The **Export Annotations** action downloads a JSON document (`schemaVersion: 1`) containing the disassembly alongside annotations so the data can be archived or shared.
+
+Snapshots include trimmed text (no empty fields) to keep storage predictable. Removing both the label and comment for an address drops the annotation entirely, ensuring exports and snapshots stay concise.
 
 ---
 

--- a/__tests__/radare2Annotations.test.tsx
+++ b/__tests__/radare2Annotations.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import Radare2 from '../components/apps/radare2';
+import sample from '../apps/radare2/sample.json';
+
+describe('Radare2 annotations workflow', () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    jest.restoreAllMocks();
+  });
+
+  it('supports inline rename, comments, undo/redo, and export', async () => {
+    render(<Radare2 initialData={{ ...sample, file: 'test.bin' }} />);
+
+    const renameButtons = screen.getAllByText('Rename');
+    fireEvent.click(renameButtons[0]);
+    const renameInput = screen.getByLabelText('Rename 0x1000');
+    fireEvent.change(renameInput, { target: { value: 'entry' } });
+    fireEvent.keyDown(renameInput, { key: 'Enter' });
+    expect(await screen.findByText('entry')).toBeInTheDocument();
+
+    const commentButtons = screen.getAllByText('Comment');
+    fireEvent.click(commentButtons[0]);
+    const commentField = screen.getByLabelText('Comment on 0x1000');
+    fireEvent.change(commentField, { target: { value: 'prologue' } });
+    fireEvent.blur(commentField);
+    expect(await screen.findByText(/; prologue/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Undo'));
+    expect(screen.queryByText(/; prologue/)).toBeNull();
+    fireEvent.click(screen.getByText('Redo'));
+    expect(await screen.findByText(/; prologue/)).toBeInTheDocument();
+
+    const stored = JSON.parse(
+      window.localStorage.getItem('r2-annotations-test.bin') || '{}',
+    );
+    expect(stored).toMatchObject({
+      '0x1000': { label: 'entry', comment: 'prologue' },
+    });
+
+    let capturedBlob: Blob | null = null;
+    URL.createObjectURL = jest.fn((blob: Blob) => {
+      capturedBlob = blob;
+      return 'blob:mock';
+    });
+    URL.revokeObjectURL = jest.fn();
+    const clickSpy = jest
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+
+    fireEvent.click(screen.getByText('Export Annotations'));
+
+    await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalled());
+    expect(clickSpy).toHaveBeenCalled();
+    expect(capturedBlob).not.toBeNull();
+    if (capturedBlob) {
+      const text = typeof (capturedBlob as any).text === 'function'
+        ? await (capturedBlob as any).text()
+        : await new Promise<string>((resolve) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(String(reader.result || ''));
+            reader.readAsText(capturedBlob);
+          });
+      const payload = JSON.parse(text);
+      expect(payload.annotations[0]).toMatchObject({
+        addr: '0x1000',
+        label: 'entry',
+        comment: 'prologue',
+      });
+    }
+  });
+});

--- a/components/apps/radare2/AnnotationManager.js
+++ b/components/apps/radare2/AnnotationManager.js
@@ -1,0 +1,209 @@
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import { normalizeAnnotations } from "./utils";
+
+const AnnotationManager = ({
+  annotations,
+  disasm,
+  onUpdate,
+  onResolve,
+  onClear,
+  onClearAll,
+  onClose,
+}) => {
+  const entries = useMemo(() => {
+    const normalized = normalizeAnnotations(annotations || {});
+    const instructions = new Map(
+      (disasm || []).map((line) => [line.addr, line.text || ""]),
+    );
+    return Object.entries(normalized)
+      .map(([addr, value]) => ({
+        addr,
+        label: value.label || "",
+        comment: value.comment || "",
+        text: instructions.get(addr) || "",
+      }))
+      .sort((a, b) => {
+        const parse = (value) => {
+          if (typeof value !== "string") return Number.MAX_SAFE_INTEGER;
+          const normalizedAddr = value.toLowerCase().startsWith("0x")
+            ? value
+            : `0x${value}`;
+          const parsed = Number.parseInt(normalizedAddr, 16);
+          return Number.isNaN(parsed) ? Number.MAX_SAFE_INTEGER : parsed;
+        };
+        return parse(a.addr) - parse(b.addr);
+      });
+  }, [annotations, disasm]);
+
+  const conflicts = useMemo(() => {
+    const byLabel = new Map();
+    entries.forEach((entry) => {
+      if (!entry.label) return;
+      if (!byLabel.has(entry.label)) byLabel.set(entry.label, []);
+      byLabel.get(entry.label).push(entry.addr);
+    });
+    return Array.from(byLabel.entries()).filter(([, list]) => list.length > 1);
+  }, [entries]);
+
+  const handleBlur = (addr, field) => (event) => {
+    const value = event.target.value;
+    onUpdate(addr, { [field]: value });
+  };
+
+  const handleKeyDown = (addr, field) => (event) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      onUpdate(addr, { [field]: event.target.value });
+      event.currentTarget.blur();
+    }
+    if (event.key === "Escape") {
+      event.currentTarget.blur();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="max-h-[80vh] w-11/12 md:w-3/4 lg:w-2/3 xl:w-1/2 overflow-auto rounded shadow-lg"
+        style={{
+          backgroundColor: "var(--r2-surface)",
+          border: "1px solid var(--r2-border)",
+          color: "var(--r2-text)",
+        }}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b" style={{ borderColor: "var(--r2-border)" }}>
+          <h2 className="text-lg font-semibold">Annotation Manager</h2>
+          <div className="flex gap-2">
+            <button
+              onClick={onClearAll}
+              className="px-3 py-1 rounded text-sm"
+              style={{
+                backgroundColor: "var(--r2-surface)",
+                border: "1px solid var(--r2-border)",
+              }}
+            >
+              Clear All
+            </button>
+            <button
+              onClick={onClose}
+              className="px-3 py-1 rounded text-sm"
+              style={{
+                backgroundColor: "var(--r2-surface)",
+                border: "1px solid var(--r2-border)",
+              }}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+        {conflicts.length > 0 && (
+          <div className="px-4 py-3 border-b text-sm" style={{ borderColor: "var(--r2-border)" }}>
+            <h3 className="font-medium mb-2">Conflicts</h3>
+            <ul className="space-y-2">
+              {conflicts.map(([label, addresses]) => (
+                <li key={label} className="flex items-center gap-3 flex-wrap">
+                  <span>
+                    <span className="font-semibold">{label}</span> used at {addresses.join(", ")}
+                  </span>
+                  <button
+                    onClick={() => onResolve(label)}
+                    className="px-2 py-1 rounded text-xs"
+                    style={{
+                      backgroundColor: "var(--r2-surface)",
+                      border: "1px solid var(--r2-border)",
+                    }}
+                  >
+                    Auto resolve
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <div className="px-4 py-3">
+          {entries.length === 0 ? (
+            <p className="text-sm opacity-80">No annotations yet. Add a rename or comment from the disassembly view.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="py-2 pr-2">Address</th>
+                  <th className="py-2 pr-2">Instruction</th>
+                  <th className="py-2 pr-2">Label</th>
+                  <th className="py-2 pr-2">Comment</th>
+                  <th className="py-2">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map((entry) => (
+                  <tr key={entry.addr} className="align-top">
+                    <td className="py-2 pr-2 font-mono whitespace-nowrap">{entry.addr}</td>
+                    <td className="py-2 pr-2">{entry.text}</td>
+                    <td className="py-2 pr-2 w-40">
+                      <input
+                        defaultValue={entry.label}
+                        onBlur={handleBlur(entry.addr, "label")}
+                        onKeyDown={handleKeyDown(entry.addr, "label")}
+                        className="w-full px-2 py-1 rounded"
+                        style={{
+                          backgroundColor: "var(--r2-bg)",
+                          border: "1px solid var(--r2-border)",
+                          color: "var(--r2-text)",
+                        }}
+                        aria-label={`Annotation label for ${entry.addr}`}
+                      />
+                    </td>
+                    <td className="py-2 pr-2 w-64">
+                      <textarea
+                        defaultValue={entry.comment}
+                        onBlur={handleBlur(entry.addr, "comment")}
+                        onKeyDown={handleKeyDown(entry.addr, "comment")}
+                        className="w-full px-2 py-1 rounded"
+                        rows={2}
+                        style={{
+                          backgroundColor: "var(--r2-bg)",
+                          border: "1px solid var(--r2-border)",
+                          color: "var(--r2-text)",
+                        }}
+                        aria-label={`Annotation comment for ${entry.addr}`}
+                      />
+                    </td>
+                    <td className="py-2">
+                      <button
+                        onClick={() => onClear(entry.addr)}
+                        className="px-2 py-1 rounded text-xs"
+                        style={{
+                          backgroundColor: "var(--r2-surface)",
+                          border: "1px solid var(--r2-border)",
+                        }}
+                      >
+                        Remove
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+AnnotationManager.propTypes = {
+  annotations: PropTypes.object.isRequired,
+  disasm: PropTypes.array.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+  onResolve: PropTypes.func.isRequired,
+  onClear: PropTypes.func.isRequired,
+  onClearAll: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default AnnotationManager;

--- a/components/apps/radare2/utils.js
+++ b/components/apps/radare2/utils.js
@@ -87,6 +87,8 @@ export const extractStrings = (hex, baseAddr = '0x0') => {
 
 const NOTES_PREFIX = 'r2-notes-';
 const BOOKMARK_PREFIX = 'r2-bookmarks-';
+const ANNOTATION_PREFIX = 'r2-annotations-';
+const SNAPSHOT_PREFIX = 'r2-annotation-snapshot-';
 
 export const loadNotes = (file) => {
   try {
@@ -112,4 +114,181 @@ export const loadBookmarks = (file) => {
 
 export const saveBookmarks = (file, bookmarks) => {
   localStorage.setItem(BOOKMARK_PREFIX + file, JSON.stringify(bookmarks));
+};
+
+const sortAnnotationEntries = (entries = []) =>
+  [...entries].sort((a, b) => {
+    const parse = (value) => {
+      if (typeof value !== 'string') return Number.MAX_SAFE_INTEGER;
+      const normalized = value.toLowerCase().startsWith('0x')
+        ? value
+        : `0x${value}`;
+      const parsed = Number.parseInt(normalized, 16);
+      return Number.isNaN(parsed) ? Number.MAX_SAFE_INTEGER : parsed;
+    };
+    return parse(a[0]) - parse(b[0]);
+  });
+
+export const normalizeAnnotations = (annotations = {}) => {
+  const entries = Object.entries(annotations || {});
+  if (!entries.length) return {};
+  const next = {};
+  entries.forEach(([addr, value]) => {
+    if (!value) return;
+    const label = typeof value.label === 'string' ? value.label.trim() : '';
+    const comment =
+      typeof value.comment === 'string' ? value.comment.trim() : '';
+    if (!label && !comment) return;
+    next[addr] = { ...value };
+    if (label) next[addr].label = label;
+    else delete next[addr].label;
+    if (comment) next[addr].comment = comment;
+    else delete next[addr].comment;
+  });
+  return next;
+};
+
+export const annotationsEqual = (a = {}, b = {}) => {
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  return keysA.every((key) => {
+    const va = a[key] || {};
+    const vb = b[key] || {};
+    return (va.label || '') === (vb.label || '') && (va.comment || '') === (vb.comment || '');
+  });
+};
+
+export const loadAnnotations = (file) => {
+  try {
+    const raw = localStorage.getItem(ANNOTATION_PREFIX + file);
+    if (!raw) return {};
+    const data = JSON.parse(raw);
+    return normalizeAnnotations(data);
+  } catch (e) {
+    return {};
+  }
+};
+
+export const saveAnnotations = (file, annotations) => {
+  const normalized = normalizeAnnotations(annotations);
+  localStorage.setItem(ANNOTATION_PREFIX + file, JSON.stringify(normalized));
+  return normalized;
+};
+
+export const loadAnnotationSnapshot = (file) => {
+  try {
+    const raw = localStorage.getItem(SNAPSHOT_PREFIX + file);
+    return raw ? JSON.parse(raw) : null;
+  } catch (e) {
+    return null;
+  }
+};
+
+export const saveAnnotationSnapshot = (file, snapshot) => {
+  localStorage.setItem(SNAPSHOT_PREFIX + file, JSON.stringify(snapshot));
+  return snapshot;
+};
+
+export const snapshotToAnnotations = (snapshot) => {
+  if (!snapshot || !Array.isArray(snapshot.annotations)) return {};
+  const out = {};
+  snapshot.annotations.forEach((entry) => {
+    if (!entry || !entry.addr) return;
+    const label = typeof entry.label === 'string' ? entry.label : '';
+    const comment = typeof entry.comment === 'string' ? entry.comment : '';
+    if (!label && !comment) return;
+    out[entry.addr] = normalizeAnnotations({
+      [entry.addr]: { label, comment },
+    })[entry.addr];
+  });
+  return out;
+};
+
+export const buildAnnotationSnapshot = (file, disasm = [], annotations = {}) => {
+  const normalized = normalizeAnnotations(annotations);
+  const disasmMap = new Map(
+    (disasm || []).map((line) => [line.addr, line.text || '']),
+  );
+  const annotationsArray = sortAnnotationEntries(Object.entries(normalized)).map(
+    ([addr, value]) => ({
+      addr,
+      label: value.label || null,
+      comment: value.comment || null,
+      text: disasmMap.get(addr) || null,
+    }),
+  );
+  return {
+    version: 1,
+    file,
+    generatedAt: new Date().toISOString(),
+    annotations: annotationsArray,
+  };
+};
+
+export const persistAnnotations = (file, disasm, annotations) => {
+  const normalized = normalizeAnnotations(annotations);
+  if (typeof window === 'undefined') return normalized;
+  saveAnnotations(file, normalized);
+  const snapshot = buildAnnotationSnapshot(file, disasm, normalized);
+  saveAnnotationSnapshot(file, snapshot);
+  return normalized;
+};
+
+export const createAnnotationExport = (file, disasm = [], annotations = {}) => {
+  const normalized = normalizeAnnotations(annotations);
+  const disasmMap = new Map(
+    (disasm || []).map((line) => [line.addr, { ...line }]),
+  );
+  const annotatedLines = sortAnnotationEntries(Object.entries(normalized)).map(
+    ([addr, value]) => ({
+      addr,
+      label: value.label || null,
+      comment: value.comment || null,
+      text: disasmMap.get(addr)?.text || null,
+    }),
+  );
+  return {
+    schemaVersion: 1,
+    file,
+    generatedAt: new Date().toISOString(),
+    annotations: annotatedLines,
+    disassembly: (disasm || []).map((line) => ({ ...line })),
+  };
+};
+
+export const createHistory = (initial = {}) => ({
+  past: [],
+  present: initial,
+  future: [],
+});
+
+export const pushHistory = (history, nextPresent, meta) => {
+  if (annotationsEqual(history.present, nextPresent)) return history;
+  return {
+    past: [...history.past, { state: history.present, meta }],
+    present: nextPresent,
+    future: [],
+  };
+};
+
+export const undoHistory = (history) => {
+  if (!history.past.length) return history;
+  const past = [...history.past];
+  const previous = past.pop();
+  return {
+    past,
+    present: previous.state,
+    future: [{ state: history.present, meta: previous.meta }, ...history.future],
+  };
+};
+
+export const redoHistory = (history) => {
+  if (!history.future.length) return history;
+  const [next, ...rest] = history.future;
+  return {
+    past: [...history.past, { state: history.present, meta: next.meta }],
+    present: next.state,
+    future: rest,
+  };
 };


### PR DESCRIPTION
## Summary
- add inline rename/comment annotations with undo/redo controls in the Radare2 disassembly view
- persist annotations into localStorage snapshots and expose export plus management UI for conflicts
- document annotation usage and add tests that cover persistence, history, and export flows

## Testing
- yarn test radare2

------
https://chatgpt.com/codex/tasks/task_e_68dc93898a308328b5596b29ac37cbcb