### PR TITLE
[fixtures] Stream JSON parsing and progress reporting

### DIFF
--- a/__tests__/jsonChunker.test.ts
+++ b/__tests__/jsonChunker.test.ts
@@ -1,0 +1,107 @@
+import { ReadableStream } from 'node:stream/web';
+
+import { jsonChunker } from '../utils/streams/jsonChunker';
+
+describe('jsonChunker', () => {
+  jest.setTimeout(60000);
+
+  const encoder = new TextEncoder();
+
+  function stringStream(chunks: string[]): ReadableStream<Uint8Array> {
+    let index = 0;
+    return new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (index >= chunks.length) {
+          controller.close();
+          return;
+        }
+        const chunk = encoder.encode(chunks[index]);
+        index += 1;
+        controller.enqueue(chunk);
+      },
+    });
+  }
+
+  it('parses NDJSON incrementally and reports errors', async () => {
+    const stream = stringStream(['{"a":1}\n', '{"a":2}\n{"b":3}\n', 'invalid\n', '{"c":4}\n']);
+    const items: any[] = [];
+    const errors: string[] = [];
+    let progressEvents = 0;
+
+    for await (const event of jsonChunker(stream, { progressThrottleMs: 0 })) {
+      if (event.type === 'item') {
+        items.push(event.value);
+      } else if (event.type === 'error') {
+        errors.push(event.error.message);
+      } else if (event.type === 'progress') {
+        progressEvents += 1;
+      }
+    }
+
+    expect(items).toHaveLength(4);
+    expect(items[0]).toEqual({ a: 1 });
+    expect(items[2]).toEqual({ b: 3 });
+    expect(items[3]).toEqual({ c: 4 });
+    expect(errors).toHaveLength(1);
+    expect(progressEvents).toBeGreaterThan(0);
+  });
+
+  it('processes a 50MB stream without blocking the event loop for long', async () => {
+    const totalBytes = 50 * 1024 * 1024;
+    const stream = createLargeStream(totalBytes);
+    const delays: number[] = [];
+    let last = performance.now();
+    const interval = setInterval(() => {
+      const now = performance.now();
+      delays.push(now - last);
+      last = now;
+    }, 10);
+
+    let parsed = 0;
+    await (async () => {
+      for await (const event of jsonChunker(stream, {
+        totalBytes,
+        progressThrottleMs: 0,
+        yieldIntervalMs: 8,
+      })) {
+        if (event.type === 'item' || event.type === 'error') {
+          parsed += 1;
+        }
+      }
+    })();
+
+    clearInterval(interval);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(parsed).toBeGreaterThan(0);
+    const maxDelay = delays.length ? Math.max(...delays) : 0;
+    expect(maxDelay).toBeLessThan(50);
+  });
+
+  function createLargeStream(totalBytes: number): ReadableStream<Uint8Array> {
+    const line = `{"value":"${'x'.repeat(900)}"}\n`;
+    const chunkText = line.repeat(32);
+    const chunkBytes = encoder.encode(chunkText);
+    let sent = 0;
+    return new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (sent >= totalBytes) {
+          controller.close();
+          return;
+        }
+        const remaining = totalBytes - sent;
+        const size = Math.min(chunkBytes.length, remaining);
+        controller.enqueue(chunkBytes.subarray(0, size));
+        sent += size;
+        if (sent >= totalBytes) {
+          controller.close();
+          return;
+        }
+        return new Promise<void>((resolve) => setTimeout(resolve, 0));
+      },
+      cancel() {
+        sent = totalBytes;
+      },
+    });
+  }
+});

--- a/components/FixturesLoader.tsx
+++ b/components/FixturesLoader.tsx
@@ -1,69 +1,177 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 interface LoaderProps {
   onData: (rows: any[]) => void;
 }
 
+type WorkerParseSource =
+  | { kind: 'file'; file: File }
+  | { kind: 'url'; url: string }
+  | { kind: 'text'; text: string };
+
+type WorkerProgressMessage = {
+  type: 'progress';
+  payload: {
+    loaded: number;
+    total: number | null;
+    items: number;
+    lines: number;
+    done?: boolean;
+  };
+};
+
+type WorkerResultMessage = {
+  type: 'result';
+  payload: {
+    rows: any[];
+    errors: { line: number; message: string; raw: string }[];
+  };
+};
+
+type WorkerErrorMessage = { type: 'error'; payload: { message: string } };
+type WorkerCancelledMessage = { type: 'cancelled' };
+
+type WorkerMessage =
+  | WorkerProgressMessage
+  | WorkerResultMessage
+  | WorkerErrorMessage
+  | WorkerCancelledMessage;
+
+type LoaderStatus = 'idle' | 'parsing' | 'complete' | 'error' | 'cancelled';
+
 export default function FixturesLoader({ onData }: LoaderProps) {
   const [progress, setProgress] = useState(0);
+  const [itemsParsed, setItemsParsed] = useState(0);
+  const [status, setStatus] = useState<LoaderStatus>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [parseErrors, setParseErrors] = useState<WorkerResultMessage['payload']['errors']>([]);
   const [worker, setWorker] = useState<Worker | null>(null);
 
   useEffect(() => {
     const w = new Worker(new URL('../workers/fixturesParser.ts', import.meta.url));
-    w.onmessage = (e) => {
-      const { type, payload } = e.data;
-      if (type === 'progress') setProgress(payload);
-      if (type === 'result') {
-        onData(payload);
+    w.onmessage = (event: MessageEvent<WorkerMessage>) => {
+      const message = event.data;
+      if (message.type === 'progress') {
+        const { loaded, total, items, done } = message.payload;
+        setItemsParsed(items);
+        setProgress((prev) => {
+          if (typeof total === 'number' && total > 0) {
+            return Math.min(100, Math.round((loaded / total) * 100));
+          }
+          if (done) return 100;
+          if (prev >= 99) return prev;
+          return Math.min(99, prev + 1);
+        });
+        setStatus((prev) => (prev === 'idle' ? 'parsing' : prev));
+      } else if (message.type === 'result') {
+        const { rows, errors } = message.payload;
+        onData(rows);
+        setParseErrors(errors);
+        setStatus('complete');
+        setProgress(100);
+        setItemsParsed(rows.length);
         try {
-          localStorage.setItem('fixtures-last', JSON.stringify(payload));
+          localStorage.setItem('fixtures-last', JSON.stringify(rows));
         } catch {
           /* ignore */
         }
+      } else if (message.type === 'error') {
+        setStatus('error');
+        setErrorMessage(message.payload.message || 'Failed to parse fixtures');
+      } else if (message.type === 'cancelled') {
+        setStatus('cancelled');
       }
     };
     setWorker(w);
     return () => w.terminate();
   }, [onData]);
 
-  const loadSample = async () => {
-    const res = await fetch('/fixtures/sample.json');
-    const text = await res.text();
-    worker?.postMessage({ type: 'parse', text });
-  };
+  const startParse = useCallback(
+    (source: WorkerParseSource) => {
+      if (!worker) return;
+      setStatus('parsing');
+      setErrorMessage(null);
+      setParseErrors([]);
+      setProgress(0);
+      setItemsParsed(0);
+      worker.postMessage({ type: 'parse', source });
+    },
+    [worker],
+  );
+
+  const loadSample = useCallback(() => {
+    startParse({ kind: 'url', url: '/fixtures/sample.json' });
+  }, [startParse]);
 
   const onFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => {
-      worker?.postMessage({ type: 'parse', text: reader.result });
-    };
-    reader.readAsText(file);
+    startParse({ kind: 'file', file });
+    e.target.value = '';
   };
 
-  const cancel = () => worker?.postMessage({ type: 'cancel' });
+  const cancel = () => {
+    setStatus('cancelled');
+    setProgress(0);
+    setItemsParsed(0);
+    setParseErrors([]);
+    setErrorMessage(null);
+    worker?.postMessage({ type: 'cancel' });
+  };
+
+  const statusLabel: Record<LoaderStatus, string> = {
+    idle: 'Idle',
+    parsing: 'Parsing…',
+    complete: 'Complete',
+    error: 'Error',
+    cancelled: 'Cancelled',
+  };
 
   return (
     <div className="text-xs" aria-label="fixtures loader">
-      <div className="mb-2 flex items-center">
-        <button onClick={loadSample} className="px-2 py-1 bg-ub-cool-grey text-white mr-2" type="button">
+      <div className="mb-2 flex items-center gap-2">
+        <button
+          onClick={loadSample}
+          className="px-2 py-1 bg-ub-cool-grey text-white"
+          type="button"
+          disabled={!worker}
+        >
           Load Sample
         </button>
-        <label className="px-2 py-1 bg-ub-cool-grey text-white mr-2 cursor-pointer">
+        <label className="px-2 py-1 bg-ub-cool-grey text-white cursor-pointer">
           Import
-          <input type="file" onChange={onFile} className="hidden" aria-label="import fixture" />
+          <input
+            type="file"
+            onChange={onFile}
+            className="hidden"
+            aria-label="import fixture"
+            disabled={!worker}
+          />
         </label>
-        <button onClick={cancel} className="px-2 py-1 bg-ub-red text-white" type="button">
+        <button onClick={cancel} className="px-2 py-1 bg-ub-red text-white" type="button" disabled={!worker}>
           Cancel
         </button>
       </div>
       <div className="mb-2" aria-label="progress">
-        Parsing: {progress}%
+        Parsing: {progress}% ({itemsParsed} rows) — Status: {statusLabel[status]}
       </div>
+      {parseErrors.length > 0 && (
+        <div className="mb-2 text-ub-orange" aria-label="fixture warnings">
+          <p className="mb-1">Skipped {parseErrors.length} invalid row(s). Showing first issues:</p>
+          <ul className="list-disc list-inside space-y-1">
+            {parseErrors.slice(0, 3).map((err) => (
+              <li key={`${err.line}-${err.message}`}>Line {err.line}: {err.message}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {errorMessage && (
+        <div className="text-red-500" aria-live="polite">
+          {errorMessage}
+        </div>
+      )}
     </div>
   );
 }
-

--- a/utils/streams/jsonChunker.ts
+++ b/utils/streams/jsonChunker.ts
@@ -1,0 +1,136 @@
+const DEFAULT_PROGRESS_THROTTLE_MS = 50;
+const DEFAULT_YIELD_INTERVAL_MS = 16;
+
+const now = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+export interface JsonChunkerOptions {
+  /** Total bytes expected from the source stream. Used to emit progress percentages. */
+  totalBytes?: number;
+  /** Abort parsing early. */
+  signal?: AbortSignal | null;
+  /** Minimum time between progress events (ms). Defaults to 50ms. */
+  progressThrottleMs?: number;
+  /** Maximum time to run without yielding back to the event loop (ms). Defaults to 16ms. */
+  yieldIntervalMs?: number;
+}
+
+export type JsonChunkEvent<T = unknown> =
+  | { type: 'item'; value: T }
+  | { type: 'progress'; loaded: number; total?: number }
+  | { type: 'error'; error: Error; raw: string };
+
+function shouldYield(last: number, interval: number | undefined) {
+  if (!interval || interval <= 0) return false;
+  return now() - last >= interval;
+}
+
+async function yieldToEventLoop() {
+  await new Promise<void>((resolve) => {
+    if (typeof setTimeout === 'function') {
+      setTimeout(resolve, 0);
+    } else if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => resolve());
+    } else {
+      resolve();
+    }
+  });
+}
+
+function sanitizeLine(line: string) {
+  return line.replace(/\r$/, '').trim();
+}
+
+function toError(error: unknown) {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+export async function* jsonChunker<T = unknown>(
+  stream: ReadableStream<Uint8Array>,
+  options: JsonChunkerOptions = {},
+): AsyncGenerator<JsonChunkEvent<T>> {
+  const {
+    totalBytes,
+    signal,
+    progressThrottleMs = DEFAULT_PROGRESS_THROTTLE_MS,
+    yieldIntervalMs = DEFAULT_YIELD_INTERVAL_MS,
+  } = options;
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let loaded = 0;
+  let lastProgress = 0;
+  let lastYield = now();
+
+  const abortIfNeeded = () => {
+    if (signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
+  };
+
+  try {
+    while (true) {
+      abortIfNeeded();
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      loaded += value.byteLength;
+      buffer += decoder.decode(value, { stream: true });
+
+      let newlineIndex = buffer.indexOf('\n');
+      while (newlineIndex !== -1) {
+        abortIfNeeded();
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        const trimmed = sanitizeLine(line);
+        if (trimmed) {
+          try {
+            const parsed = JSON.parse(trimmed) as T;
+            yield { type: 'item', value: parsed };
+          } catch (error) {
+            yield { type: 'error', error: toError(error), raw: trimmed };
+          }
+        }
+        if (shouldYield(lastYield, yieldIntervalMs)) {
+          await yieldToEventLoop();
+          lastYield = now();
+        }
+        newlineIndex = buffer.indexOf('\n');
+      }
+
+      const current = now();
+      if (!progressThrottleMs || current - lastProgress >= progressThrottleMs) {
+        lastProgress = current;
+        yield { type: 'progress', loaded, total: totalBytes };
+      }
+    }
+
+    buffer += decoder.decode();
+    if (buffer) {
+      const lines = buffer.split('\n');
+      for (const line of lines) {
+        abortIfNeeded();
+        const trimmed = sanitizeLine(line);
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed) as T;
+          yield { type: 'item', value: parsed };
+        } catch (error) {
+          yield { type: 'error', error: toError(error), raw: trimmed };
+        }
+        if (shouldYield(lastYield, yieldIntervalMs)) {
+          await yieldToEventLoop();
+          lastYield = now();
+        }
+      }
+    }
+
+    const finalLoaded = totalBytes ?? loaded;
+    yield { type: 'progress', loaded: finalLoaded, total: totalBytes ?? finalLoaded };
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/workers/fixturesParser.ts
+++ b/workers/fixturesParser.ts
@@ -1,32 +1,174 @@
-let cancelled = false;
+import { jsonChunker } from '../utils/streams/jsonChunker';
 
-self.onmessage = (e: MessageEvent) => {
-  const { type, text } = e.data as { type: string; text?: string };
-  if (type === 'cancel') {
-    cancelled = true;
+type FileSource = { kind: 'file'; file: File };
+type UrlSource = { kind: 'url'; url: string };
+type TextSource = { kind: 'text'; text: string };
+type ParseSource = FileSource | UrlSource | TextSource;
+
+type ParseCommand = { type: 'parse'; source: ParseSource };
+type CancelCommand = { type: 'cancel' };
+type WorkerCommand = ParseCommand | CancelCommand;
+
+type ProgressPayload = {
+  loaded: number;
+  total: number | null;
+  items: number;
+  lines: number;
+  done?: boolean;
+};
+
+type RowError = { line: number; message: string; raw: string };
+
+type ResultPayload = {
+  rows: any[];
+  errors: RowError[];
+};
+
+type WorkerResponse =
+  | { type: 'progress'; payload: ProgressPayload }
+  | { type: 'result'; payload: ResultPayload }
+  | { type: 'error'; payload: { message: string } }
+  | { type: 'cancelled' };
+
+const ctx = self as unknown as DedicatedWorkerGlobalScope;
+
+const MAX_ERRORS = 50;
+const DEFAULT_PROGRESS_THROTTLE_MS = 64;
+
+let currentController: AbortController | null = null;
+let currentParseId = 0;
+
+ctx.onmessage = (event: MessageEvent<WorkerCommand>) => {
+  const message = event.data;
+  if (message.type === 'cancel') {
+    cancelCurrent();
+    ctx.postMessage({ type: 'cancelled' } satisfies WorkerResponse);
     return;
   }
-  if (type === 'parse' && text) {
-    cancelled = false;
-    const lines = text.split(/\n/);
-    const total = lines.length;
-    const result: any[] = [];
-    for (let i = 0; i < lines.length; i++) {
-      if (cancelled) return;
-      const line = lines[i].trim();
-      if (!line) continue;
-      try {
-        result.push(JSON.parse(line));
-      } catch {
-        result.push({ line });
-      }
-      if (i % 100 === 0) {
-        (self as any).postMessage({ type: 'progress', payload: Math.round((i / total) * 100) });
-      }
-    }
-    (self as any).postMessage({ type: 'progress', payload: 100 });
-    (self as any).postMessage({ type: 'result', payload: result });
+  if (message.type === 'parse') {
+    startParse(message.source).catch((error) => {
+      const err = error instanceof Error ? error : new Error(String(error));
+      ctx.postMessage({ type: 'error', payload: { message: err.message } } satisfies WorkerResponse);
+    });
   }
 };
+
+function cancelCurrent() {
+  if (currentController) {
+    currentController.abort();
+    currentController = null;
+  }
+}
+
+async function startParse(source: ParseSource) {
+  cancelCurrent();
+  const controller = new AbortController();
+  currentController = controller;
+  const parseId = ++currentParseId;
+
+  try {
+    const { stream, totalBytes } = await getStream(source);
+    const rows: any[] = [];
+    const errors: RowError[] = [];
+    let lineNumber = 0;
+
+    for await (const event of jsonChunker(stream, {
+      totalBytes,
+      signal: controller.signal,
+      progressThrottleMs: DEFAULT_PROGRESS_THROTTLE_MS,
+    })) {
+      if (parseId !== currentParseId) {
+        controller.abort();
+        return;
+      }
+
+      if (event.type === 'item') {
+        lineNumber += 1;
+        rows.push(event.value);
+      } else if (event.type === 'error') {
+        lineNumber += 1;
+        if (errors.length < MAX_ERRORS) {
+          errors.push({ line: lineNumber, message: event.error.message, raw: event.raw });
+        }
+      } else if (event.type === 'progress') {
+        ctx.postMessage({
+          type: 'progress',
+          payload: {
+            loaded: event.loaded,
+            total: event.total ?? null,
+            items: rows.length,
+            lines: lineNumber,
+          },
+        } satisfies WorkerResponse);
+      }
+    }
+
+    if (!controller.signal.aborted) {
+      ctx.postMessage({
+        type: 'progress',
+        payload: {
+          loaded: totalBytes ?? rows.length,
+          total: totalBytes ?? rows.length,
+          items: rows.length,
+          lines: lineNumber,
+          done: true,
+        },
+      } satisfies WorkerResponse);
+      ctx.postMessage({ type: 'result', payload: { rows, errors } } satisfies WorkerResponse);
+    }
+  } catch (error) {
+    if (controller.signal.aborted) {
+      return;
+    }
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      return;
+    }
+    throw error;
+  } finally {
+    if (currentController === controller) {
+      currentController = null;
+    }
+  }
+}
+
+async function getStream(
+  source: ParseSource,
+): Promise<{ stream: ReadableStream<Uint8Array>; totalBytes?: number }> {
+  if (source.kind === 'file') {
+    const { file } = source;
+    if (typeof file.stream === 'function') {
+      return { stream: file.stream(), totalBytes: file.size };
+    }
+    const text = await file.text();
+    return stringToStream(text);
+  }
+  if (source.kind === 'url') {
+    const res = await fetch(source.url);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch ${source.url}: ${res.status} ${res.statusText}`);
+    }
+    const totalHeader = res.headers.get('content-length');
+    const totalBytes = totalHeader ? Number(totalHeader) : undefined;
+    if (res.body) {
+      return { stream: res.body, totalBytes };
+    }
+    const text = await res.text();
+    const fallback = stringToStream(text);
+    return { stream: fallback.stream, totalBytes: fallback.totalBytes };
+  }
+  return stringToStream(source.text);
+}
+
+function stringToStream(text: string): { stream: ReadableStream<Uint8Array>; totalBytes: number } {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(text);
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+  return { stream, totalBytes: bytes.byteLength };
+}
 
 export {}; // ensure module scope


### PR DESCRIPTION
## Summary
- add a streaming NDJSON chunker that yields items, progress events, and respects abort signals
- refactor the fixtures parser worker to consume streams from files or URLs and to forward progress, errors, and cancellation states
- update the fixtures loader UI to react to streaming updates, expose status feedback, and surface parse errors, plus add regression tests for the chunker including a 50MB stall check

## Testing
- yarn lint components/FixturesLoader.tsx workers/fixturesParser.ts utils/streams/jsonChunker.ts __tests__/jsonChunker.test.ts
- yarn test jsonChunker

------
https://chatgpt.com/codex/tasks/task_e_68dca4d077a08328bbb17b92e44730c0