### PR TITLE
[settings] add compliance checklist

### DIFF
--- a/apps/settings/components/ComplianceChecklist.tsx
+++ b/apps/settings/components/ComplianceChecklist.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useMemo, useRef } from "react";
+import {
+  COMPLIANCE_ITEMS,
+  COMPLIANCE_STATUS_OPTIONS,
+  ComplianceChecklistState,
+  ComplianceStatus,
+  deserializeComplianceChecklist,
+  serializeComplianceChecklist,
+} from "../../../utils/complianceChecklist";
+
+type Props = {
+  state: ComplianceChecklistState;
+  onChange: (state: ComplianceChecklistState) => void;
+};
+
+const statusClassNames: Record<ComplianceStatus, string> = {
+  "not-started": "bg-gray-700 text-gray-100",
+  "in-progress": "bg-yellow-600 text-white",
+  blocked: "bg-red-700 text-white",
+  compliant: "bg-green-600 text-white",
+  "not-applicable": "bg-slate-600 text-white",
+};
+
+const statusLabels = COMPLIANCE_STATUS_OPTIONS.reduce<Record<ComplianceStatus, string>>(
+  (acc, option) => {
+    acc[option.value] = option.label;
+    return acc;
+  },
+  {
+    "not-started": "Not started",
+    "in-progress": "In progress",
+    blocked: "Blocked",
+    compliant: "Compliant",
+    "not-applicable": "Not applicable",
+  }
+);
+
+const ComplianceChecklist = ({ state, onChange }: Props) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const entries = useMemo(() => {
+    const map = new Map(state.items.map((item) => [item.id, item]));
+    return COMPLIANCE_ITEMS.map((item) => {
+      const entry = map.get(item.id);
+      return {
+        ...item,
+        status: entry?.status ?? "not-started",
+        note: entry?.note ?? "",
+        updatedAt: entry?.updatedAt,
+      };
+    });
+  }, [state.items]);
+
+  const updateStatus = (id: string, status: ComplianceStatus) => {
+    const updatedItems = entries.map((entry) =>
+      entry.id === id
+        ? {
+            id: entry.id,
+            status,
+            note: entry.note,
+            updatedAt: new Date().toISOString(),
+          }
+        : {
+            id: entry.id,
+            status: entry.status,
+            note: entry.note,
+            updatedAt: entry.updatedAt,
+          }
+    );
+    onChange({
+      version: state.version,
+      items: updatedItems,
+      lastUpdated: new Date().toISOString(),
+    });
+  };
+
+  const updateNote = (id: string, note: string) => {
+    const updatedItems = entries.map((entry) =>
+      entry.id === id
+        ? {
+            id: entry.id,
+            status: entry.status,
+            note,
+            updatedAt: new Date().toISOString(),
+          }
+        : {
+            id: entry.id,
+            status: entry.status,
+            note: entry.note,
+            updatedAt: entry.updatedAt,
+          }
+    );
+    onChange({
+      version: state.version,
+      items: updatedItems,
+      lastUpdated: new Date().toISOString(),
+    });
+  };
+
+  const handleExport = () => {
+    const data = serializeComplianceChecklist({
+      version: state.version,
+      items: entries.map((entry) => ({
+        id: entry.id,
+        status: entry.status,
+        note: entry.note,
+        updatedAt: entry.updatedAt,
+      })),
+      lastUpdated: new Date().toISOString(),
+    });
+    const blob = new Blob([data], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "compliance-checklist.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = async (file: File) => {
+    const text = await file.text();
+    const parsed = deserializeComplianceChecklist(text);
+    if (!parsed) {
+      window.alert("Invalid compliance checklist file.");
+      return;
+    }
+    onChange({
+      version: parsed.version,
+      items: parsed.items.map((item) => ({
+        ...item,
+        updatedAt: item.updatedAt ?? new Date().toISOString(),
+      })),
+      lastUpdated: parsed.lastUpdated ?? new Date().toISOString(),
+    });
+  };
+
+  return (
+    <div className="px-6 py-6 space-y-6 text-ubt-grey">
+      <section aria-labelledby="compliance-overview">
+        <h2 id="compliance-overview" className="text-xl font-semibold text-white mb-2">
+          Compliance Overview
+        </h2>
+        <p className="text-sm leading-6">
+          Track the operational status of key governance controls. Each item links to documentation so teams can confirm scope
+          and responsibilities before marking a status. Export the checklist for audit trails or import updates from another
+          workspace.
+        </p>
+      </section>
+
+      <section aria-labelledby="compliance-actions" className="bg-ub-dark rounded-lg border border-gray-900 p-4">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h3 id="compliance-actions" className="text-lg font-semibold text-white">
+              Checklist actions
+            </h3>
+            <p className="text-xs text-ubt-grey/80">
+              Export creates a JSON snapshot. Import merges stored statuses with new checklist items.
+            </p>
+          </div>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={handleExport}
+              className="px-4 py-2 rounded bg-ub-orange text-white hover:bg-ub-orange/90"
+            >
+              Export
+            </button>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="px-4 py-2 rounded bg-ub-orange text-white hover:bg-ub-orange/90"
+            >
+              Import
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              accept="application/json"
+              aria-label="Import compliance checklist JSON"
+              onChange={(event) => {
+                const file = event.target.files?.[0];
+                if (file) {
+                  void handleImport(file);
+                }
+                event.target.value = "";
+              }}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="compliance-checklist-table" className="space-y-4">
+        <h3 id="compliance-checklist-table" className="text-lg font-semibold text-white">
+          Control checklist
+        </h3>
+        <div className="space-y-4">
+          {entries.map((entry) => {
+            const statusId = `${entry.id}-status`;
+            const notesId = `${entry.id}-notes`;
+            return (
+              <article
+                key={entry.id}
+                className="bg-ub-dark border border-gray-900 rounded-lg p-4 focus-within:ring-2 focus-within:ring-ub-orange"
+              >
+                <header className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-3">
+                  <div>
+                    <h4 className="text-base font-semibold text-white">{entry.title}</h4>
+                    <p className="text-xs text-ubt-grey/80">Owned by {entry.owner}</p>
+                  </div>
+                <span
+                  className={`px-3 py-1 rounded-full text-xs font-semibold ${statusClassNames[entry.status]}`}
+                  aria-live="polite"
+                >
+                  {statusLabels[entry.status]}
+                </span>
+              </header>
+              <p className="text-sm leading-6 mb-3">{entry.description}</p>
+              <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                <div className="flex flex-col md:w-1/2 text-sm">
+                  <label
+                    htmlFor={statusId}
+                    className="text-xs uppercase tracking-wide text-ubt-grey/80"
+                  >
+                    Status
+                  </label>
+                  <select
+                    id={statusId}
+                    value={entry.status}
+                    onChange={(event) => updateStatus(entry.id, event.target.value as ComplianceStatus)}
+                    className="mt-1 bg-ub-cool-grey text-white border border-gray-700 rounded px-2 py-1"
+                    aria-label={`${entry.title} status`}
+                  >
+                    {COMPLIANCE_STATUS_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="flex flex-col md:w-1/2 text-sm">
+                  <label
+                    htmlFor={notesId}
+                    className="text-xs uppercase tracking-wide text-ubt-grey/80"
+                  >
+                    Notes
+                  </label>
+                  <textarea
+                    id={notesId}
+                    value={entry.note ?? ""}
+                    onChange={(event) => updateNote(entry.id, event.target.value)}
+                    className="mt-1 bg-ub-cool-grey text-white border border-gray-700 rounded px-2 py-2 min-h-[80px]"
+                    placeholder="Status context, blockers, or next steps"
+                    aria-label={`${entry.title} notes`}
+                  />
+                </div>
+              </div>
+              <footer className="mt-3 flex flex-col md:flex-row md:items-center md:justify-between gap-3 text-xs text-ubt-grey/70">
+                <a
+                  href={entry.docUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-ub-orange hover:underline"
+                >
+                  View documentation
+                </a>
+                <span>
+                  {entry.updatedAt
+                    ? `Last updated ${new Date(entry.updatedAt).toLocaleString()}`
+                    : 'Not reviewed yet'}
+                </span>
+              </footer>
+            </article>
+          );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ComplianceChecklist;
+

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -1,0 +1,44 @@
+# Compliance Operations Overview
+
+This document captures the controls tracked in the Kali Linux Portfolio settings checklist. Each section names the control, describes what teams must verify, documents the telemetry or logging expectations, and lists the responsible owner.
+
+## Content Security Policy (CSP)
+- **Expectation:** Enforce a restrictive CSP that whitelists required domains for scripts, styles, fonts, images, media, frames, and connections. Review inline allowances and nonce usage quarterly.
+- **Permissions:** Browser feature permissions (camera, microphone, notifications, clipboard, and pointer lock) must be requested only when a user explicitly opts in within the relevant app window.
+- **Audit & Telemetry:** Capture CSP violation reports and surface them in security dashboards; correlate with release changes to detect regressions.
+- **Owner:** Platform Security Engineering.
+- **Documentation:** `/docs/compliance.md#content-security-policy-csp` (this document).
+- **Update Cadence:** Full review during every major release and whenever third-party embeds or CDN endpoints change.
+
+## Desktop Permissions Governance
+- **Expectation:** Inventory permissions requested by each simulated desktop app. Maintain least-privilege defaults and expose toggles in settings where runtime revocation is supported.
+- **Permissions:** Track usage of notifications, clipboard, filesystem access (File System Access API), and any custom browser permissions used by simulations.
+- **Audit & Telemetry:** Log permission prompts, acceptance/denial, and revocations. Store anonymized metrics to validate opt-in flows.
+- **Owner:** Application Platform Team.
+- **Documentation:** `/docs/compliance.md#desktop-permissions-governance`.
+- **Update Cadence:** Validate before each monthly release window and whenever a new application requests elevated capabilities.
+
+## Audit Logging
+- **Expectation:** Ensure app windows emitting security-relevant events write structured audit logs (JSON) that include actor, action, target, result, and timestamp. Retain logs for at least 90 days.
+- **Permissions:** Limit access to audit log configuration to administrators; expose read-only viewers in observability tools.
+- **Audit & Telemetry:** Forward logs to the centralized SIEM and alert on suspicious sequences (e.g., repeated failed authentications in simulated tools).
+- **Owner:** Security Operations Center (SOC).
+- **Documentation:** `/docs/compliance.md#audit-logging`.
+- **Update Cadence:** Quarterly verification plus ad-hoc reviews after every incident postmortem.
+
+## Telemetry Transparency
+- **Expectation:** Disclose analytics collectors (Google Analytics, Vercel Analytics, Speed Insights) in the privacy settings. Offer opt-out switches backed by feature flags.
+- **Permissions:** Restrict addition of new telemetry sinks without documented review and explicit user messaging.
+- **Audit & Telemetry:** Monitor flag usage and ensure opt-out state propagates to analytics wrappers. Record consent changes for compliance review.
+- **Owner:** Privacy Engineering & Developer Experience.
+- **Documentation:** `/docs/compliance.md#telemetry-transparency`.
+- **Update Cadence:** Review opt-out flow at every minor release and whenever analytics packages upgrade.
+
+## Responsible Ownership and Updates
+- **Checklist Stewardship:** The Settings → About compliance checklist is owned by the Governance, Risk, and Compliance (GRC) working group. They coordinate updates with Platform Security, Application Platform, SOC, and Privacy Engineering.
+- **Update Cadence:**
+  - **Routine:** Monthly sync to confirm statuses and refresh notes.
+  - **Release Gates:** Mandatory verification during major release readiness reviews.
+  - **Incident Response:** Immediate re-validation following any incident or audit finding related to these controls.
+- **Change Process:** Owners should update the checklist through the UI, export a JSON snapshot for records, and submit documentation updates via pull request referencing this file.
+

--- a/utils/complianceChecklist.ts
+++ b/utils/complianceChecklist.ts
@@ -1,0 +1,191 @@
+import { safeLocalStorage } from './safeStorage';
+
+export type ComplianceStatus =
+  | 'not-started'
+  | 'in-progress'
+  | 'blocked'
+  | 'compliant'
+  | 'not-applicable';
+
+export interface ComplianceItem {
+  id: string;
+  title: string;
+  description: string;
+  owner: string;
+  docUrl: string;
+}
+
+export interface ComplianceChecklistEntry {
+  id: string;
+  status: ComplianceStatus;
+  note?: string;
+  updatedAt?: string;
+}
+
+export interface ComplianceChecklistState {
+  version: number;
+  items: ComplianceChecklistEntry[];
+  lastUpdated?: string;
+}
+
+export const COMPLIANCE_ITEMS: ComplianceItem[] = [
+  {
+    id: 'csp',
+    title: 'Content Security Policy',
+    description:
+      'Confirm the desktop shell and hosted apps enforce the documented CSP and monitor violation reports.',
+    owner: 'Platform Security Engineering',
+    docUrl: 'https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/compliance.md#content-security-policy-csp',
+  },
+  {
+    id: 'permissions',
+    title: 'Desktop Permissions Governance',
+    description:
+      'Review requested browser permissions per app and verify least-privilege defaults with revocation paths.',
+    owner: 'Application Platform Team',
+    docUrl: 'https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/compliance.md#desktop-permissions-governance',
+  },
+  {
+    id: 'audit-logs',
+    title: 'Audit Logging',
+    description:
+      'Validate that audit events are structured, forwarded to the SIEM, and retained for the full policy window.',
+    owner: 'Security Operations Center (SOC)',
+    docUrl: 'https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/compliance.md#audit-logging',
+  },
+  {
+    id: 'telemetry',
+    title: 'Telemetry Transparency',
+    description:
+      'Ensure telemetry opt-outs are honored across analytics providers and new collectors are reviewed.',
+    owner: 'Privacy Engineering & Developer Experience',
+    docUrl: 'https://github.com/Alex-Unnippillil/kali-linux-portfolio/blob/main/docs/compliance.md#telemetry-transparency',
+  },
+];
+
+export const COMPLIANCE_STATUS_OPTIONS: { value: ComplianceStatus; label: string }[] = [
+  { value: 'not-started', label: 'Not started' },
+  { value: 'in-progress', label: 'In progress' },
+  { value: 'blocked', label: 'Blocked' },
+  { value: 'compliant', label: 'Compliant' },
+  { value: 'not-applicable', label: 'Not applicable' },
+];
+
+const STORAGE_KEY = 'compliance-checklist';
+const CURRENT_VERSION = 1;
+
+const toEntryMap = (items: ComplianceChecklistEntry[]) =>
+  items.reduce<Record<string, ComplianceChecklistEntry>>((acc, item) => {
+    acc[item.id] = item;
+    return acc;
+  }, {});
+
+const getDefaultEntry = (id: string): ComplianceChecklistEntry => ({
+  id,
+  status: 'not-started',
+  note: '',
+});
+
+export const getDefaultComplianceChecklist = (): ComplianceChecklistState => ({
+  version: CURRENT_VERSION,
+  items: COMPLIANCE_ITEMS.map((item) => getDefaultEntry(item.id)),
+});
+
+const normalizeChecklist = (
+  input?: Partial<ComplianceChecklistState>
+): ComplianceChecklistState => {
+  const base = getDefaultComplianceChecklist();
+  if (!input) return base;
+
+  const existingMap = input.items ? toEntryMap(input.items) : {};
+  const mergedItems = COMPLIANCE_ITEMS.map((item) => {
+    const stored = existingMap[item.id];
+    if (!stored) {
+      return getDefaultEntry(item.id);
+    }
+    return {
+      id: item.id,
+      status: stored.status ?? 'not-started',
+      note: stored.note ?? '',
+      updatedAt: stored.updatedAt,
+    };
+  });
+
+  return {
+    version: CURRENT_VERSION,
+    items: mergedItems,
+    lastUpdated: input.lastUpdated,
+  };
+};
+
+export const loadComplianceChecklist = (): ComplianceChecklistState => {
+  if (!safeLocalStorage) {
+    return getDefaultComplianceChecklist();
+  }
+
+  const raw = safeLocalStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return getDefaultComplianceChecklist();
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<ComplianceChecklistState>;
+    return normalizeChecklist(parsed);
+  } catch (error) {
+    console.warn('Failed to parse compliance checklist from storage', error);
+    return getDefaultComplianceChecklist();
+  }
+};
+
+export const saveComplianceChecklist = (state: ComplianceChecklistState) => {
+  if (!safeLocalStorage) return;
+  const payload: ComplianceChecklistState = {
+    ...state,
+    version: CURRENT_VERSION,
+    lastUpdated: new Date().toISOString(),
+  };
+  safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+export const serializeComplianceChecklist = (
+  state: ComplianceChecklistState
+): string => {
+  const payload = {
+    version: CURRENT_VERSION,
+    exportedAt: new Date().toISOString(),
+    items: state.items,
+  };
+  return JSON.stringify(payload, null, 2);
+};
+
+export const deserializeComplianceChecklist = (
+  json: string
+): ComplianceChecklistState | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (error) {
+    console.error('Invalid compliance checklist JSON', error);
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return null;
+  }
+
+  const candidate = parsed as Partial<ComplianceChecklistState> & {
+    exportedAt?: string;
+  };
+
+  if (!candidate.items || !Array.isArray(candidate.items)) {
+    return null;
+  }
+
+  return normalizeChecklist(candidate);
+};
+
+export const clearComplianceChecklist = () => {
+  if (!safeLocalStorage) return;
+  safeLocalStorage.removeItem(STORAGE_KEY);
+};
+


### PR DESCRIPTION
## Summary
- document CSP, permissions, audit logging, and telemetry owners and review cadence in docs/compliance.md
- add a Settings → About compliance checklist with status tracking, notes, and linked documentation backed by local persistence
- fold checklist data into settings export/import and reset flows for easy backup and restoration

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc936f860483288f0cad08b9590ca1