### PR TITLE
[firefox] add macro recorder with playback engine

### DIFF
--- a/__tests__/firefoxRecorder.test.tsx
+++ b/__tests__/firefoxRecorder.test.tsx
@@ -1,0 +1,129 @@
+import React, { forwardRef, useRef, useState } from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import Recorder, {
+  MACRO_VERSION,
+  RecorderHandle,
+  FirefoxMacro,
+  parseMacro,
+  playMacro,
+} from '@/components/apps/firefox/Recorder';
+
+describe('Firefox Recorder', () => {
+  const Harness = forwardRef<RecorderHandle>((_, ref) => {
+    const targetRef = useRef<HTMLDivElement | null>(null);
+    const [clicks, setClicks] = useState(0);
+
+    return (
+      <div>
+        <div ref={targetRef}>
+          <label htmlFor="test-input">Search</label>
+          <input id="test-input" aria-label="Search" data-testid="recorder-input" defaultValue="" />
+          <button type="button" data-testid="recorder-button" onClick={() => setClicks((value) => value + 1)}>
+            Capture
+          </button>
+          <span data-testid="click-count">{clicks}</span>
+        </div>
+        <Recorder ref={ref} targetRef={targetRef} />
+      </div>
+    );
+  });
+
+  Harness.displayName = 'Harness';
+
+  it('records interactions and replays them with high fidelity', async () => {
+    const ref = React.createRef<RecorderHandle>();
+    render(<Harness ref={ref} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /start recording/i }));
+
+    const input = screen.getByTestId('recorder-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'https://www.kali.org/' } });
+
+    const button = screen.getByTestId('recorder-button');
+    fireEvent.click(button);
+
+    fireEvent.click(screen.getByRole('button', { name: /stop/i }));
+
+    const textarea = screen.getByLabelText('Macro JSON') as HTMLTextAreaElement;
+    const macro = parseMacro(textarea.value) as FirefoxMacro;
+
+    expect(macro.version).toBe(MACRO_VERSION);
+    expect(macro.metadata.eventCount).toBeGreaterThanOrEqual(2);
+    expect(screen.getByTestId('click-count')).toHaveTextContent('1');
+
+    let replayReport: Awaited<ReturnType<RecorderHandle['play']>> | undefined;
+    await act(async () => {
+      // attach listener for verification before replay
+      button.addEventListener('click', () => {
+        /* no-op, just ensure event dispatches */
+      });
+      replayReport = await ref.current?.play();
+    });
+
+    expect(screen.getByTestId('recorder-input')).toHaveValue('https://www.kali.org/');
+    expect(screen.getByTestId('click-count')).toHaveTextContent('2');
+    expect(replayReport?.accuracy ?? 0).toBeGreaterThanOrEqual(0.95);
+  });
+
+  it('waits for asynchronous elements when replaying macros', async () => {
+    jest.useFakeTimers();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    try {
+      let clicked = false;
+
+      const macro: FirefoxMacro = {
+        version: MACRO_VERSION,
+        createdAt: new Date().toISOString(),
+        duration: 120,
+        events: [
+          {
+            type: 'click',
+            timestamp: 100,
+            target: {
+              dataSelector: '[data-testid="delayed-button"]',
+              path: 'button[data-testid="delayed-button"]',
+              text: 'Delayed',
+            },
+            pointer: {
+              button: 0,
+            },
+          },
+        ],
+        metadata: {
+          eventCount: 1,
+        },
+      };
+
+      const playbackPromise = playMacro(container as HTMLElement, macro, { waitForElementTimeout: 500 });
+
+      setTimeout(() => {
+        const button = document.createElement('button');
+        button.dataset.testid = 'delayed-button';
+        button.textContent = 'Delayed';
+        button.addEventListener('click', () => {
+          clicked = true;
+        });
+        container.appendChild(button);
+      }, 50);
+
+      await act(async () => {
+        jest.advanceTimersByTime(60);
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(200);
+      });
+
+      const report = await playbackPromise;
+
+      expect(clicked).toBe(true);
+      expect(report.accuracy).toBeGreaterThanOrEqual(0.95);
+      expect(report.successCount).toBe(1);
+    } finally {
+      jest.useRealTimers();
+      document.body.removeChild(container);
+    }
+  });
+});

--- a/components/apps/firefox/Recorder.tsx
+++ b/components/apps/firefox/Recorder.tsx
@@ -1,0 +1,793 @@
+import React, {
+  ForwardedRef,
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+const CONTROL_ATTRIBUTE = 'data-firefox-recorder-control';
+const RECORDER_ID_ATTRIBUTE = 'data-firefox-recorder-id';
+const MACRO_NAMESPACE = 'firefox.macro';
+const SUPPORTED_MAJOR_VERSION = 1;
+
+export const MACRO_VERSION = `${MACRO_NAMESPACE}/1.0.0` as const;
+
+const cssEscape = (value: string) => {
+  if (typeof (globalThis as any).CSS !== 'undefined' && typeof (globalThis as any).CSS.escape === 'function') {
+    return (globalThis as any).CSS.escape(value);
+  }
+  return value.replace(/([\0-\x1f\x7f-\x9f!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, '\\$1');
+};
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => {
+    if (ms <= 0) {
+      resolve();
+      return;
+    }
+    const timeout = globalThis.setTimeout(() => {
+      resolve();
+    }, ms);
+    if (typeof timeout === 'object' && 'unref' in timeout && typeof timeout.unref === 'function') {
+      timeout.unref();
+    }
+  });
+
+const now = () => {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+};
+
+let descriptorCounter = 0;
+
+const createDescriptorId = () => {
+  descriptorCounter += 1;
+  return `ff-rec-${descriptorCounter}`;
+};
+
+type MacroEventType = 'click' | 'input' | 'change' | 'keydown' | 'keyup' | 'submit';
+
+type MacroEventTargetDescriptor = {
+  dataSelector?: string;
+  path: string;
+  text?: string | null;
+};
+
+type MacroEvent = {
+  type: MacroEventType;
+  timestamp: number;
+  target: MacroEventTargetDescriptor;
+  value?: string;
+  checked?: boolean;
+  key?: string;
+  code?: string;
+  pointer?: {
+    button: number;
+  };
+  modifiers?: {
+    altKey: boolean;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    shiftKey: boolean;
+  };
+};
+
+export type FirefoxMacroEvent = MacroEvent;
+
+export type FirefoxMacro = {
+  version: typeof MACRO_VERSION;
+  createdAt: string;
+  duration: number;
+  events: FirefoxMacroEvent[];
+  metadata: {
+    eventCount: number;
+    notes?: string;
+  };
+};
+
+type RecorderStatus = 'idle' | 'recording' | 'playing';
+
+export type MacroPlaybackResult = {
+  successCount: number;
+  failureCount: number;
+  skippedCount: number;
+  accuracy: number;
+  duration: number;
+};
+
+type PlayMacroOptions = {
+  playbackRate?: number;
+  waitForElementTimeout?: number;
+  signal?: AbortSignal;
+  onEvent?: (event: FirefoxMacroEvent, result: 'played' | 'skipped' | 'failed', detail?: string) => void;
+};
+
+const defaultPlayOptions: Required<Omit<PlayMacroOptions, 'signal' | 'onEvent'>> = {
+  playbackRate: 1,
+  waitForElementTimeout: 2000,
+};
+
+const parseVersion = (value: string) => {
+  const [namespace, semver] = value.split('/');
+  if (!namespace || !semver) {
+    throw new Error('Invalid macro version format.');
+  }
+  const [majorStr] = semver.split('.');
+  const major = Number.parseInt(majorStr, 10);
+  if (Number.isNaN(major)) {
+    throw new Error('Invalid macro version number.');
+  }
+  return { namespace, major };
+};
+
+export const serializeMacro = (macro: FirefoxMacro) => JSON.stringify(macro, null, 2);
+
+export const parseMacro = (input: string): FirefoxMacro => {
+  const candidate = JSON.parse(input) as Partial<FirefoxMacro>;
+  if (!candidate || typeof candidate !== 'object') {
+    throw new Error('Macro payload is not an object.');
+  }
+  if (typeof candidate.version !== 'string') {
+    throw new Error('Macro payload is missing a version tag.');
+  }
+  const { namespace, major } = parseVersion(candidate.version);
+  if (namespace !== MACRO_NAMESPACE) {
+    throw new Error(`Unsupported macro namespace: ${namespace}`);
+  }
+  if (major !== SUPPORTED_MAJOR_VERSION) {
+    throw new Error(`Incompatible macro version: ${candidate.version}`);
+  }
+  if (!Array.isArray(candidate.events)) {
+    throw new Error('Macro payload is missing event data.');
+  }
+  return {
+    version: MACRO_VERSION,
+    createdAt: candidate.createdAt ?? new Date().toISOString(),
+    duration: candidate.duration ?? 0,
+    events: candidate.events as FirefoxMacroEvent[],
+    metadata: {
+      eventCount: candidate.metadata?.eventCount ?? candidate.events.length,
+      notes: candidate.metadata?.notes,
+    },
+  };
+};
+
+const buildPath = (element: Element, root: Element): string => {
+  const segments: string[] = [];
+  let current: Element | null = element;
+  while (current && current !== root) {
+    let selector = current.tagName.toLowerCase();
+    if (current.id) {
+      selector += `#${cssEscape(current.id)}`;
+      segments.unshift(selector);
+      break;
+    }
+    const classList = Array.from(current.classList || []).slice(0, 3);
+    if (classList.length > 0) {
+      selector += classList.map((className) => `.${cssEscape(className)}`).join('');
+    }
+    const parent = current.parentElement;
+    if (parent) {
+      const siblings = Array.from(parent.children).filter((child) => (child as Element).tagName === current.tagName);
+      if (siblings.length > 1) {
+        const index = siblings.indexOf(current) + 1;
+        selector += `:nth-of-type(${index})`;
+      }
+    }
+    segments.unshift(selector);
+    current = current.parentElement;
+  }
+  return segments.join(' > ');
+};
+
+const ensureDescriptor = (element: Element, root: Element): MacroEventTargetDescriptor | null => {
+  if (!root.contains(element)) {
+    return null;
+  }
+  const descriptor: MacroEventTargetDescriptor = {
+    path: buildPath(element, root),
+    text: element.textContent?.trim().slice(0, 120) ?? null,
+  };
+  if (element instanceof HTMLElement || element instanceof SVGElement) {
+    const existing = element.getAttribute(RECORDER_ID_ATTRIBUTE);
+    if (existing) {
+      descriptor.dataSelector = `[${RECORDER_ID_ATTRIBUTE}="${existing}"]`;
+    } else if (element instanceof HTMLElement) {
+      const id = createDescriptorId();
+      element.setAttribute(RECORDER_ID_ATTRIBUTE, id);
+      descriptor.dataSelector = `[${RECORDER_ID_ATTRIBUTE}="${id}"]`;
+    }
+  }
+  return descriptor;
+};
+
+const queryTarget = (root: HTMLElement, descriptor: MacroEventTargetDescriptor): HTMLElement | null => {
+  if (descriptor.dataSelector) {
+    const byData = root.querySelector(descriptor.dataSelector);
+    if (byData instanceof HTMLElement) {
+      return byData;
+    }
+  }
+  if (descriptor.path) {
+    const byPath = root.querySelector(descriptor.path);
+    if (byPath instanceof HTMLElement) {
+      return byPath;
+    }
+    if (descriptor.text) {
+      const candidates = Array.from(root.querySelectorAll(descriptor.path));
+      const match = candidates.find((candidate) => candidate.textContent?.trim() === descriptor.text);
+      if (match instanceof HTMLElement) {
+        return match;
+      }
+    }
+  }
+  if (descriptor.text) {
+    const textMatch = Array.from(root.querySelectorAll('*')).find(
+      (candidate) => candidate.textContent?.trim() === descriptor.text,
+    );
+    if (textMatch instanceof HTMLElement) {
+      return textMatch;
+    }
+  }
+  return null;
+};
+
+const waitForTarget = async (
+  root: HTMLElement,
+  descriptor: MacroEventTargetDescriptor,
+  timeout: number,
+  signal?: AbortSignal,
+): Promise<HTMLElement | null> => {
+  const existing = queryTarget(root, descriptor);
+  if (existing) {
+    return existing;
+  }
+  const start = now();
+  return new Promise<HTMLElement | null>((resolve) => {
+    let settled = false;
+    const attempt = () => {
+      if (settled) {
+        return;
+      }
+      if (signal?.aborted) {
+        settled = true;
+        cleanup();
+        resolve(null);
+        return;
+      }
+      const candidate = queryTarget(root, descriptor);
+      if (candidate) {
+        settled = true;
+        cleanup();
+        resolve(candidate);
+        return;
+      }
+      if (now() - start >= timeout) {
+        settled = true;
+        cleanup();
+        resolve(null);
+      }
+    };
+    const observer = new MutationObserver(() => attempt());
+    observer.observe(root, { childList: true, subtree: true, attributes: true });
+    const interval = globalThis.setInterval(() => attempt(), 16);
+    const cleanup = () => {
+      observer.disconnect();
+      globalThis.clearInterval(interval);
+    };
+    if (signal) {
+      signal.addEventListener('abort', () => {
+        settled = true;
+        cleanup();
+        resolve(null);
+      });
+    }
+    attempt();
+  });
+};
+
+const dispatchMacroEvent = (target: HTMLElement, event: FirefoxMacroEvent) => {
+  switch (event.type) {
+    case 'click': {
+      const pointer = event.pointer ?? { button: 0 };
+      const mouseEvent = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        button: pointer.button ?? 0,
+      });
+      target.dispatchEvent(mouseEvent);
+      break;
+    }
+    case 'input':
+    case 'change': {
+      if ('value' in target && typeof event.value === 'string') {
+        (target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement).value = event.value;
+      }
+      if ('checked' in target && typeof event.checked === 'boolean') {
+        (target as HTMLInputElement).checked = event.checked;
+      }
+      const inputEvent = new Event(event.type, {
+        bubbles: true,
+        cancelable: event.type === 'change',
+      });
+      target.dispatchEvent(inputEvent);
+      break;
+    }
+    case 'keydown':
+    case 'keyup': {
+      const modifiers = event.modifiers ?? {
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+      };
+      const keyboardEvent = new KeyboardEvent(event.type, {
+        bubbles: true,
+        cancelable: true,
+        key: event.key,
+        code: event.code,
+        altKey: modifiers.altKey,
+        ctrlKey: modifiers.ctrlKey,
+        metaKey: modifiers.metaKey,
+        shiftKey: modifiers.shiftKey,
+      });
+      target.dispatchEvent(keyboardEvent);
+      break;
+    }
+    case 'submit': {
+      const form = target instanceof HTMLFormElement ? target : target.closest('form');
+      if (form) {
+        const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+        form.dispatchEvent(submitEvent);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+};
+
+export const playMacro = async (
+  root: HTMLElement,
+  macro: FirefoxMacro,
+  options: PlayMacroOptions = {},
+): Promise<MacroPlaybackResult> => {
+  const mergedOptions = { ...defaultPlayOptions, ...options };
+  const { playbackRate, waitForElementTimeout, signal, onEvent } = mergedOptions;
+  const result: MacroPlaybackResult = {
+    successCount: 0,
+    failureCount: 0,
+    skippedCount: 0,
+    accuracy: 1,
+    duration: macro.duration,
+  };
+  if (macro.events.length === 0) {
+    return result;
+  }
+  const effectiveRate = playbackRate <= 0 ? 1 : playbackRate;
+  let lastTimestamp = 0;
+  for (const event of macro.events) {
+    if (signal?.aborted) {
+      result.skippedCount += 1;
+      onEvent?.(event, 'skipped', 'Playback aborted');
+      continue;
+    }
+    const waitTime = Math.max(0, event.timestamp - lastTimestamp);
+    await delay(waitTime / effectiveRate);
+    lastTimestamp = event.timestamp;
+    const target = await waitForTarget(root, event.target, waitForElementTimeout / effectiveRate, signal);
+    if (!target) {
+      result.failureCount += 1;
+      onEvent?.(event, 'failed', 'Target not found');
+      continue;
+    }
+    dispatchMacroEvent(target, event);
+    result.successCount += 1;
+    onEvent?.(event, 'played');
+  }
+  const playedEvents = result.successCount + result.failureCount;
+  result.accuracy = playedEvents === 0 ? 1 : result.successCount / playedEvents;
+  return result;
+};
+
+type RecorderProps = {
+  targetRef: MutableRefObject<HTMLElement | null>;
+  className?: string;
+};
+
+export type RecorderHandle = {
+  start: () => void;
+  stop: () => FirefoxMacro | null;
+  play: () => Promise<MacroPlaybackResult>;
+  getMacro: () => FirefoxMacro | null;
+  loadFromJSON: (payload: string) => void;
+  exportToJSON: () => string | null;
+};
+
+const isControlElement = (element: Element | null) => {
+  if (!element) {
+    return false;
+  }
+  return Boolean(element.closest(`[${CONTROL_ATTRIBUTE}]`));
+};
+
+const useRecorderHandlers = (
+  targetRef: MutableRefObject<HTMLElement | null>,
+  controlsRef: MutableRefObject<HTMLDivElement | null>,
+) => {
+  const [status, setStatus] = useState<RecorderStatus>('idle');
+  const [macro, setMacro] = useState<FirefoxMacro | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [macroDraft, setMacroDraft] = useState('');
+  const [playbackReport, setPlaybackReport] = useState<MacroPlaybackResult | null>(null);
+  const eventsRef = useRef<FirefoxMacroEvent[]>([]);
+  const startRef = useRef<number | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const statusRef = useRef<RecorderStatus>('idle');
+
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
+  const finaliseMacro = useCallback((): FirefoxMacro | null => {
+    if (!startRef.current) {
+      return null;
+    }
+    const events = eventsRef.current.slice();
+    const duration = events.length > 0 ? events[events.length - 1].timestamp : 0;
+    const result: FirefoxMacro = {
+      version: MACRO_VERSION,
+      createdAt: new Date().toISOString(),
+      duration,
+      events,
+      metadata: {
+        eventCount: events.length,
+      },
+    };
+    return result;
+  }, []);
+
+  const stopRecording = useCallback(() => {
+    cleanupRef.current?.();
+    cleanupRef.current = null;
+    if (status !== 'recording') {
+      return null;
+    }
+    setStatus('idle');
+    const finalMacro = finaliseMacro();
+    if (finalMacro) {
+      setMacro(finalMacro);
+      setMacroDraft(serializeMacro(finalMacro));
+    }
+    startRef.current = null;
+    return finalMacro ?? null;
+  }, [finaliseMacro, status]);
+
+  useEffect(() => {
+    return () => {
+      cleanupRef.current?.();
+      cleanupRef.current = null;
+    };
+  }, []);
+
+  const recordEvent = useCallback(
+    (event: Event, type: MacroEventType) => {
+      const root = targetRef.current;
+      if (!root || statusRef.current !== 'recording') {
+        return;
+      }
+      const target = event.target as Element | null;
+      if (!target || !root.contains(target)) {
+        return;
+      }
+      if (isControlElement(target) || (controlsRef.current && controlsRef.current.contains(target))) {
+        return;
+      }
+      const descriptor = ensureDescriptor(target, root);
+      if (!descriptor) {
+        return;
+      }
+      if (!startRef.current) {
+        startRef.current = now();
+      }
+      const timestamp = now() - (startRef.current ?? 0);
+      const modifiers = (event as KeyboardEvent | MouseEvent) ?? null;
+      const macroEvent: FirefoxMacroEvent = {
+        type,
+        timestamp,
+        target: descriptor,
+      };
+      if (type === 'click') {
+        const pointer = event as MouseEvent;
+        macroEvent.pointer = {
+          button: pointer.button ?? 0,
+        };
+      }
+      if (type === 'input' || type === 'change') {
+        const field = event.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
+        if (typeof field.value !== 'undefined') {
+          macroEvent.value = field.value;
+        }
+        if ('checked' in field) {
+          macroEvent.checked = Boolean((field as HTMLInputElement).checked);
+        }
+      }
+      if (type === 'keydown' || type === 'keyup') {
+        const keyboard = event as KeyboardEvent;
+        macroEvent.key = keyboard.key;
+        macroEvent.code = keyboard.code;
+        macroEvent.modifiers = {
+          altKey: keyboard.altKey,
+          ctrlKey: keyboard.ctrlKey,
+          metaKey: keyboard.metaKey,
+          shiftKey: keyboard.shiftKey,
+        };
+      }
+      eventsRef.current = [...eventsRef.current, macroEvent];
+    },
+    [controlsRef, targetRef],
+  );
+
+  const startRecording = useCallback(() => {
+    const root = targetRef.current;
+    if (!root) {
+      setError('Recorder target is not mounted.');
+      return;
+    }
+    if (status === 'recording') {
+      return;
+    }
+    setError(null);
+    setMessage(null);
+    setPlaybackReport(null);
+    eventsRef.current = [];
+    startRef.current = now();
+    const listenerMap: Array<[keyof GlobalEventHandlersEventMap, EventListener]> = [
+      ['click', (event) => recordEvent(event, 'click')],
+      ['input', (event) => recordEvent(event, 'input')],
+      ['change', (event) => recordEvent(event, 'change')],
+      ['keydown', (event) => recordEvent(event, 'keydown')],
+      ['keyup', (event) => recordEvent(event, 'keyup')],
+      ['submit', (event) => recordEvent(event, 'submit')],
+    ];
+    listenerMap.forEach(([eventName, handler]) => {
+      root.addEventListener(eventName, handler, true);
+    });
+    cleanupRef.current = () => {
+      listenerMap.forEach(([eventName, handler]) => {
+        root.removeEventListener(eventName, handler, true);
+      });
+    };
+    setStatus('recording');
+  }, [recordEvent, status, targetRef]);
+
+  const play = useCallback(async () => {
+    const root = targetRef.current;
+    if (!root || !macro) {
+      throw new Error('No macro available for playback.');
+    }
+    setStatus('playing');
+    setMessage(null);
+    setError(null);
+    const report = await playMacro(root, macro);
+    setPlaybackReport(report);
+    setStatus('idle');
+    if (report.accuracy >= 0.95) {
+      setMessage(`Playback completed with ${(report.accuracy * 100).toFixed(1)}% fidelity.`);
+    } else {
+      setError(`Playback fidelity below threshold: ${(report.accuracy * 100).toFixed(1)}%`);
+    }
+    return report;
+  }, [macro, targetRef]);
+
+  const importFromDraft = useCallback(() => {
+    try {
+      const parsed = parseMacro(macroDraft);
+      setMacro(parsed);
+      setMacroDraft(serializeMacro(parsed));
+      setError(null);
+      setMessage('Macro imported successfully.');
+    } catch (importError) {
+      setError(importError instanceof Error ? importError.message : 'Failed to import macro.');
+    }
+  }, [macroDraft]);
+
+  const exportMacro = useCallback(async () => {
+    if (!macro) {
+      setError('No macro available to export.');
+      return;
+    }
+    const payload = serializeMacro(macro);
+    setMacroDraft(payload);
+    try {
+      if (navigator?.clipboard && typeof navigator.clipboard.writeText === 'function') {
+        await navigator.clipboard.writeText(payload);
+        setMessage('Macro copied to clipboard.');
+        return;
+      }
+    } catch (clipboardError) {
+      setError(clipboardError instanceof Error ? clipboardError.message : 'Failed to copy macro.');
+      return;
+    }
+    setMessage('Clipboard unavailable. Macro JSON updated below.');
+  }, [macro]);
+
+  const loadFromJSON = useCallback(
+    (payload: string) => {
+      const parsed = parseMacro(payload);
+      setMacro(parsed);
+      setMacroDraft(serializeMacro(parsed));
+    },
+    [],
+  );
+
+  return {
+    status,
+    macro,
+    macroDraft,
+    setMacroDraft,
+    startRecording,
+    stopRecording,
+    play,
+    error,
+    message,
+    importFromDraft,
+    exportMacro,
+    loadFromJSON,
+    playbackReport,
+  };
+};
+
+const RecorderInner = (
+  { targetRef, className }: RecorderProps,
+  ref: ForwardedRef<RecorderHandle>,
+) => {
+  const controlsRef = useRef<HTMLDivElement | null>(null);
+  const {
+    status,
+    macro,
+    macroDraft,
+    setMacroDraft,
+    startRecording,
+    stopRecording,
+    play,
+    error,
+    message,
+    importFromDraft,
+    exportMacro,
+    loadFromJSON,
+    playbackReport,
+  } = useRecorderHandlers(targetRef, controlsRef as MutableRefObject<HTMLDivElement | null>);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      start: startRecording,
+      stop: () => stopRecording(),
+      play,
+      getMacro: () => macro,
+      loadFromJSON,
+      exportToJSON: () => (macro ? serializeMacro(macro) : null),
+    }),
+    [loadFromJSON, macro, play, startRecording, stopRecording],
+  );
+
+  const statusLabel = useMemo(() => {
+    switch (status) {
+      case 'recording':
+        return 'Recording';
+      case 'playing':
+        return 'Replaying';
+      default:
+        return 'Idle';
+    }
+  }, [status]);
+
+  return (
+    <div
+      ref={controlsRef}
+      className={`pointer-events-auto absolute bottom-3 right-3 z-20 w-80 max-w-full rounded-md border border-gray-700 bg-gray-900/95 p-4 text-xs text-gray-100 shadow-lg ${
+        className ?? ''
+      }`}
+      {...{ [CONTROL_ATTRIBUTE]: true }}
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-200">Macro Recorder</h3>
+        <span className="rounded bg-gray-800 px-2 py-1 text-[11px] uppercase tracking-wider text-gray-300">{statusLabel}</span>
+      </div>
+      <p className="mt-2 text-[11px] text-gray-400">
+        Record Firefox simulation interactions and replay them later. Macros are versioned as {MACRO_VERSION}.
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2 text-xs">
+        <button
+          type="button"
+          onClick={startRecording}
+          disabled={status === 'recording'}
+          className="rounded bg-blue-600 px-3 py-1 font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-900"
+        >
+          Start recording
+        </button>
+        <button
+          type="button"
+          onClick={stopRecording}
+          disabled={status !== 'recording'}
+          className="rounded bg-gray-700 px-3 py-1 font-medium text-gray-200 hover:bg-gray-600 disabled:cursor-not-allowed disabled:bg-gray-800"
+        >
+          Stop
+        </button>
+        <button
+          type="button"
+          onClick={play}
+          disabled={!macro || status === 'recording'}
+          className="rounded bg-emerald-600 px-3 py-1 font-medium text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:bg-emerald-900"
+        >
+          Replay macro
+        </button>
+        <button
+          type="button"
+          onClick={exportMacro}
+          disabled={!macro}
+          className="rounded bg-indigo-600 px-3 py-1 font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:bg-indigo-900"
+        >
+          Export
+        </button>
+      </div>
+      <label htmlFor="firefox-recorder-macro" className="mt-3 block text-[11px] font-semibold text-gray-300">
+        Macro JSON
+      </label>
+      <textarea
+        id="firefox-recorder-macro"
+        aria-label="Macro JSON"
+        value={macroDraft}
+        onChange={(event) => setMacroDraft(event.target.value)}
+        className="mt-1 h-32 w-full rounded border border-gray-700 bg-gray-950 px-2 py-2 font-mono text-[11px] text-gray-200 focus:border-blue-500 focus:outline-none"
+        placeholder="Macro JSON will appear here after recording."
+      />
+      <div className="mt-2 flex gap-2">
+        <button
+          type="button"
+          onClick={importFromDraft}
+          className="rounded bg-gray-700 px-3 py-1 font-medium text-gray-200 hover:bg-gray-600"
+        >
+          Import
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setMacroDraft('');
+          }}
+          className="rounded bg-gray-800 px-3 py-1 font-medium text-gray-200 hover:bg-gray-700"
+        >
+          Clear draft
+        </button>
+      </div>
+      {playbackReport ? (
+        <p className="mt-2 text-[11px] text-gray-400">
+          Last replay fidelity: {(playbackReport.accuracy * 100).toFixed(1)}% ({playbackReport.successCount} succeeded,
+          {` ${playbackReport.failureCount}`} failed).
+        </p>
+      ) : null}
+      {message ? (
+        <p className="mt-2 text-[11px] text-emerald-400" role="status">
+          {message}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="mt-2 text-[11px] text-red-400" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+};
+
+const Recorder = React.forwardRef<RecorderHandle, RecorderProps>(RecorderInner);
+
+export default Recorder;

--- a/components/apps/firefox/index.tsx
+++ b/components/apps/firefox/index.tsx
@@ -1,5 +1,6 @@
-import React, { FormEvent, useMemo, useState } from 'react';
+import React, { FormEvent, useMemo, useRef, useState } from 'react';
 import { FirefoxSimulationView, SIMULATIONS, toSimulationKey } from './simulations';
+import Recorder from './Recorder';
 
 const DEFAULT_URL = 'https://www.kali.org/docs/';
 const STORAGE_KEY = 'firefox:last-url';
@@ -86,29 +87,33 @@ const Firefox: React.FC = () => {
     updateAddress(inputValue);
   };
 
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
   return (
-    <div className="flex h-full flex-col bg-ub-cool-grey text-gray-100">
-      <form
-        onSubmit={handleSubmit}
-        className="flex items-center gap-2 border-b border-gray-700 bg-gray-900 px-3 py-2"
-      >
-        <label htmlFor="firefox-address" className="sr-only">
-          Address
-        </label>
-        <input
-          id="firefox-address"
-          value={inputValue}
-          onChange={(event) => setInputValue(event.target.value)}
-          placeholder="Enter a URL"
-          className="flex-1 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-400 focus:border-blue-500 focus:outline-none"
-        />
-        <button
-          type="submit"
-          className="rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
+    <div className="relative h-full">
+      <div ref={containerRef} className="flex h-full flex-col bg-ub-cool-grey text-gray-100">
+        <form
+          onSubmit={handleSubmit}
+          className="flex items-center gap-2 border-b border-gray-700 bg-gray-900 px-3 py-2"
         >
-          Go
-        </button>
-      </form>
+          <label htmlFor="firefox-address" className="sr-only">
+            Address
+          </label>
+          <input
+            id="firefox-address"
+            aria-label="Address"
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value)}
+            placeholder="Enter a URL"
+            className="flex-1 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-400 focus:border-blue-500 focus:outline-none"
+          />
+          <button
+            type="submit"
+            className="rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
+          >
+            Go
+          </button>
+        </form>
       <nav className="flex flex-wrap gap-1 border-b border-gray-800 bg-gray-900 px-3 py-2 text-xs">
         {BOOKMARKS.map((bookmark) => (
           <button
@@ -121,20 +126,22 @@ const Firefox: React.FC = () => {
           </button>
         ))}
       </nav>
-      <div className="flex-1 bg-black">
-        {simulation ? (
-          <FirefoxSimulationView simulation={simulation} />
-        ) : (
-          <iframe
-            key={address}
-            title="Firefox"
-            src={address}
-            className="h-full w-full border-0"
-            sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          />
-        )}
+        <div className="flex-1 bg-black">
+          {simulation ? (
+            <FirefoxSimulationView simulation={simulation} />
+          ) : (
+            <iframe
+              key={address}
+              title="Firefox"
+              src={address}
+              className="h-full w-full border-0"
+              sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            />
+          )}
+        </div>
       </div>
+      <Recorder targetRef={containerRef} />
     </div>
   );
 };

--- a/docs/firefox-recorder.md
+++ b/docs/firefox-recorder.md
@@ -1,0 +1,41 @@
+# Firefox macro recorder workflow
+
+The Firefox simulation includes a macro recorder that captures interactions inside the window and replays them with high fidelity. This guide explains how to operate the recorder, how macros are stored, and which interactions are currently unsupported.
+
+## Recording a macro
+
+1. Open the Firefox application and click **Start recording** in the macro recorder panel.
+2. Interact with the simulation as usual (type in fields, click links or buttons, submit forms, etc.).
+3. When finished, click **Stop**. The captured macro is converted to JSON and displayed in the **Macro JSON** editor.
+
+While recording, the toolbar shows the active status. The recorder automatically tags DOM elements with stable identifiers so that selectors stay consistent between sessions. Events are timestamped relative to the recording start to preserve delays and asynchronous behaviour during playback.
+
+## Exporting and importing macros
+
+- **Export**: Click the **Export** button to copy the JSON macro to the clipboard (if available) and refresh the editor contents.
+- **Import**: Paste a previously exported JSON macro into the editor and click **Import**. The recorder validates the payload and loads it for playback.
+- **Clear draft**: Clears the editor without affecting the loaded macro, handy when composing or reviewing macros manually.
+
+Macros use the `firefox.macro/1.0.0` version tag. The importer accepts any macro whose namespace matches `firefox.macro` and whose major version is `1`, allowing future backward-compatible revisions. If the version is incompatible, the recorder raises a descriptive error so contributors can migrate the macro safely.
+
+## Replaying macros
+
+1. Ensure a macro is loaded (either by recording or importing one).
+2. Click **Replay macro**. The recorder dispatches events in order, preserving the relative timing between interactions. The playback engine waits for elements to appear in the DOM (up to two seconds by default), which lets it handle asynchronous UI such as simulated network responses.
+3. After the run, the panel displays the measured fidelity and a success/failure breakdown. Macros that meet or exceed 95% accuracy are highlighted as successful replays.
+
+## Known limitations
+
+- The recorder only observes elements within the Firefox simulation container; it does not capture interactions inside cross-origin iframes because of browser sandboxing rules.
+- Drag-and-drop, pointer lock, and multi-touch gestures are not yet captured.
+- Clipboard operations are best-effort. When the Clipboard API is unavailable, the recorder keeps the JSON in the editor and reports the limitation instead of failing.
+- Extremely dynamic layouts may rename or remove the DOM elements that macros rely on. When that happens, replay fidelity may drop and the panel will report the affected events.
+
+## Testing strategy
+
+Unit tests cover two canonical flows:
+
+1. Recording and replaying standard input and click interactions, ensuring the recorded macro round-trips correctly and achieves at least 95% fidelity.
+2. Replaying a macro against UI that mounts asynchronously, validating that the wait logic handles delayed DOM nodes without regressing accuracy.
+
+These tests run under Jest with fake timers for deterministic scheduling and enforce the fidelity guarantees that the recorder advertises.


### PR DESCRIPTION
## Summary
- add a recorder overlay to the Firefox simulation that captures user interactions and exports/imports JSON macros
- implement versioned macro serialization plus a playback engine that replays events with async element waiting
- document the workflow and add Jest coverage to verify 95%+ fidelity for canonical scenarios

## Testing
- yarn lint components/apps/firefox
- yarn test firefoxRecorder

------
https://chatgpt.com/codex/tasks/task_e_68dc937adb508328a702a27898b91fe5