### PR TITLE
[desktop] add extension diagnostics overlay

### DIFF
--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -21,6 +21,14 @@ function DesktopMenu(props) {
         props.openApp("settings");
     }
 
+    const openDiagnostics = () => {
+        if (typeof props.openExtensionDiagnostics === 'function') {
+            props.openExtensionDiagnostics();
+        } else if (typeof window !== 'undefined') {
+            window.dispatchEvent(new Event('extensions:diagnostics:open'));
+        }
+    }
+
     const checkFullScreen = () => {
         if (document.fullscreenElement) {
             setIsFullScreen(true)
@@ -127,6 +135,16 @@ function DesktopMenu(props) {
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
                 <span className="ml-5">Clear Session</span>
+            </button>
+            <Devider />
+            <button
+                onClick={openDiagnostics}
+                type="button"
+                role="menuitem"
+                aria-label="Extension Diagnostics"
+                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
+            >
+                <span className="ml-5">Extension Diagnostics</span>
             </button>
         </div>
     )

--- a/components/extensions/Diagnostics.tsx
+++ b/components/extensions/Diagnostics.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import clsx from 'clsx';
+import {
+  ExtensionDiagnosticsEntry,
+  getDiagnosticsSnapshot,
+  subscribeToDiagnostics,
+  toggleExtensionEnabled,
+} from '../../utils/extensionDiagnostics';
+
+const KEYBOARD_SHORTCUT = { ctrlKey: true, shiftKey: true, key: 'e' } as const;
+const OPEN_EVENT = 'extensions:diagnostics:open';
+const TOGGLE_EVENT = 'extensions:diagnostics:toggle';
+const CLOSE_EVENT = 'extensions:diagnostics:close';
+
+const formatDuration = (ms?: number) => {
+  if (typeof ms !== 'number') return 'Pending';
+  if (ms < 1) return '<1 ms';
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+};
+
+const formatTimestamp = (timestamp?: number) => {
+  if (!timestamp) return '—';
+  try {
+    const formatter = new Intl.DateTimeFormat(undefined, {
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+    });
+    return formatter.format(new Date(timestamp));
+  } catch {
+    return new Date(timestamp).toLocaleTimeString();
+  }
+};
+
+const useDiagnosticsData = () => {
+  const [entries, setEntries] = useState<ExtensionDiagnosticsEntry[]>(() => getDiagnosticsSnapshot());
+  useEffect(() => subscribeToDiagnostics(setEntries), []);
+  return entries;
+};
+
+const ExtensionDiagnosticsOverlay: React.FC = () => {
+  const entries = useDiagnosticsData();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const node = containerRef.current;
+    if (!node) return;
+    node.focus({ preventScroll: true });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const node = containerRef.current;
+    if (!node) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setOpen(false);
+      }
+      if (event.key === 'Tab') {
+        const focusable = Array.from(
+          node.querySelectorAll<HTMLElement>(
+            'a[href], button:not([disabled]), input, [tabindex]:not([tabindex="-1"])',
+          ),
+        );
+        if (focusable.length === 0) {
+          event.preventDefault();
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    node.addEventListener('keydown', handleKeyDown);
+    return () => node.removeEventListener('keydown', handleKeyDown);
+  }, [open]);
+
+  useEffect(() => {
+    const handleKeyboardToggle = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+        return;
+      }
+      if (
+        event.ctrlKey === KEYBOARD_SHORTCUT.ctrlKey &&
+        event.shiftKey === KEYBOARD_SHORTCUT.shiftKey &&
+        event.key.toLowerCase() === KEYBOARD_SHORTCUT.key
+      ) {
+        event.preventDefault();
+        setOpen((value) => !value);
+      }
+    };
+    window.addEventListener('keydown', handleKeyboardToggle);
+    return () => window.removeEventListener('keydown', handleKeyboardToggle);
+  }, []);
+
+  useEffect(() => {
+    const handleOpen = () => setOpen(true);
+    const handleToggle = () => setOpen((value) => !value);
+    const handleClose = () => setOpen(false);
+    window.addEventListener(OPEN_EVENT, handleOpen as EventListener);
+    window.addEventListener(TOGGLE_EVENT, handleToggle as EventListener);
+    window.addEventListener(CLOSE_EVENT, handleClose as EventListener);
+    return () => {
+      window.removeEventListener(OPEN_EVENT, handleOpen as EventListener);
+      window.removeEventListener(TOGGLE_EVENT, handleToggle as EventListener);
+      window.removeEventListener(CLOSE_EVENT, handleClose as EventListener);
+    };
+  }, []);
+
+  const summary = useMemo(() => {
+    const totalMessages = entries.reduce((sum, entry) => sum + entry.messageCount, 0);
+    const disabledCount = entries.filter((entry) => !entry.enabled).length;
+    return {
+      totalMessages,
+      disabledCount,
+    };
+  }, [entries]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center bg-slate-950/80 p-4 text-white">
+      <div
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="extension-diagnostics-title"
+        tabIndex={-1}
+        className="max-h-full w-full max-w-4xl overflow-hidden rounded-lg border border-white/10 bg-slate-900/95 shadow-2xl backdrop-blur"
+      >
+        <header className="flex items-start justify-between gap-4 border-b border-white/10 px-6 py-4">
+          <div>
+            <h2 id="extension-diagnostics-title" className="text-xl font-semibold text-white">
+              Extension diagnostics
+            </h2>
+            <p className="mt-1 text-sm text-white/70">
+              Ctrl+Shift+E to toggle · {entries.length} registered · {summary.disabledCount} disabled ·{' '}
+              {summary.totalMessages} messages logged
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="rounded border border-white/20 px-3 py-1 text-sm text-white transition hover:border-white/40 hover:bg-white/10"
+          >
+            Close
+          </button>
+        </header>
+        <div className="max-h-[70vh] overflow-auto">
+          <table className="min-w-full divide-y divide-white/10 text-sm">
+            <thead className="bg-white/5">
+              <tr>
+                <th scope="col" className="px-4 py-2 text-left font-medium text-white/80">
+                  Extension
+                </th>
+                <th scope="col" className="px-4 py-2 text-left font-medium text-white/80">
+                  Permissions
+                </th>
+                <th scope="col" className="px-4 py-2 text-left font-medium text-white/80">
+                  Init
+                </th>
+                <th scope="col" className="px-4 py-2 text-left font-medium text-white/80">
+                  Messages
+                </th>
+                <th scope="col" className="px-4 py-2 text-left font-medium text-white/80">
+                  Status
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {entries.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-6 text-center text-sm text-white/70">
+                    No extensions have registered diagnostics yet.
+                  </td>
+                </tr>
+              ) : (
+                entries.map((entry) => {
+                  const labelId = `${entry.id}-diagnostic-label`;
+                  return (
+                    <tr key={entry.id} data-extension-id={entry.id}>
+                      <th
+                        id={labelId}
+                        scope="row"
+                        className="px-4 py-3 text-left text-sm font-semibold text-white"
+                      >
+                        {entry.name}
+                        <div className="text-xs font-normal text-white/60">{entry.id}</div>
+                      </th>
+                      <td className="px-4 py-3 align-top text-xs text-white/70">
+                        {entry.permissions.length > 0 ? entry.permissions.join(', ') : '—'}
+                      </td>
+                      <td className="px-4 py-3 align-top text-xs text-white/70">
+                        <div>{formatDuration(entry.initDurationMs)}</div>
+                        <div className="mt-0.5 text-[0.65rem] uppercase tracking-wide text-white/40">
+                          started {formatTimestamp(entry.initStartedAt)}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 align-top text-xs text-white/70">
+                        <div className="font-semibold text-white">{entry.messageCount}</div>
+                        <div className="mt-0.5 text-[0.65rem] uppercase tracking-wide text-white/40">
+                          last {formatTimestamp(entry.lastMessageAt)}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 align-top text-xs text-white/70">
+                        <div className="mb-2 text-sm font-semibold">
+                          {entry.enabled ? 'Enabled' : 'Disabled'}
+                        </div>
+                        <button
+                          type="button"
+                          role="switch"
+                          aria-labelledby={labelId}
+                          aria-checked={entry.enabled}
+                          data-extension-toggle
+                          className={clsx(
+                            'flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400',
+                            entry.enabled
+                              ? 'border-emerald-400/60 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/20'
+                              : 'border-rose-400/60 bg-rose-500/10 text-rose-200 hover:bg-rose-500/20',
+                          )}
+                          onClick={() => toggleExtensionEnabled(entry.id)}
+                        >
+                          <span
+                            aria-hidden="true"
+                            className={clsx(
+                              'h-2.5 w-2.5 rounded-full',
+                              entry.enabled ? 'bg-emerald-300 shadow-[0_0_10px_rgba(16,185,129,0.6)]' : 'bg-rose-300 shadow-[0_0_10px_rgba(244,63,94,0.6)]',
+                            )}
+                          />
+                          {entry.enabled ? 'Disable' : 'Enable'}
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExtensionDiagnosticsOverlay;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -838,6 +838,12 @@ export class Desktop extends Component {
         this.setupGestureListeners();
     }
 
+    openExtensionDiagnostics = () => {
+        if (typeof window !== 'undefined') {
+            window.dispatchEvent(new Event('extensions:diagnostics:open'));
+        }
+    };
+
     componentDidUpdate(_prevProps, prevState) {
         if (
             prevState.activeWorkspace !== this.state.activeWorkspace ||
@@ -1808,6 +1814,7 @@ export class Desktop extends Component {
                     addNewFolder={this.addNewFolder}
                     openShortcutSelector={this.openShortcutSelector}
                     clearSession={() => { this.props.clearSession(); window.location.reload(); }}
+                    openExtensionDiagnostics={this.openExtensionDiagnostics}
                 />
                 <DefaultMenu active={this.state.context_menus.default} onClose={this.hideAllContextMenu} />
                 <AppMenu

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -12,6 +12,7 @@ import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import ExtensionDiagnosticsOverlay from '../components/extensions/Diagnostics';
 import NotificationCenter from '../components/common/NotificationCenter';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
@@ -163,6 +164,7 @@ function MyApp(props) {
               <div aria-live="polite" id="live-region" />
               <Component {...pageProps} />
               <ShortcutOverlay />
+              <ExtensionDiagnosticsOverlay />
               <Analytics
                 beforeSend={(e) => {
                   if (e.url.includes('/admin') || e.url.includes('/private')) return null;

--- a/tests/extension-diagnostics.spec.ts
+++ b/tests/extension-diagnostics.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test';
+
+declare global {
+  interface Window {
+    __EXTENSION_DIAGNOSTICS__?: {
+      getSnapshot: () => Array<{ id: string; enabled: boolean; messageCount: number }>;
+      setEnabled: (id: string, enabled: boolean) => boolean;
+      toggle: (id: string) => boolean;
+    };
+    __EXTENSION_MOCKS__?: {
+      notifications?: {
+        push: (input: { appId: string; title: string; timestamp?: number }) => string;
+        clear?: (appId?: string) => void;
+        enabled?: () => boolean;
+      };
+    };
+  }
+}
+
+test.describe('Extension diagnostics overlay', () => {
+  test('supports toggling extensions without breaking mocks', async ({ page }) => {
+    await page.goto('/');
+
+    await page.waitForFunction(
+      () =>
+        typeof window !== 'undefined' &&
+        Boolean(window.__EXTENSION_DIAGNOSTICS__?.getSnapshot()?.length),
+    );
+
+    await page.keyboard.press('Control+Shift+E');
+
+    const dialog = page.getByRole('dialog', { name: /Extension diagnostics/i });
+    await expect(dialog).toBeVisible();
+
+    const notificationToggle = dialog.getByRole('switch', { name: /Notification Center/i });
+    await expect(notificationToggle).toHaveAttribute('aria-checked', 'true');
+
+    await notificationToggle.click();
+    await expect(notificationToggle).toHaveAttribute('aria-checked', 'false');
+
+    const stateAfterDisable = await page.evaluate(() => {
+      const snapshot = window.__EXTENSION_DIAGNOSTICS__?.getSnapshot() ?? [];
+      return snapshot.find((entry: any) => entry.id === 'notification-center');
+    });
+    expect(stateAfterDisable?.enabled).toBe(false);
+
+    // Attempt to push a notification while disabled (should no-op)
+    const messagesWhileDisabled = await page.evaluate(() => {
+      window.__EXTENSION_MOCKS__?.notifications?.push({
+        appId: 'diagnostic-test',
+        title: 'Disabled test event',
+        timestamp: Date.now(),
+      });
+      const snapshot = window.__EXTENSION_DIAGNOSTICS__?.getSnapshot() ?? [];
+      return snapshot.find((entry: any) => entry.id === 'notification-center')?.messageCount ?? 0;
+    });
+
+    await notificationToggle.click();
+    await expect(notificationToggle).toHaveAttribute('aria-checked', 'true');
+
+    await page.evaluate(() => {
+      window.__EXTENSION_MOCKS__?.notifications?.push({
+        appId: 'diagnostic-test',
+        title: 'Enabled test event',
+        timestamp: Date.now(),
+      });
+    });
+
+    await page.waitForFunction(
+      (previous) => {
+        const snapshot = window.__EXTENSION_DIAGNOSTICS__?.getSnapshot() ?? [];
+        const entry = snapshot.find((item: any) => item.id === 'notification-center');
+        return entry && entry.enabled && entry.messageCount > previous;
+      },
+      messagesWhileDisabled,
+    );
+  });
+});

--- a/utils/extensionDiagnostics.ts
+++ b/utils/extensionDiagnostics.ts
@@ -1,0 +1,270 @@
+import { safeLocalStorage } from './safeStorage';
+
+export type ExtensionRegistration = {
+  id: string;
+  name: string;
+  permissions: readonly string[];
+};
+
+export type ExtensionDiagnosticsEntry = {
+  id: string;
+  name: string;
+  permissions: string[];
+  initStartedAt: number;
+  initCompletedAt?: number;
+  initDurationMs?: number;
+  messageCount: number;
+  lastMessageAt?: number;
+  enabled: boolean;
+  disabledAt?: number;
+};
+
+export type ExtensionHandle = {
+  markReady: (timestamp?: number) => void;
+  logMessage: (count?: number, timestamp?: number) => void;
+  dispose: () => void;
+};
+
+export type DiagnosticsListener = (entries: ExtensionDiagnosticsEntry[]) => void;
+
+type StatusListener = (enabled: boolean) => void;
+
+type InternalEntry = ExtensionDiagnosticsEntry & {
+  permissions: string[];
+};
+
+type GlobalDiagnosticsState = {
+  metrics: Map<string, InternalEntry>;
+  listeners: Set<DiagnosticsListener>;
+  statusListeners: Map<string, Set<StatusListener>>;
+  disabledIds: Set<string>;
+};
+
+const STORAGE_KEY = 'extensions:softDisabled';
+const GLOBAL_SYMBOL = Symbol.for('kali.extensionDiagnostics');
+
+type GlobalWithDiagnostics = typeof globalThis & {
+  [GLOBAL_SYMBOL]?: GlobalDiagnosticsState;
+  __EXTENSION_DIAGNOSTICS__?: {
+    getSnapshot: () => ExtensionDiagnosticsEntry[];
+    setEnabled: (id: string, enabled: boolean) => boolean;
+    toggle: (id: string) => boolean;
+    recordMessage: (id: string, count?: number, timestamp?: number) => boolean;
+  };
+};
+
+const globalObj = globalThis as GlobalWithDiagnostics;
+
+const getDiagnosticsState = (): GlobalDiagnosticsState => {
+  if (!globalObj[GLOBAL_SYMBOL]) {
+    globalObj[GLOBAL_SYMBOL] = {
+      metrics: new Map(),
+      listeners: new Set(),
+      statusListeners: new Map(),
+      disabledIds: new Set(readDisabledFromStorage()),
+    };
+  }
+  return globalObj[GLOBAL_SYMBOL]!;
+};
+
+function readDisabledFromStorage(): string[] {
+  if (!safeLocalStorage) return [];
+  try {
+    const raw = safeLocalStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((value): value is string => typeof value === 'string');
+  } catch {
+    return [];
+  }
+}
+
+function persistDisabled(ids: Set<string>) {
+  if (!safeLocalStorage) return;
+  try {
+    const list = Array.from(ids);
+    safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    // ignore
+  }
+}
+
+function cloneEntry(entry: InternalEntry): ExtensionDiagnosticsEntry {
+  return {
+    ...entry,
+    permissions: [...entry.permissions],
+  };
+}
+
+function emitDiagnostics(state: GlobalDiagnosticsState) {
+  const snapshot = Array.from(state.metrics.values())
+    .map(cloneEntry)
+    .sort((a, b) => a.name.localeCompare(b.name));
+  state.listeners.forEach((listener) => {
+    try {
+      listener(snapshot);
+    } catch {
+      // ignore listener failures
+    }
+  });
+  attachDebugInterface();
+}
+
+export const getDiagnosticsSnapshot = (): ExtensionDiagnosticsEntry[] => {
+  const state = getDiagnosticsState();
+  return Array.from(state.metrics.values())
+    .map(cloneEntry)
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
+
+export const subscribeToDiagnostics = (listener: DiagnosticsListener): (() => void) => {
+  const state = getDiagnosticsState();
+  state.listeners.add(listener);
+  listener(getDiagnosticsSnapshot());
+  return () => {
+    state.listeners.delete(listener);
+  };
+};
+
+const ensureEntry = (id: string, draft: Partial<InternalEntry> & { id: string; name: string; permissions: readonly string[] }): InternalEntry => {
+  const state = getDiagnosticsState();
+  const existing = state.metrics.get(id);
+  const now = Date.now();
+  if (existing) {
+    const mergedPermissions = new Set(existing.permissions);
+    draft.permissions.forEach((perm) => mergedPermissions.add(perm));
+    existing.permissions = Array.from(mergedPermissions);
+    existing.name = draft.name;
+    if (!existing.initStartedAt) existing.initStartedAt = now;
+    emitDiagnostics(state);
+    return existing;
+  }
+  const enabled = !state.disabledIds.has(id);
+  const entry: InternalEntry = {
+    id,
+    name: draft.name,
+    permissions: Array.from(new Set(draft.permissions)) as string[],
+    initStartedAt: draft.initStartedAt ?? now,
+    initCompletedAt: draft.initCompletedAt,
+    initDurationMs: draft.initDurationMs,
+    messageCount: draft.messageCount ?? 0,
+    lastMessageAt: draft.lastMessageAt,
+    enabled,
+    disabledAt: enabled ? undefined : now,
+  };
+  state.metrics.set(id, entry);
+  emitDiagnostics(state);
+  return entry;
+};
+
+const setEnabledInternal = (id: string, enabled: boolean): boolean => {
+  const state = getDiagnosticsState();
+  const entry = state.metrics.get(id);
+  if (!entry || entry.enabled === enabled) {
+    return Boolean(entry);
+  }
+  entry.enabled = enabled;
+  entry.disabledAt = enabled ? undefined : Date.now();
+  if (enabled) {
+    state.disabledIds.delete(id);
+  } else {
+    state.disabledIds.add(id);
+  }
+  persistDisabled(state.disabledIds);
+  const listeners = state.statusListeners.get(id);
+  if (listeners) {
+    listeners.forEach((listener) => {
+      try {
+        listener(enabled);
+      } catch {
+        // ignore
+      }
+    });
+  }
+  emitDiagnostics(state);
+  return true;
+};
+
+const recordMessageInternal = (id: string, count = 1, timestamp = Date.now()): boolean => {
+  const state = getDiagnosticsState();
+  const entry = state.metrics.get(id);
+  if (!entry) return false;
+  if (count <= 0) return true;
+  entry.messageCount += count;
+  entry.lastMessageAt = timestamp;
+  emitDiagnostics(state);
+  return true;
+};
+
+export const setExtensionEnabled = (id: string, enabled: boolean): boolean => setEnabledInternal(id, enabled);
+
+export const toggleExtensionEnabled = (id: string): boolean => {
+  const state = getDiagnosticsState();
+  const entry = state.metrics.get(id);
+  if (!entry) return false;
+  return setEnabledInternal(id, !entry.enabled);
+};
+
+export const recordExtensionMessage = (id: string, count = 1, timestamp = Date.now()): boolean =>
+  recordMessageInternal(id, count, timestamp);
+
+export const registerExtension = (
+  extension: ExtensionRegistration,
+  options?: { onEnabledChange?: StatusListener },
+): ExtensionHandle => {
+  const entry = ensureEntry(extension.id, {
+    id: extension.id,
+    name: extension.name,
+    permissions: extension.permissions,
+    initStartedAt: Date.now(),
+  });
+  if (options?.onEnabledChange) {
+    const state = getDiagnosticsState();
+    let listeners = state.statusListeners.get(extension.id);
+    if (!listeners) {
+      listeners = new Set();
+      state.statusListeners.set(extension.id, listeners);
+    }
+    listeners.add(options.onEnabledChange);
+    options.onEnabledChange(entry.enabled);
+  }
+  const handle: ExtensionHandle = {
+    markReady: (timestamp = Date.now()) => {
+      const state = getDiagnosticsState();
+      const current = state.metrics.get(extension.id);
+      if (!current) return;
+      if (!current.initCompletedAt) {
+        current.initCompletedAt = timestamp;
+        current.initDurationMs = Math.max(0, timestamp - current.initStartedAt);
+        emitDiagnostics(state);
+      }
+    },
+    logMessage: (count = 1, timestamp = Date.now()) => {
+      recordMessageInternal(extension.id, count, timestamp);
+    },
+    dispose: () => {
+      const state = getDiagnosticsState();
+      const listeners = state.statusListeners.get(extension.id);
+      if (!listeners || !options?.onEnabledChange) return;
+      listeners.delete(options.onEnabledChange);
+      if (listeners.size === 0) {
+        state.statusListeners.delete(extension.id);
+      }
+    },
+  };
+  return handle;
+};
+
+function attachDebugInterface() {
+  const existing = globalObj.__EXTENSION_DIAGNOSTICS__ ?? {};
+  globalObj.__EXTENSION_DIAGNOSTICS__ = {
+    ...existing,
+    getSnapshot: getDiagnosticsSnapshot,
+    setEnabled: setExtensionEnabled,
+    toggle: toggleExtensionEnabled,
+    recordMessage: recordExtensionMessage,
+  };
+}
+
+attachDebugInterface();


### PR DESCRIPTION
## Summary
- add an extension diagnostics overlay with keyboard shortcut support and metrics surfaced from a shared registry
- instrument simulated extensions (notification center, PiP helper) to register, honour soft-disable state, and expose diagnostics via the desktop menu
- add Playwright smoke coverage to ensure diagnostics toggles and mocks continue working

## Testing
- yarn lint --max-warnings=10
- npx playwright test tests/extension-diagnostics.spec.ts *(fails: missing system deps for Chromium in the runner)*

------
https://chatgpt.com/codex/tasks/task_e_68dccaa1a8488328a0632cd95c6394de