### PR TITLE
[accessibility] Add cursor thickness controls

### DIFF
--- a/__tests__/cursorThickness.test.tsx
+++ b/__tests__/cursorThickness.test.tsx
@@ -1,0 +1,47 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { SettingsProvider, useSettings } from '../hooks/useSettings';
+
+const getCaretWidth = () =>
+  document.documentElement.style.getPropertyValue('--text-caret-width');
+
+const getCaretShape = () =>
+  document.documentElement.style.getPropertyValue('--text-caret-shape');
+
+describe('cursor thickness setting', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.style.removeProperty('--text-caret-width');
+    document.documentElement.style.removeProperty('--text-caret-shape');
+    document.documentElement.style.removeProperty('--text-caret-transition');
+  });
+
+  test('persists selection and updates css variables', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+
+    act(() => {
+      result.current.setCursorThickness('thick');
+    });
+
+    expect(result.current.cursorThickness).toBe('thick');
+    expect(window.localStorage.getItem('cursor-thickness')).toBe('thick');
+    expect(getCaretWidth()).toBe('4px');
+    expect(getCaretShape()).toBe('block');
+
+    input.focus();
+    expect(getCaretWidth()).toBe('4px');
+    input.blur();
+    expect(getCaretWidth()).toBe('4px');
+  });
+
+  test('restores saved cursor thickness on load', async () => {
+    window.localStorage.setItem('cursor-thickness', 'thin');
+    const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+
+    await waitFor(() => expect(result.current.cursorThickness).toBe('thin'));
+    expect(getCaretWidth()).toBe('1px');
+    expect(getCaretShape()).toBe('bar');
+  });
+});

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -4,10 +4,16 @@ import { resetSettings, defaults, exportSettings as exportSettingsData, importSe
 import KaliWallpaper from '../util-components/kali-wallpaper';
 
 export function Settings() {
-    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
+    const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, cursorThickness, setCursorThickness, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
+
+    const thicknessOptions = [
+        { value: 'thin', label: 'Thin', description: '1px caret for minimal footprint.' },
+        { value: 'regular', label: 'Regular', description: '2px caret balanced for most users.' },
+        { value: 'thick', label: 'Thick', description: '4px block-style caret for low-vision support.' },
+    ];
 
     const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
 
@@ -159,6 +165,40 @@ export function Settings() {
                     Large Hit Areas
                 </label>
             </div>
+            <div className="flex flex-col items-center my-4">
+                <fieldset className="flex flex-col items-center" role="radiogroup" aria-label="Cursor thickness">
+                    <legend className="text-ubt-grey mb-2">Cursor Thickness:</legend>
+                    <div className="flex flex-wrap justify-center gap-2">
+                        {thicknessOptions.map((option) => (
+                            <label key={option.value} className={`px-3 py-1 rounded border ${cursorThickness === option.value ? 'border-ubt-cool-grey bg-ub-cool-grey/40' : 'border-transparent bg-ub-cool-grey/10'} transition-colors` }>
+                                <input
+                                    type="radio"
+                                    name="cursor-thickness"
+                                    value={option.value}
+                                    checked={cursorThickness === option.value}
+                                    onChange={(e) => setCursorThickness(e.target.value)}
+                                    className="sr-only"
+                                />
+                                <span className="text-ubt-grey">{option.label}</span>
+                            </label>
+                        ))}
+                    </div>
+                </fieldset>
+                <div className="w-full max-w-md mt-3">
+                    <div
+                        className="caret-preview"
+                        role="textbox"
+                        aria-label="Type to preview cursor thickness"
+                        contentEditable
+                        suppressContentEditableWarning
+                    >
+                        Try typing here to preview the caret.
+                    </div>
+                    <p className="text-xs text-ubt-grey mt-2 text-center" aria-live="polite">
+                        {thicknessOptions.find(option => option.value === cursorThickness)?.description}
+                    </p>
+                </div>
+            </div>
             <div className="flex justify-center my-4">
                 <label className="mr-2 text-ubt-grey flex items-center">
                     <input
@@ -275,6 +315,7 @@ export function Settings() {
                         setDensity(defaults.density);
                         setReducedMotion(defaults.reducedMotion);
                         setLargeHitAreas(defaults.largeHitAreas);
+                        setCursorThickness(defaults.cursorThickness);
                         setFontScale(defaults.fontScale);
                         setHighContrast(defaults.highContrast);
                         setTheme('default');
@@ -300,6 +341,7 @@ export function Settings() {
                         if (parsed.density !== undefined) setDensity(parsed.density);
                         if (parsed.reducedMotion !== undefined) setReducedMotion(parsed.reducedMotion);
                         if (parsed.largeHitAreas !== undefined) setLargeHitAreas(parsed.largeHitAreas);
+                        if (parsed.cursorThickness !== undefined) setCursorThickness(parsed.cursorThickness);
                         if (parsed.highContrast !== undefined) setHighContrast(parsed.highContrast);
                         if (parsed.theme !== undefined) { setTheme(parsed.theme); }
                     } catch (err) {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -22,6 +22,10 @@
   --color-control-accent: var(--color-accent);
   --kali-text: #f5f5f5;
   accent-color: var(--color-control-accent);
+  --text-caret-color: var(--color-focus-ring);
+  --text-caret-width: 2px;
+  --text-caret-shape: auto;
+  --text-caret-transition: 150ms;
 }
 
 body {
@@ -87,6 +91,54 @@ html[data-theme='matrix'] {
 
 html {
   scrollbar-color: var(--kali-border, var(--color-border)) transparent;
+}
+
+input,
+textarea,
+[contenteditable='true'],
+.caret-preview,
+.monaco-editor textarea {
+  caret-color: var(--text-caret-color);
+}
+
+@supports (caret-shape: bar) {
+  input,
+  textarea,
+  [contenteditable='true'],
+  .caret-preview {
+    caret-shape: var(--text-caret-shape);
+  }
+}
+
+.caret-preview {
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  padding: var(--space-3, 0.75rem);
+  background: var(--color-surface);
+  color: var(--color-text);
+  min-height: 2.75rem;
+  line-height: 1.5;
+  transition: border-color var(--text-caret-transition), box-shadow var(--text-caret-transition);
+}
+
+.caret-preview:focus {
+  outline: none;
+  box-shadow: 0 0 0 calc(var(--text-caret-width) + 1px) color-mix(in srgb, var(--text-caret-color) 40%, transparent);
+  border-color: var(--text-caret-color);
+}
+
+.monaco-editor .cursor {
+  width: var(--text-caret-width) !important;
+  background-color: var(--text-caret-color) !important;
+  transition: width var(--text-caret-transition), background-color var(--text-caret-transition);
+}
+
+.monaco-editor .cursor.secondary {
+  background-color: color-mix(in srgb, var(--text-caret-color) 65%, transparent) !important;
+}
+
+.monaco-editor .inputarea.ime-input {
+  caret-color: var(--text-caret-color) !important;
 }
 
 ::-webkit-scrollbar {

--- a/styles/index.css
+++ b/styles/index.css
@@ -228,6 +228,13 @@ input[type=range].ubuntu-slider::-webkit-slider-thumb {
 
 .xterm .xterm-cursor {
     animation: cursor-pulse 1s steps(2) infinite;
+    border-left: var(--text-caret-width) solid var(--text-caret-color);
+    transition: border-color var(--text-caret-transition), border-width var(--text-caret-transition);
+}
+
+.xterm .xterm-cursor-block,
+.xterm .xterm-cursor.xterm-cursor-block {
+    background-color: color-mix(in srgb, var(--text-caret-color) 85%, transparent);
 }
 
 dialog {

--- a/utils/settingsStore.js
+++ b/utils/settingsStore.js
@@ -12,6 +12,7 @@ const DEFAULT_SETTINGS = {
   fontScale: 1,
   highContrast: false,
   largeHitAreas: false,
+  cursorThickness: 'regular',
   pongSpin: true,
   allowNetwork: false,
   haptics: true,
@@ -103,6 +104,16 @@ export async function setLargeHitAreas(value) {
   window.localStorage.setItem('large-hit-areas', value ? 'true' : 'false');
 }
 
+export async function getCursorThickness() {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS.cursorThickness;
+  return window.localStorage.getItem('cursor-thickness') || DEFAULT_SETTINGS.cursorThickness;
+}
+
+export async function setCursorThickness(value) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem('cursor-thickness', value);
+}
+
 export async function getHaptics() {
   if (typeof window === 'undefined') return DEFAULT_SETTINGS.haptics;
   const val = window.localStorage.getItem('haptics');
@@ -146,6 +157,7 @@ export async function resetSettings() {
   window.localStorage.removeItem('font-scale');
   window.localStorage.removeItem('high-contrast');
   window.localStorage.removeItem('large-hit-areas');
+  window.localStorage.removeItem('cursor-thickness');
   window.localStorage.removeItem('pong-spin');
   window.localStorage.removeItem('allow-network');
   window.localStorage.removeItem('haptics');
@@ -162,6 +174,7 @@ export async function exportSettings() {
     fontScale,
     highContrast,
     largeHitAreas,
+    cursorThickness,
     pongSpin,
     allowNetwork,
     haptics,
@@ -174,6 +187,7 @@ export async function exportSettings() {
     getFontScale(),
     getHighContrast(),
     getLargeHitAreas(),
+    getCursorThickness(),
     getPongSpin(),
     getAllowNetwork(),
     getHaptics(),
@@ -187,6 +201,7 @@ export async function exportSettings() {
     fontScale,
     highContrast,
     largeHitAreas,
+    cursorThickness,
     pongSpin,
     allowNetwork,
     haptics,
@@ -213,6 +228,7 @@ export async function importSettings(json) {
     fontScale,
     highContrast,
     largeHitAreas,
+    cursorThickness,
     pongSpin,
     allowNetwork,
     haptics,
@@ -226,6 +242,7 @@ export async function importSettings(json) {
   if (fontScale !== undefined) await setFontScale(fontScale);
   if (highContrast !== undefined) await setHighContrast(highContrast);
   if (largeHitAreas !== undefined) await setLargeHitAreas(largeHitAreas);
+  if (cursorThickness !== undefined) await setCursorThickness(cursorThickness);
   if (pongSpin !== undefined) await setPongSpin(pongSpin);
   if (allowNetwork !== undefined) await setAllowNetwork(allowNetwork);
   if (haptics !== undefined) await setHaptics(haptics);


### PR DESCRIPTION
## Summary
- extend settings store and React hook to persist cursor thickness selection and expose CSS custom properties
- update global and terminal/editor styles to honor caret width and shape variables
- add accessibility controls with live preview in the Settings app and cover behavior with new Jest tests

## Testing
- yarn test cursorThickness --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dccab668bc832886998eee9eeed86b