### PR TITLE
[ui] Add tabbed layout presets and persistence

### DIFF
--- a/__tests__/tabbedWindowLayout.test.tsx
+++ b/__tests__/tabbedWindowLayout.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import TabbedWindow, { TabDefinition } from '../components/ui/TabbedWindow';
+import { DEFAULT_CASCADE_OFFSETS, TABBED_WINDOW_LAYOUT_STORAGE_KEY } from '../utils/windowLayout';
+
+const createTabs = (count: number): TabDefinition[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `tab-${index + 1}`,
+    title: `Tab ${index + 1}`,
+    content: <div>Content {index + 1}</div>,
+  }));
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('TabbedWindow layout presets', () => {
+  it('applies grid layout preset', async () => {
+    render(
+      <TabbedWindow
+        initialTabs={createTabs(3)}
+      />,
+    );
+
+    const select = screen.getByLabelText(/layout preset/i);
+    fireEvent.change(select, { target: { value: 'grid' } });
+
+    const container = await screen.findByTestId('tabbed-window-multi-layout');
+    expect(container).toHaveAttribute('data-layout-mode', 'grid');
+    expect(container.querySelector('.grid')).not.toBeNull();
+    const panels = screen.getAllByTestId('tabbed-window-panel');
+    expect(panels).toHaveLength(3);
+  });
+
+  it('cascades panels with deterministic spacing', async () => {
+    render(<TabbedWindow initialTabs={createTabs(2)} />);
+
+    const select = screen.getByLabelText(/layout preset/i);
+    fireEvent.change(select, { target: { value: 'cascade' } });
+
+    const container = await screen.findByTestId('tabbed-window-multi-layout');
+    expect(container).toHaveAttribute('data-layout-mode', 'cascade');
+    const panels = screen.getAllByTestId('tabbed-window-panel');
+    expect(panels[0].style.top).toBe('0px');
+    expect(panels[0].style.left).toBe('0px');
+    expect(panels[1].style.top).toBe(`${DEFAULT_CASCADE_OFFSETS.y}px`);
+    expect(panels[1].style.left).toBe(`${DEFAULT_CASCADE_OFFSETS.x}px`);
+  });
+
+  it('persists layout selection across reloads', async () => {
+    const layoutKey = 'test-layout';
+    const first = render(
+      <TabbedWindow
+        initialTabs={createTabs(2)}
+        layoutStorageKey={layoutKey}
+      />,
+    );
+
+    const select = screen.getByLabelText(/layout preset/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'grid' } });
+
+    await waitFor(() => {
+      const stored = localStorage.getItem(TABBED_WINDOW_LAYOUT_STORAGE_KEY);
+      expect(stored).toContain(layoutKey);
+      expect(stored).toContain('grid');
+    });
+
+    first.unmount();
+
+    render(
+      <TabbedWindow
+        initialTabs={createTabs(2)}
+        layoutStorageKey={layoutKey}
+      />,
+    );
+
+    const persistedSelect = screen.getByLabelText(/layout preset/i) as HTMLSelectElement;
+    expect(persistedSelect.value).toBe('grid');
+    const gridContainer = await screen.findByTestId('tabbed-window-multi-layout');
+    expect(gridContainer).toHaveAttribute('data-layout-mode', 'grid');
+  });
+});
+

--- a/apps/http/index.tsx
+++ b/apps/http/index.tsx
@@ -76,6 +76,7 @@ const HTTPPreview: React.FC = () => {
       className="min-h-screen bg-gray-900 text-white"
       initialTabs={[createTab()]}
       onNewTab={createTab}
+      layoutStorageKey="http-request-layout"
     />
   );
 };

--- a/apps/hydra/index.tsx
+++ b/apps/hydra/index.tsx
@@ -19,7 +19,11 @@ const HydraPreview: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gray-900 text-white">
-      <TabbedWindow initialTabs={[createTab()]} onNewTab={createTab} />
+      <TabbedWindow
+        initialTabs={[createTab()]}
+        onNewTab={createTab}
+        layoutStorageKey="hydra-session-layout"
+      />
       <StrategyTrainer />
     </div>
   );

--- a/apps/reaver/index.tsx
+++ b/apps/reaver/index.tsx
@@ -367,6 +367,7 @@ const ReaverPage: React.FC = () => {
       className="min-h-screen bg-gray-900 text-white"
       initialTabs={[createTab()]}
       onNewTab={createTab}
+      layoutStorageKey="reaver-session-layout"
     />
   );
 };

--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -85,6 +85,7 @@ const SSHPreview: React.FC = () => {
       className="min-h-screen bg-gray-900 text-white"
       initialTabs={[createTab()]}
       onNewTab={createTab}
+      layoutStorageKey="ssh-session-layout"
     />
   );
 };

--- a/apps/terminal/tabs/index.tsx
+++ b/apps/terminal/tabs/index.tsx
@@ -21,6 +21,7 @@ const TerminalTabs: React.FC<TerminalProps> = ({ openApp }) => {
       className="h-full w-full"
       initialTabs={[createTab()]}
       onNewTab={createTab}
+      layoutStorageKey="terminal-session-layout"
     />
   );
 };

--- a/utils/windowLayout.js
+++ b/utils/windowLayout.js
@@ -1,3 +1,5 @@
+import { safeLocalStorage } from './safeStorage';
+
 const NAVBAR_SELECTOR = '.main-navbar-vp';
 const DEFAULT_NAVBAR_HEIGHT = 48;
 const WINDOW_TOP_MARGIN = 16;
@@ -65,4 +67,57 @@ export const clampWindowTopPosition = (value, topOffset) => {
     return safeOffset;
   }
   return Math.max(value, safeOffset);
+};
+
+export const TABBED_WINDOW_LAYOUT_STORAGE_KEY = 'tabbed-window-layouts';
+export const DEFAULT_TABBED_LAYOUT = 'tabs';
+export const DEFAULT_CASCADE_OFFSETS = { x: 32, y: 28 };
+
+const readStoredLayouts = () => {
+  if (!safeLocalStorage) return {};
+  try {
+    const raw = safeLocalStorage.getItem(TABBED_WINDOW_LAYOUT_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to parse stored tabbed window layouts', error);
+    return {};
+  }
+};
+
+const writeStoredLayouts = (layouts) => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(
+      TABBED_WINDOW_LAYOUT_STORAGE_KEY,
+      JSON.stringify(layouts || {}),
+    );
+  } catch (error) {
+    console.warn('Failed to persist tabbed window layouts', error);
+  }
+};
+
+export const getStoredTabbedLayout = (key, fallback = DEFAULT_TABBED_LAYOUT) => {
+  if (!key) return fallback;
+  const layouts = readStoredLayouts();
+  const stored = layouts[key];
+  return typeof stored === 'string' ? stored : fallback;
+};
+
+export const setStoredTabbedLayout = (key, layout) => {
+  if (!key || typeof layout !== 'string') return;
+  const layouts = readStoredLayouts();
+  const next = { ...layouts, [key]: layout };
+  writeStoredLayouts(next);
+};
+
+export const clearStoredTabbedLayout = (key) => {
+  if (!key) return;
+  const layouts = readStoredLayouts();
+  if (!Object.prototype.hasOwnProperty.call(layouts, key)) return;
+  const next = { ...layouts };
+  delete next[key];
+  writeStoredLayouts(next);
 };


### PR DESCRIPTION
## Summary
- add selectable layout presets (tabs, columns, grid, cascade) to TabbedWindow with UI controls
- persist the chosen preset via window layout utilities and restore it for each app
- add Jest coverage for grid rendering, cascade offsets, and persistence across reloads

## Testing
- yarn test tabbedWindowLayout.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dccaa436dc8328bd7611a6c5e8a618