### PR TITLE
[routes] add typed builders for app pages

### DIFF
--- a/docs/new-app-checklist.md
+++ b/docs/new-app-checklist.md
@@ -19,6 +19,11 @@ const MyApp = dynamic(() => import('./components/apps/my-app'), {
 export const displayMyApp = () => <MyApp />;
 ```
 
+## Routes
+
+- Use `buildAppRoute({ appId: 'my-app' })` from `utils/routes` when generating links (for example in menus or metadata).
+- Parse incoming paths with `parseAppRoute` to validate that a string targets a known `/apps/*` page before opening windows.
+
 ## Content Security Policy
 
 - Apps that fetch data or embed external sites must whitelist their domains in `next.config.js`.

--- a/lib/appRegistry.ts
+++ b/lib/appRegistry.ts
@@ -1,3 +1,5 @@
+import { buildAppRoute } from '../utils/routes';
+
 export type AppMetadata = {
   title: string;
   description: string;
@@ -6,10 +8,11 @@ export type AppMetadata = {
   icon?: string;
 };
 
-type AppEntry = {
+export type AppEntry = {
   id: string;
   title: string;
   icon?: string;
+  disabled?: boolean;
 };
 
 const DEFAULT_KEYBOARD_HINTS = [
@@ -79,7 +82,7 @@ export const buildAppMetadata = (app: AppEntry): AppMetadata => {
     icon: app.icon,
     description:
       override.description ?? `Launch the ${app.title} demo environment.`,
-    path: override.path ?? `/apps/${app.id}`,
+    path: override.path ?? buildAppRoute({ appId: app.id }),
     keyboard: override.keyboard ?? DEFAULT_KEYBOARD_HINTS,
   };
 };

--- a/pages/apps/index.tsx
+++ b/pages/apps/index.tsx
@@ -4,14 +4,17 @@ import Link from 'next/link';
 import DelayedTooltip from '../../components/ui/DelayedTooltip';
 import AppTooltipContent from '../../components/ui/AppTooltipContent';
 import {
+  type AppEntry,
+  type AppMetadata,
   buildAppMetadata,
   loadAppRegistry,
 } from '../../lib/appRegistry';
+import { buildAppRoute } from '../../utils/routes';
 
 const AppsPage = () => {
-  const [apps, setApps] = useState([]);
+  const [apps, setApps] = useState<AppEntry[]>([]);
   const [query, setQuery] = useState('');
-  const [metadata, setMetadata] = useState({});
+  const [metadata, setMetadata] = useState<Record<string, AppMetadata>>({});
 
   useEffect(() => {
     let isMounted = true;
@@ -47,11 +50,12 @@ const AppsPage = () => {
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Search apps"
+        aria-label="Search apps"
         className="mb-4 w-full rounded border p-2"
       />
       <div
         id="app-grid"
-        tabIndex="-1"
+        tabIndex={-1}
         className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
       >
         {filteredApps.map((app) => {
@@ -69,7 +73,7 @@ const AppsPage = () => {
                   className="flex flex-col items-center"
                 >
                   <Link
-                    href={`/apps/${app.id}`}
+                    href={buildAppRoute({ appId: app.id })}
                     className="flex h-full w-full flex-col items-center rounded border p-4 text-center focus:outline-none focus:ring"
                     aria-label={app.title}
                     onFocus={onFocus}

--- a/tests/apps.smoke.spec.ts
+++ b/tests/apps.smoke.spec.ts
@@ -1,16 +1,18 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
+import { AppRoute, buildAppRoute } from '../utils/routes';
 
 const appDir = path.join(process.cwd(), 'pages', 'apps');
 
-function getRoutes(dir: string, prefix = ''): string[] {
+function getRoutes(dir: string, prefix = ''): AppRoute[] {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
-  const routes: string[] = [];
+  const routes: AppRoute[] = [];
   for (const entry of entries) {
     if (entry.isFile() && /\.(jsx?|tsx?)$/.test(entry.name)) {
       const rel = path.join(prefix, entry.name).replace(/\\/g, '/');
-      routes.push('/apps/' + rel.replace(/\.(jsx?|tsx?)$/, ''));
+      const appId = rel.replace(/\.(jsx?|tsx?)$/, '');
+      routes.push(buildAppRoute({ appId }));
     } else if (entry.isDirectory()) {
       routes.push(...getRoutes(path.join(dir, entry.name), path.join(prefix, entry.name)));
     }
@@ -18,8 +20,10 @@ function getRoutes(dir: string, prefix = ''): string[] {
   return routes;
 }
 
+const APP_INDEX_ROUTE = buildAppRoute({ appId: 'index' });
+
 const routes = getRoutes(appDir)
-  .filter((r) => r !== '/apps/index')
+  .filter((r) => r !== APP_INDEX_ROUTE)
   .map((r) => r.replace(/\/index$/, ''));
 
 for (const route of routes) {

--- a/tests/types/routes.type-test.ts
+++ b/tests/types/routes.type-test.ts
@@ -1,0 +1,31 @@
+import { AppRoute, buildAppRoute, isAppRoute, parseAppRoute } from '../../utils/routes';
+
+const literalRoute: AppRoute<'terminal'> = buildAppRoute({ appId: 'terminal' });
+const nestedRoute: AppRoute<'solitaire/index'> = buildAppRoute({ appId: 'solitaire/index' });
+
+const dynamicId = 'weather';
+const dynamicRoute = buildAppRoute({ appId: dynamicId });
+const acceptsString: string = dynamicRoute;
+
+const parsed = parseAppRoute('/apps/weather');
+if (parsed) {
+  const parsedId: string = parsed.appId;
+  const backToRoute: AppRoute = buildAppRoute({ appId: parsedId });
+}
+
+const maybeRoute: string = '/apps/sticky_notes';
+if (isAppRoute(maybeRoute)) {
+  const confirmedRoute: AppRoute = maybeRoute;
+}
+
+// @ts-expect-error App id must be provided.
+buildAppRoute({});
+
+// @ts-expect-error App id cannot be empty.
+buildAppRoute({ appId: '' });
+
+// @ts-expect-error App id must not start with '/'.
+buildAppRoute({ appId: '/leading-slash' });
+
+// @ts-expect-error parseAppRoute only accepts strings.
+parseAppRoute(123);

--- a/utils/routes.ts
+++ b/utils/routes.ts
@@ -1,0 +1,92 @@
+export const APP_ROUTE_PREFIX = '/apps';
+
+export type ValidAppId<Id extends string> = Id extends ''
+  ? never
+  : Id extends `/${string}`
+    ? never
+    : Id;
+
+export type AppRoute<Id extends string = string> = `${typeof APP_ROUTE_PREFIX}/${Id}`;
+
+export type AppRouteParams<Id extends string = string> = {
+  appId: ValidAppId<Id>;
+};
+
+const normalizeAppId = (appId: string): string => {
+  const trimmed = appId.trim();
+
+  if (!trimmed) {
+    throw new Error('App id must be a non-empty string.');
+  }
+
+  if (trimmed.startsWith('/')) {
+    throw new Error('App id must not start with a forward slash.');
+  }
+
+  return trimmed;
+};
+
+export const buildAppRoute = <Id extends string>(
+  params: AppRouteParams<Id>,
+): AppRoute<ValidAppId<Id>> => {
+  const normalized = normalizeAppId(params.appId);
+  return `${APP_ROUTE_PREFIX}/${normalized}` as AppRoute<ValidAppId<Id>>;
+};
+
+export type ParseAppRouteResult<Id extends string = string> = {
+  appId: ValidAppId<Id>;
+};
+
+const stripQueryAndHash = (path: string): string => {
+  const queryIndex = path.indexOf('?');
+  const hashIndex = path.indexOf('#');
+
+  if (queryIndex === -1 && hashIndex === -1) {
+    return path;
+  }
+
+  const endIndex = [queryIndex, hashIndex]
+    .filter((index) => index >= 0)
+    .reduce((min, index) => Math.min(min, index), Number.POSITIVE_INFINITY);
+
+  return path.slice(0, Number.isFinite(endIndex) ? endIndex : undefined);
+};
+
+export const parseAppRoute = <Id extends string>(
+  input: string,
+): ParseAppRouteResult<Id> | null => {
+  if (typeof input !== 'string') {
+    return null;
+  }
+
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const normalized = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+
+  if (!normalized.startsWith(`${APP_ROUTE_PREFIX}/`)) {
+    return null;
+  }
+
+  const withoutPrefix = stripQueryAndHash(normalized.slice(APP_ROUTE_PREFIX.length + 1));
+  if (!withoutPrefix) {
+    return null;
+  }
+
+  const appId = withoutPrefix.replace(/\/+$/, '');
+  if (!appId) {
+    return null;
+  }
+
+  try {
+    return { appId: normalizeAppId(appId) } as ParseAppRouteResult<Id>;
+  } catch {
+    return null;
+  }
+};
+
+export const isAppRoute = <Id extends string>(value: string): value is AppRoute<Id> => {
+  return parseAppRoute<Id>(value) !== null;
+};


### PR DESCRIPTION
## Summary
- add typed builders/parsers for `/apps/*` routes with runtime guards
- update the apps index, registry metadata, and smoke test to use the new helpers
- add type tests and documentation covering safe route construction

## Testing
- yarn lint
- yarn typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dccaccfd8083288c819d4e23969625