### PR TITLE
[perf] add containment utilities for cards

### DIFF
--- a/components/BadgeList.js
+++ b/components/BadgeList.js
@@ -52,14 +52,15 @@ const BadgeList = ({ badges, className = '' }) => {
       <label htmlFor="badge-filter" className="mb-1">
         Filter skills
       </label>
-      <input
-        id="badge-filter"
-        type="text"
-        placeholder="Filter skills"
-        className="mb-2 px-2 py-1 rounded text-black font-normal"
-        value={filter}
-        onChange={(e) => setFilter(e.target.value)}
-      />
+        <input
+          id="badge-filter"
+          type="text"
+          placeholder="Filter skills"
+          className="mb-2 px-2 py-1 rounded text-black font-normal"
+          aria-label="Filter skills"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
       <div ref={listRef} className="flex flex-wrap justify-center items-start w-full">
         {listVisible &&
           filteredBadges.map((badge) => (
@@ -90,7 +91,7 @@ const BadgeList = ({ badges, className = '' }) => {
         >
           <div
             ref={modalRef}
-            className="bg-white text-black p-4 rounded shadow max-w-sm"
+            className="bg-white text-black p-4 rounded shadow max-w-sm contain-layout-paint cis-panel"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="font-bold mb-2">{selected.label}</div>

--- a/components/ExplainerPane.tsx
+++ b/components/ExplainerPane.tsx
@@ -11,7 +11,7 @@ interface Props {
 export default function ExplainerPane({ lines, resources }: Props) {
   return (
     <aside
-      className="h-full overflow-auto border-t border-ub-cool-grey p-2 text-xs lg:border-t-0 lg:border-l"
+      className="h-full overflow-auto border-t border-ub-cool-grey p-2 text-xs lg:border-t-0 lg:border-l contain-layout-paint cis-panel"
       aria-label="explainer pane"
     >
       <h3 className="font-bold mb-2">Key Points</h3>

--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -65,7 +65,7 @@ export default function HelpPanel({ appId, docPath }: HelpPanelProps) {
           onClick={toggle}
         >
           <div
-            className="bg-white text-black p-4 rounded max-w-md w-full h-full overflow-auto"
+            className="bg-white text-black p-4 rounded max-w-md w-full h-full overflow-auto contain-layout-paint cis-panel md:cis-panel-lg"
             onClick={(e) => e.stopPropagation()}
           >
             <div dangerouslySetInnerHTML={{ __html: html }} />

--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -33,7 +33,7 @@ export default function ModuleCard({
   return (
     <button
       onClick={() => onSelect(module)}
-      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none ${
+      className={`w-full text-left border rounded p-3 flex items-start justify-between hover:bg-gray-50 focus:outline-none contain-layout-paint cis-card md:cis-card-lg ${
         selected ? 'bg-gray-100' : ''
       }`}
     >

--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -198,13 +198,14 @@ const PopularModules: React.FC = () => {
         )}
       </div>
       {updateMessage && <p className="text-sm">{updateMessage}</p>}
-      <input
-        type="text"
-        placeholder="Search modules"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        className="w-full p-2 text-black rounded"
-      />
+        <input
+          type="text"
+          placeholder="Search modules"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full p-2 text-black rounded"
+          aria-label="Search modules"
+        />
       <div className="flex flex-wrap gap-2">
         <button
           onClick={() => setFilter('')}
@@ -231,7 +232,7 @@ const PopularModules: React.FC = () => {
           <button
             key={m.id}
             onClick={() => handleSelect(m)}
-            className="p-3 text-left bg-ub-grey rounded border border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            className="p-3 text-left bg-ub-grey rounded border border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400 contain-layout-paint cis-card"
           >
             <h3 className="font-semibold">{m.name}</h3>
             <p className="text-sm text-gray-300">{m.description}</p>
@@ -282,16 +283,18 @@ const PopularModules: React.FC = () => {
             </button>
           </div>
           <div className="space-y-1">
-            <label className="block text-sm">
-              Filter logs
+              <label className="block text-sm" htmlFor="module-log-filter">
+                Filter logs
+              </label>
               <input
+                id="module-log-filter"
                 placeholder="Filter logs"
                 type="text"
                 value={logFilter}
                 onChange={(e) => setLogFilter(e.target.value)}
                 className="w-full p-1 mt-1 text-black rounded"
+                aria-label="Filter module logs"
               />
-            </label>
             <button
               type="button"
               onClick={copyLogs}

--- a/components/WorkflowCard.tsx
+++ b/components/WorkflowCard.tsx
@@ -25,7 +25,7 @@ const steps: Step[] = [
 ];
 
 const WorkflowCard: React.FC = () => (
-  <section className="p-4 rounded bg-ub-grey text-white">
+  <section className="p-4 rounded bg-ub-grey text-white contain-layout-paint cis-panel">
     <h2 className="text-xl font-bold mb-2">Workflow</h2>
     <ul>
       {steps.map((s) => (

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,3 +7,10 @@ The project is a desktop-style portfolio built with Next.js.
 - **pages/api/** exposes serverless functions for backend features.
 
 For setup instructions, see the [Getting Started](./getting-started.md) guide.
+
+## Layout containment
+
+- Tailwind utilities now expose `.contain-content`, `.contain-layout`, `.contain-layout-paint`, and `.contain-strict` for setting the CSS `contain` property on interactive shells.
+- Size fallbacks are available through `.cis-card`, `.cis-card-lg`, `.cis-panel`, and `.cis-panel-lg`, which map to sensible block sizes for cards and panels.
+- Apply the containment classes to window panels, dashboards, and modal bodies to isolate their layout and provide intrinsic sizing while content streams in.
+- Pair `.contain-layout-paint` with the appropriate `cis-*` helper (for example, `.cis-card` on module tiles or `.cis-panel` on detail panes) to keep cumulative layout shift low as data and icons hydrate.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -126,6 +126,23 @@ module.exports = {
         }
       }
       addUtilities(cols, ['responsive']);
+
+      const containUtilities = {
+        '.contain-content': { contain: 'content' },
+        '.contain-layout': { contain: 'layout' },
+        '.contain-layout-paint': { contain: 'layout paint' },
+        '.contain-strict': { contain: 'strict' },
+      };
+
+      const intrinsicSizeUtilities = {
+        '.cis-card': { containIntrinsicSize: '12rem' },
+        '.cis-card-lg': { containIntrinsicSize: '16rem' },
+        '.cis-panel': { containIntrinsicSize: '20rem' },
+        '.cis-panel-lg': { containIntrinsicSize: '24rem' },
+      };
+
+      addUtilities(containUtilities, ['responsive']);
+      addUtilities(intrinsicSizeUtilities, ['responsive']);
     }),
   ],
 };


### PR DESCRIPTION
## Summary
- add Tailwind utilities for CSS contain and contain-intrinsic-size helpers
- apply containment classes to key card and panel components to stabilize layout
- document containment usage expectations in docs/architecture.md

## Testing
- yarn lint
- node playwright CLS measurement script for /, /post_exploitation, /popular-modules

------
https://chatgpt.com/codex/tasks/task_e_68dccac2883c832891e3d12f2985be37