### PR TITLE
[infra] share intersection observer pool

### DIFF
--- a/__tests__/viewport.test.ts
+++ b/__tests__/viewport.test.ts
@@ -1,0 +1,86 @@
+type MockInstance = {
+  observe: jest.Mock;
+  unobserve: jest.Mock;
+  disconnect: jest.Mock;
+  callback: IntersectionObserverCallback;
+  options?: IntersectionObserverInit;
+  trigger(entries: IntersectionObserverEntry[]): void;
+};
+
+describe('observeViewport', () => {
+  type ObserveViewport = typeof import('../utils/viewport')['observeViewport'];
+  let observeViewport: ObserveViewport;
+  let instances: MockInstance[];
+  const originalIntersectionObserver = global.IntersectionObserver;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    instances = [];
+
+    class MockIntersectionObserver {
+      public observe = jest.fn();
+      public unobserve = jest.fn();
+      public disconnect = jest.fn();
+      public callback: IntersectionObserverCallback;
+      public options?: IntersectionObserverInit;
+
+      constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+        this.callback = callback;
+        this.options = options;
+        instances.push(this as unknown as MockInstance);
+      }
+
+      trigger(entries: IntersectionObserverEntry[]) {
+        this.callback(entries, this as unknown as IntersectionObserver);
+      }
+    }
+
+    (global as any).IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+    ({ observeViewport } = await import('../utils/viewport'));
+  });
+
+  afterEach(() => {
+    if (originalIntersectionObserver) {
+      (global as any).IntersectionObserver = originalIntersectionObserver as typeof IntersectionObserver;
+    } else {
+      delete (global as any).IntersectionObserver;
+    }
+  });
+
+  it('reuses a single observer for many targets sharing the same viewport options', () => {
+    const elements = Array.from({ length: 50 }, () => document.createElement('div'));
+    const unsubscribers = elements.map((el) => observeViewport(el, () => {}));
+
+    expect(instances).toHaveLength(1);
+    const [instance] = instances;
+    expect(instance.observe).toHaveBeenCalledTimes(elements.length);
+    elements.forEach((el) => {
+      expect(instance.observe).toHaveBeenCalledWith(el);
+    });
+
+    unsubscribers.forEach((unsubscribe) => unsubscribe());
+    expect(instance.unobserve).toHaveBeenCalledTimes(elements.length);
+    expect(instance.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('disconnects the shared observer when the final subscriber unsubscribes', () => {
+    const root = document.createElement('div');
+    const first = document.createElement('div');
+    const second = document.createElement('div');
+
+    const unsubscribeFirst = observeViewport(first, () => {}, { root, threshold: 0.5 });
+    const unsubscribeSecond = observeViewport(second, () => {}, { root, threshold: 0.5 });
+
+    expect(instances).toHaveLength(1);
+    const [instance] = instances;
+    expect(instance.observe).toHaveBeenCalledTimes(2);
+
+    unsubscribeFirst();
+    expect(instance.unobserve).toHaveBeenCalledWith(first);
+    expect(instance.disconnect).not.toHaveBeenCalled();
+
+    unsubscribeSecond();
+    expect(instance.unobserve).toHaveBeenCalledWith(second);
+    expect(instance.disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/GitHubStars.js
+++ b/components/GitHubStars.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import usePersistentState from '../hooks/usePersistentState';
+import { observeViewport } from '../utils/viewport';
 
 const GitHubStars = ({ user, repo }) => {
   const ref = useRef(null);
@@ -22,16 +23,19 @@ const GitHubStars = ({ user, repo }) => {
   }, [user, repo, setStars]);
 
   useEffect(() => {
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          setVisible(true);
-          observer.disconnect();
-        }
-      });
+    const node = ref.current;
+    if (!node) return undefined;
+
+    let unsubscribe = observeViewport(node, (entry) => {
+      if (entry.isIntersecting) {
+        setVisible(true);
+        unsubscribe();
+      }
     });
-    if (ref.current) observer.observe(ref.current);
-    return () => observer.disconnect();
+
+    return () => {
+      unsubscribe();
+    };
   }, []);
 
   useEffect(() => {

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -6,6 +6,7 @@ import Certs from './certs';
 import data from './alex/data.json';
 import resumeData from './alex/resume.json';
 import ActivityCalendar from 'react-activity-calendar';
+import { observeViewport } from '../../utils/viewport';
 
 export class AboutAlex extends Component {
 
@@ -203,29 +204,33 @@ function Timeline() {
     const [liveMessage, setLiveMessage] = React.useState('');
 
     React.useEffect(() => {
-        const elements = document.querySelectorAll('.timeline-item');
+        const elements = Array.from(document.querySelectorAll('.timeline-item'));
         const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
         if (prefersReducedMotion.matches) {
-            elements.forEach(el => el.classList.add('opacity-100', 'translate-y-0'));
-            return;
+            elements.forEach((el) => el.classList.add('opacity-100', 'translate-y-0'));
+            return undefined;
         }
 
-        const observer = new IntersectionObserver((entries) => {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    requestAnimationFrame(() => {
-                        entry.target.classList.add('opacity-100', 'translate-y-0');
-                        setLiveMessage(entry.target.getAttribute('data-description') || '');
-                    });
-                    observer.unobserve(entry.target);
-                }
-            });
-        }, { threshold: 0.1 });
-
-        elements.forEach(el => observer.observe(el));
+        const subscriptions = elements.map((el) => {
+            let unsubscribe = () => {};
+            unsubscribe = observeViewport(
+                el,
+                (entry) => {
+                    if (entry.isIntersecting) {
+                        requestAnimationFrame(() => {
+                            entry.target.classList.add('opacity-100', 'translate-y-0');
+                            setLiveMessage(entry.target.getAttribute('data-description') || '');
+                        });
+                        unsubscribe();
+                    }
+                },
+                { threshold: 0.1 }
+            );
+            return unsubscribe;
+        });
 
         return () => {
-            elements.forEach(el => observer.unobserve(el));
+            subscriptions.forEach((unsubscribe) => unsubscribe());
         };
     }, []);
 
@@ -488,23 +493,27 @@ function Resume({ data: resume }) {
     const experiences = filter === 'all' ? resume.experience : resume.experience.filter((e) => e.tags.includes(filter));
 
     React.useEffect(() => {
-        const elements = document.querySelectorAll('.exp-item');
-        const observer = new IntersectionObserver((entries) => {
-            entries.forEach((entry) => {
-                if (entry.isIntersecting) {
-                    requestAnimationFrame(() => {
-                        entry.target.classList.add('opacity-100', 'translate-y-0');
-                        setLiveMessage(entry.target.getAttribute('data-description') || '');
-                    });
-                    observer.unobserve(entry.target);
-                }
-            });
-        }, { threshold: 0.1 });
-
-        elements.forEach((el) => observer.observe(el));
+        const elements = Array.from(document.querySelectorAll('.exp-item'));
+        const subscriptions = elements.map((el) => {
+            let unsubscribe = () => {};
+            unsubscribe = observeViewport(
+                el,
+                (entry) => {
+                    if (entry.isIntersecting) {
+                        requestAnimationFrame(() => {
+                            entry.target.classList.add('opacity-100', 'translate-y-0');
+                            setLiveMessage(entry.target.getAttribute('data-description') || '');
+                        });
+                        unsubscribe();
+                    }
+                },
+                { threshold: 0.1 }
+            );
+            return unsubscribe;
+        });
 
         return () => {
-            elements.forEach((el) => observer.unobserve(el));
+            subscriptions.forEach((unsubscribe) => unsubscribe());
         };
     }, [filter]);
 

--- a/hooks/useIntersection.ts
+++ b/hooks/useIntersection.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { observeViewport } from '../utils/viewport';
 
 /**
  * useIntersection observes the given element and reports whether it is
@@ -14,17 +15,14 @@ export default function useIntersection<T extends Element>(
   useEffect(() => {
     const node = ref.current;
     if (!node) return;
-    if (typeof IntersectionObserver === 'undefined') {
-      setIntersecting(true);
-      return;
-    }
 
-    const observer = new IntersectionObserver(([entry]) => {
+    const unsubscribe = observeViewport(node, (entry) => {
       setIntersecting(entry.isIntersecting);
     }, options);
 
-    observer.observe(node);
-    return () => observer.disconnect();
+    return () => {
+      unsubscribe();
+    };
   }, [ref, options]);
 
   return isIntersecting;

--- a/utils/viewport.ts
+++ b/utils/viewport.ts
@@ -1,0 +1,146 @@
+export type ViewportCallback = (entry: IntersectionObserverEntry) => void;
+export type ViewportUnsubscribe = () => void;
+
+type RootType = Element | Document | null | undefined;
+
+interface SharedObserver {
+  observer: IntersectionObserver;
+  targets: Map<Element, Set<ViewportCallback>>;
+}
+
+const defaultRootObservers = new Map<string, SharedObserver>();
+const rootObservers = new WeakMap<Element | Document, Map<string, SharedObserver>>();
+const noop: ViewportUnsubscribe = () => {};
+
+function getObserverKey(options?: IntersectionObserverInit) {
+  const rootMargin = options?.rootMargin ?? '0px';
+  const threshold = options?.threshold ?? 0;
+  const thresholdKey = Array.isArray(threshold) ? threshold.join(',') : `${threshold}`;
+  return `${rootMargin}|${thresholdKey}`;
+}
+
+function getRootObserverMap(root: RootType) {
+  if (root == null) {
+    return defaultRootObservers;
+  }
+
+  let map = rootObservers.get(root);
+  if (!map) {
+    map = new Map<string, SharedObserver>();
+    rootObservers.set(root, map);
+  }
+  return map;
+}
+
+function createSharedObserver(root: RootType, options?: IntersectionObserverInit): SharedObserver {
+  const targets = new Map<Element, Set<ViewportCallback>>();
+
+  const observerOptions: IntersectionObserverInit = {
+    root: (root ?? null) as Element | Document | null,
+  };
+
+  if (options?.rootMargin !== undefined) {
+    observerOptions.rootMargin = options.rootMargin;
+  }
+  if (options?.threshold !== undefined) {
+    observerOptions.threshold = options.threshold;
+  }
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      const callbacks = targets.get(entry.target as Element);
+      if (!callbacks || callbacks.size === 0) {
+        return;
+      }
+
+      const handlers = Array.from(callbacks);
+      handlers.forEach((handler) => handler(entry));
+    });
+  }, observerOptions);
+
+  return { observer, targets };
+}
+
+function cleanupSharedObserver(
+  root: RootType,
+  key: string,
+  map: Map<string, SharedObserver>,
+  shared: SharedObserver,
+) {
+  if (shared.targets.size === 0) {
+    shared.observer.disconnect();
+    map.delete(key);
+    if (root != null && map.size === 0) {
+      rootObservers.delete(root);
+    }
+  }
+}
+
+function createFallbackEntry(target: Element): IntersectionObserverEntry {
+  const rect = typeof target.getBoundingClientRect === 'function'
+    ? target.getBoundingClientRect()
+    : ({} as DOMRectReadOnly);
+
+  const time = typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+
+  return {
+    isIntersecting: true,
+    target,
+    intersectionRatio: 1,
+    time,
+    boundingClientRect: rect,
+    intersectionRect: rect,
+    rootBounds: null,
+  } as IntersectionObserverEntry;
+}
+
+export function observeViewport(
+  target: Element | null | undefined,
+  callback: ViewportCallback,
+  options?: IntersectionObserverInit,
+): ViewportUnsubscribe {
+  if (!target) {
+    return noop;
+  }
+
+  if (typeof IntersectionObserver === 'undefined') {
+    callback(createFallbackEntry(target));
+    return noop;
+  }
+
+  const key = getObserverKey(options);
+  const root = options?.root ?? null;
+  const map = getRootObserverMap(root);
+  let shared = map.get(key);
+  if (!shared) {
+    shared = createSharedObserver(root, options);
+    map.set(key, shared);
+  }
+
+  let targetCallbacks = shared.targets.get(target);
+  if (!targetCallbacks) {
+    targetCallbacks = new Set<ViewportCallback>();
+    shared.targets.set(target, targetCallbacks);
+    shared.observer.observe(target);
+  }
+
+  targetCallbacks.add(callback);
+  const sharedObserver = shared;
+  const callbacksRef = targetCallbacks;
+
+  let active = true;
+  return () => {
+    if (!active) {
+      return;
+    }
+    active = false;
+    callbacksRef.delete(callback);
+    if (callbacksRef.size === 0) {
+      sharedObserver.observer.unobserve(target);
+      sharedObserver.targets.delete(target);
+      cleanupSharedObserver(root, key, map, sharedObserver);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add utils/viewport.ts to provide a shared IntersectionObserver registry with automatic teardown
- migrate useIntersection, ScrollableTimeline, GitHubStars, and alex app animations to use the shared observer pool
- add targeted tests that confirm one observer handles many nodes and disconnects after all subscribers unsubscribe

## Testing
- yarn lint
- yarn test --runTestsByPath __tests__/viewport.test.ts
- yarn test --runTestsByPath __tests__/scrollableTimeline.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dccac0d2e48328af36e03f9b41ceca