### PR TITLE
[lint] add performance plugin for render hygiene

### DIFF
--- a/__tests__/eslint-plugin-performance/no-heavy-effects.test.js
+++ b/__tests__/eslint-plugin-performance/no-heavy-effects.test.js
@@ -1,0 +1,53 @@
+const { RuleTester } = require('eslint');
+const rule = require('../../eslint-plugin-performance/rules/no-heavy-effects');
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+tester.run('no-heavy-effects', rule, {
+  valid: [
+    {
+      code: "useEffect(() => {\n  log('render');\n});",
+    },
+    {
+      code: "useEffect(() => {\n  for (const item of items) {\n    crunch(item);\n  }\n}, [items]);",
+    },
+  ],
+  invalid: [
+    {
+      code: "useEffect(() => {\n  for (let i = 0; i < items.length; i += 1) {\n    crunch(items[i]);\n  }\n});",
+      errors: [
+        {
+          messageId: 'heavyEffect',
+          suggestions: [
+            {
+              messageId: 'addDependencies',
+              output: "useEffect(() => {\n  for (let i = 0; i < items.length; i += 1) {\n    crunch(items[i]);\n  }\n}, []);",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'useEffect(() => Promise.all(tasks.map(runTask)));',
+      errors: [
+        {
+          messageId: 'heavyEffect',
+          suggestions: [
+            {
+              messageId: 'addDependencies',
+              output: 'useEffect(() => Promise.all(tasks.map(runTask)), []);',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});

--- a/__tests__/eslint-plugin-performance/no-inline-functions-in-lists.test.js
+++ b/__tests__/eslint-plugin-performance/no-inline-functions-in-lists.test.js
@@ -1,0 +1,55 @@
+const { RuleTester } = require('eslint');
+const rule = require('../../eslint-plugin-performance/rules/no-inline-functions-in-lists');
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+tester.run('no-inline-functions-in-lists', rule, {
+  valid: [
+    {
+      code: `
+        const Item = ({ onSelect }) => <button onClick={onSelect} />;
+        const Example = ({ items, onSelect }) => (
+          <div>
+            {items.map((item) => (
+              <Item key={item.id} onSelect={onSelect} />
+            ))}
+          </div>
+        );
+      `,
+    },
+    {
+      code: `
+        items.map((item) => {
+          const onClick = createHandler(item);
+          return <button key={item.id} onClick={onClick} />;
+        });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        items.map((item) => (
+          <button key={item.id} onClick={() => handle(item)} />
+        ));
+      `,
+      errors: [{ messageId: 'moveHandler' }],
+    },
+    {
+      code: `
+        list.filter(Boolean).map(function (item) {
+          return <input key={item.id} onChange={function (event) { update(item, event.target.value); }} />;
+        });
+      `,
+      errors: 1,
+    },
+  ],
+});

--- a/__tests__/eslint-plugin-performance/no-unnecessary-renders.test.js
+++ b/__tests__/eslint-plugin-performance/no-unnecessary-renders.test.js
@@ -1,0 +1,57 @@
+const { RuleTester } = require('eslint');
+const rule = require('../../eslint-plugin-performance/rules/no-unnecessary-renders');
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+tester.run('no-unnecessary-renders', rule, {
+  valid: [
+    {
+      code: 'const value = useMemo(() => compute(input), [input]);',
+    },
+    {
+      code: 'const handler = React.useCallback(() => dispatch(action), [dispatch, action]);',
+    },
+  ],
+  invalid: [
+    {
+      code: 'const value = useMemo(() => compute(input));',
+      errors: [
+        {
+          messageId: 'provideDependencies',
+          suggestions: [
+            {
+              messageId: 'addEmptyDependencyArray',
+              output: 'const value = useMemo(() => compute(input), []);',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'const handler = React.useCallback(() => dispatch(action));',
+      errors: [
+        {
+          messageId: 'provideDependencies',
+          suggestions: [
+            {
+              messageId: 'addEmptyDependencyArray',
+              output: 'const handler = React.useCallback(() => dispatch(action), []);',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'const memoized = useMemo(() => build(), dependencies);',
+      errors: [{ messageId: 'provideDependencies' }],
+    },
+  ],
+});

--- a/components/apps/alex.js
+++ b/components/apps/alex.js
@@ -296,9 +296,36 @@ const SkillSection = ({ title, badges }) => {
   const [filter, setFilter] = React.useState('');
   const [selected, setSelected] = React.useState(null);
 
-  const filteredBadges = badges.filter(b =>
-    b.alt.toLowerCase().includes(filter.toLowerCase())
+  const filteredBadges = React.useMemo(
+    () => badges.filter((badge) => badge.alt.toLowerCase().includes(filter.toLowerCase())),
+    [badges, filter]
   );
+
+  const handleFilterChange = React.useCallback((event) => {
+    setFilter(event.target.value);
+  }, []);
+
+  const handleBadgeClick = React.useCallback(
+    (event) => {
+      const { alt } = event.currentTarget.dataset;
+      if (!alt) {
+        return;
+      }
+      const nextBadge = badges.find((badge) => badge.alt === alt);
+      if (nextBadge) {
+        setSelected(nextBadge);
+      }
+    },
+    [badges]
+  );
+
+  const handleOverlayClose = React.useCallback(() => {
+    setSelected(null);
+  }, []);
+
+  const handleDialogClick = React.useCallback((event) => {
+    event.stopPropagation();
+  }, []);
 
   return (
     <div className="px-2 w-full">
@@ -309,35 +336,30 @@ const SkillSection = ({ title, badges }) => {
         className="mt-2 w-full px-2 py-1 rounded text-black"
         value={filter}
         aria-label="Filter skills"
-        onChange={(e) => setFilter(e.target.value)}
+        onChange={handleFilterChange}
       />
       <div className="flex flex-wrap justify-center items-start w-full mt-2">
-        {filteredBadges.map(badge => (
+        {filteredBadges.map((badge) => (
           <img
             key={badge.alt}
             className="m-1 cursor-pointer"
             src={badge.src}
             alt={badge.alt}
             title={badge.description}
-            onClick={() => setSelected(badge)}
+            data-alt={badge.alt}
+            onClick={handleBadgeClick}
           />
         ))}
       </div>
       {selected && (
         <div
           className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
-          onClick={() => setSelected(null)}
+          onClick={handleOverlayClose}
         >
-          <div
-            className="bg-ub-cool-grey p-4 rounded max-w-xs"
-            onClick={(e) => e.stopPropagation()}
-          >
+          <div className="bg-ub-cool-grey p-4 rounded max-w-xs" onClick={handleDialogClick}>
             <div className="font-bold mb-2 text-center">{selected.alt}</div>
             <p className="text-sm text-center">{selected.description}</p>
-            <button
-              className="mt-2 px-2 py-1 bg-ubt-blue rounded"
-              onClick={() => setSelected(null)}
-            >
+            <button className="mt-2 px-2 py-1 bg-ubt-blue rounded" onClick={handleOverlayClose}>
               Close
             </button>
           </div>
@@ -487,6 +509,11 @@ function Resume({ data: resume }) {
     );
     const experiences = filter === 'all' ? resume.experience : resume.experience.filter((e) => e.tags.includes(filter));
 
+    const handleFilterClick = React.useCallback((event) => {
+        const nextFilter = event.currentTarget.dataset.filter || 'all';
+        setFilter(nextFilter);
+    }, []);
+
     React.useEffect(() => {
         const elements = document.querySelectorAll('.exp-item');
         const observer = new IntersectionObserver((entries) => {
@@ -581,7 +608,8 @@ function Resume({ data: resume }) {
                     <div className="font-bold text-lg">Experience</div>
                     <div className="flex flex-wrap my-2">
                         <button
-                            onClick={() => setFilter('all')}
+                            data-filter="all"
+                            onClick={handleFilterClick}
                             className={(filter === 'all' ? 'bg-ubt-blue' : 'bg-ub-gedit-light') + ' text-xs px-2 py-1 rounded m-1'}
                         >
                             All
@@ -589,7 +617,8 @@ function Resume({ data: resume }) {
                         {tags.map((tag) => (
                             <button
                                 key={tag}
-                                onClick={() => setFilter(tag)}
+                                data-filter={tag}
+                                onClick={handleFilterClick}
                                 className={(filter === tag ? 'bg-ubt-blue' : 'bg-ub-gedit-light') + ' text-xs px-2 py-1 rounded m-1'}
                             >
                                 {tag}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -648,8 +648,10 @@ export class Desktop extends Component {
         });
     };
 
-    handleIconPointerDown = (event, appId) => {
+    handleIconPointerDown = (event) => {
         if (event.button !== 0) return;
+        const appId = event.currentTarget.dataset.appId;
+        if (!appId) return;
         const container = event.currentTarget;
         const rect = container.getBoundingClientRect();
         const offsetX = event.clientX - rect.left;
@@ -1292,7 +1294,8 @@ export class Desktop extends Component {
                 <div
                     key={app.id}
                     style={wrapperStyle}
-                    onPointerDown={(event) => this.handleIconPointerDown(event, app.id)}
+                    data-app-id={app.id}
+                    onPointerDown={this.handleIconPointerDown}
                     onPointerMove={this.handleIconPointerMove}
                     onPointerUp={this.handleIconPointerUp}
                     onPointerCancel={this.handleIconPointerCancel}

--- a/eslint-plugin-performance/docs/rules/no-heavy-effects.md
+++ b/eslint-plugin-performance/docs/rules/no-heavy-effects.md
@@ -1,0 +1,35 @@
+# no-heavy-effects
+
+Expensive computations inside `useEffect` without a dependency array run after every render. That work can dominate interaction time
+and keep React busy even when nothing meaningful changed.
+
+## Rule details
+
+This rule looks for loops or heavy collection operations inside a `useEffect` callback that does not specify a dependency array.
+When found, it reports the effect and suggests limiting it with an empty dependency array.
+
+### Incorrect
+
+```jsx
+function Dashboard({ reports }) {
+  React.useEffect(() => {
+    for (const report of reports) {
+      crunchReport(report);
+    }
+  });
+}
+```
+
+### Correct
+
+```jsx
+function Dashboard({ reports }) {
+  React.useEffect(() => {
+    for (const report of reports) {
+      crunchReport(report);
+    }
+  }, [reports]);
+}
+```
+
+If the work is still expensive, move it out of the effect entirely or throttle it with background scheduling APIs.

--- a/eslint-plugin-performance/docs/rules/no-inline-functions-in-lists.md
+++ b/eslint-plugin-performance/docs/rules/no-inline-functions-in-lists.md
@@ -1,0 +1,59 @@
+# no-inline-functions-in-lists
+
+Inline handlers created inside list rendering callbacks (such as `Array#map`) are recreated on every render. This increases garbage
+collection pressure and can cause avoidable re-renders for memoized children.
+
+## Rule details
+
+This rule flags inline function expressions that are assigned to JSX attributes while rendering inside common list helpers.
+
+### Incorrect
+
+```jsx
+function List({ items, onSelect }) {
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id} onClick={() => onSelect(item)}>
+          {item.label}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+### Correct
+
+```jsx
+function ListItem({ item, onSelect }) {
+  return (
+    <li data-id={item.id} onClick={onSelect}>
+      {item.label}
+    </li>
+  );
+}
+
+function List({ items, onSelect }) {
+  const handleSelect = React.useCallback(
+    (event) => {
+      const id = event.currentTarget.dataset.id;
+      const next = items.find((entry) => String(entry.id) === id);
+      if (next) {
+        onSelect(next);
+      }
+    },
+    [items, onSelect]
+  );
+
+  return (
+    <ul>
+      {items.map((item) => (
+        <ListItem key={item.id} item={item} onSelect={handleSelect} />
+      ))}
+    </ul>
+  );
+}
+```
+
+Extract the handler outside of the list callback or memoize it so that React can preserve prop references between renders.

--- a/eslint-plugin-performance/docs/rules/no-unnecessary-renders.md
+++ b/eslint-plugin-performance/docs/rules/no-unnecessary-renders.md
@@ -1,0 +1,23 @@
+# no-unnecessary-renders
+
+Memoization hooks such as `useMemo` and `useCallback` require a dependency array. Without it, React recomputes the value on every
+render, negating the optimization and creating new references that can cascade into more renders.
+
+## Rule details
+
+The rule flags calls to `useMemo` or `useCallback` that omit the dependency array or provide a non-array second argument. When
+possible it suggests adding an empty array so the value is memoized until its inputs change.
+
+### Incorrect
+
+```jsx
+const expensive = React.useMemo(() => heavyCalculation(data));
+```
+
+### Correct
+
+```jsx
+const expensive = React.useMemo(() => heavyCalculation(data), [data]);
+```
+
+If the memoized callback or value depends on multiple props, include each one in the array.

--- a/eslint-plugin-performance/index.js
+++ b/eslint-plugin-performance/index.js
@@ -1,0 +1,11 @@
+const noInlineFunctionsInLists = require('./rules/no-inline-functions-in-lists');
+const noHeavyEffects = require('./rules/no-heavy-effects');
+const noUnnecessaryRenders = require('./rules/no-unnecessary-renders');
+
+module.exports = {
+  rules: {
+    'no-inline-functions-in-lists': noInlineFunctionsInLists,
+    'no-heavy-effects': noHeavyEffects,
+    'no-unnecessary-renders': noUnnecessaryRenders,
+  },
+};

--- a/eslint-plugin-performance/rules/no-heavy-effects.js
+++ b/eslint-plugin-performance/rules/no-heavy-effects.js
@@ -1,0 +1,130 @@
+const HEAVY_LOOP_TYPES = new Set([
+  'ForStatement',
+  'ForInStatement',
+  'ForOfStatement',
+  'WhileStatement',
+  'DoWhileStatement',
+]);
+
+const HEAVY_MEMBER_METHODS = new Set(['map', 'forEach', 'reduce', 'filter', 'flatMap', 'sort']);
+
+const HEAVY_CALL_IDENTIFIERS = new Set(['fetch', 'requestAnimationFrame', 'setTimeout', 'setInterval', 'Promise', 'queueMicrotask']);
+
+function isUseEffectCall(node) {
+  if (node.callee.type === 'Identifier') {
+    return node.callee.name === 'useEffect';
+  }
+
+  if (
+    node.callee.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    node.callee.property &&
+    node.callee.property.type === 'Identifier'
+  ) {
+    return node.callee.property.name === 'useEffect';
+  }
+
+  return false;
+}
+
+function isHeavyCallExpression(node) {
+  if (node.callee.type === 'Identifier') {
+    return HEAVY_CALL_IDENTIFIERS.has(node.callee.name);
+  }
+
+  if (node.callee.type === 'MemberExpression' && !node.callee.computed && node.callee.property.type === 'Identifier') {
+    if (HEAVY_MEMBER_METHODS.has(node.callee.property.name)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function containsHeavyWork(node, context) {
+  if (!node) {
+    return false;
+  }
+
+  if (HEAVY_LOOP_TYPES.has(node.type)) {
+    return true;
+  }
+
+  if (node.type === 'CallExpression' && isHeavyCallExpression(node)) {
+    return true;
+  }
+
+  const sourceCode = context.getSourceCode();
+  const visitorKeys = sourceCode.visitorKeys[node.type] || [];
+
+  for (const key of visitorKeys) {
+    const value = node[key];
+    if (Array.isArray(value)) {
+      if (value.some((child) => child && containsHeavyWork(child, context))) {
+        return true;
+      }
+    } else if (value && containsHeavyWork(value, context)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'warn when heavy computations are performed in useEffect without a dependency array, which can cause repeated expensive work',
+      recommended: false,
+    },
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      heavyEffect:
+        'Avoid heavy operations inside useEffect without dependencies. Move the computation or limit the effect with a dependency array.',
+      addDependencies: 'Add an empty dependency array so the effect only runs on mount.',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!isUseEffectCall(node) || node.arguments.length === 0) {
+          return;
+        }
+
+        const callback = node.arguments[0];
+        if (callback.type !== 'ArrowFunctionExpression' && callback.type !== 'FunctionExpression') {
+          return;
+        }
+
+        const body = callback.body;
+        let hasHeavyWork = false;
+
+        if (body.type === 'BlockStatement') {
+          hasHeavyWork = containsHeavyWork(body, context);
+        } else {
+          hasHeavyWork = containsHeavyWork(body, context);
+        }
+
+        if (!hasHeavyWork || node.arguments.length > 1) {
+          return;
+        }
+
+        context.report({
+          node: callback,
+          messageId: 'heavyEffect',
+          suggest: [
+            {
+              messageId: 'addDependencies',
+              fix(fixer) {
+                return fixer.insertTextAfter(callback, ', []');
+              },
+            },
+          ],
+        });
+      },
+    };
+  },
+};

--- a/eslint-plugin-performance/rules/no-inline-functions-in-lists.js
+++ b/eslint-plugin-performance/rules/no-inline-functions-in-lists.js
@@ -1,0 +1,69 @@
+const LIST_METHODS = new Set(['map', 'forEach', 'filter', 'reduce', 'flatMap']);
+
+function isListCallback(node) {
+  if (!node.parent || node.parent.type !== 'CallExpression') {
+    return false;
+  }
+
+  const callExpression = node.parent;
+  if (callExpression.arguments[0] !== node) {
+    return false;
+  }
+
+  const callee = callExpression.callee;
+
+  if (callee.type === 'MemberExpression' && !callee.computed && callee.property && LIST_METHODS.has(callee.property.name)) {
+    return true;
+  }
+
+  return false;
+}
+
+function isInlineFunctionExpression(expression) {
+  return expression && (expression.type === 'ArrowFunctionExpression' || expression.type === 'FunctionExpression');
+}
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'discourage defining inline handlers inside list rendering callbacks to avoid re-creating them on every render',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      moveHandler: 'Avoid creating inline functions inside list rendering. Extract the handler or memoize it outside the loop.',
+    },
+  },
+  create(context) {
+    const listCallbackStack = [];
+
+    function enterFunction(node) {
+      listCallbackStack.push(isListCallback(node));
+    }
+
+    function exitFunction() {
+      listCallbackStack.pop();
+    }
+
+    return {
+      ArrowFunctionExpression: enterFunction,
+      'ArrowFunctionExpression:exit': exitFunction,
+      FunctionExpression: enterFunction,
+      'FunctionExpression:exit': exitFunction,
+      JSXAttribute(node) {
+        if (!listCallbackStack.length || !listCallbackStack[listCallbackStack.length - 1]) {
+          return;
+        }
+
+        if (!node.value || node.value.type !== 'JSXExpressionContainer') {
+          return;
+        }
+
+        if (isInlineFunctionExpression(node.value.expression)) {
+          context.report({ node: node.value.expression, messageId: 'moveHandler' });
+        }
+      },
+    };
+  },
+};

--- a/eslint-plugin-performance/rules/no-unnecessary-renders.js
+++ b/eslint-plugin-performance/rules/no-unnecessary-renders.js
@@ -1,0 +1,59 @@
+const TARGET_HOOKS = new Set(['useMemo', 'useCallback']);
+
+function isTargetHook(node) {
+  if (node.callee.type === 'Identifier') {
+    return TARGET_HOOKS.has(node.callee.name);
+  }
+
+  if (node.callee.type === 'MemberExpression' && !node.callee.computed && node.callee.property.type === 'Identifier') {
+    return TARGET_HOOKS.has(node.callee.property.name);
+  }
+
+  return false;
+}
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'ensure memoization hooks provide dependency arrays so memoized values are not recreated on every render',
+      recommended: false,
+    },
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      provideDependencies: 'Provide a dependency array so the memoized value does not trigger unnecessary renders.',
+      addEmptyDependencyArray: 'Add an empty dependency array to memoize the result until inputs change.',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!isTargetHook(node) || node.arguments.length === 0) {
+          return;
+        }
+
+        if (node.arguments.length > 1 && node.arguments[1].type === 'ArrayExpression') {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'provideDependencies',
+          suggest:
+            node.arguments.length === 1
+              ? [
+                  {
+                    messageId: 'addEmptyDependencyArray',
+                    fix(fixer) {
+                      return fixer.insertTextAfter(node.arguments[0], ', []');
+                    },
+                  },
+                ]
+              : [],
+        });
+      },
+    };
+  },
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import { FlatCompat } from '@eslint/eslintrc';
 import noTopLevelWindow from './eslint-plugin-no-top-level-window/index.js';
+import performancePlugin from './eslint-plugin-performance/index.js';
 
 const compat = new FlatCompat();
 
@@ -8,9 +9,13 @@ const config = [
   {
     plugins: {
       'no-top-level-window': noTopLevelWindow,
+      performance: performancePlugin,
     },
     rules: {
       'no-top-level-window/no-top-level-window-or-document': 'error',
+      'performance/no-inline-functions-in-lists': 'warn',
+      'performance/no-heavy-effects': 'warn',
+      'performance/no-unnecessary-renders': 'warn',
     },
   },
   {


### PR DESCRIPTION
## Summary
- add `eslint-plugin-performance` with rules for inline handlers, heavy effects, and missing memo dependencies
- document each rule and enable the plugin in the root ESLint flat config
- add RuleTester coverage and refactor affected components to satisfy the new lint rules

## Testing
- yarn lint
- yarn test __tests__/eslint-plugin-performance --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dccac7588c8328982214afd54f122a