### PR TITLE
[performance] add SmartImage heuristics and preload hints

### DIFF
--- a/__tests__/performanceLabConfig.test.ts
+++ b/__tests__/performanceLabConfig.test.ts
@@ -1,0 +1,11 @@
+import config from "../performance-lab.config";
+
+describe("performance lab configuration", () => {
+  it("tracks the wallpaper as the LCP element", () => {
+    const desktopScenario = config.scenarios.find(
+      (scenario) => scenario.label === "desktop-home-lcp"
+    );
+    expect(desktopScenario).toBeDefined();
+    expect(desktopScenario?.assertions.lcpSelector).toBe("[data-lcp-image='true']");
+  });
+});

--- a/__tests__/smartImage.test.tsx
+++ b/__tests__/smartImage.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import SmartImage from "../components/ui/SmartImage";
+
+describe("SmartImage", () => {
+  it("applies high priority and eager loading for critical images", () => {
+    render(<SmartImage src="/hero.webp" alt="hero" importance="critical" />);
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute("fetchpriority", "high");
+    expect(img).toHaveAttribute("loading", "eager");
+  });
+
+  it("marks LCP imagery with a data attribute", () => {
+    render(<SmartImage src="/wall.webp" alt="wall" lcp />);
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute("data-lcp-image", "true");
+  });
+
+  it("uses responsive sizes based on viewport heuristics", async () => {
+    const originalWidth = window.innerWidth;
+    window.innerWidth = 540;
+    render(<SmartImage src="/mobile.webp" alt="mobile" />);
+    const img = screen.getByRole("img");
+    await waitFor(() => {
+      expect(img).toHaveAttribute("sizes", "100vw");
+    });
+    window.innerWidth = originalWidth;
+  });
+
+  it("falls back gracefully when rendered without a browser window", () => {
+    const originalWindow = global.window as Window | undefined;
+    // @ts-expect-error intentionally removing the window object
+    delete (global as any).window;
+    const markup = renderToStaticMarkup(
+      <SmartImage src="/ssr.webp" alt="ssr" importance="standard" />
+    );
+    expect(markup).toContain("loading=\"lazy\"");
+    (global as any).window = originalWindow;
+  });
+});

--- a/__tests__/videoPlayer.preload.test.tsx
+++ b/__tests__/videoPlayer.preload.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import VideoPlayer from "../components/ui/VideoPlayer";
+
+describe("VideoPlayer network hints", () => {
+  it("sets preload metadata on the video element", async () => {
+    const { container } = render(
+      <VideoPlayer src="/stream.mp4" poster="/poster.jpg" className="w-96" />
+    );
+
+    await waitFor(() => {
+      const video = container.querySelector("video");
+      expect(video).not.toBeNull();
+      expect(video).toHaveAttribute("preload", "metadata");
+    });
+  });
+
+  it("injects preload hints for the stream and poster", async () => {
+    const { unmount } = render(
+      <VideoPlayer src="/media/clip.mp4" poster="/media/poster.jpg" />
+    );
+
+    await waitFor(() => {
+      expect(
+        document.head.querySelector("link[rel='preload'][as='video'][href='/media/clip.mp4']")
+      ).not.toBeNull();
+    });
+    await waitFor(() => {
+      expect(
+        document.head.querySelector("link[rel='preload'][as='image'][href='/media/poster.jpg']")
+      ).not.toBeNull();
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      expect(
+        document.head.querySelector("link[rel='preload'][as='video'][href='/media/clip.mp4']")
+      ).toBeNull();
+    });
+  });
+});

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
 import KaliWallpaper from '../util-components/kali-wallpaper';
+import SmartImage from '../ui/SmartImage';
 
 export default function LockScreen(props) {
 
@@ -23,10 +24,14 @@ export default function LockScreen(props) {
                     className={`absolute top-0 left-0 h-full w-full transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
                 />
             ) : (
-                <img
+                <SmartImage
                     src={`/wallpapers/${bgImageName}.webp`}
                     alt=""
-                    className={`absolute top-0 left-0 w-full h-full object-cover transform z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                    className={`absolute top-0 left-0 h-full w-full transform object-cover z-20 transition duration-500 ${props.isLocked ? 'blur-sm' : 'blur-none'}`}
+                    width={1920}
+                    height={1080}
+                    importance="critical"
+                    lcp
                 />
             )}
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">

--- a/components/ui/SmartImage.tsx
+++ b/components/ui/SmartImage.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+
+type ImageImportance = "critical" | "standard" | "low";
+
+export interface SmartImageProps
+  extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, "loading" | "sizes"> {
+  /**
+   * Relative importance of the image for paint.
+   * `critical` will request high priority and eager loading.
+   */
+  importance?: ImageImportance;
+  /**
+   * Marks the image as the expected Largest Contentful Paint target.
+   */
+  lcp?: boolean;
+  /**
+   * Custom responsive sizes definition. If omitted, a viewport-aware fallback is used.
+   */
+  sizes?: string;
+  /**
+   * Override loading behaviour. Defaults to heuristics derived from priority and viewport.
+   */
+  loading?: "eager" | "lazy";
+}
+
+type ViewportBucket = "mobile" | "desktop" | "unknown";
+
+const MOBILE_BREAKPOINT = 768;
+const DEFAULT_SIZES = "(max-width: 1280px) 60vw, 40vw";
+const CRITICAL_DESKTOP_SIZES = "(max-width: 1280px) 70vw, 50vw";
+const STANDARD_DESKTOP_SIZES = "(max-width: 1280px) 45vw, 30vw";
+
+const clampImportance = (value?: ImageImportance): ImageImportance => {
+  if (value === "critical" || value === "low") return value;
+  return "standard";
+};
+
+const SmartImage: React.FC<SmartImageProps> = ({
+  importance = "standard",
+  lcp = false,
+  sizes,
+  loading,
+  fetchPriority,
+  decoding,
+  className,
+  src,
+  alt = "",
+  width,
+  height,
+  ...rest
+}) => {
+  const [viewport, setViewport] = useState<ViewportBucket>("unknown");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const computeBucket = () =>
+      window.innerWidth <= MOBILE_BREAKPOINT ? "mobile" : "desktop";
+    setViewport(computeBucket());
+    const handleResize = () => setViewport(computeBucket());
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const normalizedImportance = clampImportance(importance);
+
+  const resolvedFetchPriority = useMemo<"high" | "low" | "auto">(() => {
+    if (fetchPriority) {
+      return fetchPriority as "high" | "low" | "auto";
+    }
+    if (lcp || normalizedImportance === "critical") {
+      return "high";
+    }
+    if (normalizedImportance === "low") {
+      return "low";
+    }
+    if (viewport === "mobile" && (typeof width === "number" ? width : Number(width)) >= 960) {
+      return "high";
+    }
+    return "auto";
+  }, [fetchPriority, lcp, normalizedImportance, viewport, width]);
+
+  const resolvedLoading = useMemo<"eager" | "lazy">(() => {
+    if (loading) return loading;
+    return resolvedFetchPriority === "high" ? "eager" : "lazy";
+  }, [loading, resolvedFetchPriority]);
+
+  const resolvedSizes = useMemo(() => {
+    if (sizes) return sizes;
+    if (viewport === "mobile") {
+      return "100vw";
+    }
+    if (viewport === "desktop") {
+      if (lcp || normalizedImportance === "critical") {
+        return CRITICAL_DESKTOP_SIZES;
+      }
+      if (normalizedImportance === "low") {
+        return STANDARD_DESKTOP_SIZES;
+      }
+      return DEFAULT_SIZES;
+    }
+    return DEFAULT_SIZES;
+  }, [sizes, viewport, lcp, normalizedImportance]);
+
+  const resolvedDecoding = decoding || "async";
+
+  return (
+    <img
+      src={src}
+      className={className}
+      width={width}
+      height={height}
+      alt={alt}
+      data-lcp-image={lcp ? "true" : undefined}
+      loading={resolvedLoading}
+      fetchPriority={resolvedFetchPriority === "auto" ? undefined : resolvedFetchPriority}
+      sizes={resolvedSizes}
+      decoding={resolvedDecoding}
+      {...rest}
+    />
+  );
+};
+
+export default SmartImage;

--- a/components/ui/VideoPlayer.tsx
+++ b/components/ui/VideoPlayer.tsx
@@ -21,6 +21,35 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
   const [isPip, setIsPip] = useState(false);
 
   useEffect(() => {
+    if (typeof document === "undefined") return;
+    const videoLink = document.createElement("link");
+    videoLink.rel = "preload";
+    videoLink.href = src;
+    videoLink.setAttribute("fetchpriority", "high");
+    videoLink.setAttribute("importance", "high");
+    videoLink.setAttribute("as", "video");
+    document.head.appendChild(videoLink);
+
+    return () => {
+      document.head.removeChild(videoLink);
+    };
+  }, [src]);
+
+  useEffect(() => {
+    if (!poster || typeof document === "undefined") return;
+    const posterLink = document.createElement("link");
+    posterLink.rel = "preload";
+    posterLink.href = poster;
+    posterLink.setAttribute("fetchpriority", "high");
+    posterLink.setAttribute("as", "image");
+    document.head.appendChild(posterLink);
+
+    return () => {
+      document.head.removeChild(posterLink);
+    };
+  }, [poster]);
+
+  useEffect(() => {
     const video = videoRef.current;
     setPipSupported(
       typeof document !== "undefined" &&
@@ -114,6 +143,7 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
             max={1}
             step={0.05}
             value={vol}
+            aria-label="Adjust volume"
             onChange={(e) => {
               const v = parseFloat(e.target.value);
               setVol(v);
@@ -129,7 +159,15 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
 
   return (
     <div className={`relative ${className}`.trim()}>
-      <video ref={videoRef} src={src} poster={poster} controls className="w-full h-auto" />
+      <video
+        ref={videoRef}
+        src={src}
+        poster={poster}
+        controls
+        preload="metadata"
+        aria-label="Video player"
+        className="w-full h-auto"
+      />
       {pipSupported && (
         <button
           type="button"

--- a/components/util-components/background-image.js
+++ b/components/util-components/background-image.js
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react'
 import { useSettings } from '../../hooks/useSettings';
 import KaliWallpaper from './kali-wallpaper';
+import SmartImage from '../ui/SmartImage';
 
 export default function BackgroundImage() {
     const { bgImageName, useKaliWallpaper } = useSettings();
@@ -47,10 +48,14 @@ export default function BackgroundImage() {
                 <KaliWallpaper />
             ) : (
                 <>
-                    <img
+                    <SmartImage
                         src={`/wallpapers/${bgImageName}.webp`}
                         alt=""
-                        className="w-full h-full object-cover"
+                        className="h-full w-full object-cover"
+                        width={1920}
+                        height={1080}
+                        importance="critical"
+                        lcp
                     />
                     {needsOverlay && (
                         <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" aria-hidden="true"></div>

--- a/performance-lab.config.ts
+++ b/performance-lab.config.ts
@@ -1,0 +1,53 @@
+interface PerformanceLabAssertion {
+  /**
+   * CSS selector that should match the element reported as Largest Contentful Paint.
+   */
+  lcpSelector: string;
+  /**
+   * Maximum LCP value (in milliseconds) tolerated during automated checks.
+   */
+  maxLcpMs?: number;
+}
+
+interface PerformanceLabScenario {
+  /** Unique label for the run so results are easy to identify. */
+  label: string;
+  /** URL path that will be tested. */
+  url: string;
+  /** Optional viewport to emulate during the run. */
+  viewport?: {
+    width: number;
+    height: number;
+    deviceScaleFactor?: number;
+  };
+  assertions: PerformanceLabAssertion;
+}
+
+interface PerformanceLabConfig {
+  project: string;
+  description?: string;
+  scenarios: PerformanceLabScenario[];
+}
+
+const config: PerformanceLabConfig = {
+  project: "kali-linux-portfolio",
+  description:
+    "Ensures the boot wallpaper is tagged as the LCP element and keeps paint time budgets within limits.",
+  scenarios: [
+    {
+      label: "desktop-home-lcp",
+      url: "/",
+      viewport: {
+        width: 1280,
+        height: 720,
+        deviceScaleFactor: 1,
+      },
+      assertions: {
+        lcpSelector: "[data-lcp-image='true']",
+        maxLcpMs: 2600,
+      },
+    },
+  ],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add a SmartImage utility that applies fetchpriority, loading, and size heuristics for LCP imagery
- update wallpaper consumers and the video player to emit preload hints and mark the largest contentful element
- configure the performance lab runner and cover the new helpers with regression tests

## Testing
- [x] yarn lint
- [ ] yarn test *(fails because the full suite currently has unrelated failing cases)*
- [x] npx jest --runTestsByPath __tests__/videoPlayer.preload.test.tsx
- [x] npx jest --runTestsByPath __tests__/smartImage.test.tsx __tests__/performanceLabConfig.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68dccac3888c8328a4b47faccfa04840