### PR TITLE
[components] Add contextual help overlay

### DIFF
--- a/__tests__/contextHelp.test.tsx
+++ b/__tests__/contextHelp.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ContextHelp from '../components/common/ContextHelp';
+import {
+  contextHelpRegistry,
+  createRuleRegistry,
+  ContextHelpRule,
+} from '../modules/context-help/registry';
+
+const mockRouter = {
+  asPath: '/',
+  pathname: '/',
+  locale: 'en',
+};
+
+jest.mock('next/router', () => ({
+  useRouter: () => mockRouter,
+}));
+
+describe('contextHelpRegistry', () => {
+  it('matches routes and localises text', () => {
+    const cards = contextHelpRegistry.resolve({
+      route: '/apps/ssh',
+      appId: 'ssh',
+      locale: 'es',
+    });
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].title).toContain('SSH');
+    expect(cards[0].body).toContain('demostración');
+  });
+
+  it('allows custom registries', () => {
+    const rules: ContextHelpRule[] = [
+      {
+        id: 'test.rule',
+        match: (context) => context.route === '/apps/tester',
+        cards: [
+          {
+            id: 'test.card',
+            title: { en: 'Tester', fr: 'Testeur' },
+            body: { en: 'English', fr: 'Français' },
+          },
+        ],
+      },
+    ];
+
+    const registry = createRuleRegistry(rules);
+    const cards = registry.resolve({ route: '/apps/tester', locale: 'fr' });
+    expect(cards).toHaveLength(1);
+    expect(cards[0].title).toBe('Testeur');
+  });
+});
+
+describe('ContextHelp component', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockRouter.asPath = '/apps/ssh';
+    mockRouter.pathname = '/apps/[app]';
+    mockRouter.locale = 'en';
+  });
+
+  it('opens with F1, focuses the dialog, and exposes accessibility attributes', async () => {
+    render(<ContextHelp />);
+
+    fireEvent.keyDown(window, { key: 'F1' });
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    await waitFor(() => {
+      expect(document.activeElement).toBe(dialog);
+    });
+    expect(screen.getByRole('heading', { level: 3, name: /Simulated SSH sessions/i })).toBeInTheDocument();
+  });
+
+  it('persists dismissed cards and announces when none remain', async () => {
+    const { unmount } = render(<ContextHelp />);
+    fireEvent.keyDown(window, { key: 'F1' });
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss this help card/i }));
+
+    await waitFor(() => {
+      const stored = window.localStorage.getItem('context-help:dismissed');
+      expect(stored).toContain('apps.ssh.connection');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    unmount();
+
+    const rerenderResult = render(<ContextHelp />);
+    fireEvent.keyDown(window, { key: 'F1' });
+
+    await screen.findByRole('dialog');
+    expect(
+      await screen.findByText(/all available help cards for this screen were dismissed/i)
+    ).toBeInTheDocument();
+
+    rerenderResult.unmount();
+  });
+});

--- a/components/common/ContextHelp.tsx
+++ b/components/common/ContextHelp.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
+import type {
+  ContextHelpRegistry,
+  HelpContext,
+  ResolvedContextHelpCard,
+} from '../../modules/context-help/registry';
+import contextHelpRegistry from '../../modules/context-help/registry';
+
+export type ContextHelpProps = {
+  registry?: ContextHelpRegistry;
+  context?: Partial<HelpContext>;
+  storageKey?: string;
+};
+
+const DEFAULT_STORAGE_KEY = 'context-help:dismissed';
+
+const isEditableElement = (element: EventTarget | null): boolean => {
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+  const tag = element.tagName;
+  return (
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    element.isContentEditable ||
+    (element.getAttribute('role') === 'textbox' && element.tabIndex >= 0)
+  );
+};
+
+const deriveAppId = (path: string): string | undefined => {
+  const clean = path.split('?')[0];
+  const segments = clean.split('/').filter(Boolean);
+  if (segments[0] === 'apps' && segments[1]) {
+    return segments[1];
+  }
+  return undefined;
+};
+
+const ContextHelp: React.FC<ContextHelpProps> = ({
+  registry = contextHelpRegistry,
+  context,
+  storageKey = DEFAULT_STORAGE_KEY,
+}) => {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [dismissed, setDismissed] = useState<string[]>(() => {
+    if (typeof window === 'undefined') return [];
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (!stored) return [];
+      const parsed = JSON.parse(stored);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  });
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const lastActiveElementRef = useRef<Element | null>(null);
+
+  const helpContext = useMemo<HelpContext>(() => {
+    const route = context?.route ?? router.asPath?.split('?')[0] ?? router.pathname ?? '/';
+    return {
+      route,
+      appId: context?.appId ?? deriveAppId(route),
+      locale: context?.locale ?? router.locale ?? 'en',
+      state: context?.state,
+    };
+  }, [context?.appId, context?.locale, context?.route, context?.state, router.asPath, router.locale, router.pathname]);
+
+  const allCards = useMemo<ResolvedContextHelpCard[]>(() => {
+    return registry.resolve(helpContext);
+  }, [registry, helpContext]);
+
+  const visibleCards = useMemo(
+    () => allCards.filter((card) => !dismissed.includes(card.id)),
+    [allCards, dismissed]
+  );
+
+  const closeHelp = useCallback(() => {
+    setOpen(false);
+    const lastActive = lastActiveElementRef.current as HTMLElement | null;
+    if (lastActive && typeof lastActive.focus === 'function') {
+      lastActive.focus();
+    }
+  }, []);
+
+  const handleDismiss = useCallback((id: string) => {
+    setDismissed((current) => {
+      if (current.includes(id)) return current;
+      return [...current, id];
+    });
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (isEditableElement(event.target)) return;
+      if (event.key === 'F1') {
+        if (!visibleCards.length && !allCards.length) return;
+        event.preventDefault();
+        lastActiveElementRef.current = document.activeElement;
+        setOpen(true);
+      }
+      if (event.key === 'Escape' && open) {
+        event.preventDefault();
+        closeHelp();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [closeHelp, open, visibleCards.length, allCards.length]);
+
+  useEffect(() => {
+    if (!open) return;
+    const timeout = window.setTimeout(() => {
+      overlayRef.current?.focus();
+    }, 0);
+    return () => window.clearTimeout(timeout);
+  }, [open]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(dismissed));
+    } catch {
+      // ignore storage errors
+    }
+  }, [dismissed, storageKey]);
+
+  if (!visibleCards.length && !open) {
+    return null;
+  }
+
+  return (
+    <>
+      {open && (
+        <div
+          ref={overlayRef}
+          className="fixed inset-0 z-50 flex items-start justify-center bg-slate-900/80 p-6 text-slate-100"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="context-help-title"
+          tabIndex={-1}
+        >
+          <div className="w-full max-w-xl space-y-4" role="document">
+            <div className="flex items-center justify-between">
+              <h2 id="context-help-title" className="text-xl font-semibold">
+                Contextual help
+              </h2>
+              <button
+                type="button"
+                onClick={closeHelp}
+                className="rounded px-3 py-1 text-sm font-medium text-slate-100 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+              >
+                Close
+              </button>
+            </div>
+            <div className="space-y-3">
+              {visibleCards.length === 0 ? (
+                <p role="status" aria-live="polite">
+                  All available help cards for this screen were dismissed.
+                </p>
+              ) : (
+                visibleCards.map((card) => {
+                  const headingId = `${card.id}-title`;
+                  return (
+                    <article
+                      key={card.id}
+                      aria-labelledby={headingId}
+                      className="rounded-md bg-slate-800/80 p-4 shadow-lg focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-sky-400"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div>
+                          <h3 id={headingId} className="text-lg font-semibold">
+                            {card.title}
+                          </h3>
+                          <p className="mt-1 text-sm text-slate-200">{card.body}</p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => handleDismiss(card.id)}
+                          className="rounded px-2 py-1 text-xs font-medium uppercase tracking-wide text-slate-200 hover:bg-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+                          aria-label="Dismiss this help card"
+                        >
+                          Dismiss
+                        </button>
+                      </div>
+                      {card.actions.length > 0 && (
+                        <ul className="mt-3 flex flex-wrap gap-2" aria-label="Helpful actions">
+                          {card.actions.map((action) => (
+                            <li key={action.label}>
+                              {action.href ? (
+                                <a
+                                  href={action.href}
+                                  target={action.external ? '_blank' : undefined}
+                                  rel={action.external ? 'noreferrer' : undefined}
+                                  className="inline-flex items-center rounded bg-sky-600 px-3 py-1 text-sm font-semibold text-white hover:bg-sky-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300"
+                                >
+                                  {action.label}
+                                  {action.external && (
+                                    <span className="ml-1 text-xs" aria-hidden="true">
+                                      ↗
+                                    </span>
+                                  )}
+                                </a>
+                              ) : (
+                                <span className="inline-flex items-center rounded bg-slate-700 px-3 py-1 text-sm font-semibold text-white">
+                                  {action.label}
+                                </span>
+                              )}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </article>
+                  );
+                })
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ContextHelp;

--- a/modules/context-help/registry.ts
+++ b/modules/context-help/registry.ts
@@ -1,0 +1,158 @@
+export type LocalizedText = string | Partial<Record<string, string>>;
+
+export type HelpContext = {
+  route: string;
+  appId?: string | null;
+  locale?: string | null;
+  state?: Record<string, unknown>;
+};
+
+export type ContextHelpAction = {
+  label: LocalizedText;
+  href?: string;
+  external?: boolean;
+};
+
+export type ContextHelpCard = {
+  id: string;
+  title: LocalizedText;
+  body: LocalizedText;
+  actions?: ContextHelpAction[];
+};
+
+export type ContextHelpRule = {
+  id: string;
+  match: (context: HelpContext) => boolean;
+  cards: ContextHelpCard[];
+};
+
+export type ResolvedContextHelpAction = {
+  label: string;
+  href?: string;
+  external?: boolean;
+};
+
+export type ResolvedContextHelpCard = {
+  id: string;
+  ruleId: string;
+  title: string;
+  body: string;
+  actions: ResolvedContextHelpAction[];
+};
+
+const resolveLocalizedText = (text: LocalizedText, locale?: string | null): string => {
+  if (typeof text === 'string') {
+    return text;
+  }
+
+  if (!text) {
+    return '';
+  }
+
+  if (!locale) {
+    return text.en ?? Object.values(text)[0] ?? '';
+  }
+
+  const normalized = locale.toLowerCase();
+  const candidates = [
+    normalized,
+    normalized.split('-')[0],
+    'en',
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const value = text[candidate];
+    if (value) return value;
+  }
+
+  const first = Object.values(text).find(Boolean);
+  return first ?? '';
+};
+
+export interface ContextHelpRegistry {
+  resolve(context: HelpContext): ResolvedContextHelpCard[];
+}
+
+export const createRuleRegistry = (
+  rules: ContextHelpRule[]
+): ContextHelpRegistry => ({
+  resolve: (context: HelpContext) =>
+    rules
+      .filter((rule) => {
+        try {
+          return rule.match(context);
+        } catch {
+          return false;
+        }
+      })
+      .flatMap((rule) =>
+        rule.cards.map((card) => ({
+          id: card.id,
+          ruleId: rule.id,
+          title: resolveLocalizedText(card.title, context.locale),
+          body: resolveLocalizedText(card.body, context.locale),
+          actions:
+            card.actions?.map((action) => ({
+              label: resolveLocalizedText(action.label, context.locale),
+              href: action.href,
+              external: action.external,
+            })) ?? [],
+        }))
+      ),
+});
+
+const baseRules: ContextHelpRule[] = [
+  {
+    id: 'desktop.overview',
+    match: ({ route }) => route === '/' || route === '/desktop',
+    cards: [
+      {
+        id: 'desktop.overview.layout',
+        title: { en: 'Explore the desktop', es: 'Explora el escritorio' },
+        body: {
+          en: 'Use the dock to launch apps, right-click anywhere for contextual actions, and press Super to open the launcher.',
+          es: 'Utiliza el dock para abrir aplicaciones, haz clic derecho para ver acciones contextuales y pulsa Super para abrir el lanzador.',
+        },
+        actions: [
+          {
+            label: { en: 'Open keyboard shortcuts', es: 'Ver atajos de teclado' },
+            href: '#',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'apps.ssh.quickstart',
+    match: ({ appId }) => appId === 'ssh',
+    cards: [
+      {
+        id: 'apps.ssh.connection',
+        title: { en: 'Simulated SSH sessions', es: 'Sesiones SSH simuladas' },
+        body: {
+          en: 'Start a demo connection with the presets on the left. Commands are emulated so you can practice safely.',
+          es: 'Inicia una conexión de demostración con los preajustes de la izquierda. Los comandos están emulados para practicar de forma segura.',
+        },
+      },
+    ],
+  },
+  {
+    id: 'apps.project-gallery.tour',
+    match: ({ appId }) => appId === 'project-gallery',
+    cards: [
+      {
+        id: 'apps.project-gallery.navigation',
+        title: { en: 'Browsing projects', es: 'Explorar proyectos' },
+        body: {
+          en: 'Filter the gallery with the tags above the grid. Select a project to open its case study in a window.',
+          es: 'Filtra la galería con las etiquetas sobre la cuadrícula. Selecciona un proyecto para abrir su caso práctico en una ventana.',
+        },
+      },
+    ],
+  },
+];
+
+export const contextHelpRegistry = createRuleRegistry(baseRules);
+
+export default contextHelpRegistry;


### PR DESCRIPTION
## Summary
- add a keyboard-accessible contextual help overlay component and persistence logic
- register desktop and app-specific help cards with localized content
- cover rule resolution and accessibility behaviour with targeted tests

## Testing
- yarn test contextHelp.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dccaad29608328a673901ba0b80613