### PR TITLE
[utils] idle queue scheduling for PDF viewer

### DIFF
--- a/components/common/PdfViewer/index.tsx
+++ b/components/common/PdfViewer/index.tsx
@@ -4,6 +4,13 @@ import React, { useEffect, useRef, useState } from 'react';
 import useRovingTabIndex from '../../../hooks/useRovingTabIndex';
 import type { PDFDocumentProxy } from 'pdfjs-dist';
 import type { TextItem } from 'pdfjs-dist/types/src/display/api';
+import getIdleQueue from '@/utils/idleQueue';
+
+type ProgressState = {
+  state: 'idle' | 'running' | 'complete';
+  completed: number;
+  total: number;
+};
 
 interface PdfViewerProps {
   url: string;
@@ -17,12 +24,44 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
   const [query, setQuery] = useState('');
   const [matches, setMatches] = useState<number[]>([]);
   const thumbListRef = useRef<HTMLDivElement | null>(null);
+  const pageTextIndexRef = useRef<string[]>([]);
+  const mountedRef = useRef(true);
+  const [thumbProgress, setThumbProgress] = useState<ProgressState>({
+    state: 'idle',
+    completed: 0,
+    total: 0,
+  });
+  const [indexProgress, setIndexProgress] = useState<ProgressState>({
+    state: 'idle',
+    completed: 0,
+    total: 0,
+  });
+  const [isIndexReady, setIsIndexReady] = useState(false);
 
   useRovingTabIndex(
     thumbListRef as React.RefObject<HTMLElement>,
     thumbs.length > 0,
     'horizontal',
   );
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const queue = getIdleQueue();
+    if (!queue) return;
+    let lastBlocked = queue.getMetrics().blockedInputs;
+    return queue.subscribe((metrics) => {
+      if (metrics.blockedInputs > lastBlocked && process.env.NODE_ENV !== 'production') {
+        console.debug('Idle queue paused for user input', metrics);
+      }
+      lastBlocked = metrics.blockedInputs;
+    });
+  }, []);
 
   useEffect(() => {
     let mounted = true;
@@ -44,6 +83,17 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
 
   useEffect(() => {
     if (!pdf) return;
+    setPage(1);
+    setThumbs([]);
+    setMatches([]);
+    setThumbProgress({ state: 'running', completed: 0, total: pdf.numPages });
+    setIndexProgress({ state: 'running', completed: 0, total: pdf.numPages });
+    setIsIndexReady(false);
+    pageTextIndexRef.current = new Array(pdf.numPages).fill('');
+  }, [pdf]);
+
+  useEffect(() => {
+    if (!pdf) return;
     const render = async () => {
       const pg = await pdf.getPage(page);
       const viewport = pg.getViewport({ scale: 1.5 });
@@ -61,10 +111,25 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
 
   useEffect(() => {
     if (!pdf) return;
-    const loadThumbs = async () => {
-      const arr: HTMLCanvasElement[] = [];
-      for (let i = 1; i <= pdf.numPages; i++) {
-        const pg = await pdf.getPage(i);
+
+    let cancelled = false;
+    const queue = getIdleQueue();
+    const totalPages = pdf.numPages;
+    let currentPage = 1;
+
+    const updateProgress = (completed: number, done: boolean) => {
+      if (!mountedRef.current) return;
+      setThumbProgress({
+        state: done ? 'complete' : 'running',
+        completed,
+        total: totalPages,
+      });
+    };
+
+    const fallback = async () => {
+      let processed = 0;
+      while (currentPage <= totalPages && !cancelled) {
+        const pg = await pdf.getPage(currentPage);
         const viewport = pg.getViewport({ scale: 0.2 });
         const canvas = document.createElement('canvas');
         canvas.height = viewport.height;
@@ -72,25 +137,190 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
         await pg
           .render({ canvasContext: canvas.getContext('2d')!, viewport, canvas })
           .promise;
-
-        arr.push(canvas);
+        processed += 1;
+        if (mountedRef.current) {
+          setThumbs((prev) => [...prev, canvas]);
+        }
+        currentPage += 1;
+        updateProgress(processed, processed >= totalPages);
       }
-      setThumbs(arr);
     };
-    loadThumbs();
-  }, [pdf]);
+
+    if (!queue) {
+      void fallback();
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const handle = queue.enqueue({
+      id: `pdf:${url}:thumbnails`,
+      label: 'pdf-thumbnails',
+      total: totalPages,
+      run: async ({ shouldYield, signal }) => {
+        let processed = 0;
+        while (currentPage <= totalPages && !shouldYield()) {
+          if (signal.aborted || cancelled) return { done: true, processed };
+          const pgIndex = currentPage;
+          currentPage += 1;
+          const pg = await pdf.getPage(pgIndex);
+          const viewport = pg.getViewport({ scale: 0.2 });
+          const canvas = document.createElement('canvas');
+          canvas.height = viewport.height;
+          canvas.width = viewport.width;
+          await pg
+            .render({ canvasContext: canvas.getContext('2d')!, viewport, canvas })
+            .promise;
+          if (signal.aborted || cancelled) return { done: true, processed };
+          processed += 1;
+          if (mountedRef.current) {
+            setThumbs((prev) => [...prev, canvas]);
+          }
+        }
+
+        const done = currentPage > totalPages;
+        updateProgress(Math.min(totalPages, currentPage - 1), done);
+        return { done, processed };
+      },
+      onProgress: ({ completed, total }) => {
+        if (cancelled) return;
+        updateProgress(Math.min(totalPages, completed), completed >= (total ?? totalPages));
+      },
+    });
+
+    return () => {
+      cancelled = true;
+      handle.cancel();
+    };
+  }, [pdf, url]);
+
+  useEffect(() => {
+    if (!pdf) return;
+
+    let cancelled = false;
+    const queue = getIdleQueue();
+    const totalPages = pdf.numPages;
+    let currentPage = 1;
+
+    const updateProgress = (completed: number, done: boolean) => {
+      if (!mountedRef.current) return;
+      setIndexProgress({
+        state: done ? 'complete' : 'running',
+        completed,
+        total: totalPages,
+      });
+      if (done) {
+        setIsIndexReady(true);
+      }
+    };
+
+    const fallback = async () => {
+      let processed = 0;
+      while (currentPage <= totalPages && !cancelled) {
+        const pg = await pdf.getPage(currentPage);
+        const textContent = await pg.getTextContent();
+        if (cancelled) return;
+        const text = (textContent.items as TextItem[])
+          .map((it) => it.str)
+          .join(' ');
+        pageTextIndexRef.current[currentPage - 1] = text;
+        processed += 1;
+        updateProgress(processed, processed >= totalPages);
+        currentPage += 1;
+      }
+    };
+
+    if (!queue) {
+      void fallback();
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const handle = queue.enqueue({
+      id: `pdf:${url}:index`,
+      label: 'pdf-indexer',
+      total: totalPages,
+      run: async ({ shouldYield, signal }) => {
+        let processed = 0;
+        while (currentPage <= totalPages && !shouldYield()) {
+          if (signal.aborted || cancelled) return { done: true, processed };
+          const pgIndex = currentPage;
+          currentPage += 1;
+          const pg = await pdf.getPage(pgIndex);
+          const textContent = await pg.getTextContent();
+          if (signal.aborted || cancelled) return { done: true, processed };
+          const text = (textContent.items as TextItem[])
+            .map((it) => it.str)
+            .join(' ');
+          pageTextIndexRef.current[pgIndex - 1] = text;
+          processed += 1;
+        }
+
+        const done = currentPage > totalPages;
+        updateProgress(Math.min(totalPages, currentPage - 1), done);
+      return { done, processed };
+      },
+      onProgress: ({ completed, total }) => {
+        if (cancelled) return;
+        updateProgress(Math.min(totalPages, completed), completed >= (total ?? totalPages));
+      },
+    });
+
+    return () => {
+      cancelled = true;
+      handle.cancel();
+    };
+  }, [pdf, url]);
 
   const search = async () => {
     if (!pdf) return;
-    const found: number[] = [];
-    for (let i = 1; i <= pdf.numPages; i++) {
-      const pg = await pdf.getPage(i);
-      const textContent = await pg.getTextContent();
-      const text = (textContent.items as TextItem[])
-        .map((it) => it.str)
-        .join(' ');
-      if (text.toLowerCase().includes(query.toLowerCase())) found.push(i);
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) {
+      setMatches([]);
+      return;
     }
+
+    const totalPages = pdf.numPages;
+    const found: number[] = [];
+    const textCache = pageTextIndexRef.current;
+
+    const hasCompleteIndex =
+      isIndexReady && textCache.length === totalPages && textCache.every((value) => Boolean(value));
+
+    if (hasCompleteIndex) {
+      textCache.forEach((text, idx) => {
+        if (text && text.toLowerCase().includes(normalized)) {
+          found.push(idx + 1);
+        }
+      });
+    } else {
+      let completed = textCache.filter((value) => value).length;
+      for (let i = 1; i <= totalPages; i++) {
+        let text = textCache[i - 1];
+        if (!text) {
+          const pg = await pdf.getPage(i);
+          const textContent = await pg.getTextContent();
+          text = (textContent.items as TextItem[])
+            .map((it) => it.str)
+            .join(' ');
+          pageTextIndexRef.current[i - 1] = text;
+          completed += 1;
+          setIndexProgress({
+            state: completed >= totalPages ? 'complete' : 'running',
+            completed,
+            total: totalPages,
+          });
+          if (completed >= totalPages) {
+            setIsIndexReady(true);
+          }
+        }
+        if (text.toLowerCase().includes(normalized)) {
+          found.push(i);
+        }
+      }
+    }
+
     setMatches(found);
     if (found[0]) setPage(found[0]);
   };
@@ -98,14 +328,40 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
   return (
     <div>
       <div className="flex gap-2 mb-2">
+        <label htmlFor="pdf-search" className="sr-only">
+          Search document text
+        </label>
         <input
+          id="pdf-search"
+          aria-label="Search document text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search"
         />
-        <button onClick={search}>Search</button>
+        <button
+          onClick={() => {
+            void search();
+          }}
+        >
+          Search
+        </button>
       </div>
-      <canvas ref={canvasRef} data-testid="pdf-canvas" />
+      {(thumbProgress.state === 'running' || thumbProgress.state === 'complete') && (
+        <p aria-live="polite" className="text-xs text-slate-400">
+          Thumbnails {thumbProgress.completed}/{thumbProgress.total}
+        </p>
+      )}
+      {(indexProgress.state === 'running' || indexProgress.state === 'complete') && (
+        <p aria-live="polite" className="text-xs text-slate-400">
+          Indexing {indexProgress.completed}/{indexProgress.total}
+          {!isIndexReady && indexProgress.state === 'running' && ' (in progress)'}
+        </p>
+      )}
+      <canvas
+        ref={canvasRef}
+        data-testid="pdf-canvas"
+        aria-label="PDF page"
+      />
       <div
         className="flex gap-2 overflow-x-auto mt-2"
         role="listbox"
@@ -126,6 +382,7 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
             }}
             width={t.width}
             height={t.height}
+            aria-label={`Page ${i + 1}`}
           />
         ))}
       </div>

--- a/utils/idleQueue.ts
+++ b/utils/idleQueue.ts
@@ -1,0 +1,381 @@
+type IdleRequestCallback = (deadline: IdleDeadline) => void;
+
+type IdleCallbackId = number;
+
+interface IdleJobContext {
+  shouldYield: () => boolean;
+  signal: AbortSignal;
+}
+
+export interface IdleJobResult {
+  done: boolean;
+  processed?: number;
+}
+
+export interface IdleJobProgress {
+  id: string;
+  label?: string;
+  completed: number;
+  total?: number;
+}
+
+export interface IdleJobOptions {
+  id: string;
+  label?: string;
+  total?: number;
+  priority?: 'normal' | 'high';
+  run: (context: IdleJobContext) => IdleJobResult | Promise<IdleJobResult>;
+  onProgress?: (progress: IdleJobProgress) => void;
+}
+
+export interface IdleJobHandle {
+  cancel: () => void;
+}
+
+export interface IdleQueueMetrics {
+  blockedInputs: number;
+  longestInputDelay: number;
+  lastInputEvent: number;
+  runningJobId: string | null;
+  queuedJobs: number;
+}
+
+type MetricsListener = (metrics: IdleQueueMetrics) => void;
+
+interface IdleJobInternal extends IdleJobOptions {
+  controller: AbortController;
+  completed: number;
+}
+
+const DEFAULT_CHUNK_BUDGET = 12;
+const MAX_TIMEOUT = 1000;
+const FALLBACK_FRAME = 16;
+const INPUT_PAUSE_WINDOW = 150;
+
+const globalScope =
+  typeof globalThis !== 'undefined' ? (globalThis as Window & typeof globalThis) : undefined;
+
+const isBrowser = Boolean(globalScope && 'document' in globalScope);
+
+const now = (): number => {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+};
+
+const supportsRequestIdleCallback = Boolean(globalScope?.requestIdleCallback);
+
+const requestIdle = supportsRequestIdleCallback
+  ? (cb: IdleRequestCallback): IdleCallbackId =>
+      (globalScope!.requestIdleCallback as typeof requestIdleCallback)(cb, { timeout: MAX_TIMEOUT })
+  : (cb: IdleRequestCallback): IdleCallbackId =>
+      globalScope!.setTimeout(() => cb(createFallbackDeadline(DEFAULT_CHUNK_BUDGET)), FALLBACK_FRAME);
+
+const cancelIdle = supportsRequestIdleCallback
+  ? (id: IdleCallbackId) => (globalScope!.cancelIdleCallback as typeof cancelIdleCallback)(id)
+  : (id: IdleCallbackId) => globalScope!.clearTimeout(id);
+
+function createFallbackDeadline(budget: number): IdleDeadline {
+  const start = now();
+  return {
+    didTimeout: false,
+    timeRemaining: () => Math.max(0, budget - (now() - start)),
+  } as IdleDeadline;
+}
+
+const hasPendingInput = (): boolean => {
+  if (typeof navigator === 'undefined') return false;
+  const sched = (navigator as unknown as { scheduling?: { isInputPending?: (opts?: { includeContinuous: boolean }) => boolean } }).scheduling;
+  if (sched?.isInputPending) {
+    try {
+      return sched.isInputPending({ includeContinuous: true });
+    } catch {
+      return sched.isInputPending();
+    }
+  }
+  return false;
+};
+
+export class IdleQueue {
+  private jobs: IdleJobInternal[] = [];
+
+  private pendingId: IdleCallbackId | null = null;
+
+  private pendingType: 'idle' | 'timeout' | null = null;
+
+  private pausedUntil = 0;
+
+  private lastInput = 0;
+
+  private metrics: IdleQueueMetrics = {
+    blockedInputs: 0,
+    longestInputDelay: 0,
+    lastInputEvent: 0,
+    runningJobId: null,
+    queuedJobs: 0,
+  };
+
+  private metricsListeners = new Set<MetricsListener>();
+
+  private currentJob: IdleJobInternal | null = null;
+
+  private currentChunkStart = 0;
+
+  constructor(private chunkBudget = DEFAULT_CHUNK_BUDGET) {
+    if (!isBrowser) return;
+
+    const handler = () => {
+      this.lastInput = now();
+      this.pausedUntil = this.lastInput + INPUT_PAUSE_WINDOW;
+      this.metrics.lastInputEvent = this.lastInput;
+      if (this.currentJob) {
+        this.metrics.blockedInputs += 1;
+        const delay = this.currentChunkStart ? now() - this.currentChunkStart : 0;
+        if (delay > this.metrics.longestInputDelay) {
+          this.metrics.longestInputDelay = delay;
+        }
+        this.emitMetrics();
+      }
+      if (this.pendingId !== null) {
+        cancelIdle(this.pendingId);
+        this.pendingId = null;
+        this.pendingType = null;
+      }
+      this.schedule();
+    };
+
+    ['pointerdown', 'keydown', 'touchstart', 'wheel'].forEach((eventName) => {
+      globalScope?.addEventListener(eventName, handler as EventListener, {
+        passive: true,
+        capture: true,
+      });
+    });
+  }
+
+  enqueue(options: IdleJobOptions): IdleJobHandle {
+    if (!isBrowser) {
+      return { cancel: () => undefined };
+    }
+
+    const controller = new AbortController();
+    const job: IdleJobInternal = {
+      ...options,
+      controller,
+      completed: 0,
+    };
+
+    if (options.priority === 'high') {
+      this.jobs.unshift(job);
+    } else {
+      this.jobs.push(job);
+    }
+
+    this.updateQueueMetrics();
+    this.schedule();
+
+    return {
+      cancel: () => {
+        if (controller.signal.aborted) return;
+        controller.abort();
+        const idx = this.jobs.indexOf(job);
+        if (idx >= 0) {
+          this.jobs.splice(idx, 1);
+        }
+        if (this.currentJob === job) {
+          this.currentJob = null;
+        }
+        this.updateQueueMetrics();
+      },
+    };
+  }
+
+  subscribe(listener: MetricsListener): () => void {
+    this.metricsListeners.add(listener);
+    listener({ ...this.metrics });
+    return () => {
+      this.metricsListeners.delete(listener);
+    };
+  }
+
+  getMetrics(): IdleQueueMetrics {
+    return { ...this.metrics };
+  }
+
+  private emitMetrics(): void {
+    const snapshot = { ...this.metrics };
+    this.metricsListeners.forEach((listener) => listener(snapshot));
+    if (isBrowser) {
+      (globalScope as unknown as { __idleQueueMetrics?: IdleQueueMetrics }).__idleQueueMetrics = snapshot;
+    }
+  }
+
+  private updateQueueMetrics(): void {
+    this.metrics.queuedJobs = this.jobs.length;
+    this.metrics.runningJobId = this.currentJob?.id ?? null;
+    this.emitMetrics();
+  }
+
+  private schedule(): void {
+    if (!isBrowser) return;
+    if (this.jobs.length === 0 || this.pendingId !== null || this.pendingType === 'timeout') return;
+
+    const nowTime = now();
+    if (this.pausedUntil > nowTime) {
+      const delay = Math.max(0, this.pausedUntil - nowTime);
+      this.pendingType = 'timeout';
+      this.pendingId = globalScope!.setTimeout(() => {
+        this.pendingType = null;
+        this.pendingId = null;
+        this.schedule();
+      }, delay);
+      return;
+    }
+
+    this.pendingType = supportsRequestIdleCallback ? 'idle' : 'timeout';
+    if (supportsRequestIdleCallback) {
+      this.pendingId = requestIdle((deadline) => this.handleIdle(deadline));
+    } else {
+      this.pendingId = requestIdle((deadline) => this.handleIdle(deadline));
+    }
+  }
+
+  private handleIdle(deadline: IdleDeadline): void {
+    this.pendingId = null;
+    this.pendingType = null;
+
+    if (this.jobs.length === 0) {
+      this.updateQueueMetrics();
+      return;
+    }
+
+    const maybePromise = this.processJobs(deadline);
+    if (maybePromise && typeof (maybePromise as Promise<unknown>).then === 'function') {
+      (maybePromise as Promise<void>)
+        .catch((error) => {
+          if (process.env.NODE_ENV !== 'production') {
+            console.error('Idle job failed', error);
+          }
+        })
+        .finally(() => {
+          this.currentJob = null;
+          this.updateQueueMetrics();
+          this.schedule();
+        });
+    } else {
+      this.currentJob = null;
+      this.updateQueueMetrics();
+      this.schedule();
+    }
+  }
+
+  private processJobs(deadline: IdleDeadline): void | Promise<void> {
+    if (!this.jobs.length) return;
+
+    if (this.shouldPauseForInput()) {
+      this.schedule();
+      return;
+    }
+
+    const job = this.jobs[0];
+
+    if (job.controller.signal.aborted) {
+      this.jobs.shift();
+      return this.processJobs(deadline);
+    }
+
+    this.currentJob = job;
+    this.currentChunkStart = now();
+    this.metrics.runningJobId = job.id;
+    this.emitMetrics();
+
+    const budget = Math.max(1, Math.min(this.chunkBudget, this.safeTimeRemaining(deadline)));
+    const chunkEnd = this.currentChunkStart + budget;
+
+    const context: IdleJobContext = {
+      signal: job.controller.signal,
+      shouldYield: () => this.shouldYield(deadline, chunkEnd),
+    };
+
+    try {
+      const result = job.run(context);
+      if (result && typeof (result as PromiseLike<IdleJobResult>).then === 'function') {
+        return (result as PromiseLike<IdleJobResult>)
+          .then((value) => {
+            this.onJobResult(job, value);
+          })
+          .catch((error) => {
+            if (process.env.NODE_ENV !== 'production') {
+              console.error('Idle job failed', error);
+            }
+            this.jobs.shift();
+          });
+      }
+      this.onJobResult(job, result as IdleJobResult);
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('Idle job failed', error);
+      }
+      this.jobs.shift();
+    }
+  }
+
+  private onJobResult(job: IdleJobInternal, result: IdleJobResult): void {
+    if (typeof result.processed === 'number' && !Number.isNaN(result.processed)) {
+      job.completed += result.processed;
+      const total = job.total ?? job.completed;
+      job.onProgress?.({
+        id: job.id,
+        label: job.label,
+        completed: Math.min(job.completed, total),
+        total,
+      });
+    }
+
+    if (result.done || job.controller.signal.aborted) {
+      this.jobs.shift();
+      const total = job.total ?? job.completed;
+      job.onProgress?.({
+        id: job.id,
+        label: job.label,
+        completed: total,
+        total,
+      });
+    }
+  }
+
+  private shouldYield(deadline: IdleDeadline, chunkEnd: number): boolean {
+    if (this.shouldPauseForInput()) return true;
+    if (deadline.didTimeout) return false;
+    if (this.safeTimeRemaining(deadline) <= 1) return true;
+    return now() >= chunkEnd;
+  }
+
+  private shouldPauseForInput(): boolean {
+    const nowTime = now();
+    if (hasPendingInput()) return true;
+    if (this.pausedUntil > nowTime) return true;
+    if (this.lastInput && nowTime - this.lastInput < INPUT_PAUSE_WINDOW) return true;
+    return false;
+  }
+
+  private safeTimeRemaining(deadline: IdleDeadline): number {
+    try {
+      return deadline.timeRemaining();
+    } catch {
+      return this.chunkBudget;
+    }
+  }
+}
+
+let sharedQueue: IdleQueue | null = null;
+
+export const getIdleQueue = (): IdleQueue | null => {
+  if (!isBrowser) return null;
+  if (!sharedQueue) {
+    sharedQueue = new IdleQueue();
+  }
+  return sharedQueue;
+};
+
+export default getIdleQueue;


### PR DESCRIPTION
## Summary
- add a shared idle queue scheduler that chunks work, pauses on input, and reports metrics
- render PDF thumbnails and search index in idle tasks with user-visible progress in the viewer
- log idle queue pauses in development so we can monitor input latency impact

## Testing
- [x] yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dca4c4d33c83288fe112f599d65611