### PR TITLE
[system] Add backpressure limiter and UI messaging

### DIFF
--- a/__tests__/BackpressureNotice.test.tsx
+++ b/__tests__/BackpressureNotice.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { fireEvent, render, screen, act } from '@testing-library/react';
+import BackpressureNotice from '../components/system/BackpressureNotice';
+import {
+  enqueueJob,
+  registerJobType,
+  resetBackpressureForTests,
+} from '../utils/backpressure';
+
+describe('BackpressureNotice', () => {
+  beforeEach(() => {
+    resetBackpressureForTests();
+    registerJobType('ui:test', { label: 'UI test job', concurrency: 1 });
+  });
+
+  afterEach(() => {
+    act(() => {
+      resetBackpressureForTests();
+    });
+  });
+
+  test('shows queue messaging with cancel and resume controls', async () => {
+    enqueueJob(
+      'ui:test',
+      {
+        run: () => new Promise<void>(() => {}),
+      },
+      { id: 'ui:running' },
+    );
+
+    const queued = enqueueJob(
+      'ui:test',
+      {
+        run: async () => undefined,
+      },
+      { id: 'ui:queued', label: 'Queued job' },
+    );
+
+    render(
+      <BackpressureNotice jobId={queued.id} description="Queued demo job" />,
+    );
+
+    expect(screen.getByTestId('backpressure-title')).toHaveTextContent(
+      'Queued demo job',
+    );
+    expect(screen.getByTestId('backpressure-message').textContent).toMatch(
+      /Waiting/,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('backpressure-message').textContent).toMatch(
+      /paused/,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Resume' }));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('backpressure-message').textContent).toMatch(
+      /Waiting/,
+    );
+  });
+});

--- a/__tests__/HashConverterBackpressure.test.tsx
+++ b/__tests__/HashConverterBackpressure.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import HashConverter from '../components/apps/converter/HashConverter';
+import { enqueueJob, resetBackpressureForTests } from '../utils/backpressure';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var Worker: any;
+}
+
+describe('HashConverter backpressure UI', () => {
+  beforeAll(() => {
+    class MockWorker {
+      onmessage: ((event: any) => void) | null = null;
+
+      postMessage() {}
+
+      terminate() {}
+    }
+
+    global.Worker = MockWorker;
+  });
+
+  beforeEach(() => {
+    resetBackpressureForTests();
+  });
+
+  afterEach(() => {
+    act(() => {
+      resetBackpressureForTests();
+    });
+  });
+
+  test('shows queue notice when hashing is delayed', async () => {
+    enqueueJob(
+      'hash:compute',
+      {
+        run: () => new Promise<void>(() => {}),
+      },
+      { id: 'hash:hold' },
+    );
+
+    render(<HashConverter />);
+
+    const fileInput = screen.getByLabelText('Drag & drop a file or click to select');
+
+    await act(async () => {
+      fireEvent.change(fileInput, {
+        target: { files: [new File(['test'], 'test.txt')] },
+      });
+      await Promise.resolve();
+    });
+
+    const notice = await screen.findByTestId('backpressure-message');
+    expect(notice.textContent).toMatch(/Waiting/);
+  });
+});

--- a/__tests__/backpressure.test.ts
+++ b/__tests__/backpressure.test.ts
@@ -1,0 +1,93 @@
+import {
+  cancelJob,
+  enqueueJob,
+  registerJobType,
+  resetBackpressureForTests,
+  resumeJob,
+} from '../utils/backpressure';
+
+beforeEach(() => {
+  resetBackpressureForTests();
+  registerJobType('test:job', { label: 'Test job', concurrency: 1 });
+});
+
+afterEach(() => {
+  resetBackpressureForTests();
+});
+
+describe('backpressure limiter', () => {
+  test('queues jobs beyond configured concurrency', async () => {
+    let releaseFirst: () => void = () => {};
+    const first = enqueueJob(
+      'test:job',
+      {
+        run: () =>
+          new Promise<void>((resolve) => {
+            releaseFirst = resolve;
+          }),
+      },
+      { id: 'job:first' },
+    );
+
+    let secondStarted = false;
+    const second = enqueueJob(
+      'test:job',
+      {
+        run: () => {
+          secondStarted = true;
+        },
+      },
+      { id: 'job:second' },
+    );
+
+    expect(secondStarted).toBe(false);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    releaseFirst();
+    await first.done;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(secondStarted).toBe(true);
+    await second.done;
+  });
+
+  test('supports cancellation and resume for queued work', async () => {
+    let releaseFirst: () => void = () => {};
+    const first = enqueueJob(
+      'test:job',
+      {
+        run: () =>
+          new Promise<void>((resolve) => {
+            releaseFirst = resolve;
+          }),
+      },
+      { id: 'job:first' },
+    );
+
+    const secondState = { started: false };
+    const second = enqueueJob(
+      'test:job',
+      {
+        run: () => {
+          secondState.started = true;
+        },
+      },
+      { id: 'job:second' },
+    );
+
+    expect(cancelJob(second.id)).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(secondState.started).toBe(false);
+
+    expect(resumeJob(second.id)).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(secondState.started).toBe(false);
+
+    releaseFirst();
+    await first.done;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(secondState.started).toBe(true);
+    await second.done;
+  });
+});

--- a/components/system/BackpressureNotice.tsx
+++ b/components/system/BackpressureNotice.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import clsx from 'clsx';
+import useBackpressureJob from '../../hooks/useBackpressureJob';
+import { cancelJob, resumeJob } from '../../utils/backpressure';
+
+interface BackpressureNoticeProps {
+  jobId?: string | null;
+  className?: string;
+  description?: string;
+}
+
+const BackpressureNotice: React.FC<BackpressureNoticeProps> = ({
+  jobId,
+  className,
+  description,
+}) => {
+  const job = useBackpressureJob(jobId);
+
+  if (!job) return null;
+
+  const isWaiting = job.status === 'queued';
+  const isPaused = job.status === 'paused';
+
+  if (!isWaiting && !isPaused) return null;
+
+  const label = description || job.label || job.type;
+  const queueMessage = isWaiting
+    ? `Waiting for available worker capacity. ${
+        job.position ? `Position ${job.position} of ${job.queued}.` : ''
+      }`
+    : 'Job is paused. Resume to continue processing.';
+
+  const cancel = () => {
+    if (jobId) cancelJob(jobId);
+  };
+
+  const resume = () => {
+    if (jobId) resumeJob(jobId);
+  };
+
+  return (
+    <div
+      className={clsx(
+        'rounded border border-ub-orange/60 bg-black/70 p-3 text-xs text-white shadow-lg',
+        className,
+      )}
+      role="status"
+      aria-live="polite"
+    >
+      <p className="font-semibold text-sm" data-testid="backpressure-title">
+        {label}
+      </p>
+      <p className="mt-1 leading-relaxed" data-testid="backpressure-message">
+        {queueMessage}
+      </p>
+      <div className="mt-2 flex gap-2">
+        <button
+          type="button"
+          className="rounded bg-ub-red px-3 py-1 text-xs font-medium text-white"
+          onClick={cancel}
+        >
+          {isPaused ? 'Remove' : 'Cancel'}
+        </button>
+        {isPaused && job.allowResume && (
+          <button
+            type="button"
+            className="rounded bg-ub-green px-3 py-1 text-xs font-medium text-black"
+            onClick={resume}
+          >
+            Resume
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BackpressureNotice;

--- a/docs/backpressure.md
+++ b/docs/backpressure.md
@@ -1,0 +1,78 @@
+# Backpressure and Worker Pool Limiting
+
+Heavy apps such as OpenVAS parsing, hash conversion, and fixtures imports share
+CPU-bound Web Worker pipelines. To prevent the UI from scheduling more work than
+browsers can handle, use the shared limiter defined in `utils/backpressure.ts`.
+
+## Registering job types
+
+Each job type needs a label and a concurrency cap. Defaults exist for common
+apps (`hash:compute`, `openvas:scan`, `fixtures:parse`, `scanner:scheduled`),
+but you can register new ones or override limits:
+
+```ts
+import { registerJobType } from '../utils/backpressure';
+
+registerJobType('pcap:decode', {
+  label: 'PCAP decoder',
+  concurrency: 2,
+});
+```
+
+Registration is idempotent and can run during module load.
+
+## Enqueueing work
+
+Wrap CPU-heavy tasks so they are routed through the limiter. Jobs are started
+only when a slot is available; otherwise they are queued.
+
+```ts
+import { enqueueJob } from '../utils/backpressure';
+
+const handle = enqueueJob(
+  'pcap:decode',
+  {
+    run: () => decodePackets(blob),
+    cancel: () => controller.abort(),
+  },
+  {
+    label: `Decoding ${fileName}`,
+    metadata: { fileName },
+  },
+);
+
+handle.done.finally(() => console.log('Job finished'));
+```
+
+Cancel callbacks should tear down workers (terminate or post a cancel message),
+reset progress state, and release any abort controllers.
+
+## UI feedback
+
+Use the shared `<BackpressureNotice />` component to inform users that their job
+is queued or paused and expose cancel/resume controls:
+
+```tsx
+<BackpressureNotice
+  jobId={jobId}
+  description="PCAP decode queued behind existing jobs"
+/>
+```
+
+The notice auto-subscribes to limiter state, so it updates when the queue moves
+or when a user pauses/resumes a job.
+
+## Scheduling with limits
+
+`scheduleScan` now accepts an optional options object. Provide a `jobType` to run
+scheduled callbacks through the limiter so recurring scans respect global
+concurrency:
+
+```ts
+scheduleScan('daily', '0 */1 * * * *', () => runDailyScan(), {
+  jobType: 'scanner:scheduled',
+  metadata: { scope: 'daily' },
+});
+```
+
+If you omit `jobType` the callback runs immediately, matching legacy behavior.

--- a/hooks/useBackpressureJob.ts
+++ b/hooks/useBackpressureJob.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import {
+  getBackpressureSnapshot,
+  JobSnapshot,
+  subscribeToBackpressure,
+} from '../utils/backpressure';
+
+export const useBackpressureJob = (jobId?: string | null): JobSnapshot | null => {
+  const [job, setJob] = useState<JobSnapshot | null>(() => {
+    if (!jobId) return null;
+    return getBackpressureSnapshot().jobs.find((j) => j.id === jobId) ?? null;
+  });
+
+  useEffect(() => {
+    if (!jobId) {
+      setJob(null);
+      return () => {};
+    }
+    return subscribeToBackpressure((snapshot) => {
+      const next = snapshot.jobs.find((j) => j.id === jobId) ?? null;
+      setJob(next);
+    });
+  }, [jobId]);
+
+  return job;
+};
+
+export default useBackpressureJob;

--- a/utils/backpressure.ts
+++ b/utils/backpressure.ts
@@ -1,0 +1,397 @@
+export type JobStatus = 'queued' | 'running' | 'completed' | 'paused' | 'failed' | 'cancelled';
+
+export interface JobTypeConfig {
+  /**
+   * Human readable label shown in UI to describe the kind of work taking place.
+   */
+  label: string;
+  /**
+   * Maximum number of jobs allowed to run concurrently for this job type.
+   */
+  concurrency: number;
+  /**
+   * Optional hard limit on queued jobs waiting for a slot. If omitted the
+   * queue may grow unbounded (in-memory only).
+   */
+  queueLimit?: number;
+}
+
+export interface JobMetadata {
+  [key: string]: unknown;
+}
+
+export interface JobSnapshot {
+  id: string;
+  type: string;
+  status: JobStatus;
+  label?: string;
+  metadata?: JobMetadata;
+  createdAt: number;
+  startedAt?: number;
+  finishedAt?: number;
+  error?: string;
+  /**
+   * 1-based position in the queue for the current job type. Null when not
+   * queued.
+   */
+  position: number | null;
+  /**
+   * Number of jobs currently running for this job type.
+   */
+  running: number;
+  /**
+   * Number of jobs currently waiting for this job type.
+   */
+  queued: number;
+  concurrency: number;
+  allowResume: boolean;
+}
+
+export interface BackpressureSnapshot {
+  jobs: JobSnapshot[];
+  jobTypes: Record<string, { config: JobTypeConfig; running: number; queued: number }>;
+}
+
+interface JobExecutor {
+  run: () => Promise<void> | void;
+  cancel?: () => void;
+}
+
+interface EnqueueOptions {
+  id?: string;
+  label?: string;
+  metadata?: JobMetadata;
+  allowResume?: boolean;
+}
+
+interface JobRecord extends EnqueueOptions, JobExecutor {
+  id: string;
+  type: string;
+  status: JobStatus;
+  createdAt: number;
+  startedAt?: number;
+  finishedAt?: number;
+  error?: string;
+  allowResume: boolean;
+  ignoreCompletion: boolean;
+  resolve: () => void;
+  reject: (err: unknown) => void;
+  done: Promise<void>;
+}
+
+interface JobTypeState {
+  config: JobTypeConfig;
+  queue: JobRecord[];
+  running: Set<JobRecord>;
+}
+
+const DEFAULT_JOB_TYPES: Record<string, JobTypeConfig> = {
+  'hash:compute': { label: 'Hash conversion', concurrency: 1 },
+  'openvas:scan': { label: 'OpenVAS scan', concurrency: 1 },
+  'fixtures:parse': { label: 'Fixtures parsing', concurrency: 2 },
+  'scanner:scheduled': { label: 'Scheduled scan trigger', concurrency: 1 },
+};
+
+let instance: BackpressureLimiter | null = null;
+
+const ensureInstance = () => {
+  if (!instance) instance = new BackpressureLimiter(DEFAULT_JOB_TYPES);
+  return instance;
+};
+
+export interface JobHandle {
+  id: string;
+  type: string;
+  done: Promise<void>;
+  cancel: () => boolean;
+  resume: () => boolean;
+}
+
+export class BackpressureLimiter {
+  private registry = new Map<string, JobTypeState>();
+
+  private jobs = new Map<string, JobRecord>();
+
+  private listeners = new Set<(snapshot: BackpressureSnapshot) => void>();
+
+  private counter = 0;
+
+  constructor(defaults: Record<string, JobTypeConfig> = {}) {
+    Object.entries(defaults).forEach(([type, config]) => this.registerType(type, config));
+  }
+
+  registerType(type: string, config: JobTypeConfig) {
+    if (!config || typeof config.concurrency !== 'number' || config.concurrency < 1) {
+      throw new Error('Concurrency must be >= 1');
+    }
+    const state = this.registry.get(type);
+    if (state) {
+      state.config = { ...state.config, ...config };
+      this.notify();
+      return;
+    }
+    this.registry.set(type, {
+      config: { ...config },
+      queue: [],
+      running: new Set(),
+    });
+    this.notify();
+  }
+
+  enqueue(type: string, executor: JobExecutor, options: EnqueueOptions = {}): JobHandle {
+    const state = this.ensureType(type);
+    if (state.config.queueLimit && state.queue.length >= state.config.queueLimit) {
+      throw new Error(`Queue limit reached for ${type}`);
+    }
+
+    const record: JobRecord = {
+      ...options,
+      ...executor,
+      id: options.id ?? this.createId(type),
+      type,
+      status: 'queued',
+      createdAt: Date.now(),
+      allowResume: options.allowResume ?? true,
+      ignoreCompletion: false,
+      resolve: () => {},
+      reject: () => {},
+      done: Promise.resolve(undefined),
+    } as JobRecord;
+
+    record.done = new Promise<void>((resolve, reject) => {
+      record.resolve = resolve;
+      record.reject = reject;
+    });
+
+    state.queue.push(record);
+    this.jobs.set(record.id, record);
+    this.notify();
+    this.process(type);
+
+    return {
+      id: record.id,
+      type,
+      done: record.done,
+      cancel: () => this.cancel(record.id),
+      resume: () => this.resume(record.id),
+    };
+  }
+
+  cancel(id: string): boolean {
+    const record = this.jobs.get(id);
+    if (!record) return false;
+    const state = this.registry.get(record.type);
+    if (!state) return false;
+
+    if (record.status === 'queued') {
+      const idx = state.queue.indexOf(record);
+      if (idx >= 0) state.queue.splice(idx, 1);
+      record.status = record.allowResume ? 'paused' : 'cancelled';
+      record.finishedAt = Date.now();
+      if (!record.allowResume) {
+        record.resolve();
+        this.jobs.delete(id);
+      }
+      this.notify();
+      return true;
+    }
+
+    if (record.status === 'running') {
+      record.ignoreCompletion = true;
+      record.cancel?.();
+      state.running.delete(record);
+      record.status = record.allowResume ? 'paused' : 'cancelled';
+      record.finishedAt = Date.now();
+      if (!record.allowResume) {
+        record.resolve();
+        this.jobs.delete(id);
+      }
+      this.notify();
+      this.process(record.type);
+      return true;
+    }
+
+    if (record.status === 'paused') {
+      record.status = 'cancelled';
+      record.finishedAt = Date.now();
+      this.jobs.delete(id);
+      record.resolve();
+      this.notify();
+      return true;
+    }
+
+    return false;
+  }
+
+  resume(id: string): boolean {
+    const record = this.jobs.get(id);
+    if (!record) return false;
+    if (record.status !== 'paused') return false;
+    const state = this.ensureType(record.type);
+    record.status = 'queued';
+    record.ignoreCompletion = false;
+    record.finishedAt = undefined;
+    state.queue.push(record);
+    this.notify();
+    this.process(record.type);
+    return true;
+  }
+
+  subscribe(listener: (snapshot: BackpressureSnapshot) => void): () => void {
+    this.listeners.add(listener);
+    listener(this.getSnapshot());
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getSnapshot(): BackpressureSnapshot {
+    const jobTypes: BackpressureSnapshot['jobTypes'] = {};
+
+    this.registry.forEach((state, type) => {
+      jobTypes[type] = {
+        config: { ...state.config },
+        running: state.running.size,
+        queued: state.queue.length,
+      };
+    });
+
+    const jobs: JobSnapshot[] = Array.from(this.jobs.values()).map((job) => {
+      const state = this.registry.get(job.type)!;
+      const position = job.status === 'queued' ? state.queue.indexOf(job) : -1;
+      return {
+        id: job.id,
+        type: job.type,
+        status: job.status,
+        label: job.label,
+        metadata: job.metadata,
+        createdAt: job.createdAt,
+        startedAt: job.startedAt,
+        finishedAt: job.finishedAt,
+        error: job.error,
+        position: position >= 0 ? position + 1 : null,
+        running: state.running.size,
+        queued: state.queue.length,
+        concurrency: state.config.concurrency,
+        allowResume: job.allowResume,
+      };
+    });
+
+    jobs.sort((a, b) => a.createdAt - b.createdAt);
+
+    return { jobs, jobTypes };
+  }
+
+  reset() {
+    this.registry.forEach((state) => {
+      state.queue.length = 0;
+      state.running.clear();
+    });
+    this.jobs.clear();
+    this.notify();
+  }
+
+  private ensureType(type: string): JobTypeState {
+    const state = this.registry.get(type);
+    if (state) return state;
+    const fallback = DEFAULT_JOB_TYPES[type];
+    if (!fallback) {
+      throw new Error(`Job type ${type} is not registered`);
+    }
+    this.registerType(type, fallback);
+    return this.registry.get(type)!;
+  }
+
+  private process(type: string) {
+    const state = this.registry.get(type);
+    if (!state) return;
+
+    while (
+      state.running.size < state.config.concurrency &&
+      state.queue.length > 0
+    ) {
+      const job = state.queue.shift()!;
+      this.startJob(job, state);
+    }
+  }
+
+  private startJob(job: JobRecord, state: JobTypeState) {
+    job.status = 'running';
+    job.startedAt = Date.now();
+    job.ignoreCompletion = false;
+    state.running.add(job);
+    this.notify();
+
+    Promise.resolve()
+      .then(() => job.run())
+      .then(() => {
+        if (job.ignoreCompletion) return;
+        if (job.status === 'running') {
+          job.status = 'completed';
+          job.finishedAt = Date.now();
+          job.resolve();
+        }
+      })
+      .catch((err) => {
+        if (job.ignoreCompletion) return;
+        job.status = 'failed';
+        job.error = err instanceof Error ? err.message : String(err);
+        job.finishedAt = Date.now();
+        job.reject(err);
+      })
+      .finally(() => {
+        if (!state.running.has(job)) return;
+        state.running.delete(job);
+        if (job.status === 'completed' || job.status === 'failed') {
+          this.jobs.delete(job.id);
+        }
+        this.notify();
+        this.process(job.type);
+      });
+  }
+
+  private notify() {
+    const snapshot = this.getSnapshot();
+    this.listeners.forEach((listener) => listener(snapshot));
+  }
+
+  private createId(type: string) {
+    const globalCrypto =
+      typeof globalThis !== 'undefined' && typeof (globalThis as any).crypto !== 'undefined'
+        ? (globalThis as any).crypto
+        : undefined;
+    if (globalCrypto && typeof globalCrypto.randomUUID === 'function') {
+      return `${type}:${globalCrypto.randomUUID().slice(0, 8)}`;
+    }
+    this.counter += 1;
+    return `${type}:${this.counter}`;
+  }
+}
+
+export const registerJobType = (
+  type: string,
+  config: JobTypeConfig,
+): void => {
+  ensureInstance().registerType(type, config);
+};
+
+export const enqueueJob = (
+  type: string,
+  executor: JobExecutor,
+  options?: EnqueueOptions,
+): JobHandle => ensureInstance().enqueue(type, executor, options);
+
+export const cancelJob = (id: string): boolean => ensureInstance().cancel(id);
+
+export const resumeJob = (id: string): boolean => ensureInstance().resume(id);
+
+export const subscribeToBackpressure = (
+  listener: (snapshot: BackpressureSnapshot) => void,
+): (() => void) => ensureInstance().subscribe(listener);
+
+export const getBackpressureSnapshot = (): BackpressureSnapshot =>
+  ensureInstance().getSnapshot();
+
+export const resetBackpressureForTests = () => {
+  ensureInstance().reset();
+};


### PR DESCRIPTION
## Summary
- implement a reusable backpressure limiter with job registration, cancellation, and resume APIs
- surface queue state in CPU-heavy apps via a shared BackpressureNotice component and new hook
- document limiter usage and cover queueing, cancellation, and UI messaging with targeted tests

## Testing
- yarn test backpressure

------
https://chatgpt.com/codex/tasks/task_e_68dc937356c883288eb36d2acc9cbfd5