### PR TITLE
[scheduler] add overload shedding controls

### DIFF
--- a/components/ResultViewer.tsx
+++ b/components/ResultViewer.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useId } from 'react';
+
+import {
+  configureScheduler,
+  getSchedulerDiagnostics,
+  runInputTask,
+  subscribeScheduler,
+  type SchedulerDiagnostics,
+} from '../scanner/schedule';
 
 interface ViewerProps {
   data: any[];
@@ -10,6 +18,13 @@ export default function ResultViewer({ data }: ViewerProps) {
   const [tab, setTab] = useState<'raw' | 'parsed' | 'chart'>('raw');
   const [sortKey, setSortKey] = useState('');
   const [filter, setFilter] = useState('');
+  const [diagnostics, setDiagnostics] = useState<SchedulerDiagnostics | null>(null);
+  const [overloadLag, setOverloadLag] = useState(120);
+  const [lowFpsCap, setLowFpsCap] = useState(10);
+  const [eventLogSize, setEventLogSize] = useState(25);
+  const overloadId = useId();
+  const lowFpsId = useId();
+  const eventLogId = useId();
 
   useEffect(() => {
     try {
@@ -27,6 +42,25 @@ export default function ResultViewer({ data }: ViewerProps) {
       /* ignore */
     }
   }, [sortKey]);
+
+  useEffect(() => {
+    setDiagnostics(getSchedulerDiagnostics());
+    const unsubscribe = subscribeScheduler((snapshot) => {
+      setDiagnostics(snapshot);
+    });
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    if (!diagnostics) return;
+    const configLag = Math.round(diagnostics.config.overloadLagMs);
+    if (configLag !== overloadLag) setOverloadLag(configLag);
+    const lowMs = diagnostics.config.minIntervalMs.low;
+    const derivedFps = lowMs > 0 ? Math.round(1000 / lowMs) : 0;
+    if (derivedFps !== lowFpsCap) setLowFpsCap(derivedFps);
+    const configuredLog = diagnostics.config.maxEventLog;
+    if (configuredLog !== eventLogSize) setEventLogSize(configuredLog);
+  }, [diagnostics, eventLogSize, overloadLag, lowFpsCap]);
 
   const keys = data[0] ? Object.keys(data[0]) : [];
   const filtered = useMemo(() => {
@@ -52,13 +86,31 @@ export default function ResultViewer({ data }: ViewerProps) {
   return (
     <div className="text-xs" aria-label="result viewer">
       <div role="tablist" className="mb-2 flex flex-wrap gap-2">
-        <button role="tab" aria-selected={tab === 'raw'} onClick={() => setTab('raw')} className="rounded bg-ub-cool-grey px-2 py-1 text-white" type="button">
+        <button
+          role="tab"
+          aria-selected={tab === 'raw'}
+          onClick={() => runInputTask('result-viewer:tab-raw', () => setTab('raw'))}
+          className="rounded bg-ub-cool-grey px-2 py-1 text-white"
+          type="button"
+        >
           Raw
         </button>
-        <button role="tab" aria-selected={tab === 'parsed'} onClick={() => setTab('parsed')} className="rounded bg-ub-cool-grey px-2 py-1 text-white" type="button">
+        <button
+          role="tab"
+          aria-selected={tab === 'parsed'}
+          onClick={() => runInputTask('result-viewer:tab-parsed', () => setTab('parsed'))}
+          className="rounded bg-ub-cool-grey px-2 py-1 text-white"
+          type="button"
+        >
           Parsed
         </button>
-        <button role="tab" aria-selected={tab === 'chart'} onClick={() => setTab('chart')} className="rounded bg-ub-cool-grey px-2 py-1 text-white" type="button">
+        <button
+          role="tab"
+          aria-selected={tab === 'chart'}
+          onClick={() => runInputTask('result-viewer:tab-chart', () => setTab('chart'))}
+          className="rounded bg-ub-cool-grey px-2 py-1 text-white"
+          type="button"
+        >
           Chart
         </button>
       </div>
@@ -74,7 +126,9 @@ export default function ResultViewer({ data }: ViewerProps) {
                 <span>Filter</span>
                 <input
                   value={filter}
-                  onChange={(e) => setFilter(e.target.value)}
+                  onChange={(e) =>
+                    runInputTask('result-viewer:filter-change', () => setFilter(e.target.value))
+                  }
                   className="w-full flex-1 rounded border border-black/40 bg-white p-1 text-black"
                   aria-label="Filter rows"
                 />
@@ -84,7 +138,7 @@ export default function ResultViewer({ data }: ViewerProps) {
                   {keys.map((k) => (
                     <button
                       key={k}
-                      onClick={() => setSortKey(k)}
+                      onClick={() => runInputTask(`result-viewer:sort-${k}`, () => setSortKey(k))}
                       className={`rounded px-2 py-1 ${sortKey === k ? 'bg-ub-yellow text-black' : 'bg-ub-cool-grey text-white'}`}
                       type="button"
                     >
@@ -96,6 +150,108 @@ export default function ResultViewer({ data }: ViewerProps) {
               <button onClick={exportCsv} className="self-start rounded bg-ub-green px-2 py-1 text-black" type="button">
                 Export CSV
               </button>
+              <section className="rounded border border-black/40 bg-black/20 p-2 text-[11px]">
+                <h4 className="mb-1 font-semibold uppercase tracking-wide">Scheduler diagnostics</h4>
+                <div className="mb-2 grid gap-2 sm:grid-cols-2">
+                  <div className="flex flex-col gap-1">
+                    <label htmlFor={overloadId}>Overload threshold (ms)</label>
+                    <input
+                      id={overloadId}
+                      type="number"
+                      min={0}
+                      value={overloadLag}
+                      onChange={(e) => {
+                        const next = Number(e.target.value);
+                        const sanitized = Number.isFinite(next) ? Math.max(0, Math.round(next)) : 0;
+                        setOverloadLag(sanitized);
+                        configureScheduler({ overloadLagMs: sanitized });
+                      }}
+                      aria-label="Overload threshold (ms)"
+                      className="rounded border border-black/40 bg-white p-1 text-black"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <label htmlFor={lowFpsId}>Low priority FPS cap</label>
+                    <input
+                      id={lowFpsId}
+                      type="number"
+                      min={0}
+                      max={120}
+                      value={lowFpsCap}
+                      onChange={(e) => {
+                        const next = Number(e.target.value);
+                        const sanitized = Number.isFinite(next)
+                          ? Math.max(0, Math.min(120, Math.round(next)))
+                          : 0;
+                        setLowFpsCap(sanitized);
+                        const ms = sanitized > 0 ? Math.round(1000 / sanitized) : 0;
+                        configureScheduler({ minIntervalMs: { low: ms } });
+                      }}
+                      aria-label="Low priority FPS cap"
+                      className="rounded border border-black/40 bg-white p-1 text-black"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <label htmlFor={eventLogId}>Event log size</label>
+                    <input
+                      id={eventLogId}
+                      type="number"
+                      min={1}
+                      max={100}
+                      value={eventLogSize}
+                      onChange={(e) => {
+                        const next = Number(e.target.value);
+                        const sanitized = Number.isFinite(next)
+                          ? Math.max(1, Math.min(100, Math.round(next)))
+                          : 1;
+                        setEventLogSize(sanitized);
+                        configureScheduler({ maxEventLog: sanitized });
+                      }}
+                      aria-label="Event log size"
+                      className="rounded border border-black/40 bg-white p-1 text-black"
+                    />
+                  </div>
+                  <div className="flex flex-col justify-center gap-1 rounded border border-black/40 bg-black/10 p-2">
+                    <span>Last lag: {diagnostics ? diagnostics.metrics.lastLagMs.toFixed(1) : '0.0'} ms</span>
+                    <span>Overload events: {diagnostics?.metrics.overloadEvents ?? 0}</span>
+                    <span>Input events processed: {diagnostics?.metrics.inputExecutions ?? 0}</span>
+                  </div>
+                </div>
+                <div>
+                  <h5 className="mb-1 font-semibold">Recent shed events</h5>
+                  {diagnostics?.metrics.shedEvents.length ? (
+                    <div className="max-h-32 overflow-auto rounded border border-black/30">
+                      <table className="w-full text-left">
+                        <thead>
+                          <tr>
+                            <th className="border px-1">Time</th>
+                            <th className="border px-1">Task</th>
+                            <th className="border px-1">Reason</th>
+                            <th className="border px-1">Lag</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {diagnostics.metrics.shedEvents.map((event) => (
+                            <tr key={`${event.id}-${event.timestamp}-${event.skipped}`}>
+                              <td className="border px-1">
+                                {new Date(event.timestamp).toLocaleTimeString()}
+                              </td>
+                              <td className="border px-1">
+                                <span className="font-semibold">{event.label}</span>
+                                <span className="ml-1 text-[10px] uppercase">[{event.priority}]</span>
+                              </td>
+                              <td className="border px-1">{event.reason}</td>
+                              <td className="border px-1">{event.lagMs.toFixed(1)} ms</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  ) : (
+                    <p className="text-[11px] italic text-white/70">No shed events recorded.</p>
+                  )}
+                </div>
+              </section>
             </div>
           </details>
           <div className="overflow-auto max-h-60">

--- a/scanner/schedule.ts
+++ b/scanner/schedule.ts
@@ -3,13 +3,129 @@ export interface ScheduledScan {
   schedule: string;
 }
 
+export type SchedulerPriority = 'input' | 'high' | 'normal' | 'low';
+
+interface SchedulerConfig {
+  overloadLagMs: number;
+  minIntervalMs: Record<SchedulerPriority, number>;
+  /**
+   * Number of most recent shed events to retain for diagnostics.
+   */
+  maxEventLog: number;
+}
+
+export interface SchedulerEvent {
+  id: string;
+  label: string;
+  priority: SchedulerPriority;
+  reason: 'overload' | 'min-interval';
+  timestamp: number;
+  lagMs: number;
+  skipped: number;
+}
+
+export interface SchedulerDiagnostics {
+  config: SchedulerConfig;
+  metrics: {
+    overloadEvents: number;
+    lastLagMs: number;
+    lastOverloadAt: number | null;
+    inputExecutions: number;
+    lastInputLabel: string | null;
+    lastInputDurationMs: number;
+    shedEvents: SchedulerEvent[];
+  };
+  running: Array<
+    ScheduledScan & {
+      priority: SchedulerPriority;
+      shedCount: number;
+      label: string;
+    }
+  >;
+}
+
 interface RunningScan extends ScheduledScan {
   timer: ReturnType<typeof setInterval>;
   callback: () => void;
+  interval: number;
+  priority: SchedulerPriority;
+  minInterval: number;
+  lastRun: number;
+  shedCount: number;
+  label: string;
+  usesCustomMinInterval: boolean;
+}
+
+interface ScheduleOptions {
+  priority?: SchedulerPriority;
+  /**
+   * Override the default minimum interval between callback executions.
+   */
+  minIntervalMs?: number;
+  /**
+   * Human readable label for diagnostics.
+   */
+  label?: string;
 }
 
 const STORAGE_KEY = 'scanSchedules';
 const runningScans: RunningScan[] = [];
+
+const defaultConfig: SchedulerConfig = {
+  overloadLagMs: 120,
+  minIntervalMs: {
+    input: 0,
+    high: 8,
+    normal: 33,
+    low: 100,
+  },
+  maxEventLog: 25,
+};
+
+let schedulerConfig: SchedulerConfig = { ...defaultConfig };
+
+const metrics = {
+  overloadEvents: 0,
+  lastLagMs: 0,
+  lastOverloadAt: null as number | null,
+  inputExecutions: 0,
+  lastInputLabel: null as string | null,
+  lastInputDurationMs: 0,
+  shedEvents: [] as SchedulerEvent[],
+};
+
+type Listener = (diagnostics: SchedulerDiagnostics) => void;
+
+const listeners = new Set<Listener>();
+
+const now = () =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+
+const notify = () => {
+  if (listeners.size === 0) return;
+  const snapshot = getSchedulerDiagnostics();
+  listeners.forEach((listener) => listener(snapshot));
+};
+
+const recordShedEvent = (event: SchedulerEvent) => {
+  metrics.shedEvents = [event, ...metrics.shedEvents].slice(
+    0,
+    schedulerConfig.maxEventLog,
+  );
+  notify();
+};
+
+const resetMetrics = () => {
+  metrics.overloadEvents = 0;
+  metrics.lastLagMs = 0;
+  metrics.lastOverloadAt = null;
+  metrics.inputExecutions = 0;
+  metrics.lastInputLabel = null;
+  metrics.lastInputDurationMs = 0;
+  metrics.shedEvents = [];
+};
 
 export const loadScheduledScans = (): ScheduledScan[] => {
   if (typeof window === 'undefined') return [];
@@ -23,6 +139,7 @@ export const loadScheduledScans = (): ScheduledScan[] => {
 const persistSchedules = (jobs: ScheduledScan[]) => {
   if (typeof window === 'undefined') return;
   localStorage.setItem(STORAGE_KEY, JSON.stringify(jobs));
+  notify();
 };
 
 export const cronToInterval = (expr: string): number => {
@@ -44,13 +161,72 @@ export const scheduleScan = (
   id: string,
   schedule: string,
   callback: () => void,
+  options: ScheduleOptions = {},
 ): ScheduledScan => {
   const jobs = loadScheduledScans();
   jobs.push({ id, schedule });
   persistSchedules(jobs);
   const interval = cronToInterval(schedule);
-  const timer = setInterval(callback, interval);
-  runningScans.push({ id, schedule, timer, callback });
+  const priority = options.priority ?? 'normal';
+  const minInterval = Math.max(
+    0,
+    options.minIntervalMs ?? schedulerConfig.minIntervalMs[priority],
+  );
+  const label = options.label ?? id;
+  const usesCustomMinInterval = options.minIntervalMs !== undefined;
+  const job: RunningScan = {
+    id,
+    schedule,
+    timer: undefined as unknown as ReturnType<typeof setInterval>,
+    callback,
+    interval,
+    priority,
+    minInterval,
+    lastRun: 0,
+    shedCount: 0,
+    label,
+    usesCustomMinInterval,
+  };
+
+  const runner = () => {
+    const current = now();
+    const expected = job.lastRun ? job.lastRun + job.interval : current;
+    const lag = current - expected;
+    metrics.lastLagMs = lag;
+    const overloaded = lag > schedulerConfig.overloadLagMs;
+    if (overloaded) {
+      metrics.overloadEvents += 1;
+      metrics.lastOverloadAt = Date.now();
+    }
+
+    const timeSinceRun = current - job.lastRun;
+    const enforceCap = job.lastRun > 0 && timeSinceRun < job.minInterval;
+    const shouldShed =
+      job.priority !== 'input' &&
+      (enforceCap || (overloaded && job.priority === 'low'));
+
+    if (shouldShed) {
+      job.shedCount += 1;
+      recordShedEvent({
+        id: job.id,
+        label: job.label,
+        priority: job.priority,
+        reason: enforceCap ? 'min-interval' : 'overload',
+        timestamp: Date.now(),
+        lagMs: lag,
+        skipped: job.shedCount,
+      });
+      return;
+    }
+
+    job.lastRun = current;
+    callback();
+  };
+
+  const timer = setInterval(runner, interval);
+  job.timer = timer;
+  runningScans.push(job);
+  notify();
   return { id, schedule };
 };
 
@@ -64,4 +240,96 @@ export const clearSchedules = () => {
   runningScans.forEach((j) => clearInterval(j.timer));
   runningScans.length = 0;
   persistSchedules([]);
+  resetMetrics();
+  notify();
+};
+
+export const configureScheduler = (update: {
+  overloadLagMs?: number;
+  minIntervalMs?: Partial<Record<SchedulerPriority, number>>;
+  maxEventLog?: number;
+}) => {
+  if (typeof update.overloadLagMs === 'number') {
+    schedulerConfig = {
+      ...schedulerConfig,
+      overloadLagMs: Math.max(0, update.overloadLagMs),
+    };
+  }
+
+  if (typeof update.maxEventLog === 'number') {
+    schedulerConfig = {
+      ...schedulerConfig,
+      maxEventLog: Math.max(1, Math.floor(update.maxEventLog)),
+    };
+    metrics.shedEvents = metrics.shedEvents.slice(0, schedulerConfig.maxEventLog);
+  }
+
+  if (update.minIntervalMs) {
+    const updated: Record<SchedulerPriority, number> = {
+      ...schedulerConfig.minIntervalMs,
+    };
+    (Object.keys(update.minIntervalMs) as SchedulerPriority[]).forEach((key) => {
+      const value = update.minIntervalMs?.[key];
+      if (typeof value === 'number' && !Number.isNaN(value)) {
+        updated[key] = Math.max(0, value);
+        runningScans.forEach((job) => {
+          if (job.priority === key && !job.usesCustomMinInterval) {
+            job.minInterval = Math.max(0, value);
+          }
+        });
+      }
+    });
+    schedulerConfig = {
+      ...schedulerConfig,
+      minIntervalMs: updated,
+    };
+  }
+
+  notify();
+};
+
+export const getSchedulerDiagnostics = (): SchedulerDiagnostics => ({
+  config: {
+    ...schedulerConfig,
+    minIntervalMs: { ...schedulerConfig.minIntervalMs },
+  },
+  metrics: {
+    overloadEvents: metrics.overloadEvents,
+    lastLagMs: metrics.lastLagMs,
+    lastOverloadAt: metrics.lastOverloadAt,
+    inputExecutions: metrics.inputExecutions,
+    lastInputLabel: metrics.lastInputLabel,
+    lastInputDurationMs: metrics.lastInputDurationMs,
+    shedEvents: [...metrics.shedEvents],
+  },
+  running: runningScans.map(({ id, schedule, priority, shedCount, label }) => ({
+    id,
+    schedule,
+    priority,
+    shedCount,
+    label,
+  })),
+});
+
+export const subscribeScheduler = (listener: Listener) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+export const runInputTask = <T>(label: string, task: () => T): T => {
+  const start = now();
+  try {
+    return task();
+  } finally {
+    metrics.inputExecutions += 1;
+    metrics.lastInputLabel = label;
+    metrics.lastInputDurationMs = now() - start;
+    notify();
+  }
+};
+
+export const resetSchedulerConfig = () => {
+  schedulerConfig = { ...defaultConfig };
+  resetMetrics();
+  notify();
 };


### PR DESCRIPTION
## Summary
- add scheduler overload detection, configurable throttles, and diagnostics helpers
- expose scheduler metrics in ResultViewer with developer controls and high-priority input handling

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dca4cfe3348328b4f9ec9ae1de9a12