### PR TITLE
[analytics] make web vitals sampling configurable

### DIFF
--- a/__tests__/reportWebVitals.test.ts
+++ b/__tests__/reportWebVitals.test.ts
@@ -1,5 +1,10 @@
 import ReactGA from 'react-ga4';
 import { reportWebVitals } from '../utils/reportWebVitals';
+import {
+  getWebVitalsClientId,
+  resetWebVitalsConfig,
+  updateWebVitalsConfig,
+} from '../utils/webVitalsConfig';
 
 jest.mock('react-ga4', () => ({
   event: jest.fn(),
@@ -9,16 +14,32 @@ describe('reportWebVitals', () => {
   const mockEvent = ReactGA.event as jest.Mock;
   const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   const originalEnv = process.env;
+  const originalRandom = Math.random;
+
+  const setSampleConfig = (config: Parameters<typeof updateWebVitalsConfig>[0]) => {
+    updateWebVitalsConfig({
+      defaultSampleRate: 1,
+      sampleRates: { LCP: 1, INP: 1 },
+      allowRoutes: [],
+      allowClients: [],
+    });
+    updateWebVitalsConfig(config);
+  };
 
   beforeEach(() => {
     mockEvent.mockReset();
     warnSpy.mockClear();
     process.env = { ...originalEnv };
+    Math.random = originalRandom;
+    resetWebVitalsConfig();
+    setSampleConfig({});
+    window.history.replaceState(null, '', '/');
   });
 
   afterAll(() => {
     warnSpy.mockRestore();
     process.env = originalEnv;
+    Math.random = originalRandom;
   });
 
   it('does nothing outside preview', () => {
@@ -46,5 +67,39 @@ describe('reportWebVitals', () => {
       expect.objectContaining({ action: 'INP degraded' })
     );
     expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('skips events when sampling rate blocks them', () => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview';
+    setSampleConfig({ defaultSampleRate: 0, sampleRates: { LCP: 0 } });
+    reportWebVitals({ id: '4', name: 'LCP', value: 2100 });
+    expect(mockEvent).not.toHaveBeenCalled();
+  });
+
+  it('samples when the current route is allowlisted', () => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview';
+    setSampleConfig({ defaultSampleRate: 0, allowRoutes: ['/focused/*'] });
+    window.history.pushState(null, '', '/focused/test');
+    reportWebVitals({ id: '5', name: 'LCP', value: 2100 });
+    expect(mockEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('samples when the client is allowlisted', () => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview';
+    const clientId = getWebVitalsClientId();
+    setSampleConfig({ defaultSampleRate: 0, allowClients: [clientId] });
+    reportWebVitals({ id: '6', name: 'INP', value: 210 });
+    expect(mockEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies sampling changes immediately', () => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview';
+    setSampleConfig({ defaultSampleRate: 0, sampleRates: { LCP: 0 } });
+    reportWebVitals({ id: '7', name: 'LCP', value: 1900 });
+    expect(mockEvent).not.toHaveBeenCalled();
+
+    setSampleConfig({ defaultSampleRate: 1, sampleRates: { LCP: 1 } });
+    reportWebVitals({ id: '8', name: 'LCP', value: 1900 });
+    expect(mockEvent).toHaveBeenCalledTimes(1);
   });
 });

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,7 +1,9 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 import KaliWallpaper from '../util-components/kali-wallpaper';
+import WebVitalsSamplingSettings from '../util-components/WebVitalsSamplingSettings';
 
 export function Settings() {
     const { accent, setAccent, wallpaper, setWallpaper, useKaliWallpaper, setUseKaliWallpaper, density, setDensity, reducedMotion, setReducedMotion, largeHitAreas, setLargeHitAreas, fontScale, setFontScale, highContrast, setHighContrast, pongSpin, setPongSpin, allowNetwork, setAllowNetwork, haptics, setHaptics, theme, setTheme } = useSettings();
@@ -202,6 +204,9 @@ export function Settings() {
                     />
                     Pong Spin
                 </label>
+            </div>
+            <div className="w-full px-6">
+                <WebVitalsSamplingSettings />
             </div>
             <div className="flex justify-center my-4">
                 <div

--- a/components/util-components/WebVitalsSamplingSettings.tsx
+++ b/components/util-components/WebVitalsSamplingSettings.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { type ChangeEvent, useEffect, useMemo, useState } from 'react';
+import {
+  getWebVitalsClientId,
+  getWebVitalsConfig,
+  resetWebVitalsConfig,
+  subscribeToWebVitalsConfig,
+  updateWebVitalsConfig,
+  WebVitalsSamplingConfig,
+} from '../../utils/webVitalsConfig';
+
+const METRICS: Array<{ key: string; label: string }> = [
+  { key: 'LCP', label: 'Largest Contentful Paint (LCP)' },
+  { key: 'INP', label: 'Interaction to Next Paint (INP)' },
+];
+
+const rateToPercent = (rate: number): number => Math.round(rate * 100);
+
+const percentToRate = (value: number): number => Math.min(Math.max(value / 100, 0), 1);
+
+const toTextareaValue = (values: string[]): string => values.join('\n');
+
+const parseTextareaValue = (value: string): string[] =>
+  value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+const formatPercentLabel = (percent: number): string => `${percent}%`;
+
+const WebVitalsSamplingSettings = () => {
+  const [config, setConfig] = useState<WebVitalsSamplingConfig>(() => getWebVitalsConfig());
+  const [clientId, setClientId] = useState('');
+  const defaultRateId = 'web-vitals-default-rate';
+  const routeAllowlistId = 'web-vitals-route-allowlist';
+  const deviceToggleId = 'web-vitals-device-allow';
+
+  useEffect(() => {
+    const unsubscribe = subscribeToWebVitalsConfig((next) => {
+      setConfig(next);
+    });
+    setClientId(getWebVitalsClientId());
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  const defaultPercent = useMemo(
+    () => rateToPercent(config.defaultSampleRate),
+    [config.defaultSampleRate]
+  );
+
+  const handleDefaultRateChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextPercent = Number(event.target.value);
+    const next = updateWebVitalsConfig({ defaultSampleRate: percentToRate(nextPercent) });
+    setConfig(next);
+  };
+
+  const handleMetricRateChange = (
+    metric: string,
+    event: ChangeEvent<HTMLInputElement>
+  ) => {
+    const nextPercent = Number(event.target.value);
+    const next = updateWebVitalsConfig({ sampleRates: { [metric]: percentToRate(nextPercent) } });
+    setConfig(next);
+  };
+
+  const handleRoutesChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const routes = parseTextareaValue(event.target.value);
+    const next = updateWebVitalsConfig({ allowRoutes: routes });
+    setConfig(next);
+  };
+
+  const handleClientToggle = (event: ChangeEvent<HTMLInputElement>) => {
+    const allow = event.target.checked;
+    const nextAllowClients = new Set(config.allowClients);
+    if (allow) {
+      nextAllowClients.add(clientId);
+    } else {
+      nextAllowClients.delete(clientId);
+    }
+    const next = updateWebVitalsConfig({ allowClients: Array.from(nextAllowClients) });
+    setConfig(next);
+  };
+
+  const handleReset = () => {
+    const next = resetWebVitalsConfig();
+    setConfig(next);
+  };
+
+  const allowlistValue = useMemo(
+    () => toTextareaValue(config.allowRoutes),
+    [config.allowRoutes]
+  );
+
+  const isClientAllowlisted = clientId ? config.allowClients.includes(clientId) : false;
+
+  return (
+    <section className="mt-6 rounded border border-ubt-cool-grey bg-ub-cool-grey/40 p-4 text-left text-ubt-grey">
+      <h2 className="text-lg font-semibold text-white">Performance Sampling</h2>
+      <p className="mt-1 text-xs text-ubt-grey/70">
+        Control how often Web Vitals events are sent during preview deployments. Allowlisted routes or this
+        device bypass the sampler.
+      </p>
+      <div className="mt-4">
+        <label className="text-sm font-medium" htmlFor={defaultRateId}>
+          Default sample rate: {formatPercentLabel(defaultPercent)}
+        </label>
+        <input
+          id={defaultRateId}
+          type="range"
+          min="0"
+          max="100"
+          step="5"
+          value={defaultPercent}
+          onChange={handleDefaultRateChange}
+          className="ubuntu-slider mt-2 w-full"
+          aria-label="Default sample rate"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={defaultPercent}
+          aria-valuetext={formatPercentLabel(defaultPercent)}
+        />
+      </div>
+      <div className="mt-4 space-y-4">
+        {METRICS.map(({ key, label }) => {
+          const percent = rateToPercent(config.sampleRates[key] ?? config.defaultSampleRate);
+          const metricId = `web-vitals-rate-${key.toLowerCase()}`;
+          return (
+            <div key={key}>
+              <label className="text-sm font-medium" htmlFor={metricId}>
+                {label}: {formatPercentLabel(percent)}
+              </label>
+              <input
+                id={metricId}
+                type="range"
+                min="0"
+                max="100"
+                step="5"
+                value={percent}
+                onChange={(event) => handleMetricRateChange(key, event)}
+                className="ubuntu-slider mt-2 w-full"
+                aria-label={`Sample rate for ${label}`}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={percent}
+                aria-valuetext={formatPercentLabel(percent)}
+              />
+            </div>
+          );
+        })}
+      </div>
+      <div className="mt-4">
+        <label className="text-sm font-medium" htmlFor={routeAllowlistId}>
+          Route allowlist
+        </label>
+        <textarea
+          id={routeAllowlistId}
+          className="mt-2 w-full rounded border border-ubt-cool-grey bg-black/40 p-2 text-sm text-white"
+          rows={3}
+          value={allowlistValue}
+          onChange={handleRoutesChange}
+          placeholder="/apps/*"
+          aria-label="Route allowlist"
+        />
+        <span className="mt-1 block text-xs text-ubt-grey/60">
+          Use one pattern per line. The <code className="text-ub-orange">*</code> wildcard matches any characters.
+        </span>
+      </div>
+      <div className="mt-4 flex items-center gap-2 text-sm">
+        <input
+          id={deviceToggleId}
+          type="checkbox"
+          checked={isClientAllowlisted}
+          onChange={handleClientToggle}
+          aria-label="Always sample on this device"
+        />
+        <label htmlFor={deviceToggleId} className="select-none">
+          Always sample on this device
+        </label>
+      </div>
+      {clientId && (
+        <p className="mt-1 break-all text-xs text-ubt-grey/60">Client ID: {clientId}</p>
+      )}
+      <div className="mt-4 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={handleReset}
+          className="rounded bg-ub-orange px-3 py-1 text-sm font-medium text-white"
+        >
+          Reset sampling overrides
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default WebVitalsSamplingSettings;

--- a/utils/webVitalsConfig.ts
+++ b/utils/webVitalsConfig.ts
@@ -1,0 +1,307 @@
+export interface WebVitalsSamplingConfig {
+  defaultSampleRate: number;
+  sampleRates: Record<string, number>;
+  allowRoutes: string[];
+  allowClients: string[];
+}
+
+export interface PartialWebVitalsSamplingConfig {
+  defaultSampleRate?: number;
+  sampleRates?: Record<string, number>;
+  allowRoutes?: string[] | string;
+  allowClients?: string[] | string;
+}
+
+export type WebVitalsConfigListener = (config: WebVitalsSamplingConfig) => void;
+
+export type WebVitalMetricName = 'LCP' | 'INP' | string;
+
+export const WEB_VITALS_CONFIG_STORAGE_KEY = 'web-vitals-sampling-config';
+const WEB_VITALS_CLIENT_ID_KEY = 'web-vitals-client-id';
+
+const getWindowObject = (): Window | undefined => {
+  if (typeof globalThis === 'undefined') return undefined;
+  return (globalThis as { window?: Window }).window;
+};
+
+const getLocalStorage = (): Storage | undefined => {
+  const win = getWindowObject();
+  return win?.localStorage;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const clampRate = (value: unknown, fallback = 1): number => {
+  const numeric =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string'
+        ? parseFloat(value)
+        : Number.NaN;
+  if (!Number.isFinite(numeric)) {
+    return Math.min(Math.max(fallback, 0), 1);
+  }
+  return Math.min(Math.max(numeric, 0), 1);
+};
+
+const sanitizeList = (value: unknown): string[] => {
+  if (value === undefined) return [];
+  const raw = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(/\r?\n|,/)
+      : [];
+  const cleaned = raw
+    .map((entry) => String(entry).trim())
+    .filter((entry) => entry.length > 0);
+  return Array.from(new Set(cleaned));
+};
+
+const sanitizeSampleRates = (value: unknown): Record<string, number> => {
+  if (!isRecord(value)) return {};
+  const result: Record<string, number> = {};
+  Object.entries(value).forEach(([metric, rate]) => {
+    result[metric] = clampRate(rate, 1);
+  });
+  return result;
+};
+
+const parseSampleRatesString = (value: string | undefined): Record<string, number> => {
+  if (!value) return {};
+  return value
+    .split(',')
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .reduce<Record<string, number>>((acc, segment) => {
+      const [metric, rate] = segment.split(':');
+      if (!metric) return acc;
+      acc[metric.trim()] = clampRate(rate ?? 1, 1);
+      return acc;
+    }, {});
+};
+
+const normalizeConfig = (
+  input: PartialWebVitalsSamplingConfig | undefined,
+  fallback: WebVitalsSamplingConfig
+): WebVitalsSamplingConfig => {
+  const defaultSampleRate = clampRate(
+    input?.defaultSampleRate ?? fallback.defaultSampleRate,
+    fallback.defaultSampleRate
+  );
+
+  const sampleRates = { ...fallback.sampleRates };
+  if (input?.sampleRates) {
+    const sanitized = sanitizeSampleRates(input.sampleRates);
+    Object.entries(sanitized).forEach(([metric, rate]) => {
+      sampleRates[metric] = rate;
+    });
+  }
+
+  const allowRoutes =
+    input?.allowRoutes !== undefined
+      ? sanitizeList(input.allowRoutes)
+      : [...fallback.allowRoutes];
+
+  const allowClients =
+    input?.allowClients !== undefined
+      ? sanitizeList(input.allowClients)
+      : [...fallback.allowClients];
+
+  return {
+    defaultSampleRate,
+    sampleRates,
+    allowRoutes,
+    allowClients,
+  };
+};
+
+const parseEnvJson = (): PartialWebVitalsSamplingConfig => {
+  const raw = process.env.NEXT_PUBLIC_WEB_VITALS_CONFIG;
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (!isRecord(parsed)) return {};
+    return parsed as PartialWebVitalsSamplingConfig;
+  } catch (error) {
+    if (typeof console !== 'undefined') {
+      console.warn('Invalid NEXT_PUBLIC_WEB_VITALS_CONFIG JSON:', error);
+    }
+  }
+  return {};
+};
+
+const envJson = parseEnvJson();
+
+const envInitialConfig: PartialWebVitalsSamplingConfig = {
+  defaultSampleRate:
+    envJson.defaultSampleRate ?? process.env.NEXT_PUBLIC_WEB_VITALS_SAMPLE_RATE,
+  sampleRates: {
+    ...parseSampleRatesString(process.env.NEXT_PUBLIC_WEB_VITALS_SAMPLE_RATES),
+    ...(isRecord(envJson.sampleRates) ? (envJson.sampleRates as Record<string, number>) : {}),
+  },
+  allowRoutes:
+    envJson.allowRoutes !== undefined
+      ? envJson.allowRoutes
+      : process.env.NEXT_PUBLIC_WEB_VITALS_ALLOW_ROUTES,
+  allowClients:
+    envJson.allowClients !== undefined
+      ? envJson.allowClients
+      : process.env.NEXT_PUBLIC_WEB_VITALS_ALLOW_CLIENTS,
+};
+
+const BASE_CONFIG: WebVitalsSamplingConfig = {
+  defaultSampleRate: 1,
+  sampleRates: {},
+  allowRoutes: [],
+  allowClients: [],
+};
+
+const DEFAULT_CONFIG = normalizeConfig(envInitialConfig, BASE_CONFIG);
+
+let configCache: WebVitalsSamplingConfig = { ...DEFAULT_CONFIG, sampleRates: { ...DEFAULT_CONFIG.sampleRates }, allowRoutes: [...DEFAULT_CONFIG.allowRoutes], allowClients: [...DEFAULT_CONFIG.allowClients] };
+
+const listeners = new Set<WebVitalsConfigListener>();
+
+const persistConfig = (config: WebVitalsSamplingConfig) => {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  storage.setItem(WEB_VITALS_CONFIG_STORAGE_KEY, JSON.stringify(config));
+};
+
+const notifyListeners = () => {
+  const snapshot = getWebVitalsConfig();
+  listeners.forEach((listener) => listener(snapshot));
+};
+
+const applyConfig = (config: WebVitalsSamplingConfig, persist = true) => {
+  configCache = config;
+  if (persist) {
+    persistConfig(config);
+  }
+  notifyListeners();
+};
+
+const bootstrapStoredConfig = () => {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  try {
+    const stored = storage.getItem(WEB_VITALS_CONFIG_STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored) as PartialWebVitalsSamplingConfig;
+      const normalized = normalizeConfig(parsed, DEFAULT_CONFIG);
+      configCache = normalized;
+    }
+  } catch (error) {
+    if (typeof console !== 'undefined') {
+      console.warn('Failed to read stored Web Vitals config:', error);
+    }
+  }
+};
+
+const subscribeToStorageChanges = () => {
+  const win = getWindowObject();
+  if (!win) return;
+  win.addEventListener('storage', (event) => {
+    if (event.key !== WEB_VITALS_CONFIG_STORAGE_KEY) return;
+    if (!event.newValue) {
+      applyConfig(normalizeConfig(undefined, DEFAULT_CONFIG), false);
+      return;
+    }
+    try {
+      const parsed = JSON.parse(event.newValue) as PartialWebVitalsSamplingConfig;
+      const normalized = normalizeConfig(parsed, DEFAULT_CONFIG);
+      applyConfig(normalized, false);
+    } catch (error) {
+      if (typeof console !== 'undefined') {
+        console.warn('Failed to parse incoming Web Vitals config:', error);
+      }
+    }
+  });
+};
+
+bootstrapStoredConfig();
+subscribeToStorageChanges();
+
+export const getWebVitalsConfig = (): WebVitalsSamplingConfig => ({
+  defaultSampleRate: configCache.defaultSampleRate,
+  sampleRates: { ...configCache.sampleRates },
+  allowRoutes: [...configCache.allowRoutes],
+  allowClients: [...configCache.allowClients],
+});
+
+export const setWebVitalsConfig = (
+  config: PartialWebVitalsSamplingConfig,
+  fallback: WebVitalsSamplingConfig = configCache
+): WebVitalsSamplingConfig => {
+  const normalized = normalizeConfig(config, fallback);
+  applyConfig(normalized);
+  return getWebVitalsConfig();
+};
+
+export const updateWebVitalsConfig = (
+  config: PartialWebVitalsSamplingConfig
+): WebVitalsSamplingConfig => setWebVitalsConfig(config, configCache);
+
+export const resetWebVitalsConfig = (): WebVitalsSamplingConfig => {
+  const storage = getLocalStorage();
+  storage?.removeItem(WEB_VITALS_CONFIG_STORAGE_KEY);
+  const normalized = normalizeConfig(undefined, DEFAULT_CONFIG);
+  applyConfig(normalized);
+  return getWebVitalsConfig();
+};
+
+export const subscribeToWebVitalsConfig = (
+  listener: WebVitalsConfigListener
+): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const wildcardToRegex = (pattern: string): RegExp => {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const normalized = `^${escaped.replace(/\\\*/g, '.*')}$`;
+  return new RegExp(normalized);
+};
+
+export const isRouteAllowlisted = (route: string, patterns: string[]): boolean =>
+  patterns.some((pattern) => {
+    try {
+      return wildcardToRegex(pattern).test(route);
+    } catch (error) {
+      if (typeof console !== 'undefined') {
+        console.warn('Invalid route allowlist pattern:', pattern, error);
+      }
+      return false;
+    }
+  });
+
+export const isClientAllowlisted = (
+  clientId: string,
+  allowClients: string[]
+): boolean => allowClients.includes(clientId);
+
+export const getWebVitalsClientId = (): string => {
+  const storage = getLocalStorage();
+  if (!storage) return 'server';
+  let clientId = storage.getItem(WEB_VITALS_CLIENT_ID_KEY);
+  if (!clientId) {
+    clientId =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `client-${Math.random().toString(16).slice(2)}`;
+    storage.setItem(WEB_VITALS_CLIENT_ID_KEY, clientId);
+  }
+  return clientId;
+};
+
+export const getSampleRateForMetric = (
+  metric: WebVitalMetricName,
+  config: WebVitalsSamplingConfig
+): number => {
+  const specific = config.sampleRates[metric];
+  const rate = specific === undefined ? config.defaultSampleRate : specific;
+  return clampRate(rate, config.defaultSampleRate);
+};


### PR DESCRIPTION
## Summary
- add a shared web vitals sampling store with per-metric rates, route/client allowlists, and persistence
- gate reportWebVitals emission behind the sampling configuration and expose runtime controls in the settings app
- expand reportWebVitals tests to cover sampling behavior and configuration updates

## Testing
- yarn lint utils/reportWebVitals.ts utils/webVitalsConfig.ts components/util-components/WebVitalsSamplingSettings.tsx components/apps/settings.js __tests__/reportWebVitals.test.ts
- yarn test __tests__/reportWebVitals.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68dccabebd6c8328bb5e1db257a78002