### PR TITLE
[utils] add blob manager for url cleanup

### DIFF
--- a/__tests__/blobManager.test.tsx
+++ b/__tests__/blobManager.test.tsx
@@ -1,0 +1,90 @@
+import { render, act } from '@testing-library/react';
+import React from 'react';
+import { blobManager, useBlobUrl } from '@/utils/blobManager';
+
+type Listener = (...args: any[]) => void;
+const routeListeners: Record<string, Listener[]> = {};
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  default: {
+    events: {
+      on: jest.fn((event: string, handler: Listener) => {
+        routeListeners[event] = routeListeners[event] || [];
+        routeListeners[event].push(handler);
+      }),
+      off: jest.fn((event: string, handler: Listener) => {
+        if (!routeListeners[event]) return;
+        routeListeners[event] = routeListeners[event].filter((fn) => fn !== handler);
+      }),
+    },
+  },
+}));
+
+describe('blobManager', () => {
+  beforeEach(() => {
+    (global as any).URL.createObjectURL = jest.fn(() => 'blob:test');
+    (global as any).URL.revokeObjectURL = jest.fn();
+    blobManager.revokeAll();
+  });
+
+  test('reference counts and releases URLs when the last consumer releases', () => {
+    const blob = new Blob(['test']);
+    const url = blobManager.register(blob);
+    expect(blobManager.size).toBe(1);
+    blobManager.retain(url);
+    expect(blobManager.size).toBe(1);
+    blobManager.release(url);
+    expect(blobManager.size).toBe(1);
+    expect((global as any).URL.revokeObjectURL).not.toHaveBeenCalled();
+    blobManager.release(url);
+    expect(blobManager.size).toBe(0);
+    expect((global as any).URL.revokeObjectURL).toHaveBeenCalledWith(url);
+  });
+
+  test('useBlobUrl releases URLs on dependency change and unmount', async () => {
+    const blob = new Blob(['payload']);
+
+    const Harness: React.FC<{ active: boolean }> = ({ active }) => {
+      const resource = active ? blob : null;
+      useBlobUrl(resource);
+      return null;
+    };
+
+    const { rerender, unmount } = render(<Harness active={true} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(blobManager.size).toBe(1);
+
+    rerender(<Harness active={false} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(blobManager.size).toBe(0);
+    expect((global as any).URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect((global as any).URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  test('cleans up on navigation and memory pressure events', () => {
+    const blob = new Blob(['data']);
+    const url = blobManager.register(blob);
+    expect(blobManager.has(url)).toBe(true);
+
+    window.dispatchEvent(new Event('pagehide'));
+    expect(blobManager.has(url)).toBe(false);
+
+    const secondUrl = blobManager.register(blob);
+    const handlers = routeListeners['routeChangeStart'];
+    expect(handlers?.length).toBeGreaterThan(0);
+    handlers?.forEach((handler) => handler());
+    expect(blobManager.has(secondUrl)).toBe(false);
+
+    const thirdUrl = blobManager.register(blob);
+    window.dispatchEvent(new Event('memorypressure'));
+    expect(blobManager.has(thirdUrl)).toBe(false);
+    expect((global as any).URL.revokeObjectURL).toHaveBeenCalled();
+  });
+});

--- a/apps/resource-monitor/export.ts
+++ b/apps/resource-monitor/export.ts
@@ -1,4 +1,5 @@
 import { FetchEntry } from '../../lib/fetchProxy';
+import { blobManager } from '@/utils/blobManager';
 
 export function serializeMetrics(entries: FetchEntry[]): string {
   return JSON.stringify(entries, null, 2);
@@ -6,12 +7,12 @@ export function serializeMetrics(entries: FetchEntry[]): string {
 
 export function exportMetrics(entries: FetchEntry[], filename = 'network-insights.json'): void {
   const blob = new Blob([serializeMetrics(entries)], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
+  const url = blobManager.register(blob);
   const a = document.createElement('a');
   a.href = url;
   a.download = filename;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+  blobManager.release(url);
 }

--- a/components/apps/reconng/components/ReportTemplates.tsx
+++ b/components/apps/reconng/components/ReportTemplates.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import usePersistentState from '../../../../hooks/usePersistentState';
 import defaultTemplates from '../../../../templates/export/report-templates.json';
+import { blobManager } from '@/utils/blobManager';
 
 interface Finding {
   title: string;
@@ -57,12 +58,12 @@ export default function ReportTemplates() {
 
   const exportReport = () => {
     const blob = new Blob([report], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
+    const url = blobManager.register(blob);
     const a = document.createElement('a');
     a.href = url;
     a.download = `${templateKey}-report.txt`;
     a.click();
-    URL.revokeObjectURL(url);
+    blobManager.release(url);
   };
 
   const [showDialog, setShowDialog] = useState(false);

--- a/components/apps/screen-recorder.tsx
+++ b/components/apps/screen-recorder.tsx
@@ -1,14 +1,17 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useBlobUrl } from '@/utils/blobManager';
 
 function ScreenRecorder() {
     const [recording, setRecording] = useState(false);
-    const [videoUrl, setVideoUrl] = useState<string | null>(null);
+    const [videoBlob, setVideoBlob] = useState<Blob | null>(null);
     const recorderRef = useRef<MediaRecorder | null>(null);
     const chunksRef = useRef<Blob[]>([]);
     const streamRef = useRef<MediaStream | null>(null);
+    const videoUrl = useBlobUrl(videoBlob);
 
     const startRecording = async () => {
         try {
+            setVideoBlob(null);
             const stream = await navigator.mediaDevices.getDisplayMedia({
                 video: true,
                 audio: true,
@@ -21,8 +24,7 @@ function ScreenRecorder() {
             };
             recorder.onstop = () => {
                 const blob = new Blob(chunksRef.current, { type: 'video/webm' });
-                const url = URL.createObjectURL(blob);
-                setVideoUrl(url);
+                setVideoBlob(blob);
                 stream.getTracks().forEach((t) => t.stop());
             };
             recorder.start();
@@ -39,8 +41,8 @@ function ScreenRecorder() {
     };
 
     const saveRecording = async () => {
-        if (!videoUrl) return;
-        const blob = new Blob(chunksRef.current, { type: 'video/webm' });
+        if (!videoBlob || !videoUrl) return;
+        const blob = videoBlob;
         if ('showSaveFilePicker' in window) {
             try {
                 const handle = await (window as any).showSaveFilePicker({

--- a/utils/blobManager.ts
+++ b/utils/blobManager.ts
@@ -1,0 +1,138 @@
+import Router from 'next/router';
+import { DependencyList, useEffect, useRef, useState } from 'react';
+
+type BlobLike = Blob | MediaSource;
+
+class BlobManager {
+  private refCounts = new Map<string, number>();
+  private listenersAttached = false;
+  private readonly handleGlobalCleanup = () => {
+    this.revokeAll();
+  };
+
+  register(blob: BlobLike): string {
+    const url = URL.createObjectURL(blob);
+    this.retain(url);
+    this.ensureListeners();
+    return url;
+  }
+
+  retain(url: string): void {
+    const current = this.refCounts.get(url) ?? 0;
+    this.refCounts.set(url, current + 1);
+    this.ensureListeners();
+  }
+
+  release(url: string): void {
+    const current = this.refCounts.get(url);
+    if (current === undefined) return;
+
+    if (current <= 1) {
+      this.refCounts.delete(url);
+      URL.revokeObjectURL(url);
+    } else {
+      this.refCounts.set(url, current - 1);
+    }
+  }
+
+  revokeAll(): void {
+    if (this.refCounts.size === 0) return;
+    for (const url of this.refCounts.keys()) {
+      URL.revokeObjectURL(url);
+    }
+    this.refCounts.clear();
+  }
+
+  has(url: string): boolean {
+    return this.refCounts.has(url);
+  }
+
+  get size(): number {
+    return this.refCounts.size;
+  }
+
+  private ensureListeners(): void {
+    if (this.listenersAttached || typeof window === 'undefined') {
+      return;
+    }
+    this.listenersAttached = true;
+
+    window.addEventListener('pagehide', this.handleGlobalCleanup);
+    window.addEventListener('beforeunload', this.handleGlobalCleanup);
+    window.addEventListener('freeze', this.handleGlobalCleanup);
+    window.addEventListener('memorypressure' as any, this.handleGlobalCleanup);
+
+    if (Router?.events?.on) {
+      Router.events.on('routeChangeStart', this.handleGlobalCleanup);
+    }
+  }
+}
+
+export const blobManager = new BlobManager();
+
+export function useBlobUrl(
+  source: BlobLike | null | undefined,
+  deps: DependencyList = [],
+): string | null {
+  const [url, setUrl] = useState<string | null>(null);
+  const currentUrl = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (currentUrl.current) {
+      blobManager.release(currentUrl.current);
+      currentUrl.current = null;
+    }
+
+    if (!source) {
+      setUrl(null);
+      return () => {
+        if (currentUrl.current) {
+          blobManager.release(currentUrl.current);
+          currentUrl.current = null;
+        }
+      };
+    }
+
+    const nextUrl = blobManager.register(source);
+    currentUrl.current = nextUrl;
+    setUrl(nextUrl);
+
+    return () => {
+      if (currentUrl.current) {
+        blobManager.release(currentUrl.current);
+        currentUrl.current = null;
+      }
+    };
+  }, [source, ...deps]);
+
+  return url;
+}
+
+export function useBlobManagerScope() {
+  const urlsRef = useRef(new Set<string>());
+
+  useEffect(
+    () => () => {
+      urlsRef.current.forEach((url) => {
+        blobManager.release(url);
+      });
+      urlsRef.current.clear();
+    },
+    [],
+  );
+
+  const register = (blob: BlobLike) => {
+    const url = blobManager.register(blob);
+    urlsRef.current.add(url);
+    return url;
+  };
+
+  const release = (url: string) => {
+    if (urlsRef.current.has(url)) {
+      urlsRef.current.delete(url);
+    }
+    blobManager.release(url);
+  };
+
+  return { register, release };
+}


### PR DESCRIPTION
## Summary
- introduce a shared blob manager that tracks object URLs with reference counts and cleans up on navigation or memory-pressure events
- refactor the screen recorder and export flows to consume the manager instead of managing URLs locally
- cover the manager with Jest tests to ensure blob URLs are released after cleanup

## Testing
- yarn test blobManager

------
https://chatgpt.com/codex/tasks/task_e_68dccabf00b8832883dede4e543b58bf