### PR TITLE
[apps] Add shared URL sanitization policy

### DIFF
--- a/__tests__/urlPolicy.test.tsx
+++ b/__tests__/urlPolicy.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import ExplainerPane from '../components/ExplainerPane';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../utils/urlPolicy';
+
+describe('sanitizeUrl', () => {
+  it('allows https links and marks them as external', () => {
+    const result = sanitizeUrl('https://example.com/path');
+    expect(result).toEqual({ href: 'https://example.com/path', isExternal: true });
+  });
+
+  it('preserves relative links', () => {
+    const result = sanitizeUrl('/docs/guide');
+    expect(result).toEqual({ href: '/docs/guide', isExternal: false });
+  });
+
+  it('rejects javascript URLs', () => {
+    expect(sanitizeUrl('javascript:alert(1)')).toBeNull();
+  });
+
+  it('rejects data URLs', () => {
+    expect(sanitizeUrl('data:text/html,alert(1)')).toBeNull();
+  });
+});
+
+describe('computeRelAttribute', () => {
+  it('ensures noopener noreferrer for external links', () => {
+    expect(computeRelAttribute(true)).toBe('noopener noreferrer');
+  });
+
+  it('merges existing rel tokens', () => {
+    expect(computeRelAttribute(true, 'nofollow')).toBe('nofollow noopener noreferrer');
+  });
+});
+
+describe('ExplainerPane', () => {
+  it('shows an unavailable message for rejected URLs', () => {
+    render(
+      <ExplainerPane
+        lines={['Item']}
+        resources={[{ label: 'Unsafe', url: 'javascript:alert(1)' }]}
+      />
+    );
+
+    expect(
+      screen.getByText(`Unsafe (${LINK_UNAVAILABLE_COPY})`, { exact: false }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/About/index.tsx
+++ b/apps/About/index.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import AboutApp from '../../components/apps/About';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../../utils/urlPolicy';
 
 function GitHubIcon({ className }: { className?: string }) {
   return (
@@ -47,24 +48,48 @@ export default function AboutPage() {
             <p className="text-gray-200">Cybersecurity Specialist</p>
           </div>
           <div className="ml-4 flex gap-3">
-            <a
-              href="https://github.com/unnippillil"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="GitHub"
-              className="text-white"
-            >
-              <GitHubIcon className="w-6 h-6" />
-            </a>
-            <a
-              href="https://www.linkedin.com/in/alex-unnippillil"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="LinkedIn"
-              className="text-white"
-            >
-              <LinkedInIcon className="w-6 h-6" />
-            </a>
+            {(() => {
+              const safeGitHub = sanitizeUrl('https://github.com/unnippillil');
+              if (!safeGitHub) {
+                return (
+                  <span className="text-white/60" aria-label={`GitHub (${LINK_UNAVAILABLE_COPY})`}>
+                    <GitHubIcon className="w-6 h-6 opacity-60" aria-hidden="true" />
+                  </span>
+                );
+              }
+              return (
+                <a
+                  href={safeGitHub.href}
+                  target="_blank"
+                  rel={computeRelAttribute(safeGitHub.isExternal, 'noopener noreferrer')}
+                  aria-label="GitHub"
+                  className="text-white"
+                >
+                  <GitHubIcon className="w-6 h-6" />
+                </a>
+              );
+            })()}
+            {(() => {
+              const safeLinkedIn = sanitizeUrl('https://www.linkedin.com/in/alex-unnippillil');
+              if (!safeLinkedIn) {
+                return (
+                  <span className="text-white/60" aria-label={`LinkedIn (${LINK_UNAVAILABLE_COPY})`}>
+                    <LinkedInIcon className="w-6 h-6 opacity-60" aria-hidden="true" />
+                  </span>
+                );
+              }
+              return (
+                <a
+                  href={safeLinkedIn.href}
+                  target="_blank"
+                  rel={computeRelAttribute(safeLinkedIn.isExternal, 'noopener noreferrer')}
+                  aria-label="LinkedIn"
+                  className="text-white"
+                >
+                  <LinkedInIcon className="w-6 h-6" />
+                </a>
+              );
+            })()}
           </div>
         </section>
         <AboutApp />

--- a/apps/figlet/index.tsx
+++ b/apps/figlet/index.tsx
@@ -5,6 +5,7 @@ import { toPng, toSvg } from "html-to-image";
 import AlignmentControls from "./components/AlignmentControls";
 import FontGrid from "./components/FontGrid";
 import usePersistentState from "../../hooks/usePersistentState";
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from "../../utils/urlPolicy";
 
 interface FontInfo {
   name: string;
@@ -542,14 +543,26 @@ const FigletApp: React.FC = () => {
       </div>
       <div className="p-2 text-xs text-right">
         About this feature{" "}
-        <a
-          href="http://www.figlet.org/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline"
-        >
-          FIGlet
-        </a>
+        {(() => {
+          const safeLink = sanitizeUrl("http://www.figlet.org/");
+          if (!safeLink) {
+            return (
+              <span className="underline italic">
+                FIGlet ({LINK_UNAVAILABLE_COPY})
+              </span>
+            );
+          }
+          return (
+            <a
+              href={safeLink.href}
+              target="_blank"
+              rel={computeRelAttribute(safeLink.isExternal, "noopener noreferrer")}
+              className="underline"
+            >
+              FIGlet
+            </a>
+          );
+        })()}
       </div>
       <div aria-live="polite" className="sr-only">
         {announce}

--- a/apps/http/index.tsx
+++ b/apps/http/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../../utils/urlPolicy';
 
 const HTTPBuilder: React.FC = () => {
   const [method, setMethod] = useState('GET');
@@ -13,14 +14,26 @@ const HTTPBuilder: React.FC = () => {
       <h1 className="mb-4 text-2xl">HTTP Request Builder</h1>
       <p className="mb-4 text-sm text-yellow-300">
         Build a curl command without sending any requests. Learn more at{' '}
-        <a
-          href="https://curl.se/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline text-blue-400"
-        >
-          the curl project page
-        </a>
+        {(() => {
+          const safeLink = sanitizeUrl('https://curl.se/');
+          if (!safeLink) {
+            return (
+              <span className="underline text-blue-200 italic">
+                the curl project page ({LINK_UNAVAILABLE_COPY})
+              </span>
+            );
+          }
+          return (
+            <a
+              href={safeLink.href}
+              target="_blank"
+              rel={computeRelAttribute(safeLink.isExternal, 'noopener noreferrer')}
+              className="underline text-blue-400"
+            >
+              the curl project page
+            </a>
+          );
+        })()}
         .
       </p>
       <form onSubmit={(e) => e.preventDefault()} className="mb-4 space-y-4">
@@ -50,6 +63,7 @@ const HTTPBuilder: React.FC = () => {
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
+            aria-label="Request URL"
           />
         </div>
       </form>

--- a/apps/mimikatz/components/BlueTeamPanel.tsx
+++ b/apps/mimikatz/components/BlueTeamPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../../../utils/urlPolicy';
 
 interface LogEntry {
   step: string;
@@ -35,16 +36,26 @@ const BlueTeamPanel: React.FC<Props> = ({ logs }) => {
               <p className="mb-1">
                 <span className="font-semibold">Mitigation:</span> {entry.mitigation}
               </p>
-              {entry.resource && (
-                <a
-                  href={entry.resource}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline text-blue-200"
-                >
-                  Learn more
-                </a>
-              )}
+              {entry.resource && (() => {
+                const safeLink = sanitizeUrl(entry.resource);
+                if (!safeLink) {
+                  return (
+                    <span className="underline text-blue-100 italic">
+                      Learn more ({LINK_UNAVAILABLE_COPY})
+                    </span>
+                  );
+                }
+                return (
+                  <a
+                    href={safeLink.href}
+                    target="_blank"
+                    rel={computeRelAttribute(safeLink.isExternal, 'noopener noreferrer')}
+                    className="underline text-blue-200"
+                  >
+                    Learn more
+                  </a>
+                );
+              })()}
             </div>
           )}
         </div>

--- a/apps/mimikatz/index.tsx
+++ b/apps/mimikatz/index.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import MimikatzApp from '../../components/apps/mimikatz';
 import ExposureExplainer from './components/ExposureExplainer';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../../utils/urlPolicy';
 
 const disclaimerUrl = 'https://www.kali.org/docs/policy/disclaimer/';
 
@@ -18,14 +19,26 @@ const MimikatzPage: React.FC = () => {
             Mimikatz can execute high-risk commands that may compromise system
             security. Proceed only if you understand the risks.
           </p>
-          <a
-            href={disclaimerUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-300 underline"
-          >
-            Read the full disclaimer
-          </a>
+          {(() => {
+            const safeDisclaimer = sanitizeUrl(disclaimerUrl);
+            if (!safeDisclaimer) {
+              return (
+                <span className="text-blue-200 underline italic">
+                  Read the full disclaimer ({LINK_UNAVAILABLE_COPY})
+                </span>
+              );
+            }
+            return (
+              <a
+                href={safeDisclaimer.href}
+                target="_blank"
+                rel={computeRelAttribute(safeDisclaimer.isExternal, 'noopener noreferrer')}
+                className="text-blue-300 underline"
+              >
+                Read the full disclaimer
+              </a>
+            );
+          })()}
           <div className="flex justify-center space-x-4 pt-2">
             <button
               onClick={() => setConfirmed(true)}

--- a/apps/ssh/index.tsx
+++ b/apps/ssh/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef, useState } from 'react';
 import TabbedWindow, { TabDefinition } from '../../components/ui/TabbedWindow';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../../utils/urlPolicy';
 
 const SSHBuilder: React.FC = () => {
   const [user, setUser] = useState('');
@@ -14,14 +15,26 @@ const SSHBuilder: React.FC = () => {
       <h1 className="mb-4 text-2xl">SSH Command Builder</h1>
       <p className="mb-4 text-sm text-yellow-300">
         Generate an SSH command without executing it. Learn more at{' '}
-        <a
-          href="https://www.openssh.com/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline text-blue-400"
-        >
-          the OpenSSH project page
-        </a>
+        {(() => {
+          const safeLink = sanitizeUrl('https://www.openssh.com/');
+          if (!safeLink) {
+            return (
+              <span className="underline text-blue-200 italic">
+                the OpenSSH project page ({LINK_UNAVAILABLE_COPY})
+              </span>
+            );
+          }
+          return (
+            <a
+              href={safeLink.href}
+              target="_blank"
+              rel={computeRelAttribute(safeLink.isExternal, 'noopener noreferrer')}
+              className="underline text-blue-400"
+            >
+              the OpenSSH project page
+            </a>
+          );
+        })()}
         .
       </p>
       <form onSubmit={(e) => e.preventDefault()} className="mb-4 space-y-4">
@@ -35,6 +48,7 @@ const SSHBuilder: React.FC = () => {
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
             value={user}
             onChange={(e) => setUser(e.target.value)}
+            aria-label="SSH username"
           />
         </div>
         <div>
@@ -47,6 +61,7 @@ const SSHBuilder: React.FC = () => {
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
             value={host}
             onChange={(e) => setHost(e.target.value)}
+            aria-label="SSH host"
           />
         </div>
         <div>
@@ -59,6 +74,7 @@ const SSHBuilder: React.FC = () => {
             className="w-full rounded border border-gray-700 bg-gray-800 p-2 text-white"
             value={port}
             onChange={(e) => setPort(e.target.value)}
+            aria-label="SSH port"
           />
         </div>
       </form>

--- a/apps/terminal/components/Scripts.tsx
+++ b/apps/terminal/components/Scripts.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import usePersistentState from '../../../hooks/usePersistentState';
 import runScript, { ScriptController } from '../utils/scriptRunner';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../../../utils/urlPolicy';
 
 interface ScriptEntry {
   code: string;
@@ -106,14 +107,26 @@ const Scripts = ({ runCommand }: ScriptsProps) => {
     <div className="p-2 space-y-2 text-sm">
       <p className="text-xs">
         Need sample scripts?{' '}
-        <a
-          href={examplesHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline text-blue-400"
-        >
-          View examples
-        </a>
+        {(() => {
+          const safeExamples = sanitizeUrl(examplesHref);
+          if (!safeExamples) {
+            return (
+              <span className="underline text-blue-200 italic">
+                View examples ({LINK_UNAVAILABLE_COPY})
+              </span>
+            );
+          }
+          return (
+            <a
+              href={safeExamples.href}
+              target="_blank"
+              rel={computeRelAttribute(safeExamples.isExternal, 'noopener noreferrer')}
+              className="underline text-blue-400"
+            >
+              View examples
+            </a>
+          );
+        })()}
         . Use <code>$1</code>, <code>$2</code>… in scripts for arguments.
       </p>
       <div className="space-y-1">
@@ -122,12 +135,14 @@ const Scripts = ({ runCommand }: ScriptsProps) => {
           onChange={(e) => setName(e.target.value)}
           placeholder="script name"
           className="w-full border p-1"
+          aria-label="Script name"
         />
         <textarea
           value={code}
           onChange={(e) => setCode(e.target.value)}
           placeholder={"echo hello\nsleep 1000\necho done"}
           className="w-full border p-1 h-32"
+          aria-label="Script body"
         />
         <button
           onClick={save}

--- a/apps/wireshark/components/PcapViewer.tsx
+++ b/apps/wireshark/components/PcapViewer.tsx
@@ -5,6 +5,7 @@ import { protocolName } from '../../../components/apps/wireshark/utils';
 import FilterHelper from './FilterHelper';
 import presets from '../filters/presets.json';
 import LayerView from './LayerView';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../../../utils/urlPolicy';
 
 
 interface PcapViewerProps {
@@ -308,6 +309,7 @@ const PcapViewer: React.FC<PcapViewerProps> = ({ showLegend = true }) => {
           accept=".pcap,.pcapng"
           onChange={handleFile}
           className="text-sm"
+          aria-label="Upload capture file"
         />
         <select
           onChange={(e) => {
@@ -315,6 +317,7 @@ const PcapViewer: React.FC<PcapViewerProps> = ({ showLegend = true }) => {
             e.target.value = '';
           }}
           className="text-sm bg-gray-700 text-white rounded"
+          aria-label="Open sample capture"
         >
           <option value="">Open sample</option>
           {samples.map(({ label, path }) => (
@@ -323,14 +326,26 @@ const PcapViewer: React.FC<PcapViewerProps> = ({ showLegend = true }) => {
             </option>
           ))}
         </select>
-        <a
-          href="https://wiki.wireshark.org/SampleCaptures"
-          target="_blank"
-          rel="noreferrer"
-          className="text-xs underline"
-        >
-          Sample sources
-        </a>
+        {(() => {
+          const safeLink = sanitizeUrl('https://wiki.wireshark.org/SampleCaptures');
+          if (!safeLink) {
+            return (
+              <span className="text-xs underline italic">
+                Sample sources ({LINK_UNAVAILABLE_COPY})
+              </span>
+            );
+          }
+          return (
+            <a
+              href={safeLink.href}
+              target="_blank"
+              rel={computeRelAttribute(safeLink.isExternal, 'noreferrer')}
+              className="text-xs underline"
+            >
+              Sample sources
+            </a>
+          );
+        })()}
       </div>
       {packets.length > 0 && (
         <>
@@ -346,17 +361,18 @@ const PcapViewer: React.FC<PcapViewerProps> = ({ showLegend = true }) => {
             </button>
           </div>
           <div className="flex space-x-1">
-            {presets.map(({ label, expression }) => (
-              <button
-                key={expression}
-                onClick={() => setFilter(expression)}
-                className={`w-4 h-4 rounded ${
-                  protocolColors[label.toUpperCase()] || 'bg-gray-500'
-                }`}
-                title={label}
-                type="button"
-              />
-            ))}
+              {presets.map(({ label, expression }) => (
+                <button
+                  key={expression}
+                  onClick={() => setFilter(expression)}
+                  className={`w-4 h-4 rounded ${
+                    protocolColors[label.toUpperCase()] || 'bg-gray-500'
+                  }`}
+                  title={label}
+                  type="button"
+                  aria-label={`Filter by ${label}`}
+                />
+              ))}
           </div>
 
           {showLegend && (

--- a/apps/x/index.tsx
+++ b/apps/x/index.tsx
@@ -14,6 +14,7 @@ import { useSettings } from '../../hooks/useSettings';
 import useScheduledTweets, {
   ScheduledTweet,
 } from './state/scheduled';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../../utils/urlPolicy';
 
 const IconRefresh = (
   props: SVGProps<SVGSVGElement>,
@@ -109,6 +110,13 @@ export default function XTimeline() {
   const timeoutsRef = useRef<Record<string, number>>({});
   const [scheduled, setScheduled] = useScheduledTweets();
   const [showSetup, setShowSetup] = useState(true);
+
+  const openFeedInNewTab = () => {
+    const safeLink = feed ? sanitizeUrl(`https://x.com/${feed}`) : null;
+    if (safeLink) {
+      window.open(safeLink.href, '_blank', 'noopener,noreferrer');
+    }
+  };
 
   useEffect(() => {
     const root = document.documentElement;
@@ -271,14 +279,26 @@ export default function XTimeline() {
             </p>
             <p className="mb-4">
               You can explore with a demo account{' '}
-              <a
-                href="https://x.com/AUnnippillil"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline"
-              >
-                @AUnnippillil
-              </a>
+              {(() => {
+                const safeDemo = sanitizeUrl('https://x.com/AUnnippillil');
+                if (!safeDemo) {
+                  return (
+                    <span className="underline italic">
+                      @AUnnippillil ({LINK_UNAVAILABLE_COPY})
+                    </span>
+                  );
+                }
+                return (
+                  <a
+                    href={safeDemo.href}
+                    target="_blank"
+                    rel={computeRelAttribute(safeDemo.isExternal, 'noopener noreferrer')}
+                    className="underline"
+                  >
+                    @AUnnippillil
+                  </a>
+                );
+              })()}
               .
             </p>
             <button
@@ -317,7 +337,7 @@ export default function XTimeline() {
           <button
             type="button"
             aria-label="Open on x.com"
-            onClick={() => window.open(`https://x.com/${feed}`, '_blank')}
+            onClick={openFeedInNewTab}
             className="p-1 rounded hover:bg-[var(--color-muted)]"
           >
             <IconShare className="w-6 h-6" />
@@ -330,6 +350,7 @@ export default function XTimeline() {
             onChange={(e) => setTweetText(e.target.value)}
             placeholder="Tweet text"
             className="w-full p-2 rounded border bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            aria-label="Tweet text"
           />
           <div className="flex gap-2 items-center">
             <input
@@ -337,6 +358,7 @@ export default function XTimeline() {
               value={tweetTime}
               onChange={(e) => setTweetTime(e.target.value)}
               className="flex-1 p-2 rounded border bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+              aria-label="Schedule time"
             />
             <button
               type="submit"
@@ -412,6 +434,7 @@ export default function XTimeline() {
                 : 'Add list (owner/slug or id)'
             }
             className="flex-1 p-2 rounded border bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            aria-label="Timeline feed identifier"
           />
           <button
             type="submit"
@@ -484,15 +507,27 @@ export default function XTimeline() {
             {scriptError && (
               <div className="text-center">
                 <div className="mb-2">Nothing to see</div>
-                <a
-                  href={`https://x.com/${feed}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline"
-                  style={{ color: accent }}
-                >
-                  Open on x.com
-                </a>
+                {(() => {
+                  const safeLink = feed ? sanitizeUrl(`https://x.com/${feed}`) : null;
+                  if (!safeLink) {
+                    return (
+                      <span className="underline italic" style={{ color: accent }}>
+                        Open on x.com ({LINK_UNAVAILABLE_COPY})
+                      </span>
+                    );
+                  }
+                  return (
+                    <a
+                      href={safeLink.href}
+                      target="_blank"
+                      rel={computeRelAttribute(safeLink.isExternal, 'noopener noreferrer')}
+                      className="underline"
+                      style={{ color: accent }}
+                    >
+                      Open on x.com
+                    </a>
+                  );
+                })()}
               </div>
             )}
             {!loading && !timelineLoaded && !scriptError && (

--- a/components/ExplainerPane.tsx
+++ b/components/ExplainerPane.tsx
@@ -1,3 +1,5 @@
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../utils/urlPolicy';
+
 interface Resource {
   label: string;
   url: string;
@@ -24,14 +26,26 @@ export default function ExplainerPane({ lines, resources }: Props) {
       <ul className="list-disc list-inside">
         {resources.map((r, i) => (
           <li key={i}>
-            <a
-              href={r.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline"
-            >
-              {r.label}
-            </a>
+            {(() => {
+              const safeResource = sanitizeUrl(r.url);
+              if (!safeResource) {
+                return (
+                  <span className="italic text-ubt-grey">
+                    {r.label} ({LINK_UNAVAILABLE_COPY})
+                  </span>
+                );
+              }
+              return (
+                <a
+                  href={safeResource.href}
+                  target="_blank"
+                  rel={computeRelAttribute(safeResource.isExternal)}
+                  className="underline"
+                >
+                  {r.label}
+                </a>
+              );
+            })()}
           </li>
         ))}
       </ul>

--- a/components/PopularModules.tsx
+++ b/components/PopularModules.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import modulesData from '../data/module-index.json';
 import versionInfo from '../data/module-version.json';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../utils/urlPolicy';
 
 interface Module {
   id: string;
@@ -198,13 +199,14 @@ const PopularModules: React.FC = () => {
         )}
       </div>
       {updateMessage && <p className="text-sm">{updateMessage}</p>}
-      <input
-        type="text"
-        placeholder="Search modules"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        className="w-full p-2 text-black rounded"
-      />
+        <input
+          type="text"
+          placeholder="Search modules"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full p-2 text-black rounded"
+          aria-label="Search modules"
+        />
       <div className="flex flex-wrap gap-2">
         <button
           onClick={() => setFilter('')}
@@ -284,13 +286,14 @@ const PopularModules: React.FC = () => {
           <div className="space-y-1">
             <label className="block text-sm">
               Filter logs
-              <input
-                placeholder="Filter logs"
-                type="text"
-                value={logFilter}
-                onChange={(e) => setLogFilter(e.target.value)}
-                className="w-full p-1 mt-1 text-black rounded"
-              />
+                <input
+                  placeholder="Filter logs"
+                  type="text"
+                  value={logFilter}
+                  onChange={(e) => setLogFilter(e.target.value)}
+                  className="w-full p-1 mt-1 text-black rounded"
+                  aria-label="Filter logs"
+                />
             </label>
             <button
               type="button"
@@ -339,14 +342,26 @@ const PopularModules: React.FC = () => {
                 <li key={i}>{i}</li>
               ))}
             </ul>
-            <a
-              href={selected.lab}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline text-blue-300"
-            >
-              Practice Lab
-            </a>
+            {(() => {
+              const safeLab = sanitizeUrl(selected.lab);
+              if (!safeLab) {
+                return (
+                  <span className="text-xs italic text-ubt-grey">
+                    {LINK_UNAVAILABLE_COPY}
+                  </span>
+                );
+              }
+              return (
+                <a
+                  href={safeLab.href}
+                  target="_blank"
+                  rel={computeRelAttribute(safeLab.isExternal)}
+                  className="underline text-blue-300"
+                >
+                  Practice Lab
+                </a>
+              );
+            })()}
           </div>
         </div>
       ) : (

--- a/components/ScrollableTimeline.tsx
+++ b/components/ScrollableTimeline.tsx
@@ -4,6 +4,7 @@ import React, {
   useRef,
   useEffect,
 } from 'react';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../utils/urlPolicy';
 import rawMilestones from '../data/milestones.json';
 
 interface Milestone {
@@ -149,19 +150,39 @@ const ScrollableTimeline: React.FC = () => {
                   <div className="text-ubt-blue font-bold text-lg mb-2">
                     {selectedYear}-{m.month}
                   </div>
-                  <a
-                    href={m.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block mb-2"
-                  >
-                    <img
-                      src={m.image}
-                      alt={m.title}
-                      className="w-full h-32 object-cover mb-2 rounded"
-                    />
-                    <p className="text-sm md:text-base">{m.title}</p>
-                  </a>
+                  {(() => {
+                    const safeLink = sanitizeUrl(m.link);
+                    const content = (
+                      <>
+                        <img
+                          src={m.image}
+                          alt={m.title}
+                          className="w-full h-32 object-cover mb-2 rounded"
+                        />
+                        <p className="text-sm md:text-base">{m.title}</p>
+                      </>
+                    );
+                    if (!safeLink) {
+                      return (
+                        <div className="block mb-2">
+                          {content}
+                          <p className="mt-2 text-xs italic text-ubt-grey">
+                            {LINK_UNAVAILABLE_COPY}
+                          </p>
+                        </div>
+                      );
+                    }
+                    return (
+                      <a
+                        href={safeLink.href}
+                        target="_blank"
+                        rel={computeRelAttribute(safeLink.isExternal)}
+                        className="block mb-2"
+                      >
+                        {content}
+                      </a>
+                    );
+                  })()}
                   {renderTags(m.tags)}
                 </li>
               ))}

--- a/components/WorkflowCard.tsx
+++ b/components/WorkflowCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../utils/urlPolicy';
 
 interface Step {
   title: string;
@@ -30,14 +31,26 @@ const WorkflowCard: React.FC = () => (
     <ul>
       {steps.map((s) => (
         <li key={s.title} className="mb-2">
-          <a
-            href={s.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-ub-orange underline"
-          >
-            {s.title}
-          </a>
+          {(() => {
+            const safeLink = sanitizeUrl(s.link);
+            if (!safeLink) {
+              return (
+                <span className="italic text-ubt-grey">
+                  {s.title} ({LINK_UNAVAILABLE_COPY})
+                </span>
+              );
+            }
+            return (
+              <a
+                href={safeLink.href}
+                target="_blank"
+                rel={computeRelAttribute(safeLink.isExternal)}
+                className="text-ub-orange underline"
+              >
+                {s.title}
+              </a>
+            );
+          })()}
           <p className="text-sm">{s.description}</p>
         </li>
       ))}

--- a/components/apps/About/SafetyNote.tsx
+++ b/components/apps/About/SafetyNote.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../../../utils/urlPolicy';
 
 /**
  * SafetyNote displays an ethics reminder for security testing.
@@ -17,14 +18,28 @@ export default function SafetyNote() {
       <p>
         Use security tools responsibly and only on systems you are authorized to
         test. Learn more about{' '}
-        <a
-          href="https://owasp.org/www-project-web-security-testing-guide/stable/en/01-Introduction/0A-Testing-Ethics"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline text-ubt-blue"
-        >
-          testing ethics
-        </a>
+        {(() => {
+          const safeLink = sanitizeUrl(
+            'https://owasp.org/www-project-web-security-testing-guide/stable/en/01-Introduction/0A-Testing-Ethics',
+          );
+          if (!safeLink) {
+            return (
+              <span className="underline italic text-ubt-grey">
+                testing ethics ({LINK_UNAVAILABLE_COPY})
+              </span>
+            );
+          }
+          return (
+            <a
+              href={safeLink.href}
+              target="_blank"
+              rel={computeRelAttribute(safeLink.isExternal)}
+              className="underline text-ubt-blue"
+            >
+              testing ethics
+            </a>
+          );
+        })()}
         .
       </p>
     </aside>

--- a/components/apps/firefox/simulations.tsx
+++ b/components/apps/firefox/simulations.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../../../utils/urlPolicy';
 
 export type SimulationLink = {
   label: string;
@@ -528,47 +529,65 @@ export const SIMULATIONS = Object.fromEntries([
   }),
 ]) as Record<string, FirefoxSimulation>;
 
-export const FirefoxSimulationView: React.FC<{ simulation: FirefoxSimulation }> = ({ simulation }) => (
-  <div className="flex h-full flex-col overflow-hidden bg-gray-950 text-gray-100">
-    <header className="border-b border-gray-800 px-6 py-5">
-      <h1 className="text-2xl font-semibold text-white">{simulation.heading}</h1>
-      <p className="mt-2 max-w-3xl text-sm text-gray-300">{simulation.description}</p>
-      <a
-        href={simulation.externalUrl}
-        target="_blank"
-        rel="noreferrer"
-        className="mt-4 inline-flex items-center gap-2 rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
-      >
-        {simulation.ctaLabel ?? 'Open official site'}
-        <span aria-hidden="true" className="text-xs">↗</span>
-      </a>
-    </header>
-    <div className="flex-1 overflow-y-auto px-6 py-6">
-      <div className="grid gap-6 lg:grid-cols-2">
-        {simulation.sections.map((section) => (
-          <section key={section.title} className="rounded-lg border border-gray-800 bg-gray-900/60 p-5 shadow-inner">
-            <h2 className="text-lg font-semibold text-white">{section.title}</h2>
-            {section.body ? <p className="mt-2 text-sm text-gray-300">{section.body}</p> : null}
-            {section.links ? (
-              <ul className="mt-4 space-y-3 text-sm">
-                {section.links.map((link) => (
-                  <li key={link.href} className="rounded-md bg-gray-900/80 p-3 transition hover:bg-gray-800/80">
-                    <a
-                      href={link.href}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="font-medium text-blue-300 hover:text-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
-                    >
-                      {link.label}
-                    </a>
-                    {link.description ? <p className="mt-1 text-xs text-gray-400">{link.description}</p> : null}
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-          </section>
-        ))}
+export const FirefoxSimulationView: React.FC<{ simulation: FirefoxSimulation }> = ({ simulation }) => {
+  const safeExternal = sanitizeUrl(simulation.externalUrl);
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-gray-950 text-gray-100">
+      <header className="border-b border-gray-800 px-6 py-5">
+        <h1 className="text-2xl font-semibold text-white">{simulation.heading}</h1>
+        <p className="mt-2 max-w-3xl text-sm text-gray-300">{simulation.description}</p>
+        {safeExternal ? (
+          <a
+            href={safeExternal.href}
+            target="_blank"
+            rel={computeRelAttribute(safeExternal.isExternal, 'noreferrer')}
+            className="mt-4 inline-flex items-center gap-2 rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
+          >
+            {simulation.ctaLabel ?? 'Open official site'}
+            <span aria-hidden="true" className="text-xs">↗</span>
+          </a>
+        ) : (
+          <span className="mt-4 inline-flex items-center gap-2 rounded bg-blue-500/40 px-4 py-2 text-sm font-medium text-blue-100">
+            {simulation.ctaLabel ?? 'Open official site'} ({LINK_UNAVAILABLE_COPY})
+          </span>
+        )}
+      </header>
+      <div className="flex-1 overflow-y-auto px-6 py-6">
+        <div className="grid gap-6 lg:grid-cols-2">
+          {simulation.sections.map((section) => (
+            <section key={section.title} className="rounded-lg border border-gray-800 bg-gray-900/60 p-5 shadow-inner">
+              <h2 className="text-lg font-semibold text-white">{section.title}</h2>
+              {section.body ? <p className="mt-2 text-sm text-gray-300">{section.body}</p> : null}
+              {section.links ? (
+                <ul className="mt-4 space-y-3 text-sm">
+                  {section.links.map((link) => {
+                    const safeLink = sanitizeUrl(link.href);
+                    return (
+                      <li key={link.href} className="rounded-md bg-gray-900/80 p-3 transition hover:bg-gray-800/80">
+                        {safeLink ? (
+                          <a
+                            href={safeLink.href}
+                            target="_blank"
+                            rel={computeRelAttribute(safeLink.isExternal, 'noreferrer')}
+                            className="font-medium text-blue-300 hover:text-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
+                          >
+                            {link.label}
+                          </a>
+                        ) : (
+                          <span className="font-medium text-blue-200 italic">
+                            {link.label} ({LINK_UNAVAILABLE_COPY})
+                          </span>
+                        )}
+                        {link.description ? <p className="mt-1 text-xs text-gray-400">{link.description}</p> : null}
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : null}
+            </section>
+          ))}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};

--- a/components/apps/youtube/index.tsx
+++ b/components/apps/youtube/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../../../utils/urlPolicy';
 
 interface Playlist {
   id: string;
@@ -286,14 +287,27 @@ function PlaylistCard({ playlist }: { playlist: Playlist }) {
         )}
         <div className="mt-auto flex items-center justify-between text-xs text-ubt-grey">
           <span>Updated {formatDate(playlist.updatedAt)}</span>
-          <a
-            href={`https://www.youtube.com/playlist?list=${playlist.id}`}
-            target="_blank"
-            rel="noreferrer"
-            className="rounded-full bg-ubt-green/10 px-3 py-1 font-semibold text-ubt-green transition hover:bg-ubt-green/20"
-          >
-            Open playlist
-          </a>
+          {(() => {
+            const playlistUrl = `https://www.youtube.com/playlist?list=${playlist.id}`;
+            const safeLink = sanitizeUrl(playlistUrl);
+            if (!safeLink) {
+              return (
+                <span className="rounded-full bg-ubt-green/10 px-3 py-1 font-semibold text-ubt-grey">
+                  {LINK_UNAVAILABLE_COPY}
+                </span>
+              );
+            }
+            return (
+              <a
+                href={safeLink.href}
+                target="_blank"
+                rel={computeRelAttribute(safeLink.isExternal, 'noreferrer')}
+                className="rounded-full bg-ubt-green/10 px-3 py-1 font-semibold text-ubt-green transition hover:bg-ubt-green/20"
+              >
+                Open playlist
+              </a>
+            );
+          })()}
         </div>
       </div>
     </article>

--- a/components/simulator/index.tsx
+++ b/components/simulator/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import usePersistentState from '../../hooks/usePersistentState';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../../utils/urlPolicy';
 import type {
   SimulatorParserRequest,
   SimulatorParserResponse,
@@ -159,10 +160,10 @@ const Simulator: React.FC = () => {
 
   return (
     <div className="space-y-4" aria-label="Simulator">
-      <div className="flex items-center space-x-2">
-        <input id="labmode" type="checkbox" checked={labMode} onChange={e=>setLabMode(e.target.checked)} />
-        <label htmlFor="labmode" className="font-semibold">Lab Mode</label>
-      </div>
+        <div className="flex items-center space-x-2">
+          <input id="labmode" type="checkbox" checked={labMode} onChange={e=>setLabMode(e.target.checked)} aria-label="Toggle lab mode" />
+          <label htmlFor="labmode" className="font-semibold">Lab Mode</label>
+        </div>
       {!labMode && (
         <div className="bg-yellow-100 text-yellow-800 p-2" role="alert">
           {LAB_BANNER}
@@ -205,9 +206,27 @@ const Simulator: React.FC = () => {
           <div key={p.line} className="text-sm">
             <span className="font-mono bg-gray-100 mr-2 px-1">{p.line}</span>
             {p.raw}
-            {p.key && (
-              <a className="ml-2 text-blue-600 underline" href={`https://example.com/search?q=${encodeURIComponent(p.key)}`} target="_blank" rel="noopener noreferrer">docs</a>
-            )}
+            {p.key && (() => {
+              const href = `https://example.com/search?q=${encodeURIComponent(p.key)}`;
+              const safeLink = sanitizeUrl(href);
+              if (!safeLink) {
+                return (
+                  <span className="ml-2 text-xs italic text-ubt-grey">
+                    docs ({LINK_UNAVAILABLE_COPY})
+                  </span>
+                );
+              }
+              return (
+                <a
+                  className="ml-2 text-blue-600 underline"
+                  href={safeLink.href}
+                  target="_blank"
+                  rel={computeRelAttribute(safeLink.isExternal)}
+                >
+                  docs
+                </a>
+              );
+            })()}
           </div>
         ))}
       </div>

--- a/docs/url-policy.md
+++ b/docs/url-policy.md
@@ -1,0 +1,35 @@
+# URL policy
+
+The portfolio renders a mix of user-provided data, static copy, and demo content. To guard against malicious links we centralize
+validation logic in [`utils/urlPolicy.ts`](../utils/urlPolicy.ts).
+
+## Allowed protocols
+
+Only the following protocols are permitted:
+
+- `http:`
+- `https:`
+- `mailto:`
+- `tel:`
+- Relative paths (`/foo`, `./bar`, `#anchor`)
+
+All other schemes (`javascript:`, `data:`, `file:`, etc.) are rejected during sanitization.
+
+## Adding a new protocol
+
+1. Update `ALLOWED_PROTOCOLS` in [`utils/urlPolicy.ts`](../utils/urlPolicy.ts). Make sure you understand the security
+   implications of the protocol—many schemes execute code or expose local files.
+2. Extend the automated tests in [`__tests__/urlPolicy.test.ts`](../__tests__/urlPolicy.test.ts) to cover the new
+   protocol. Include both acceptance and rejection cases so regressions are caught.
+3. Review any UI components that render URLs. Every consumer should go through `sanitizeUrl` so the new protocol is
+   recognized automatically. If a component needs special handling (for example `tel:` links that should not open in a new
+   tab) encapsulate that logic in the component rather than bypassing the sanitizer.
+4. Document the change in any relevant feature guides so future contributors know the protocol is supported.
+
+## Rendering guidelines
+
+- Always call `sanitizeUrl` before assigning an `href` to `<a>` tags or passing a URL to `window.open`.
+- Use `computeRelAttribute` for external links to ensure `rel="noopener noreferrer"` is present without duplicating
+  tokens.
+- If `sanitizeUrl` returns `null`, render a clear fallback (`Link unavailable`) so the UI remains accessible and does not
+  silently drop content.

--- a/pages/post_exploitation.tsx
+++ b/pages/post_exploitation.tsx
@@ -5,6 +5,7 @@ import Meta from '../components/SEO/Meta';
 import modules, { ModuleMetadata } from '../modules/metadata';
 import ModuleCard from '../components/ModuleCard';
 import VirtualList from 'rc-virtual-list';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../utils/urlPolicy';
 
 export default function PostExploitation() {
   const [query, setQuery] = useState('');
@@ -40,13 +41,25 @@ export default function PostExploitation() {
           <h1>Metasploit Post-Exploitation Modules</h1>
           <p>
             Post-exploitation refers to any actions taken after a session is opened. Rapid7&apos;s{' '}
-            <a
-              href="https://docs.rapid7.com/metasploit/about-post-exploitation/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Metasploit documentation
-            </a>{' '}
+            {(() => {
+              const safeDoc = sanitizeUrl('https://docs.rapid7.com/metasploit/about-post-exploitation/');
+              if (!safeDoc) {
+                return (
+                  <span className="italic">
+                    Metasploit documentation ({LINK_UNAVAILABLE_COPY})
+                  </span>
+                );
+              }
+              return (
+                <a
+                  href={safeDoc.href}
+                  target="_blank"
+                  rel={computeRelAttribute(safeDoc.isExternal, 'noopener noreferrer')}
+                >
+                  Metasploit documentation
+                </a>
+              );
+            })()}{' '}
             explains that these modules run on an active session to help operators gather deeper
             information, escalate privileges, pivot within the network, or maintain persistence.
           </p>
@@ -56,6 +69,7 @@ export default function PostExploitation() {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             className="mb-4 w-full rounded border p-2"
+            aria-label="Search modules"
           />
           <div className="mb-4 flex flex-wrap gap-2">
             {allTags.map((tag) => (
@@ -65,6 +79,7 @@ export default function PostExploitation() {
                   checked={selectedTags.includes(tag)}
                   onChange={() => toggleTag(tag)}
                   className="rounded"
+                  aria-label={`Toggle ${tag}`}
                 />
                 <span>{tag}</span>
               </label>

--- a/pages/spoofing.tsx
+++ b/pages/spoofing.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Meta from '../components/SEO/Meta';
+import { computeRelAttribute, LINK_UNAVAILABLE_COPY, sanitizeUrl } from '../utils/urlPolicy';
 
 interface TileProps {
   title: string;
@@ -7,18 +8,30 @@ interface TileProps {
   children: React.ReactNode;
 }
 
-const ToolTile = ({ title, link, children }: TileProps) => (
-  <a
-    href={link}
-    target="_blank"
-    rel="noopener noreferrer"
-    className="block p-4 bg-ub-grey text-white rounded shadow hover:bg-black focus:outline-none focus:ring"
-  >
-    <h2 className="text-xl mb-2">{title}</h2>
-    {children}
-    <p className="mt-2 underline text-sm">Documentation</p>
-  </a>
-);
+const ToolTile = ({ title, link, children }: TileProps) => {
+  const safeLink = sanitizeUrl(link);
+  if (!safeLink) {
+    return (
+      <div className="block p-4 bg-ub-grey text-white rounded shadow">
+        <h2 className="text-xl mb-2">{title}</h2>
+        {children}
+        <p className="mt-2 text-sm italic text-ubt-grey">{LINK_UNAVAILABLE_COPY}</p>
+      </div>
+    );
+  }
+  return (
+    <a
+      href={safeLink.href}
+      target="_blank"
+      rel={computeRelAttribute(safeLink.isExternal, 'noopener noreferrer')}
+      className="block p-4 bg-ub-grey text-white rounded shadow hover:bg-black focus:outline-none focus:ring"
+    >
+      <h2 className="text-xl mb-2">{title}</h2>
+      {children}
+      <p className="mt-2 underline text-sm">Documentation</p>
+    </a>
+  );
+};
 
 const ArpDiagram = () => (
   <svg viewBox="0 0 300 120" className="w-full h-32">

--- a/utils/urlPolicy.ts
+++ b/utils/urlPolicy.ts
@@ -1,0 +1,95 @@
+const SAFE_BASE_URL = 'https://portfolio.local';
+
+export const ALLOWED_PROTOCOLS = Object.freeze([
+  'http:',
+  'https:',
+  'mailto:',
+  'tel:',
+]);
+
+const EXTERNAL_PROTOCOLS = new Set(['http:', 'https:']);
+const ALLOWED_PROTOCOLS_SET = new Set(ALLOWED_PROTOCOLS);
+const SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+const CONTROL_CHARS_PATTERN = /[\u0000-\u001F\u007F]/;
+
+export interface SanitizedUrl {
+  href: string;
+  isExternal: boolean;
+}
+
+export const LINK_UNAVAILABLE_COPY = 'Link unavailable';
+
+export function isProtocolAllowed(rawUrl: string): boolean {
+  const protocol = extractProtocol(rawUrl);
+  if (!protocol) return true;
+  return ALLOWED_PROTOCOLS_SET.has(protocol);
+}
+
+export function sanitizeUrl(rawUrl: string | null | undefined): SanitizedUrl | null {
+  if (!rawUrl) return null;
+  const trimmed = rawUrl.trim();
+  if (!trimmed || CONTROL_CHARS_PATTERN.test(trimmed)) {
+    return null;
+  }
+
+  if (!isProtocolAllowed(trimmed)) {
+    return null;
+  }
+
+  if (trimmed.startsWith('//')) {
+    return null;
+  }
+
+  if (trimmed.startsWith('#')) {
+    return { href: trimmed, isExternal: false };
+  }
+
+  const hasScheme = SCHEME_PATTERN.test(trimmed);
+
+  try {
+    if (hasScheme) {
+      const parsed = new URL(trimmed);
+      const { protocol } = parsed;
+      if (!ALLOWED_PROTOCOLS_SET.has(protocol)) {
+        return null;
+      }
+      return {
+        href: parsed.toString(),
+        isExternal: EXTERNAL_PROTOCOLS.has(protocol),
+      };
+    }
+
+    const parsed = new URL(trimmed, SAFE_BASE_URL);
+    return {
+      href: parsed.pathname + parsed.search + parsed.hash,
+      isExternal: false,
+    };
+  } catch (error) {
+    return null;
+  }
+}
+
+export function computeRelAttribute(isExternal: boolean, existingRel?: string | null) {
+  const tokens = new Set<string>();
+  if (existingRel) {
+    existingRel
+      .split(/\s+/)
+      .map((token) => token.trim())
+      .filter(Boolean)
+      .forEach((token) => tokens.add(token));
+  }
+
+  if (isExternal) {
+    tokens.add('noopener');
+    tokens.add('noreferrer');
+  }
+
+  return tokens.size > 0 ? Array.from(tokens).join(' ') : undefined;
+}
+
+function extractProtocol(rawUrl: string | null | undefined) {
+  if (!rawUrl) return null;
+  const match = rawUrl.trim().match(SCHEME_PATTERN);
+  return match ? match[0].toLowerCase() : null;
+}
+


### PR DESCRIPTION
## Summary
- add a reusable URL policy helper that validates allowed protocols and computes rel attributes
- refactor link-rendering components/apps to sanitize repo/demo URLs and surface unavailable links accessibly
- document protocol guidelines and cover sanitizer edge cases with unit and component tests

## Testing
- yarn lint
- yarn test urlPolicy

------
https://chatgpt.com/codex/tasks/task_e_68dccad39d0883289a9478d404ce34f4