### PR TITLE
[shell] add quick notes panel

### DIFF
--- a/__tests__/QuickNotes.test.tsx
+++ b/__tests__/QuickNotes.test.tsx
@@ -1,0 +1,153 @@
+import 'fake-indexeddb/auto';
+
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import QuickNotes from '../components/common/QuickNotes';
+import {
+  clearQuickNotes,
+  getNoteForRoute,
+  searchQuickNotes,
+} from '../utils/quickNotesStore';
+
+jest.mock('marked', () => ({ marked: { parse: (text: string) => text } }));
+
+const routerMock = {
+  asPath: '/',
+  isReady: true,
+  push: jest.fn(async (url: string) => {
+    routerMock.asPath = typeof url === 'string' ? url : '/';
+    return true;
+  }),
+  events: {
+    on: jest.fn(),
+    off: jest.fn(),
+  },
+};
+
+jest.mock('next/router', () => ({
+  useRouter: () => routerMock,
+}));
+
+const setCurrentUrl = (url: string) => {
+  routerMock.asPath = url;
+};
+
+const navigate = async (url: string) => {
+  routerMock.asPath = url;
+  await Promise.resolve();
+};
+
+describe('QuickNotes', () => {
+  beforeEach(async () => {
+    setCurrentUrl('/');
+    window.localStorage.clear();
+    await clearQuickNotes();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('autosaves markdown content for the current route', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime, delay: null });
+    setCurrentUrl('/apps/autosave');
+
+    render(<QuickNotes />);
+
+    const toggle = await screen.findByRole('button', { name: /quick notes/i });
+    await user.click(toggle);
+
+    const editor = await screen.findByLabelText(/quick notes markdown editor/i);
+    await user.type(editor, 'Autosave works');
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(900);
+    });
+
+    await waitFor(async () => {
+      const record = await getNoteForRoute('/apps/autosave');
+      expect(record?.content).toBe('Autosave works');
+    });
+  });
+
+  it('indexes notes so search finds the saved content', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime, delay: null });
+    setCurrentUrl('/apps/search');
+
+    render(<QuickNotes />);
+
+    const toggle = await screen.findByRole('button', { name: /quick notes/i });
+    await user.click(toggle);
+
+    const editor = await screen.findByLabelText(/quick notes markdown editor/i);
+    await user.type(editor, 'Kali Linux portfolio notes');
+    expect(editor).toHaveValue('Kali Linux portfolio notes');
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(900);
+    });
+
+    await waitFor(async () => {
+      const note = await getNoteForRoute('/apps/search');
+      expect(note?.content).toContain('portfolio');
+    });
+
+    const search = await screen.findByLabelText(/search notes/i);
+    await user.type(search, 'portfolio');
+
+    await waitFor(() => {
+      expect(screen.getAllByText('/apps/search')[0]).toBeInTheDocument();
+      expect(screen.getByText(/portfolio/i)).toBeInTheDocument();
+    });
+
+    const results = await searchQuickNotes('portfolio');
+    expect(results[0]?.route).toBe('/apps/search');
+  });
+
+  it('scopes notes by route so content does not bleed between pages', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime, delay: null });
+    setCurrentUrl('/apps/first');
+
+    render(<QuickNotes />);
+
+    const toggle = await screen.findByRole('button', { name: /quick notes/i });
+    await user.click(toggle);
+
+    const editor = await screen.findByLabelText(/quick notes markdown editor/i);
+    await user.type(editor, 'First route content');
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(900);
+    });
+
+    await waitFor(async () => {
+      const record = await getNoteForRoute('/apps/first');
+      expect(record?.content).toBe('First route content');
+    });
+
+    await act(async () => {
+      await navigate('/apps/second');
+    });
+
+    const secondEditor = await screen.findByLabelText(/quick notes markdown editor/i);
+    expect(secondEditor).toHaveValue('');
+
+    await user.type(secondEditor, 'Second route content');
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(900);
+    });
+
+    await waitFor(async () => {
+      const firstNote = await getNoteForRoute('/apps/first');
+      const secondNote = await getNoteForRoute('/apps/second');
+      expect(firstNote?.content).toBe('First route content');
+      expect(secondNote?.content).toBe('Second route content');
+    });
+  });
+});

--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,7 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Toggle quick notes', keys: 'Ctrl+Shift+N' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {

--- a/components/common/QuickNotes.tsx
+++ b/components/common/QuickNotes.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/router";
+import { marked } from "marked";
+import DOMPurify from "dompurify";
+import useKeymap from "../../apps/settings/keymapRegistry";
+import {
+  exportNotesAsJson,
+  exportNotesAsMarkdown,
+  getNoteForRoute,
+  saveNoteForRoute,
+  searchQuickNotes,
+  type QuickNote,
+} from "../../utils/quickNotesStore";
+
+const AUTOSAVE_DELAY = 800;
+
+const formatEvent = (event: KeyboardEvent) => {
+  const parts = [
+    event.ctrlKey ? "Ctrl" : "",
+    event.metaKey ? "Meta" : "",
+    event.altKey ? "Alt" : "",
+    event.shiftKey ? "Shift" : "",
+    event.key.length === 1 ? event.key.toUpperCase() : event.key,
+  ];
+  return parts.filter(Boolean).join("+");
+};
+
+const normalizeShortcut = (shortcut: string) =>
+  shortcut
+    .split("+")
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .map((segment) =>
+      segment.length === 1 ? segment.toUpperCase() : segment.charAt(0).toUpperCase() + segment.slice(1),
+    )
+    .join("+");
+
+const sanitizeHtml = (markdown: string) => {
+  if (!markdown) return "";
+  const rendered = marked.parse(markdown, { async: false });
+  return DOMPurify.sanitize(rendered);
+};
+
+const formatTimestamp = (timestamp: number | null) => {
+  if (!timestamp) return "";
+  try {
+    return new Date(timestamp).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return "";
+  }
+};
+
+const getCleanRoute = (path?: string) => {
+  if (!path) return "/";
+  const [withoutHash] = path.split("#");
+  const [withoutQuery] = withoutHash.split("?");
+  return withoutQuery || "/";
+};
+
+const snippetFromContent = (content: string, query: string) => {
+  if (!content) return "(empty)";
+  const singleLine = content.replace(/\s+/g, " ").trim();
+  if (!query) {
+    return singleLine.length > 160 ? `${singleLine.slice(0, 157)}…` : singleLine;
+  }
+  const lower = singleLine.toLowerCase();
+  const index = lower.indexOf(query.toLowerCase());
+  if (index === -1) {
+    return singleLine.length > 160 ? `${singleLine.slice(0, 157)}…` : singleLine;
+  }
+  const start = Math.max(0, index - 40);
+  const end = Math.min(singleLine.length, index + query.length + 40);
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < singleLine.length ? "…" : "";
+  return `${prefix}${singleLine.slice(start, end)}${suffix}`;
+};
+
+const downloadFile = (content: string, filename: string, mime: string) => {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+};
+
+const QuickNotes: React.FC = () => {
+  const router = useRouter();
+  const { shortcuts } = useKeymap();
+  const toggleShortcut =
+    shortcuts.find((shortcut) => shortcut.description === "Toggle quick notes")?.keys || "Ctrl+Shift+N";
+
+  const [open, setOpen] = useState(false);
+  const [content, setContent] = useState("");
+  const [savedContent, setSavedContent] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "saving" | "saved" | "error">("idle");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [searchResults, setSearchResults] = useState<QuickNote[]>([]);
+  const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
+  const [routeLabel, setRouteLabel] = useState("/");
+
+  const skipAutosave = useRef(true);
+
+  const isRouterReady = router?.isReady ?? true;
+  const activeRoute = isRouterReady ? getCleanRoute(router?.asPath) : "/";
+
+  useEffect(() => {
+    const normalizedShortcut = normalizeShortcut(toggleShortcut);
+    const handler = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable) {
+          return;
+        }
+      }
+      if (normalizeShortcut(formatEvent(event)) === normalizedShortcut) {
+        event.preventDefault();
+        setOpen((previous) => !previous);
+      } else if (event.key === "Escape" && open) {
+        event.preventDefault();
+        setOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [toggleShortcut, open]);
+
+  useEffect(() => {
+    if (!isRouterReady) return;
+    let cancelled = false;
+    const nextRoute = activeRoute;
+    setStatus("loading");
+    setRouteLabel(nextRoute);
+    (async () => {
+      try {
+        const note = await getNoteForRoute(nextRoute);
+        if (cancelled) return;
+        const nextContent = note?.content ?? "";
+        setContent(nextContent);
+        setSavedContent(nextContent);
+        setLastSavedAt(note?.updatedAt ?? null);
+        setStatus(note ? "saved" : "idle");
+        skipAutosave.current = true;
+      } catch (error) {
+        if (!cancelled) {
+          setStatus("error");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isRouterReady, activeRoute]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const results = await searchQuickNotes(searchTerm);
+        if (!cancelled) {
+          setSearchResults(results);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setSearchResults([]);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [searchTerm, lastSavedAt]);
+
+  useEffect(() => {
+    if (!isRouterReady) return;
+    if (skipAutosave.current) {
+      skipAutosave.current = false;
+      return;
+    }
+    if (content === savedContent) return;
+    setStatus("saving");
+    const handle = window.setTimeout(() => {
+      saveNoteForRoute(activeRoute, content)
+        .then((record) => {
+          setSavedContent(content);
+          setLastSavedAt(record?.updatedAt ?? Date.now());
+          setStatus("saved");
+        })
+        .catch(() => {
+          setStatus("error");
+        });
+    }, AUTOSAVE_DELAY);
+    return () => {
+      window.clearTimeout(handle);
+    };
+  }, [content, activeRoute, savedContent, isRouterReady]);
+
+  const previewHtml = useMemo(() => sanitizeHtml(content), [content]);
+
+  const statusLabel = useMemo(() => {
+    switch (status) {
+      case "saving":
+        return "Saving…";
+      case "saved":
+        return lastSavedAt ? `Saved ${formatTimestamp(lastSavedAt)}` : "Saved";
+      case "error":
+        return "Save failed";
+      case "loading":
+        return "Loading…";
+      default:
+        return "";
+    }
+  }, [status, lastSavedAt]);
+
+  const handleExportMarkdown = useCallback(async () => {
+    const markdown = await exportNotesAsMarkdown();
+    downloadFile(markdown, "quick-notes.md", "text/markdown");
+  }, []);
+
+  const handleExportJson = useCallback(async () => {
+    const json = await exportNotesAsJson();
+    downloadFile(json, "quick-notes.json", "application/json");
+  }, []);
+
+  const handleToggle = useCallback(() => {
+    setOpen((previous) => !previous);
+  }, []);
+
+  const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value);
+  }, []);
+
+  const handleContentChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setContent(event.target.value);
+  }, []);
+
+  const currentRouteMatchesQuery = searchTerm.trim().length > 0
+    ? searchResults.some((note) => note.route === activeRoute)
+    : false;
+
+  return (
+    <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-3">
+      {open && (
+        <div
+          id="quick-notes-panel"
+          className="w-[min(100vw-2rem,28rem)] overflow-hidden rounded-xl border border-white/10 bg-slate-950/95 text-sm text-white shadow-2xl backdrop-blur"
+        >
+          <header className="flex flex-col gap-2 border-b border-white/10 bg-slate-900/80 px-4 py-3">
+            <div className="flex items-center justify-between gap-2">
+              <h2 className="text-base font-semibold">Quick Notes</h2>
+              <div className="flex items-center gap-2 text-xs text-white/70">
+                {statusLabel && <span aria-live="polite">{statusLabel}</span>}
+                <button
+                  type="button"
+                  onClick={handleToggle}
+                  className="rounded-full border border-white/10 px-2 py-1 text-xs text-white/80 transition hover:border-white/30 hover:bg-white/10"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-white/60">
+              <span className="font-mono text-white/80">{routeLabel}</span>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleExportMarkdown}
+                  className="rounded border border-white/10 px-2 py-1 transition hover:border-white/30 hover:bg-white/10"
+                >
+                  Export .md
+                </button>
+                <button
+                  type="button"
+                  onClick={handleExportJson}
+                  className="rounded border border-white/10 px-2 py-1 transition hover:border-white/30 hover:bg-white/10"
+                >
+                  Export .json
+                </button>
+              </div>
+            </div>
+          </header>
+          <div className="flex h-72 flex-col divide-y divide-white/10">
+            <div className="flex flex-1 flex-col gap-2 p-4">
+              <label className="text-xs font-semibold uppercase tracking-wide text-white/60" htmlFor="quick-notes-editor">
+                Markdown note
+              </label>
+              <textarea
+                id="quick-notes-editor"
+                aria-label="Quick notes markdown editor"
+                className="h-32 w-full resize-none rounded border border-white/10 bg-black/40 p-2 font-mono text-sm text-white/90 outline-none focus:border-cyan-400"
+                value={content}
+                onChange={handleContentChange}
+                placeholder="Write markdown notes scoped to this route…"
+              />
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-white/60">Preview</p>
+                <div
+                  className="mt-2 h-24 overflow-auto rounded border border-white/10 bg-black/30 p-2 text-sm leading-relaxed"
+                  dangerouslySetInnerHTML={{ __html: previewHtml }}
+                />
+              </div>
+            </div>
+            <div className="flex flex-col gap-2 p-4">
+              <label className="text-xs font-semibold uppercase tracking-wide text-white/60" htmlFor="quick-notes-search">
+                Search notes
+              </label>
+              <input
+                id="quick-notes-search"
+                type="search"
+                value={searchTerm}
+                onChange={handleSearchChange}
+                placeholder="Search by route or content…"
+                className="w-full rounded border border-white/10 bg-black/30 p-2 text-sm text-white/90 outline-none focus:border-cyan-400"
+              />
+              <ul className="max-h-28 space-y-2 overflow-auto">
+                {searchResults.length === 0 && searchTerm.trim() && (
+                  <li className="text-xs text-white/50">No notes found</li>
+                )}
+                {searchResults.map((note) => (
+                  <li key={note.route} className="rounded border border-white/5 bg-white/5 p-2">
+                    <div className="flex items-center justify-between gap-2 text-xs text-white/70">
+                      <span className="font-mono text-white/90">{note.route}</span>
+                      <span>{formatTimestamp(note.updatedAt)}</span>
+                    </div>
+                    <p className="mt-1 text-xs text-white/70">{snippetFromContent(note.content, searchTerm)}</p>
+                    {note.route !== activeRoute && (
+                      <a
+                        href={note.route}
+                        className="mt-1 inline-flex text-xs text-cyan-300 underline"
+                      >
+                        Open route
+                      </a>
+                    )}
+                    {note.route === activeRoute && currentRouteMatchesQuery && (
+                      <p className="mt-1 text-[0.65rem] uppercase tracking-wide text-green-300">Current route</p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={handleToggle}
+        className="rounded-full border border-white/10 bg-slate-900/80 px-4 py-2 text-sm font-medium text-white shadow-lg transition hover:border-white/30 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-300"
+        aria-expanded={open}
+        aria-controls="quick-notes-panel"
+      >
+        Quick Notes
+      </button>
+    </div>
+  );
+};
+
+export default QuickNotes;
+

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -12,6 +12,7 @@ import '@xterm/xterm/css/xterm.css';
 import 'leaflet/dist/leaflet.css';
 import { SettingsProvider } from '../hooks/useSettings';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import QuickNotes from '../components/common/QuickNotes';
 import NotificationCenter from '../components/common/NotificationCenter';
 import PipPortalProvider from '../components/common/PipPortal';
 import ErrorBoundary from '../components/core/ErrorBoundary';
@@ -163,6 +164,7 @@ function MyApp(props) {
               <div aria-live="polite" id="live-region" />
               <Component {...pageProps} />
               <ShortcutOverlay />
+              <QuickNotes />
               <Analytics
                 beforeSend={(e) => {
                   if (e.url.includes('/admin') || e.url.includes('/private')) return null;

--- a/utils/quickNotesStore.ts
+++ b/utils/quickNotesStore.ts
@@ -1,0 +1,132 @@
+import type { IDBPDatabase } from 'idb';
+import { getDb } from './safeIDB';
+
+export interface QuickNoteRecord {
+  id: string;
+  route: string;
+  content: string;
+  updatedAt: number;
+}
+
+type QuickNotesSchema = {
+  notes: QuickNoteRecord;
+};
+
+const DB_NAME = 'quick-notes';
+const STORE_NAME = 'notes';
+
+let dbPromise: Promise<IDBPDatabase<QuickNotesSchema> | null> | null = null;
+const memoryStore = new Map<string, QuickNoteRecord>();
+
+async function openNotesDb() {
+  if (!dbPromise) {
+    dbPromise = getDb(DB_NAME, 1, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+          store.createIndex('route', 'route', { unique: true });
+          store.createIndex('updatedAt', 'updatedAt');
+        }
+      },
+    }) as Promise<IDBPDatabase<QuickNotesSchema> | null>;
+  }
+  return dbPromise;
+}
+
+function cloneRecord(record: QuickNoteRecord | undefined | null) {
+  if (!record) return null;
+  return { ...record };
+}
+
+function cloneArray(records: QuickNoteRecord[]) {
+  return records.map((record) => ({ ...record }));
+}
+
+export async function getNoteForRoute(route: string) {
+  const db = await openNotesDb();
+  if (!route) return null;
+  if (db) {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const result = await store.get(route);
+    await tx.done;
+    return cloneRecord(result);
+  }
+  return cloneRecord(memoryStore.get(route));
+}
+
+export async function saveNoteForRoute(route: string, content: string) {
+  const record: QuickNoteRecord = {
+    id: route,
+    route,
+    content,
+    updatedAt: Date.now(),
+  };
+  const db = await openNotesDb();
+  if (db) {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    await tx.store.put(record);
+    await tx.done;
+  } else {
+    memoryStore.set(route, record);
+  }
+  return cloneRecord(record);
+}
+
+export async function listNotes() {
+  const db = await openNotesDb();
+  if (db) {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const notes = await store.getAll();
+    await tx.done;
+    return cloneArray(notes);
+  }
+  return cloneArray(Array.from(memoryStore.values()));
+}
+
+export async function searchQuickNotes(query: string) {
+  const needle = query.trim().toLowerCase();
+  const notes = await listNotes();
+  const filtered = needle
+    ? notes.filter((note) => {
+        const routeMatch = note.route.toLowerCase().includes(needle);
+        const contentMatch = note.content.toLowerCase().includes(needle);
+        return routeMatch || contentMatch;
+      })
+    : notes;
+  return filtered.sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export async function exportNotesAsJson() {
+  const notes = await listNotes();
+  return JSON.stringify(
+    notes.sort((a, b) => a.route.localeCompare(b.route)),
+    null,
+    2,
+  );
+}
+
+export async function exportNotesAsMarkdown() {
+  const notes = await listNotes();
+  const sorted = notes.sort((a, b) => a.route.localeCompare(b.route));
+  const sections = sorted.map((note) => {
+    const heading = note.route || '/';
+    const timestamp = new Date(note.updatedAt).toISOString();
+    const body = note.content ? `\n${note.content}` : '\n_No content_';
+    return `## ${heading}\n_Last updated: ${timestamp}_${body}`;
+  });
+  return ['# Quick Notes Export', ...sections].join('\n\n');
+}
+
+export async function clearQuickNotes() {
+  const db = await openNotesDb();
+  if (db) {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    await tx.store.clear();
+    await tx.done;
+  }
+  memoryStore.clear();
+}
+
+export type { QuickNoteRecord as QuickNote };


### PR DESCRIPTION
## Summary
- add a Quick Notes overlay with markdown editing, search, exports, and keyboard toggle
- persist notes per route in IndexedDB through a shared utility store
- extend shortcut registry and add tests for autosave, indexing, and route scoping

## Testing
- yarn test QuickNotes

------
https://chatgpt.com/codex/tasks/task_e_68dccaa9d37c8328bff7cab111504dda