### PR TITLE
[pwa] add swr caching for docs and json assets

### DIFF
--- a/__tests__/docsCacheConfig.test.js
+++ b/__tests__/docsCacheConfig.test.js
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment node
+ */
+
+const path = require('path');
+const {
+  buildDocsJsonHeaders,
+  createDocsJsonRuntimeCaching,
+} = require('../lib/docsCacheConfig.js');
+
+describe('docs/json cache configuration', () => {
+  const projectRoot = path.join(__dirname, '..');
+
+  test('emits Cache-Control with stale-while-revalidate and an ETag for docs', () => {
+    const headers = buildDocsJsonHeaders({ projectRoot });
+    const docEntry = headers.find((entry) =>
+      entry.source.endsWith('/docs/apps/terminal.md'),
+    );
+    expect(docEntry).toBeDefined();
+    expect(docEntry.headers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: 'Cache-Control',
+          value: expect.stringContaining('stale-while-revalidate'),
+        }),
+        expect.objectContaining({
+          key: 'ETag',
+          value: expect.stringMatching(/^"[a-f0-9]+"$/),
+        }),
+      ]),
+    );
+  });
+
+  test('emits Cache-Control with stale-while-revalidate and an ETag for JSON', () => {
+    const headers = buildDocsJsonHeaders({ projectRoot });
+    const jsonEntry = headers.find((entry) => entry.source.endsWith('/projects.json'));
+    expect(jsonEntry).toBeDefined();
+    expect(jsonEntry.headers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: 'Cache-Control',
+          value: expect.stringContaining('stale-while-revalidate'),
+        }),
+        expect.objectContaining({
+          key: 'ETag',
+          value: expect.stringMatching(/^"[a-f0-9]+"$/),
+        }),
+      ]),
+    );
+  });
+
+  test('runtime caching uses stale-while-revalidate handler', () => {
+    const cacheEntry = createDocsJsonRuntimeCaching({ cacheName: 'docs-json-test' });
+    expect(cacheEntry.handler).toBe('StaleWhileRevalidate');
+
+    const docUrl = new URL('https://example.com/docs/apps/terminal.md');
+    const jsonUrl = new URL('https://example.com/projects.json');
+    const dataUrl = new URL('https://example.com/_next/data/build/index.json');
+
+    expect(cacheEntry.urlPattern({ sameOrigin: true, url: docUrl })).toBe(true);
+    expect(cacheEntry.urlPattern({ sameOrigin: true, url: jsonUrl })).toBe(true);
+    expect(cacheEntry.urlPattern({ sameOrigin: true, url: dataUrl })).toBe(false);
+  });
+});

--- a/lib/docsCacheConfig.js
+++ b/lib/docsCacheConfig.js
@@ -1,0 +1,121 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function gatherFiles(dirPath, predicate) {
+  if (!dirPath || !predicate) return [];
+  if (!fs.existsSync(dirPath)) return [];
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  const results = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...gatherFiles(fullPath, predicate));
+      continue;
+    }
+    if (predicate(fullPath)) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+function computeEtagForFile(filePath) {
+  const buffer = fs.readFileSync(filePath);
+  const hash = crypto.createHash('sha1').update(buffer).digest('hex');
+  return `"${hash}"`;
+}
+
+function buildHeaderEntry({
+  publicDir,
+  absoluteFile,
+  basePath,
+  cacheControlValue,
+}) {
+  const relative = path.relative(publicDir, absoluteFile);
+  const routePath = `/${toPosixPath(relative)}`;
+  const prefix = basePath && basePath !== '/' ? basePath : '';
+  return {
+    source: `${prefix}${routePath}`,
+    headers: [
+      {
+        key: 'Cache-Control',
+        value: cacheControlValue,
+      },
+      {
+        key: 'ETag',
+        value: computeEtagForFile(absoluteFile),
+      },
+    ],
+  };
+}
+
+function buildDocsJsonHeaders({
+  projectRoot,
+  basePath = '',
+  cacheControlValue = 'public, max-age=0, stale-while-revalidate=86400',
+}) {
+  const publicDir = path.join(projectRoot, 'public');
+  const docsDir = path.join(publicDir, 'docs');
+  const headers = [];
+
+  const docFiles = gatherFiles(docsDir, (file) => file.endsWith('.md'));
+  for (const file of docFiles) {
+    headers.push(
+      buildHeaderEntry({
+        publicDir,
+        absoluteFile: file,
+        basePath,
+        cacheControlValue,
+      }),
+    );
+  }
+
+  const jsonFiles = gatherFiles(publicDir, (file) => file.endsWith('.json'));
+  for (const file of jsonFiles) {
+    headers.push(
+      buildHeaderEntry({
+        publicDir,
+        absoluteFile: file,
+        basePath,
+        cacheControlValue,
+      }),
+    );
+  }
+
+  return headers;
+}
+
+function createDocsJsonRuntimeCaching({ basePath = '', cacheName }) {
+  const prefix = basePath && basePath !== '/' ? basePath : '';
+  return {
+    urlPattern: ({ sameOrigin, url }) => {
+      if (!sameOrigin) return false;
+      if (prefix && !url.pathname.startsWith(prefix)) {
+        return false;
+      }
+      const trimmed = prefix ? url.pathname.slice(prefix.length) : url.pathname;
+      const normalized = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+      if (normalized.startsWith('/_next/')) return false;
+      if (normalized.startsWith('/api/')) return false;
+      const isDoc = normalized.startsWith('/docs/') && normalized.endsWith('.md');
+      const isJson = normalized.endsWith('.json');
+      return isDoc || isJson;
+    },
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName,
+      cacheableResponse: { statuses: [0, 200] },
+      matchOptions: { ignoreVary: true },
+    },
+  };
+}
+
+module.exports = {
+  buildDocsJsonHeaders,
+  createDocsJsonRuntimeCaching,
+};

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,10 @@
 // Update README (section "CSP External Domains") when editing domains below.
 
 const { validateServerEnv: validateEnv } = require('./lib/validate.js');
+const {
+  buildDocsJsonHeaders,
+  createDocsJsonRuntimeCaching,
+} = require('./lib/docsCacheConfig.js');
 
 const ContentSecurityPolicy = [
   "default-src 'self'",
@@ -124,8 +128,14 @@ const startUrlRuntimeCaching = {
   },
 };
 
+const docsJsonRuntimeCaching = createDocsJsonRuntimeCaching({
+  basePath: normalizedBasePath === '/' ? '' : normalizedBasePath,
+  cacheName: buildAwareCacheName('docs-json'),
+});
+
 const runtimeCaching = [
   startUrlRuntimeCaching,
+  docsJsonRuntimeCaching,
   ...defaultRuntimeCaching.map((entry) => ({
     ...entry,
     ...(entry.options
@@ -234,6 +244,11 @@ module.exports = withBundleAnalyzer(
       ? {}
       : {
           async headers() {
+            const docsAndJsonHeaders = buildDocsJsonHeaders({
+              projectRoot: __dirname,
+              basePath: normalizedBasePath === '/' ? '' : normalizedBasePath,
+            });
+
             return [
               {
                 source: '/(.*)',
@@ -257,6 +272,7 @@ module.exports = withBundleAnalyzer(
                   },
                 ],
               },
+              ...docsAndJsonHeaders,
             ];
           },
         }),


### PR DESCRIPTION
## Summary
- add utilities to compute SWR cache headers and ETags for docs and JSON assets
- wire the new headers into Next.js and register a stale-while-revalidate runtime cache for docs/JSON responses
- cover the configuration with unit tests to guard the caching contract

## Testing
- yarn lint
- yarn test docsCacheConfig.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dca4cd50648328a0495ffda4a722aa