### PR TITLE
[ui] Add idle tab preview capture

### DIFF
--- a/components/ui/TabbedWindow.tsx
+++ b/components/ui/TabbedWindow.tsx
@@ -7,6 +7,9 @@ import React, {
   createContext,
   useContext,
 } from 'react';
+import html2canvas from 'html2canvas';
+
+import BlobManager from '../../utils/blobManager';
 
 function middleEllipsis(text: string, max = 30) {
   if (text.length <= max) return text;
@@ -58,16 +61,156 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
   const [moreMenuOpen, setMoreMenuOpen] = useState(false);
   const moreButtonRef = useRef<HTMLButtonElement>(null);
   const moreMenuRef = useRef<HTMLDivElement>(null);
+  const tabContentRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const [previewUrls, setPreviewUrls] = useState<Record<string, string>>({});
+  const hoverMarkRef = useRef<{ id: string; mark: string } | null>(null);
+  const [hoveredTab, setHoveredTab] = useState<{ id: string; rect: DOMRect } | null>(null);
+  const captureTimeouts = useRef<Map<string, number>>(new Map());
+  const lastCaptureTime = useRef<Map<string, number>>(new Map());
+  const panicModeRef = useRef(false);
+  const blobManagerRef = useRef<BlobManager>();
+
+  if (!blobManagerRef.current) {
+    blobManagerRef.current = new BlobManager();
+  }
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const readPanicMode = () => {
+      try {
+        const datasetValue =
+          document.documentElement.dataset.panicMode ?? document.body?.dataset.panicMode;
+        const stored = window.localStorage?.getItem('panic-mode');
+        const enabled = datasetValue === 'true' || stored === 'true';
+        panicModeRef.current = Boolean(enabled);
+      } catch {
+        panicModeRef.current = false;
+      }
+    };
+
+    readPanicMode();
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === 'panic-mode') {
+        readPanicMode();
+      }
+    };
+
+    const handlePanicEvent = (event: Event) => {
+      const custom = event as CustomEvent<{ enabled?: boolean }>;
+      if (typeof custom.detail?.enabled === 'boolean') {
+        panicModeRef.current = custom.detail.enabled;
+        return;
+      }
+      readPanicMode();
+    };
+
+    window.addEventListener('storage', handleStorage);
+    document.addEventListener('panicmodechange', handlePanicEvent as EventListener);
+
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+      document.removeEventListener('panicmodechange', handlePanicEvent as EventListener);
+    };
+  }, []);
+
+  const captureTabPreview = useCallback(
+    async (id: string) => {
+      if (panicModeRef.current) return;
+      const manager = blobManagerRef.current;
+      if (!manager) return;
+      const node = tabContentRefs.current.get(id);
+      if (!node) return;
+
+      const now =
+        typeof performance !== 'undefined' && typeof performance.now === 'function'
+          ? performance.now()
+          : Date.now();
+      const lastTime = lastCaptureTime.current.get(id) ?? 0;
+      if (now - lastTime < 250) return;
+
+      const wasHidden = node.classList.contains('hidden');
+      const previousVisibility = node.style.visibility;
+      const previousPointerEvents = node.style.pointerEvents;
+      if (wasHidden) {
+        node.classList.remove('hidden');
+        node.style.visibility = 'hidden';
+        node.style.pointerEvents = 'none';
+      }
+
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+
+      try {
+        const scale = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+        const canvas = await html2canvas(node, {
+          backgroundColor: null,
+          scale,
+          logging: false,
+        });
+        await new Promise<void>((resolve) => {
+          canvas.toBlob((blob) => {
+            if (!blob) {
+              resolve();
+              return;
+            }
+            const url = manager.set(id, blob);
+            lastCaptureTime.current.set(id, now);
+            if (!url) {
+              resolve();
+              return;
+            }
+            setPreviewUrls((prev) => {
+              if (prev[id] === url) return prev;
+              return { ...prev, [id]: url };
+            });
+            resolve();
+          }, 'image/png', 0.9);
+        });
+      } catch (error) {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn('[TabbedWindow] Failed to capture tab preview', error);
+        }
+      } finally {
+        if (wasHidden) {
+          node.classList.add('hidden');
+          node.style.visibility = previousVisibility;
+          node.style.pointerEvents = previousPointerEvents;
+        }
+      }
+    },
+    [],
+  );
+
+  const schedulePreviewCapture = useCallback(
+    (id: string) => {
+      if (panicModeRef.current) return;
+      const timeout = captureTimeouts.current.get(id);
+      if (timeout !== undefined) {
+        window.clearTimeout(timeout);
+      }
+      const handle = window.setTimeout(() => {
+        captureTimeouts.current.delete(id);
+        void captureTabPreview(id);
+      }, 120);
+      captureTimeouts.current.set(id, handle);
+    },
+    [captureTabPreview],
+  );
 
   useEffect(() => {
     if (prevActive.current !== activeId) {
-      const prev = tabs.find((t) => t.id === prevActive.current);
+      const previousId = prevActive.current;
+      const prev = tabs.find((t) => t.id === previousId);
       const next = tabs.find((t) => t.id === activeId);
       if (prev && prev.onDeactivate) prev.onDeactivate();
+      if (previousId) {
+        schedulePreviewCapture(previousId);
+      }
       if (next && next.onActivate) next.onActivate();
       prevActive.current = activeId;
     }
-  }, [activeId, tabs]);
+  }, [activeId, schedulePreviewCapture, tabs]);
 
   const updateTabs = useCallback(
     (updater: (prev: TabDefinition[]) => TabDefinition[]) => {
@@ -104,6 +247,22 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
         const idx = prev.findIndex((t) => t.id === id);
         const removed = prev[idx];
         const next = prev.filter((t) => t.id !== id);
+        if (captureTimeouts.current.has(id)) {
+          const timeoutHandle = captureTimeouts.current.get(id);
+          if (timeoutHandle !== undefined) {
+            window.clearTimeout(timeoutHandle);
+          }
+          captureTimeouts.current.delete(id);
+        }
+        if (blobManagerRef.current?.has(id)) {
+          blobManagerRef.current.revoke(id);
+          setPreviewUrls((prevUrls) => {
+            if (!(id in prevUrls)) return prevUrls;
+            const { [id]: _removed, ...rest } = prevUrls;
+            return rest;
+          });
+        }
+        lastCaptureTime.current.delete(id);
         if (removed && removed.onClose) removed.onClose();
         if (id === activeId && next.length > 0) {
           const fallback = next[idx] || next[idx - 1];
@@ -235,6 +394,37 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
   }, [activeId, tabs, updateOverflow]);
 
   useEffect(() => {
+    const ids = new Set(tabs.map((tab) => tab.id));
+    setPreviewUrls((prev) => {
+      let changed = false;
+      const next: Record<string, string> = {};
+      Object.entries(prev).forEach(([key, value]) => {
+        if (ids.has(key)) {
+          next[key] = value;
+        } else {
+          const timeoutHandle = captureTimeouts.current.get(key);
+          if (timeoutHandle !== undefined) {
+            window.clearTimeout(timeoutHandle);
+          }
+          captureTimeouts.current.delete(key);
+          blobManagerRef.current?.revoke(key);
+          lastCaptureTime.current.delete(key);
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [tabs]);
+
+  useEffect(() => {
+    if (!hoveredTab) return;
+    if (!tabs.some((tab) => tab.id === hoveredTab.id)) {
+      hoverMarkRef.current = null;
+      setHoveredTab(null);
+    }
+  }, [hoveredTab, tabs]);
+
+  useEffect(() => {
     const container = scrollContainerRef.current;
     const activeEl = tabRefs.current.get(activeId);
     if (!container || !activeEl) return;
@@ -274,6 +464,19 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
     focusTab(activeId);
   }, [activeId, focusTab]);
 
+  useEffect(() => {
+    const timeouts = captureTimeouts.current;
+    return () => {
+      blobManagerRef.current?.clear();
+      timeouts.forEach((handle) => {
+        if (handle !== undefined) {
+          window.clearTimeout(handle);
+        }
+      });
+      timeouts.clear();
+    };
+  }, []);
+
   const overflowTabs = useMemo(() => {
     if (overflowedIds.length === 0) return [] as TabDefinition[];
     const overflowSet = new Set(overflowedIds);
@@ -301,6 +504,78 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
     },
     [focusTab, setActive],
   );
+
+  const handleTabMouseEnter = useCallback(
+    (id: string) => (event: React.MouseEvent<HTMLDivElement>) => {
+      const rect = event.currentTarget.getBoundingClientRect();
+      if (typeof performance !== 'undefined' && typeof performance.mark === 'function') {
+        const mark = `tab-preview-hover-${id}-${performance.now().toFixed(3)}`;
+        performance.mark(mark);
+        hoverMarkRef.current = { id, mark };
+      } else {
+        hoverMarkRef.current = null;
+      }
+      setHoveredTab({ id, rect });
+      if (!previewUrls[id]) {
+        schedulePreviewCapture(id);
+      }
+    },
+    [previewUrls, schedulePreviewCapture],
+  );
+
+  const handleTabMouseLeave = useCallback(() => {
+    if (
+      hoverMarkRef.current?.mark &&
+      typeof performance !== 'undefined' &&
+      typeof performance.clearMarks === 'function'
+    ) {
+      performance.clearMarks(hoverMarkRef.current.mark);
+    }
+    hoverMarkRef.current = null;
+    setHoveredTab(null);
+  }, []);
+
+  useEffect(() => {
+    if (!hoveredTab) return;
+    const markEntry = hoverMarkRef.current;
+    if (!markEntry || markEntry.id !== hoveredTab.id || !markEntry.mark) return;
+    const url = previewUrls[hoveredTab.id];
+    if (!url) return;
+
+    if (
+      typeof performance === 'undefined' ||
+      typeof performance.mark !== 'function' ||
+      typeof performance.measure !== 'function'
+    ) {
+      hoverMarkRef.current = null;
+      return;
+    }
+
+    const shownMark = `tab-preview-shown-${hoveredTab.id}-${performance.now().toFixed(3)}`;
+    performance.mark(shownMark);
+    const measureName = `tab-preview-latency-${hoveredTab.id}-${Date.now()}`;
+    try {
+      const measure = performance.measure(measureName, markEntry.mark, shownMark);
+      if (measure.duration > 50 && process.env.NODE_ENV === 'development') {
+        console.warn(
+          `[TabbedWindow] Preview tooltip latency ${measure.duration.toFixed(
+            2,
+          )}ms exceeded budget for tab ${hoveredTab.id}`,
+        );
+      }
+    } catch {
+      // ignore invalid measures
+    } finally {
+      if (typeof performance.clearMarks === 'function') {
+        performance.clearMarks(markEntry.mark);
+        performance.clearMarks(shownMark);
+      }
+      if (typeof performance.clearMeasures === 'function') {
+        performance.clearMeasures(measureName);
+      }
+      hoverMarkRef.current = null;
+    }
+  }, [hoveredTab, previewUrls]);
 
   return (
     <div
@@ -347,6 +622,8 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
                 onDragOver={handleDragOver(i)}
                 onDrop={handleDrop(i)}
                 onClick={() => setActive(t.id)}
+                onMouseEnter={handleTabMouseEnter(t.id)}
+                onMouseLeave={handleTabMouseLeave}
                 onKeyDown={(event) => {
                   if (event.key === 'Enter' || event.key === ' ') {
                     event.preventDefault();
@@ -435,11 +712,46 @@ const TabbedWindow: React.FC<TabbedWindowProps> = ({
               className={`absolute inset-0 w-full h-full ${
                 t.id === activeId ? 'block' : 'hidden'
               }`}
+              ref={(node) => {
+                if (node) {
+                  tabContentRefs.current.set(t.id, node);
+                } else {
+                  tabContentRefs.current.delete(t.id);
+                }
+              }}
             >
               {t.content}
             </div>
           </TabContext.Provider>
         ))}
+        {hoveredTab && (
+          <div
+            className="pointer-events-none fixed z-[999] -translate-x-1/2 -translate-y-full transform"
+            style={{
+              left: hoveredTab.rect.left + hoveredTab.rect.width / 2,
+              top: hoveredTab.rect.top - 8,
+            }}
+          >
+            <div className="rounded border border-gray-700 bg-black/80 p-2 shadow-xl backdrop-blur-sm">
+              {previewUrls[hoveredTab.id] ? (
+                <img
+                  src={previewUrls[hoveredTab.id]}
+                  alt={`${tabs.find((tab) => tab.id === hoveredTab.id)?.title || 'Tab'} preview`}
+                  className="h-32 w-48 rounded object-cover"
+                  loading="lazy"
+                  draggable={false}
+                />
+              ) : (
+                <div className="flex h-32 w-48 items-center justify-center text-xs text-gray-400">
+                  Generating preview…
+                </div>
+              )}
+              <div className="mt-2 max-w-[12rem] truncate text-center text-xs text-gray-200">
+                {tabs.find((tab) => tab.id === hoveredTab.id)?.title ?? ''}
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/utils/blobManager.ts
+++ b/utils/blobManager.ts
@@ -1,0 +1,59 @@
+export interface BlobEntry {
+  blob: Blob;
+  url: string;
+  timestamp: number;
+}
+
+export default class BlobManager {
+  private entries: Map<string, BlobEntry> = new Map();
+
+  set(key: string, blob: Blob): string {
+    if (typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+      return '';
+    }
+
+    const existing = this.entries.get(key);
+    if (existing) {
+      URL.revokeObjectURL(existing.url);
+    }
+
+    const url = URL.createObjectURL(blob);
+    this.entries.set(key, {
+      blob,
+      url,
+      timestamp: Date.now(),
+    });
+
+    return url;
+  }
+
+  getUrl(key: string): string | undefined {
+    return this.entries.get(key)?.url;
+  }
+
+  get(key: string): Blob | undefined {
+    return this.entries.get(key)?.blob;
+  }
+
+  has(key: string): boolean {
+    return this.entries.has(key);
+  }
+
+  revoke(key: string): void {
+    const entry = this.entries.get(key);
+    if (!entry) return;
+    if (typeof URL !== 'undefined' && typeof URL.revokeObjectURL === 'function') {
+      URL.revokeObjectURL(entry.url);
+    }
+    this.entries.delete(key);
+  }
+
+  clear(): void {
+    if (typeof URL !== 'undefined' && typeof URL.revokeObjectURL === 'function') {
+      for (const entry of this.entries.values()) {
+        URL.revokeObjectURL(entry.url);
+      }
+    }
+    this.entries.clear();
+  }
+}


### PR DESCRIPTION
## Summary
- implement offscreen tab preview capture with html2canvas and store blobs through the shared manager
- show stored previews in hover tooltips while respecting panic mode privacy controls
- add performance instrumentation and a reusable BlobManager helper

## Testing
- yarn lint
- yarn test *(fails in this environment: existing jsdom/localStorage suite issues)*

------
https://chatgpt.com/codex/tasks/task_e_68dccaa6e06083288e2d33fdbbd709c9