### PR TITLE
[core] Add crash log capture and viewer

### DIFF
--- a/__tests__/crashLog.test.ts
+++ b/__tests__/crashLog.test.ts
@@ -1,0 +1,65 @@
+import type { ErrorInfo } from 'react';
+import { exportCrashLogs, getCrashLogs, logCrash } from '../utils/crashLog';
+
+const STORAGE_KEY = 'crash-logs';
+
+describe('crashLog utilities', () => {
+  const originalWarn = console.warn;
+
+  beforeEach(() => {
+    localStorage.clear();
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+    jest.restoreAllMocks();
+  });
+
+  it('handles corrupt entries gracefully', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-json');
+
+    expect(getCrashLogs()).toEqual([]);
+
+    const validEntry = {
+      id: 'abc',
+      timestamp: '2023-01-01T00:00:00.000Z',
+      route: '/apps/test',
+      message: 'Boom',
+      stateHash: 'hash'
+    };
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([validEntry, { junk: true }]));
+
+    expect(getCrashLogs()).toEqual([validEntry]);
+  });
+
+  it('includes metadata when exporting crash logs', () => {
+    logCrash({
+      error: new Error('Boom'),
+      info: { componentStack: 'Component stack' } as ErrorInfo,
+      route: '/apps/test',
+      appId: 'terminal'
+    });
+
+    const exported = exportCrashLogs();
+    const parsed = JSON.parse(exported);
+
+    expect(parsed.meta).toEqual({
+      schemaVersion: expect.any(Number),
+      exportedAt: expect.any(String),
+      entryCount: 1
+    });
+
+    expect(Array.isArray(parsed.entries)).toBe(true);
+    expect(parsed.entries[0]).toEqual(
+      expect.objectContaining({
+        route: '/apps/test',
+        appId: 'terminal',
+        message: 'Boom',
+        stateHash: expect.any(String)
+      })
+    );
+  });
+});
+

--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { createLogger } from '../../lib/logger';
+import { logCrash } from '../../utils/crashLog';
 
 interface Props {
   children: ReactNode;
@@ -23,6 +24,7 @@ class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
     log.error('ErrorBoundary caught an error', { error, errorInfo });
+    logCrash({ error, info: errorInfo });
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/components/dev/CrashLogViewer.tsx
+++ b/components/dev/CrashLogViewer.tsx
@@ -1,0 +1,277 @@
+import { type ChangeEventHandler, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  CrashLogEntry,
+  clearCrashLogs,
+  exportCrashLogs,
+  getCrashLogs,
+  importCrashLogs,
+  removeCrashLog
+} from '../../utils/crashLog';
+
+interface FilterOption {
+  value: string;
+  label: string;
+}
+
+const ALL_ROUTES = 'all-routes';
+const ALL_APPS = 'all-apps';
+
+function buildOptions(values: (string | undefined)[], placeholder: string, allValue: string): FilterOption[] {
+  const unique = Array.from(new Set(values.filter((value): value is string => Boolean(value && value.trim())))).sort();
+  return [
+    { value: allValue, label: placeholder },
+    ...unique.map((value) => ({ value, label: value }))
+  ];
+}
+
+const CrashLogViewer = () => {
+  const [logs, setLogs] = useState<CrashLogEntry[]>([]);
+  const [routeFilter, setRouteFilter] = useState<string>(ALL_ROUTES);
+  const [appFilter, setAppFilter] = useState<string>(ALL_APPS);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [exportStatus, setExportStatus] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const refreshLogs = () => {
+    setLogs(getCrashLogs());
+  };
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    refreshLogs();
+  }, []);
+
+  useEffect(() => {
+    if (!logs.length) {
+      setRouteFilter(ALL_ROUTES);
+      setAppFilter(ALL_APPS);
+    }
+  }, [logs.length]);
+
+  const routeOptions = useMemo(
+    () => buildOptions(logs.map((log) => log.route), 'All routes', ALL_ROUTES),
+    [logs]
+  );
+
+  const appOptions = useMemo(
+    () => buildOptions(logs.map((log) => log.appId), 'All apps', ALL_APPS),
+    [logs]
+  );
+
+  const filteredLogs = useMemo(() => {
+    return logs.filter((log) => {
+      const routeMatch = routeFilter === ALL_ROUTES || log.route === routeFilter;
+      const appMatch = appFilter === ALL_APPS || log.appId === appFilter;
+      return routeMatch && appMatch;
+    });
+  }, [logs, routeFilter, appFilter]);
+
+  const handleClear = () => {
+    clearCrashLogs();
+    refreshLogs();
+  };
+
+  const handleExport = async () => {
+    const data = exportCrashLogs();
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `crash-logs-${new Date().toISOString().replace(/[:.]/g, '-')}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+
+    try {
+      await navigator.clipboard?.writeText(data);
+      setExportStatus('Exported and copied to clipboard.');
+    } catch (error) {
+      setExportStatus('Exported crash logs. Clipboard copy unavailable.');
+    }
+  };
+
+  const handleImportRequest = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImport: ChangeEventHandler<HTMLInputElement> = (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        setErrorMessage(null);
+        importCrashLogs(String(reader.result));
+        refreshLogs();
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : 'Failed to import crash logs.');
+      } finally {
+        event.target.value = '';
+      }
+    };
+    reader.onerror = () => {
+      setErrorMessage('Unable to read crash log file.');
+      event.target.value = '';
+    };
+
+    reader.readAsText(file);
+  };
+
+  const handleRemove = (id: string) => {
+    removeCrashLog(id);
+    refreshLogs();
+  };
+
+  return (
+    <div className="space-y-4 rounded-lg border border-white/20 bg-black/60 p-4 text-white">
+      <header className="flex flex-wrap items-center gap-3">
+        <h2 className="text-lg font-semibold">Crash log viewer</h2>
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={refreshLogs}
+            className="rounded border border-white/30 px-3 py-1 text-sm hover:bg-white/10"
+          >
+            Refresh
+          </button>
+          <button
+            type="button"
+            onClick={handleExport}
+            className="rounded border border-white/30 px-3 py-1 text-sm hover:bg-white/10"
+          >
+            Export
+          </button>
+          <button
+            type="button"
+            onClick={handleImportRequest}
+            className="rounded border border-white/30 px-3 py-1 text-sm hover:bg-white/10"
+          >
+            Import
+          </button>
+          <button
+            type="button"
+            onClick={handleClear}
+            className="rounded border border-red-500 px-3 py-1 text-sm text-red-300 hover:bg-red-500/20"
+          >
+            Clear all
+          </button>
+        </div>
+      </header>
+
+      <section className="flex flex-wrap gap-3">
+        <label className="flex items-center gap-2 text-sm">
+          <span>Route</span>
+          <select
+            className="rounded border border-white/20 bg-black/60 px-2 py-1 text-sm"
+            value={routeFilter}
+            onChange={(event) => setRouteFilter(event.target.value)}
+          >
+            {routeOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <span>App</span>
+          <select
+            className="rounded border border-white/20 bg-black/60 px-2 py-1 text-sm"
+            value={appFilter}
+            onChange={(event) => setAppFilter(event.target.value)}
+          >
+            {appOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+
+      {errorMessage && (
+        <p role="alert" className="rounded border border-red-500/50 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+          {errorMessage}
+        </p>
+      )}
+
+      {exportStatus && (
+        <p className="rounded border border-emerald-500/50 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200">
+          {exportStatus}
+        </p>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="application/json"
+        className="hidden"
+        onChange={handleImport}
+      />
+
+      <div className="max-h-96 overflow-auto rounded border border-white/10">
+        {filteredLogs.length === 0 ? (
+          <p className="p-4 text-sm text-white/70">No crash logs captured yet.</p>
+        ) : (
+          <table className="w-full text-left text-sm">
+            <thead className="bg-white/5 uppercase text-xs text-white/60">
+              <tr>
+                <th className="px-3 py-2">Timestamp</th>
+                <th className="px-3 py-2">Route</th>
+                <th className="px-3 py-2">App</th>
+                <th className="px-3 py-2">State hash</th>
+                <th className="px-3 py-2">Message</th>
+                <th className="px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredLogs.map((log) => (
+                <tr key={log.id} className="odd:bg-white/5">
+                  <td className="align-top px-3 py-2 font-mono text-xs text-white/80">
+                    {new Date(log.timestamp).toLocaleString()}
+                  </td>
+                  <td className="align-top px-3 py-2">
+                    <div className="max-w-xs truncate" title={log.route}>
+                      {log.route || '—'}
+                    </div>
+                  </td>
+                  <td className="align-top px-3 py-2">{log.appId ?? '—'}</td>
+                  <td className="align-top px-3 py-2 font-mono text-xs">{log.stateHash}</td>
+                  <td className="align-top px-3 py-2">
+                    <details>
+                      <summary className="cursor-pointer text-white/80 hover:text-white">{log.message}</summary>
+                      {log.stack && (
+                        <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap rounded bg-black/70 p-2 text-xs text-white/70">
+                          {log.stack}
+                        </pre>
+                      )}
+                      {log.componentStack && (
+                        <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap rounded bg-black/70 p-2 text-xs text-white/70">
+                          {log.componentStack}
+                        </pre>
+                      )}
+                    </details>
+                  </td>
+                  <td className="align-top px-3 py-2">
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(log.id)}
+                      className="rounded border border-white/30 px-2 py-1 text-xs hover:bg-white/10"
+                    >
+                      Remove
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CrashLogViewer;
+

--- a/utils/crashLog.ts
+++ b/utils/crashLog.ts
@@ -1,0 +1,241 @@
+import type { ErrorInfo } from 'react';
+
+const STORAGE_KEY = 'crash-logs';
+const MAX_ENTRIES = 100;
+const SCHEMA_VERSION = 1;
+
+export interface CrashLogEntry {
+  id: string;
+  timestamp: string;
+  route: string;
+  appId?: string;
+  message: string;
+  stack?: string;
+  componentStack?: string;
+  stateHash: string;
+}
+
+export interface CrashLogExportPayload {
+  meta: {
+    schemaVersion: number;
+    exportedAt: string;
+    entryCount: number;
+  };
+  entries: CrashLogEntry[];
+}
+
+export interface CrashLogRecordInput {
+  error: unknown;
+  info: ErrorInfo;
+  route?: string;
+  appId?: string;
+}
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch (jsonError) {
+    return String(error);
+  }
+}
+
+function toErrorStack(error: unknown): string | undefined {
+  if (error instanceof Error && typeof error.stack === 'string') {
+    return error.stack;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  return undefined;
+}
+
+function hashString(value: string): string {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0; // Convert to 32bit integer
+  }
+
+  return `h${Math.abs(hash)}`;
+}
+
+function safeParse(raw: string | null): CrashLogEntry[] {
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter((item): item is CrashLogEntry => {
+      if (!item || typeof item !== 'object') return false;
+      const candidate = item as Record<string, unknown>;
+      return (
+        typeof candidate.id === 'string' &&
+        typeof candidate.timestamp === 'string' &&
+        typeof candidate.route === 'string' &&
+        typeof candidate.message === 'string' &&
+        typeof candidate.stateHash === 'string'
+      );
+    });
+  } catch (error) {
+    console.warn('[crashLog] Failed to parse crash logs from storage', error);
+    return [];
+  }
+}
+
+function persist(entries: CrashLogEntry[]): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries.slice(-MAX_ENTRIES)));
+  } catch (error) {
+    console.warn('[crashLog] Failed to persist entries', error);
+  }
+}
+
+function detectRoute(): string {
+  if (!isBrowser()) return 'unknown';
+  try {
+    return window.location.pathname + window.location.search + window.location.hash;
+  } catch (error) {
+    return 'unknown';
+  }
+}
+
+function detectAppId(): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+
+  const selectors = [
+    '[data-context="taskbar"][data-active="true"]',
+    '[data-app-id][data-focused="true"]',
+    '[data-app-id][aria-pressed="true"]',
+    '[data-app-id]'
+  ];
+
+  for (const selector of selectors) {
+    const element = document.querySelector(selector);
+    if (element instanceof HTMLElement) {
+      const appId = element.dataset.appId;
+      if (appId) return appId;
+    }
+  }
+
+  return undefined;
+}
+
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `crash-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export function getCrashLogs(): CrashLogEntry[] {
+  if (!isBrowser()) return [];
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  return safeParse(raw);
+}
+
+export function clearCrashLogs(): void {
+  if (!isBrowser()) return;
+  window.localStorage.removeItem(STORAGE_KEY);
+}
+
+export function logCrash({ error, info, route, appId }: CrashLogRecordInput): CrashLogEntry | null {
+  if (!isBrowser()) return null;
+
+  const existing = getCrashLogs();
+  const detectedRoute = route ?? detectRoute();
+  const detectedApp = appId ?? detectAppId();
+  const stack = toErrorStack(error) ?? info.componentStack;
+  const message = toErrorMessage(error);
+
+  const stateHash = hashString([
+    detectedRoute,
+    detectedApp ?? '',
+    info.componentStack ?? '',
+    stack ?? '',
+    message
+  ].join('|'));
+
+  const entry: CrashLogEntry = {
+    id: generateId(),
+    timestamp: new Date().toISOString(),
+    route: detectedRoute,
+    appId: detectedApp,
+    message,
+    stack,
+    componentStack: info.componentStack,
+    stateHash
+  };
+
+  persist([...existing, entry]);
+
+  return entry;
+}
+
+export function exportCrashLogs(): string {
+  const entries = getCrashLogs();
+  const payload: CrashLogExportPayload = {
+    meta: {
+      schemaVersion: SCHEMA_VERSION,
+      exportedAt: new Date().toISOString(),
+      entryCount: entries.length
+    },
+    entries
+  };
+
+  return JSON.stringify(payload, null, 2);
+}
+
+export function importCrashLogs(raw: string): CrashLogEntry[] {
+  if (!isBrowser()) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error('Invalid crash log file: unable to parse JSON');
+  }
+
+  let entries: CrashLogEntry[] | null = null;
+
+  if (Array.isArray(parsed)) {
+    entries = safeParse(JSON.stringify(parsed));
+  } else if (parsed && typeof parsed === 'object' && 'entries' in parsed) {
+    const container = parsed as { entries?: unknown };
+    if (Array.isArray(container.entries)) {
+      entries = safeParse(JSON.stringify(container.entries));
+    }
+  }
+
+  if (!entries) {
+    throw new Error('Invalid crash log file: missing entries');
+  }
+
+  persist(entries);
+  return entries;
+}
+
+export function removeCrashLog(id: string): void {
+  if (!isBrowser()) return;
+  const filtered = getCrashLogs().filter((entry) => entry.id !== id);
+  persist(filtered);
+}
+


### PR DESCRIPTION
## Summary
- add a crash log utility to persist error boundary payloads with state hashes
- integrate the error boundary with crash logging and provide a dev crash log viewer
- cover corrupt entries and export metadata with unit tests

## Testing
- yarn test crashLog

------
https://chatgpt.com/codex/tasks/task_e_68dccaa2fbe083288b9538b67b20d0cb