### PR TITLE
[i18n] Add integrity-checked locale packs loader

### DIFF
--- a/__tests__/i18n/loader.test.ts
+++ b/__tests__/i18n/loader.test.ts
@@ -1,0 +1,114 @@
+import fs from 'fs';
+import path from 'path';
+import { webcrypto } from 'crypto';
+import { loadLocalePack, clearLocalePackCache, getCachedLocalePack } from '@/i18n/loader';
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES, SupportedLocale } from '@/i18n/manifest';
+
+const toArrayBuffer = (input: string): ArrayBuffer => {
+  const buffer = Buffer.from(input, 'utf-8');
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+};
+
+const readPackFixture = (locale: SupportedLocale): string => {
+  const filePath = path.join(process.cwd(), 'public', 'i18n', 'packs', `${locale}.json`);
+  return fs.readFileSync(filePath, 'utf-8');
+};
+
+describe('loadLocalePack', () => {
+  beforeAll(() => {
+    // Ensure the loader has access to SubtleCrypto in the Jest environment.
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: webcrypto as unknown as Crypto,
+    });
+  });
+
+  beforeEach(() => {
+    clearLocalePackCache();
+    jest.restoreAllMocks();
+  });
+
+  it('loads and caches locale packs when integrity matches', async () => {
+    const locale: SupportedLocale = 'es';
+    const packContents = readPackFixture(locale);
+    const arrayBuffer = toArrayBuffer(packContents);
+
+    const fetchMock = jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        arrayBuffer: async () => arrayBuffer,
+      } as unknown as Response);
+
+    const pack = await loadLocalePack(locale);
+    expect(pack.locale).toBe(locale);
+    expect(pack.messages['desktop.launch']).toBe('Iniciar');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const cachedPack = await loadLocalePack(locale);
+    expect(cachedPack).toBe(pack);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the default locale when integrity validation fails', async () => {
+    const locale: SupportedLocale = 'es';
+    const invalidBuffer = toArrayBuffer('{"tampered":true}');
+    const defaultBuffer = toArrayBuffer(readPackFixture(DEFAULT_LOCALE));
+
+    const fetchMock = jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        arrayBuffer: async () => invalidBuffer,
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        arrayBuffer: async () => defaultBuffer,
+      } as unknown as Response);
+
+    const pack = await loadLocalePack(locale);
+    expect(pack.locale).toBe(DEFAULT_LOCALE);
+    expect(pack.messages['desktop.launch']).toBe('Launch');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const cachedFallback = await loadLocalePack(locale);
+    expect(cachedFallback).toBe(pack);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when requesting an unsupported locale', async () => {
+    const unsupportedLocale = 'fr' as SupportedLocale;
+    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+    await expect(loadLocalePack(unsupportedLocale)).rejects.toThrow('Unsupported locale');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('exposes cached packs for supported locales', async () => {
+    const locale: SupportedLocale = 'en';
+    const buffer = toArrayBuffer(readPackFixture(locale));
+
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      arrayBuffer: async () => buffer,
+    } as unknown as Response);
+
+    expect(getCachedLocalePack(locale)).toBeUndefined();
+
+    const pack = await loadLocalePack(locale);
+    expect(getCachedLocalePack(locale)).toBe(pack);
+  });
+
+  it('has fixtures for all supported locales to keep manifest and packs in sync', () => {
+    for (const locale of SUPPORTED_LOCALES) {
+      expect(() => readPackFixture(locale)).not.toThrow();
+    }
+  });
+});

--- a/i18n/loader.ts
+++ b/i18n/loader.ts
@@ -1,0 +1,161 @@
+import { DEFAULT_LOCALE, PACK_MANIFEST, SupportedLocale } from './manifest';
+
+export interface LocalePack {
+  locale: SupportedLocale;
+  messages: Record<string, string>;
+}
+
+export class IntegrityError extends Error {
+  readonly locale: SupportedLocale;
+  readonly expected: string;
+  readonly actual: string;
+
+  constructor(locale: SupportedLocale, expected: string, actual: string) {
+    super(`Integrity check failed for locale "${locale}": expected ${expected}, received ${actual}`);
+    this.name = 'IntegrityError';
+    this.locale = locale;
+    this.expected = expected;
+    this.actual = actual;
+  }
+}
+
+const packCache = new Map<SupportedLocale, LocalePack>();
+const textDecoder = typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8') : undefined;
+let nodeSubtle: SubtleCrypto | null | undefined;
+let nodeSubtlePromise: Promise<SubtleCrypto | null> | null | undefined;
+
+const toBase64 = (buffer: ArrayBuffer): string => {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(buffer).toString('base64');
+  }
+
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+
+  if (typeof btoa === 'function') {
+    return btoa(binary);
+  }
+
+  throw new Error('Unable to convert ArrayBuffer to base64: environment lacks Buffer and btoa.');
+};
+
+const decodeUtf8 = (buffer: ArrayBuffer): string => {
+  if (textDecoder) {
+    return textDecoder.decode(buffer);
+  }
+
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(buffer).toString('utf-8');
+  }
+
+  throw new Error('Unable to decode locale pack: environment lacks TextDecoder and Buffer.');
+};
+
+const getSubtleCrypto = async (): Promise<SubtleCrypto | null> => {
+  if (typeof globalThis !== 'undefined') {
+    const cryptoFromGlobal = (globalThis as typeof globalThis & { crypto?: Crypto }).crypto;
+    if (cryptoFromGlobal?.subtle) {
+      return cryptoFromGlobal.subtle;
+    }
+  }
+
+  if (nodeSubtle !== undefined) {
+    return nodeSubtle;
+  }
+
+  if (typeof process !== 'undefined' && typeof process.versions?.node === 'string') {
+    if (nodeSubtlePromise === undefined) {
+      nodeSubtlePromise = import('crypto')
+        .then((nodeCrypto) => nodeCrypto.webcrypto?.subtle ?? null)
+        .catch(() => null);
+    }
+
+    nodeSubtle = await nodeSubtlePromise;
+    return nodeSubtle;
+  }
+
+  return null;
+};
+
+const computeIntegrity = async (buffer: ArrayBuffer): Promise<string> => {
+  const subtle = await getSubtleCrypto();
+  if (!subtle) {
+    throw new Error('SubtleCrypto is not available in this environment.');
+  }
+
+  const digest = await subtle.digest('SHA-384', buffer);
+  return `sha384-${toBase64(digest)}`;
+};
+
+const loadLocalePackInternal = async (
+  locale: SupportedLocale,
+  visited: Set<SupportedLocale>,
+): Promise<LocalePack> => {
+  if (packCache.has(locale)) {
+    return packCache.get(locale)!;
+  }
+
+  const manifestEntry = PACK_MANIFEST[locale];
+  if (!manifestEntry) {
+    throw new Error(`Unsupported locale: ${locale}`);
+  }
+
+  const response = await fetch(manifestEntry.path);
+  if (!response.ok) {
+    throw new Error(`Failed to load locale pack for ${locale}: ${response.status} ${response.statusText}`);
+  }
+
+  const buffer = await response.arrayBuffer();
+  const computedIntegrity = await computeIntegrity(buffer);
+
+  if (computedIntegrity !== manifestEntry.integrity) {
+    const error = new IntegrityError(locale, manifestEntry.integrity, computedIntegrity);
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      console.warn(error);
+    }
+
+    if (visited.has(locale)) {
+      throw error;
+    }
+    visited.add(locale);
+
+    const fallbackPack = await resolveFallback(locale, visited, error);
+    packCache.set(locale, fallbackPack);
+    return fallbackPack;
+  }
+
+  const jsonText = decodeUtf8(buffer);
+  const pack = JSON.parse(jsonText) as LocalePack;
+  packCache.set(locale, pack);
+  return pack;
+};
+
+const resolveFallback = async (
+  locale: SupportedLocale,
+  visited: Set<SupportedLocale>,
+  error: IntegrityError,
+): Promise<LocalePack> => {
+  if (packCache.has(locale)) {
+    return packCache.get(locale)!;
+  }
+
+  if (locale !== DEFAULT_LOCALE) {
+    const fallbackPack = await loadLocalePackInternal(DEFAULT_LOCALE, visited);
+    return fallbackPack;
+  }
+
+  throw error;
+};
+
+export const loadLocalePack = async (locale: SupportedLocale): Promise<LocalePack> =>
+  loadLocalePackInternal(locale, new Set());
+
+export const clearLocalePackCache = (): void => {
+  packCache.clear();
+};
+
+export const getCachedLocalePack = (locale: SupportedLocale): LocalePack | undefined =>
+  packCache.get(locale);

--- a/i18n/manifest.ts
+++ b/i18n/manifest.ts
@@ -1,0 +1,24 @@
+export type SupportedLocale = 'en' | 'es';
+
+export interface PackManifestEntry {
+  locale: SupportedLocale;
+  path: string;
+  integrity: string;
+}
+
+export const DEFAULT_LOCALE: SupportedLocale = 'en';
+
+export const PACK_MANIFEST: Record<SupportedLocale, PackManifestEntry> = {
+  en: {
+    locale: 'en',
+    path: '/i18n/packs/en.json',
+    integrity: 'sha384-Cy0uSm8gLN43MfifLmiZi0rKYNUl/qgtaqjHJj2GouX+c7VrIJ5tytaYf8IctD79',
+  },
+  es: {
+    locale: 'es',
+    path: '/i18n/packs/es.json',
+    integrity: 'sha384-1AzicERvpJrzQCwkTABGKZ/7JbIXKEMnpNGqZPQIKf+1ntDko0MyXxlr9AJAlaPS',
+  },
+};
+
+export const SUPPORTED_LOCALES = Object.keys(PACK_MANIFEST) as SupportedLocale[];

--- a/public/i18n/packs/en.json
+++ b/public/i18n/packs/en.json
@@ -1,0 +1,11 @@
+{
+  "locale": "en",
+  "messages": {
+    "desktop.welcome": "Welcome to the Kali Linux portfolio",
+    "desktop.launch": "Launch",
+    "desktop.loading": "Loading…",
+    "desktop.search": "Search applications",
+    "desktop.recent": "Recent activity",
+    "desktop.language": "Language"
+  }
+}

--- a/public/i18n/packs/es.json
+++ b/public/i18n/packs/es.json
@@ -1,0 +1,11 @@
+{
+  "locale": "es",
+  "messages": {
+    "desktop.welcome": "Bienvenido al portafolio de Kali Linux",
+    "desktop.launch": "Iniciar",
+    "desktop.loading": "Cargando…",
+    "desktop.search": "Buscar aplicaciones",
+    "desktop.recent": "Actividad reciente",
+    "desktop.language": "Idioma"
+  }
+}


### PR DESCRIPTION
## Summary
- add localized JSON packs for English and Spanish with precomputed SRI hashes
- implement an integrity-checked locale pack loader with caching and fallback behaviour
- add Jest coverage to ensure packs only load when integrity validation passes

## Testing
- yarn test __tests__/i18n/loader.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dccab9a6808328b2eb59876f2c5b56