### PR TITLE
[nmap-nse] Add trend explorer with virtualization

### DIFF
--- a/__tests__/nmapNse.test.tsx
+++ b/__tests__/nmapNse.test.tsx
@@ -13,6 +13,8 @@ describe('NmapNSEApp', () => {
             Promise.resolve(
               typeof url === 'string' && url.includes('nmap-results')
                 ? { hosts: [] }
+                : typeof url === 'string' && url.includes('trends')
+                ? { runs: [] }
                 : { 'ftp-anon': 'FTP output' }
             ),
         })
@@ -36,6 +38,8 @@ describe('NmapNSEApp', () => {
             Promise.resolve(
               typeof url === 'string' && url.includes('nmap-results')
                 ? { hosts: [] }
+                : typeof url === 'string' && url.includes('trends')
+                ? { runs: [] }
                 : {}
             ),
         })
@@ -65,6 +69,8 @@ describe('NmapNSEApp', () => {
             Promise.resolve(
               typeof url === 'string' && url.includes('nmap-results')
                 ? { hosts: [] }
+                : typeof url === 'string' && url.includes('trends')
+                ? { runs: [] }
                 : { 'http-title': 'Sample output' }
             ),
         })
@@ -82,7 +88,7 @@ describe('NmapNSEApp', () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Sample output')
     );
-    expect(await screen.findByRole('alert')).toHaveTextContent(/copied/i);
+    expect(await screen.findByRole('status')).toHaveTextContent(/copied/i);
 
     mockFetch.mockRestore();
   });
@@ -115,6 +121,8 @@ describe('NmapNSEApp', () => {
                       },
                     ],
                   }
+                : typeof url === 'string' && url.includes('trends')
+                ? { runs: [] }
                 : {}
             ),
         })

--- a/apps/nmap-nse/index.tsx
+++ b/apps/nmap-nse/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import share, { canShare } from '../../utils/share';
+import Trends, { TrendRun } from '../../components/apps/nmap-nse/Trends';
 
 interface Script {
   name: string;
@@ -25,6 +26,7 @@ const NmapNSE: React.FC = () => {
   const [result, setResult] = useState<{ script: string; output: string } | null>(
     null
   );
+  const [trendRuns, setTrendRuns] = useState<TrendRun[]>([]);
 
   // load static script metadata
   useEffect(() => {
@@ -41,6 +43,23 @@ const NmapNSE: React.FC = () => {
       }
     };
     load();
+  }, []);
+
+  useEffect(() => {
+    const loadRuns = async () => {
+      try {
+        const res = await fetch('/demo-data/nmap/trends.json');
+        const json = await res.json();
+        if (Array.isArray(json)) {
+          setTrendRuns(json as TrendRun[]);
+        } else if (Array.isArray(json?.runs)) {
+          setTrendRuns(json.runs as TrendRun[]);
+        }
+      } catch {
+        /* ignore */
+      }
+    };
+    loadRuns();
   }, []);
 
   const tags = useMemo(() => Array.from(new Set(data.map((s) => s.tag))), [
@@ -213,6 +232,11 @@ const NmapNSE: React.FC = () => {
           ) : (
             <p>Select a script to view details.</p>
           )}
+          <div className="mt-8">
+            <CollapsibleSection title="Trend Explorer">
+              <Trends runs={trendRuns} />
+            </CollapsibleSection>
+          </div>
         </main>
       </div>
     </div>

--- a/components/apps/nmap-nse/Trends.tsx
+++ b/components/apps/nmap-nse/Trends.tsx
@@ -1,0 +1,589 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { List, ListChildComponentProps } from 'react-window';
+
+export interface TrendService {
+  port: number;
+  service: string;
+  state?: 'open' | 'closed' | 'filtered';
+  latencyMs?: number;
+}
+
+export interface TrendHost {
+  host: string;
+  hostname?: string;
+  services: TrendService[];
+}
+
+export interface TrendRun {
+  id: string;
+  label?: string;
+  startedAt: string;
+  hosts: TrendHost[];
+}
+
+type TrendValue = {
+  value: number | null;
+  state: TrendService['state'] | null;
+};
+
+type AggregatedEntry = {
+  key: string;
+  host: string;
+  hostname?: string;
+  service: string;
+  port: number;
+  values: TrendValue[];
+};
+
+type DisplayEntry = AggregatedEntry & {
+  valuesInRange: TrendValue[];
+  labelsInRange: string[];
+  uptime: number;
+  openRuns: number;
+  observedRuns: number;
+  averageLatency: number | null;
+  latestState: TrendService['state'] | null;
+};
+
+const SPARKLINE_WIDTH = 220;
+const SPARKLINE_HEIGHT = 48;
+const MAX_POINTS = 80;
+
+const formatLabel = (run: TrendRun, index: number) => {
+  if (run.label) return run.label;
+  try {
+    const date = new Date(run.startedAt);
+    if (!Number.isNaN(date.valueOf())) {
+      return date.toLocaleString('en-US', {
+        month: 'short',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      });
+    }
+  } catch {
+    // ignore
+  }
+  return `Run ${index + 1}`;
+};
+
+const decimateSeries = (
+  series: TrendValue[],
+  maxPoints: number,
+): TrendValue[] => {
+  if (series.length <= maxPoints) return series;
+  const buckets = maxPoints;
+  const bucketSize = series.length / buckets;
+  const result: TrendValue[] = [];
+  for (let i = 0; i < buckets; i += 1) {
+    const start = Math.floor(i * bucketSize);
+    const end = Math.min(series.length, Math.floor((i + 1) * bucketSize));
+    const slice = series.slice(start, end);
+    if (!slice.length) continue;
+    const nonNull = slice.filter((point) => point.value != null);
+    if (nonNull.length === 0) {
+      const state = slice.find((point) => point.state != null)?.state ?? null;
+      result.push({ value: null, state });
+    } else {
+      const value =
+        nonNull.reduce((acc, point) => acc + (point.value ?? 0), 0) /
+        nonNull.length;
+      const state = nonNull[nonNull.length - 1].state ?? null;
+      result.push({ value, state });
+    }
+  }
+  return result;
+};
+
+interface SparklineProps {
+  series: TrendValue[];
+  color: string;
+  labels: string[];
+}
+
+const Sparkline: React.FC<SparklineProps> = ({ series, color, labels }) => {
+  const decimated = useMemo(
+    () => decimateSeries(series, MAX_POINTS),
+    [series],
+  );
+  const values = decimated.map((point) => point.value).filter((v) => v != null) as number[];
+  const max = Math.max(1, ...values);
+  const path = decimated
+    .map((point, index) => {
+      const x = (index / Math.max(decimated.length - 1, 1)) * SPARKLINE_WIDTH;
+      if (point.value == null) {
+        return null;
+      }
+      const y =
+        SPARKLINE_HEIGHT - (point.value / max) * (SPARKLINE_HEIGHT - 8) - 4;
+      return `${index === 0 ? 'M' : 'L'}${x},${y}`;
+    })
+    .filter(Boolean)
+    .join(' ');
+
+  const title = labels
+    .map((label, index) => {
+      const value = series[index]?.value;
+      const state = series[index]?.state;
+      return `${label}: ${value != null ? `${value} ms` : 'n/a'}${
+        state ? ` (${state})` : ''
+      }`;
+    })
+    .join('\n');
+
+  return (
+    <svg
+      width={SPARKLINE_WIDTH}
+      height={SPARKLINE_HEIGHT}
+      className="bg-gray-900 rounded"
+      role="img"
+      aria-label="Latency trend"
+    >
+      {path && (
+        <path
+          d={path}
+          fill="none"
+          stroke={color}
+          strokeWidth={2}
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+      <title>{title}</title>
+    </svg>
+  );
+};
+
+interface TrendsProps {
+  runs: TrendRun[];
+}
+
+const Row: React.FC<ListChildComponentProps<DisplayEntry[]>> = ({
+  index,
+  style,
+  data,
+}) => {
+  const entry = data[index];
+  const { host, hostname, service, port, uptime, openRuns, observedRuns } = entry;
+  const uptimePct = observedRuns ? Math.round(uptime * 100) : 0;
+  const latest = entry.latestState ?? 'unknown';
+  const avgLatency =
+    entry.averageLatency != null ? `${Math.round(entry.averageLatency)} ms` : 'n/a';
+
+  return (
+    <div style={style} className="px-2 py-3 border-b border-gray-800">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <div className="font-mono text-sm text-white">
+            {host}
+            <span className="text-gray-500"> · {service}:{port}</span>
+          </div>
+          {hostname && (
+            <div className="text-xs text-gray-400">{hostname}</div>
+          )}
+          <div className="text-xs text-gray-400">
+            {uptimePct}% uptime · {openRuns}/{observedRuns} responsive · latest {latest}
+          </div>
+          <div className="text-xs text-gray-400">Avg latency: {avgLatency}</div>
+        </div>
+        <Sparkline
+          series={entry.valuesInRange}
+          labels={entry.labelsInRange}
+          color={uptimePct > 80 ? '#22d3ee' : uptimePct > 40 ? '#fbbf24' : '#f97316'}
+        />
+      </div>
+    </div>
+  );
+};
+
+const Trends: React.FC<TrendsProps> = ({ runs }) => {
+  const [hostFilter, setHostFilter] = useState('');
+  const [serviceFilter, setServiceFilter] = useState('all');
+  const [stateFilter, setStateFilter] = useState('all');
+  const [minPort, setMinPort] = useState('');
+  const [maxPort, setMaxPort] = useState('');
+  const [range, setRange] = useState<[number, number]>([0, Math.max(runs.length - 1, 0)]);
+
+  useEffect(() => {
+    setRange([0, Math.max(runs.length - 1, 0)]);
+  }, [runs.length]);
+
+  const runLabels = useMemo(
+    () => runs.map((run, index) => formatLabel(run, index)),
+    [runs],
+  );
+
+  const aggregated = useMemo(() => {
+    const map = new Map<string, AggregatedEntry>();
+    runs.forEach((run, runIdx) => {
+      run.hosts.forEach((host) => {
+        host.services.forEach((svc) => {
+          const key = `${host.host}::${svc.service}::${svc.port}`;
+          if (!map.has(key)) {
+            map.set(key, {
+              key,
+              host: host.host,
+              hostname: host.hostname,
+              service: svc.service,
+              port: svc.port,
+              values: Array.from({ length: runs.length }, () => ({
+                value: null,
+                state: null,
+              })),
+            });
+          }
+          const entry = map.get(key);
+          if (!entry) return;
+          entry.values[runIdx] = {
+            value:
+              typeof svc.latencyMs === 'number' ? Math.max(svc.latencyMs, 0) : null,
+            state: svc.state ?? null,
+          };
+        });
+      });
+    });
+    return Array.from(map.values());
+  }, [runs]);
+
+  const serviceOptions = useMemo(() => {
+    const set = new Set<string>();
+    aggregated.forEach((entry) => set.add(entry.service));
+    return Array.from(set).sort();
+  }, [aggregated]);
+
+  const [start, end] = range;
+  const clampedStart = Math.max(0, Math.min(start, runs.length - 1));
+  const clampedEnd = Math.max(clampedStart, Math.min(end, runs.length - 1));
+
+  const displayEntries = useMemo(() => {
+    const lowerHost = hostFilter.trim().toLowerCase();
+    return aggregated
+      .map((entry) => {
+        const slice = entry.values.slice(clampedStart, clampedEnd + 1);
+        const labels = runLabels.slice(clampedStart, clampedEnd + 1);
+        const observed = slice.filter((v) => v.state != null).length;
+        const openRuns = slice.filter((v) => v.state === 'open').length;
+        const latencyValues = slice
+          .map((v) => v.value)
+          .filter((v): v is number => typeof v === 'number');
+        const averageLatency =
+          latencyValues.length > 0
+            ? latencyValues.reduce((acc, v) => acc + v, 0) / latencyValues.length
+            : null;
+        let latestState: TrendService['state'] | null = null;
+        for (let i = slice.length - 1; i >= 0; i -= 1) {
+          if (slice[i].state) {
+            latestState = slice[i].state;
+            break;
+          }
+        }
+        const uptime = observed > 0 ? openRuns / observed : 0;
+        return {
+          ...entry,
+          valuesInRange: slice,
+          labelsInRange: labels,
+          uptime,
+          openRuns,
+          observedRuns: observed,
+          averageLatency,
+          latestState,
+        };
+      })
+      .filter((entry) => {
+        if (lowerHost && !entry.host.toLowerCase().includes(lowerHost)) {
+          return false;
+        }
+        if (serviceFilter !== 'all' && entry.service !== serviceFilter) {
+          return false;
+        }
+        const minPortValue = minPort ? Number(minPort) : null;
+        const maxPortValue = maxPort ? Number(maxPort) : null;
+        if (minPortValue != null && Number.isFinite(minPortValue)) {
+          if (entry.port < minPortValue) return false;
+        }
+        if (maxPortValue != null && Number.isFinite(maxPortValue)) {
+          if (entry.port > maxPortValue) return false;
+        }
+        if (stateFilter === 'always-open' && !(entry.observedRuns > 0 && entry.uptime === 1)) {
+          return false;
+        }
+        if (stateFilter === 'never-open' && entry.openRuns > 0) {
+          return false;
+        }
+        if (
+          stateFilter === 'flapping' &&
+          !(entry.openRuns > 0 && entry.openRuns < entry.observedRuns)
+        ) {
+          return false;
+        }
+        return true;
+      })
+      .sort((a, b) => {
+        if (a.host === b.host) {
+          return a.port - b.port;
+        }
+        return a.host.localeCompare(b.host, undefined, { numeric: true });
+      });
+  }, [
+    aggregated,
+    clampedEnd,
+    clampedStart,
+    hostFilter,
+    maxPort,
+    minPort,
+    runLabels,
+    serviceFilter,
+    stateFilter,
+  ]);
+
+  const exportJson = useCallback(() => {
+    const data = displayEntries.map((entry) => ({
+      host: entry.host,
+      hostname: entry.hostname,
+      service: entry.service,
+      port: entry.port,
+      uptime: entry.uptime,
+      openRuns: entry.openRuns,
+      observedRuns: entry.observedRuns,
+      averageLatency: entry.averageLatency,
+      runs: entry.valuesInRange.map((value, index) => ({
+        label: entry.labelsInRange[index],
+        latencyMs: value.value,
+        state: value.state,
+      })),
+    }));
+    const blob = new Blob([JSON.stringify({
+      range: {
+        start: clampedStart,
+        end: clampedEnd,
+        labels: runLabels.slice(clampedStart, clampedEnd + 1),
+      },
+      entries: data,
+    }, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'nmap-trends.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [clampedEnd, clampedStart, displayEntries, runLabels]);
+
+  const exportCsv = useCallback(() => {
+    const rows = ['host,hostname,service,port,run_label,state,latency_ms'];
+    displayEntries.forEach((entry) => {
+      entry.valuesInRange.forEach((value, index) => {
+        const label = entry.labelsInRange[index];
+        rows.push(
+          [
+            entry.host,
+            entry.hostname ?? '',
+            entry.service,
+            entry.port,
+            label,
+            value.state ?? '',
+            value.value ?? '',
+          ]
+            .map((field) =>
+              typeof field === 'number' ? field.toString() : `"${String(field).replace(/"/g, '""')}"`,
+            )
+            .join(','),
+        );
+      });
+    });
+    const blob = new Blob([rows.join('\n')], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'nmap-trends.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [displayEntries]);
+
+  if (!runs.length) {
+    return (
+      <div className="text-sm text-gray-400" role="status">
+        Trend history will appear after you import run data.
+      </div>
+    );
+  }
+
+  return (
+    <section className="space-y-4" aria-label="Nmap trend explorer">
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="trend-host-filter" className="text-xs uppercase tracking-wide text-gray-400">
+            Host filter
+          </label>
+          <input
+            id="trend-host-filter"
+            type="text"
+            value={hostFilter}
+            onChange={(event) => setHostFilter(event.target.value)}
+            className="px-2 py-1 rounded bg-gray-900 border border-gray-700 text-sm"
+            placeholder="192.0.2.10"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="trend-service-filter" className="text-xs uppercase tracking-wide text-gray-400">
+            Service
+          </label>
+          <select
+            id="trend-service-filter"
+            value={serviceFilter}
+            onChange={(event) => setServiceFilter(event.target.value)}
+            className="px-2 py-1 rounded bg-gray-900 border border-gray-700 text-sm"
+          >
+            <option value="all">All</option>
+            {serviceOptions.map((service) => (
+              <option key={service} value={service}>
+                {service}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="trend-state-filter" className="text-xs uppercase tracking-wide text-gray-400">
+            State
+          </label>
+          <select
+            id="trend-state-filter"
+            value={stateFilter}
+            onChange={(event) => setStateFilter(event.target.value)}
+            className="px-2 py-1 rounded bg-gray-900 border border-gray-700 text-sm"
+          >
+            <option value="all">All</option>
+            <option value="always-open">Always open</option>
+            <option value="flapping">Flapping</option>
+            <option value="never-open">Never open</option>
+          </select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="trend-port-min" className="text-xs uppercase tracking-wide text-gray-400">
+            Min port
+          </label>
+          <input
+            id="trend-port-min"
+            type="number"
+            inputMode="numeric"
+            value={minPort}
+            onChange={(event) => setMinPort(event.target.value)}
+            className="px-2 py-1 rounded bg-gray-900 border border-gray-700 text-sm"
+            placeholder="0"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="trend-port-max" className="text-xs uppercase tracking-wide text-gray-400">
+            Max port
+          </label>
+          <input
+            id="trend-port-max"
+            type="number"
+            inputMode="numeric"
+            value={maxPort}
+            onChange={(event) => setMaxPort(event.target.value)}
+            className="px-2 py-1 rounded bg-gray-900 border border-gray-700 text-sm"
+            placeholder="65535"
+          />
+        </div>
+        <div className="flex items-end gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setHostFilter('');
+              setServiceFilter('all');
+              setStateFilter('all');
+              setMinPort('');
+              setMaxPort('');
+              setRange([0, Math.max(runs.length - 1, 0)]);
+            }}
+            className="px-3 py-1 bg-gray-800 rounded text-sm"
+          >
+            Reset
+          </button>
+          <div className="text-xs text-gray-500">
+            Showing {displayEntries.length} of {aggregated.length}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-xs uppercase tracking-wide text-gray-400">Run range</span>
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <label htmlFor="trend-range-start" className="sr-only">
+            Start run
+          </label>
+          <select
+            id="trend-range-start"
+            value={clampedStart}
+            onChange={(event) => {
+              const next = Number(event.target.value);
+              setRange([next, Math.max(next, clampedEnd)]);
+            }}
+            className="px-2 py-1 rounded bg-gray-900 border border-gray-700"
+          >
+            {runLabels.map((label, index) => (
+              <option key={label} value={index}>
+                {label}
+              </option>
+            ))}
+          </select>
+          <span>to</span>
+          <label htmlFor="trend-range-end" className="sr-only">
+            End run
+          </label>
+          <select
+            id="trend-range-end"
+            value={clampedEnd}
+            onChange={(event) => {
+              const next = Number(event.target.value);
+              setRange([Math.min(clampedStart, next), next]);
+            }}
+            className="px-2 py-1 rounded bg-gray-900 border border-gray-700"
+          >
+            {runLabels.map((label, index) => (
+              <option key={label} value={index}>
+                {label}
+              </option>
+            ))}
+          </select>
+          <div className="ml-auto flex gap-2">
+            <button
+              type="button"
+              onClick={exportJson}
+              className="px-3 py-1 bg-blue-700 rounded text-sm"
+            >
+              Export JSON
+            </button>
+            <button
+              type="button"
+              onClick={exportCsv}
+              className="px-3 py-1 bg-green-700 rounded text-sm"
+            >
+              Export CSV
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="border border-gray-800 rounded bg-gray-950">
+        {displayEntries.length > 0 ? (
+          <List
+            height={Math.min(440, displayEntries.length * 78)}
+            itemCount={displayEntries.length}
+            itemSize={78}
+            width="100%"
+            itemData={displayEntries}
+          >
+            {Row}
+          </List>
+        ) : (
+          <div className="p-4 text-sm text-gray-400">No entries match the filters.</div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default Trends;

--- a/public/demo-data/nmap/trends.json
+++ b/public/demo-data/nmap/trends.json
@@ -1,0 +1,890 @@
+{
+  "runs": [
+    {
+      "id": "run-1",
+      "label": "Jan 01, 08:00",
+      "startedAt": "2024-01-01T08:00:00.000Z",
+      "hosts": [
+        {
+          "host": "192.0.2.10",
+          "hostname": "web01",
+          "services": [
+            {
+              "port": 80,
+              "service": "http",
+              "state": "open",
+              "latencyMs": 45
+            },
+            {
+              "port": 443,
+              "service": "https",
+              "state": "open",
+              "latencyMs": 60
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.20",
+          "hostname": "db01",
+          "services": [
+            {
+              "port": 5432,
+              "service": "postgres",
+              "state": "open",
+              "latencyMs": 71
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.30",
+          "hostname": "ftp01",
+          "services": [
+            {
+              "port": 21,
+              "service": "ftp",
+              "state": "open",
+              "latencyMs": 43
+            }
+          ]
+        },
+        {
+          "host": "198.51.100.10",
+          "hostname": "edge-proxy",
+          "services": [
+            {
+              "port": 8080,
+              "service": "http",
+              "state": "open",
+              "latencyMs": 65
+            },
+            {
+              "port": 22,
+              "service": "ssh",
+              "state": "open",
+              "latencyMs": 51
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.5",
+          "hostname": "vpn01",
+          "services": [
+            {
+              "port": 1194,
+              "service": "openvpn",
+              "state": "open",
+              "latencyMs": 83
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.40",
+          "hostname": "rdp-gateway",
+          "services": [
+            {
+              "port": 3389,
+              "service": "rdp",
+              "state": "open",
+              "latencyMs": 106
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "run-2",
+      "label": "Jan 02, 08:00",
+      "startedAt": "2024-01-02T08:00:00.000Z",
+      "hosts": [
+        {
+          "host": "192.0.2.10",
+          "hostname": "web01",
+          "services": [
+            {
+              "port": 80,
+              "service": "http",
+              "state": "open",
+              "latencyMs": 45
+            },
+            {
+              "port": 443,
+              "service": "https",
+              "state": "open",
+              "latencyMs": 56
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.20",
+          "hostname": "db01",
+          "services": [
+            {
+              "port": 5432,
+              "service": "postgres",
+              "state": "open",
+              "latencyMs": 71
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.30",
+          "hostname": "ftp01",
+          "services": [
+            {
+              "port": 21,
+              "service": "ftp",
+              "state": "closed"
+            }
+          ]
+        },
+        {
+          "host": "198.51.100.10",
+          "hostname": "edge-proxy",
+          "services": [
+            {
+              "port": 8080,
+              "service": "http",
+              "state": "filtered"
+            },
+            {
+              "port": 22,
+              "service": "ssh",
+              "state": "open",
+              "latencyMs": 46
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.5",
+          "hostname": "vpn01",
+          "services": [
+            {
+              "port": 1194,
+              "service": "openvpn",
+              "state": "open",
+              "latencyMs": 82
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.40",
+          "hostname": "rdp-gateway",
+          "services": [
+            {
+              "port": 3389,
+              "service": "rdp",
+              "state": "open",
+              "latencyMs": 105
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "run-3",
+      "label": "Jan 03, 08:00",
+      "startedAt": "2024-01-03T08:00:00.000Z",
+      "hosts": [
+        {
+          "host": "192.0.2.10",
+          "hostname": "web01",
+          "services": [
+            {
+              "port": 80,
+              "service": "http",
+              "state": "open",
+              "latencyMs": 45
+            },
+            {
+              "port": 443,
+              "service": "https",
+              "state": "open",
+              "latencyMs": 54
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.20",
+          "hostname": "db01",
+          "services": [
+            {
+              "port": 5432,
+              "service": "postgres",
+              "state": "filtered"
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.30",
+          "hostname": "ftp01",
+          "services": [
+            {
+              "port": 21,
+              "service": "ftp",
+              "state": "open",
+              "latencyMs": 42
+            }
+          ]
+        },
+        {
+          "host": "198.51.100.10",
+          "hostname": "edge-proxy",
+          "services": [
+            {
+              "port": 8080,
+              "service": "http",
+              "state": "closed"
+            },
+            {
+              "port": 22,
+              "service": "ssh",
+              "state": "open",
+              "latencyMs": 42
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.5",
+          "hostname": "vpn01",
+          "services": [
+            {
+              "port": 1194,
+              "service": "openvpn",
+              "state": "open",
+              "latencyMs": 82
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.40",
+          "hostname": "rdp-gateway",
+          "services": [
+            {
+              "port": 3389,
+              "service": "rdp",
+              "state": "filtered"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "run-4",
+      "label": "Jan 04, 08:00",
+      "startedAt": "2024-01-04T08:00:00.000Z",
+      "hosts": [
+        {
+          "host": "192.0.2.10",
+          "hostname": "web01",
+          "services": [
+            {
+              "port": 80,
+              "service": "http",
+              "state": "closed"
+            },
+            {
+              "port": 443,
+              "service": "https",
+              "state": "open",
+              "latencyMs": 66
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.20",
+          "hostname": "db01",
+          "services": [
+            {
+              "port": 5432,
+              "service": "postgres",
+              "state": "open",
+              "latencyMs": 57
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.30",
+          "hostname": "ftp01",
+          "services": [
+            {
+              "port": 21,
+              "service": "ftp",
+              "state": "closed"
+            }
+          ]
+        },
+        {
+          "host": "198.51.100.10",
+          "hostname": "edge-proxy",
+          "services": [
+            {
+              "port": 8080,
+              "service": "http",
+              "state": "open",
+              "latencyMs": 43
+            },
+            {
+              "port": 22,
+              "service": "ssh",
+              "state": "open",
+              "latencyMs": 59
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.5",
+          "hostname": "vpn01",
+          "services": [
+            {
+              "port": 1194,
+              "service": "openvpn",
+              "state": "closed"
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.40",
+          "hostname": "rdp-gateway",
+          "services": [
+            {
+              "port": 3389,
+              "service": "rdp",
+              "state": "open",
+              "latencyMs": 69
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "run-5",
+      "label": "Jan 05, 08:00",
+      "startedAt": "2024-01-05T08:00:00.000Z",
+      "hosts": [
+        {
+          "host": "192.0.2.10",
+          "hostname": "web01",
+          "services": [
+            {
+              "port": 80,
+              "service": "http",
+              "state": "open",
+              "latencyMs": 29
+            },
+            {
+              "port": 443,
+              "service": "https",
+              "state": "open",
+              "latencyMs": 52
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.20",
+          "hostname": "db01",
+          "services": [
+            {
+              "port": 5432,
+              "service": "postgres",
+              "state": "open",
+              "latencyMs": 51
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.30",
+          "hostname": "ftp01",
+          "services": [
+            {
+              "port": 21,
+              "service": "ftp",
+              "state": "open",
+              "latencyMs": 18
+            }
+          ]
+        },
+        {
+          "host": "198.51.100.10",
+          "hostname": "edge-proxy",
+          "services": [
+            {
+              "port": 22,
+              "service": "ssh",
+              "state": "open",
+              "latencyMs": 41
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.5",
+          "hostname": "vpn01",
+          "services": [
+            {
+              "port": 1194,
+              "service": "openvpn",
+              "state": "open",
+              "latencyMs": 42
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.40",
+          "hostname": "rdp-gateway",
+          "services": [
+            {
+              "port": 3389,
+              "service": "rdp",
+              "state": "open",
+              "latencyMs": 56
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "run-6",
+      "label": "Jan 06, 08:00",
+      "startedAt": "2024-01-06T08:00:00.000Z",
+      "hosts": [
+        {
+          "host": "192.0.2.10",
+          "hostname": "web01",
+          "services": [
+            {
+              "port": 80,
+              "service": "http",
+              "state": "open",
+              "latencyMs": 41
+            },
+            {
+              "port": 443,
+              "service": "https",
+              "state": "open",
+              "latencyMs": 57
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.20",
+          "hostname": "db01",
+          "services": [
+            {
+              "port": 5432,
+              "service": "postgres",
+              "state": "open",
+              "latencyMs": 66
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.30",
+          "hostname": "ftp01",
+          "services": [
+            {
+              "port": 21,
+              "service": "ftp",
+              "state": "closed"
+            }
+          ]
+        },
+        {
+          "host": "198.51.100.10",
+          "hostname": "edge-proxy",
+          "services": [
+            {
+              "port": 8080,
+              "service": "http",
+              "state": "closed"
+            },
+            {
+              "port": 22,
+              "service": "ssh",
+              "state": "open",
+              "latencyMs": 46
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.5",
+          "hostname": "vpn01",
+          "services": [
+            {
+              "port": 1194,
+              "service": "openvpn",
+              "state": "open",
+              "latencyMs": 73
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.40",
+          "hostname": "rdp-gateway",
+          "services": [
+            {
+              "port": 3389,
+              "service": "rdp",
+              "state": "open",
+              "latencyMs": 94
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "run-7",
+      "label": "Jan 07, 08:00",
+      "startedAt": "2024-01-07T08:00:00.000Z",
+      "hosts": [
+        {
+          "host": "192.0.2.10",
+          "hostname": "web01",
+          "services": [
+            {
+              "port": 80,
+              "service": "http",
+              "state": "open",
+              "latencyMs": 46
+            },
+            {
+              "port": 443,
+              "service": "https",
+              "state": "open",
+              "latencyMs": 62
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.20",
+          "hostname": "db01",
+          "services": [
+            {
+              "port": 5432,
+              "service": "postgres",
+              "state": "filtered"
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.30",
+          "hostname": "ftp01",
+          "services": [
+            {
+              "port": 21,
+              "service": "ftp",
+              "state": "open",
+              "latencyMs": 44
+            }
+          ]
+        },
+        {
+          "host": "198.51.100.10",
+          "hostname": "edge-proxy",
+          "services": [
+            {
+              "port": 8080,
+              "service": "http",
+              "state": "open",
+              "latencyMs": 66
+            },
+            {
+              "port": 22,
+              "service": "ssh",
+              "state": "open",
+              "latencyMs": 54
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.5",
+          "hostname": "vpn01",
+          "services": [
+            {
+              "port": 1194,
+              "service": "openvpn",
+              "state": "open",
+              "latencyMs": 85
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.40",
+          "hostname": "rdp-gateway",
+          "services": [
+            {
+              "port": 3389,
+              "service": "rdp",
+              "state": "filtered"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "run-8",
+      "label": "Jan 08, 08:00",
+      "startedAt": "2024-01-08T08:00:00.000Z",
+      "hosts": [
+        {
+          "host": "192.0.2.10",
+          "hostname": "web01",
+          "services": [
+            {
+              "port": 80,
+              "service": "http",
+              "state": "open",
+              "latencyMs": 44
+            },
+            {
+              "port": 443,
+              "service": "https",
+              "state": "open",
+              "latencyMs": 58
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.20",
+          "hostname": "db01",
+          "services": [
+            {
+              "port": 5432,
+              "service": "postgres",
+              "state": "open",
+              "latencyMs": 70
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.30",
+          "hostname": "ftp01",
+          "services": [
+            {
+              "port": 21,
+              "service": "ftp",
+              "state": "closed"
+            }
+          ]
+        },
+        {
+          "host": "198.51.100.10",
+          "hostname": "edge-proxy",
+          "services": [
+            {
+              "port": 8080,
+              "service": "http",
+              "state": "filtered"
+            },
+            {
+              "port": 22,
+              "service": "ssh",
+              "state": "open",
+              "latencyMs": 47
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.5",
+          "hostname": "vpn01",
+          "services": [
+            {
+              "port": 1194,
+              "service": "openvpn",
+              "state": "open",
+              "latencyMs": 80
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.40",
+          "hostname": "rdp-gateway",
+          "services": [
+            {
+              "port": 3389,
+              "service": "rdp",
+              "state": "open",
+              "latencyMs": 103
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "run-9",
+      "label": "Jan 09, 08:00",
+      "startedAt": "2024-01-09T08:00:00.000Z",
+      "hosts": [
+        {
+          "host": "192.0.2.10",
+          "hostname": "web01",
+          "services": [
+            {
+              "port": 80,
+              "service": "http",
+              "state": "closed"
+            },
+            {
+              "port": 443,
+              "service": "https",
+              "state": "open",
+              "latencyMs": 53
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.20",
+          "hostname": "db01",
+          "services": [
+            {
+              "port": 5432,
+              "service": "postgres",
+              "state": "open",
+              "latencyMs": 72
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.30",
+          "hostname": "ftp01",
+          "services": [
+            {
+              "port": 21,
+              "service": "ftp",
+              "state": "open",
+              "latencyMs": 44
+            }
+          ]
+        },
+        {
+          "host": "198.51.100.10",
+          "hostname": "edge-proxy",
+          "services": [
+            {
+              "port": 8080,
+              "service": "http",
+              "state": "closed"
+            },
+            {
+              "port": 22,
+              "service": "ssh",
+              "state": "open",
+              "latencyMs": 41
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.5",
+          "hostname": "vpn01",
+          "services": [
+            {
+              "port": 1194,
+              "service": "openvpn",
+              "state": "closed"
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.40",
+          "hostname": "rdp-gateway",
+          "services": [
+            {
+              "port": 3389,
+              "service": "rdp",
+              "state": "open",
+              "latencyMs": 109
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "run-10",
+      "label": "Jan 10, 08:00",
+      "startedAt": "2024-01-10T08:00:00.000Z",
+      "hosts": [
+        {
+          "host": "192.0.2.10",
+          "hostname": "web01",
+          "services": [
+            {
+              "port": 80,
+              "service": "http",
+              "state": "open",
+              "latencyMs": 37
+            },
+            {
+              "port": 443,
+              "service": "https",
+              "state": "open",
+              "latencyMs": 64
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.20",
+          "hostname": "db01",
+          "services": [
+            {
+              "port": 5432,
+              "service": "postgres",
+              "state": "open",
+              "latencyMs": 62
+            }
+          ]
+        },
+        {
+          "host": "192.0.2.30",
+          "hostname": "ftp01",
+          "services": [
+            {
+              "port": 21,
+              "service": "ftp",
+              "state": "closed"
+            }
+          ]
+        },
+        {
+          "host": "198.51.100.10",
+          "hostname": "edge-proxy",
+          "services": [
+            {
+              "port": 8080,
+              "service": "http",
+              "state": "open",
+              "latencyMs": 50
+            },
+            {
+              "port": 22,
+              "service": "ssh",
+              "state": "open",
+              "latencyMs": 56
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.5",
+          "hostname": "vpn01",
+          "services": [
+            {
+              "port": 1194,
+              "service": "openvpn",
+              "state": "open",
+              "latencyMs": 63
+            }
+          ]
+        },
+        {
+          "host": "203.0.113.40",
+          "hostname": "rdp-gateway",
+          "services": [
+            {
+              "port": 3389,
+              "service": "rdp",
+              "state": "open",
+              "latencyMs": 82
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a trend explorer component that aggregates run history by host/service/port with sparklines and virtualization
- load canned run data in the Nmap NSE app and expose exportable filters
- expand unit tests to cover new fetch path and updated toast role

## Testing
- yarn test nmapNse.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dca4f573448328b329ab1c85868542