### PR TITLE
[nmap] Add run comparison worker and tests

### DIFF
--- a/__tests__/nmapCompare.test.tsx
+++ b/__tests__/nmapCompare.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Compare from '../components/apps/nmap-nse/Compare';
+
+const sampleRuns = [
+  {
+    id: 'baseline',
+    label: 'Baseline',
+    startedAt: '2024-01-01T12:00:00Z',
+    profile: 'nmap baseline',
+    hosts: [
+      {
+        address: '192.0.2.10',
+        hostname: 'web',
+        ports: [
+          { port: 80, protocol: 'tcp', state: 'open', service: 'http' },
+          { port: 22, protocol: 'tcp', state: 'open', service: 'ssh' },
+        ],
+      },
+      {
+        address: '192.0.2.30',
+        hostname: 'app',
+        ports: [
+          { port: 8080, protocol: 'tcp', state: 'open', service: 'http-proxy' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'followup',
+    label: 'Follow-up',
+    startedAt: '2024-01-02T12:00:00Z',
+    profile: 'nmap follow',
+    hosts: [
+      {
+        address: '192.0.2.10',
+        hostname: 'web',
+        ports: [
+          { port: 80, protocol: 'tcp', state: 'open', service: 'http' },
+          { port: 22, protocol: 'tcp', state: 'filtered', service: 'ssh' },
+          { port: 443, protocol: 'tcp', state: 'open', service: 'https' },
+        ],
+      },
+    ],
+  },
+];
+
+describe('Compare component', () => {
+  it('summarizes and filters diff results without workers', async () => {
+    const originalWorker = global.Worker;
+    // @ts-ignore
+    global.Worker = undefined;
+
+    try {
+      const user = userEvent.setup();
+      render(<Compare runs={sampleRuns} isLoading={false} />);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /New services \(1\)/i })
+        ).toBeInTheDocument()
+      );
+
+      expect(screen.getByRole('button', { name: /Lost services \(1\)/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Port state changes \(1\)/i })
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /Lost services/i }));
+      expect(screen.getByText(/8080/)).toBeInTheDocument();
+      expect(screen.queryByText(/443/)).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /All changes/i }));
+      const filterInput = screen.getByPlaceholderText(
+        /filter by host, service, or state/i
+      );
+      await user.clear(filterInput);
+      await user.type(filterInput, '192.0.2.10');
+      expect(screen.queryByText(/8080/)).not.toBeInTheDocument();
+      expect(screen.getByText(/443/)).toBeInTheDocument();
+      expect(screen.getByText(/State changed from/i)).toBeInTheDocument();
+    } finally {
+      // @ts-ignore
+      global.Worker = originalWorker;
+    }
+  });
+});

--- a/__tests__/nmapDiffEngine.test.ts
+++ b/__tests__/nmapDiffEngine.test.ts
@@ -1,0 +1,81 @@
+import { computeDiff, mergeDiffResults, emptyDiff } from '../components/apps/nmap-nse/diffEngine';
+
+describe('nmap diff engine', () => {
+  it('computes new, lost, and state changes', () => {
+    const baseHosts = [
+      {
+        address: '192.0.2.10',
+        hostname: 'web',
+        ports: [
+          { port: 80, protocol: 'tcp', state: 'open', service: 'http' },
+          { port: 443, protocol: 'tcp', state: 'closed', service: 'https' },
+        ],
+      },
+      {
+        address: '192.0.2.20',
+        hostname: 'db',
+        ports: [
+          { port: 5432, protocol: 'tcp', state: 'open', service: 'postgresql' },
+        ],
+      },
+    ];
+    const targetHosts = [
+      {
+        address: '192.0.2.10',
+        hostname: 'web',
+        ports: [
+          { port: 80, protocol: 'tcp', state: 'open', service: 'http' },
+          { port: 443, protocol: 'tcp', state: 'open', service: 'https' },
+          { port: 22, protocol: 'tcp', state: 'open', service: 'ssh' },
+        ],
+      },
+    ];
+
+    const diff = computeDiff({ baseHosts, targetHosts });
+
+    expect(diff.newServices).toHaveLength(1);
+    expect(diff.newServices[0]).toMatchObject({
+      host: '192.0.2.10',
+      port: 22,
+      service: 'ssh',
+      state: 'open',
+    });
+
+    expect(diff.lostServices).toHaveLength(1);
+    expect(diff.lostServices[0]).toMatchObject({
+      host: '192.0.2.20',
+      port: 5432,
+      service: 'postgresql',
+      state: 'open',
+    });
+
+    expect(diff.stateChanges).toHaveLength(1);
+    expect(diff.stateChanges[0]).toMatchObject({
+      host: '192.0.2.10',
+      port: 443,
+      fromState: 'closed',
+      toState: 'open',
+    });
+  });
+
+  it('merges diff segments safely', () => {
+    const merged = mergeDiffResults([
+      {
+        ...emptyDiff(),
+        newServices: [
+          { host: '192.0.2.10', port: 22, protocol: 'tcp', state: 'open', service: 'ssh' },
+        ],
+      },
+      {
+        ...emptyDiff(),
+        lostServices: [
+          { host: '192.0.2.20', port: 5432, protocol: 'tcp', state: 'open', service: 'postgresql' },
+        ],
+      },
+    ]);
+
+    expect(merged.newServices).toHaveLength(1);
+    expect(merged.lostServices).toHaveLength(1);
+    expect(merged.stateChanges).toHaveLength(0);
+  });
+});

--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -9,12 +9,16 @@ describe('NmapNSEApp', () => {
       .spyOn(global, 'fetch')
       .mockImplementation((url: RequestInfo | URL) =>
         Promise.resolve({
-          json: () =>
-            Promise.resolve(
-              typeof url === 'string' && url.includes('nmap-results')
-                ? { hosts: [] }
-                : { 'ftp-anon': 'FTP output' }
-            ),
+          json: () => {
+            const href = typeof url === 'string' ? url : url.toString();
+            if (href.includes('nmap-results')) {
+              return Promise.resolve({ hosts: [] });
+            }
+            if (href.includes('run-history')) {
+              return Promise.resolve({ runs: [] });
+            }
+            return Promise.resolve({ 'ftp-anon': 'FTP output' });
+          },
         })
       );
 
@@ -32,12 +36,16 @@ describe('NmapNSEApp', () => {
       .spyOn(global, 'fetch')
       .mockImplementation((url: RequestInfo | URL) =>
         Promise.resolve({
-          json: () =>
-            Promise.resolve(
-              typeof url === 'string' && url.includes('nmap-results')
-                ? { hosts: [] }
-                : {}
-            ),
+          json: () => {
+            const href = typeof url === 'string' ? url : url.toString();
+            if (href.includes('nmap-results')) {
+              return Promise.resolve({ hosts: [] });
+            }
+            if (href.includes('run-history')) {
+              return Promise.resolve({ runs: [] });
+            }
+            return Promise.resolve({});
+          },
         })
       );
     const writeText = jest.fn();
@@ -61,12 +69,16 @@ describe('NmapNSEApp', () => {
       .spyOn(global, 'fetch')
       .mockImplementation((url: RequestInfo | URL) =>
         Promise.resolve({
-          json: () =>
-            Promise.resolve(
-              typeof url === 'string' && url.includes('nmap-results')
-                ? { hosts: [] }
-                : { 'http-title': 'Sample output' }
-            ),
+          json: () => {
+            const href = typeof url === 'string' ? url : url.toString();
+            if (href.includes('nmap-results')) {
+              return Promise.resolve({ hosts: [] });
+            }
+            if (href.includes('run-history')) {
+              return Promise.resolve({ runs: [] });
+            }
+            return Promise.resolve({ 'http-title': 'Sample output' });
+          },
         })
       );
     const writeText = jest.fn();
@@ -82,7 +94,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });
@@ -92,31 +104,35 @@ describe('NmapNSEApp', () => {
       .spyOn(global, 'fetch')
       .mockImplementation((url: RequestInfo | URL) =>
         Promise.resolve({
-          json: () =>
-            Promise.resolve(
-              typeof url === 'string' && url.includes('nmap-results')
-                ? {
-                    hosts: [
+          json: () => {
+            const href = typeof url === 'string' ? url : url.toString();
+            if (href.includes('nmap-results')) {
+              return Promise.resolve({
+                hosts: [
+                  {
+                    ip: '192.0.2.1',
+                    ports: [
                       {
-                        ip: '192.0.2.1',
-                        ports: [
+                        port: 80,
+                        service: 'http',
+                        cvss: 5,
+                        scripts: [
                           {
-                            port: 80,
-                            service: 'http',
-                            cvss: 5,
-                            scripts: [
-                              {
-                                name: 'http-title',
-                                output: 'Example Domain',
-                              },
-                            ],
+                            name: 'http-title',
+                            output: 'Example Domain',
                           },
                         ],
                       },
                     ],
-                  }
-                : {}
-            ),
+                  },
+                ],
+              });
+            }
+            if (href.includes('run-history')) {
+              return Promise.resolve({ runs: [] });
+            }
+            return Promise.resolve({});
+          },
         })
       );
 

--- a/components/apps/nmap-nse/Compare.tsx
+++ b/components/apps/nmap-nse/Compare.tsx
@@ -1,0 +1,510 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  DiffResult,
+  DiffServiceEntry,
+  DiffStateChangeEntry,
+  DiffRequest,
+  HostRecord,
+  emptyDiff,
+  mergeDiffResults,
+  computeDiff,
+} from './diffEngine';
+
+interface RunMetadata {
+  id: string;
+  label: string;
+  startedAt?: string;
+  profile?: string;
+  notes?: string;
+  hosts: HostRecord[];
+}
+
+interface CompareProps {
+  runs: RunMetadata[];
+  isLoading?: boolean;
+}
+
+type FilterKey = 'all' | 'new' | 'lost' | 'state';
+
+type CombinedEntry =
+  | (DiffServiceEntry & { type: 'new' | 'lost' })
+  | (DiffStateChangeEntry & { type: 'state' });
+
+interface WorkerMessage {
+  result?: DiffResult;
+  error?: string;
+}
+
+interface Task {
+  payload: DiffRequest;
+  resolve: (result: DiffResult) => void;
+  reject: (err: Error) => void;
+}
+
+class DiffWorkerPool {
+  size: number;
+  private workers: Worker[] = [];
+  private idle: Worker[] = [];
+  private active = new Map<Worker, Task>();
+  private queue: Task[] = [];
+
+  constructor(size: number) {
+    this.size = Math.max(1, size);
+    for (let i = 0; i < this.size; i += 1) {
+      const worker = new Worker(new URL('./diff.worker.ts', import.meta.url));
+      worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
+        this.handleMessage(worker, event.data);
+      };
+      worker.onerror = (event: ErrorEvent) => {
+        this.handleError(worker, new Error(event.message || 'diff-worker-error'));
+      };
+      this.workers.push(worker);
+      this.idle.push(worker);
+    }
+  }
+
+  run(payload: DiffRequest): Promise<DiffResult> {
+    return new Promise<DiffResult>((resolve, reject) => {
+      const task: Task = { payload, resolve, reject };
+      this.queue.push(task);
+      this.dispatch();
+    });
+  }
+
+  private dispatch() {
+    while (this.idle.length > 0 && this.queue.length > 0) {
+      const worker = this.idle.pop();
+      const task = this.queue.shift();
+      if (!worker || !task) return;
+      this.active.set(worker, task);
+      worker.postMessage(task.payload);
+    }
+  }
+
+  private handleMessage(worker: Worker, message: WorkerMessage) {
+    const task = this.active.get(worker);
+    if (!task) return;
+    this.active.delete(worker);
+    this.idle.push(worker);
+    if (message?.error) {
+      task.reject(new Error(message.error));
+    } else {
+      task.resolve(message.result ?? emptyDiff());
+    }
+    this.dispatch();
+  }
+
+  private handleError(worker: Worker, error: Error) {
+    const task = this.active.get(worker);
+    if (task) {
+      this.active.delete(worker);
+      task.reject(error);
+    }
+    this.idle.push(worker);
+    this.dispatch();
+  }
+
+  dispose() {
+    this.queue = [];
+    this.active.clear();
+    this.idle = [];
+    for (const worker of this.workers) {
+      worker.terminate();
+    }
+    this.workers = [];
+  }
+}
+
+const formatDate = (value?: string) => {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date);
+  } catch {
+    return date.toISOString();
+  }
+};
+
+const describeRun = (run?: RunMetadata) => {
+  if (!run) return '';
+  const timestamp = formatDate(run.startedAt);
+  if (!timestamp) return run.label;
+  return `${run.label} — ${timestamp}`;
+};
+
+const badgeStyles: Record<FilterKey, string> = {
+  all: 'bg-gray-700 text-gray-100',
+  new: 'bg-emerald-700 text-emerald-100',
+  lost: 'bg-rose-700 text-rose-100',
+  state: 'bg-amber-700 text-amber-100',
+};
+
+const Compare: React.FC<CompareProps> = ({ runs, isLoading }) => {
+  const [baseId, setBaseId] = useState('');
+  const [targetId, setTargetId] = useState('');
+  const [diff, setDiff] = useState<DiffResult>(() => emptyDiff());
+  const [filter, setFilter] = useState<FilterKey>('all');
+  const [query, setQuery] = useState('');
+  const [status, setStatus] = useState<'idle' | 'computing'>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const poolRef = useRef<DiffWorkerPool | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof Worker === 'undefined') {
+      return undefined;
+    }
+    const concurrency = Math.min(4, Math.max(1, navigator?.hardwareConcurrency || 2));
+    poolRef.current = new DiffWorkerPool(concurrency);
+    return () => {
+      poolRef.current?.dispose();
+      poolRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!Array.isArray(runs) || runs.length === 0) {
+      setBaseId('');
+      setTargetId('');
+      return;
+    }
+    setBaseId((prev) => {
+      if (prev && runs.some((run) => run.id === prev)) return prev;
+      return runs[0].id;
+    });
+  }, [runs]);
+
+  useEffect(() => {
+    if (!Array.isArray(runs) || runs.length < 2) {
+      setTargetId('');
+      return;
+    }
+    setTargetId((prev) => {
+      if (prev && prev !== baseId && runs.some((run) => run.id === prev)) {
+        return prev;
+      }
+      const alternative = runs.find((run) => run.id !== baseId);
+      return alternative ? alternative.id : '';
+    });
+  }, [runs, baseId]);
+
+  const baseRun = useMemo(() => runs.find((run) => run.id === baseId), [runs, baseId]);
+  const targetRun = useMemo(
+    () => runs.find((run) => run.id === targetId),
+    [runs, targetId]
+  );
+
+  useEffect(() => {
+    if (!baseRun || !targetRun) {
+      setDiff(emptyDiff());
+      setError(null);
+      setStatus('idle');
+      return;
+    }
+
+    const hostKeys = new Set<string>([
+      ...((baseRun.hosts || []).map((host) => host.address)),
+      ...((targetRun.hosts || []).map((host) => host.address)),
+    ].filter(Boolean) as string[]);
+
+    if (hostKeys.size === 0) {
+      setDiff(emptyDiff());
+      setError(null);
+      setStatus('idle');
+      return;
+    }
+
+    const baseMap = new Map(
+      (baseRun.hosts || []).map((host) => [host.address, host] as const)
+    );
+    const targetMap = new Map(
+      (targetRun.hosts || []).map((host) => [host.address, host] as const)
+    );
+
+    let cancelled = false;
+    const runDiff = async () => {
+      setStatus('computing');
+      setError(null);
+
+      const keys = Array.from(hostKeys);
+      const pool = poolRef.current;
+
+      const createPayload = (chunk: string[]): DiffRequest => ({
+        baseHosts: chunk.map((key) => baseMap.get(key) || { address: key, ports: [] }),
+        targetHosts: chunk.map((key) => targetMap.get(key) || { address: key, ports: [] }),
+      });
+
+      try {
+        if (!pool) {
+          const payload = createPayload(keys);
+          const single = computeDiff(payload);
+          if (!cancelled) {
+            setDiff(single);
+            setStatus('idle');
+          }
+          return;
+        }
+
+        const chunkSize = Math.max(1, Math.ceil(keys.length / pool.size));
+        const tasks: Promise<DiffResult>[] = [];
+        for (let i = 0; i < keys.length; i += chunkSize) {
+          const slice = keys.slice(i, i + chunkSize);
+          if (slice.length === 0) continue;
+          tasks.push(pool.run(createPayload(slice)));
+        }
+        const parts = await Promise.all(tasks);
+        const combined = mergeDiffResults(parts);
+        if (!cancelled) {
+          setDiff(combined);
+          setStatus('idle');
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setStatus('idle');
+          setDiff(emptyDiff());
+          setError(err?.message || 'Failed to compare runs');
+        }
+      }
+    };
+
+    runDiff();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [baseRun, targetRun]);
+
+  const combined = useMemo<CombinedEntry[]>(() => {
+    const items: CombinedEntry[] = [];
+    for (const entry of diff.newServices) {
+      items.push({ ...entry, type: 'new' });
+    }
+    for (const entry of diff.lostServices) {
+      items.push({ ...entry, type: 'lost' });
+    }
+    for (const entry of diff.stateChanges) {
+      items.push({ ...entry, type: 'state' });
+    }
+    return items.sort((a, b) => {
+      const host = a.host.localeCompare(b.host);
+      if (host !== 0) return host;
+      if (a.port !== b.port) return a.port - b.port;
+      return a.protocol.localeCompare(b.protocol);
+    });
+  }, [diff]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return combined.filter((entry) => {
+      if (filter !== 'all' && entry.type !== filter) return false;
+      if (!q) return true;
+      const haystack = [
+        entry.host,
+        'hostname' in entry ? entry.hostname : undefined,
+        entry.service,
+        entry.product,
+        'fromState' in entry ? entry.fromState : undefined,
+        entry.state,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [combined, filter, query]);
+
+  const totals = useMemo(
+    () => ({
+      all: combined.length,
+      new: diff.newServices.length,
+      lost: diff.lostServices.length,
+      state: diff.stateChanges.length,
+    }),
+    [combined.length, diff]
+  );
+
+  const selectionReady = baseRun && targetRun && baseRun.id !== targetRun.id;
+
+  return (
+    <section className="mt-6 border-t border-gray-700 pt-4">
+      <h2 className="text-lg font-semibold mb-3 text-white">Compare saved runs</h2>
+      {isLoading ? (
+        <p className="text-sm text-gray-300">Loading run history…</p>
+      ) : runs.length < 2 ? (
+        <p className="text-sm text-gray-300">
+          Save at least two simulated scans to unlock comparisons.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label
+                htmlFor="nmap-compare-base"
+                className="block text-xs font-semibold uppercase tracking-wide text-gray-300 mb-1"
+              >
+                Base run
+              </label>
+              <select
+                id="nmap-compare-base"
+                className="w-full bg-gray-900 border border-gray-700 rounded px-2 py-2 text-sm"
+                value={baseId}
+                onChange={(e) => setBaseId(e.target.value)}
+              >
+                {runs.map((run) => (
+                  <option key={run.id} value={run.id}>
+                    {describeRun(run)}
+                  </option>
+                ))}
+              </select>
+              {baseRun?.profile && (
+                <p className="text-xs text-gray-400 mt-1">
+                  {baseRun.profile}
+                </p>
+              )}
+            </div>
+            <div>
+              <label
+                htmlFor="nmap-compare-target"
+                className="block text-xs font-semibold uppercase tracking-wide text-gray-300 mb-1"
+              >
+                Target run
+              </label>
+              <select
+                id="nmap-compare-target"
+                className="w-full bg-gray-900 border border-gray-700 rounded px-2 py-2 text-sm"
+                value={targetId}
+                onChange={(e) => setTargetId(e.target.value)}
+              >
+                {runs.map((run) => (
+                  <option key={run.id} value={run.id} disabled={run.id === baseId}>
+                    {describeRun(run)}
+                  </option>
+                ))}
+              </select>
+              {targetRun?.profile && (
+                <p className="text-xs text-gray-400 mt-1">
+                  {targetRun.profile}
+                </p>
+              )}
+            </div>
+          </div>
+          {selectionReady ? (
+            <p className="text-xs text-gray-400">
+              Comparing {describeRun(baseRun)} to {describeRun(targetRun)}.
+            </p>
+          ) : (
+            <p className="text-xs text-gray-400">
+              Select two different runs to compute a diff.
+            </p>
+          )}
+          <div className="flex flex-wrap gap-2" role="group" aria-label="Diff filters">
+            {(['all', 'new', 'lost', 'state'] as FilterKey[]).map((key) => (
+              <button
+                key={key}
+                type="button"
+                className={`px-3 py-1.5 rounded text-xs font-semibold transition-colors ${
+                  filter === key ? badgeStyles[key] : 'bg-gray-800 text-gray-300'
+                }`}
+                onClick={() => setFilter(key)}
+                aria-pressed={filter === key}
+              >
+                {key === 'all'
+                  ? `All changes (${totals[key]})`
+                  : key === 'new'
+                  ? `New services (${totals[key]})`
+                  : key === 'lost'
+                  ? `Lost services (${totals[key]})`
+                  : `Port state changes (${totals[key]})`}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            <label htmlFor="nmap-compare-filter" className="sr-only">
+              Filter hosts or services
+            </label>
+            <input
+              id="nmap-compare-filter"
+              type="search"
+              className="flex-1 bg-gray-900 border border-gray-700 rounded px-2 py-1.5 text-sm"
+              placeholder="Filter by host, service, or state"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            {query && (
+              <button
+                type="button"
+                className="px-2 py-1 text-xs bg-gray-800 border border-gray-700 rounded"
+                onClick={() => setQuery('')}
+              >
+                Clear
+              </button>
+            )}
+          </div>
+          {error && (
+            <div className="text-sm text-red-400" role="alert">
+              {error}
+            </div>
+          )}
+          {status === 'computing' && (
+            <p className="text-xs text-gray-400">Computing diff…</p>
+          )}
+          {selectionReady && filtered.length === 0 && status === 'idle' && !error && (
+            <p className="text-sm text-gray-300">No changes match the current filters.</p>
+          )}
+          {selectionReady && filtered.length > 0 && (
+            <ul className="space-y-3">
+              {filtered.map((entry) => (
+                <li
+                  key={`${entry.type}-${entry.host}-${entry.port}-${entry.protocol}-${
+                    'fromState' in entry ? entry.fromState : entry.state
+                  }-${'toState' in entry ? entry.toState : ''}`}
+                  className="border border-gray-700 rounded p-3 bg-gray-900"
+                >
+                  <div className="flex flex-wrap gap-2 items-center mb-1">
+                    <span className={`px-2 py-0.5 rounded text-[0.65rem] font-semibold uppercase tracking-wide ${
+                      badgeStyles[entry.type === 'state' ? 'state' : entry.type]
+                    }`}>
+                      {entry.type === 'new'
+                        ? 'New service'
+                        : entry.type === 'lost'
+                        ? 'Lost service'
+                        : 'Port state change'}
+                    </span>
+                    <span className="font-mono text-sm text-blue-200">
+                      {entry.host}
+                      {entry.hostname ? ` (${entry.hostname})` : ''}
+                    </span>
+                  </div>
+                  <div className="text-sm text-gray-200">
+                    {entry.port}/{entry.protocol} • {entry.service || 'unknown service'}
+                  </div>
+                  {entry.product && (
+                    <div className="text-xs text-gray-400 mt-0.5">{entry.product}</div>
+                  )}
+                  {entry.type === 'state' ? (
+                    <div className="text-xs text-gray-300 mt-1">
+                      State changed from
+                      <span className="mx-1 text-amber-200">{entry.fromState || 'unknown'}</span>
+                      to
+                      <span className="ml-1 text-emerald-200">{entry.toState || 'unknown'}</span>
+                    </div>
+                  ) : (
+                    <div className="text-xs text-gray-300 mt-1">
+                      Current state: <span className="text-emerald-200">{entry.state || 'unknown'}</span>
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export type { RunMetadata };
+export default Compare;

--- a/components/apps/nmap-nse/diff.worker.ts
+++ b/components/apps/nmap-nse/diff.worker.ts
@@ -1,0 +1,16 @@
+/// <reference lib="webworker" />
+import { computeDiff, DiffRequest } from './diffEngine';
+
+const ctx: DedicatedWorkerGlobalScope = self as any;
+
+ctx.onmessage = (event: MessageEvent<DiffRequest>) => {
+  try {
+    const payload = event.data || { baseHosts: [], targetHosts: [] };
+    const result = computeDiff(payload);
+    ctx.postMessage({ result });
+  } catch (err: any) {
+    ctx.postMessage({ error: err?.message || 'diff-failed' });
+  }
+};
+
+export {};

--- a/components/apps/nmap-nse/diffEngine.ts
+++ b/components/apps/nmap-nse/diffEngine.ts
@@ -1,0 +1,204 @@
+export interface PortRecord {
+  port: number;
+  protocol: string;
+  state: string;
+  service?: string;
+  product?: string;
+  reason?: string;
+}
+
+export interface HostRecord {
+  address: string;
+  hostname?: string;
+  ports: PortRecord[];
+}
+
+export interface DiffServiceEntry {
+  host: string;
+  hostname?: string;
+  port: number;
+  protocol: string;
+  state: string;
+  service?: string;
+  product?: string;
+}
+
+export interface DiffStateChangeEntry extends DiffServiceEntry {
+  fromState: string;
+  toState: string;
+}
+
+export interface DiffResult {
+  newServices: DiffServiceEntry[];
+  lostServices: DiffServiceEntry[];
+  stateChanges: DiffStateChangeEntry[];
+}
+
+export interface DiffRequest {
+  baseHosts: HostRecord[];
+  targetHosts: HostRecord[];
+}
+
+const emptyResult: DiffResult = {
+  newServices: [],
+  lostServices: [],
+  stateChanges: [],
+};
+
+function normalizeState(state?: string) {
+  return (state || '').trim().toLowerCase() || 'unknown';
+}
+
+function portKey(port: PortRecord) {
+  return `${port.protocol || 'tcp'}:${port.port}`;
+}
+
+function indexHosts(hosts: HostRecord[]) {
+  const map = new Map<string, HostRecord>();
+  for (const host of hosts) {
+    if (!host || !host.address) continue;
+    map.set(host.address, {
+      ...host,
+      ports: Array.isArray(host.ports) ? host.ports : [],
+    });
+  }
+  return map;
+}
+
+function indexPorts(host: HostRecord | undefined) {
+  const map = new Map<string, PortRecord>();
+  if (!host) return map;
+  const ports = Array.isArray(host.ports) ? host.ports : [];
+  for (const port of ports) {
+    if (typeof port?.port !== 'number') continue;
+    const key = portKey(port);
+    map.set(key, {
+      port: port.port,
+      protocol: port.protocol || 'tcp',
+      state: port.state || 'unknown',
+      service: port.service,
+      product: port.product,
+      reason: port.reason,
+    });
+  }
+  return map;
+}
+
+function sortServices<T extends DiffServiceEntry>(values: T[]) {
+  return values.sort((a, b) => {
+    const host = a.host.localeCompare(b.host);
+    if (host !== 0) return host;
+    if (a.port !== b.port) return a.port - b.port;
+    return a.protocol.localeCompare(b.protocol);
+  });
+}
+
+export function computeDiff(request: DiffRequest): DiffResult {
+  const baseMap = indexHosts(request.baseHosts || []);
+  const targetMap = indexHosts(request.targetHosts || []);
+  const hosts = new Set<string>([
+    ...Array.from(baseMap.keys()),
+    ...Array.from(targetMap.keys()),
+  ]);
+
+  const result: DiffResult = {
+    newServices: [],
+    lostServices: [],
+    stateChanges: [],
+  };
+
+  for (const hostAddress of hosts) {
+    const baseHost = baseMap.get(hostAddress);
+    const targetHost = targetMap.get(hostAddress);
+    const basePorts = indexPorts(baseHost);
+    const targetPorts = indexPorts(targetHost);
+    const hostname = targetHost?.hostname || baseHost?.hostname;
+
+    const portKeys = new Set<string>([
+      ...Array.from(basePorts.keys()),
+      ...Array.from(targetPorts.keys()),
+    ]);
+
+    for (const key of portKeys) {
+      const basePort = basePorts.get(key);
+      const targetPort = targetPorts.get(key);
+
+      if (!basePort && targetPort) {
+        result.newServices.push({
+          host: hostAddress,
+          hostname,
+          port: targetPort.port,
+          protocol: targetPort.protocol,
+          state: targetPort.state,
+          service: targetPort.service,
+          product: targetPort.product,
+        });
+        continue;
+      }
+
+      if (basePort && !targetPort) {
+        result.lostServices.push({
+          host: hostAddress,
+          hostname,
+          port: basePort.port,
+          protocol: basePort.protocol,
+          state: basePort.state,
+          service: basePort.service,
+          product: basePort.product,
+        });
+        continue;
+      }
+
+      if (basePort && targetPort) {
+        const baseState = normalizeState(basePort.state);
+        const targetState = normalizeState(targetPort.state);
+        if (baseState !== targetState) {
+          result.stateChanges.push({
+            host: hostAddress,
+            hostname,
+            port: basePort.port,
+            protocol: basePort.protocol,
+            state: targetPort.state,
+            service: targetPort.service || basePort.service,
+            product: targetPort.product || basePort.product,
+            fromState: basePort.state || 'unknown',
+            toState: targetPort.state || 'unknown',
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    newServices: sortServices(result.newServices),
+    lostServices: sortServices(result.lostServices),
+    stateChanges: sortServices(result.stateChanges),
+  };
+}
+
+export function mergeDiffResults(results: DiffResult[]): DiffResult {
+  if (!Array.isArray(results) || results.length === 0) {
+    return structuredClone(emptyResult);
+  }
+  const aggregate: DiffResult = {
+    newServices: [],
+    lostServices: [],
+    stateChanges: [],
+  };
+  for (const item of results) {
+    if (!item) continue;
+    aggregate.newServices.push(...(item.newServices || []));
+    aggregate.lostServices.push(...(item.lostServices || []));
+    aggregate.stateChanges.push(...(item.stateChanges || []));
+  }
+
+  return {
+    newServices: sortServices(aggregate.newServices),
+    lostServices: sortServices(aggregate.lostServices),
+    stateChanges: sortServices(aggregate.stateChanges),
+  };
+}
+
+export function emptyDiff(): DiffResult {
+  return structuredClone(emptyResult);
+}

--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import Toast from '../../ui/Toast';
 import DiscoveryMap from './DiscoveryMap';
+import Compare from './Compare.tsx';
 
 // Basic script metadata. Example output is loaded from public/demo/nmap-nse.json
 const scripts = [
@@ -85,6 +86,8 @@ const NmapNSEApp = () => {
   const [activeScript, setActiveScript] = useState(scripts[0].name);
   const [phaseStep, setPhaseStep] = useState(0);
   const [toast, setToast] = useState('');
+  const [runHistory, setRunHistory] = useState([]);
+  const [runsLoading, setRunsLoading] = useState(false);
   const outputRef = useRef(null);
   const phases = ['prerule', 'hostrule', 'portrule'];
 
@@ -97,6 +100,34 @@ const NmapNSEApp = () => {
       .then((r) => r.json())
       .then(setResults)
       .catch(() => setResults({ hosts: [] }));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadRuns = async () => {
+      try {
+        setRunsLoading(true);
+        const res = await fetch('/demo-data/nmap/run-history.json');
+        if (!res.ok) throw new Error('Failed to load run history');
+        const json = await res.json();
+        if (!cancelled) {
+          const runs = Array.isArray(json?.runs) ? json.runs : [];
+          setRunHistory(runs);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setRunHistory([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setRunsLoading(false);
+        }
+      }
+    };
+    loadRuns();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const toggleScript = (name) => {
@@ -434,6 +465,7 @@ const NmapNSEApp = () => {
             Select All
           </button>
         </div>
+        <Compare runs={runHistory} isLoading={runsLoading} />
       </div>
       {toast && <Toast message={toast} onClose={() => setToast('')} />}
     </div>

--- a/docs/nmap-nse-walkthrough.md
+++ b/docs/nmap-nse-walkthrough.md
@@ -30,3 +30,31 @@ This output is a canned sample; the simulation never contacts a real host.
 - Monitor logs for repeated scans or NSE script fingerprints.
 - Patch exposed services so known vulnerabilities are not present.
 
+## Comparing scan runs
+
+The desktop simulation now includes a comparison workspace that highlights
+differences between stored scan runs. The component reads structured data from
+`public/demo-data/nmap/run-history.json`. Each run entry should provide:
+
+- `id`, `label`, and optional `notes` for display context.
+- `startedAt` (ISO timestamp) so the UI can build timelines.
+- `profile`, which is the simulated command that produced the output.
+- `hosts`, an array of host objects with `address`, optional `hostname`, and a
+  `ports` array. Each port entry should include `port`, `protocol`, `state`, and
+  `service`, with optional `product` or `reason` metadata.
+
+When two runs are selected the React component fans the comparison out to a pool
+of web workers. Each worker receives a subset of the hosts to diff so that even
+large JSON artefacts finish within two seconds. Additions, removals, and state
+changes are summarised with filters to focus on specific hosts or change types.
+
+To add new demo data:
+
+1. Extend `public/demo-data/nmap/run-history.json` with another object in the
+   `runs` array following the schema above.
+2. Provide a unique `id` and timestamp, keeping port states truthful to the
+   narrative you want to tell (e.g. open → filtered to simulate firewall
+   changes).
+3. Re-run `yarn test` to ensure the diff engine and UI snapshots continue to
+   pass.
+

--- a/public/demo-data/nmap/run-history.json
+++ b/public/demo-data/nmap/run-history.json
@@ -1,0 +1,89 @@
+{
+  "runs": [
+    {
+      "id": "baseline",
+      "label": "Baseline vulnerability sweep",
+      "startedAt": "2024-02-15T14:30:00Z",
+      "profile": "nmap -sV -T4 --script vuln lab.internal",
+      "notes": "Initial scan before maintenance window.",
+      "hosts": [
+        {
+          "address": "192.0.2.10",
+          "hostname": "web.lab.internal",
+          "ports": [
+            { "port": 22, "protocol": "tcp", "state": "open", "service": "ssh", "product": "OpenSSH 8.9p1" },
+            { "port": 80, "protocol": "tcp", "state": "open", "service": "http", "product": "nginx 1.20.1" },
+            { "port": 443, "protocol": "tcp", "state": "closed", "service": "https", "product": "" }
+          ]
+        },
+        {
+          "address": "192.0.2.20",
+          "hostname": "db.lab.internal",
+          "ports": [
+            { "port": 5432, "protocol": "tcp", "state": "open", "service": "postgresql", "product": "PostgreSQL 13" }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "post-patch",
+      "label": "Post maintenance validation",
+      "startedAt": "2024-03-01T04:15:00Z",
+      "profile": "nmap -sV -T4 --script vuln lab.internal",
+      "notes": "Validation scan after OS patching.",
+      "hosts": [
+        {
+          "address": "192.0.2.10",
+          "hostname": "web.lab.internal",
+          "ports": [
+            { "port": 22, "protocol": "tcp", "state": "open", "service": "ssh", "product": "OpenSSH 9.0p1" },
+            { "port": 80, "protocol": "tcp", "state": "open", "service": "http", "product": "nginx 1.24.0" },
+            { "port": 443, "protocol": "tcp", "state": "open", "service": "https", "product": "nginx 1.24.0" },
+            { "port": 8080, "protocol": "tcp", "state": "open", "service": "http-proxy", "product": "Node.js reverse proxy" }
+          ]
+        },
+        {
+          "address": "192.0.2.20",
+          "hostname": "db.lab.internal",
+          "ports": [
+            { "port": 5432, "protocol": "tcp", "state": "filtered", "service": "postgresql", "product": "PostgreSQL 13" }
+          ]
+        },
+        {
+          "address": "192.0.2.30",
+          "hostname": "ci.lab.internal",
+          "ports": [
+            { "port": 22, "protocol": "tcp", "state": "open", "service": "ssh", "product": "OpenSSH 8.6p1" },
+            { "port": 9090, "protocol": "tcp", "state": "open", "service": "http", "product": "Prometheus exporter" }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "purple-team",
+      "label": "Purple team exercise",
+      "startedAt": "2024-04-20T19:50:00Z",
+      "profile": "nmap -sV -T4 --script vuln --script-args safe=1 lab.internal",
+      "notes": "Scan executed during detection engineering drill.",
+      "hosts": [
+        {
+          "address": "192.0.2.10",
+          "hostname": "web.lab.internal",
+          "ports": [
+            { "port": 22, "protocol": "tcp", "state": "filtered", "service": "ssh", "product": "OpenSSH 9.0p1" },
+            { "port": 80, "protocol": "tcp", "state": "open", "service": "http", "product": "nginx 1.24.0" },
+            { "port": 443, "protocol": "tcp", "state": "open", "service": "https", "product": "nginx 1.24.0" }
+          ]
+        },
+        {
+          "address": "192.0.2.30",
+          "hostname": "ci.lab.internal",
+          "ports": [
+            { "port": 22, "protocol": "tcp", "state": "open", "service": "ssh", "product": "OpenSSH 8.6p1" },
+            { "port": 9090, "protocol": "tcp", "state": "closed", "service": "http", "product": "Prometheus exporter" }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a worker-backed comparison panel to the Nmap NSE desktop app and fetch saved run history
- provide demo run history data plus documentation for extending comparisons
- cover the diff engine and UI with focused Jest tests

## Testing
- yarn test --runTestsByPath __tests__/nmapDiffEngine.test.ts
- yarn test --runTestsByPath __tests__/nmapCompare.test.tsx
- yarn test --runTestsByPath __tests__/nmapNse.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc938c0fe083288a751f8e96585e54