### PR TITLE
[reconng] Add import risk gating

### DIFF
--- a/__tests__/components/apps/reconng/ReportTemplates.import.test.tsx
+++ b/__tests__/components/apps/reconng/ReportTemplates.import.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ReportTemplates from '../../../../components/apps/reconng/components/ReportTemplates';
+import { IMPORT_LOG_KEY } from '../../../../components/apps/reconng/utils/importRisk';
+
+describe('ReportTemplates import risk panel', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows low risk badge and allows import without preview for safe files', async () => {
+    const user = userEvent.setup();
+    render(<ReportTemplates />);
+
+    await user.click(screen.getByRole('button', { name: /Import\/Share/i }));
+    const input = screen.getByLabelText(/Import templates/i);
+    const file = new File(
+      [
+        JSON.stringify({
+          custom: { name: 'Custom Template', template: 'Example {{title}}' },
+        }),
+      ],
+      'templates.json',
+      {
+        type: 'application/json',
+      },
+    );
+    await user.upload(input, file);
+
+    expect(screen.getByText(/^Low risk$/i)).toBeInTheDocument();
+
+    const importButton = screen.getByRole('button', { name: /^Import$/i });
+    expect(importButton).toBeEnabled();
+
+    await user.click(importButton);
+
+    await waitFor(() => {
+      const logs = JSON.parse(localStorage.getItem(IMPORT_LOG_KEY) || '[]');
+      expect(logs[0]).toMatchObject({ fileName: 'templates.json', level: 'low' });
+    });
+  });
+
+  it('requires preview before importing high risk files', async () => {
+    const user = userEvent.setup();
+    render(<ReportTemplates />);
+
+    await user.click(screen.getByRole('button', { name: /Import\/Share/i }));
+    const input = screen.getByLabelText(/Import templates/i);
+    const largeFile = new File([new Array(600 * 1024).join('a')], 'templates.json', {
+      type: 'application/json',
+    });
+    await user.upload(input, largeFile);
+
+    expect(screen.getByText(/^High risk$/i)).toBeInTheDocument();
+
+    const importButton = screen.getByRole('button', { name: /^Import$/i });
+    expect(importButton).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: /Preview/i }));
+
+    await waitFor(() => expect(importButton).toBeEnabled());
+  });
+});

--- a/__tests__/components/apps/reconng/importRisk.test.ts
+++ b/__tests__/components/apps/reconng/importRisk.test.ts
@@ -1,0 +1,23 @@
+import { computeImportRisk } from '../../../../components/apps/reconng/utils/importRisk';
+
+describe('computeImportRisk', () => {
+  it('returns low risk for small JSON files', () => {
+    const file = new File(['{}'], 'templates.json', { type: 'application/json' });
+    const result = computeImportRisk(file);
+    expect(result.level).toBe('low');
+  });
+
+  it('flags high risk for large files', () => {
+    const file = new File([new Array(600 * 1024).join('a')], 'templates.json', {
+      type: 'application/json',
+    });
+    const result = computeImportRisk(file);
+    expect(result.level).toBe('high');
+  });
+
+  it('flags high risk for executable extensions', () => {
+    const file = new File(['{}'], 'dangerous.exe', { type: 'application/octet-stream' });
+    const result = computeImportRisk(file);
+    expect(result.level).toBe('high');
+  });
+});

--- a/components/apps/reconng/components/ReportTemplates.tsx
+++ b/components/apps/reconng/components/ReportTemplates.tsx
@@ -1,6 +1,12 @@
 import React, { useMemo, useState } from 'react';
 import usePersistentState from '../../../../hooks/usePersistentState';
 import defaultTemplates from '../../../../templates/export/report-templates.json';
+import {
+  computeImportRisk,
+  logImportMetadata,
+  type ImportRisk,
+  type RiskLevel,
+} from '../utils/importRisk';
 
 interface Finding {
   title: string;
@@ -44,10 +50,56 @@ const renderTemplate = (tpl: string, findings: Finding[]) =>
       .join(''),
   );
 
+const MAX_PREVIEW_LENGTH = 2000;
+
+const isTemplateRecord = (value: unknown): value is Record<string, TemplateDef> => {
+  if (!value || typeof value !== 'object') return false;
+  return Object.values(value).every(
+    (entry) =>
+      entry &&
+      typeof entry === 'object' &&
+      'name' in entry &&
+      'template' in entry &&
+      typeof (entry as TemplateDef).name === 'string' &&
+      typeof (entry as TemplateDef).template === 'string',
+  );
+};
+
+function RiskBadge({ level }: { level: RiskLevel }) {
+  const styles: Record<RiskLevel, string> = {
+    low: 'bg-green-700 text-green-100',
+    medium: 'bg-yellow-700 text-yellow-100',
+    high: 'bg-red-700 text-red-100',
+  };
+
+  const labelMap: Record<RiskLevel, string> = {
+    low: 'Low risk',
+    medium: 'Medium risk',
+    high: 'High risk',
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold uppercase tracking-wide ${styles[level]}`}
+      role="status"
+      aria-live="polite"
+    >
+      {labelMap[level]}
+    </span>
+  );
+}
+
 export default function ReportTemplates() {
   const [templateData, setTemplateData] = useState<Record<string, TemplateDef>>(defaultTemplates);
   const keys = Object.keys(templateData);
   const [template, setTemplate] = usePersistentState('reconng-report-template', keys[0]);
+
+  const [showDialog, setShowDialog] = useState(false);
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [importRisk, setImportRisk] = useState<ImportRisk | null>(null);
+  const [hasPreviewed, setHasPreviewed] = useState(false);
+  const [previewContent, setPreviewContent] = useState('');
+  const [importError, setImportError] = useState<string | null>(null);
 
   const templateKey = keys.includes(template) ? template : keys[0];
   const report = useMemo(
@@ -65,23 +117,87 @@ export default function ReportTemplates() {
     URL.revokeObjectURL(url);
   };
 
-  const [showDialog, setShowDialog] = useState(false);
+  const resetImportState = () => {
+    setPendingFile(null);
+    setImportRisk(null);
+    setHasPreviewed(false);
+    setPreviewContent('');
+    setImportError(null);
+  };
 
-  const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileSelection = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => {
-      try {
-        const parsed = JSON.parse(reader.result as string) as Record<string, TemplateDef>;
-        setTemplateData(parsed);
-        const first = Object.keys(parsed)[0];
-        if (first) setTemplate(first);
-      } catch {
-        // ignore parse errors
+
+    const riskAssessment = computeImportRisk(file);
+    setPendingFile(file);
+    setImportRisk(riskAssessment);
+    setHasPreviewed(riskAssessment.level !== 'high');
+    setPreviewContent('');
+    setImportError(null);
+  };
+
+  const readFileAsText = (file: File) =>
+    new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result;
+        if (typeof result === 'string') {
+          resolve(result);
+        } else {
+          reject(new Error('Unsupported file result.'));
+        }
+      };
+      reader.onerror = () => {
+        reject(reader.error ?? new Error('Failed to read file.'));
+      };
+      reader.readAsText(file);
+    });
+
+  const previewFile = async () => {
+    if (!pendingFile) return;
+    try {
+      const text = await readFileAsText(pendingFile);
+      setPreviewContent(text.slice(0, MAX_PREVIEW_LENGTH));
+      setHasPreviewed(true);
+    } catch (error) {
+      setImportError('Unable to preview file.');
+    }
+  };
+
+  const importFile = async () => {
+    if (!pendingFile) return;
+
+    try {
+      const text = await readFileAsText(pendingFile);
+      const parsed = JSON.parse(text) as unknown;
+      if (!isTemplateRecord(parsed)) {
+        throw new Error('Invalid template format');
       }
-    };
-    reader.readAsText(file);
+      setTemplateData(parsed);
+      const first = Object.keys(parsed)[0];
+      if (first) setTemplate(first);
+      logImportMetadata({
+        fileName: pendingFile.name,
+        fileType: pendingFile.type,
+        fileSize: pendingFile.size,
+        level: importRisk?.level ?? 'low',
+        timestamp: Date.now(),
+      });
+      setShowDialog(false);
+      resetImportState();
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.error(error);
+      }
+      setImportError('Unable to import template file. Ensure it is valid JSON.');
+    }
+  };
+
+  const closeDialog = () => {
+    setShowDialog(false);
+    resetImportState();
   };
 
   const shareJson = JSON.stringify(templateData, null, 2);
@@ -92,6 +208,9 @@ export default function ReportTemplates() {
       // ignore
     }
   };
+
+  const importDisabled =
+    !pendingFile || (importRisk?.level === 'high' && !hasPreviewed);
 
   return (
     <div className="flex flex-col h-full">
@@ -128,34 +247,118 @@ export default function ReportTemplates() {
         {report}
       </pre>
       {showDialog && (
-        <dialog open className="p-4 bg-gray-800 text-white rounded max-w-md">
-          <p className="mb-2">Import templates (JSON)</p>
-          <input type="file" accept="application/json" onChange={handleImport} />
-          <p className="mt-4 mb-2">Share templates</p>
-          <textarea
-            readOnly
-            value={shareJson}
-            className="w-full h-40 p-1 text-black"
-          />
-          <div className="flex gap-2 mt-2">
-            <button
-              type="button"
-              onClick={copyShare}
-              className="bg-blue-600 hover:bg-blue-500 px-2 py-1 rounded"
-            >
-              Copy
-            </button>
-            <button
-              type="button"
-              onClick={() => setShowDialog(false)}
-              className="bg-gray-600 hover:bg-gray-500 px-2 py-1 rounded"
-            >
-              Close
-            </button>
-          </div>
+        <dialog open className="p-4 bg-gray-800 text-white rounded max-w-2xl">
+          <form method="dialog" className="space-y-3">
+            <div>
+              <label htmlFor="template-upload" className="font-semibold">
+                Import templates (JSON)
+              </label>
+              <input
+                id="template-upload"
+                type="file"
+                accept="application/json"
+                onChange={handleFileSelection}
+                className="mt-1"
+              />
+              {importRisk && (
+                <div className="mt-2 space-y-1">
+                  <RiskBadge level={importRisk.level} />
+                  <ul className="list-disc list-inside text-xs text-gray-200">
+                    {importRisk.reasons.map((reason) => (
+                      <li key={reason}>{reason}</li>
+                    ))}
+                  </ul>
+                  {importRisk.level === 'high' && (
+                    <p className="text-xs text-red-300">
+                      Preview is required before importing high risk files.
+                    </p>
+                  )}
+                </div>
+              )}
+              <p className="text-xs text-gray-300 mt-2">
+                Templates never leave your browser. File name, type, size, and
+                risk rating are logged locally for auditability.
+              </p>
+            </div>
+
+            {previewContent && (
+              <div>
+                <label htmlFor="template-preview" className="font-semibold">
+                  Preview
+                </label>
+                <textarea
+                  id="template-preview"
+                  readOnly
+                  value={previewContent}
+                  className="w-full h-40 p-2 text-black"
+                  aria-label="Template preview"
+                />
+                {pendingFile && pendingFile.size > MAX_PREVIEW_LENGTH && (
+                  <p className="text-xs text-gray-300 mt-1">
+                    Preview truncated to first {MAX_PREVIEW_LENGTH.toLocaleString()} characters.
+                  </p>
+                )}
+              </div>
+            )}
+
+            {importError && (
+              <p className="text-sm text-red-300" role="alert">
+                {importError}
+              </p>
+            )}
+
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  void previewFile();
+                }}
+                className="bg-gray-600 hover:bg-gray-500 px-2 py-1 rounded"
+                disabled={!pendingFile}
+              >
+                Preview
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  void importFile();
+                }}
+                className="bg-blue-600 hover:bg-blue-500 px-2 py-1 rounded disabled:opacity-60"
+                disabled={importDisabled}
+              >
+                Import
+              </button>
+              <button
+                type="button"
+                onClick={copyShare}
+                className="bg-blue-600 hover:bg-blue-500 px-2 py-1 rounded"
+              >
+                Copy Share JSON
+              </button>
+              <button
+                type="button"
+                onClick={closeDialog}
+                className="bg-gray-600 hover:bg-gray-500 px-2 py-1 rounded"
+              >
+                Close
+              </button>
+            </div>
+
+            <div>
+              <label htmlFor="template-share" className="font-semibold">
+                Share templates
+              </label>
+              <textarea
+                id="template-share"
+                readOnly
+                value={shareJson}
+                className="w-full h-40 p-1 text-black"
+                aria-label="Template JSON"
+              />
+            </div>
+          </form>
         </dialog>
       )}
     </div>
   );
 }
-

--- a/components/apps/reconng/utils/importRisk.ts
+++ b/components/apps/reconng/utils/importRisk.ts
@@ -1,0 +1,86 @@
+export type RiskLevel = 'low' | 'medium' | 'high';
+
+export interface ImportRisk {
+  level: RiskLevel;
+  reasons: string[];
+}
+
+export interface ImportLogEntry {
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+  level: RiskLevel;
+  timestamp: number;
+}
+
+const SAFE_MIME_TYPES = new Set([
+  'application/json',
+  'text/json',
+  'application/x-json',
+  'application/vnd.api+json',
+  '',
+]);
+
+const JSON_EXTENSIONS = new Set(['json']);
+const HIGH_RISK_EXTENSIONS = new Set(['zip', 'exe', 'dll', 'bin']);
+
+const HIGH_SIZE_BYTES = 512 * 1024; // 512 KB
+const MEDIUM_SIZE_BYTES = 128 * 1024; // 128 KB
+
+export const IMPORT_LOG_KEY = 'reconng-template-import-log';
+
+export function computeImportRisk(file: Pick<File, 'name' | 'type' | 'size'>): ImportRisk {
+  const reasons: string[] = [];
+  const extension = file.name.split('.').pop()?.toLowerCase() ?? '';
+  let level: RiskLevel = 'low';
+
+  if (!JSON_EXTENSIONS.has(extension) && file.type === '') {
+    level = 'high';
+    reasons.push('Unknown file extension. Only JSON files are expected.');
+  }
+
+  if (!SAFE_MIME_TYPES.has(file.type) && JSON_EXTENSIONS.has(extension)) {
+    level = level === 'high' ? 'high' : 'medium';
+    reasons.push('MIME type does not match JSON.');
+  }
+
+  if (!JSON_EXTENSIONS.has(extension) && file.type && !SAFE_MIME_TYPES.has(file.type)) {
+    level = 'high';
+    reasons.push('File type is not supported for template import.');
+  }
+
+  if (HIGH_RISK_EXTENSIONS.has(extension)) {
+    level = 'high';
+    reasons.push('Executable or archive formats are blocked.');
+  }
+
+  if (file.size > HIGH_SIZE_BYTES) {
+    level = 'high';
+    reasons.push('File is larger than 512 KB.');
+  } else if (file.size > MEDIUM_SIZE_BYTES && level !== 'high') {
+    level = 'medium';
+    reasons.push('File is larger than 128 KB.');
+  }
+
+  if (reasons.length === 0) {
+    reasons.push('File matches expected JSON template format.');
+  }
+
+  return { level, reasons };
+}
+
+export function logImportMetadata(entry: ImportLogEntry) {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+
+  try {
+    const existingRaw = window.localStorage.getItem(IMPORT_LOG_KEY);
+    const existing: ImportLogEntry[] = existingRaw ? JSON.parse(existingRaw) : [];
+    const next = [...existing.slice(-24), entry];
+    window.localStorage.setItem(IMPORT_LOG_KEY, JSON.stringify(next));
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to record import log entry', error);
+  }
+}


### PR DESCRIPTION
## Summary
- add risk assessment, preview gating, and disclosure messaging to the Recon-ng report template import dialog
- record import metadata locally for audit history while keeping exports unchanged
- cover the new risk model and UI flow with focused unit tests

## Testing
- yarn test ReportTemplates.import
- yarn test importRisk

------
https://chatgpt.com/codex/tasks/task_e_68dccad5f23483288eb79131574eae46