### PR TITLE
[pwa] Refresh manifest shortcuts from MRU data

### DIFF
--- a/__tests__/shortcutStore.test.ts
+++ b/__tests__/shortcutStore.test.ts
@@ -1,0 +1,41 @@
+import 'fake-indexeddb/auto';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var crypto: Crypto;
+}
+
+beforeAll(() => {
+  if (typeof globalThis.crypto === 'undefined') {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    globalThis.crypto = require('crypto').webcrypto as Crypto;
+  }
+});
+
+beforeEach(async () => {
+  const { clearShortcutDataForTests } = await import('../services/mru/store');
+  await clearShortcutDataForTests();
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+test('records usage updates shortcut ordering', async () => {
+  const store = await import('../services/mru/store');
+  await store.recordShortcutUsage('2048');
+  const entries = await store.getTopShortcuts(4);
+  expect(entries.some((entry) => entry.id === '2048')).toBe(true);
+  expect(entries[0].pinned).toBe(true);
+});
+
+test('new sessions retain pinned shortcuts without reinstall', async () => {
+  const store = await import('../services/mru/store');
+  await store.setShortcutPinned('sticky_notes', true);
+  jest.resetModules();
+  const reloaded = await import('../services/mru/store');
+  const entries = await reloaded.getTopShortcuts(4);
+  const pinnedNote = entries.find((entry) => entry.id === 'sticky_notes');
+  expect(pinnedNote).toBeDefined();
+  expect(pinnedNote?.pinned).toBe(true);
+});

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
+import ShortcutSettings from './settings/ShortcutSettings';
 import KaliWallpaper from '../util-components/kali-wallpaper';
 
 export function Settings() {
@@ -309,6 +310,7 @@ export function Settings() {
                 }}
                 className="hidden"
             />
+            <ShortcutSettings />
         </div>
     )
 }

--- a/components/apps/settings/ShortcutSettings.tsx
+++ b/components/apps/settings/ShortcutSettings.tsx
@@ -1,0 +1,134 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import type { ShortcutRecord } from '../../../services/mru/store';
+import { getShortcutCandidates, setShortcutPinned } from '../../../services/mru/store';
+
+const formatLastUsed = (timestamp: number): string => {
+  if (!timestamp) return 'Not used yet';
+  try {
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return 'Not used yet';
+    return date.toLocaleString();
+  } catch {
+    return 'Not used yet';
+  }
+};
+
+type ShortcutView = ShortcutRecord & { isUpdating?: boolean };
+
+const ShortcutSettings: React.FC = () => {
+  const [shortcuts, setShortcuts] = useState<ShortcutView[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const entries = await getShortcutCandidates();
+      setShortcuts(entries.map((entry) => ({ ...entry, isUpdating: false })));
+      setError(null);
+    } catch (err) {
+      console.error('Failed to load shortcut candidates', err);
+      setError('Unable to load shortcuts from storage.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const togglePinned = async (entry: ShortcutView) => {
+    setShortcuts((prev) =>
+      prev.map((item) =>
+        item.id === entry.id
+          ? {
+              ...item,
+              isUpdating: true,
+              pinned: !entry.pinned,
+            }
+          : item,
+      ),
+    );
+    try {
+      await setShortcutPinned(entry.id, !entry.pinned);
+      await refresh();
+    } catch (err) {
+      console.error('Failed to update shortcut pin', err);
+      setError('Failed to update shortcut pin state.');
+      setShortcuts((prev) =>
+        prev.map((item) =>
+          item.id === entry.id
+            ? {
+                ...item,
+                isUpdating: false,
+                pinned: entry.pinned,
+              }
+            : item,
+        ),
+      );
+    }
+  };
+
+  return (
+    <section className="px-6 py-4 border-t border-gray-900 mt-6">
+      <header className="flex items-center justify-between mb-3">
+        <div>
+          <h2 className="text-lg font-semibold text-ubt-grey">App Shortcuts</h2>
+          <p className="text-xs text-ubt-grey/70">
+            Pin the shortcuts that should appear in your installed PWA manifest.
+          </p>
+        </div>
+        {isLoading && <span className="text-xs text-ubt-grey/70">Loading…</span>}
+      </header>
+      {error && (
+        <div className="mb-3 rounded border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-200">
+          {error}
+        </div>
+      )}
+      <ul className="space-y-3">
+        {shortcuts.map((entry) => (
+          <li
+            key={entry.id}
+            className="flex flex-col rounded border border-ubt-cool-grey/40 bg-black/20 p-3 text-ubt-grey"
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-sm font-medium text-white">{entry.manifest.name}</h3>
+                {entry.manifest.description && (
+                  <p className="text-xs text-ubt-grey/70">{entry.manifest.description}</p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => void togglePinned(entry)}
+                disabled={entry.isUpdating}
+                className={`px-3 py-1 rounded text-xs transition-colors duration-150 ${
+                  entry.pinned
+                    ? 'bg-ub-orange/90 text-white hover:bg-ub-orange'
+                    : 'bg-ubt-cool-grey/30 text-white hover:bg-ubt-cool-grey/60'
+                } ${entry.isUpdating ? 'opacity-70 cursor-wait' : ''}`}
+              >
+                {entry.pinned ? 'Unpin' : 'Pin'}
+              </button>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-ubt-grey/60">
+              <span className="rounded bg-black/30 px-2 py-1">{formatLastUsed(entry.lastUsed)}</span>
+              <span className="rounded bg-black/30 px-2 py-1 break-all">
+                {entry.manifest.url}
+              </span>
+              <span className="rounded bg-black/30 px-2 py-1 font-mono">
+                {entry.integrity || 'sha256-…'}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {!shortcuts.length && !isLoading && (
+        <p className="text-xs text-ubt-grey/70">No shortcut metadata available.</p>
+      )}
+    </section>
+  );
+};
+
+export default ShortcutSettings;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -22,6 +22,7 @@ import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
 import { addRecentApp } from '../../utils/recentStorage';
+import { recordShortcutUsage } from '../../services/mru/store';
 import { DESKTOP_TOP_PADDING } from '../../utils/uiConstants';
 import { useSnapSetting } from '../../hooks/usePersistentState';
 import {
@@ -1449,6 +1450,8 @@ export class Desktop extends Component {
         const contextState = context
             ? { ...this.state.window_context, [objId]: context }
             : this.state.window_context;
+
+        recordShortcutUsage(objId).catch(() => {});
 
 
         // google analytics

--- a/data/pwa-shortcuts.json
+++ b/data/pwa-shortcuts.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": "terminal",
+    "name": "Open Terminal",
+    "shortName": "Terminal",
+    "url": "/?open=terminal",
+    "description": "Resume your Kali terminal session instantly.",
+    "icons": [
+      {
+        "src": "/themes/Yaru/apps/bash.png",
+        "sizes": "96x96",
+        "type": "image/png"
+      }
+    ],
+    "defaultPinned": true,
+    "mruScore": 90
+  },
+  {
+    "id": "sticky_notes",
+    "name": "New Sticky Note",
+    "shortName": "Notes",
+    "url": "/apps/sticky_notes/",
+    "description": "Capture a quick thought in Sticky Notes.",
+    "icons": [
+      {
+        "src": "/themes/Yaru/apps/gnome-control-center.png",
+        "sizes": "96x96",
+        "type": "image/png"
+      }
+    ],
+    "defaultPinned": false,
+    "mruScore": 55
+  },
+  {
+    "id": "2048",
+    "name": "Open 2048 Daily",
+    "shortName": "2048",
+    "url": "/?open=2048&daily=true",
+    "description": "Return to the daily 2048 puzzle.",
+    "icons": [
+      {
+        "src": "/themes/Yaru/apps/2048.svg",
+        "sizes": "96x96",
+        "type": "image/svg+xml"
+      }
+    ],
+    "defaultPinned": false,
+    "mruScore": 48
+  },
+  {
+    "id": "weather",
+    "name": "View Weather Dashboard",
+    "shortName": "Weather",
+    "url": "/apps/weather",
+    "description": "Jump back into the weather dashboard.",
+    "icons": [
+      {
+        "src": "/themes/Yaru/apps/weather.svg",
+        "sizes": "96x96",
+        "type": "image/svg+xml"
+      }
+    ],
+    "defaultPinned": false,
+    "mruScore": 42
+  }
+]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://unnippillil.com/",
   "scripts": {
     "build:gamepad": "tsc -p tsconfig.gamepad.json",
-    "prebuild": "tsc -p tsconfig.gamepad.json",
+    "prebuild": "node scripts/generate-manifest-shortcuts.mjs && tsc -p tsconfig.gamepad.json",
     "dev": "next dev",
     "build": "next build",
     "postbuild": "node scripts/safe-copy.mjs",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -29,7 +29,9 @@
       "files": [
         {
           "name": "files",
-          "accept": ["*/*"]
+          "accept": [
+            "*/*"
+          ]
         }
       ]
     }
@@ -38,17 +40,58 @@
     {
       "name": "Open Terminal",
       "short_name": "Terminal",
-      "url": "/?open=terminal"
+      "url": "/?open=terminal",
+      "description": "Resume your Kali terminal session instantly.",
+      "icons": [
+        {
+          "src": "/themes/Yaru/apps/bash.png",
+          "sizes": "96x96",
+          "type": "image/png"
+        }
+      ],
+      "integrity": "sha256-lULHA9VW9r9mzSxQ50ZemkH8tP4cdhB5nJuTcZdh7SY="
     },
     {
-      "name": "New Note",
-      "short_name": "Note",
-      "url": "/apps/sticky_notes/"
+      "name": "New Sticky Note",
+      "short_name": "Notes",
+      "url": "/apps/sticky_notes/",
+      "description": "Capture a quick thought in Sticky Notes.",
+      "icons": [
+        {
+          "src": "/themes/Yaru/apps/gnome-control-center.png",
+          "sizes": "96x96",
+          "type": "image/png"
+        }
+      ],
+      "integrity": "sha256-C1/BmHrIPeKB/dgAeOyhQk75GAndcO7Ci8sxCPzfgTM="
     },
     {
       "name": "Open 2048 Daily",
       "short_name": "2048",
-      "url": "/?open=2048&daily=true"
+      "url": "/?open=2048&daily=true",
+      "description": "Return to the daily 2048 puzzle.",
+      "icons": [
+        {
+          "src": "/themes/Yaru/apps/2048.svg",
+          "sizes": "96x96",
+          "type": "image/svg+xml"
+        }
+      ],
+      "integrity": "sha256-Bf+EXczvXls5e10FdZH8iEWNGL3Q8/QeBbfY82GMotg="
+    },
+    {
+      "name": "View Weather Dashboard",
+      "short_name": "Weather",
+      "url": "/apps/weather",
+      "description": "Jump back into the weather dashboard.",
+      "icons": [
+        {
+          "src": "/themes/Yaru/apps/weather.svg",
+          "sizes": "96x96",
+          "type": "image/svg+xml"
+        }
+      ],
+      "integrity": "sha256-Z2jKRfRckBZUcCHTXgu2sUPGopoiyvmHr6Kj1X2d3Mg="
     }
   ]
 }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,2 +1,169 @@
-self.addEventListener('install', () => self.skipWaiting());
-self.addEventListener('activate', () => self.clients.claim());
+const SHORTCUT_DB_NAME = 'kali-shortcuts';
+const SHORTCUT_STORE = 'shortcuts';
+const MANIFEST_CACHE = 'shortcut-manifest-v1';
+const MANIFEST_URL = '/manifest.webmanifest';
+const MANIFEST_LIMIT = 4;
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+  event.waitUntil(caches.open(MANIFEST_CACHE));
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      await self.clients.claim();
+      await refreshShortcutsFromDb();
+    })(),
+  );
+});
+
+self.addEventListener('message', (event) => {
+  if (!event.data || typeof event.data !== 'object') return;
+  if (event.data.type === 'shortcuts:refresh') {
+    event.waitUntil(refreshShortcutsFromDb());
+  }
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+  if (url.pathname.endsWith('manifest.webmanifest')) {
+    event.respondWith(
+      caches.open(MANIFEST_CACHE).then(async (cache) => {
+        const cached = await cache.match(request);
+        if (cached) return cached;
+        try {
+          const response = await fetch(request);
+          cache.put(request, response.clone()).catch(() => {});
+          return response;
+        } catch (error) {
+          return cached ?? Response.error();
+        }
+      }),
+    );
+  }
+});
+
+const openShortcutDb = () =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.open(SHORTCUT_DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(SHORTCUT_STORE)) {
+        db.createObjectStore(SHORTCUT_STORE, { keyPath: 'id' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+const readShortcutRecords = (db) =>
+  new Promise((resolve, reject) => {
+    const tx = db.transaction(SHORTCUT_STORE, 'readonly');
+    const store = tx.objectStore(SHORTCUT_STORE);
+    const request = store.getAll();
+    request.onsuccess = () => resolve(Array.isArray(request.result) ? request.result : []);
+    request.onerror = () => reject(request.error);
+  });
+
+const sortShortcuts = (records) =>
+  [...records]
+    .filter((entry) => entry && entry.manifest)
+    .sort((a, b) => {
+      if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+      const aScore = typeof a.lastUsed === 'number' ? a.lastUsed : 0;
+      const bScore = typeof b.lastUsed === 'number' ? b.lastUsed : 0;
+      return bScore - aScore;
+    });
+
+const readBaseManifest = async () => {
+  try {
+    const response = await fetch(MANIFEST_URL, { cache: 'no-cache' });
+    if (response.ok) {
+      return await response.json();
+    }
+  } catch (error) {
+    // fall back to cache
+  }
+  try {
+    const cache = await caches.open(MANIFEST_CACHE);
+    const cached = await cache.match(MANIFEST_URL);
+    if (cached) {
+      return await cached.json();
+    }
+  } catch (error) {
+    // ignore cache failures
+  }
+  return null;
+};
+
+const updateClients = async (records) => {
+  const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+  const payload = {
+    type: 'shortcuts-updated',
+    count: records.filter((entry) => entry.pinned).length,
+    shortcuts: records.map((entry) => ({ id: entry.id, pinned: entry.pinned })),
+  };
+  for (const client of clients) {
+    client.postMessage(payload);
+  }
+};
+
+const refreshShortcutsFromDb = async () => {
+  if (typeof indexedDB === 'undefined') return;
+  let db;
+  try {
+    db = await openShortcutDb();
+  } catch (error) {
+    return;
+  }
+  if (!db) return;
+
+  let records;
+  try {
+    records = await readShortcutRecords(db);
+  } catch (error) {
+    db.close();
+    return;
+  }
+  db.close();
+
+  const sorted = sortShortcuts(records).slice(0, MANIFEST_LIMIT);
+  if (!sorted.length) {
+    if (self.registration && self.registration.clearAppBadge) {
+      self.registration.clearAppBadge().catch(() => {});
+    }
+    await updateClients([]);
+    return;
+  }
+
+  const manifest = (await readBaseManifest()) || {};
+  const shortcuts = sorted.map((entry) => ({
+    ...entry.manifest,
+    integrity: entry.integrity,
+  }));
+
+  manifest.shortcuts = shortcuts;
+
+  try {
+    const cache = await caches.open(MANIFEST_CACHE);
+    const response = new Response(JSON.stringify(manifest, null, 2), {
+      headers: { 'Content-Type': 'application/manifest+json' },
+    });
+    await cache.put(new Request(MANIFEST_URL), response);
+  } catch (error) {
+    // ignore cache write failures
+  }
+
+  if (self.registration && self.registration.setAppBadge) {
+    const pinnedCount = shortcuts.filter((entry, index) => sorted[index].pinned).length;
+    if (pinnedCount > 0) {
+      self.registration.setAppBadge(pinnedCount).catch(() => {});
+    } else if (self.registration.clearAppBadge) {
+      self.registration.clearAppBadge().catch(() => {});
+    }
+  }
+
+  await updateClients(sorted);
+};

--- a/scripts/generate-manifest-shortcuts.mjs
+++ b/scripts/generate-manifest-shortcuts.mjs
@@ -1,0 +1,90 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
+const MANIFEST_PATH = path.join(ROOT, 'public', 'manifest.webmanifest');
+const DATASET_PATH = path.join(ROOT, 'data', 'pwa-shortcuts.json');
+const MAX_SHORTCUTS = 4;
+
+const computeIntegrity = (entry) => {
+  const raw = `${entry.url}|${entry.name}|${entry.short_name ?? entry.name}`;
+  const digest = createHash('sha256').update(raw, 'utf8').digest('base64');
+  return `sha256-${digest}`;
+};
+
+const toManifestShortcut = (definition) => {
+  const manifestEntry = {
+    name: definition.name,
+    short_name: definition.shortName ?? definition.name,
+    url: definition.url,
+    description: definition.description,
+    icons: definition.icons,
+  };
+  return {
+    ...manifestEntry,
+    integrity: computeIntegrity(manifestEntry),
+  };
+};
+
+const normalizeDefinition = (definition) => ({
+  ...definition,
+  mruScore: typeof definition.mruScore === 'number' ? definition.mruScore : 0,
+  defaultPinned: Boolean(definition.defaultPinned),
+});
+
+async function main() {
+  let manifestRaw;
+  let datasetRaw;
+
+  try {
+    [manifestRaw, datasetRaw] = await Promise.all([
+      readFile(MANIFEST_PATH, 'utf8'),
+      readFile(DATASET_PATH, 'utf8'),
+    ]);
+  } catch (error) {
+    console.error('[manifest-shortcuts] Failed to read source files', error);
+    process.exitCode = 1;
+    return;
+  }
+
+  let manifest;
+  let dataset;
+  try {
+    manifest = JSON.parse(manifestRaw);
+    dataset = JSON.parse(datasetRaw).map(normalizeDefinition);
+  } catch (error) {
+    console.error('[manifest-shortcuts] Failed to parse JSON', error);
+    process.exitCode = 1;
+    return;
+  }
+
+  const topShortcuts = dataset
+    .filter((entry) => entry && !entry.disabled)
+    .sort((a, b) => {
+      if (a.defaultPinned !== b.defaultPinned) {
+        return a.defaultPinned ? -1 : 1;
+      }
+      return b.mruScore - a.mruScore;
+    })
+    .slice(0, MAX_SHORTCUTS)
+    .map(toManifestShortcut);
+
+  const nextManifest = {
+    ...manifest,
+    shortcuts: topShortcuts,
+  };
+
+  try {
+    await writeFile(MANIFEST_PATH, `${JSON.stringify(nextManifest, null, 2)}\n`, 'utf8');
+    console.log(`[manifest-shortcuts] Updated ${MANIFEST_PATH} with ${topShortcuts.length} shortcuts.`);
+  } catch (error) {
+    console.error('[manifest-shortcuts] Failed to write manifest', error);
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/services/mru/store.ts
+++ b/services/mru/store.ts
@@ -1,0 +1,314 @@
+import type { DBSchema, IDBPDatabase } from 'idb';
+import shortcuts from '../../data/pwa-shortcuts.json';
+import { getDb } from '../../utils/safeIDB';
+import { isBrowser } from '../../utils/isBrowser';
+
+const DB_NAME = 'kali-shortcuts';
+const STORE_NAME = 'shortcuts';
+const MAX_MANIFEST_SHORTCUTS = 4;
+
+type ShortcutDefinition = {
+  id: string;
+  name: string;
+  shortName?: string;
+  url: string;
+  description?: string;
+  icons?: Array<{ src: string; sizes: string; type: string }>;
+  defaultPinned?: boolean;
+  mruScore?: number;
+};
+
+type ManifestShortcut = {
+  name: string;
+  short_name: string;
+  url: string;
+  description?: string;
+  icons?: Array<{ src: string; sizes: string; type: string }>;
+};
+
+export type ShortcutRecord = {
+  id: string;
+  pinned: boolean;
+  lastUsed: number;
+  manifest: ManifestShortcut;
+  integrity: string;
+};
+
+interface ShortcutDB extends DBSchema {
+  shortcuts: {
+    key: string;
+    value: ShortcutRecord;
+    indexes: {
+      'by-last-used': number;
+      'by-pinned': boolean;
+    };
+  };
+}
+
+const definitions: ShortcutDefinition[] = (shortcuts as ShortcutDefinition[]).map((definition) => ({
+  ...definition,
+  defaultPinned: Boolean(definition.defaultPinned),
+  mruScore: typeof definition.mruScore === 'number' ? definition.mruScore : 0,
+}));
+
+const definitionById = new Map(definitions.map((definition) => [definition.id, definition]));
+
+let dbPromise: Promise<IDBPDatabase<ShortcutDB> | null> | null = null;
+
+const openShortcutDb = async (): Promise<IDBPDatabase<ShortcutDB> | null> => {
+  if (!dbPromise) {
+    const raw = getDb<ShortcutDB>(DB_NAME, 1, {
+      upgrade(database) {
+        if (!database.objectStoreNames.contains(STORE_NAME)) {
+          const store = database.createObjectStore(STORE_NAME, {
+            keyPath: 'id',
+          });
+          store.createIndex('by-last-used', 'lastUsed');
+          store.createIndex('by-pinned', 'pinned');
+        }
+      },
+    });
+    if (!raw) {
+      dbPromise = Promise.resolve(null);
+    } else {
+      dbPromise = raw.then(async (db) => {
+        if (!db) return null;
+        await seedDefaultPinned(db);
+        return db;
+      });
+    }
+  }
+
+  return dbPromise;
+};
+
+const toManifestShortcut = (definition: ShortcutDefinition): ManifestShortcut => ({
+  name: definition.name,
+  short_name: definition.shortName ?? definition.name,
+  url: definition.url,
+  description: definition.description,
+  icons: definition.icons,
+});
+
+const bytesToBase64 = (bytes: Uint8Array): string => {
+  if (typeof btoa === 'function') {
+    let binary = '';
+    for (let i = 0; i < bytes.length; i += 1) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+  }
+
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64');
+  }
+
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return binary;
+};
+
+export const computeShortcutIntegrity = async (manifest: ManifestShortcut): Promise<string> => {
+  const encoder = new TextEncoder();
+  const raw = `${manifest.url}|${manifest.name}|${manifest.short_name}`;
+  const payload = encoder.encode(raw);
+  const webCrypto: Crypto | undefined =
+    (typeof globalThis !== 'undefined' && (globalThis as { crypto?: Crypto }).crypto) || undefined;
+  if (webCrypto?.subtle?.digest) {
+    const digest = await webCrypto.subtle.digest('SHA-256', payload);
+    return `sha256-${bytesToBase64(new Uint8Array(digest))}`;
+  }
+  return '';
+};
+
+const ensureRecord = async (
+  db: IDBPDatabase<ShortcutDB>,
+  id: string,
+  overrides?: Partial<ShortcutRecord>,
+): Promise<ShortcutRecord | null> => {
+  const existing = await db.transaction(STORE_NAME).store.get(id);
+  if (existing) {
+    if (overrides) {
+      const next = { ...existing, ...overrides };
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      await tx.store.put(next);
+      await tx.done;
+      return next;
+    }
+    return existing;
+  }
+
+  const definition = definitionById.get(id);
+  if (!definition) {
+    return null;
+  }
+
+  const manifest = toManifestShortcut(definition);
+  const integrity = await computeShortcutIntegrity(manifest);
+  const record: ShortcutRecord = {
+    id,
+    pinned: overrides?.pinned ?? definition.defaultPinned ?? false,
+    lastUsed: overrides?.lastUsed ?? 0,
+    manifest,
+    integrity,
+  };
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  await tx.store.put(record);
+  await tx.done;
+  return record;
+};
+
+const seedDefaultPinned = async (db: IDBPDatabase<ShortcutDB>): Promise<void> => {
+  const defaults = definitions.filter((definition) => definition.defaultPinned);
+  if (!defaults.length) return;
+
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  for (const definition of defaults) {
+    const existing = await tx.store.get(definition.id);
+    if (existing) continue;
+    const manifest = toManifestShortcut(definition);
+    const integrity = await computeShortcutIntegrity(manifest);
+    await tx.store.put({
+      id: definition.id,
+      pinned: true,
+      lastUsed: 0,
+      manifest,
+      integrity,
+    });
+  }
+  await tx.done;
+};
+
+const notifyServiceWorker = () => {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+    return;
+  }
+
+  const sendMessage = async () => {
+    try {
+      const registration = await navigator.serviceWorker.getRegistration();
+      const target = registration?.active ?? navigator.serviceWorker.controller;
+      target?.postMessage({ type: 'shortcuts:refresh' });
+    } catch {
+      // Ignore notification failures
+    }
+  };
+
+  void sendMessage();
+};
+
+const definitionScore = (id: string): number => definitionById.get(id)?.mruScore ?? 0;
+
+const sortShortcuts = (records: ShortcutRecord[]): ShortcutRecord[] =>
+  [...records].sort((a, b) => {
+    if (a.pinned !== b.pinned) {
+      return a.pinned ? -1 : 1;
+    }
+    const aScore = a.lastUsed || definitionScore(a.id);
+    const bScore = b.lastUsed || definitionScore(b.id);
+    return bScore - aScore;
+  });
+
+export const recordShortcutUsage = async (id: string): Promise<void> => {
+  if (!isBrowser) return;
+  const db = await openShortcutDb();
+  if (!db) return;
+  const existing = await ensureRecord(db, id);
+  if (!existing) return;
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  await tx.store.put({
+    ...existing,
+    lastUsed: Date.now(),
+  });
+  await tx.done;
+  notifyServiceWorker();
+};
+
+export const setShortcutPinned = async (id: string, pinned: boolean): Promise<void> => {
+  if (!isBrowser) return;
+  const db = await openShortcutDb();
+  if (!db) return;
+  const record = await ensureRecord(db, id);
+  if (!record) return;
+  if (record.pinned === pinned) {
+    notifyServiceWorker();
+    return;
+  }
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  await tx.store.put({
+    ...record,
+    pinned,
+  });
+  await tx.done;
+  notifyServiceWorker();
+};
+
+export const getShortcutCandidates = async (): Promise<ShortcutRecord[]> => {
+  const db = await openShortcutDb();
+  if (!db) {
+    const fallbacks: ShortcutRecord[] = [];
+    for (const definition of definitions) {
+      const manifest = toManifestShortcut(definition);
+      const integrity = await computeShortcutIntegrity(manifest);
+      fallbacks.push({
+        id: definition.id,
+        pinned: definition.defaultPinned ?? false,
+        lastUsed: 0,
+        manifest,
+        integrity,
+      });
+    }
+    return sortShortcuts(fallbacks);
+  }
+
+  const tx = db.transaction(STORE_NAME, 'readonly');
+  const stored = await tx.store.getAll();
+  await tx.done;
+
+  const mapped = new Map(stored.map((record) => [record.id, record]));
+  const merged: ShortcutRecord[] = [];
+  for (const definition of definitions) {
+    const existing = mapped.get(definition.id);
+    if (existing) {
+      merged.push(existing);
+    } else {
+      const manifest = toManifestShortcut(definition);
+      const integrity = await computeShortcutIntegrity(manifest);
+      merged.push({
+        id: definition.id,
+        pinned: definition.defaultPinned ?? false,
+        lastUsed: 0,
+        manifest,
+        integrity,
+      });
+    }
+  }
+  return sortShortcuts(merged);
+};
+
+export const getTopShortcuts = async (
+  limit = MAX_MANIFEST_SHORTCUTS,
+): Promise<ShortcutRecord[]> => {
+  const candidates = await getShortcutCandidates();
+  return candidates.slice(0, limit);
+};
+
+export const clearShortcutDataForTests = async (): Promise<void> => {
+  if (typeof indexedDB === 'undefined') return;
+  await new Promise<void>((resolve) => {
+    const request = indexedDB.deleteDatabase(DB_NAME);
+    request.onsuccess = () => {
+      dbPromise = null;
+      resolve();
+    };
+    request.onerror = () => {
+      dbPromise = null;
+      resolve();
+    };
+    request.onblocked = () => {
+      resolve();
+    };
+  });
+};

--- a/utils/safeIDB.ts
+++ b/utils/safeIDB.ts
@@ -1,7 +1,11 @@
-import { openDB } from 'idb';
+import { openDB, type DBSchema, type IDBPDatabase, type OpenDBCallbacks } from 'idb';
 import { hasIndexedDB } from './isBrowser';
 
-export function getDb(name: string, version = 1, upgrade?: Parameters<typeof openDB>[2]) {
+export function getDb<Schema extends DBSchema = DBSchema>(
+  name: string,
+  version = 1,
+  options?: OpenDBCallbacks<Schema>,
+): Promise<IDBPDatabase<Schema>> | null {
   if (!hasIndexedDB) return null;
-  return openDB(name, version, upgrade);
+  return openDB<Schema>(name, version, options);
 }


### PR DESCRIPTION
## Summary
- add a prebuild manifest generator that merges curated MRU shortcut definitions with integrity hashes
- introduce an IndexedDB-backed MRU store, settings UI, and desktop hook to record usage and pin shortcuts
- update the service worker to refresh cached shortcuts and app badges when MRU data changes

## Testing
- yarn test __tests__/shortcutStore.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dccab250fc8328ac4a20364d2c4ebe