### PR TITLE
[dev] Add long task performance hints

### DIFF
--- a/components/dev/PerfHints.tsx
+++ b/components/dev/PerfHints.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import React, { ChangeEvent, useEffect, useMemo, useState, useId } from "react";
+import {
+  clearLongTaskData,
+  getLongTaskSnapshot,
+  setLongTaskDebugLogging,
+  setLongTaskThreshold,
+  startLongTaskObserver,
+  stopLongTaskObserver,
+  subscribeToLongTaskInsights,
+  type LongTaskInsight,
+  type LongTaskSnapshot,
+} from "../../utils/longTasks";
+
+const toggleButtonClass = (active: boolean) =>
+  `rounded px-3 py-1 text-xs font-semibold transition-colors ${
+    active
+      ? "bg-emerald-400 text-slate-900 shadow"
+      : "bg-slate-800 text-slate-200 hover:bg-slate-700"
+  }`;
+
+const secondaryButtonClass =
+  "rounded px-3 py-1 text-xs font-semibold bg-slate-800 text-slate-200 hover:bg-slate-700 transition-colors";
+
+const candidateHeuristic = (insight: LongTaskInsight) =>
+  insight.avgDuration >= 80 || (insight.maxDuration >= 120 && insight.occurrences >= 2);
+
+const stackLink = (stack: string, index: number) =>
+  `data:text/plain;charset=utf-8,${encodeURIComponent(stack)}#stack-${index + 1}`;
+
+const PerfHints: React.FC = () => {
+  const [snapshot, setSnapshot] = useState<LongTaskSnapshot>(getLongTaskSnapshot);
+  const [enabled, setEnabled] = useState(snapshot.observing);
+  const [debug, setDebug] = useState(snapshot.debug);
+  const [threshold, setThreshold] = useState(snapshot.threshold);
+  const thresholdId = useId();
+
+  useEffect(() => {
+    return subscribeToLongTaskInsights((next) => {
+      setSnapshot(next);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (snapshot.observing !== enabled) {
+      setEnabled(snapshot.observing);
+    }
+  }, [snapshot.observing, enabled]);
+
+  useEffect(() => {
+    if (snapshot.debug !== debug) {
+      setDebug(snapshot.debug);
+    }
+  }, [snapshot.debug, debug]);
+
+  useEffect(() => {
+    if (snapshot.threshold !== threshold) {
+      setThreshold(snapshot.threshold);
+    }
+  }, [snapshot.threshold, threshold]);
+
+  useEffect(() => {
+    if (!enabled) {
+      stopLongTaskObserver();
+      return;
+    }
+
+    const ok = startLongTaskObserver({ threshold });
+    if (!ok) {
+      setEnabled(false);
+    }
+  }, [enabled, threshold]);
+
+  useEffect(() => {
+    setLongTaskDebugLogging(debug);
+  }, [debug]);
+
+  const workerCandidates = useMemo(
+    () => snapshot.insights.filter(candidateHeuristic),
+    [snapshot.insights],
+  );
+
+  const handleThresholdChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const next = Number(event.target.value);
+    if (!Number.isFinite(next) || next <= 0) return;
+    setThreshold(next);
+    setLongTaskThreshold(next);
+  };
+
+  const insights = snapshot.insights;
+  const samples = snapshot.samples;
+
+  return (
+    <section className="rounded-lg border border-slate-700/70 bg-slate-950/70 p-4 text-xs text-slate-200 shadow-lg">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-sky-200">Performance hints</h2>
+          <p className="text-slate-400">
+            Observes main-thread long tasks above {threshold}ms and groups frequent offenders.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            aria-pressed={enabled}
+            className={toggleButtonClass(enabled)}
+            onClick={() => setEnabled((value) => !value)}
+            disabled={!snapshot.supported}
+          >
+            {enabled ? "Tracking" : "Start tracking"}
+          </button>
+          <button
+            type="button"
+            aria-pressed={debug}
+            className={toggleButtonClass(debug)}
+            onClick={() => setDebug((value) => !value)}
+            disabled={!snapshot.supported}
+          >
+            {debug ? "Debug on" : "Enable debug"}
+          </button>
+          <button
+            type="button"
+            className={secondaryButtonClass}
+            onClick={() => clearLongTaskData()}
+            disabled={!snapshot.supported}
+          >
+            Clear data
+          </button>
+        </div>
+      </header>
+
+      {!snapshot.supported ? (
+        <p className="mt-4 rounded border border-amber-500/40 bg-amber-500/10 p-3 text-amber-200">
+          This browser does not expose the PerformanceObserver long task entry type.
+        </p>
+      ) : (
+        <>
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <div className="flex items-center gap-2 text-slate-300">
+              <label className="text-slate-300" htmlFor={thresholdId}>
+                Threshold
+              </label>
+              <input
+                type="number"
+                className="w-20 rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-100"
+                min={10}
+                step={10}
+                id={thresholdId}
+                value={threshold}
+                onChange={handleThresholdChange}
+                aria-label="Long task threshold"
+              />
+            </div>
+            <span className="text-slate-400">
+              {insights.length} offender{insights.length === 1 ? "" : "s"} · {samples.length} sample
+              {samples.length === 1 ? "" : "s"}
+            </span>
+            {workerCandidates.length > 0 && (
+              <span className="rounded-full bg-amber-500/20 px-3 py-1 text-amber-200">
+                {workerCandidates.length} worker candidate{workerCandidates.length === 1 ? "" : "s"}
+              </span>
+            )}
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {insights.length === 0 ? (
+              <p className="rounded border border-slate-800 bg-slate-900/60 p-3 text-slate-400">
+                No long tasks recorded yet. Interact with the UI or keep this panel open while navigating.
+              </p>
+            ) : (
+              insights.map((insight) => {
+                const candidate = candidateHeuristic(insight);
+                return (
+                  <article
+                    key={insight.key}
+                    className={`rounded border p-3 transition-colors ${
+                      candidate
+                        ? "border-amber-400/60 bg-amber-500/10"
+                        : "border-slate-800 bg-slate-900/60"
+                    }`}
+                  >
+                    <header className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <h3 className="text-sm font-semibold text-slate-100">{insight.label}</h3>
+                        <p className="text-slate-400">
+                          {insight.occurrences} hit{insight.occurrences === 1 ? "" : "s"} · avg {Math.round(insight.avgDuration)}ms ·
+                          max {Math.round(insight.maxDuration)}ms · total {Math.round(insight.totalDuration)}ms
+                        </p>
+                      </div>
+                      {candidate && (
+                        <span className="rounded-full bg-amber-400/20 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-wide text-amber-200">
+                          Likely worker candidate
+                        </span>
+                      )}
+                    </header>
+                    <div className="mt-2 space-y-2 text-slate-300">
+                      {insight.scriptURL && (
+                        <a
+                          href={insight.scriptURL}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex items-center gap-2 text-sky-300 hover:text-sky-200"
+                        >
+                          <span className="rounded bg-sky-500/20 px-2 py-0.5 text-[0.65rem] uppercase tracking-wide text-sky-100">
+                            Script
+                          </span>
+                          <span className="truncate">{insight.scriptURL}</span>
+                        </a>
+                      )}
+                      {insight.stackTraces.length > 0 && (
+                        <div className="space-y-1">
+                          <span className="text-[0.65rem] uppercase tracking-wide text-slate-400">Stack traces</span>
+                          <div className="flex flex-wrap gap-2">
+                            {insight.stackTraces.map((stack, index) => (
+                              <a
+                                key={`${insight.key}-stack-${index}`}
+                                href={stackLink(stack, index)}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="rounded bg-slate-800 px-2 py-1 text-[0.65rem] text-slate-200 hover:bg-slate-700"
+                              >
+                                View stack #{index + 1}
+                              </a>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </article>
+                );
+              })
+            )}
+          </div>
+
+          {samples.length > 0 && (
+            <div className="mt-5">
+              <h4 className="text-[0.7rem] font-semibold uppercase tracking-wide text-sky-200">
+                Recent samples (latest first)
+              </h4>
+              <ul className="mt-2 max-h-60 space-y-2 overflow-y-auto pr-1">
+                {samples.slice(0, 10).map((sample) => (
+                  <li
+                    key={sample.id}
+                    className="rounded border border-slate-800 bg-slate-900/60 p-2 text-slate-300"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="font-semibold text-slate-100">{sample.label}</span>
+                      <span className="text-slate-400">{Math.round(sample.duration)}ms @ {Math.round(sample.startTime)}ms</span>
+                    </div>
+                    {sample.scriptURL && (
+                      <div className="mt-1 text-slate-400">
+                        <span className="text-[0.65rem] uppercase tracking-wide text-slate-500">Script</span>{" "}
+                        <a
+                          href={sample.scriptURL}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-sky-300 hover:text-sky-200"
+                        >
+                          {sample.scriptURL}
+                        </a>
+                      </div>
+                    )}
+                    {sample.stack && (
+                      <div className="mt-1 text-slate-400">
+                        <span className="text-[0.65rem] uppercase tracking-wide text-slate-500">Stack</span>{" "}
+                        <a
+                          href={stackLink(sample.stack, 0)}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-sky-300 hover:text-sky-200"
+                        >
+                          Open stack trace
+                        </a>
+                      </div>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+};
+
+export default PerfHints;

--- a/utils/longTasks.ts
+++ b/utils/longTasks.ts
@@ -1,0 +1,337 @@
+/*
+ * Performance long task tracking utilities.
+ *
+ * Collects long tasks (> threshold) using the PerformanceObserver API and
+ * aggregates offenders so developer tooling can surface likely issues.
+ */
+
+interface PerformanceEntryAttribution {
+  name?: string;
+  entryType?: string;
+  startTime?: number;
+  duration?: number;
+  containerType?: string;
+  containerName?: string;
+  containerId?: string;
+  containerSrc?: string;
+  nodeId?: string;
+  url?: string;
+  scriptId?: string;
+  scriptURL?: string;
+  workerName?: string;
+  stack?: string;
+  toJSON?: () => Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface PerformanceEntryWithAttribution extends PerformanceEntry {
+  duration: number;
+  startTime: number;
+  attribution?: PerformanceEntryAttribution[];
+  toJSON?: () => {
+    attribution?: PerformanceEntryAttribution[];
+    [key: string]: unknown;
+  };
+}
+
+const MICRO_TASK: (cb: () => void) => void =
+  typeof queueMicrotask === 'function'
+    ? queueMicrotask
+    : (cb: () => void) => {
+        Promise.resolve().then(cb);
+      };
+
+type Listener = (snapshot: LongTaskSnapshot) => void;
+
+type InternalInsight = {
+  key: string;
+  label: string;
+  occurrences: number;
+  totalDuration: number;
+  maxDuration: number;
+  lastStartTime: number;
+  scriptURL?: string;
+  stackTraces: Set<string>;
+};
+
+type InternalSample = {
+  id: string;
+  key: string;
+  label: string;
+  duration: number;
+  startTime: number;
+  scriptURL?: string;
+  stack?: string;
+};
+
+const state: {
+  threshold: number;
+  observing: boolean;
+  debug: boolean;
+  observer: PerformanceObserver | null;
+  insights: Map<string, InternalInsight>;
+  samples: InternalSample[];
+} = {
+  threshold: 50,
+  observing: false,
+  debug: false,
+  observer: null,
+  insights: new Map(),
+  samples: [],
+};
+
+const listeners = new Set<Listener>();
+let notifyPending = false;
+
+export interface LongTaskInsight {
+  key: string;
+  label: string;
+  occurrences: number;
+  totalDuration: number;
+  avgDuration: number;
+  maxDuration: number;
+  lastStartTime: number;
+  scriptURL?: string;
+  stackTraces: string[];
+}
+
+export interface LongTaskSample {
+  id: string;
+  key: string;
+  label: string;
+  duration: number;
+  startTime: number;
+  scriptURL?: string;
+  stack?: string;
+}
+
+export interface LongTaskSnapshot {
+  insights: LongTaskInsight[];
+  samples: LongTaskSample[];
+  observing: boolean;
+  debug: boolean;
+  threshold: number;
+  supported: boolean;
+}
+
+const isWindowAvailable = () => typeof window !== 'undefined';
+
+export const isLongTaskObserverSupported = () => {
+  if (!isWindowAvailable()) return false;
+  return (
+    typeof PerformanceObserver !== 'undefined' &&
+    // @ts-expect-error Checking existence in window for browsers that expose it.
+    typeof (window as unknown as { PerformanceLongTaskTiming?: unknown })
+      .PerformanceLongTaskTiming !== 'undefined'
+  );
+};
+
+const buildStackLink = (
+  attribution?: PerformanceEntryAttribution,
+  entry?: PerformanceEntryWithAttribution,
+) => {
+  const stackFromAttr = attribution && ('stack' in attribution ? attribution.stack : undefined);
+  if (stackFromAttr && typeof stackFromAttr === 'string' && stackFromAttr.trim().length) {
+    return stackFromAttr;
+  }
+
+  const fromAttrJson = attribution?.toJSON?.();
+  const jsonStack = fromAttrJson && typeof fromAttrJson.stack === 'string' ? fromAttrJson.stack : undefined;
+  if (jsonStack && jsonStack.trim().length) return jsonStack;
+
+  const json = entry?.toJSON?.();
+  const entryStack =
+    json && Array.isArray(json.attribution) && typeof json.attribution[0]?.stack === 'string'
+      ? (json.attribution[0]?.stack as string)
+      : undefined;
+  return entryStack && entryStack.trim().length ? entryStack : undefined;
+};
+
+const describeEntry = (entry: PerformanceEntryWithAttribution) => {
+  const attribution = entry.attribution && entry.attribution[0];
+  const scriptURL = attribution?.scriptURL || attribution?.containerSrc;
+  const labelParts = [attribution?.name, attribution?.containerName, scriptURL]
+    .filter(Boolean)
+    .map((part) => String(part));
+  const label = labelParts.length ? labelParts.join(' · ') : entry.name || 'Long task';
+  const key = scriptURL || attribution?.name || attribution?.containerName || entry.name || 'unknown';
+  const stack = buildStackLink(attribution, entry);
+
+  return {
+    attribution,
+    key,
+    label,
+    scriptURL,
+    stack,
+  };
+};
+
+const toPublicInsights = (): LongTaskInsight[] => {
+  const items = Array.from(state.insights.values()).map((insight) => ({
+    key: insight.key,
+    label: insight.label,
+    occurrences: insight.occurrences,
+    totalDuration: insight.totalDuration,
+    avgDuration: insight.totalDuration / Math.max(insight.occurrences, 1),
+    maxDuration: insight.maxDuration,
+    lastStartTime: insight.lastStartTime,
+    scriptURL: insight.scriptURL,
+    stackTraces: Array.from(insight.stackTraces),
+  }));
+
+  return items.sort((a, b) => b.totalDuration - a.totalDuration);
+};
+
+const toPublicSamples = (): LongTaskSample[] => state.samples.slice();
+
+const scheduleNotify = () => {
+  if (notifyPending) return;
+  notifyPending = true;
+  MICRO_TASK(() => {
+    notifyPending = false;
+    const snapshot = getLongTaskSnapshot();
+    listeners.forEach((listener) => listener(snapshot));
+  });
+};
+
+const debugLog = (...args: unknown[]) => {
+  if (!state.debug) return;
+  if (typeof console !== 'undefined' && typeof console.debug === 'function') {
+    console.debug('[perf:long-task]', ...args);
+  }
+};
+
+const processEntries = (entries: PerformanceEntry[]) => {
+  entries.forEach((entry) => {
+    const longTask = entry as PerformanceEntryWithAttribution;
+    if (!longTask || typeof longTask.duration !== 'number') return;
+    if (longTask.duration < state.threshold) return;
+
+    const description = describeEntry(longTask);
+    const existing = state.insights.get(description.key);
+
+    if (existing) {
+      existing.occurrences += 1;
+      existing.totalDuration += longTask.duration;
+      existing.maxDuration = Math.max(existing.maxDuration, longTask.duration);
+      existing.lastStartTime = longTask.startTime;
+      existing.label = description.label;
+      if (description.scriptURL) existing.scriptURL = description.scriptURL;
+      if (description.stack) existing.stackTraces.add(description.stack);
+    } else {
+      state.insights.set(description.key, {
+        key: description.key,
+        label: description.label,
+        occurrences: 1,
+        totalDuration: longTask.duration,
+        maxDuration: longTask.duration,
+        lastStartTime: longTask.startTime,
+        scriptURL: description.scriptURL,
+        stackTraces: new Set(description.stack ? [description.stack] : []),
+      });
+    }
+
+    const sample: InternalSample = {
+      id: `${Math.round(longTask.startTime)}-${Math.round(longTask.duration * 1000)}`,
+      key: description.key,
+      label: description.label,
+      duration: longTask.duration,
+      startTime: longTask.startTime,
+      scriptURL: description.scriptURL,
+      stack: description.stack,
+    };
+
+    state.samples.unshift(sample);
+    if (state.samples.length > 40) {
+      state.samples.length = 40;
+    }
+
+    debugLog('Long task recorded', {
+      key: description.key,
+      duration: longTask.duration,
+      scriptURL: description.scriptURL,
+      stack: description.stack,
+    });
+  });
+
+  if (entries.length) scheduleNotify();
+};
+
+export const getLongTaskSnapshot = (): LongTaskSnapshot => ({
+  insights: toPublicInsights(),
+  samples: toPublicSamples(),
+  observing: state.observing,
+  debug: state.debug,
+  threshold: state.threshold,
+  supported: isLongTaskObserverSupported(),
+});
+
+export const subscribeToLongTaskInsights = (listener: Listener) => {
+  listeners.add(listener);
+  listener(getLongTaskSnapshot());
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const startLongTaskObserver = (options?: { threshold?: number }) => {
+  if (options?.threshold) {
+    state.threshold = options.threshold;
+  }
+
+  if (!isLongTaskObserverSupported()) {
+    debugLog('PerformanceObserver longtask support is unavailable.');
+    return false;
+  }
+
+  if (state.observing) return true;
+
+  try {
+    state.observer = new PerformanceObserver((list) => {
+      processEntries(list.getEntries());
+    });
+    state.observer.observe({ type: 'longtask', buffered: true });
+    state.observing = true;
+    scheduleNotify();
+    debugLog('Long task observer started.', { threshold: state.threshold });
+    return true;
+  } catch (error) {
+    debugLog('Failed to start long task observer', error);
+    state.observer = null;
+    state.observing = false;
+    return false;
+  }
+};
+
+export const stopLongTaskObserver = () => {
+  if (state.observer) {
+    state.observer.disconnect();
+    state.observer = null;
+  }
+  if (state.observing) {
+    state.observing = false;
+    scheduleNotify();
+    debugLog('Long task observer stopped.');
+  }
+};
+
+export const clearLongTaskData = () => {
+  state.insights.clear();
+  state.samples.length = 0;
+  scheduleNotify();
+  debugLog('Cleared long task data.');
+};
+
+export const setLongTaskDebugLogging = (enabled: boolean) => {
+  if (state.debug === enabled) return;
+  state.debug = enabled;
+  scheduleNotify();
+  debugLog('Debug logging toggled.', { enabled });
+};
+
+export const setLongTaskThreshold = (threshold: number) => {
+  if (Number.isNaN(threshold) || threshold <= 0) return;
+  state.threshold = threshold;
+  scheduleNotify();
+  debugLog('Threshold updated.', { threshold });
+};


### PR DESCRIPTION
## Summary
- add a PerformanceObserver-powered long task tracker utility that groups offenders and stores recent samples
- create a dev-only Performance Hints panel with controls for enabling tracking, debugging output, and clearing collected data

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dca4ce3e7083288ca60921de2ba6c7