### PR TITLE
[hydra] add anonymized credential playbooks

### DIFF
--- a/__tests__/hydra-credsets.test.ts
+++ b/__tests__/hydra-credsets.test.ts
@@ -1,0 +1,63 @@
+import { webcrypto } from 'node:crypto';
+import { redactText } from '../utils/redaction';
+import {
+  defaultDraft,
+  toCredentialSet,
+  validateCredentialDraft,
+} from '../components/apps/hydra/credsetsLogic';
+import {
+  HYDRA_CREDSET_STORAGE_KEY,
+  loadHydraCredentialSets,
+  saveHydraCredentialSets,
+} from '../components/apps/hydra/credsetsStorage';
+
+describe('Hydra credential set helpers', () => {
+  beforeAll(() => {
+    if (!global.crypto || !(global.crypto as Crypto).subtle) {
+      Object.defineProperty(global, 'crypto', {
+        value: webcrypto,
+      });
+    }
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('redacts sensitive password assignments', () => {
+    const input = 'password=SuperSecret123';
+    const result = redactText(input);
+    expect(result).toContain('<redacted:password>');
+    expect(result).not.toContain('SuperSecret123');
+  });
+
+  it('flags drafts that contain raw secrets', () => {
+    const draft = {
+      ...defaultDraft,
+      label: 'Production VPN',
+      alias: 'analyst-tier1',
+      secret: 'password=Spring2025!',
+    };
+    const validation = validateCredentialDraft(draft);
+    expect(validation.errors.some((error) => error.field === 'secret')).toBe(true);
+  });
+
+  it('persists credential sets via the secure store', async () => {
+    const draft = {
+      ...defaultDraft,
+      label: 'VPN Portal',
+      alias: 'Tier1 Analyst',
+      secret: '12 char rotated quarterly',
+      notes: 'MFA required; reset via service desk.',
+      tags: 'vpn,internal',
+    };
+    const set = toCredentialSet(draft);
+    await saveHydraCredentialSets([set]);
+    const stored = localStorage.getItem(HYDRA_CREDSET_STORAGE_KEY);
+    expect(stored).toBeTruthy();
+    expect(stored).not.toContain('Tier1 Analyst');
+
+    const loaded = await loadHydraCredentialSets();
+    expect(loaded).toEqual([set]);
+  });
+});

--- a/components/apps/hydra/CredSets.tsx
+++ b/components/apps/hydra/CredSets.tsx
@@ -1,0 +1,382 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  patternDescriptions,
+  detectSensitiveContent,
+  redactRecord,
+} from '../../../utils/redaction';
+import {
+  defaultDraft,
+  toCredentialSet,
+  validateCredentialDraft,
+  type CredentialDraft,
+  type CredentialSet,
+} from './credsetsLogic';
+import { loadHydraCredentialSets, saveHydraCredentialSets } from './credsetsStorage';
+
+const warningFromPattern = (pattern: string): string =>
+  patternDescriptions[pattern] || `Sensitive pattern detected: ${pattern}`;
+
+const createDraftFromSet = (set: CredentialSet): CredentialDraft => ({
+  label: set.label,
+  alias: set.usernameAlias,
+  secret: set.passwordSummary,
+  notes: set.notes,
+  tags: set.tags.join(', '),
+});
+
+const CredSets: React.FC = () => {
+  const [credentialSets, setCredentialSets] = useState<CredentialSet[]>([]);
+  const [draft, setDraft] = useState<CredentialDraft>(defaultDraft);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [errors, setErrors] = useState<Partial<Record<keyof CredentialDraft, string>>>({});
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const [status, setStatus] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    let alive = true;
+    loadHydraCredentialSets()
+      .then((sets) => {
+        if (!alive) return;
+        setCredentialSets(sets);
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const anonymizedExport = useMemo(
+    () =>
+      credentialSets.map((set) =>
+        redactRecord({ ...set }, ['usernameAlias', 'passwordSummary', 'notes']),
+      ),
+    [credentialSets],
+  );
+
+  const upsertCredentialSet = (next: CredentialSet) => {
+    setCredentialSets((prev) => {
+      const exists = prev.some((item) => item.id === next.id);
+      const updated = exists
+        ? prev.map((item) => (item.id === next.id ? next : item))
+        : [...prev, next];
+      void saveHydraCredentialSets(updated);
+      return updated;
+    });
+  };
+
+  const deleteCredentialSet = (id: string) => {
+    setCredentialSets((prev) => {
+      const filtered = prev.filter((item) => item.id !== id);
+      void saveHydraCredentialSets(filtered);
+      return filtered;
+    });
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const validation = validateCredentialDraft(draft);
+    const errorMap: Partial<Record<keyof CredentialDraft, string>> = {};
+    validation.errors.forEach((error) => {
+      errorMap[error.field] = error.message;
+    });
+    setErrors(errorMap);
+    setWarnings(validation.warnings);
+    if (validation.errors.length > 0) {
+      setStatus('Fix the highlighted fields before saving.');
+      return;
+    }
+    const base = editingId
+      ? credentialSets.find((item) => item.id === editingId)
+      : undefined;
+    const record = toCredentialSet(draft, base);
+    upsertCredentialSet(record);
+    setStatus(editingId ? 'Credential playbook updated.' : 'Credential playbook saved.');
+    setDraft(defaultDraft);
+    setEditingId(null);
+    setErrors({});
+  };
+
+  const handleEdit = (set: CredentialSet) => {
+    setDraft(createDraftFromSet(set));
+    setEditingId(set.id);
+    setWarnings([]);
+    setErrors({});
+    setStatus('Editing existing playbook.');
+  };
+
+  const handleDelete = (set: CredentialSet) => {
+    const confirmed = window.confirm(
+      `Remove "${set.label}"? This only deletes the anonymized playbook.`,
+    );
+    if (!confirmed) return;
+    deleteCredentialSet(set.id);
+    if (editingId === set.id) {
+      setEditingId(null);
+      setDraft(defaultDraft);
+    }
+    setStatus('Credential playbook removed.');
+  };
+
+  const handleCancelEdit = () => {
+    setDraft(defaultDraft);
+    setEditingId(null);
+    setErrors({});
+    setWarnings([]);
+    setStatus('');
+  };
+
+  const handleFieldChange = <K extends keyof CredentialDraft>(
+    field: K,
+    value: CredentialDraft[K],
+  ) => {
+    setDraft((prev) => ({ ...prev, [field]: value }));
+    setErrors((prev) => ({ ...prev, [field]: undefined }));
+  };
+
+  const handlePaste = (field: keyof CredentialDraft) =>
+    (event: React.ClipboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const text = event.clipboardData?.getData('text') || '';
+      if (!text) return;
+      const matches = detectSensitiveContent(text);
+      if (matches.length) {
+        setWarnings((prev) => {
+          const merged = new Set(prev);
+          matches.forEach((match) => merged.add(warningFromPattern(match)));
+          return Array.from(merged);
+        });
+      }
+      if (field !== 'notes' && matches.length) {
+        setStatus('We spotted sensitive looking data in the paste. Double-check anonymization.');
+      }
+    };
+
+  const handleExport = () => {
+    if (!credentialSets.length) {
+      setStatus('Create at least one playbook before exporting.');
+      return;
+    }
+    const blob = new Blob([JSON.stringify(anonymizedExport, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'hydra-credential-playbooks.json';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    setStatus('Anonymized credential export generated.');
+  };
+
+  return (
+    <section className="mt-6 bg-gray-800/60 border border-gray-700 rounded p-4" aria-label="Credential playbooks">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-4">
+        <div className="flex items-center gap-2">
+          <img
+            src="/themes/Yaru/status/dialog-password-symbolic.svg"
+            alt=""
+            aria-hidden="true"
+            className="w-5 h-5"
+          />
+          <div>
+            <h2 className="text-lg font-semibold">Credential playbooks</h2>
+            <p className="text-sm text-gray-300">
+              Plan login simulations with aliases—never store actual usernames or passwords.
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={handleExport}
+          className="self-start md:self-auto px-3 py-1.5 bg-gray-700 hover:bg-gray-600 rounded text-sm"
+        >
+          Export anonymized JSON
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="grid gap-3" noValidate>
+        <div className="grid gap-3 md:grid-cols-2">
+          <div>
+            <label className="block text-sm font-semibold mb-1" htmlFor="cred-label">
+              Playbook label
+            </label>
+            <input
+              id="cred-label"
+              type="text"
+              value={draft.label}
+              onChange={(event) => handleFieldChange('label', event.target.value)}
+              onPaste={handlePaste('label')}
+              className="w-full rounded bg-gray-900 border border-gray-700 p-2 text-sm"
+              placeholder="Internal VPN"
+            />
+            {errors.label && <p className="text-xs text-red-400 mt-1">{errors.label}</p>}
+          </div>
+          <div>
+            <label className="block text-sm font-semibold mb-1" htmlFor="cred-alias">
+              User alias / persona
+            </label>
+            <input
+              id="cred-alias"
+              type="text"
+              value={draft.alias}
+              onChange={(event) => handleFieldChange('alias', event.target.value)}
+              onPaste={handlePaste('alias')}
+              className="w-full rounded bg-gray-900 border border-gray-700 p-2 text-sm"
+              placeholder="Tier1 Analyst"
+            />
+            {errors.alias && <p className="text-xs text-red-400 mt-1">{errors.alias}</p>}
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm font-semibold mb-1" htmlFor="cred-secret">
+            Authentication summary (no real passwords)
+          </label>
+          <textarea
+            id="cred-secret"
+            value={draft.secret}
+            onChange={(event) => handleFieldChange('secret', event.target.value)}
+            onPaste={handlePaste('secret')}
+            className="w-full rounded bg-gray-900 border border-gray-700 p-2 text-sm min-h-[80px]"
+            placeholder="8-char seasonal theme + birth year"
+          />
+          {errors.secret && <p className="text-xs text-red-400 mt-1">{errors.secret}</p>}
+        </div>
+        <div className="grid gap-3 md:grid-cols-2">
+          <div>
+            <label className="block text-sm font-semibold mb-1" htmlFor="cred-tags">
+              Tags
+            </label>
+            <input
+              id="cred-tags"
+              type="text"
+              value={draft.tags}
+              onChange={(event) => handleFieldChange('tags', event.target.value)}
+              onPaste={handlePaste('tags')}
+              className="w-full rounded bg-gray-900 border border-gray-700 p-2 text-sm"
+              placeholder="vpn, okta, privileged"
+            />
+            <p className="text-xs text-gray-400 mt-1">
+              Comma separated labels to group playbooks (max 8).
+            </p>
+          </div>
+          <div>
+            <label className="block text-sm font-semibold mb-1" htmlFor="cred-notes">
+              Notes
+            </label>
+            <textarea
+              id="cred-notes"
+              value={draft.notes}
+              onChange={(event) => handleFieldChange('notes', event.target.value)}
+              onPaste={handlePaste('notes')}
+              className="w-full rounded bg-gray-900 border border-gray-700 p-2 text-sm min-h-[80px]"
+              placeholder="MFA required, fallback to service desk social engineering script."
+            />
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="submit"
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded text-sm"
+          >
+            {editingId ? 'Update playbook' : 'Save playbook'}
+          </button>
+          {editingId && (
+            <button
+              type="button"
+              onClick={handleCancelEdit}
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded text-sm"
+            >
+              Cancel edit
+            </button>
+          )}
+          <span className="text-xs text-gray-400">
+            Clipboard pastes are scanned for secrets to help maintain anonymization.
+          </span>
+        </div>
+      </form>
+
+      {warnings.length > 0 && (
+        <div className="mt-4 bg-yellow-900/40 border border-yellow-700 text-yellow-200 rounded p-3 text-sm">
+          <p className="font-semibold mb-2">Review anonymization</p>
+          <ul className="list-disc pl-4 space-y-1">
+            {warnings.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="mt-6">
+        <h3 className="text-md font-semibold mb-2">Saved playbooks</h3>
+        {loading ? (
+          <p className="text-sm text-gray-400">Loading saved entries…</p>
+        ) : credentialSets.length === 0 ? (
+          <p className="text-sm text-gray-400">
+            No playbooks yet. Capture credential themes, MFA requirements, or escalation paths—never raw secrets.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {credentialSets.map((set) => (
+              <li key={set.id} className="bg-gray-900/60 border border-gray-700 rounded p-3">
+                <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-2">
+                  <div>
+                    <h4 className="font-semibold text-sm">{set.label}</h4>
+                    <p className="text-xs text-gray-400">Alias: {set.usernameAlias}</p>
+                    <p className="text-sm text-gray-200 mt-1 whitespace-pre-wrap">
+                      {set.passwordSummary}
+                    </p>
+                    {set.notes && (
+                      <p className="text-xs text-gray-300 mt-2 whitespace-pre-wrap">{set.notes}</p>
+                    )}
+                    {set.tags.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {set.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="text-[11px] uppercase tracking-wide bg-gray-800 border border-gray-700 px-2 py-0.5 rounded"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleEdit(set)}
+                      className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 rounded text-sm"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(set)}
+                      className="px-3 py-1.5 bg-red-700 hover:bg-red-600 rounded text-sm"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {status && (
+        <p className="mt-4 text-sm text-emerald-400" role="status" aria-live="polite">
+          {status}
+        </p>
+      )}
+    </section>
+  );
+};
+
+export default CredSets;

--- a/components/apps/hydra/credsetsLogic.ts
+++ b/components/apps/hydra/credsetsLogic.ts
@@ -1,0 +1,184 @@
+import { detectSensitiveContent, patternDescriptions } from '../../../utils/redaction';
+
+export interface CredentialDraft {
+  label: string;
+  alias: string;
+  secret: string;
+  notes: string;
+  tags: string;
+}
+
+export interface CredentialSet {
+  id: string;
+  label: string;
+  usernameAlias: string;
+  passwordSummary: string;
+  notes: string;
+  tags: string[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ValidationError {
+  field: keyof CredentialDraft;
+  message: string;
+  code: string;
+}
+
+export interface ValidationResult {
+  errors: ValidationError[];
+  warnings: string[];
+}
+
+export const defaultDraft: CredentialDraft = {
+  label: '',
+  alias: '',
+  secret: '',
+  notes: '',
+  tags: '',
+};
+
+const aliasWarningPatterns = new Set([
+  'email-address',
+  'ipv4-address',
+]);
+
+const blockingPatterns = new Set([
+  'private-key-block',
+  'password-assignment',
+  'api-token',
+  'aws-secret-key',
+  'ssh-inline-secret',
+  'credit-card',
+]);
+
+const ALIAS_MAX_LENGTH = 120;
+const LABEL_MAX_LENGTH = 80;
+const SUMMARY_MAX_LENGTH = 200;
+const NOTES_MAX_LENGTH = 1000;
+
+const createId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `cred-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+};
+
+export const normalizeTags = (input: string): string[] =>
+  input
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .slice(0, 8);
+
+const sanitizeMultiline = (value: string, max = NOTES_MAX_LENGTH): string =>
+  value
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, max);
+
+export const toCredentialSet = (
+  draft: CredentialDraft,
+  base?: CredentialSet,
+): CredentialSet => {
+  const now = Date.now();
+  return {
+    id: base?.id ?? createId(),
+    label: draft.label.trim().slice(0, LABEL_MAX_LENGTH),
+    usernameAlias: draft.alias.trim().slice(0, ALIAS_MAX_LENGTH),
+    passwordSummary: draft.secret.trim().slice(0, SUMMARY_MAX_LENGTH),
+    notes: sanitizeMultiline(draft.notes, NOTES_MAX_LENGTH),
+    tags: normalizeTags(draft.tags),
+    createdAt: base?.createdAt ?? now,
+    updatedAt: now,
+  };
+};
+
+const describeMatches = (matches: string[]): string[] =>
+  matches
+    .map((match) => patternDescriptions[match])
+    .filter(Boolean);
+
+export const validateCredentialDraft = (draft: CredentialDraft): ValidationResult => {
+  const errors: ValidationError[] = [];
+  const warnings: string[] = [];
+
+  if (!draft.label.trim()) {
+    errors.push({ field: 'label', code: 'required', message: 'Label is required.' });
+  } else if (draft.label.trim().length > LABEL_MAX_LENGTH) {
+    errors.push({
+      field: 'label',
+      code: 'length',
+      message: `Keep labels under ${LABEL_MAX_LENGTH} characters.`,
+    });
+  }
+
+  if (!draft.alias.trim()) {
+    errors.push({ field: 'alias', code: 'required', message: 'Provide an anonymized alias.' });
+  } else if (draft.alias.length > ALIAS_MAX_LENGTH) {
+    errors.push({
+      field: 'alias',
+      code: 'length',
+      message: `Alias should stay under ${ALIAS_MAX_LENGTH} characters.`,
+    });
+  }
+
+  if (!draft.secret.trim()) {
+    errors.push({
+      field: 'secret',
+      code: 'required',
+      message: 'Summarize the authentication posture without the real password.',
+    });
+  } else if (draft.secret.length > SUMMARY_MAX_LENGTH) {
+    errors.push({
+      field: 'secret',
+      code: 'length',
+      message: `Keep summaries under ${SUMMARY_MAX_LENGTH} characters.`,
+    });
+  }
+
+  if (draft.notes.length > NOTES_MAX_LENGTH) {
+    errors.push({
+      field: 'notes',
+      code: 'length',
+      message: `Notes are capped at ${NOTES_MAX_LENGTH} characters to avoid data dumps.`,
+    });
+  }
+
+  const aliasMatches = detectSensitiveContent(draft.alias);
+  const summaryMatches = detectSensitiveContent(draft.secret);
+  const noteMatches = detectSensitiveContent(draft.notes);
+
+  for (const match of aliasMatches) {
+    const description = patternDescriptions[match];
+    if (blockingPatterns.has(match)) {
+      errors.push({
+        field: 'alias',
+        code: 'sensitive',
+        message: description || 'Sensitive data detected in alias.',
+      });
+    } else if (aliasWarningPatterns.has(match)) {
+      warnings.push(description || 'Alias should avoid personal identifiers.');
+    }
+  }
+
+  for (const match of summaryMatches) {
+    const description = patternDescriptions[match];
+    if (blockingPatterns.has(match) || match === 'aws-access-key') {
+      errors.push({
+        field: 'secret',
+        code: 'sensitive',
+        message: description || 'Sensitive data detected in summary.',
+      });
+    } else {
+      warnings.push(description || 'Review the summary for anonymization.');
+    }
+  }
+
+  warnings.push(...describeMatches(noteMatches));
+
+  return {
+    errors,
+    warnings: Array.from(new Set(warnings.filter(Boolean))).slice(0, 6),
+  };
+};

--- a/components/apps/hydra/credsetsStorage.ts
+++ b/components/apps/hydra/credsetsStorage.ts
@@ -1,0 +1,13 @@
+import { secureLoad, secureSave } from '../../../utils/secureStore';
+import type { CredentialSet } from './credsetsLogic';
+
+export const HYDRA_CREDSET_STORAGE_KEY = 'hydra/credential-sets';
+
+export const loadHydraCredentialSets = async (): Promise<CredentialSet[]> =>
+  secureLoad<CredentialSet[]>(HYDRA_CREDSET_STORAGE_KEY, []);
+
+export const saveHydraCredentialSets = async (
+  sets: CredentialSet[],
+): Promise<void> => {
+  await secureSave(HYDRA_CREDSET_STORAGE_KEY, sets);
+};

--- a/components/apps/hydra/index.js
+++ b/components/apps/hydra/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState, useMemo } from 'react';
 import Stepper from './Stepper';
 import AttemptTimeline from './Timeline';
+import CredSets from './CredSets';
 
 const baseServices = ['ssh', 'ftp', 'http-get', 'http-post-form', 'smtp'];
 const pluginServices = [];
@@ -636,6 +637,8 @@ const HydraApp = () => {
           )}
         </div>
       </div>
+
+      <CredSets />
 
       <Stepper
         active={running && !paused}

--- a/docs/hydra-credsets.md
+++ b/docs/hydra-credsets.md
@@ -1,0 +1,23 @@
+# Hydra Credential Playbooks
+
+The Hydra simulation now ships with a "Credential playbooks" panel for planning
+red-team credential sprays without ever storing live secrets.
+
+## Safe usage guidelines
+
+- **Only log anonymized data.** Replace real usernames and passwords with role
+  names, password composition patterns, or MFA notes.
+- **Do not paste secrets.** The UI warns when clipboard data looks sensitive,
+  but it will still store whatever you enter. Sanitize the text before saving.
+- **Exported files are redacted.** JSON exports automatically mask secret-like
+  strings and are intended for tabletop exercises or documentation.
+- **Stay client-side.** Entries live in the browser using encrypted storage;
+  clearing the browser data removes them.
+- **Simulation only.** This feature documents hypothetical attack paths. Do not
+  connect it to real infrastructure or use it to launch attacks.
+
+## Disclaimers
+
+The credential manager is an educational aid. It cannot guarantee that data you
+enter is free of secrets—review every record before saving or sharing exports.
+Neither the maintainers nor contributors assume liability for misuse.

--- a/utils/redaction.ts
+++ b/utils/redaction.ts
@@ -1,0 +1,118 @@
+"use client";
+
+export interface SensitivePattern {
+  name: string;
+  regex: RegExp;
+  description: string;
+  replacement?: string | ((match: string, ...groups: string[]) => string);
+}
+
+const emailRegex = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+const ipv4Regex = /\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)(?:\.(?!$)|$)){4}\b/g;
+
+export const sensitivePatterns: SensitivePattern[] = [
+  {
+    name: 'private-key-block',
+    regex: /-----BEGIN [^-]+PRIVATE KEY-----[\s\S]*?-----END [^-]+PRIVATE KEY-----/gi,
+    description: 'Detected what looks like a private key block.',
+    replacement: '<redacted:private-key>',
+  },
+  {
+    name: 'ssh-inline-secret',
+    regex: /(sshpass\s+-p\s+)(["']?)([^"'\s]+)(\2)/gi,
+    description: 'Inline sshpass secrets should never be stored.',
+    replacement: (_match, prefix: string) => `${prefix}<redacted:sshpass>` ,
+  },
+  {
+    name: 'password-assignment',
+    regex: /(password\s*[=:]\s*)(["']?)([^"'\s]+)(\2)/gi,
+    description: 'Found a direct password assignment.',
+    replacement: (_match, prefix: string) => `${prefix}<redacted:password>`,
+  },
+  {
+    name: 'api-token',
+    regex: /(api[_-]?key|token|secret)\s*[=:]\s*(["']?)([^"'\s]+)(\2)/gi,
+    description: 'API tokens or secrets should stay out of saved sets.',
+    replacement: (_match, prefix: string) => `${prefix}<redacted:token>`,
+  },
+  {
+    name: 'aws-access-key',
+    regex: /\bAKIA[0-9A-Z]{16}\b/g,
+    description: 'Potential AWS access key detected.',
+    replacement: '<redacted:aws-access-key>',
+  },
+  {
+    name: 'aws-secret-key',
+    regex: /\b(?:[A-Za-z0-9+\/=]{40})\b/g,
+    description: 'Potential AWS secret access key detected.',
+    replacement: '<redacted:aws-secret>',
+  },
+  {
+    name: 'email-address',
+    regex: emailRegex,
+    description: 'Email addresses count as personal data; prefer aliases.',
+    replacement: '<redacted:email>',
+  },
+  {
+    name: 'ipv4-address',
+    regex: ipv4Regex,
+    description: 'Direct IP addresses should be generalized.',
+    replacement: '<redacted:ip>',
+  },
+  {
+    name: 'credit-card',
+    regex: /\b(?:\d[ -]?){13,19}\b/g,
+    description: 'Number sequence resembles payment data and was masked.',
+    replacement: '<redacted:number>',
+  },
+];
+
+export const patternDescriptions: Record<string, string> = sensitivePatterns.reduce(
+  (acc, pattern) => {
+    acc[pattern.name] = pattern.description;
+    return acc;
+  },
+  {} as Record<string, string>,
+);
+
+const applyReplacement = (
+  text: string,
+  pattern: SensitivePattern,
+): string => {
+  pattern.regex.lastIndex = 0;
+  if (typeof pattern.replacement === 'function') {
+    return text.replace(pattern.regex, (...args) => pattern.replacement!(...args));
+  }
+  const replacement = pattern.replacement ?? '<redacted>';
+  return text.replace(pattern.regex, replacement);
+};
+
+export const redactText = (input: string): string => {
+  if (!input) return '';
+  return sensitivePatterns.reduce((text, pattern) => applyReplacement(text, pattern), input);
+};
+
+export const detectSensitiveContent = (input: string | null | undefined): string[] => {
+  if (!input) return [];
+  const matches = new Set<string>();
+  for (const pattern of sensitivePatterns) {
+    pattern.regex.lastIndex = 0;
+    if (pattern.regex.test(input)) {
+      matches.add(pattern.name);
+    }
+  }
+  return Array.from(matches);
+};
+
+export const redactRecord = <T extends Record<string, unknown>>(record: T, fields: Array<keyof T>): T => {
+  const clone = { ...record };
+  for (const field of fields) {
+    const value = clone[field];
+    if (typeof value === 'string') {
+      clone[field] = redactText(value) as T[typeof field];
+    }
+  }
+  return clone;
+};
+
+export default redactText;

--- a/utils/secureStore.ts
+++ b/utils/secureStore.ts
@@ -1,0 +1,138 @@
+"use client";
+
+import { safeLocalStorage } from './safeStorage';
+
+const KEY_MATERIAL = 'kali-hydra-credsets::material';
+const KEY_SALT = 'kali-hydra-credsets::salt-v1';
+
+interface SecurePayload {
+  version: number;
+  iv: string;
+  data: string;
+}
+
+const textEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+const textDecoder = typeof TextDecoder !== 'undefined' ? new TextDecoder() : null;
+
+const getCrypto = () =>
+  (typeof globalThis !== 'undefined' && (globalThis.crypto || (globalThis as any).msCrypto)) ||
+  undefined;
+
+let keyPromise: Promise<CryptoKey | null> | null = null;
+
+const deriveKey = async (): Promise<CryptoKey | null> => {
+  const crypto = getCrypto();
+  if (!crypto?.subtle || !textEncoder) return null;
+  if (!keyPromise) {
+    keyPromise = (async () => {
+      const material = await crypto.subtle.importKey(
+        'raw',
+        textEncoder.encode(KEY_MATERIAL),
+        'PBKDF2',
+        false,
+        ['deriveKey'],
+      );
+      return crypto.subtle.deriveKey(
+        {
+          name: 'PBKDF2',
+          salt: textEncoder.encode(KEY_SALT),
+          iterations: 150000,
+          hash: 'SHA-256',
+        },
+        material,
+        {
+          name: 'AES-GCM',
+          length: 256,
+        },
+        false,
+        ['encrypt', 'decrypt'],
+      );
+    })().catch(() => null);
+  }
+  return keyPromise;
+};
+
+const toBase64 = (buffer: ArrayBuffer | Uint8Array): string => {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64');
+  }
+  let binary = '';
+  bytes.forEach((b) => {
+    binary += String.fromCharCode(b);
+  });
+  return btoa(binary);
+};
+
+const fromBase64 = (value: string): Uint8Array => {
+  if (typeof Buffer !== 'undefined') {
+    return Uint8Array.from(Buffer.from(value, 'base64'));
+  }
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+};
+
+const isSecurePayload = (value: unknown): value is SecurePayload =>
+  Boolean(
+    value &&
+      typeof value === 'object' &&
+      'version' in value &&
+      'iv' in value &&
+      'data' in value,
+  );
+
+export const secureSave = async (storageKey: string, value: unknown): Promise<void> => {
+  if (!safeLocalStorage) return;
+  const crypto = getCrypto();
+  const key = await deriveKey();
+  try {
+    if (key && crypto?.subtle && textEncoder) {
+      const iv = crypto.getRandomValues(new Uint8Array(12));
+      const encoded = textEncoder.encode(JSON.stringify(value));
+      const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoded);
+      const payload: SecurePayload = {
+        version: 1,
+        iv: toBase64(iv),
+        data: toBase64(encrypted),
+      };
+      safeLocalStorage.setItem(storageKey, JSON.stringify(payload));
+      return;
+    }
+  } catch {
+    // fall through to plain storage
+  }
+  safeLocalStorage.setItem(storageKey, JSON.stringify(value));
+};
+
+export const secureLoad = async <T>(storageKey: string, fallback: T): Promise<T> => {
+  if (!safeLocalStorage) return fallback;
+  const raw = safeLocalStorage.getItem(storageKey);
+  if (!raw) return fallback;
+  try {
+    const parsed = JSON.parse(raw);
+    if (isSecurePayload(parsed)) {
+      const key = await deriveKey();
+      const crypto = getCrypto();
+      if (!key || !crypto?.subtle || !textDecoder) return fallback;
+      const iv = fromBase64(parsed.iv);
+      const data = fromBase64(parsed.data);
+      const decrypted = await crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv },
+        key,
+        data,
+      );
+      return JSON.parse(textDecoder.decode(decrypted));
+    }
+    return parsed as T;
+  } catch {
+    return fallback;
+  }
+};
+
+export const secureRemove = (storageKey: string): void => {
+  safeLocalStorage?.removeItem(storageKey);
+};


### PR DESCRIPTION
## Summary
- add a credential playbook manager to Hydra with anonymized CRUD flows, paste warnings, and redacted exports
- introduce reusable redaction + secure storage utilities and wire Hydra to encrypted persistence
- document safe usage guidelines and cover redaction, validation, and storage with new tests

## Testing
- yarn test hydra-credsets

------
https://chatgpt.com/codex/tasks/task_e_68dc9386619083288e7d074df9ed1968