### PR TITLE
[utils] Add settings migration recovery

### DIFF
--- a/__mocks__/idb-keyval.js
+++ b/__mocks__/idb-keyval.js
@@ -1,0 +1,25 @@
+const store = new Map();
+
+const api = {
+  __store: store,
+  __reset: () => store.clear(),
+  get: jest.fn(async (key) => store.get(key)),
+  set: jest.fn(async (key, value) => {
+    store.set(key, value);
+  }),
+  del: jest.fn(async (key) => {
+    store.delete(key);
+  }),
+  update: jest.fn(async (key, updater) => {
+    const value = store.get(key);
+    const next = await updater(value);
+    store.set(key, next);
+    return next;
+  }),
+  keys: jest.fn(async () => Array.from(store.keys())),
+  clear: jest.fn(async () => {
+    store.clear();
+  }),
+};
+
+module.exports = api;

--- a/__tests__/settingsStore.test.ts
+++ b/__tests__/settingsStore.test.ts
@@ -1,0 +1,95 @@
+jest.mock('idb-keyval');
+
+describe('settingsStore migrations', () => {
+  const loadStore = async () => import('../utils/settingsStore');
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    const idb = require('idb-keyval');
+    idb.__reset();
+    window.localStorage.clear();
+  });
+
+  it('writes schema version and backup on first access', async () => {
+    const { getAccent } = await loadStore();
+
+    const accent = await getAccent();
+
+    expect(accent).toBe('#1793d1');
+    expect(window.localStorage.getItem('settings-schema-version')).toBe('1');
+    const backupRaw = window.localStorage.getItem('settings-backup');
+    expect(backupRaw).not.toBeNull();
+    const backup = JSON.parse(backupRaw!);
+    expect(backup.version).toBe(1);
+    expect(backup.data).toMatchObject({
+      density: null,
+      useKaliWallpaper: null,
+    });
+  });
+
+  it('restores from backup when schema version is corrupted', async () => {
+    const payload = {
+      version: 1,
+      createdAt: Date.now(),
+      data: {
+        accent: '#ff0000',
+        wallpaper: 'wall-1',
+        density: 'compact',
+        useKaliWallpaper: true,
+        reducedMotion: true,
+        fontScale: 1.5,
+        highContrast: true,
+        largeHitAreas: true,
+        pongSpin: false,
+        allowNetwork: true,
+        haptics: false,
+        theme: 'matrix',
+      },
+    };
+    window.localStorage.setItem('settings-schema-version', 'oops');
+    window.localStorage.setItem('settings-backup', JSON.stringify(payload));
+
+    const { getDensity, getUseKaliWallpaper } = await loadStore();
+
+    expect(await getDensity()).toBe('compact');
+    expect(await getUseKaliWallpaper()).toBe(true);
+    expect(window.localStorage.getItem('settings-schema-version')).toBe('1');
+
+    const idb = require('idb-keyval');
+    await expect(idb.get('accent')).resolves.toBe('#ff0000');
+  });
+
+  it('rolls back to backup when migrations fail', async () => {
+    const backup = {
+      version: 0,
+      createdAt: Date.now(),
+      data: {
+        density: 'compact',
+        useKaliWallpaper: true,
+        pongSpin: false,
+        allowNetwork: true,
+      },
+    };
+    window.localStorage.setItem('settings-schema-version', '0');
+    window.localStorage.setItem('settings-backup', JSON.stringify(backup));
+    window.localStorage.setItem('density', 'cozy');
+
+    const idb = require('idb-keyval');
+    idb.__store.set('accent', '#00ff00');
+    idb.set.mockImplementationOnce(async () => {
+      throw new Error('migration failure');
+    });
+
+    const { getDensity } = await loadStore();
+
+    expect(await getDensity()).toBe('cozy');
+    expect(window.localStorage.getItem('settings-schema-version')).toBe('1');
+
+    const backupString = window.localStorage.getItem('settings-backup');
+    expect(backupString).not.toBeNull();
+    expect(JSON.parse(backupString!).data.density).toBe('cozy');
+
+    await expect(idb.get('accent')).resolves.toBe('#00ff00');
+  });
+});

--- a/utils/migrations/index.ts
+++ b/utils/migrations/index.ts
@@ -1,0 +1,218 @@
+import { hasStorage } from '../env';
+
+export type StoreName = 'settings' | 'history';
+
+export const MIGRATION_TARGETS: Record<StoreName, number> = {
+  settings: 1,
+  history: 0,
+};
+
+export const VERSION_STORAGE_KEYS: Record<StoreName, string> = {
+  settings: 'settings-schema-version',
+  history: 'history-schema-version',
+};
+
+export const BACKUP_STORAGE_KEYS: Record<StoreName, string> = {
+  settings: 'settings-backup',
+  history: 'history-backup',
+};
+
+export interface BackupPayload<TSnapshot> {
+  version: number;
+  createdAt: number;
+  data: TSnapshot;
+}
+
+export interface MigrationContext<TSnapshot> {
+  store: StoreName;
+  dryRun: boolean;
+  fromVersion: number;
+  toVersion: number;
+  createSnapshot: () => Promise<TSnapshot>;
+  applySnapshot: (snapshot: TSnapshot) => Promise<void>;
+}
+
+export interface MigrationStep<TSnapshot> {
+  version: number;
+  description?: string;
+  migrate: (context: MigrationContext<TSnapshot>) => Promise<void> | void;
+}
+
+export interface RunMigrationOptions<TSnapshot> {
+  store: StoreName;
+  currentVersion: number;
+  targetVersion: number;
+  steps: MigrationStep<TSnapshot>[];
+  createSnapshot: () => Promise<TSnapshot>;
+  applySnapshot: (snapshot: TSnapshot) => Promise<void>;
+  dryRun?: boolean;
+  onStepStart?: (step: MigrationStep<TSnapshot>) => Promise<void> | void;
+  onStepComplete?: (step: MigrationStep<TSnapshot>) => Promise<void> | void;
+}
+
+const isBrowserEnvironment = (): boolean => typeof window !== 'undefined' && hasStorage;
+
+export const DEFAULT_START_VERSION = 0;
+
+export function getSchemaVersion(store: StoreName): number {
+  if (!isBrowserEnvironment()) return MIGRATION_TARGETS[store];
+  const raw = window.localStorage.getItem(VERSION_STORAGE_KEYS[store]);
+  if (raw === null) return DEFAULT_START_VERSION;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`Invalid schema version for ${store}`);
+  }
+  return parsed;
+}
+
+export function setSchemaVersion(store: StoreName, version: number): void {
+  if (!isBrowserEnvironment()) return;
+  window.localStorage.setItem(
+    VERSION_STORAGE_KEYS[store],
+    Number.isFinite(version) ? String(version) : String(MIGRATION_TARGETS[store]),
+  );
+}
+
+export function clearSchemaVersion(store: StoreName): void {
+  if (!isBrowserEnvironment()) return;
+  window.localStorage.removeItem(VERSION_STORAGE_KEYS[store]);
+}
+
+export async function saveBackupSnapshot<TSnapshot>(
+  store: StoreName,
+  payload: BackupPayload<TSnapshot>,
+): Promise<void> {
+  if (!isBrowserEnvironment()) return;
+  window.localStorage.setItem(
+    BACKUP_STORAGE_KEYS[store],
+    JSON.stringify(payload),
+  );
+}
+
+export function readBackupSnapshot<TSnapshot>(
+  store: StoreName,
+): BackupPayload<TSnapshot> | null {
+  if (!isBrowserEnvironment()) return null;
+  const raw = window.localStorage.getItem(BACKUP_STORAGE_KEYS[store]);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as BackupPayload<TSnapshot>;
+  } catch (error) {
+    console.warn(`Failed to parse backup for ${store}`, error);
+    return null;
+  }
+}
+
+export function clearBackup(store: StoreName): void {
+  if (!isBrowserEnvironment()) return;
+  window.localStorage.removeItem(BACKUP_STORAGE_KEYS[store]);
+}
+
+export async function restoreBackup<TSnapshot>(
+  store: StoreName,
+  applySnapshot: (snapshot: TSnapshot) => Promise<void>,
+): Promise<BackupPayload<TSnapshot> | null> {
+  const payload = readBackupSnapshot<TSnapshot>(store);
+  if (!payload) return null;
+  await applySnapshot(payload.data);
+  return payload;
+}
+
+export async function runMigrations<TSnapshot>({
+  store,
+  currentVersion,
+  targetVersion,
+  steps,
+  createSnapshot,
+  applySnapshot,
+  dryRun = false,
+  onStepStart,
+  onStepComplete,
+}: RunMigrationOptions<TSnapshot>): Promise<number> {
+  if (currentVersion >= targetVersion) return currentVersion;
+
+  const queue = steps
+    .filter((step) => step.version > currentVersion && step.version <= targetVersion)
+    .sort((a, b) => a.version - b.version);
+
+  if (!dryRun && isBrowserEnvironment()) {
+    const initialSnapshot = await createSnapshot();
+    await saveBackupSnapshot(store, {
+      version: currentVersion,
+      createdAt: Date.now(),
+      data: initialSnapshot,
+    });
+  }
+
+  let workingVersion = currentVersion;
+  for (const step of queue) {
+    await onStepStart?.(step);
+    await step.migrate({
+      store,
+      dryRun,
+      fromVersion: workingVersion,
+      toVersion: step.version,
+      createSnapshot,
+      applySnapshot,
+    });
+    workingVersion = step.version;
+    await onStepComplete?.(step);
+  }
+
+  if (!dryRun && isBrowserEnvironment()) {
+    const snapshot = await createSnapshot();
+    await saveBackupSnapshot(store, {
+      version: targetVersion,
+      createdAt: Date.now(),
+      data: snapshot,
+    });
+    setSchemaVersion(store, targetVersion);
+  }
+
+  return queue.length ? queue[queue.length - 1].version : targetVersion;
+}
+
+export interface DryRunResult<TSnapshot> {
+  finalVersion: number;
+  snapshot: TSnapshot;
+}
+
+export async function simulateMigrations<TSnapshot>({
+  store,
+  currentVersion,
+  targetVersion,
+  steps,
+  createSnapshot,
+  applySnapshot,
+}: RunMigrationOptions<TSnapshot>): Promise<DryRunResult<TSnapshot>> {
+  const snapshot = await createSnapshot();
+  const clone = JSON.parse(JSON.stringify(snapshot)) as TSnapshot;
+  let version = currentVersion;
+
+  const queue = steps
+    .filter((step) => step.version > currentVersion && step.version <= targetVersion)
+    .sort((a, b) => a.version - b.version);
+
+  for (const step of queue) {
+    await step.migrate({
+      store,
+      dryRun: true,
+      fromVersion: version,
+      toVersion: step.version,
+      createSnapshot: async () => clone,
+      applySnapshot: async (snapshotUpdate) => {
+        const base = clone as Record<string, unknown>;
+        const updates = snapshotUpdate as Record<string, unknown>;
+        Object.keys(updates).forEach((key) => {
+          base[key] = updates[key];
+        });
+      },
+    });
+    version = step.version;
+  }
+
+  return {
+    finalVersion: queue.length ? queue[queue.length - 1].version : currentVersion,
+    snapshot: clone,
+  };
+}

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -1,7 +1,16 @@
 "use client";
 
 import { get, set, del } from 'idb-keyval';
-import { getTheme, setTheme } from './theme';
+import {
+  BACKUP_STORAGE_KEYS,
+  MIGRATION_TARGETS,
+  getSchemaVersion,
+  restoreBackup,
+  runMigrations,
+  saveBackupSnapshot,
+  setSchemaVersion,
+} from './migrations';
+import { getTheme, setTheme, THEME_KEY } from './theme';
 
 const DEFAULT_SETTINGS = {
   accent: '#1793d1',
@@ -17,49 +26,283 @@ const DEFAULT_SETTINGS = {
   haptics: true,
 };
 
+const SETTINGS_STORE = 'settings';
+const TARGET_VERSION = MIGRATION_TARGETS[SETTINGS_STORE];
+const SETTINGS_BACKUP_KEY = BACKUP_STORAGE_KEYS[SETTINGS_STORE];
+
+let settingsInitPromise = null;
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const readLocalStorage = (key) => {
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    throw new Error(`Failed to read ${key} from localStorage`);
+  }
+};
+
+const writeLocalStorage = (key, value) => {
+  if (value === undefined) return;
+  if (value === null) {
+    window.localStorage.removeItem(key);
+  } else {
+    window.localStorage.setItem(key, value);
+  }
+};
+
+const writeLocalStorageBoolean = (key, value) => {
+  if (value === undefined) return;
+  if (value === null) {
+    window.localStorage.removeItem(key);
+    return;
+  }
+  window.localStorage.setItem(key, value ? 'true' : 'false');
+};
+
+const readBoolean = (key) => {
+  const value = readLocalStorage(key);
+  if (value === null) return null;
+  return value === 'true';
+};
+
+const readNumber = (key) => {
+  const value = readLocalStorage(key);
+  if (value === null) return null;
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const createDefaultSnapshot = () => ({
+  accent: null,
+  wallpaper: null,
+  useKaliWallpaper: null,
+  density: null,
+  reducedMotion: null,
+  fontScale: null,
+  highContrast: null,
+  largeHitAreas: null,
+  pongSpin: null,
+  allowNetwork: null,
+  haptics: null,
+  theme: null,
+});
+
+const SETTINGS_MIGRATIONS = [
+  {
+    version: 1,
+    description: 'Normalize persisted settings and seed backups',
+    migrate: async ({ createSnapshot, applySnapshot }) => {
+      const snapshot = await createSnapshot();
+      await applySnapshot(snapshot);
+    },
+  },
+];
+
+async function collectSettingsSnapshot() {
+  const [accent, wallpaper] = await Promise.all([
+    get('accent'),
+    get('bg-image'),
+  ]);
+
+  return {
+    accent: accent ?? null,
+    wallpaper: wallpaper ?? null,
+    useKaliWallpaper: readBoolean('use-kali-wallpaper'),
+    density: readLocalStorage('density'),
+    reducedMotion: readBoolean('reduced-motion'),
+    fontScale: readNumber('font-scale'),
+    highContrast: readBoolean('high-contrast'),
+    largeHitAreas: readBoolean('large-hit-areas'),
+    pongSpin: readBoolean('pong-spin'),
+    allowNetwork: readBoolean('allow-network'),
+    haptics: readBoolean('haptics'),
+    theme: readLocalStorage(THEME_KEY),
+  };
+}
+
+async function applySettingsSnapshot(snapshot) {
+  const applyIndexedDB = async (key, value) => {
+    if (value === undefined) return;
+    if (value === null) {
+      await del(key);
+    } else {
+      await set(key, value);
+    }
+  };
+
+  await applyIndexedDB('accent', snapshot.accent);
+  await applyIndexedDB('bg-image', snapshot.wallpaper);
+
+  writeLocalStorageBoolean('use-kali-wallpaper', snapshot.useKaliWallpaper);
+  writeLocalStorage('density', snapshot.density);
+  writeLocalStorageBoolean('reduced-motion', snapshot.reducedMotion);
+  if (snapshot.fontScale !== undefined) {
+    if (snapshot.fontScale === null) {
+      window.localStorage.removeItem('font-scale');
+    } else {
+      window.localStorage.setItem('font-scale', String(snapshot.fontScale));
+    }
+  }
+  writeLocalStorageBoolean('high-contrast', snapshot.highContrast);
+  writeLocalStorageBoolean('large-hit-areas', snapshot.largeHitAreas);
+  writeLocalStorageBoolean('pong-spin', snapshot.pongSpin);
+  writeLocalStorageBoolean('allow-network', snapshot.allowNetwork);
+  writeLocalStorageBoolean('haptics', snapshot.haptics);
+  writeLocalStorage(THEME_KEY, snapshot.theme);
+}
+
+async function ensureBackupExists() {
+  if (!isBrowser()) return;
+  if (window.localStorage.getItem(SETTINGS_BACKUP_KEY)) return;
+  try {
+    const snapshot = await collectSettingsSnapshot();
+    let version = TARGET_VERSION;
+    try {
+      version = getSchemaVersion(SETTINGS_STORE);
+    } catch {
+      version = TARGET_VERSION;
+    }
+    await saveBackupSnapshot(SETTINGS_STORE, {
+      version,
+      createdAt: Date.now(),
+      data: snapshot,
+    });
+  } catch (error) {
+    console.warn('Failed to persist settings backup', error);
+  }
+}
+
+async function recoverSettingsFromBackup(reason) {
+  if (!isBrowser()) return;
+  console.warn('Attempting to recover settings from backup', reason);
+  try {
+    const restored = await restoreBackup(SETTINGS_STORE, applySettingsSnapshot);
+    if (restored) {
+      const restoredVersion = Number.isFinite(restored.version)
+        ? restored.version
+        : TARGET_VERSION;
+      setSchemaVersion(SETTINGS_STORE, restoredVersion);
+      if (restoredVersion < TARGET_VERSION) {
+        try {
+          await runMigrations({
+            store: SETTINGS_STORE,
+            currentVersion: restoredVersion,
+            targetVersion: TARGET_VERSION,
+            steps: SETTINGS_MIGRATIONS,
+            createSnapshot: collectSettingsSnapshot,
+            applySnapshot: applySettingsSnapshot,
+          });
+        } catch (migrationError) {
+          console.error('Failed to migrate restored settings, resetting to defaults', migrationError);
+          await applySettingsSnapshot(createDefaultSnapshot());
+          setSchemaVersion(SETTINGS_STORE, TARGET_VERSION);
+        }
+      }
+      await ensureBackupExists();
+      return;
+    }
+  } catch (backupError) {
+    console.error('Failed to restore settings backup', backupError);
+  }
+
+  await applySettingsSnapshot(createDefaultSnapshot());
+  setSchemaVersion(SETTINGS_STORE, TARGET_VERSION);
+  await ensureBackupExists();
+}
+
+async function initializeSettingsStore() {
+  if (!isBrowser()) return;
+  let currentVersion = 0;
+  try {
+    currentVersion = getSchemaVersion(SETTINGS_STORE);
+  } catch (error) {
+    await recoverSettingsFromBackup(error);
+    return;
+  }
+
+  if (currentVersion < TARGET_VERSION) {
+    try {
+      await runMigrations({
+        store: SETTINGS_STORE,
+        currentVersion,
+        targetVersion: TARGET_VERSION,
+        steps: SETTINGS_MIGRATIONS,
+        createSnapshot: collectSettingsSnapshot,
+        applySnapshot: applySettingsSnapshot,
+      });
+    } catch (error) {
+      await recoverSettingsFromBackup(error);
+      return;
+    }
+  } else if (currentVersion > TARGET_VERSION) {
+    // Preserve forward-compatible data but ensure backups exist.
+    setSchemaVersion(SETTINGS_STORE, currentVersion);
+  }
+
+  await ensureBackupExists();
+}
+
+async function ensureSettingsReady() {
+  if (!isBrowser()) return;
+  if (!settingsInitPromise) {
+    settingsInitPromise = initializeSettingsStore();
+  }
+  await settingsInitPromise;
+}
+
 export async function getAccent() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.accent;
+  if (!isBrowser()) return DEFAULT_SETTINGS.accent;
+  await ensureSettingsReady();
   return (await get('accent')) || DEFAULT_SETTINGS.accent;
 }
 
 export async function setAccent(accent) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
+  await ensureSettingsReady();
   await set('accent', accent);
 }
 
 export async function getWallpaper() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.wallpaper;
+  if (!isBrowser()) return DEFAULT_SETTINGS.wallpaper;
+  await ensureSettingsReady();
   return (await get('bg-image')) || DEFAULT_SETTINGS.wallpaper;
 }
 
 export async function setWallpaper(wallpaper) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
+  await ensureSettingsReady();
   await set('bg-image', wallpaper);
 }
 
 export async function getUseKaliWallpaper() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.useKaliWallpaper;
+  if (!isBrowser()) return DEFAULT_SETTINGS.useKaliWallpaper;
+  await ensureSettingsReady();
   const stored = window.localStorage.getItem('use-kali-wallpaper');
   return stored === null ? DEFAULT_SETTINGS.useKaliWallpaper : stored === 'true';
 }
 
 export async function setUseKaliWallpaper(value) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
+  await ensureSettingsReady();
   window.localStorage.setItem('use-kali-wallpaper', value ? 'true' : 'false');
 }
 
 export async function getDensity() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.density;
+  if (!isBrowser()) return DEFAULT_SETTINGS.density;
+  await ensureSettingsReady();
   return window.localStorage.getItem('density') || DEFAULT_SETTINGS.density;
 }
 
 export async function setDensity(density) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
+  await ensureSettingsReady();
   window.localStorage.setItem('density', density);
 }
 
 export async function getReducedMotion() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.reducedMotion;
+  if (!isBrowser()) return DEFAULT_SETTINGS.reducedMotion;
+  await ensureSettingsReady();
   const stored = window.localStorage.getItem('reduced-motion');
   if (stored !== null) {
     return stored === 'true';
@@ -68,91 +311,96 @@ export async function getReducedMotion() {
 }
 
 export async function setReducedMotion(value) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
+  await ensureSettingsReady();
   window.localStorage.setItem('reduced-motion', value ? 'true' : 'false');
 }
 
 export async function getFontScale() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.fontScale;
+  if (!isBrowser()) return DEFAULT_SETTINGS.fontScale;
+  await ensureSettingsReady();
   const stored = window.localStorage.getItem('font-scale');
   return stored ? parseFloat(stored) : DEFAULT_SETTINGS.fontScale;
 }
 
 export async function setFontScale(scale) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
+  await ensureSettingsReady();
   window.localStorage.setItem('font-scale', String(scale));
 }
 
 export async function getHighContrast() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.highContrast;
+  if (!isBrowser()) return DEFAULT_SETTINGS.highContrast;
+  await ensureSettingsReady();
   return window.localStorage.getItem('high-contrast') === 'true';
 }
 
 export async function setHighContrast(value) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
+  await ensureSettingsReady();
   window.localStorage.setItem('high-contrast', value ? 'true' : 'false');
 }
 
 export async function getLargeHitAreas() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.largeHitAreas;
+  if (!isBrowser()) return DEFAULT_SETTINGS.largeHitAreas;
+  await ensureSettingsReady();
   return window.localStorage.getItem('large-hit-areas') === 'true';
 }
 
 export async function setLargeHitAreas(value) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
+  await ensureSettingsReady();
   window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
 export async function getHaptics() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
+  if (!isBrowser()) return DEFAULT_SETTINGS.haptics;
+  await ensureSettingsReady();
   const val = window.localStorage.getItem('haptics');
   return val === null ? DEFAULT_SETTINGS.haptics : val === 'true';
 }
 
 export async function setHaptics(value) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
+  await ensureSettingsReady();
   window.localStorage.setItem('haptics', value ? 'true' : 'false');
 }
 
 export async function getPongSpin() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.pongSpin;
+  if (!isBrowser()) return DEFAULT_SETTINGS.pongSpin;
+  await ensureSettingsReady();
   const val = window.localStorage.getItem('pong-spin');
   return val === null ? DEFAULT_SETTINGS.pongSpin : val === 'true';
 }
 
 export async function setPongSpin(value) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
+  await ensureSettingsReady();
   window.localStorage.setItem('pong-spin', value ? 'true' : 'false');
 }
 
 export async function getAllowNetwork() {
-  if (typeof window === 'undefined') return DEFAULT_SETTINGS.allowNetwork;
+  if (!isBrowser()) return DEFAULT_SETTINGS.allowNetwork;
+  await ensureSettingsReady();
   return window.localStorage.getItem('allow-network') === 'true';
 }
 
 export async function setAllowNetwork(value) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
+  await ensureSettingsReady();
   window.localStorage.setItem('allow-network', value ? 'true' : 'false');
 }
 
 export async function resetSettings() {
-  if (typeof window === 'undefined') return;
-  await Promise.all([
-    del('accent'),
-    del('bg-image'),
-  ]);
-  window.localStorage.removeItem('density');
-  window.localStorage.removeItem('reduced-motion');
-  window.localStorage.removeItem('font-scale');
-  window.localStorage.removeItem('high-contrast');
-  window.localStorage.removeItem('large-hit-areas');
-  window.localStorage.removeItem('pong-spin');
-  window.localStorage.removeItem('allow-network');
-  window.localStorage.removeItem('haptics');
-  window.localStorage.removeItem('use-kali-wallpaper');
+  if (!isBrowser()) return;
+  await ensureSettingsReady();
+  await applySettingsSnapshot(createDefaultSnapshot());
+  setSchemaVersion(SETTINGS_STORE, TARGET_VERSION);
+  await ensureBackupExists();
 }
 
 export async function exportSettings() {
+  await ensureSettingsReady();
   const [
     accent,
     wallpaper,
@@ -196,7 +444,8 @@ export async function exportSettings() {
 }
 
 export async function importSettings(json) {
-  if (typeof window === 'undefined') return;
+  if (!isBrowser()) return;
+  await ensureSettingsReady();
   let settings;
   try {
     settings = typeof json === 'string' ? JSON.parse(json) : json;
@@ -230,6 +479,7 @@ export async function importSettings(json) {
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);
   if (theme !== undefined) setTheme(theme);
+  await ensureBackupExists();
 }
 
 export const defaults = DEFAULT_SETTINGS;


### PR DESCRIPTION
## Summary
- add a shared migration utility with schema metadata, backups, and dry-run helpers
- run migrations and backup snapshots inside the settings store before reading or writing values
- add Jest coverage and mocks that exercise version bumps, corruption recovery, and rollback paths

## Testing
- yarn test __tests__/settingsStore.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dcca9c3b208328aa6ab2e6d0f51f92