### PR TITLE
[extensions] Add command registry and palette metadata

### DIFF
--- a/docs/extensions-command-api.md
+++ b/docs/extensions-command-api.md
@@ -1,0 +1,82 @@
+# Extensions Command API
+
+Extensions can add custom actions to the global command palette by using the
+helpers exported from `extensions/api/commands.ts`. Commands registered through
+this module appear alongside the built-in terminal commands with a badge that
+indicates their source.
+
+## Registering commands
+
+```ts
+import { registerExtensionCommand } from 'extensions/api/commands';
+
+const dispose = registerExtensionCommand('my-extension', {
+  id: 'my-extension.sayHello',
+  label: 'Say hello',
+  category: 'Examples',
+  shortcut: {
+    default: 'Ctrl+Alt+H',
+    mac: '⌘⌥H',
+  },
+  run: () => {
+    console.log('Hello from my extension!');
+  },
+});
+```
+
+`registerExtensionCommand` automatically scopes the command to the extension id
+and returns a disposer. Call the disposer from your extension's teardown hook to
+remove the command.
+
+If you are registering a core command from inside the application itself, use
+`registerCommand` instead and omit the `extensionId`:
+
+```ts
+import { registerCommand } from 'extensions/api/commands';
+
+const dispose = registerCommand({
+  id: 'core.openHelp',
+  label: 'Open Help',
+  run: openHelpWindow,
+});
+```
+
+## Metadata
+
+Each command exposes rich metadata that is surfaced in the palette:
+
+- `label` – human-readable name shown in the list.
+- `category` (optional) – used to group commands visually.
+- `shortcut` (optional) – describe default/macOS/Windows/Linux shortcuts. These
+  values are displayed as a compact summary.
+- `source` (optional) – overrides the badge text. When omitted the badge will
+  display either `Core` or the provided `extensionId`.
+
+## Command execution
+
+Use `executeCommand(id, ...args)` to invoke a command programmatically. The
+return value from the registered `run` handler is passed through, so handlers can
+return promises or synchronous values.
+
+## Listening for registry changes
+
+The command palette subscribes to updates via `onCommandsChanged(listener)`. You
+can use the same helper to react to commands being added or removed:
+
+```ts
+import { onCommandsChanged } from 'extensions/api/commands';
+
+const unsubscribe = onCommandsChanged((commands) => {
+  console.table(commands);
+});
+```
+
+The listener receives a sorted array of registered commands. Call the returned
+function to unsubscribe.
+
+## Unregistering commands
+
+- `unregisterCommand(id)` removes an individual command.
+- `unregisterExtensionCommands(extensionId)` removes all commands contributed by
+  an extension. This is used by the extension host when an extension unloads to
+  ensure the palette stays in sync.

--- a/extensions/api/commands.ts
+++ b/extensions/api/commands.ts
@@ -1,0 +1,133 @@
+export type CommandExecutor = (...args: unknown[]) => unknown | Promise<unknown>;
+
+export interface CommandShortcut {
+  /** Platform-agnostic shortcut description (e.g. "Ctrl+P"). */
+  default?: string;
+  /** macOS specific shortcut (e.g. "⌘P"). */
+  mac?: string;
+  /** Windows specific shortcut. */
+  windows?: string;
+  /** Linux specific shortcut. */
+  linux?: string;
+}
+
+export interface RegisterCommandOptions {
+  /** Unique command identifier. */
+  id: string;
+  /** Human-readable label shown in the command palette. */
+  label: string;
+  /** Optional category grouping. */
+  category?: string;
+  /** Keyboard shortcut metadata. */
+  shortcut?: CommandShortcut;
+  /** Function that executes when the command is invoked. */
+  run: CommandExecutor;
+  /**
+   * Identifier of the extension that registered the command. If omitted the
+   * command is treated as a core contribution.
+   */
+  extensionId?: string;
+  /** Optional friendly name for the badge in the palette. */
+  source?: string;
+}
+
+export interface RegisteredCommand extends RegisterCommandOptions {
+  /**
+   * Badge label rendered in the command palette. Defaults to `Core` for
+   * internal commands or the provided `extensionId`.
+   */
+  badge: string;
+}
+
+export type CommandsChangedListener = (commands: RegisteredCommand[]) => void;
+
+const registry = new Map<string, RegisteredCommand>();
+const extensionIndex = new Map<string, Set<string>>();
+const listeners = new Set<CommandsChangedListener>();
+
+function getBadgeFor(options: RegisterCommandOptions): string {
+  if (options.source) return options.source;
+  if (options.extensionId) return options.extensionId;
+  return 'Core';
+}
+
+function notifyListeners() {
+  const commands = getAllCommands();
+  listeners.forEach((listener) => listener(commands));
+}
+
+export function registerCommand(options: RegisterCommandOptions): () => void {
+  const { id, extensionId } = options;
+  if (!id) {
+    throw new Error('Command id is required');
+  }
+  if (registry.has(id)) {
+    throw new Error(`Command with id "${id}" is already registered`);
+  }
+  const record: RegisteredCommand = {
+    ...options,
+    badge: getBadgeFor(options),
+  };
+  registry.set(id, record);
+  if (extensionId) {
+    let commands = extensionIndex.get(extensionId);
+    if (!commands) {
+      commands = new Set();
+      extensionIndex.set(extensionId, commands);
+    }
+    commands.add(id);
+  }
+  notifyListeners();
+  return () => unregisterCommand(id);
+}
+
+export function registerExtensionCommand(
+  extensionId: string,
+  options: Omit<RegisterCommandOptions, 'extensionId'>,
+): () => void {
+  return registerCommand({ ...options, extensionId });
+}
+
+export function unregisterCommand(id: string): void {
+  const existing = registry.get(id);
+  if (!existing) return;
+  registry.delete(id);
+  if (existing.extensionId) {
+    const commands = extensionIndex.get(existing.extensionId);
+    commands?.delete(id);
+    if (commands && commands.size === 0) {
+      extensionIndex.delete(existing.extensionId);
+    }
+  }
+  notifyListeners();
+}
+
+export function unregisterExtensionCommands(extensionId: string): void {
+  const commands = extensionIndex.get(extensionId);
+  if (!commands) return;
+  commands.forEach((id) => registry.delete(id));
+  extensionIndex.delete(extensionId);
+  notifyListeners();
+}
+
+export function executeCommand(id: string, ...args: unknown[]): unknown {
+  const command = registry.get(id);
+  if (!command) {
+    throw new Error(`Command "${id}" is not registered`);
+  }
+  return command.run(...args);
+}
+
+export function getAllCommands(): RegisteredCommand[] {
+  return Array.from(registry.values()).sort((a, b) =>
+    a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }),
+  );
+}
+
+export function onCommandsChanged(
+  listener: CommandsChangedListener,
+): () => void {
+  listeners.add(listener);
+  listener(getAllCommands());
+  return () => listeners.delete(listener);
+}


### PR DESCRIPTION
## Summary
- add an extension command registry that tracks metadata, origin badges, and lifecycle helpers
- surface extension commands in the terminal command palette with filtering, shortcuts, and origin badges
- document the extensions command API for extension authors

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dca4d4aa60832890b45bef92b276ca