### PR TITLE
[flags] add kill switch support

### DIFF
--- a/__tests__/killSwitches.test.tsx
+++ b/__tests__/killSwitches.test.tsx
@@ -1,0 +1,90 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { setKillSwitch, resetKillSwitches } from '../flags';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+
+describe('kill switch integration', () => {
+  beforeEach(async () => {
+    await resetKillSwitches();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  function Consumer({ label }: { label: string }) {
+    const { allowNetwork, setAllowNetwork, networkKillSwitchActive } = useSettings();
+    return (
+      <div>
+        <div data-testid={`${label}-allow`}>{String(allowNetwork)}</div>
+        <div data-testid={`${label}-kill`}>{String(networkKillSwitchActive)}</div>
+        <button type="button" onClick={() => setAllowNetwork(true)}>
+          enable-{label}
+        </button>
+        <button type="button" onClick={() => setAllowNetwork(false)}>
+          disable-{label}
+        </button>
+      </div>
+    );
+  }
+
+  it('forces allowNetwork to false when the kill switch is active', async () => {
+    const user = userEvent.setup();
+    render(
+      <SettingsProvider>
+        <Consumer label="primary" />
+      </SettingsProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('primary-allow')).toHaveTextContent('false'));
+    await user.click(screen.getByText('enable-primary'));
+    await waitFor(() => expect(screen.getByTestId('primary-allow')).toHaveTextContent('true'));
+
+    await act(async () => {
+      await setKillSwitch('networkAccess', true);
+    });
+
+    await waitFor(() => expect(screen.getByTestId('primary-kill')).toHaveTextContent('true'));
+    await waitFor(() => expect(screen.getByTestId('primary-allow')).toHaveTextContent('false'));
+
+    await user.click(screen.getByText('enable-primary'));
+    await waitFor(() => expect(screen.getByTestId('primary-allow')).toHaveTextContent('false'));
+
+    await act(async () => {
+      await setKillSwitch('networkAccess', false);
+    });
+
+    await waitFor(() => expect(screen.getByTestId('primary-kill')).toHaveTextContent('false'));
+    await waitFor(() => expect(screen.getByTestId('primary-allow')).toHaveTextContent('true'));
+  });
+
+  it('broadcasts kill switch updates across providers without reload', async () => {
+    render(
+      <>
+        <SettingsProvider>
+          <Consumer label="one" />
+        </SettingsProvider>
+        <SettingsProvider>
+          <Consumer label="two" />
+        </SettingsProvider>
+      </>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('one-allow')).toHaveTextContent('false'));
+    await waitFor(() => expect(screen.getByTestId('two-allow')).toHaveTextContent('false'));
+
+    await act(async () => {
+      await setKillSwitch('networkAccess', true);
+    });
+
+    await waitFor(() => expect(screen.getByTestId('one-kill')).toHaveTextContent('true'));
+    await waitFor(() => expect(screen.getByTestId('two-kill')).toHaveTextContent('true'));
+    await waitFor(() => expect(screen.getByTestId('two-allow')).toHaveTextContent('false'));
+
+    await act(async () => {
+      await setKillSwitch('networkAccess', false);
+    });
+
+    await waitFor(() => expect(screen.getByTestId('one-kill')).toHaveTextContent('false'));
+    await waitFor(() => expect(screen.getByTestId('two-kill')).toHaveTextContent('false'));
+  });
+});

--- a/flags/index.ts
+++ b/flags/index.ts
@@ -1,0 +1,147 @@
+import { useEffect, useState } from 'react';
+import { mergeFlags, readFlags, resetFlags } from '../utils/flags';
+
+export type KillSwitchKey = 'networkAccess';
+
+export interface KillSwitchState {
+  networkAccess: boolean;
+}
+
+export interface KillSwitchDefinition {
+  label: string;
+  description: string;
+  confirmLabel: string;
+  undoLabel: string;
+}
+
+export const KILL_SWITCH_DEFAULTS: KillSwitchState = {
+  networkAccess: false,
+};
+
+export const KILL_SWITCH_DEFINITIONS: Record<KillSwitchKey, KillSwitchDefinition> = {
+  networkAccess: {
+    label: 'Emergency network kill switch',
+    description:
+      'Immediately block network-dependent simulations and disable outbound network requests across every open tab.',
+    confirmLabel: 'Activate kill switch',
+    undoLabel: 'Disable kill switch',
+  },
+};
+
+type Listener = (state: KillSwitchState) => void;
+
+const listeners = new Set<Listener>();
+let cachedState: KillSwitchState | null = null;
+
+const CHANNEL_NAME = 'kill-switch-flags';
+const globalScope: any = typeof globalThis !== 'undefined' ? globalThis : {};
+const broadcastChannel: BroadcastChannel | null = globalScope.BroadcastChannel
+  ? new globalScope.BroadcastChannel(CHANNEL_NAME)
+  : null;
+
+function applyDefaults(state?: Partial<KillSwitchState> | null): KillSwitchState {
+  return { ...KILL_SWITCH_DEFAULTS, ...(state || {}) };
+}
+
+function notify(state: KillSwitchState) {
+  listeners.forEach((listener) => listener(state));
+}
+
+function handleExternalUpdate(state?: Partial<KillSwitchState> | null) {
+  const next = applyDefaults(state);
+  cachedState = next;
+  notify(next);
+}
+
+if (broadcastChannel) {
+  broadcastChannel.addEventListener('message', (event) => {
+    if (event.data && event.data.type === 'kill-switch:update') {
+      handleExternalUpdate(event.data.state as Partial<KillSwitchState>);
+    }
+  });
+}
+
+const serviceWorkerContainer: ServiceWorkerContainer | undefined =
+  globalScope.navigator?.serviceWorker;
+
+if (serviceWorkerContainer) {
+  serviceWorkerContainer.addEventListener('message', (event: MessageEvent) => {
+    const data = event.data as { type?: string; state?: Partial<KillSwitchState> } | undefined;
+    if (data && data.type === 'kill-switch:update') {
+      handleExternalUpdate(data.state);
+    }
+  });
+}
+
+export async function getKillSwitches(): Promise<KillSwitchState> {
+  if (!cachedState) {
+    cachedState = await readFlags(KILL_SWITCH_DEFAULTS);
+  }
+  return cachedState;
+}
+
+async function updateState(state: KillSwitchState, broadcast = true) {
+  cachedState = state;
+  notify(state);
+  if (broadcast) {
+    broadcastChannel?.postMessage({ type: 'kill-switch:update', state });
+  }
+  return state;
+}
+
+export async function setKillSwitch(flag: KillSwitchKey, active: boolean): Promise<KillSwitchState> {
+  const next = await mergeFlags(KILL_SWITCH_DEFAULTS, { [flag]: active } as Partial<KillSwitchState>);
+  await updateState(next);
+  if (serviceWorkerContainer?.controller) {
+    serviceWorkerContainer.controller.postMessage({ type: 'rollback', flags: next });
+  }
+  return next;
+}
+
+export function subscribeToKillSwitches(listener: Listener): () => void {
+  listeners.add(listener);
+  if (cachedState) {
+    listener(cachedState);
+  } else {
+    void getKillSwitches().then(listener);
+  }
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function useKillSwitches() {
+  const [state, setState] = useState<KillSwitchState>(cachedState || KILL_SWITCH_DEFAULTS);
+
+  useEffect(() => {
+    let active = true;
+    if (cachedState) {
+      setState(cachedState);
+    } else {
+      getKillSwitches().then((flags) => {
+        if (active) setState(flags);
+      });
+    }
+    const unsubscribe = subscribeToKillSwitches((flags) => {
+      if (active) setState(flags);
+    });
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, []);
+
+  return {
+    state,
+    setKillSwitch,
+  };
+}
+
+export async function resetKillSwitches(): Promise<KillSwitchState> {
+  const next = await resetFlags(KILL_SWITCH_DEFAULTS);
+  return updateState(next, false);
+}
+
+export function isKillSwitchActive(state: KillSwitchState, flag: KillSwitchKey): boolean {
+  return state[flag];
+}

--- a/utils/flags.ts
+++ b/utils/flags.ts
@@ -1,0 +1,44 @@
+import { createStore, get, set } from 'idb-keyval';
+
+const STORE_NAME = 'app-flags';
+const STORE_KEY = 'flags';
+const STATE_KEY = 'state';
+
+const store = createStore(STORE_NAME, STORE_KEY);
+
+const hasIndexedDB = typeof indexedDB !== 'undefined';
+
+export type FlagRecord = Record<string, boolean>;
+
+export async function readFlags<T extends FlagRecord>(defaults: T): Promise<T> {
+  if (!hasIndexedDB) {
+    return { ...defaults };
+  }
+
+  const stored = (await get(STATE_KEY, store)) as Partial<T> | undefined;
+  return { ...defaults, ...(stored || {}) };
+}
+
+export async function writeFlags<T extends FlagRecord>(flags: T): Promise<T> {
+  if (!hasIndexedDB) {
+    return { ...flags };
+  }
+
+  await set(STATE_KEY, flags, store);
+  return flags;
+}
+
+export async function mergeFlags<T extends FlagRecord>(
+  defaults: T,
+  patch: Partial<T>,
+): Promise<T> {
+  const current = await readFlags(defaults);
+  const next = { ...current, ...patch } as T;
+  await writeFlags(next);
+  return next;
+}
+
+export async function resetFlags<T extends FlagRecord>(defaults: T): Promise<T> {
+  await writeFlags(defaults);
+  return { ...defaults };
+}

--- a/workers/service-worker.js
+++ b/workers/service-worker.js
@@ -39,9 +39,53 @@ self.addEventListener('periodicsync', (event) => {
   }
 });
 
+const FLAG_DB_NAME = 'app-flags';
+const FLAG_STORE_NAME = 'flags';
+const FLAG_STATE_KEY = 'state';
+const FLAG_DEFAULTS = { networkAccess: false };
+
+function persistFlags(flags) {
+  const next = { ...FLAG_DEFAULTS, ...(flags || {}) };
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(FLAG_DB_NAME);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(FLAG_STORE_NAME)) {
+        db.createObjectStore(FLAG_STORE_NAME);
+      }
+    };
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const db = request.result;
+      const tx = db.transaction(FLAG_STORE_NAME, 'readwrite');
+      tx.oncomplete = () => {
+        db.close();
+        resolve(next);
+      };
+      tx.onerror = () => {
+        db.close();
+        reject(tx.error);
+      };
+      tx.objectStore(FLAG_STORE_NAME).put(next, FLAG_STATE_KEY);
+    };
+  });
+}
+
+async function handleRollback(flags) {
+  const next = await persistFlags(flags);
+  const clients = await self.clients.matchAll({ includeUncontrolled: true, type: 'window' });
+  clients.forEach((client) => {
+    client.postMessage({ type: 'kill-switch:update', state: next });
+  });
+}
+
 self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'refresh') {
+  if (!event.data) return;
+  if (event.data.type === 'refresh') {
     event.waitUntil(prefetchAssets());
+  }
+  if (event.data.type === 'rollback') {
+    event.waitUntil(handleRollback(event.data.flags));
   }
 });
 


### PR DESCRIPTION
## Summary
- add reusable flag store and kill switch module backed by indexedDB
- integrate kill switch state with settings context and UI, including confirmation flow
- persist kill switch updates through the service worker and broadcast changes across tabs

## Testing
- yarn lint
- yarn test killSwitches.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dcca9a37ec8328808e925b1369e6b8