### PR TITLE
[performance] Capability-aware scheduler polish

### DIFF
--- a/__tests__/reportWebVitals.test.ts
+++ b/__tests__/reportWebVitals.test.ts
@@ -1,8 +1,13 @@
 import ReactGA from 'react-ga4';
 import { reportWebVitals } from '../utils/reportWebVitals';
+import { recordInputLatencyMetric } from '../utils/capabilities';
 
 jest.mock('react-ga4', () => ({
   event: jest.fn(),
+}));
+
+jest.mock('../utils/capabilities', () => ({
+  recordInputLatencyMetric: jest.fn(),
 }));
 
 describe('reportWebVitals', () => {
@@ -35,6 +40,7 @@ describe('reportWebVitals', () => {
       expect.objectContaining({ action: 'LCP' })
     );
     expect(warnSpy).not.toHaveBeenCalled();
+    expect(recordInputLatencyMetric).not.toHaveBeenCalled();
   });
 
   it('alerts when INP exceeds threshold', () => {
@@ -46,5 +52,6 @@ describe('reportWebVitals', () => {
       expect.objectContaining({ action: 'INP degraded' })
     );
     expect(warnSpy).toHaveBeenCalled();
+    expect(recordInputLatencyMetric).toHaveBeenCalledWith(300);
   });
 });

--- a/__tests__/scannerSchedule.test.ts
+++ b/__tests__/scannerSchedule.test.ts
@@ -1,8 +1,69 @@
 import { jest } from '@jest/globals';
+import type { DeviceCapabilities } from '../utils/capabilities';
+
+const baseCapabilities: DeviceCapabilities = {
+  battery: {
+    supported: false,
+    saver: false,
+    timestamp: 0,
+  },
+  hardware: {
+    cores: 4,
+    memory: 4,
+    cpuClass: 'mid',
+  },
+  network: {
+    saveData: false,
+    effectiveType: '4g',
+  },
+  platform: {
+    os: 'linux',
+    isMobile: false,
+    hints: [],
+  },
+  performance: {
+    mode: 'auto',
+    shouldThrottle: false,
+    intervalMultiplier: 1,
+    maxConcurrency: Number.POSITIVE_INFINITY,
+    reasons: [],
+    lastInputLatency: null,
+  },
+};
+
+const listeners: ((caps: DeviceCapabilities) => void)[] = [];
+let currentCaps: DeviceCapabilities = { ...baseCapabilities };
+
+jest.mock('../utils/capabilities', () => ({
+  getCachedCapabilities: jest.fn(() => currentCaps),
+  loadCapabilities: jest.fn(() => Promise.resolve(currentCaps)),
+  onCapabilitiesChange: jest.fn((listener: (caps: DeviceCapabilities) => void) => {
+    listeners.push(listener);
+    listener(currentCaps);
+    return () => {
+      const index = listeners.indexOf(listener);
+      if (index !== -1) listeners.splice(index, 1);
+    };
+  }),
+}));
+
+const setCapabilities = (caps: DeviceCapabilities) => {
+  currentCaps = caps;
+  listeners.forEach((listener) => listener(caps));
+};
+
+const restoreCapabilities = () => {
+  setCapabilities({ ...baseCapabilities });
+};
+
 import {
   scheduleScan,
   loadScheduledScans,
   clearSchedules,
+  __getSchedulerStateForTests,
+  __getRunningScansForTests,
+  __setTestCapabilitiesOverride,
+  __attemptExecuteForTests,
 } from '../scanner/schedule';
 
 describe('scan scheduler', () => {
@@ -10,6 +71,8 @@ describe('scan scheduler', () => {
     jest.useFakeTimers();
     clearSchedules();
     localStorage.clear();
+    restoreCapabilities();
+    __setTestCapabilitiesOverride(null);
   });
 
   afterEach(() => {
@@ -31,5 +94,70 @@ describe('scan scheduler', () => {
     expect(fn).toHaveBeenCalledTimes(1);
     jest.advanceTimersByTime(2000);
     expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test('slows scan cadence when capabilities recommend throttling', () => {
+    expect(typeof window).not.toBe('undefined');
+    const throttledCaps: DeviceCapabilities = {
+      battery: baseCapabilities.battery,
+      hardware: baseCapabilities.hardware,
+      network: baseCapabilities.network,
+      platform: baseCapabilities.platform,
+      performance: {
+        mode: 'auto',
+        shouldThrottle: true,
+        intervalMultiplier: 3,
+        maxConcurrency: 1,
+        reasons: ['battery-saver'],
+        lastInputLatency: null,
+      },
+    };
+    expect(throttledCaps.performance.intervalMultiplier).toBe(3);
+    __setTestCapabilitiesOverride(throttledCaps);
+    setCapabilities(throttledCaps);
+    expect(currentCaps.performance.intervalMultiplier).toBe(3);
+    expect(__getSchedulerStateForTests().intervalMultiplier).toBe(3);
+    const fn = jest.fn();
+    scheduleScan('slow', '*/1 * * * * *', fn);
+    const job = __getRunningScansForTests()[0];
+    expect(job.remainingDelay).toBeGreaterThan(0);
+    jest.advanceTimersByTime(2000);
+    expect(fn).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1000);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('limits concurrent asynchronous scans when throttled', async () => {
+    const limitedCaps: DeviceCapabilities = {
+      battery: baseCapabilities.battery,
+      hardware: baseCapabilities.hardware,
+      network: baseCapabilities.network,
+      platform: baseCapabilities.platform,
+      performance: {
+        mode: 'auto',
+        shouldThrottle: true,
+        intervalMultiplier: 1,
+        maxConcurrency: 1,
+        reasons: ['low-hardware'],
+        lastInputLatency: null,
+      },
+    };
+    __setTestCapabilitiesOverride(limitedCaps);
+    setCapabilities(limitedCaps);
+
+    const asyncFn = jest.fn();
+    const fastFn = jest.fn();
+
+    scheduleScan('async', '*/1 * * * * *', asyncFn);
+    scheduleScan('fast', '*/1 * * * * *', fastFn);
+    const jobs = __getRunningScansForTests();
+    expect(jobs).toHaveLength(2);
+    jobs[0].active = true;
+    expect(__attemptExecuteForTests(1)).toBe(false);
+    jobs[0].active = false;
+    expect(__attemptExecuteForTests(0)).toBe(true);
+    expect(asyncFn).toHaveBeenCalledTimes(1);
+    expect(__attemptExecuteForTests(1)).toBe(true);
+    expect(fastFn).toHaveBeenCalled();
   });
 });

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -4,7 +4,7 @@ import { resetSettings, defaults, exportSettings as exportSettingsData, importSe
 import KaliWallpaper from '../util-components/kali-wallpaper';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, performanceMode, setPerformanceMode, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
@@ -70,8 +70,16 @@ export function Settings() {
                 )}
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Theme:</label>
+                <label
+                    id="settings-theme-label"
+                    className="mr-2 text-ubt-grey"
+                    htmlFor="settings-theme-select"
+                >
+                    Theme:
+                </label>
                 <select
+                    id="settings-theme-select"
+                    aria-labelledby="settings-theme-label"
                     value={theme}
                     onChange={(e) => setTheme(e.target.value)}
                     className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
@@ -82,14 +90,20 @@ export function Settings() {
                     <option value="matrix">Matrix</option>
                 </select>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={useKaliWallpaper}
-                        onChange={(e) => setUseKaliWallpaper(e.target.checked)}
-                        className="mr-2"
-                    />
+            <div className="flex justify-center items-center my-4">
+                <input
+                    id="settings-kali-wallpaper"
+                    aria-labelledby="settings-kali-wallpaper-label"
+                    type="checkbox"
+                    checked={useKaliWallpaper}
+                    onChange={(e) => setUseKaliWallpaper(e.target.checked)}
+                    className="mr-2"
+                />
+                <label
+                    id="settings-kali-wallpaper-label"
+                    className="text-ubt-grey"
+                    htmlFor="settings-kali-wallpaper"
+                >
                     Kali Gradient Wallpaper
                 </label>
             </div>
@@ -115,8 +129,16 @@ export function Settings() {
                 </div>
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Density:</label>
+                <label
+                    id="settings-density-label"
+                    className="mr-2 text-ubt-grey"
+                    htmlFor="settings-density-select"
+                >
+                    Density:
+                </label>
                 <select
+                    id="settings-density-select"
+                    aria-labelledby="settings-density-label"
                     value={density}
                     onChange={(e) => setDensity(e.target.value)}
                     className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
@@ -126,8 +148,16 @@ export function Settings() {
                 </select>
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Font Size:</label>
+                <label
+                    id="settings-font-scale-label"
+                    className="mr-2 text-ubt-grey"
+                    htmlFor="settings-font-scale"
+                >
+                    Font Size:
+                </label>
                 <input
+                    id="settings-font-scale"
+                    aria-labelledby="settings-font-scale-label"
                     type="range"
                     min="0.75"
                     max="1.5"
@@ -137,69 +167,129 @@ export function Settings() {
                     className="ubuntu-slider"
                 />
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={reducedMotion}
-                        onChange={(e) => setReducedMotion(e.target.checked)}
-                        className="mr-2"
-                    />
+            <div className="flex justify-center items-center my-4">
+                <input
+                    id="settings-reduced-motion"
+                    aria-labelledby="settings-reduced-motion-label"
+                    type="checkbox"
+                    checked={reducedMotion}
+                    onChange={(e) => setReducedMotion(e.target.checked)}
+                    className="mr-2"
+                />
+                <label
+                    id="settings-reduced-motion-label"
+                    className="text-ubt-grey"
+                    htmlFor="settings-reduced-motion"
+                >
                     Reduced Motion
                 </label>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={largeHitAreas}
-                        onChange={(e) => setLargeHitAreas(e.target.checked)}
-                        className="mr-2"
-                    />
+            <div className="flex justify-center items-center my-4">
+                <input
+                    id="settings-large-hit-areas"
+                    aria-labelledby="settings-large-hit-areas-label"
+                    type="checkbox"
+                    checked={largeHitAreas}
+                    onChange={(e) => setLargeHitAreas(e.target.checked)}
+                    className="mr-2"
+                />
+                <label
+                    id="settings-large-hit-areas-label"
+                    className="text-ubt-grey"
+                    htmlFor="settings-large-hit-areas"
+                >
                     Large Hit Areas
                 </label>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={highContrast}
-                        onChange={(e) => setHighContrast(e.target.checked)}
-                        className="mr-2"
-                    />
+            <div className="flex justify-center items-center my-4">
+                <input
+                    id="settings-high-contrast"
+                    aria-labelledby="settings-high-contrast-label"
+                    type="checkbox"
+                    checked={highContrast}
+                    onChange={(e) => setHighContrast(e.target.checked)}
+                    className="mr-2"
+                />
+                <label
+                    id="settings-high-contrast-label"
+                    className="text-ubt-grey"
+                    htmlFor="settings-high-contrast"
+                >
                     High Contrast
                 </label>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={allowNetwork}
-                        onChange={(e) => setAllowNetwork(e.target.checked)}
-                        className="mr-2"
-                    />
+            <div className="flex justify-center items-center my-4">
+                <input
+                    id="settings-allow-network"
+                    aria-labelledby="settings-allow-network-label"
+                    type="checkbox"
+                    checked={allowNetwork}
+                    onChange={(e) => setAllowNetwork(e.target.checked)}
+                    className="mr-2"
+                />
+                <label
+                    id="settings-allow-network-label"
+                    className="text-ubt-grey"
+                    htmlFor="settings-allow-network"
+                >
                     Allow Network Requests
                 </label>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={haptics}
-                        onChange={(e) => setHaptics(e.target.checked)}
-                        className="mr-2"
-                    />
+            <div className="flex justify-center items-center my-4">
+                <input
+                    id="settings-haptics"
+                    aria-labelledby="settings-haptics-label"
+                    type="checkbox"
+                    checked={haptics}
+                    onChange={(e) => setHaptics(e.target.checked)}
+                    className="mr-2"
+                />
+                <label
+                    id="settings-haptics-label"
+                    className="text-ubt-grey"
+                    htmlFor="settings-haptics"
+                >
                     Haptics
                 </label>
             </div>
             <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={pongSpin}
-                        onChange={(e) => setPongSpin(e.target.checked)}
-                        className="mr-2"
-                    />
+                <label
+                    id="settings-performance-mode-label"
+                    className="mr-2 text-ubt-grey"
+                    htmlFor="settings-performance-mode"
+                >
+                    Performance Mode:
+                </label>
+                <select
+                    id="settings-performance-mode"
+                    aria-labelledby="settings-performance-mode-label"
+                    value={performanceMode}
+                    onChange={(e) => setPerformanceMode(e.target.value)}
+                    className="bg-ub-cool-grey text-ubt-grey px-2 py-1 rounded border border-ubt-cool-grey"
+                >
+                    <option value="auto">Auto (recommended)</option>
+                    <option value="battery-saver">Battery Saver</option>
+                    <option value="high-performance">High Performance</option>
+                </select>
+            </div>
+            <p className="text-center text-xs text-ubt-grey/70 px-6 -mt-2 mb-4">
+                Auto throttles background workers when battery saver, low-end hardware, or input latency spikes are detected.
+                Override when you need full speed or maximum efficiency.
+            </p>
+            <div className="flex justify-center items-center my-4">
+                <input
+                    id="settings-pong-spin"
+                    aria-labelledby="settings-pong-spin-label"
+                    type="checkbox"
+                    checked={pongSpin}
+                    onChange={(e) => setPongSpin(e.target.checked)}
+                    className="mr-2"
+                />
+                <label
+                    id="settings-pong-spin-label"
+                    className="text-ubt-grey"
+                    htmlFor="settings-pong-spin"
+                >
                     Pong Spin
                 </label>
             </div>
@@ -308,6 +398,7 @@ export function Settings() {
                     e.target.value = '';
                 }}
                 className="hidden"
+                aria-label="Import settings file"
             />
         </div>
     )

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -22,9 +22,12 @@ import {
   setAllowNetwork as saveAllowNetwork,
   getHaptics as loadHaptics,
   setHaptics as saveHaptics,
+  getPerformanceMode as loadPerformanceMode,
+  setPerformanceMode as savePerformanceMode,
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import type { PerformanceMode } from '../utils/capabilities';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -66,6 +69,7 @@ interface SettingsContextValue {
   pongSpin: boolean;
   allowNetwork: boolean;
   haptics: boolean;
+  performanceMode: PerformanceMode;
   theme: string;
   setAccent: (accent: string) => void;
   setWallpaper: (wallpaper: string) => void;
@@ -78,6 +82,7 @@ interface SettingsContextValue {
   setPongSpin: (value: boolean) => void;
   setAllowNetwork: (value: boolean) => void;
   setHaptics: (value: boolean) => void;
+  setPerformanceMode: (value: PerformanceMode) => void;
   setTheme: (value: string) => void;
 }
 
@@ -94,6 +99,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   pongSpin: defaults.pongSpin,
   allowNetwork: defaults.allowNetwork,
   haptics: defaults.haptics,
+  performanceMode: defaults.performanceMode as PerformanceMode,
   theme: 'default',
   setAccent: () => {},
   setWallpaper: () => {},
@@ -106,6 +112,7 @@ export const SettingsContext = createContext<SettingsContextValue>({
   setPongSpin: () => {},
   setAllowNetwork: () => {},
   setHaptics: () => {},
+  setPerformanceMode: () => {},
   setTheme: () => {},
 });
 
@@ -121,6 +128,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
   const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
   const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
+  const [performanceMode, setPerformanceMode] = useState<PerformanceMode>(
+    defaults.performanceMode as PerformanceMode,
+  );
   const [theme, setTheme] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
 
@@ -137,6 +147,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setPongSpin(await loadPongSpin());
       setAllowNetwork(await loadAllowNetwork());
       setHaptics(await loadHaptics());
+      setPerformanceMode((await loadPerformanceMode()) as PerformanceMode);
       setTheme(loadTheme());
     })();
   }, []);
@@ -250,6 +261,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     saveHaptics(haptics);
   }, [haptics]);
 
+  useEffect(() => {
+    savePerformanceMode(performanceMode);
+  }, [performanceMode]);
+
   const bgImageName = useKaliWallpaper ? 'kali-gradient' : wallpaper;
 
   return (
@@ -267,6 +282,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         pongSpin,
         allowNetwork,
         haptics,
+        performanceMode,
         theme,
         setAccent,
         setWallpaper,
@@ -279,6 +295,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setPongSpin,
         setAllowNetwork,
         setHaptics,
+        setPerformanceMode,
         setTheme,
       }}
     >

--- a/scanner/schedule.ts
+++ b/scanner/schedule.ts
@@ -1,28 +1,98 @@
+import {
+  getCachedCapabilities,
+  loadCapabilities,
+  onCapabilitiesChange,
+  type DeviceCapabilities,
+} from '../utils/capabilities';
+
 export interface ScheduledScan {
   id: string;
   schedule: string;
 }
 
+type ScanCallback = () => void | Promise<void>;
+
 interface RunningScan extends ScheduledScan {
-  timer: ReturnType<typeof setInterval>;
-  callback: () => void;
+  timer: ReturnType<typeof setInterval> | null;
+  callback: ScanCallback;
+  active: boolean;
+  remainingDelay: number;
 }
 
 const STORAGE_KEY = 'scanSchedules';
 const runningScans: RunningScan[] = [];
 
-export const loadScheduledScans = (): ScheduledScan[] => {
-  if (typeof window === 'undefined') return [];
+const getWindow = (): Window | undefined => {
+  if (typeof globalThis === 'undefined') return undefined;
+  const candidate = (globalThis as typeof globalThis & { window?: Window }).window;
+  return candidate;
+};
+
+const getStorage = () => {
+  const win = getWindow();
+  if (!win) return null;
   try {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+    return win.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+const schedulerState = {
+  intervalMultiplier: 1,
+  maxConcurrency: Number.POSITIVE_INFINITY,
+};
+
+let testCapabilitiesOverride: DeviceCapabilities | null = null;
+
+const applyCapabilities = (caps: DeviceCapabilities) => {
+  schedulerState.intervalMultiplier = Math.max(1, caps.performance.intervalMultiplier || 1);
+  schedulerState.maxConcurrency = caps.performance.shouldThrottle
+    ? Math.max(1, caps.performance.maxConcurrency || 1)
+    : Math.max(1, caps.performance.maxConcurrency || Number.POSITIVE_INFINITY);
+};
+
+applyCapabilities(getCachedCapabilities());
+
+onCapabilitiesChange(applyCapabilities);
+
+if (getWindow()) {
+  void loadCapabilities().catch(() => {});
+}
+
+const countActiveJobs = () => runningScans.reduce((count, job) => count + (job.active ? 1 : 0), 0);
+
+const executeJob = (job: RunningScan) => {
+  if (job.active) return;
+  try {
+    const result = job.callback();
+    if (result && typeof (result as Promise<unknown>).then === 'function') {
+      job.active = true;
+      (result as Promise<unknown>).finally(() => {
+        job.active = false;
+      });
+    }
+  } catch (error) {
+    if (typeof console !== 'undefined' && error) {
+      console.warn('Scheduled scan failed', error);
+    }
+  }
+};
+
+export const loadScheduledScans = (): ScheduledScan[] => {
+  const storage = getStorage();
+  if (!storage) return [];
+  try {
+    return JSON.parse(storage.getItem(STORAGE_KEY) || '[]');
   } catch {
     return [];
   }
 };
 
 const persistSchedules = (jobs: ScheduledScan[]) => {
-  if (typeof window === 'undefined') return;
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(jobs));
+  const storage = getStorage();
+  if (!storage) return;
+  storage.setItem(STORAGE_KEY, JSON.stringify(jobs));
 };
 
 export const cronToInterval = (expr: string): number => {
@@ -43,14 +113,46 @@ export const cronToInterval = (expr: string): number => {
 export const scheduleScan = (
   id: string,
   schedule: string,
-  callback: () => void,
+  callback: ScanCallback,
 ): ScheduledScan => {
+  const caps = testCapabilitiesOverride ?? getCachedCapabilities();
+  applyCapabilities(caps);
   const jobs = loadScheduledScans();
   jobs.push({ id, schedule });
   persistSchedules(jobs);
-  const interval = cronToInterval(schedule);
-  const timer = setInterval(callback, interval);
-  runningScans.push({ id, schedule, timer, callback });
+  const baseInterval = cronToInterval(schedule);
+  const effectiveInterval = Math.max(
+    1,
+    Math.round(baseInterval * (caps.performance.intervalMultiplier || 1)),
+  );
+  const job: RunningScan = {
+    id,
+    schedule,
+    callback,
+    timer: null,
+    active: false,
+    remainingDelay: effectiveInterval,
+  };
+
+  const tick = () => {
+    const tickCaps = testCapabilitiesOverride ?? getCachedCapabilities();
+    applyCapabilities(tickCaps);
+    const nextInterval = Math.max(
+      1,
+      Math.round(baseInterval * (tickCaps.performance.intervalMultiplier || 1)),
+    );
+    job.remainingDelay -= baseInterval;
+    if (job.remainingDelay > 0) return;
+    if (countActiveJobs() >= schedulerState.maxConcurrency) {
+      job.remainingDelay = Math.max(baseInterval, job.remainingDelay + baseInterval);
+      return;
+    }
+    executeJob(job);
+    job.remainingDelay = nextInterval;
+  };
+
+  job.timer = setInterval(tick, baseInterval);
+  runningScans.push(job);
   return { id, schedule };
 };
 
@@ -61,7 +163,27 @@ export const startStoredSchedules = (trigger: (id: string) => void) => {
 };
 
 export const clearSchedules = () => {
-  runningScans.forEach((j) => clearInterval(j.timer));
+  runningScans.forEach((j) => {
+    if (j.timer) clearInterval(j.timer);
+    j.timer = null;
+    j.active = false;
+    j.remainingDelay = 0;
+  });
   runningScans.length = 0;
   persistSchedules([]);
+};
+
+export const __getSchedulerStateForTests = () => schedulerState;
+export const __applyCapabilitiesForTests = applyCapabilities;
+export const __getRunningScansForTests = () => runningScans;
+export const __setTestCapabilitiesOverride = (caps: DeviceCapabilities | null) => {
+  testCapabilitiesOverride = caps;
+  if (caps) applyCapabilities(caps);
+};
+export const __attemptExecuteForTests = (index: number) => {
+  const job = runningScans[index];
+  if (!job) return false;
+  if (countActiveJobs() >= schedulerState.maxConcurrency) return false;
+  executeJob(job);
+  return true;
 };

--- a/utils/capabilities.ts
+++ b/utils/capabilities.ts
@@ -1,0 +1,309 @@
+export type PerformanceMode = 'auto' | 'battery-saver' | 'high-performance';
+
+type Listener = (caps: DeviceCapabilities) => void;
+
+interface BatteryCapabilities {
+  supported: boolean;
+  charging?: boolean;
+  level?: number;
+  saver: boolean;
+  timestamp: number;
+}
+
+interface HardwareCapabilities {
+  cores?: number;
+  memory?: number;
+  cpuClass: 'low' | 'mid' | 'high';
+}
+
+interface NetworkCapabilities {
+  saveData: boolean;
+  effectiveType?: string;
+}
+
+export interface PlatformCapabilities {
+  os: 'windows' | 'mac' | 'linux' | 'android' | 'ios' | 'chromeos' | 'unknown';
+  isMobile: boolean;
+  hints: string[];
+}
+
+export interface DeviceCapabilities {
+  battery: BatteryCapabilities;
+  hardware: HardwareCapabilities;
+  network: NetworkCapabilities;
+  platform: PlatformCapabilities;
+  performance: {
+    mode: PerformanceMode;
+    shouldThrottle: boolean;
+    intervalMultiplier: number;
+    maxConcurrency: number;
+    reasons: string[];
+    lastInputLatency: number | null;
+  };
+}
+
+const DEFAULT_CAPABILITIES: DeviceCapabilities = {
+  battery: {
+    supported: false,
+    saver: false,
+    timestamp: 0,
+  },
+  hardware: {
+    cpuClass: 'mid',
+  },
+  network: {
+    saveData: false,
+  },
+  platform: {
+    os: 'unknown',
+    isMobile: false,
+    hints: [],
+  },
+  performance: {
+    mode: 'auto',
+    shouldThrottle: false,
+    intervalMultiplier: 1,
+    maxConcurrency: Number.POSITIVE_INFINITY,
+    reasons: [],
+    lastInputLatency: null,
+  },
+};
+
+let cachedCapabilities: DeviceCapabilities = { ...DEFAULT_CAPABILITIES };
+let baseCapabilities: DeviceCapabilities = { ...DEFAULT_CAPABILITIES };
+let lastInputLatency: number | null = null;
+const listeners = new Set<Listener>();
+let loadingPromise: Promise<DeviceCapabilities> | null = null;
+
+const getWindow = (): Window | undefined => {
+  if (typeof globalThis === 'undefined') return undefined;
+  const candidate = (globalThis as typeof globalThis & { window?: Window }).window;
+  return candidate;
+};
+
+const parsePerformanceMode = (value: string | null): PerformanceMode => {
+  if (value === 'battery-saver' || value === 'high-performance') return value;
+  return 'auto';
+};
+
+const getStoredPerformanceMode = (): PerformanceMode => {
+  const win = getWindow();
+  if (!win) return 'auto';
+  try {
+    return parsePerformanceMode(win.localStorage.getItem('performance-mode'));
+  } catch {
+    return 'auto';
+  }
+};
+
+const classifyCpu = (cores?: number, memory?: number): HardwareCapabilities['cpuClass'] => {
+  if ((cores && cores <= 2) || (memory && memory <= 2)) return 'low';
+  if ((cores && cores <= 4) || (memory && memory <= 4)) return 'mid';
+  return 'high';
+};
+
+const detectHardware = (): HardwareCapabilities => {
+  if (typeof navigator === 'undefined') return { ...DEFAULT_CAPABILITIES.hardware };
+  const cores = navigator.hardwareConcurrency;
+  const memory = typeof (navigator as any).deviceMemory === 'number'
+    ? (navigator as any).deviceMemory
+    : undefined;
+  return {
+    cores,
+    memory,
+    cpuClass: classifyCpu(cores, memory),
+  };
+};
+
+const detectPlatform = (): PlatformCapabilities => {
+  if (typeof navigator === 'undefined') return { ...DEFAULT_CAPABILITIES.platform };
+  const uaData = (navigator as any).userAgentData;
+  const ua = navigator.userAgent || '';
+  const platform = (uaData?.platform || navigator.platform || '').toLowerCase();
+  const isMobile = uaData?.mobile ?? /android|iphone|ipad|ipod|mobile|mobi/i.test(ua);
+  let os: PlatformCapabilities['os'] = 'unknown';
+  if (platform.includes('win')) os = 'windows';
+  else if (platform.includes('mac')) os = 'mac';
+  else if (platform.includes('linux')) os = 'linux';
+  else if (platform.includes('android')) os = 'android';
+  else if (platform.includes('ios') || platform.includes('iphone') || platform.includes('ipad')) os = 'ios';
+  else if (platform.includes('cros') || platform.includes('chrome os')) os = 'chromeos';
+  else if (/android/.test(ua)) os = 'android';
+  else if (/iphone|ipad|ipod/.test(ua)) os = 'ios';
+  else if (/windows/.test(ua)) os = 'windows';
+  else if (/mac os/.test(ua)) os = 'mac';
+
+  const hints: string[] = [];
+  if (isMobile) hints.push('mobile');
+  if ('maxTouchPoints' in navigator && (navigator as any).maxTouchPoints > 1) hints.push('touch');
+  if (typeof (navigator as any).standalone === 'boolean' && (navigator as any).standalone) hints.push('standalone');
+  if (ua.toLowerCase().includes('electron')) hints.push('electron');
+
+  return {
+    os,
+    isMobile,
+    hints,
+  };
+};
+
+const detectNetwork = (): NetworkCapabilities => {
+  if (typeof navigator === 'undefined') return { ...DEFAULT_CAPABILITIES.network };
+  const connection =
+    (navigator as any).connection ||
+    (navigator as any).mozConnection ||
+    (navigator as any).webkitConnection;
+  return {
+    saveData: Boolean(connection?.saveData),
+    effectiveType: connection?.effectiveType,
+  };
+};
+
+const detectBattery = async (): Promise<BatteryCapabilities> => {
+  const status: BatteryCapabilities = {
+    supported: false,
+    saver: false,
+    timestamp: Date.now(),
+  };
+  if (typeof navigator === 'undefined') return status;
+  const getBattery = (navigator as any).getBattery;
+  if (typeof getBattery !== 'function') return status;
+  try {
+    const battery = await getBattery.call(navigator);
+    status.supported = true;
+    status.charging = battery.charging;
+    status.level = typeof battery.level === 'number' ? battery.level : undefined;
+    status.saver = !battery.charging && typeof battery.level === 'number' && battery.level <= 0.2;
+  } catch {
+    // Ignore battery errors and fall back to defaults.
+  }
+  return status;
+};
+
+const finaliseCapabilities = (base: DeviceCapabilities): DeviceCapabilities => {
+  const batterySaver = base.battery.saver || base.network.saveData;
+  const lowHardware = base.hardware.cpuClass === 'low';
+  const degradedInput = lastInputLatency !== null && lastInputLatency > 200;
+  const reasons: string[] = [];
+  if (batterySaver) reasons.push('battery-saver');
+  if (lowHardware) reasons.push('low-hardware');
+  if (degradedInput) reasons.push('inp-degraded');
+
+  const mode = base.performance.mode;
+  let shouldThrottle = mode === 'battery-saver';
+  if (mode === 'auto') {
+    shouldThrottle = batterySaver || lowHardware || degradedInput;
+  }
+
+  let intervalMultiplier = shouldThrottle ? (batterySaver ? 2 : 1.5) : 1;
+  if (degradedInput) {
+    const penalty = Math.min((lastInputLatency! - 200) / 400, 0.5);
+    intervalMultiplier = Math.max(intervalMultiplier, 1.5 + penalty);
+  }
+
+  const cores = base.hardware.cores ?? 2;
+  const baselineConcurrency = Math.max(1, Math.min(4, cores));
+  let maxConcurrency = shouldThrottle ? Math.max(1, Math.min(2, Math.floor(cores / 2) || 1)) : baselineConcurrency;
+
+  if (mode === 'high-performance') {
+    shouldThrottle = false;
+    intervalMultiplier = 1;
+    maxConcurrency = Math.max(2, cores);
+  }
+
+  return {
+    ...base,
+    performance: {
+      mode,
+      shouldThrottle,
+      intervalMultiplier,
+      maxConcurrency,
+      reasons,
+      lastInputLatency,
+    },
+  };
+};
+
+const notifyListeners = () => {
+  listeners.forEach((listener) => {
+    try {
+      listener(cachedCapabilities);
+    } catch {
+      // Ignore listener errors to avoid breaking loop.
+    }
+  });
+};
+
+const detectCapabilitiesInternal = async (): Promise<DeviceCapabilities> => {
+  const performanceMode = getStoredPerformanceMode();
+  const hardware = detectHardware();
+  const platform = detectPlatform();
+  const network = detectNetwork();
+  const battery = await detectBattery();
+
+  baseCapabilities = {
+    battery,
+    hardware,
+    network,
+    platform,
+    performance: {
+      ...DEFAULT_CAPABILITIES.performance,
+      mode: performanceMode,
+    },
+  };
+
+  cachedCapabilities = finaliseCapabilities(baseCapabilities);
+  notifyListeners();
+  return cachedCapabilities;
+};
+
+export const loadCapabilities = async (): Promise<DeviceCapabilities> => {
+  if (!loadingPromise) {
+    loadingPromise = detectCapabilitiesInternal().finally(() => {
+      loadingPromise = null;
+    });
+  }
+  return loadingPromise;
+};
+
+export const getCachedCapabilities = (): DeviceCapabilities => cachedCapabilities;
+
+export const onCapabilitiesChange = (listener: Listener): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const recordInputLatencyMetric = (value: number): void => {
+  lastInputLatency = value;
+  cachedCapabilities = finaliseCapabilities(baseCapabilities);
+  notifyListeners();
+};
+
+const handlePerformanceModeChange = (mode: PerformanceMode) => {
+  baseCapabilities = {
+    ...baseCapabilities,
+    performance: {
+      ...baseCapabilities.performance,
+      mode,
+    },
+  };
+  cachedCapabilities = finaliseCapabilities(baseCapabilities);
+  notifyListeners();
+};
+
+const win = getWindow();
+if (win) {
+  void loadCapabilities();
+  win.addEventListener('performance-mode-change', (event: Event) => {
+    const detail = (event as CustomEvent<{ mode?: PerformanceMode }>).detail;
+    if (detail?.mode) handlePerformanceModeChange(detail.mode);
+  });
+  win.addEventListener('storage', (event: StorageEvent) => {
+    if (event.key === 'performance-mode') {
+      handlePerformanceModeChange(parsePerformanceMode(event.newValue ?? null));
+    }
+  });
+}
+
+export default getCachedCapabilities;

--- a/utils/reportWebVitals.ts
+++ b/utils/reportWebVitals.ts
@@ -1,4 +1,5 @@
 import ReactGA from 'react-ga4';
+import { recordInputLatencyMetric } from './capabilities';
 
 interface WebVitalMetric {
   id: string;
@@ -36,6 +37,10 @@ export const reportWebVitals = ({ id, name, value }: WebVitalMetric): void => {
     if (typeof console !== 'undefined') {
       console.warn(`Web Vitals alert: ${name} ${rounded}`);
     }
+  }
+
+  if (name === 'INP') {
+    recordInputLatencyMetric(value);
   }
 };
 

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -15,6 +15,7 @@ const DEFAULT_SETTINGS = {
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
+  performanceMode: 'auto',
 };
 
 export async function getAccent() {
@@ -114,6 +115,21 @@ export async function setHaptics(value) {
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
+const PERFORMANCE_OPTIONS = ['auto', 'battery-saver', 'high-performance'];
+
+export async function getPerformanceMode() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.performanceMode;
+  const stored = window.localStorage.getItem('performance-mode');
+  return PERFORMANCE_OPTIONS.includes(stored) ? stored : DEFAULT_SETTINGS.performanceMode;
+}
+
+export async function setPerformanceMode(mode) {
+  if (typeof window === 'undefined') return;
+  const next = PERFORMANCE_OPTIONS.includes(mode) ? mode : DEFAULT_SETTINGS.performanceMode;
+  window.localStorage.setItem('performance-mode', next);
+  window.dispatchEvent(new CustomEvent('performance-mode-change', { detail: { mode: next } }));
+}
+
 export async function getPongSpin() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
   const val = window.localStorage.getItem('pong-spin');
@@ -150,6 +166,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
   window.localStorage.removeItem('use-kali-wallpaper');
+  window.localStorage.removeItem('performance-mode');
 }
 
 export async function exportSettings() {
@@ -165,6 +182,7 @@ export async function exportSettings() {
     pongSpin,
     allowNetwork,
     haptics,
+    performanceMode,
   ] = await Promise.all([
     getAccent(),
     getWallpaper(),
@@ -177,6 +195,7 @@ export async function exportSettings() {
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
+    getPerformanceMode(),
   ]);
   const theme = getTheme();
   return JSON.stringify({
@@ -192,6 +211,7 @@ export async function exportSettings() {
     haptics,
     useKaliWallpaper,
     theme,
+    performanceMode,
   });
 }
 
@@ -217,6 +237,7 @@ export async function importSettings(json) {
     allowNetwork,
     haptics,
     theme,
+    performanceMode,
   } = settings;
   if (accent !== undefined) await setAccent(accent);
   if (wallpaper !== undefined) await setWallpaper(wallpaper);
@@ -230,6 +251,7 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  if (performanceMode !== undefined) await setPerformanceMode(performanceMode);
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- harden capability detection with battery/CPU/platform profiling, INP tracking, and listener updates
- guard the scanner scheduler against window-less environments and reuse capability-driven throttling
- expose a performance mode setting with accessible controls and persistence hooks

## Testing
- yarn lint
- yarn test *(fails: pre-existing suite regressions in games/workspaces/desktop tests)*

------
https://chatgpt.com/codex/tasks/task_e_68dca4c6d7e08328afb401b48f36b110