### PR TITLE
[hashcat] add rule editor simulation

### DIFF
--- a/components/apps/hashcat/RuleEditor.tsx
+++ b/components/apps/hashcat/RuleEditor.tsx
@@ -1,0 +1,327 @@
+import React, { useEffect, useMemo } from 'react';
+
+type RuleError = {
+  line: number;
+  message: string;
+  rule: string;
+};
+
+type RulePreviewRecord = {
+  word: string;
+  outputs: string[];
+};
+
+type RuleEditorUpdate = {
+  validRules: string[];
+  errors: RuleError[];
+  uniqueCandidateCount: number;
+  preview: RulePreviewRecord[];
+  truncated: boolean;
+};
+
+type RuleEditorProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onRulesUpdate?: (update: RuleEditorUpdate) => void;
+  sampleWords?: string[];
+  sampleLabel?: string;
+  limit?: number;
+};
+
+type RuleResult = { ok: true; value: string } | { ok: false; error: string };
+
+const defaultSampleWords = ['password', 'admin', 'letmein', 'kali2024'];
+
+const ruleSnippets = [
+  { label: 'Lowercase (l)', rule: 'l' },
+  { label: 'Uppercase (u)', rule: 'u' },
+  { label: 'Capitalize (c)', rule: 'c' },
+  { label: 'Toggle Case (t)', rule: 't' },
+  { label: 'Reverse (r)', rule: 'r' },
+  { label: 'Append ! ($!)', rule: '$!' },
+  { label: 'Prepend 1 (^1)', rule: '^1' },
+  { label: 'Swap a→@ (sa@)', rule: 'sa@' },
+  { label: 'Duplicate (d)', rule: 'd' },
+];
+
+const toggleCase = (input: string) =>
+  input
+    .split('')
+    .map((char) => {
+      const upper = char.toUpperCase();
+      const lower = char.toLowerCase();
+      if (char === upper && char === lower) {
+        return char;
+      }
+      return char === upper ? lower : upper;
+    })
+    .join('');
+
+const applyRule = (rule: string, word: string): RuleResult => {
+  let output = word;
+  for (let i = 0; i < rule.length; i += 1) {
+    const command = rule[i];
+    switch (command) {
+      case ':':
+        break;
+      case 'l':
+        output = output.toLowerCase();
+        break;
+      case 'u':
+        output = output.toUpperCase();
+        break;
+      case 'c':
+        output =
+          output.charAt(0).toUpperCase() + output.slice(1).toLowerCase();
+        break;
+      case 't':
+        output = toggleCase(output);
+        break;
+      case 'r':
+        output = output.split('').reverse().join('');
+        break;
+      case 'd':
+      case 'p':
+        output = `${output}${output}`;
+        if (output.length > 128) {
+          output = output.slice(0, 128);
+        }
+        break;
+      case '$': {
+        i += 1;
+        if (i >= rule.length) {
+          return { ok: false, error: 'Append ($) requires a character to follow.' };
+        }
+        output += rule[i];
+        break;
+      }
+      case '^': {
+        i += 1;
+        if (i >= rule.length) {
+          return { ok: false, error: 'Prepend (^) requires a character to follow.' };
+        }
+        output = `${rule[i]}${output}`;
+        break;
+      }
+      case 's': {
+        if (i + 2 >= rule.length) {
+          return {
+            ok: false,
+            error: 'Substitute (s) requires two characters to define the swap.',
+          };
+        }
+        const from = rule[i + 1];
+        const to = rule[i + 2];
+        output = output.split(from).join(to);
+        i += 2;
+        break;
+      }
+      case 'q':
+        output = output.slice(0, -1);
+        break;
+      case 'x':
+        output = output.slice(1);
+        break;
+      default:
+        return {
+          ok: false,
+          error: `Unknown or unsupported command "${command}" in this demo.`,
+        };
+    }
+  }
+  return { ok: true, value: output };
+};
+
+const parseRules = (value: string) => {
+  const lines = value.replace(/\r/g, '').split('\n');
+  const validRules: string[] = [];
+  const errors: RuleError[] = [];
+
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      return;
+    }
+    const result = applyRule(trimmed, 'Password');
+    if (!result.ok) {
+      errors.push({
+        line: index + 1,
+        message: result.error,
+        rule: trimmed,
+      });
+      return;
+    }
+    validRules.push(trimmed);
+  });
+
+  return { validRules, errors };
+};
+
+const buildPreview = (
+  rules: string[],
+  sampleWords: string[],
+  limit: number
+): { records: RulePreviewRecord[]; uniqueCount: number; truncated: boolean } => {
+  const unique = new Set<string>();
+  const records: RulePreviewRecord[] = [];
+  let truncated = false;
+
+  sampleWords.slice(0, 6).forEach((word) => {
+    if (truncated) {
+      return;
+    }
+    const outputs: string[] = [];
+    for (let i = 0; i < rules.length; i += 1) {
+      const execution = applyRule(rules[i], word);
+      if (!execution.ok) {
+        continue;
+      }
+      const candidate = execution.value;
+      unique.add(candidate);
+      if (outputs.length < 5) {
+        outputs.push(candidate);
+      }
+      if (unique.size >= limit) {
+        truncated = true;
+        break;
+      }
+    }
+    records.push({ word, outputs });
+  });
+
+  return { records, uniqueCount: unique.size, truncated };
+};
+
+const RuleEditor: React.FC<RuleEditorProps> = ({
+  value,
+  onChange,
+  onRulesUpdate,
+  sampleWords = defaultSampleWords,
+  sampleLabel,
+  limit = 200,
+}) => {
+  const textareaId = 'hashcat-rule-editor';
+  const { validRules, errors } = useMemo(() => parseRules(value || ''), [value]);
+  const preview = useMemo(
+    () => buildPreview(validRules, sampleWords, limit),
+    [validRules, sampleWords, limit]
+  );
+
+  useEffect(() => {
+    onRulesUpdate?.({
+      validRules,
+      errors,
+      uniqueCandidateCount: preview.uniqueCount,
+      preview: preview.records,
+      truncated: preview.truncated,
+    });
+  }, [validRules, errors, preview, onRulesUpdate]);
+
+  return (
+      <div className="w-full max-w-xl bg-black/30 border border-ub-grey rounded p-4 mt-4">
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <span
+            className="font-semibold"
+            id={`${textareaId}-label`}
+          >
+            Rule Editor
+          </span>
+        <div className="flex flex-wrap gap-2 text-xs">
+          {ruleSnippets.map((snippet) => (
+            <button
+              key={snippet.label}
+              type="button"
+              className="px-2 py-1 bg-ub-grey text-white rounded hover:bg-ub-grey-light transition"
+              onClick={() => onChange(value ? `${value}\n${snippet.rule}` : snippet.rule)}
+            >
+              {snippet.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <textarea
+        id={textareaId}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        aria-invalid={errors.length > 0}
+        aria-labelledby={`${textareaId}-label`}
+        aria-describedby={errors.length ? `${textareaId}-errors` : undefined}
+        className={`mt-3 w-full h-32 bg-black text-green-200 font-mono text-sm p-2 rounded border focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+          errors.length ? 'border-red-500 focus:ring-red-500' : 'border-ub-grey'
+        }`}
+        spellCheck={false}
+        placeholder={
+          '# Enter hashcat-style rules.\n' +
+          '# Comments begin with # and are ignored.\n' +
+          '# Example: $!\nl\n' +
+          '# Supported demo commands: l, u, c, t, r, d/p, $, ^, s, :, q, x.'
+        }
+      />
+      <div className="mt-2 text-xs text-ubt-grey">
+        Supported operations are a curated subset for the demo. Complex commands
+        such as bracketed position moves are intentionally omitted to avoid
+        executing real cracking logic.
+      </div>
+      {errors.length > 0 && (
+        <div
+          id={`${textareaId}-errors`}
+          className="mt-3 bg-red-900/50 border border-red-600 text-red-200 text-sm rounded p-2"
+          role="alert"
+        >
+          <p className="font-semibold">Syntax issues detected:</p>
+          <ul className="list-disc list-inside space-y-1">
+            {errors.map((error) => (
+              <li key={`${error.line}-${error.rule}`}>
+                Line {error.line}: {error.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div className="mt-4 text-sm">
+        <div className="font-semibold">
+          Preview against {sampleLabel ?? 'demo wordlist'}:
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-2">
+          {preview.records.length === 0 && (
+            <div className="text-xs text-ubt-grey">
+              Provide at least one rule to see transformed candidates.
+            </div>
+          )}
+          {preview.records.map((record) => (
+            <div
+              key={record.word}
+              className="bg-black/40 border border-ub-grey rounded p-2"
+            >
+              <div className="text-xs uppercase tracking-wide text-ubt-grey">
+                Source
+              </div>
+              <div className="font-mono text-green-200">{record.word}</div>
+              <div className="text-xs uppercase tracking-wide text-ubt-grey mt-2">
+                Variations
+              </div>
+              {record.outputs.length ? (
+                <ul className="mt-1 space-y-1 text-xs font-mono text-green-300">
+                  {record.outputs.map((output, index) => (
+                    <li key={`${record.word}-${index}`}>{output}</li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="text-xs text-ubt-grey mt-1">
+                  No change for this rule set.
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+        <div className="mt-3 text-xs text-ubt-grey">
+          Unique transformed candidates: {preview.uniqueCount}
+          {preview.truncated && ' (preview limited to keep the demo responsive)'}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RuleEditor;
+export type { RuleEditorUpdate, RuleError };

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import progressInfo from './progress.json';
 import StatsChart from '../../StatsChart';
+import RuleEditor from './RuleEditor';
 
 export const hashTypes = [
   {
@@ -54,6 +55,12 @@ const ruleSets = {
   none: [],
   best64: ['c', 'u', 'l', 'r', 'd', 'p', 't', 's'],
   quick: ['l', 'u', 'c', 'd'],
+};
+
+const sampleWordlists = {
+  default: ['password', 'letmein', 'summer2024', 'trustno1', 'welcome'],
+  rockyou: ['password', 'dragon', 'qwerty', 'princess', 'iloveyou'],
+  top100: ['123456', 'password1', 'monkey', 'shadow', 'football'],
 };
 
 const sampleOutput = `hashcat (v6.2.6) starting in benchmark mode...
@@ -176,7 +183,14 @@ function HashcatApp() {
   const [maskStats, setMaskStats] = useState({ count: 0, time: 0 });
   const showMask = ['3', '6', '7'].includes(attackMode);
   const [ruleSet, setRuleSet] = useState('none');
-  const rulePreview = (ruleSets[ruleSet] || []).slice(0, 10).join('\n');
+  const [ruleText, setRuleText] = useState('');
+  const [ruleMetrics, setRuleMetrics] = useState({
+    validRules: [],
+    errors: [],
+    uniqueCandidateCount: 0,
+    preview: [],
+    truncated: false,
+  });
   const workerRef = useRef(null);
   const frameRef = useRef(null);
 
@@ -302,6 +316,16 @@ function HashcatApp() {
     attackModes.find((m) => m.value === attackMode)?.label ||
     attackModes[0].label;
   const info = { ...progressInfo, mode: selectedMode };
+  const sampleWords = sampleWordlists[wordlist] || sampleWordlists.default;
+  const sampleLabel = wordlist ? `${wordlist}.txt` : 'demo wordlist';
+  const ruleArgument =
+    ruleSet === 'custom'
+      ? ruleMetrics.validRules.length
+        ? ' -r demo-custom.rule'
+        : ''
+      : ruleSet !== 'none'
+      ? ` -r ${ruleSet}.rule`
+      : '';
 
   const handleHashChange = (e) => {
     const value = e.target.value.trim();
@@ -322,6 +346,25 @@ function HashcatApp() {
     const blob = new Blob([list.join('\n')], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
     setWordlistUrl(url);
+  };
+
+  const handleRuleSetChange = (value) => {
+    setRuleSet(value);
+    if (value !== 'custom') {
+      const presetRules = ruleSets[value] || [];
+      setRuleText(presetRules.join('\n'));
+    }
+  };
+
+  const handleRuleTextChange = (value) => {
+    setRuleText(value);
+    if (ruleSet !== 'custom') {
+      setRuleSet('custom');
+    }
+  };
+
+  const handleRuleEditorUpdate = (update) => {
+    setRuleMetrics(update);
   };
 
   return (
@@ -434,15 +477,36 @@ function HashcatApp() {
           id="rule-set"
           className="text-black px-2 py-1"
           value={ruleSet}
-          onChange={(e) => setRuleSet(e.target.value)}
+          onChange={(e) => handleRuleSetChange(e.target.value)}
         >
           <option value="none">None</option>
           <option value="best64">best64</option>
           <option value="quick">quick</option>
+          <option value="custom">Custom</option>
         </select>
-        <pre className="bg-black p-2 text-xs mt-2 overflow-auto h-24">
-          {rulePreview || '(no rules)'}
-        </pre>
+        <div className="text-xs mt-2 text-ubt-grey max-w-xl">
+          Preset selections load their contents into the editor. Changing the
+          text automatically switches to the custom profile for this session.
+        </div>
+        <RuleEditor
+          value={ruleText}
+          onChange={handleRuleTextChange}
+          onRulesUpdate={handleRuleEditorUpdate}
+          sampleWords={sampleWords}
+          sampleLabel={sampleLabel}
+        />
+        {ruleSet === 'custom' && (
+          <div className="text-xs mt-2 text-ubt-grey max-w-xl">
+            {ruleMetrics.validRules.length
+              ? `${ruleMetrics.validRules.length} valid rule${
+                  ruleMetrics.validRules.length === 1 ? '' : 's'
+                } will be included in the demo command.`
+              : 'Add valid rules above to include them in the demo command.'}
+            {ruleMetrics.errors.length
+              ? ' Fix the highlighted lines to use them here.'
+              : ''}
+          </div>
+        )}
       </div>
       <div>Detected: {selectedHash}</div>
       <div>Summary: {selected.summary}</div>
@@ -525,7 +589,7 @@ function HashcatApp() {
               hashInput || 'hash.txt'
             } ${wordlist ? `${wordlist}.txt` : 'wordlist.txt'}${
               showMask && mask ? ` ${mask}` : ''
-            }${ruleSet !== 'none' ? ` -r ${ruleSet}.rule` : ''}`}
+            }${ruleArgument}`}
           </code>
           <button
             className="ml-2"
@@ -537,7 +601,7 @@ function HashcatApp() {
                     hashInput || 'hash.txt'
                   } ${wordlist ? `${wordlist}.txt` : 'wordlist.txt'}${
                     showMask && mask ? ` ${mask}` : ''
-                  }${ruleSet !== 'none' ? ` -r ${ruleSet}.rule` : ''}`
+                  }${ruleArgument}`
                 );
               }
             }}


### PR DESCRIPTION
## Summary
- add a dedicated RuleEditor component that validates hashcat-style syntax and previews rule effects on sample wordlists
- wire the RuleEditor into the hashcat demo with preset loading, custom editing, and command updates
- surface preview counts and guidance so invalid rules are highlighted without touching real hashcat binaries

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dca4e3cdd88328bf4ce3073e92b071