### PR TITLE
[nmap-nse] Add script argument builder with planner sync

### DIFF
--- a/components/apps/nmap-nse/ScriptArgs.tsx
+++ b/components/apps/nmap-nse/ScriptArgs.tsx
@@ -1,0 +1,906 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import usePersistentState from '../../../hooks/usePersistentState';
+
+type ArgPrimitive = string | number | boolean;
+
+type ArgType = 'string' | 'number' | 'boolean' | 'select';
+
+interface ArgOption {
+  label: string;
+  value: string;
+}
+
+interface ArgDefinition {
+  key: string;
+  label: string;
+  type: ArgType;
+  required?: boolean;
+  description?: string;
+  placeholder?: string;
+  defaultValue?: ArgPrimitive;
+  min?: number;
+  max?: number;
+  step?: number;
+  options?: ArgOption[];
+  dependsOn?: {
+    key: string;
+    values: ArgPrimitive[];
+    message?: string;
+  };
+}
+
+export type ScriptArgValues = Record<string, ArgPrimitive>;
+
+type ValidationRule = (values: ScriptArgValues) => string | null;
+
+interface PlannerMetadata {
+  summary: string;
+  tags: string[];
+}
+
+interface ScriptMetadata {
+  args: ArgDefinition[];
+  presets?: Record<string, ScriptArgValues>;
+  planner: PlannerMetadata;
+  rules?: ValidationRule[];
+}
+
+export interface PlannerEntry {
+  script: string;
+  summary: string;
+  tags: string[];
+  args: ScriptArgValues;
+}
+
+export interface ScriptArgsChange {
+  values: ScriptArgValues;
+  errors: string[];
+  isValid: boolean;
+  planner: PlannerEntry | null;
+}
+
+const isPresetMap = (value: unknown): value is Record<string, ScriptArgValues> => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value as Record<string, unknown>).every((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return false;
+    }
+    return true;
+  });
+};
+
+export const scriptArgumentMetadata: Record<string, ScriptMetadata> = {
+  'http-title': {
+    planner: {
+      summary: 'Profile HTTP services by collecting page titles.',
+      tags: ['http', 'discovery'],
+    },
+    presets: {
+      Baseline: {
+        path: '/',
+        https: false,
+        maxLength: 80,
+        statusOnly: false,
+      },
+      'Strict TLS': {
+        path: '/',
+        https: true,
+        maxLength: 60,
+        statusOnly: false,
+      },
+    },
+    args: [
+      {
+        key: 'path',
+        label: 'Request path',
+        type: 'string',
+        required: true,
+        placeholder: '/index.html',
+        defaultValue: '/',
+        description: 'Relative path to request from the target HTTP service.',
+      },
+      {
+        key: 'https',
+        label: 'Force HTTPS',
+        type: 'boolean',
+        defaultValue: false,
+        description: 'Upgrade the probe to HTTPS even when scanning a plain HTTP port.',
+      },
+      {
+        key: 'maxLength',
+        label: 'Max title length',
+        type: 'number',
+        min: 10,
+        max: 200,
+        step: 10,
+        defaultValue: 80,
+        description: 'Maximum number of characters to capture from the HTML <title>.',
+      },
+      {
+        key: 'statusOnly',
+        label: 'Status-only mode',
+        type: 'boolean',
+        defaultValue: false,
+        description: 'Skip HTML parsing and only record the HTTP status line.',
+      },
+    ],
+    rules: [
+      (values) => {
+        if (values.statusOnly && typeof values.maxLength === 'number' && values.maxLength > 80) {
+          return 'Status-only mode streams only headers. Reduce the max title length to 80 characters or disable status-only.';
+        }
+        return null;
+      },
+      (values) => {
+        if (values.https && typeof values.path === 'string' && values.path.startsWith('http')) {
+          return 'Provide a relative request path when forcing HTTPS. Remove the scheme prefix (http:// or https://).';
+        }
+        return null;
+      },
+    ],
+  },
+  'ssl-cert': {
+    planner: {
+      summary: 'Collect TLS certificate metadata for crypto hygiene reviews.',
+      tags: ['ssl', 'crypto'],
+    },
+    presets: {
+      Baseline: {
+        showExpired: false,
+        showTrusted: true,
+        minKeyBits: 2048,
+        issuer: 'any',
+      },
+      'Legacy Inventory': {
+        showExpired: true,
+        showTrusted: false,
+        minKeyBits: 1024,
+        issuer: 'any',
+      },
+    },
+    args: [
+      {
+        key: 'showExpired',
+        label: 'Include expired certs',
+        type: 'boolean',
+        defaultValue: false,
+        description: 'Display certificates that are past their validity period.',
+      },
+      {
+        key: 'showTrusted',
+        label: 'Only trusted issuers',
+        type: 'boolean',
+        defaultValue: true,
+        description: 'Limit output to certificates chaining to trusted roots.',
+      },
+      {
+        key: 'minKeyBits',
+        label: 'Minimum key size',
+        type: 'number',
+        min: 512,
+        max: 8192,
+        step: 256,
+        defaultValue: 2048,
+        description: 'Discard results that negotiate keys weaker than this size.',
+      },
+      {
+        key: 'issuer',
+        label: 'Preferred issuer',
+        type: 'select',
+        defaultValue: 'any',
+        options: [
+          { label: 'Any', value: 'any' },
+          { label: 'Let’s Encrypt', value: 'letsencrypt' },
+          { label: 'DigiCert', value: 'digicert' },
+          { label: 'Sectigo', value: 'sectigo' },
+        ],
+        description: 'Focus on certificates issued by a specific authority.',
+      },
+    ],
+    rules: [
+      (values) => {
+        if (
+          typeof values.minKeyBits === 'number' &&
+          values.minKeyBits > 4096 &&
+          values.issuer === 'any'
+        ) {
+          return 'A minimum key size above 4096 bits with any issuer selected will filter most findings. Reduce the threshold or pick an issuer.';
+        }
+        return null;
+      },
+    ],
+  },
+  'smb-os-discovery': {
+    planner: {
+      summary: 'Fingerprint SMB services to map operating systems.',
+      tags: ['smb', 'host-discovery'],
+    },
+    presets: {
+      Baseline: {
+        useCache: true,
+        maxAttempts: 3,
+        workgroup: '',
+      },
+      'Impatient Sweep': {
+        useCache: false,
+        maxAttempts: 2,
+        workgroup: '',
+      },
+    },
+    args: [
+      {
+        key: 'useCache',
+        label: 'Cache session info',
+        type: 'boolean',
+        defaultValue: true,
+        description: 'Reuse negotiated sessions to speed up large scans.',
+      },
+      {
+        key: 'maxAttempts',
+        label: 'Max attempts',
+        type: 'number',
+        min: 1,
+        max: 6,
+        step: 1,
+        defaultValue: 3,
+        description: 'Number of retries before a host is considered unresponsive.',
+      },
+      {
+        key: 'workgroup',
+        label: 'Workgroup hint',
+        type: 'string',
+        defaultValue: '',
+        placeholder: 'CORP',
+        description: 'Optional workgroup or domain name to seed the probe.',
+      },
+    ],
+    rules: [
+      (values) => {
+        if (!values.useCache && typeof values.maxAttempts === 'number' && values.maxAttempts > 4) {
+          return 'Disabling cache with more than 4 attempts can overwhelm legacy SMB stacks. Either enable caching or drop retries to 4 or fewer.';
+        }
+        return null;
+      },
+    ],
+  },
+  'ftp-anon': {
+    planner: {
+      summary: 'Check anonymous FTP posture and optional upload rights.',
+      tags: ['ftp', 'auth'],
+    },
+    presets: {
+      Baseline: {
+        username: 'anonymous',
+        timeout: 10,
+        checkUpload: false,
+      },
+      'Upload Audit': {
+        username: 'anonymous',
+        timeout: 20,
+        checkUpload: true,
+      },
+    },
+    args: [
+      {
+        key: 'username',
+        label: 'Login username',
+        type: 'string',
+        defaultValue: 'anonymous',
+        placeholder: 'anonymous',
+        description: 'User name supplied during the FTP handshake.',
+      },
+      {
+        key: 'timeout',
+        label: 'Timeout (s)',
+        type: 'number',
+        min: 5,
+        max: 60,
+        step: 1,
+        defaultValue: 10,
+        description: 'Maximum seconds to wait for banner and login responses.',
+      },
+      {
+        key: 'checkUpload',
+        label: 'Probe upload capability',
+        type: 'boolean',
+        defaultValue: false,
+        description: 'Attempt a harmless upload to confirm write permissions.',
+      },
+    ],
+    rules: [
+      (values) => {
+        if (values.checkUpload && values.username !== 'anonymous') {
+          return 'Upload probing only supports the anonymous account in this demo. Switch the username back to "anonymous" or disable the upload check.';
+        }
+        return null;
+      },
+    ],
+  },
+  'http-enum': {
+    planner: {
+      summary: 'Enumerate web content and common application routes.',
+      tags: ['http', 'content-enum'],
+    },
+    presets: {
+      Baseline: {
+        profile: 'common',
+        maxDepth: 3,
+        respectRobots: true,
+      },
+      'CMS Hunter': {
+        profile: 'cms',
+        maxDepth: 4,
+        respectRobots: false,
+      },
+    },
+    args: [
+      {
+        key: 'profile',
+        label: 'Path profile',
+        type: 'select',
+        defaultValue: 'common',
+        options: [
+          { label: 'Common paths', value: 'common' },
+          { label: 'CMS paths', value: 'cms' },
+          { label: 'IoT firmware', value: 'iot' },
+        ],
+        description: 'Select a curated wordlist tailored to the target surface.',
+      },
+      {
+        key: 'maxDepth',
+        label: 'Recursion depth',
+        type: 'number',
+        min: 1,
+        max: 6,
+        step: 1,
+        defaultValue: 3,
+        description: 'How deep to recurse into discovered directories.',
+      },
+      {
+        key: 'respectRobots',
+        label: 'Respect robots.txt',
+        type: 'boolean',
+        defaultValue: true,
+        description: 'Skip paths disallowed by the site’s robots.txt.',
+      },
+      {
+        key: 'testLoginFlows',
+        label: 'Test login workflows',
+        type: 'boolean',
+        defaultValue: false,
+        description: 'Replay lightweight login probes on detected admin panels.',
+        dependsOn: {
+          key: 'profile',
+          values: ['cms'],
+          message: 'Login replay is only available when the CMS profile is selected.',
+        },
+      },
+    ],
+    rules: [
+      (values) => {
+        if (values.profile === 'iot' && typeof values.maxDepth === 'number' && values.maxDepth > 4) {
+          return 'The IoT profile ships with deeply nested paths already. Reduce recursion depth to 4 or less when using the IoT dictionary.';
+        }
+        return null;
+      },
+    ],
+  },
+  'dns-brute': {
+    planner: {
+      summary: 'Enumerate DNS subdomains using layered dictionaries.',
+      tags: ['dns', 'brute'],
+    },
+    presets: {
+      Baseline: {
+        dictionary: 'small',
+        threads: 10,
+        wildcard: false,
+      },
+      'Wide Sweep': {
+        dictionary: 'medium',
+        threads: 15,
+        wildcard: false,
+      },
+      'Depth Charge': {
+        dictionary: 'huge',
+        threads: 20,
+        wildcard: true,
+      },
+    },
+    args: [
+      {
+        key: 'dictionary',
+        label: 'Dictionary size',
+        type: 'select',
+        defaultValue: 'small',
+        options: [
+          { label: 'Small (fast)', value: 'small' },
+          { label: 'Medium', value: 'medium' },
+          { label: 'Huge (slow)', value: 'huge' },
+        ],
+        description: 'Select the wordlist used for brute forcing subdomains.',
+      },
+      {
+        key: 'threads',
+        label: 'Concurrent lookups',
+        type: 'number',
+        min: 1,
+        max: 50,
+        step: 1,
+        defaultValue: 10,
+        description: 'Number of parallel DNS queries issued at a time.',
+      },
+      {
+        key: 'wildcard',
+        label: 'Detect wildcard records',
+        type: 'boolean',
+        defaultValue: false,
+        description: 'Run a control query to detect wildcard DNS responses.',
+      },
+      {
+        key: 'pauseOnHit',
+        label: 'Pause when a hit is found',
+        type: 'boolean',
+        defaultValue: false,
+        description: 'Stop the run when a subdomain is discovered to review manually.',
+        dependsOn: {
+          key: 'wildcard',
+          values: [false],
+          message: 'Pause on hit is disabled when wildcard detection is active.',
+        },
+      },
+    ],
+    rules: [
+      (values) => {
+        if (values.dictionary === 'huge' && typeof values.threads === 'number' && values.threads > 25) {
+          return 'The huge dictionary saturates DNS resolvers with high concurrency. Drop concurrent lookups to 25 or fewer.';
+        }
+        return null;
+      },
+    ],
+  },
+};
+
+const getDefaultValues = (metadata?: ScriptMetadata): ScriptArgValues => {
+  if (!metadata) return {};
+  return metadata.args.reduce<ScriptArgValues>((acc, arg) => {
+    if (typeof arg.defaultValue !== 'undefined') {
+      acc[arg.key] = arg.defaultValue;
+    } else if (arg.type === 'boolean') {
+      acc[arg.key] = false;
+    } else {
+      acc[arg.key] = '';
+    }
+    return acc;
+  }, {});
+};
+
+const validateValues = (
+  metadata: ScriptMetadata | undefined,
+  values: ScriptArgValues,
+): string[] => {
+  if (!metadata) return [];
+  const messages: string[] = [];
+
+  metadata.args.forEach((arg) => {
+    const dependency = arg.dependsOn;
+    if (dependency) {
+      const dependencyValue = values[dependency.key];
+      const satisfied = dependency.values.includes(dependencyValue);
+      if (!satisfied) {
+        return;
+      }
+    }
+
+    const value = values[arg.key];
+    if (arg.required) {
+      const isEmpty =
+        typeof value === 'undefined' ||
+        value === '' ||
+        (typeof value === 'number' && Number.isNaN(value));
+      if (isEmpty) {
+        messages.push(`${arg.label} is required.`);
+        return;
+      }
+    }
+
+    if (typeof value === 'undefined' || value === '') {
+      return;
+    }
+
+    switch (arg.type) {
+      case 'number': {
+        if (typeof value !== 'number' || Number.isNaN(value)) {
+          messages.push(`${arg.label} must be a number.`);
+          return;
+        }
+        if (typeof arg.min === 'number' && value < arg.min) {
+          messages.push(`${arg.label} must be ≥ ${arg.min}.`);
+        }
+        if (typeof arg.max === 'number' && value > arg.max) {
+          messages.push(`${arg.label} must be ≤ ${arg.max}.`);
+        }
+        break;
+      }
+      case 'select': {
+        if (
+          typeof value !== 'string' ||
+          !arg.options?.some((option) => option.value === value)
+        ) {
+          messages.push(`${arg.label} must match an available option.`);
+        }
+        break;
+      }
+      case 'boolean': {
+        if (typeof value !== 'boolean') {
+          messages.push(`${arg.label} must be enabled or disabled.`);
+        }
+        break;
+      }
+      case 'string': {
+        if (typeof value !== 'string') {
+          messages.push(`${arg.label} must be text.`);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  });
+
+  metadata.rules?.forEach((rule) => {
+    const result = rule(values);
+    if (result) {
+      messages.push(result);
+    }
+  });
+
+  return messages;
+};
+
+export const serializeScriptArgs = (
+  script: string,
+  values: ScriptArgValues | undefined,
+): string => {
+  if (!values) return '';
+  const metadata = scriptArgumentMetadata[script];
+  if (!metadata) return '';
+
+  const parts: string[] = [];
+  metadata.args.forEach((arg) => {
+    const dependency = arg.dependsOn;
+    if (dependency) {
+      const dependencyValue = values[dependency.key];
+      const satisfied = dependency.values.includes(dependencyValue);
+      if (!satisfied) {
+        return;
+      }
+    }
+
+    const value = values[arg.key];
+    if (typeof value === 'undefined' || value === '') {
+      return;
+    }
+    if (typeof value === 'boolean') {
+      parts.push(`${script}.${arg.key}=${value ? 'true' : 'false'}`);
+      return;
+    }
+    parts.push(`${script}.${arg.key}=${value}`);
+  });
+
+  return parts.join(',');
+};
+
+interface ScriptArgsProps {
+  script: string;
+  value?: ScriptArgValues;
+  onChange: (change: ScriptArgsChange) => void;
+}
+
+const ScriptArgs: React.FC<ScriptArgsProps> = ({ script, value, onChange }) => {
+  const metadata = scriptArgumentMetadata[script];
+  const defaults = useMemo(() => getDefaultValues(metadata), [metadata]);
+  const [localValues, setLocalValues] = useState<ScriptArgValues>(() => ({
+    ...defaults,
+    ...(value || {}),
+  }));
+
+  useEffect(() => {
+    setLocalValues({
+      ...defaults,
+      ...(value || {}),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [script]);
+
+  const [presets, setPresets] = usePersistentState<Record<string, ScriptArgValues>>(
+    `nmap-nse:presets:${script}`,
+    metadata?.presets || {},
+    isPresetMap,
+  );
+
+  const [presetName, setPresetName] = useState('');
+  const [selectedPreset, setSelectedPreset] = useState('');
+
+  useEffect(() => {
+    if (!metadata) {
+      onChange({
+        values: {},
+        errors: [],
+        isValid: true,
+        planner: null,
+      });
+      return;
+    }
+
+    const errors = validateValues(metadata, localValues);
+    const planner: PlannerEntry | null = errors.length
+      ? null
+      : {
+          script,
+          summary: metadata.planner.summary,
+          tags: metadata.planner.tags,
+          args: localValues,
+        };
+
+    onChange({
+      values: localValues,
+      errors,
+      isValid: errors.length === 0,
+      planner,
+    });
+  }, [localValues, metadata, onChange, script]);
+
+  if (!metadata) {
+    return (
+      <p className="mt-2 text-xs text-red-500">No argument metadata available.</p>
+    );
+  }
+
+  const updateValue = (key: string, next: ArgPrimitive | '') => {
+    setLocalValues((prev) => ({
+      ...prev,
+      [key]: next,
+    }));
+  };
+
+  const renderField = (arg: ArgDefinition) => {
+    const dependency = arg.dependsOn;
+    const dependencySatisfied = dependency
+      ? dependency.values.includes(localValues[dependency.key])
+      : true;
+    const value = localValues[arg.key];
+    const baseLabelId = `${script}-${arg.key}`;
+
+    const commonProps = {
+      id: baseLabelId,
+      name: baseLabelId,
+      disabled: !dependencySatisfied,
+      className:
+        'w-full rounded border border-gray-400 bg-white p-1 text-sm text-black focus:outline-none focus:ring-2 focus:ring-ub-yellow',
+      'aria-describedby': dependencySatisfied
+        ? undefined
+        : `${baseLabelId}-dependency`,
+    } as const;
+
+    switch (arg.type) {
+      case 'string':
+        return (
+          <input
+            {...commonProps}
+            type="text"
+            value={typeof value === 'string' ? value : ''}
+            placeholder={arg.placeholder}
+            onChange={(event) => updateValue(arg.key, event.target.value)}
+          />
+        );
+      case 'number':
+        return (
+          <input
+            {...commonProps}
+            type="number"
+            value={typeof value === 'number' ? value : value === '' ? '' : Number(value) || ''}
+            min={arg.min}
+            max={arg.max}
+            step={arg.step}
+            onChange={(event) => {
+              const raw = event.target.value;
+              updateValue(
+                arg.key,
+                raw === '' ? '' : Number.isNaN(Number(raw)) ? '' : Number(raw),
+              );
+            }}
+          />
+        );
+      case 'boolean':
+        return (
+          <input
+            id={baseLabelId}
+            name={baseLabelId}
+            type="checkbox"
+            className="h-4 w-4"
+            checked={Boolean(value)}
+            disabled={!dependencySatisfied}
+            aria-label={arg.label}
+            onChange={(event) => updateValue(arg.key, event.target.checked)}
+          />
+        );
+      case 'select':
+        return (
+          <select
+            {...commonProps}
+            value={typeof value === 'string' ? value : ''}
+            onChange={(event) => updateValue(arg.key, event.target.value)}
+          >
+            {arg.options?.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const resetToDefaults = () => {
+    setLocalValues({ ...defaults });
+    setSelectedPreset('');
+  };
+
+  const applyPreset = (name: string) => {
+    const preset = presets?.[name];
+    if (!preset) return;
+    setLocalValues({
+      ...defaults,
+      ...preset,
+    });
+    setSelectedPreset(name);
+  };
+
+  const savePreset = () => {
+    if (!presetName.trim()) return;
+    const name = presetName.trim();
+    setPresets((current) => ({
+      ...(current || {}),
+      [name]: localValues,
+    }));
+    setSelectedPreset(name);
+    setPresetName('');
+  };
+
+  const removePreset = () => {
+    if (!selectedPreset) return;
+    setPresets((current) => {
+      if (!current) return current;
+      const next = { ...current };
+      delete next[selectedPreset];
+      return next;
+    });
+    setSelectedPreset('');
+  };
+
+  const errors = validateValues(metadata, localValues);
+
+  return (
+    <div className="mt-2 space-y-3 rounded border border-gray-300 bg-gray-50 p-2 text-black">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+          Arguments
+        </span>
+        <button
+          type="button"
+          onClick={resetToDefaults}
+          className="text-xs font-medium text-blue-600 hover:underline"
+        >
+          Reset
+        </button>
+      </div>
+      {metadata.args.map((arg) => {
+        const dependency = arg.dependsOn;
+        const dependencySatisfied = dependency
+          ? dependency.values.includes(localValues[dependency.key])
+          : true;
+        const baseLabelId = `${script}-${arg.key}`;
+        return (
+          <div key={arg.key} className="space-y-1">
+            <label htmlFor={baseLabelId} className="flex items-center gap-2 text-sm font-medium text-gray-800">
+              {arg.label}
+              {arg.type === 'boolean' && renderField(arg)}
+            </label>
+            {arg.type !== 'boolean' && renderField(arg)}
+            {arg.description && (
+              <p className="text-xs text-gray-600">{arg.description}</p>
+            )}
+            {dependency && !dependencySatisfied && (
+              <p
+                id={`${baseLabelId}-dependency`}
+                className="text-xs text-orange-600"
+              >
+                {dependency.message || 'Adjust the related option to enable this setting.'}
+              </p>
+            )}
+          </div>
+        );
+      })}
+      <div className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+          Presets
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            className="min-w-[8rem] rounded border border-gray-400 bg-white p-1 text-sm"
+            value={selectedPreset}
+            aria-label="Load saved preset"
+            onChange={(event) => applyPreset(event.target.value)}
+          >
+            <option value="">Load preset…</option>
+            {presets &&
+              Object.keys(presets).map((name) => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+          </select>
+          <button
+            type="button"
+            onClick={removePreset}
+            disabled={!selectedPreset}
+            className="rounded bg-gray-800 px-2 py-1 text-xs text-white disabled:opacity-50"
+          >
+            Delete
+          </button>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            type="text"
+            value={presetName}
+            onChange={(event) => setPresetName(event.target.value)}
+            placeholder="Preset name"
+            aria-label="Preset name"
+            className="flex-1 min-w-[8rem] rounded border border-gray-400 bg-white p-1 text-sm text-black"
+          />
+          <button
+            type="button"
+            onClick={savePreset}
+            className="rounded bg-blue-700 px-2 py-1 text-xs text-white"
+          >
+            Save current
+          </button>
+        </div>
+      </div>
+      <div className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+          Planner context
+        </p>
+        <p className="text-xs text-gray-700">{metadata.planner.summary}</p>
+        <div className="flex flex-wrap gap-1">
+          {metadata.planner.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded bg-gray-200 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-700"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+      {errors.length > 0 && (
+        <div className="rounded border border-red-400 bg-red-50 p-2 text-xs text-red-700">
+          <p className="font-semibold">Resolve before running:</p>
+          <ul className="list-disc pl-4">
+            {errors.map((error) => (
+              <li key={error}>{error}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ScriptArgs;
+

--- a/components/apps/nmap-nse/index.js
+++ b/components/apps/nmap-nse/index.js
@@ -1,6 +1,14 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import Toast from '../../ui/Toast';
 import DiscoveryMap from './DiscoveryMap';
+import usePersistentState from '../../../hooks/usePersistentState';
+import ScriptArgs, { serializeScriptArgs } from './ScriptArgs';
 
 // Basic script metadata. Example output is loaded from public/demo/nmap-nse.json
 const scripts = [
@@ -81,7 +89,23 @@ const NmapNSEApp = () => {
   const [portFlag, setPortFlag] = useState('');
   const [examples, setExamples] = useState({});
   const [results, setResults] = useState({ hosts: [] });
-  const [scriptOptions, setScriptOptions] = useState({});
+  const [scriptArgs, setScriptArgs] = useState({});
+  const [scriptErrors, setScriptErrors] = useState({});
+  const [executionPlan, setExecutionPlan] = usePersistentState(
+    'nmap-nse:execution-plan',
+    [],
+    (value) =>
+      Array.isArray(value) &&
+      value.every(
+        (entry) =>
+          entry &&
+          typeof entry === 'object' &&
+          typeof entry.script === 'string' &&
+          typeof entry.summary === 'string' &&
+          Array.isArray(entry.tags) &&
+          entry.tags.every((tag) => typeof tag === 'string'),
+      ),
+  );
   const [activeScript, setActiveScript] = useState(scripts[0].name);
   const [phaseStep, setPhaseStep] = useState(0);
   const [toast, setToast] = useState('');
@@ -110,18 +134,86 @@ const NmapNSEApp = () => {
   };
 
   useEffect(() => {
+    setScriptArgs((prev) => {
+      const next = {};
+      selectedScripts.forEach((name) => {
+        if (prev[name]) {
+          next[name] = prev[name];
+        }
+      });
+      if (Object.keys(next).length === Object.keys(prev).length) {
+        return prev;
+      }
+      return next;
+    });
+    setScriptErrors((prev) => {
+      const next = {};
+      selectedScripts.forEach((name) => {
+        if (prev[name]) {
+          next[name] = prev[name];
+        }
+      });
+      if (Object.keys(next).length === Object.keys(prev).length) {
+        return prev;
+      }
+      return next;
+    });
+  }, [selectedScripts]);
+
+  useEffect(() => {
+    setExecutionPlan((current) => {
+      if (!Array.isArray(current)) return [];
+      const filtered = current.filter((entry) =>
+        selectedScripts.includes(entry.script),
+      );
+      if (filtered.length === current.length) {
+        return current;
+      }
+      return filtered;
+    });
+  }, [selectedScripts, setExecutionPlan]);
+
+  useEffect(() => {
     if (!selectedScripts.includes(activeScript)) {
       setActiveScript(selectedScripts[0] || '');
       setPhaseStep(0);
     }
   }, [selectedScripts, activeScript]);
 
+  const handleArgsChange = useCallback(
+    (name, change) => {
+      setScriptArgs((prev) => ({
+        ...prev,
+        [name]: change.values,
+      }));
+      setScriptErrors((prev) => ({
+        ...prev,
+        [name]: change.errors,
+      }));
+      setExecutionPlan((current) => {
+        const safeCurrent = Array.isArray(current) ? current : [];
+        const without = safeCurrent.filter((entry) => entry.script !== name);
+        if (change.isValid && change.planner) {
+          return [...without, change.planner];
+        }
+        if (without.length === safeCurrent.length) {
+          return safeCurrent;
+        }
+        return without;
+      });
+    },
+    [setExecutionPlan],
+  );
+
   const filteredScripts = scripts.filter((s) =>
     s.name.toLowerCase().includes(scriptQuery.toLowerCase())
   );
 
   const argsString = selectedScripts
-    .map((s) => scriptOptions[s])
+    .map((s) => {
+      if (scriptErrors[s]?.length) return null;
+      return serializeScriptArgs(s, scriptArgs[s]);
+    })
     .filter(Boolean)
     .join(',');
   const command = `nmap ${portFlag} ${
@@ -130,7 +222,38 @@ const NmapNSEApp = () => {
     .replace(/\s+/g, ' ')
     .trim();
 
+  const scriptValidationMessages = selectedScripts.flatMap(
+    (name) => scriptErrors[name] || [],
+  );
+  const globalValidationMessages = [];
+  const ipv4Pattern = /^(?:\d{1,3}\.){3}\d{1,3}$/;
+  if (selectedScripts.includes('dns-brute') && ipv4Pattern.test(target.trim())) {
+    globalValidationMessages.push(
+      'dns-brute targets hostnames. Switch the target to a domain before running.',
+    );
+  }
+  const blockingMessages = [...new Set([...scriptValidationMessages, ...globalValidationMessages])];
+  const canExecute = blockingMessages.length === 0 && target.trim().length > 0;
+
+  const sortedPlan = useMemo(() => {
+    const order = new Map(selectedScripts.map((name, index) => [name, index]));
+    const list = Array.isArray(executionPlan) ? executionPlan.slice() : [];
+    return list.sort((a, b) => {
+      const aIndex = order.has(a.script)
+        ? order.get(a.script)
+        : Number.MAX_SAFE_INTEGER;
+      const bIndex = order.has(b.script)
+        ? order.get(b.script)
+        : Number.MAX_SAFE_INTEGER;
+      return aIndex - bIndex;
+    });
+  }, [executionPlan, selectedScripts]);
+
   const copyCommand = async () => {
+    if (!canExecute) {
+      setToast('Resolve validation issues before copying the command.');
+      return;
+    }
     if (typeof window !== 'undefined') {
       try {
         await navigator.clipboard.writeText(command);
@@ -197,36 +320,45 @@ const NmapNSEApp = () => {
             Educational use only. Do not scan systems without permission.
           </p>
         </div>
-        <div className="mb-4">
-          <label className="block text-sm mb-1" htmlFor="target">Target</label>
-          <input
-            id="target"
-            value={target}
-            onChange={(e) => setTarget(e.target.value)}
-            className="w-full p-2 text-black"
-          />
-        </div>
-        <div className="mb-4">
-          <label className="block text-sm mb-1" htmlFor="scripts">
-            Scripts
-          </label>
-          <input
-            id="scripts"
-            value={scriptQuery}
-            onChange={(e) => setScriptQuery(e.target.value)}
-            placeholder="Search scripts"
-            className="w-full p-2 text-black mb-2"
-          />
-          <div className="max-h-64 overflow-y-auto grid grid-cols-1 sm:grid-cols-2 gap-2">
-            {filteredScripts.map((s) => (
-              <div key={s.name} className="bg-white text-black p-2 rounded">
-                <label className="flex items-center space-x-2">
-                  <input
-                    type="checkbox"
-                    checked={selectedScripts.includes(s.name)}
-                    onChange={() => toggleScript(s.name)}
-                  />
-                  <span className="font-mono">{s.name}</span>
+          <div className="mb-4">
+            <label className="block text-sm mb-1" htmlFor="target">Target</label>
+            <input
+              id="target"
+              type="text"
+              value={target}
+              onChange={(e) => setTarget(e.target.value)}
+              aria-label="Scan target"
+              className="w-full p-2 text-black"
+            />
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm mb-1" htmlFor="scripts">
+              Scripts
+            </label>
+            <input
+              id="scripts"
+              type="text"
+              value={scriptQuery}
+              onChange={(e) => setScriptQuery(e.target.value)}
+              placeholder="Search scripts"
+              aria-label="Filter scripts"
+              className="w-full p-2 text-black mb-2"
+            />
+            <div className="max-h-64 overflow-y-auto grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {filteredScripts.map((s) => (
+                <div key={s.name} className="bg-white text-black p-2 rounded">
+                  <label
+                    className="flex items-center space-x-2"
+                    htmlFor={`script-toggle-${s.name}`}
+                  >
+                    <input
+                      id={`script-toggle-${s.name}`}
+                      type="checkbox"
+                      checked={selectedScripts.includes(s.name)}
+                      onChange={() => toggleScript(s.name)}
+                      aria-label={`Toggle ${s.name}`}
+                    />
+                    <span className="font-mono">{s.name}</span>
                 </label>
                 <p className="text-xs mb-1">{s.description}</p>
                 <div className="flex flex-wrap gap-1 mb-1">
@@ -237,17 +369,11 @@ const NmapNSEApp = () => {
                   ))}
                 </div>
                 {selectedScripts.includes(s.name) && (
-                  <input
-                    type="text"
-                    value={scriptOptions[s.name] || ''}
-                    onChange={(e) =>
-                      setScriptOptions((prev) => ({
-                        ...prev,
-                        [s.name]: e.target.value,
-                      }))
-                    }
-                    placeholder="arg=value"
-                    className="w-full p-1 border rounded text-black"
+                  <ScriptArgs
+                    key={s.name}
+                    script={s.name}
+                    value={scriptArgs[s.name]}
+                    onChange={(change) => handleArgsChange(s.name, change)}
                   />
                 )}
               </div>
@@ -274,6 +400,16 @@ const NmapNSEApp = () => {
             ))}
           </div>
         </div>
+        {blockingMessages.length > 0 && (
+          <div className="mb-4 rounded border border-red-600 bg-red-900/60 p-3 text-sm text-red-100">
+            <p className="font-semibold">Resolve before running:</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-xs">
+              {blockingMessages.map((msg) => (
+                <li key={msg}>{msg}</li>
+              ))}
+            </ul>
+          </div>
+        )}
         <div className="flex items-center mb-4">
           <pre className="flex-1 bg-black text-green-400 p-2 rounded overflow-auto">
             {command}
@@ -281,10 +417,50 @@ const NmapNSEApp = () => {
           <button
             type="button"
             onClick={copyCommand}
-            className="ml-2 px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow"
+            className="ml-2 px-2 py-1 bg-ub-grey text-black rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ub-yellow disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={!canExecute}
           >
             Copy Command
           </button>
+        </div>
+        <div className="mb-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-300">
+            Execution planner sync
+          </h3>
+          <p className="text-xs text-gray-400">
+            Valid script configurations are stored for the orchestration planners.
+          </p>
+          {sortedPlan.length > 0 ? (
+            <ul className="mt-2 space-y-2 text-xs">
+              {sortedPlan.map((entry) => (
+                <li
+                  key={entry.script}
+                  className="rounded border border-gray-700 bg-black/40 p-2"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="font-mono text-ub-yellow">{entry.script}</span>
+                    <div className="flex flex-wrap gap-1">
+                      {entry.tags.map((tag) => (
+                        <span
+                          key={`${entry.script}-${tag}`}
+                          className="rounded bg-gray-700 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-gray-200"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  <p className="mt-1 text-[11px] text-gray-300">
+                    {entry.summary}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-2 text-xs text-gray-500">
+              No valid scripts synced yet.
+            </p>
+          )}
         </div>
       </div>
       <div className="md:w-1/2 p-4 bg-black overflow-y-auto">


### PR DESCRIPTION
## Summary
- add a typed `ScriptArgs` component that renders NSE script arguments from metadata, validates combinations, and stores presets
- connect the Nmap NSE app to the new argument builder with cross-script validation, disable execution on errors, and surface planner sync details
- surface execution planner status alongside the command builder so valid configurations persist to orchestration tools

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dca4f4507c83288788b293d87cf5a6