### PR TITLE
[deeplink] add validation and guard app routes

### DIFF
--- a/__tests__/deeplink.test.ts
+++ b/__tests__/deeplink.test.ts
@@ -1,0 +1,90 @@
+import { parseDeepLinkQuery, resolveDeepLink } from '../utils/deeplink';
+import type { DeepLinkParams } from '../utils/deeplink';
+
+describe('parseDeepLinkQuery', () => {
+  it('returns none when no deep-link parameters are present', () => {
+    expect(parseDeepLinkQuery({})).toEqual({ kind: 'none' });
+  });
+
+  it('rejects malformed context payloads', () => {
+    const result = parseDeepLinkQuery({
+      open: 'terminal',
+      v: '1',
+      ctx: '%7Bnot-json',
+    });
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.error.code).toBe('invalid');
+      expect(result.error.message).toContain('Unable to parse deep link');
+    }
+  });
+
+  it('rejects unsupported versions', () => {
+    const result = parseDeepLinkQuery({ open: 'terminal', v: '99' });
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.error.code).toBe('unsupported-version');
+      expect(result.error.message).toContain('not supported');
+    }
+  });
+});
+
+describe('resolveDeepLink', () => {
+  const available = ['terminal', 'wireshark', '2048'];
+
+  it('resolves exact matches', () => {
+    const params: DeepLinkParams = {
+      version: 1,
+      targetId: 'terminal',
+      fallback: 'exact',
+    };
+    const result = resolveDeepLink(params, { availableIds: available, expectedId: 'terminal' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.appId).toBe('terminal');
+      expect(result.value.reason).toBe('exact');
+    }
+  });
+
+  it('falls back to the closest match when permitted', () => {
+    const params: DeepLinkParams = {
+      version: 1,
+      targetId: 'wirehark',
+      fallback: 'open-closest',
+    };
+    const result = resolveDeepLink(params, { availableIds: available, expectedId: 'wireshark' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.appId).toBe('wireshark');
+      expect(result.value.reason).toBe('open-closest');
+    }
+  });
+
+  it('reports when the resolved app differs from the expected route', () => {
+    const params: DeepLinkParams = {
+      version: 1,
+      targetId: 'wirehark',
+      fallback: 'open-closest',
+    };
+    const result = resolveDeepLink(params, { availableIds: available, expectedId: 'terminal' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('mismatch');
+      expect(result.error.suggestion).toBe('wireshark');
+    }
+  });
+
+  it('reports when no app can be resolved', () => {
+    const params: DeepLinkParams = {
+      version: 1,
+      targetId: 'non-existent',
+      fallback: 'exact',
+    };
+    const result = resolveDeepLink(params, { availableIds: available, expectedId: 'terminal' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('not-found');
+      expect(result.error.target).toBe('non-existent');
+    }
+  });
+});

--- a/components/common/DeepLinkRescue.tsx
+++ b/components/common/DeepLinkRescue.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import type { DeepLinkError } from '../../utils/deeplink';
+
+type DeepLinkRescueProps = {
+  appTitle: string;
+  error: DeepLinkError;
+};
+
+const resolveMessage = (error: DeepLinkError) => {
+  switch (error.code) {
+    case 'unsupported-version':
+      return `${error.message}. Supported version is v${error.supported}.`;
+    case 'mismatch':
+    case 'not-found':
+      return error.message;
+    case 'invalid':
+    default:
+      return error.message;
+  }
+};
+
+const DeepLinkRescue = ({ appTitle, error }: DeepLinkRescueProps) => {
+  const message = resolveMessage(error);
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center bg-ub-cool-grey p-6 text-center text-white">
+      <h1 className="mb-2 text-2xl font-semibold">Unable to open {appTitle}</h1>
+      <p className="mb-4 max-w-lg text-sm text-ubt-grey">{message}</p>
+      {error.suggestion && (
+        <Link
+          href={`/apps/${error.suggestion}`}
+          className="rounded bg-ub-orange px-4 py-2 font-medium text-black transition hover:bg-ub-orange-light"
+        >
+          Open {error.suggestion}
+        </Link>
+      )}
+    </div>
+  );
+};
+
+export default DeepLinkRescue;

--- a/docs/internal-layouts.md
+++ b/docs/internal-layouts.md
@@ -20,3 +20,32 @@ Offsets are also available through `offset-*` classes.
   <div class="col-4 offset-4">Centered</div>
 </div>
 ```
+
+## Deep links
+
+App routes now accept a versioned deep-link format so shortcuts and external
+launchers can request specific windows. The query string schema is validated by
+`utils/deeplink.ts` using Zod to ensure malformed input cannot crash the page.
+
+### Format
+
+```
+?v=1&open=<app-id>[&fallback=open-closest][&ctx=<url-encoded JSON>]
+```
+
+* `v` – Deep-link version. Only `1` is supported at the moment. Any other value
+  triggers a rescue screen with a friendly error.
+* `open` – The requested application ID. This must match an ID from
+  `apps.config.js` (for example `terminal`, `wireshark`, or
+  `mimikatz/offline`).
+* `fallback` – Optional. Set to `open-closest` to allow the router to pick the
+  nearest matching application when the requested ID does not exist. If omitted
+  the lookup requires an exact match.
+* `ctx` – Optional JSON payload describing extra context for the destination.
+  It must be URL-encoded JSON (for example `%7B%22path%22%3A%22logs%22%7D`).
+
+Pages wrapped with `withDeepLinkBoundary` (used across `pages/apps/*`) or
+created via `createDeepLinkPage` will surface a rescue view whenever validation
+fails or the resolved app does not match the current route. When a fallback
+succeeds, the page still loads normally and receives the parsed payload via the
+optional `deepLink` prop.

--- a/pages/apps/2048.jsx
+++ b/pages/apps/2048.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Page2048 = dynamic(() => import('../../apps/2048'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default Page2048;
+export default withDeepLinkBoundary('2048', Page2048);

--- a/pages/apps/ascii-art.jsx
+++ b/pages/apps/ascii-art.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const AsciiArt = dynamic(() => import('../../apps/ascii-art'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default AsciiArt;
+export default withDeepLinkBoundary('ascii-art', AsciiArt);

--- a/pages/apps/autopsy.jsx
+++ b/pages/apps/autopsy.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Autopsy = dynamic(() => import('../../apps/autopsy'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function AutopsyPage() {
+function AutopsyPage() {
   return <Autopsy />;
 }
+
+export default withDeepLinkBoundary('autopsy', AutopsyPage);

--- a/pages/apps/beef.jsx
+++ b/pages/apps/beef.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Beef = dynamic(() => import('../../apps/beef'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function BeefPage() {
+function BeefPage() {
   return <Beef />;
 }
+
+export default withDeepLinkBoundary('beef', BeefPage);

--- a/pages/apps/blackjack.jsx
+++ b/pages/apps/blackjack.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Blackjack = dynamic(() => import('../../apps/blackjack'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function BlackjackPage() {
+function BlackjackPage() {
   return <Blackjack />;
 }
+
+export default withDeepLinkBoundary('blackjack', BlackjackPage);

--- a/pages/apps/calculator.jsx
+++ b/pages/apps/calculator.jsx
@@ -1,12 +1,14 @@
 import '../../utils/decimal';
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Calculator = dynamic(() => import('../../apps/calculator'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function CalculatorPage() {
+function CalculatorPage() {
   return <Calculator />;
 }
 
+export default withDeepLinkBoundary('calculator', CalculatorPage);

--- a/pages/apps/checkers.jsx
+++ b/pages/apps/checkers.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Checkers = dynamic(() => import('../../apps/checkers'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function CheckersPage() {
+function CheckersPage() {
   return <Checkers />;
 }
+
+export default withDeepLinkBoundary('checkers', CheckersPage);

--- a/pages/apps/connect-four.jsx
+++ b/pages/apps/connect-four.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const ConnectFour = dynamic(() => import('../../apps/connect-four'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default ConnectFour;
+export default withDeepLinkBoundary('connect-four', ConnectFour);

--- a/pages/apps/contact.jsx
+++ b/pages/apps/contact.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const ContactApp = dynamic(() => import('../../apps/contact'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function ContactPage() {
+function ContactPage() {
   return <ContactApp />;
 }
+
+export default withDeepLinkBoundary('contact', ContactPage);

--- a/pages/apps/converter.jsx
+++ b/pages/apps/converter.jsx
@@ -1,10 +1,13 @@
 import dynamic from "next/dynamic";
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Converter = dynamic(() => import("../../apps/converter"), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function ConverterPage() {
+function ConverterPage() {
   return <Converter />;
 }
+
+export default withDeepLinkBoundary('converter', ConverterPage);

--- a/pages/apps/figlet.jsx
+++ b/pages/apps/figlet.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const FigletPage = dynamic(() => import('../../apps/figlet'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default FigletPage;
+export default withDeepLinkBoundary('figlet', FigletPage);

--- a/pages/apps/firefox.jsx
+++ b/pages/apps/firefox.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const FirefoxApp = dynamic(() => import('../../apps/firefox'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default FirefoxApp;
+export default withDeepLinkBoundary('firefox', FirefoxApp);

--- a/pages/apps/http.jsx
+++ b/pages/apps/http.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const HTTPPreview = dynamic(() => import('../../apps/http'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function HTTPPage() {
+function HTTPPage() {
   return <HTTPPreview />;
 }
+
+export default withDeepLinkBoundary('http', HTTPPage);

--- a/pages/apps/input-lab.jsx
+++ b/pages/apps/input-lab.jsx
@@ -1,7 +1,10 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const InputLab = dynamic(() => import('../../apps/input-lab'), { ssr: false });
 
-export default function InputLabPage() {
+function InputLabPage() {
   return <InputLab />;
 }
+
+export default withDeepLinkBoundary('input-lab', InputLabPage);

--- a/pages/apps/john.jsx
+++ b/pages/apps/john.jsx
@@ -1,11 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const John = dynamic(() => import('../../apps/john'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function JohnPage() {
+function JohnPage() {
   return <John />;
 }
 
+export default withDeepLinkBoundary('john', JohnPage);

--- a/pages/apps/kismet.jsx
+++ b/pages/apps/kismet.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Kismet = dynamic(() => import('../../apps/kismet'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function KismetPage() {
+function KismetPage() {
   return <Kismet />;
 }
+
+export default withDeepLinkBoundary('kismet', KismetPage);

--- a/pages/apps/metasploit-post.jsx
+++ b/pages/apps/metasploit-post.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const MetasploitPost = dynamic(() => import('../../apps/metasploit-post'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function MetasploitPostPage() {
+function MetasploitPostPage() {
   return <MetasploitPost />;
 }
+
+export default withDeepLinkBoundary('metasploit-post', MetasploitPostPage);

--- a/pages/apps/metasploit.jsx
+++ b/pages/apps/metasploit.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Metasploit = dynamic(() => import('../../apps/metasploit'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function MetasploitPage() {
+function MetasploitPage() {
   return <Metasploit />;
 }
+
+export default withDeepLinkBoundary('metasploit', MetasploitPage);

--- a/pages/apps/mimikatz/offline.jsx
+++ b/pages/apps/mimikatz/offline.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../../utils/deeplink';
 
 const MimikatzOffline = dynamic(() => import('../../../apps/mimikatz/offline'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function MimikatzOfflinePage() {
+function MimikatzOfflinePage() {
   return <MimikatzOffline />;
 }
+
+export default withDeepLinkBoundary('mimikatz/offline', MimikatzOfflinePage);

--- a/pages/apps/minesweeper.jsx
+++ b/pages/apps/minesweeper.jsx
@@ -1,11 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Minesweeper = dynamic(() => import('../../apps/minesweeper'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function MinesweeperPage() {
+function MinesweeperPage() {
   return <Minesweeper />;
 }
 
+export default withDeepLinkBoundary('minesweeper', MinesweeperPage);

--- a/pages/apps/nmap-nse.jsx
+++ b/pages/apps/nmap-nse.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const NmapNSE = dynamic(() => import('../../apps/nmap-nse'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function NmapNSEPage() {
+function NmapNSEPage() {
   return <NmapNSE />;
 }
+
+export default withDeepLinkBoundary('nmap-nse', NmapNSEPage);

--- a/pages/apps/password_generator.jsx
+++ b/pages/apps/password_generator.jsx
@@ -1,11 +1,14 @@
 import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const PasswordGenerator = dynamic(() => import('../../apps/password_generator'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function PasswordGeneratorPage() {
+function PasswordGeneratorPage() {
   return <PasswordGenerator getDailySeed={() => getDailySeed('password_generator')} />;
 }
+
+export default withDeepLinkBoundary('password_generator', PasswordGeneratorPage);

--- a/pages/apps/phaser_matter.jsx
+++ b/pages/apps/phaser_matter.jsx
@@ -1,11 +1,14 @@
 import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const PhaserMatter = dynamic(() => import('../../apps/phaser_matter'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function PhaserMatterPage() {
+function PhaserMatterPage() {
   return <PhaserMatter getDailySeed={() => getDailySeed('phaser_matter')} />;
 }
+
+export default withDeepLinkBoundary('phaser_matter', PhaserMatterPage);

--- a/pages/apps/pinball.jsx
+++ b/pages/apps/pinball.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Pinball = dynamic(() => import('../../apps/pinball'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default Pinball;
+export default withDeepLinkBoundary('pinball', Pinball);

--- a/pages/apps/project-gallery.jsx
+++ b/pages/apps/project-gallery.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const ProjectGalleryApp = dynamic(() => import('../../apps/project-gallery/pages'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default ProjectGalleryApp;
+export default withDeepLinkBoundary('project-gallery', ProjectGalleryApp);

--- a/pages/apps/qr.jsx
+++ b/pages/apps/qr.jsx
@@ -1,11 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const QRApp = dynamic(() => import('../../apps/qr'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function QRPage() {
+function QRPage() {
   return <QRApp />;
 }
 
+export default withDeepLinkBoundary('qr', QRPage);

--- a/pages/apps/settings.jsx
+++ b/pages/apps/settings.jsx
@@ -1,8 +1,10 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const SettingsApp = dynamic(() => import('../../apps/settings'), { ssr: false });
 
-export default function SettingsPage() {
+function SettingsPage() {
   return <SettingsApp />;
 }
 
+export default withDeepLinkBoundary('settings', SettingsPage);

--- a/pages/apps/simon.jsx
+++ b/pages/apps/simon.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Simon = dynamic(() => import('../../apps/simon'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function SimonPage() {
+function SimonPage() {
   return <Simon />;
 }
+
+export default withDeepLinkBoundary('simon', SimonPage);

--- a/pages/apps/sokoban.jsx
+++ b/pages/apps/sokoban.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Sokoban = dynamic(() => import('../../apps/sokoban'), {
   ssr: false,
@@ -11,4 +12,4 @@ const SokobanPage = () => (
   <Sokoban getDailySeed={() => getDailySeed('sokoban')} />
 );
 
-export default SokobanPage;
+export default withDeepLinkBoundary('sokoban', SokobanPage);

--- a/pages/apps/solitaire.jsx
+++ b/pages/apps/solitaire.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const PageSolitaire = dynamic(() => import('../../apps/solitaire'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default PageSolitaire;
+export default withDeepLinkBoundary('solitaire', PageSolitaire);

--- a/pages/apps/spotify.jsx
+++ b/pages/apps/spotify.jsx
@@ -1,9 +1,9 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const SpotifyApp = dynamic(() => import('../../apps/spotify'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default SpotifyApp;
-
+export default withDeepLinkBoundary('spotify', SpotifyApp);

--- a/pages/apps/ssh.jsx
+++ b/pages/apps/ssh.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const SSHPreview = dynamic(() => import('../../apps/ssh'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function SSHPage() {
+function SSHPage() {
   return <SSHPreview />;
 }
+
+export default withDeepLinkBoundary('ssh', SSHPage);

--- a/pages/apps/sticky_notes.jsx
+++ b/pages/apps/sticky_notes.jsx
@@ -1,11 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const StickyNotes = dynamic(() => import('../../apps/sticky_notes'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function StickyNotesPage() {
+function StickyNotesPage() {
   return <StickyNotes />;
 }
 
+export default withDeepLinkBoundary('sticky_notes', StickyNotesPage);

--- a/pages/apps/subnet-calculator.jsx
+++ b/pages/apps/subnet-calculator.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const SubnetCalculator = dynamic(() => import('../../apps/subnet-calculator'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function SubnetCalculatorPage() {
+function SubnetCalculatorPage() {
   return <SubnetCalculator />;
 }
+
+export default withDeepLinkBoundary('subnet-calculator', SubnetCalculatorPage);

--- a/pages/apps/timer_stopwatch.jsx
+++ b/pages/apps/timer_stopwatch.jsx
@@ -1,11 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const TimerStopwatch = dynamic(() => import('../../apps/timer_stopwatch'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function TimerStopwatchPage() {
+function TimerStopwatchPage() {
   return <TimerStopwatch />;
 }
 
+export default withDeepLinkBoundary('timer_stopwatch', TimerStopwatchPage);

--- a/pages/apps/tower-defense.jsx
+++ b/pages/apps/tower-defense.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const TowerDefense = dynamic(() => import('../../apps/tower-defense'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default TowerDefense;
+export default withDeepLinkBoundary('tower-defense', TowerDefense);

--- a/pages/apps/volatility.jsx
+++ b/pages/apps/volatility.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Volatility = dynamic(() => import('../../apps/volatility'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function VolatilityPage() {
+function VolatilityPage() {
   return <Volatility />;
 }
+
+export default withDeepLinkBoundary('volatility', VolatilityPage);

--- a/pages/apps/vscode.jsx
+++ b/pages/apps/vscode.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const VSCode = dynamic(() => import('../../apps/vscode'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function VSCodePage() {
+function VSCodePage() {
   return <VSCode />;
 }
+
+export default withDeepLinkBoundary('vscode', VSCodePage);

--- a/pages/apps/weather.jsx
+++ b/pages/apps/weather.jsx
@@ -1,4 +1,5 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const WeatherApp = dynamic(
   () =>
@@ -12,5 +13,4 @@ const WeatherApp = dynamic(
   }
 );
 
-export default WeatherApp;
-
+export default withDeepLinkBoundary('weather', WeatherApp);

--- a/pages/apps/weather_widget.jsx
+++ b/pages/apps/weather_widget.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
   ssr: false,
@@ -7,7 +8,7 @@ const WeatherWidget = dynamic(() => import('../../apps/weather_widget'), {
 });
 
 // Display stored unit preference and the browser's location consent status.
-export default function WeatherWidgetPage() {
+function WeatherWidgetPage() {
   const [unit, setUnit] = useState('metric');
   const [locationConsent, setLocationConsent] = useState('unknown');
 
@@ -47,3 +48,4 @@ export default function WeatherWidgetPage() {
   );
 }
 
+export default withDeepLinkBoundary('weather_widget', WeatherWidgetPage);

--- a/pages/apps/wireshark.jsx
+++ b/pages/apps/wireshark.jsx
@@ -1,10 +1,13 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const Wireshark = dynamic(() => import('../../apps/wireshark'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default function WiresharkPage() {
+function WiresharkPage() {
   return <Wireshark />;
 }
+
+export default withDeepLinkBoundary('wireshark', WiresharkPage);

--- a/pages/apps/word_search.jsx
+++ b/pages/apps/word_search.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import { getDailySeed } from '../../utils/dailySeed';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const WordSearch = dynamic(
   () => import('../../apps/word_search'),
   { ssr: false, loading: () => <p>Loading...</p> },
 );
 
-export default function WordSearchPage() {
+function WordSearchPage() {
   return <WordSearch getDailySeed={() => getDailySeed('word_search')} />;
 }
+
+export default withDeepLinkBoundary('word_search', WordSearchPage);

--- a/pages/apps/x.jsx
+++ b/pages/apps/x.jsx
@@ -1,8 +1,9 @@
 import dynamic from 'next/dynamic';
+import { withDeepLinkBoundary } from '../../utils/deeplink';
 
 const PageX = dynamic(() => import('../../apps/x'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });
 
-export default PageX;
+export default withDeepLinkBoundary('x', PageX);

--- a/utils/deeplink.tsx
+++ b/utils/deeplink.tsx
@@ -1,0 +1,332 @@
+import type { ComponentType, JSX } from 'react';
+import type { ParsedUrlQuery } from 'querystring';
+import dynamic from 'next/dynamic';
+import { useMemo } from 'react';
+import { useRouter } from 'next/router';
+import { z } from 'zod';
+import apps from '../apps.config';
+import DeepLinkRescue from '../components/common/DeepLinkRescue';
+
+const CURRENT_VERSION = 1;
+
+const FALLBACK_ALIASES: Record<string, DeepLinkFallbackMode> = {
+  exact: 'exact',
+  none: 'exact',
+  'open-closest': 'open-closest',
+  openclosest: 'open-closest',
+  closest: 'open-closest',
+  'open_closest': 'open-closest',
+};
+
+const DeepLinkSchema = z
+  .object({
+    v: z.preprocess(
+      (value) => {
+        if (value === undefined || value === null || value === '') return CURRENT_VERSION;
+        if (typeof value === 'string' && value.trim() === '') return CURRENT_VERSION;
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : value;
+      },
+      z.number().int().min(1)
+    ),
+    open: z.string().min(1),
+    fallback: z
+      .string()
+      .optional()
+      .transform((value) => {
+        if (!value) return 'exact';
+        const normalized = value.toLowerCase().replace(/\s+/g, '-');
+        return FALLBACK_ALIASES[normalized] ?? 'exact';
+      }),
+    ctx: z
+      .string()
+      .optional()
+      .transform((raw, ctx) => {
+        if (raw === undefined) return undefined;
+        try {
+          const decoded = decodeURIComponent(raw);
+          const parsed = JSON.parse(decoded);
+          if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'Deep link context must be an object',
+            });
+            return z.NEVER;
+          }
+          return parsed as Record<string, unknown>;
+        } catch (error) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Deep link context payload could not be parsed',
+          });
+          return z.NEVER;
+        }
+      }),
+  })
+  .transform((value) => ({
+    version: value.v,
+    targetId: value.open,
+    fallback: (value.fallback ?? 'exact') as DeepLinkFallbackMode,
+    context: value.ctx,
+  }));
+
+type DeepLinkFallbackMode = 'exact' | 'open-closest';
+
+export type DeepLinkParams = {
+  version: number;
+  targetId: string;
+  fallback: DeepLinkFallbackMode;
+  context?: Record<string, unknown>;
+};
+
+export type DeepLinkError =
+  | {
+      code: 'invalid';
+      message: string;
+      issues?: string[];
+    }
+  | {
+      code: 'unsupported-version';
+      message: string;
+      received: number;
+      supported: number;
+    }
+  | {
+      code: 'not-found';
+      message: string;
+      target: string;
+      suggestion?: string;
+    }
+  | {
+      code: 'mismatch';
+      message: string;
+      expected: string;
+      resolved: string;
+      suggestion?: string;
+    };
+
+export type DeepLinkParseResult =
+  | { kind: 'none' }
+  | { kind: 'parsed'; params: DeepLinkParams }
+  | { kind: 'error'; error: DeepLinkError };
+
+const defaultAppIds = apps.map((app) => app.id);
+
+const hasDeepLinkKeys = (query: Record<string, string>) =>
+  ['open', 'v', 'fallback', 'ctx'].some((key) => key in query);
+
+const normalizeQuery = (query: ParsedUrlQuery | URLSearchParams | string | Record<string, unknown>) => {
+  if (typeof query === 'string') {
+    return normalizeQuery(new URLSearchParams(query));
+  }
+  if (query instanceof URLSearchParams) {
+    const result: Record<string, string> = {};
+    query.forEach((value, key) => {
+      result[key] = value;
+    });
+    return result;
+  }
+  const result: Record<string, string> = {};
+  Object.entries(query).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      if (value.length > 0) result[key] = value[0];
+    } else if (value !== undefined && value !== null) {
+      result[key] = String(value);
+    }
+  });
+  return result;
+};
+
+export const parseDeepLinkQuery = (
+  query: ParsedUrlQuery | URLSearchParams | string | Record<string, unknown>
+): DeepLinkParseResult => {
+  const normalized = normalizeQuery(query);
+  if (!hasDeepLinkKeys(normalized)) {
+    return { kind: 'none' };
+  }
+  const parsed = DeepLinkSchema.safeParse(normalized);
+  if (!parsed.success) {
+    return {
+      kind: 'error',
+      error: {
+        code: 'invalid',
+        message: 'Unable to parse deep link parameters',
+        issues: parsed.error.issues.map((issue) => issue.message),
+      },
+    };
+  }
+  if (parsed.data.version !== CURRENT_VERSION) {
+    return {
+      kind: 'error',
+      error: {
+        code: 'unsupported-version',
+        message: `Deep link version ${parsed.data.version} is not supported`,
+        received: parsed.data.version,
+        supported: CURRENT_VERSION,
+      },
+    };
+  }
+  return { kind: 'parsed', params: parsed.data };
+};
+
+const levenshtein = (a: string, b: string) => {
+  const matrix: number[][] = Array.from({ length: a.length + 1 }, () => []);
+  for (let i = 0; i <= a.length; i += 1) matrix[i][0] = i;
+  for (let j = 0; j <= b.length; j += 1) matrix[0][j] = j;
+  for (let i = 1; i <= a.length; i += 1) {
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost
+      );
+    }
+  }
+  return matrix[a.length][b.length];
+};
+
+const findClosestApp = (target: string, candidates: string[]) => {
+  let best: { id: string; distance: number } | null = null;
+  const lowerTarget = target.toLowerCase();
+  candidates.forEach((candidate) => {
+    const lowerCandidate = candidate.toLowerCase();
+    const distance = levenshtein(lowerTarget, lowerCandidate);
+    const threshold = Math.max(1, Math.floor(Math.min(lowerTarget.length, lowerCandidate.length) / 2));
+    if (distance > threshold) return;
+    if (!best || distance < best.distance || (distance === best.distance && candidate.length < best.id.length)) {
+      best = { id: candidate, distance };
+    }
+  });
+  return best;
+};
+
+export type DeepLinkResolution =
+  | {
+      ok: true;
+      value: {
+        appId: string;
+        reason: DeepLinkFallbackMode;
+        context?: Record<string, unknown>;
+      };
+    }
+  | {
+      ok: false;
+      error: DeepLinkError;
+    };
+
+export const resolveDeepLink = (
+  params: DeepLinkParams,
+  options: { availableIds?: string[]; expectedId?: string } = {}
+): DeepLinkResolution => {
+  const available = options.availableIds ?? defaultAppIds;
+  const expected = options.expectedId;
+  if (available.includes(params.targetId)) {
+    if (expected && params.targetId !== expected) {
+      return {
+        ok: false,
+        error: {
+          code: 'mismatch',
+          message: `Deep link targets \"${params.targetId}\" but this page handles \"${expected}\"`,
+          expected,
+          resolved: params.targetId,
+          suggestion: params.targetId,
+        },
+      };
+    }
+    return {
+      ok: true,
+      value: { appId: params.targetId, reason: 'exact', context: params.context },
+    };
+  }
+  if (params.fallback === 'open-closest') {
+    const closest = findClosestApp(params.targetId, available);
+    if (closest) {
+      if (expected && closest.id !== expected) {
+        return {
+          ok: false,
+          error: {
+            code: 'mismatch',
+            message: `Deep link resolves to \"${closest.id}\" via fallback but this page handles \"${expected}\"`,
+            expected,
+            resolved: closest.id,
+            suggestion: closest.id,
+          },
+        };
+      }
+      return {
+        ok: true,
+        value: { appId: closest.id, reason: 'open-closest', context: params.context },
+      };
+    }
+  }
+  return {
+    ok: false,
+    error: {
+      code: 'not-found',
+      message: `Unable to locate application \"${params.targetId}\"`,
+      target: params.targetId,
+    },
+  };
+};
+
+type DeepLinkPageOptions = {
+  id: string;
+  loader: () => Promise<{ default: React.ComponentType<any> }>;
+  title?: string;
+  loading?: () => JSX.Element;
+};
+
+const defaultLoading = () => <p>Loading...</p>;
+
+export const withDeepLinkBoundary = <P extends Record<string, unknown>>(
+  id: string,
+  Component: ComponentType<P>,
+  options?: { title?: string }
+) => {
+  const Boundary = (props: P) => {
+    const router = useRouter();
+    const state = useMemo(() => {
+      if (!router.isReady) {
+        return { kind: 'pending' } as const;
+      }
+      const parsed = parseDeepLinkQuery(router.query);
+      if (parsed.kind === 'none') return { kind: 'ready', deepLink: undefined } as const;
+      if (parsed.kind === 'error') return { kind: 'error', error: parsed.error } as const;
+      const resolution = resolveDeepLink(parsed.params, { expectedId: id });
+      if (!resolution.ok) {
+        return { kind: 'error', error: resolution.error } as const;
+      }
+      return { kind: 'ready', deepLink: resolution.value } as const;
+    }, [router.isReady, router.query]);
+
+    if (state.kind === 'error') {
+      return <DeepLinkRescue appTitle={options?.title ?? id} error={state.error} />;
+    }
+
+    const mergedProps: P & { deepLink?: typeof state.deepLink } = { ...props };
+    if (state.deepLink) {
+      (mergedProps as any).deepLink = state.deepLink;
+    }
+    return <Component {...mergedProps} />;
+  };
+
+  Boundary.displayName = `DeepLinkBoundary(${Component.displayName ?? Component.name ?? 'Component'})`;
+  return Boundary;
+};
+
+export const createDeepLinkPage = ({ id, loader, title, loading }: DeepLinkPageOptions) => {
+  const DynamicComponent = dynamic(loader, {
+    ssr: false,
+    loading: loading ?? defaultLoading,
+  });
+  return withDeepLinkBoundary(id, DynamicComponent, { title });
+};
+
+export const __private__ = {
+  levenshtein,
+  findClosestApp,
+  hasDeepLinkKeys,
+  normalizeQuery,
+  CURRENT_VERSION,
+};


### PR DESCRIPTION
## Summary
- add a shared deep-link parser/resolver with schema validation and route boundary helper
- wrap `pages/apps/*` entries with the deep-link boundary so invalid requests render a rescue screen
- document the deep-link query format for internal routes

## Testing
- yarn test deeplink.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dccaab916083288819209abf5cfddd