### PR TITLE
[settings] add backup merge workflow

### DIFF
--- a/__tests__/backupMerge.test.ts
+++ b/__tests__/backupMerge.test.ts
@@ -1,0 +1,99 @@
+import type { MergeAuditEntry, MergeDecisionMap, BackupBuckets } from '../utils/backupMerge';
+
+describe('backupMerge utilities', () => {
+  const setupStorage = () => {
+    const store = new Map<string, string>();
+    const storageMock = {
+      getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+      clear: () => {
+        store.clear();
+      },
+    } as Storage;
+
+    Object.defineProperty(global, 'localStorage', {
+      value: storageMock,
+      configurable: true,
+    });
+  };
+
+  afterEach(() => {
+    delete (global as any).localStorage;
+  });
+
+  test('mergeSnapshots resolves conflicts deterministically', async () => {
+    const { mergeSnapshots } = await import('../utils/backupMerge');
+
+    const local: BackupBuckets = {
+      settings: { accent: 'blue', theme: 'default' },
+      progress: { level: 2 },
+    };
+    const incoming: BackupBuckets = {
+      settings: { accent: 'red', theme: 'default', wallpaper: 'wall-2' },
+      progress: { level: 3 },
+    };
+    const decisions: MergeDecisionMap = {
+      settings: 'incoming',
+      progress: 'local',
+    };
+
+    const { merged, auditEntries } = mergeSnapshots(local, incoming, decisions);
+
+    expect(merged.settings).toEqual({ accent: 'red', theme: 'default', wallpaper: 'wall-2' });
+    expect(merged.progress).toEqual({ level: 2 });
+
+    expect(auditEntries).toHaveLength(2);
+    expect(auditEntries[0].bucket).toBe('progress');
+    expect(auditEntries[0].decision).toBe('local');
+    expect(auditEntries[0].changedKeys).toContain('level');
+    expect(auditEntries[1].bucket).toBe('settings');
+    expect(auditEntries[1].decision).toBe('incoming');
+    expect(auditEntries[1].changedKeys).toEqual(['accent', 'wallpaper']);
+  });
+
+  test('appendAuditEntries persists sorted audit log', async () => {
+    jest.resetModules();
+    setupStorage();
+    const { appendAuditEntries, loadAuditLog, clearAuditLog } = await import('../utils/backupMerge');
+
+    clearAuditLog();
+
+    const entries: MergeAuditEntry[] = [
+      {
+        id: '2-b',
+        bucket: 'bucket-b',
+        decision: 'incoming',
+        changedKeys: ['beta'],
+        timestamp: 2,
+      },
+      {
+        id: '1-a',
+        bucket: 'bucket-a',
+        decision: 'local',
+        changedKeys: ['alpha'],
+        timestamp: 1,
+      },
+    ];
+
+    let combined = appendAuditEntries(entries);
+    expect(combined.map((entry) => entry.id)).toEqual(['1-a', '2-b']);
+
+    combined = appendAuditEntries([
+      {
+        id: '3-c',
+        bucket: 'bucket-c',
+        decision: 'incoming',
+        changedKeys: ['charlie'],
+        timestamp: 3,
+      },
+    ]);
+
+    expect(combined.map((entry) => entry.id)).toEqual(['1-a', '2-b', '3-c']);
+    expect(loadAuditLog().map((entry) => entry.id)).toEqual(['1-a', '2-b', '3-c']);
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
@@ -13,6 +13,24 @@ import KeymapOverlay from "./components/KeymapOverlay";
 import Tabs from "../../components/Tabs";
 import ToggleSwitch from "../../components/ToggleSwitch";
 import KaliWallpaper from "../../components/util-components/kali-wallpaper";
+import BackupMerge from "../../components/common/BackupMerge";
+import {
+  mergeSnapshots,
+  appendAuditEntries,
+  loadAuditLog,
+  MergeDecisionMap,
+  MergeAuditEntry,
+  BackupBuckets,
+} from "../../utils/backupMerge";
+import { getLocalBackupBuckets, applyBackupBuckets } from "../../utils/backupService";
+
+const SUPPORTED_BUCKETS = ["settings", "progress", "keybinds", "replays"] as const;
+
+interface PendingMergeState {
+  local: BackupBuckets;
+  incoming: BackupBuckets;
+  fileName?: string;
+}
 
 export default function Settings() {
   const {
@@ -30,12 +48,25 @@ export default function Settings() {
     setFontScale,
     highContrast,
     setHighContrast,
+    setLargeHitAreas,
+    setPongSpin,
+    setAllowNetwork,
     haptics,
     setHaptics,
     theme,
     setTheme,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const backupInputRef = useRef<HTMLInputElement>(null);
+  const [pendingMerge, setPendingMerge] = useState<PendingMergeState | null>(null);
+  const [mergeError, setMergeError] = useState<string | null>(null);
+  const [mergeStatus, setMergeStatus] = useState<string | null>(null);
+  const [auditLog, setAuditLog] = useState<MergeAuditEntry[]>([]);
+  const [lastMergeSnapshot, setLastMergeSnapshot] = useState<BackupBuckets | null>(null);
+
+  useEffect(() => {
+    setAuditLog(loadAuditLog());
+  }, []);
 
   const tabs = [
     { id: "appearance", label: "Appearance" },
@@ -107,6 +138,94 @@ export default function Settings() {
     setTheme("default");
   };
 
+  const applySettingsToContext = (data: Record<string, unknown>) => {
+    if (!data) return;
+    if (typeof data.accent === "string") setAccent(data.accent);
+    if (typeof data.wallpaper === "string") setWallpaper(data.wallpaper);
+    if (typeof data.useKaliWallpaper === "boolean")
+      setUseKaliWallpaper(data.useKaliWallpaper);
+    if (data.density === "regular" || data.density === "compact")
+      setDensity(data.density);
+    if (typeof data.reducedMotion === "boolean") setReducedMotion(data.reducedMotion);
+    if (typeof data.fontScale === "number") setFontScale(data.fontScale);
+    if (typeof data.highContrast === "boolean") setHighContrast(data.highContrast);
+    if (typeof data.largeHitAreas === "boolean") setLargeHitAreas(data.largeHitAreas);
+    if (typeof data.pongSpin === "boolean") setPongSpin(data.pongSpin);
+    if (typeof data.allowNetwork === "boolean") setAllowNetwork(data.allowNetwork);
+    if (typeof data.haptics === "boolean") setHaptics(data.haptics);
+    if (typeof data.theme === "string") setTheme(data.theme);
+  };
+
+  const parseBackupPayload = (text: string): BackupBuckets | null => {
+    try {
+      const parsed = JSON.parse(text);
+      if (!parsed || typeof parsed !== "object") return null;
+      const source =
+        "buckets" in parsed && parsed.buckets && typeof parsed.buckets === "object"
+          ? (parsed.buckets as Record<string, unknown>)
+          : (parsed as Record<string, unknown>);
+      const result: BackupBuckets = {};
+      for (const bucket of SUPPORTED_BUCKETS) {
+        if (bucket in source) {
+          result[bucket] = source[bucket];
+        }
+      }
+      return Object.keys(result).length > 0 ? result : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const handleBackupFile = async (file: File) => {
+    const text = await file.text();
+    const parsed = parseBackupPayload(text);
+    if (!parsed) {
+      setMergeError("Backup file is invalid or contains no supported buckets.");
+      setPendingMerge(null);
+      return;
+    }
+    const localSnapshot = await getLocalBackupBuckets();
+    setPendingMerge({ local: localSnapshot, incoming: parsed, fileName: file.name });
+    setMergeError(null);
+    setMergeStatus(null);
+  };
+
+  const handleMergeSubmit = async (decisions: MergeDecisionMap) => {
+    if (!pendingMerge) return;
+    const { merged, auditEntries } = mergeSnapshots(
+      pendingMerge.local,
+      pendingMerge.incoming,
+      decisions,
+    );
+    await applyBackupBuckets(merged);
+    if (merged.settings && typeof merged.settings === "object") {
+      applySettingsToContext(merged.settings as Record<string, unknown>);
+    }
+    const updatedLog = appendAuditEntries(auditEntries);
+    setAuditLog(updatedLog);
+    setLastMergeSnapshot(pendingMerge.local);
+    setPendingMerge(null);
+    setMergeError(null);
+    setMergeStatus("Merge applied successfully.");
+  };
+
+  const handleMergeCancel = () => {
+    setPendingMerge(null);
+  };
+
+  const handleUndoMerge = async () => {
+    if (!lastMergeSnapshot) return;
+    await applyBackupBuckets(lastMergeSnapshot);
+    if (lastMergeSnapshot.settings && typeof lastMergeSnapshot.settings === "object") {
+      applySettingsToContext(lastMergeSnapshot.settings as Record<string, unknown>);
+    }
+    setLastMergeSnapshot(null);
+    setMergeStatus("Last merge undone.");
+  };
+
+  const formatDecision = (entry: MergeAuditEntry) =>
+    entry.decision === "incoming" ? "Used backup" : "Kept local";
+
   const [showKeymap, setShowKeymap] = useState(false);
 
   return (
@@ -157,16 +276,17 @@ export default function Settings() {
             </div>
           </div>
           <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey flex items-center">
-              <input
-                type="checkbox"
-                checked={useKaliWallpaper}
-                onChange={(e) => setUseKaliWallpaper(e.target.checked)}
-                className="mr-2"
-              />
-              Kali Gradient Wallpaper
-            </label>
-          </div>
+              <label className="mr-2 text-ubt-grey flex items-center">
+                <input
+                  type="checkbox"
+                  checked={useKaliWallpaper}
+                  onChange={(e) => setUseKaliWallpaper(e.target.checked)}
+                  className="mr-2"
+                  aria-label="Use Kali gradient wallpaper"
+                />
+                Kali Gradient Wallpaper
+              </label>
+            </div>
           {useKaliWallpaper && (
             <p className="text-center text-xs text-ubt-grey/70 px-6 -mt-2 mb-4">
               Your previous wallpaper selection is preserved for when you turn this off.
@@ -294,7 +414,7 @@ export default function Settings() {
       )}
       {activeTab === "privacy" && (
         <>
-          <div className="flex justify-center my-4 space-x-4">
+          <div className="flex flex-wrap justify-center gap-3 my-4">
             <button
               onClick={handleExport}
               className="px-4 py-2 rounded bg-ub-orange text-white"
@@ -308,20 +428,109 @@ export default function Settings() {
               Import Settings
             </button>
           </div>
+          <div className="mx-auto w-full max-w-3xl px-4">
+            <div className="rounded border border-gray-900 bg-gray-800/40 p-4 shadow-inner">
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h3 className="text-lg font-semibold text-ubt-grey">Backup merge</h3>
+                  <p className="text-sm text-ubt-grey/70">
+                    Load a backup snapshot and decide how each data bucket should be resolved.
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    onClick={() => backupInputRef.current?.click()}
+                    className="px-3 py-1 rounded bg-blue-600 text-white hover:bg-blue-500"
+                  >
+                    Load backup
+                  </button>
+                  <button
+                    onClick={handleUndoMerge}
+                    disabled={!lastMergeSnapshot}
+                    className={`px-3 py-1 rounded border text-sm ${lastMergeSnapshot ? 'border-gray-600 text-ubt-grey hover:bg-gray-800' : 'border-gray-800 text-gray-500 cursor-not-allowed'}`}
+                  >
+                    Undo last merge
+                  </button>
+                  {mergeStatus && (
+                    <span className="text-xs text-green-300">{mergeStatus}</span>
+                  )}
+                </div>
+              </div>
+              {mergeError && (
+                <p className="mt-3 text-sm text-red-400">{mergeError}</p>
+              )}
+              {pendingMerge && (
+                <div className="mt-4 space-y-3">
+                  <p className="text-xs text-ubt-grey/70">
+                    {pendingMerge.fileName
+                      ? `Loaded "${pendingMerge.fileName}".`
+                      : 'Loaded backup data.'}
+                    {" "}
+                    Choose how to resolve each bucket below.
+                  </p>
+                  <BackupMerge
+                    localBuckets={pendingMerge.local}
+                    incomingBuckets={pendingMerge.incoming}
+                    onSubmit={handleMergeSubmit}
+                    onCancel={handleMergeCancel}
+                  />
+                </div>
+              )}
+              <input
+                type="file"
+                accept="application/json"
+                ref={backupInputRef}
+                aria-label="Load backup file"
+                className="hidden"
+                onChange={async (e) => {
+                  const file = e.target.files && e.target.files[0];
+                  if (file) await handleBackupFile(file);
+                  e.target.value = "";
+                }}
+              />
+              <div className="mt-6 border-t border-gray-900 pt-3">
+                <h4 className="text-sm font-semibold text-ubt-grey">Recent merge activity</h4>
+                {auditLog.length === 0 ? (
+                  <p className="mt-2 text-xs text-ubt-grey/70">No merges recorded yet.</p>
+                ) : (
+                  <ul className="mt-2 space-y-2 text-xs text-ubt-grey/80">
+                    {auditLog
+                      .slice(-5)
+                      .reverse()
+                      .map((entry) => (
+                        <li
+                          key={entry.id}
+                          className="flex flex-col gap-1 rounded border border-gray-900/60 bg-gray-900/40 p-2 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                          <span>
+                            <span className="font-semibold text-ubt-grey">{entry.bucket}</span>
+                            {" "}· {formatDecision(entry)} ·{' '}
+                            {entry.changedKeys.join(', ')}
+                          </span>
+                          <time className="text-ubt-grey/60">
+                            {new Date(entry.timestamp).toLocaleString()}
+                          </time>
+                        </li>
+                      ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          </div>
         </>
       )}
-        <input
-          type="file"
-          accept="application/json"
-          ref={fileInputRef}
-          aria-label="Import settings file"
-          onChange={(e) => {
-            const file = e.target.files && e.target.files[0];
-            if (file) handleImport(file);
-            e.target.value = "";
-          }}
-          className="hidden"
-        />
+      <input
+        type="file"
+        accept="application/json"
+        ref={fileInputRef}
+        aria-label="Import settings file"
+        onChange={(e) => {
+          const file = e.target.files && e.target.files[0];
+          if (file) handleImport(file);
+          e.target.value = "";
+        }}
+        className="hidden"
+      />
       <KeymapOverlay open={showKeymap} onClose={() => setShowKeymap(false)} />
     </div>
   );

--- a/components/common/BackupMerge.tsx
+++ b/components/common/BackupMerge.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  BucketDiff,
+  MergeDecision,
+  MergeDecisionMap,
+  computeBucketDiffs,
+} from '../../utils/backupMerge';
+
+interface BackupMergeProps {
+  localBuckets: Record<string, unknown>;
+  incomingBuckets: Record<string, unknown>;
+  onSubmit: (decisions: MergeDecisionMap) => void;
+  onCancel?: () => void;
+  initialDecisions?: MergeDecisionMap;
+}
+
+const decisionLabel: Record<MergeDecision, string> = {
+  local: 'Keep local',
+  incoming: 'Use backup',
+};
+
+const summarizeDiff = (diff: BucketDiff): string => {
+  if (!diff.hasDifferences) return 'No differences detected.';
+
+  if (diff.incomingOnly) {
+    return 'New bucket found in backup.';
+  }
+  if (diff.localOnly) {
+    return 'Bucket missing from backup; keeping local preserves it.';
+  }
+
+  const segments: string[] = [];
+  if (diff.added.length > 0) {
+    segments.push(`${diff.added.length} new ${diff.added.length === 1 ? 'key' : 'keys'}`);
+  }
+  if (diff.removed.length > 0) {
+    segments.push(`${diff.removed.length} removed ${diff.removed.length === 1 ? 'key' : 'keys'}`);
+  }
+  if (diff.changed.length > 0) {
+    const label = diff.type === 'array' ? 'entries' : 'keys';
+    segments.push(`${diff.changed.length} changed ${diff.changed.length === 1 ? label.slice(0, -1) : label}`);
+  }
+
+  if (segments.length === 0) {
+    return 'Bucket contents differ between backup and local state.';
+  }
+
+  return segments.join(', ') + '.';
+};
+
+const renderDetails = (diff: BucketDiff) => {
+  if (!diff.hasDifferences) {
+    return (
+      <p className="text-xs text-gray-300">Buckets match exactly; nothing to resolve.</p>
+    );
+  }
+
+  if (diff.type === 'primitive' && !diff.incomingOnly && !diff.localOnly) {
+    return (
+      <p className="text-xs text-gray-300">
+        Value differs between backup and local data.
+      </p>
+    );
+  }
+
+  const renderList = (label: string, values: string[], tone: string) => (
+    <div>
+      <p className="text-xs font-semibold text-gray-200">{label}</p>
+      <ul className="mt-1 space-y-1 text-xs">
+        {values.map((key) => (
+          <li key={`${label}-${key}`} className={tone}>
+            {key}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+
+  return (
+    <div className="mt-2 grid gap-2 sm:grid-cols-3 text-xs text-gray-300">
+      {diff.added.length > 0 && renderList('Added', diff.added, 'text-green-300')}
+      {diff.removed.length > 0 && renderList('Removed', diff.removed, 'text-red-300')}
+      {diff.changed.length > 0 && renderList('Changed', diff.changed, 'text-yellow-200')}
+      {diff.incomingOnly && (
+        <p className="text-green-300">Entire bucket will be created from backup.</p>
+      )}
+      {diff.localOnly && (
+        <p className="text-red-300">
+          Backup lacks this bucket; keeping local preserves existing data.
+        </p>
+      )}
+    </div>
+  );
+};
+
+const BackupMerge = ({
+  localBuckets,
+  incomingBuckets,
+  onSubmit,
+  onCancel,
+  initialDecisions = {},
+}: BackupMergeProps) => {
+  const diffs = useMemo(
+    () => computeBucketDiffs(localBuckets, incomingBuckets),
+    [localBuckets, incomingBuckets],
+  );
+
+  const defaultDecisions = useMemo(() => {
+    const map: MergeDecisionMap = {};
+    for (const diff of diffs) {
+      if (initialDecisions[diff.bucket]) {
+        map[diff.bucket] = initialDecisions[diff.bucket];
+        continue;
+      }
+      if (diff.incomingOnly && !diff.localOnly) {
+        map[diff.bucket] = 'incoming';
+      } else {
+        map[diff.bucket] = 'local';
+      }
+    }
+    return map;
+  }, [diffs, initialDecisions]);
+
+  const [decisions, setDecisions] = useState<MergeDecisionMap>(defaultDecisions);
+
+  useEffect(() => {
+    setDecisions(defaultDecisions);
+  }, [defaultDecisions]);
+
+  const hasDifferences = diffs.some((diff) => diff.hasDifferences);
+
+  const handleDecision = (bucket: string, decision: MergeDecision) => {
+    setDecisions((prev) => ({ ...prev, [bucket]: decision }));
+  };
+
+  const handleSubmit = () => {
+    onSubmit(decisions);
+  };
+
+  return (
+    <div className="rounded-md border border-gray-700 bg-gray-900 p-4 text-white">
+      <h3 className="text-lg font-semibold">Resolve backup conflicts</h3>
+      {diffs.length === 0 ? (
+        <p className="mt-2 text-sm text-gray-300">
+          No data buckets found in the backup.
+        </p>
+      ) : (
+        <ul className="mt-4 space-y-4">
+          {diffs.map((diff) => (
+            <li key={diff.bucket} className="rounded border border-gray-800 bg-gray-950 p-4">
+              <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <p className="text-sm font-semibold uppercase tracking-wide text-gray-200">
+                    {diff.bucket}
+                  </p>
+                  <p className="mt-1 text-xs text-gray-300">{summarizeDiff(diff)}</p>
+                </div>
+                <div className="flex items-center gap-2 self-start">
+                  {(Object.keys(decisionLabel) as MergeDecision[]).map((value) => (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => handleDecision(diff.bucket, value)}
+                      className={`rounded border px-3 py-1 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${decisions[diff.bucket] === value ? 'border-blue-400 bg-blue-500/20 text-blue-100' : 'border-gray-700 bg-gray-800 text-gray-200 hover:bg-gray-700/70'}`}
+                      aria-pressed={decisions[diff.bucket] === value}
+                    >
+                      {decisionLabel[value]}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <details className="mt-3">
+                <summary className="cursor-pointer text-xs text-blue-300">
+                  View details
+                </summary>
+                <div className="mt-2">{renderDetails(diff)}</div>
+              </details>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="mt-6 flex justify-end gap-2">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded border border-gray-700 px-3 py-1 text-sm text-gray-200 hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!hasDifferences}
+          className={`rounded px-3 py-1 text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 ${hasDifferences ? 'bg-blue-600 text-white hover:bg-blue-500' : 'cursor-not-allowed bg-gray-700 text-gray-400'}`}
+        >
+          Apply decisions
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default BackupMerge;
+

--- a/utils/backupMerge.ts
+++ b/utils/backupMerge.ts
@@ -1,0 +1,362 @@
+import { safeLocalStorage } from './safeStorage';
+
+export type BackupBuckets = Record<string, unknown>;
+
+export type MergeDecision = 'local' | 'incoming';
+
+export type MergeDecisionMap = Record<string, MergeDecision>;
+
+export interface BucketDiff {
+  bucket: string;
+  type: 'object' | 'array' | 'primitive';
+  added: string[];
+  removed: string[];
+  changed: string[];
+  incomingOnly: boolean;
+  localOnly: boolean;
+  hasDifferences: boolean;
+}
+
+export interface MergeAuditEntry {
+  id: string;
+  bucket: string;
+  decision: MergeDecision;
+  changedKeys: string[];
+  timestamp: number;
+}
+
+export interface MergeResult {
+  merged: BackupBuckets;
+  auditEntries: MergeAuditEntry[];
+}
+
+export const AUDIT_LOG_STORAGE_KEY = 'backup-merge-audit-log';
+
+const BUCKET_ADDED_TOKEN = '[bucket added]';
+const BUCKET_REMOVED_TOKEN = '[bucket removed]';
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const cloneValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(cloneValue);
+  }
+  if (isPlainObject(value)) {
+    const result: Record<string, unknown> = {};
+    const keys = Object.keys(value).sort();
+    for (const key of keys) {
+      result[key] = cloneValue(value[key]);
+    }
+    return result;
+  }
+  return value;
+};
+
+const stableStringify = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+  if (isPlainObject(value)) {
+    const entries = Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  if (value === undefined) return 'undefined';
+  return JSON.stringify(value);
+};
+
+const compareValues = (a: unknown, b: unknown): boolean =>
+  stableStringify(a) === stableStringify(b);
+
+const createDiffForObjects = (
+  bucket: string,
+  localValue: Record<string, unknown>,
+  incomingValue: Record<string, unknown>,
+): BucketDiff => {
+  const localKeys = new Set(Object.keys(localValue));
+  const incomingKeys = new Set(Object.keys(incomingValue));
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: string[] = [];
+
+  const allKeys = new Set([...localKeys, ...incomingKeys]);
+  const sortedKeys = Array.from(allKeys).sort();
+
+  for (const key of sortedKeys) {
+    const hasLocal = localKeys.has(key);
+    const hasIncoming = incomingKeys.has(key);
+    if (!hasLocal && hasIncoming) {
+      added.push(key);
+    } else if (hasLocal && !hasIncoming) {
+      removed.push(key);
+    } else if (!compareValues(localValue[key], incomingValue[key])) {
+      changed.push(key);
+    }
+  }
+
+  const hasDifferences = added.length > 0 || removed.length > 0 || changed.length > 0;
+
+  return {
+    bucket,
+    type: 'object',
+    added,
+    removed,
+    changed,
+    incomingOnly: false,
+    localOnly: false,
+    hasDifferences,
+  };
+};
+
+const createDiffForArrays = (
+  bucket: string,
+  localValue: unknown[],
+  incomingValue: unknown[],
+): BucketDiff => {
+  const maxLength = Math.max(localValue.length, incomingValue.length);
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: string[] = [];
+
+  for (let index = 0; index < maxLength; index += 1) {
+    const hasLocal = index < localValue.length;
+    const hasIncoming = index < incomingValue.length;
+    const label = `[${index}]`;
+    if (!hasLocal && hasIncoming) {
+      added.push(label);
+    } else if (hasLocal && !hasIncoming) {
+      removed.push(label);
+    } else if (!compareValues(localValue[index], incomingValue[index])) {
+      changed.push(label);
+    }
+  }
+
+  const hasDifferences = added.length > 0 || removed.length > 0 || changed.length > 0;
+
+  return {
+    bucket,
+    type: 'array',
+    added,
+    removed,
+    changed,
+    incomingOnly: false,
+    localOnly: false,
+    hasDifferences,
+  };
+};
+
+const createDiffForPrimitive = (
+  bucket: string,
+  localValue: unknown,
+  incomingValue: unknown,
+): BucketDiff => ({
+  bucket,
+  type: 'primitive',
+  added: [],
+  removed: [],
+  changed: compareValues(localValue, incomingValue) ? [] : ['value'],
+  incomingOnly: false,
+  localOnly: false,
+  hasDifferences: !compareValues(localValue, incomingValue),
+});
+
+export const computeBucketDiffs = (
+  localBuckets: BackupBuckets,
+  incomingBuckets: BackupBuckets,
+): BucketDiff[] => {
+  const names = new Set([
+    ...Object.keys(localBuckets || {}),
+    ...Object.keys(incomingBuckets || {}),
+  ]);
+  const sortedNames = Array.from(names).sort();
+  const diffs: BucketDiff[] = [];
+
+  for (const bucket of sortedNames) {
+    const localValue = localBuckets[bucket];
+    const incomingValue = incomingBuckets[bucket];
+
+    if (localValue === undefined && incomingValue === undefined) {
+      continue;
+    }
+
+    if (localValue === undefined) {
+      const diff: BucketDiff = {
+        bucket,
+        type: Array.isArray(incomingValue)
+          ? 'array'
+          : isPlainObject(incomingValue)
+            ? 'object'
+            : 'primitive',
+        added: isPlainObject(incomingValue)
+          ? Object.keys(incomingValue).sort()
+          : Array.isArray(incomingValue)
+            ? incomingValue.map((_, index) => `[${index}]`)
+            : ['value'],
+        removed: [],
+        changed: [],
+        incomingOnly: true,
+        localOnly: false,
+        hasDifferences: true,
+      };
+      diffs.push(diff);
+      continue;
+    }
+
+    if (incomingValue === undefined) {
+      const diff: BucketDiff = {
+        bucket,
+        type: Array.isArray(localValue)
+          ? 'array'
+          : isPlainObject(localValue)
+            ? 'object'
+            : 'primitive',
+        added: [],
+        removed: isPlainObject(localValue)
+          ? Object.keys(localValue).sort()
+          : Array.isArray(localValue)
+            ? localValue.map((_, index) => `[${index}]`)
+            : ['value'],
+        changed: [],
+        incomingOnly: false,
+        localOnly: true,
+        hasDifferences: true,
+      };
+      diffs.push(diff);
+      continue;
+    }
+
+    if (Array.isArray(localValue) && Array.isArray(incomingValue)) {
+      diffs.push(createDiffForArrays(bucket, localValue, incomingValue));
+    } else if (isPlainObject(localValue) && isPlainObject(incomingValue)) {
+      diffs.push(createDiffForObjects(bucket, localValue, incomingValue));
+    } else {
+      diffs.push(createDiffForPrimitive(bucket, localValue, incomingValue));
+    }
+  }
+
+  return diffs;
+};
+
+export const mergeSnapshots = (
+  localBuckets: BackupBuckets,
+  incomingBuckets: BackupBuckets,
+  decisions: MergeDecisionMap,
+): MergeResult => {
+  const names = new Set([
+    ...Object.keys(localBuckets || {}),
+    ...Object.keys(incomingBuckets || {}),
+  ]);
+  const sortedNames = Array.from(names).sort();
+  const merged: BackupBuckets = {};
+  const auditEntries: MergeAuditEntry[] = [];
+  const diffs = computeBucketDiffs(localBuckets, incomingBuckets);
+  const diffMap = new Map<string, BucketDiff>(diffs.map((diff) => [diff.bucket, diff]));
+  const baseTime = Date.now();
+  let counter = 0;
+
+  for (const bucket of sortedNames) {
+    const decision = decisions[bucket]
+      ?? (incomingBuckets[bucket] !== undefined ? 'incoming' : 'local');
+    const source = decision === 'incoming'
+      ? incomingBuckets[bucket]
+      : localBuckets[bucket];
+
+    if (source !== undefined) {
+      merged[bucket] = cloneValue(source);
+    }
+
+    const diff = diffMap.get(bucket);
+    if (diff && diff.hasDifferences) {
+      const changedSet = new Set<string>();
+      diff.added.forEach((key) => changedSet.add(key));
+      diff.removed.forEach((key) => changedSet.add(key));
+      diff.changed.forEach((key) => changedSet.add(key));
+      if (diff.incomingOnly) changedSet.add(BUCKET_ADDED_TOKEN);
+      if (diff.localOnly) changedSet.add(BUCKET_REMOVED_TOKEN);
+      const changedKeys = Array.from(changedSet).sort();
+      if (changedKeys.length > 0) {
+        const timestamp = baseTime + counter;
+        auditEntries.push({
+          id: `${timestamp}-${bucket}-${decision}`,
+          bucket,
+          decision,
+          changedKeys,
+          timestamp,
+        });
+        counter += 1;
+      }
+    }
+  }
+
+  return { merged, auditEntries };
+};
+
+const validateAuditEntry = (value: unknown): value is MergeAuditEntry => {
+  if (!value || typeof value !== 'object') return false;
+  const entry = value as MergeAuditEntry;
+  return (
+    typeof entry.id === 'string'
+    && typeof entry.bucket === 'string'
+    && (entry.decision === 'local' || entry.decision === 'incoming')
+    && Array.isArray(entry.changedKeys)
+    && typeof entry.timestamp === 'number'
+  );
+};
+
+export const loadAuditLog = (): MergeAuditEntry[] => {
+  if (!safeLocalStorage) return [];
+  try {
+    const raw = safeLocalStorage.getItem(AUDIT_LOG_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(validateAuditEntry)
+      .map((entry) => ({
+        ...entry,
+        changedKeys: [...entry.changedKeys].sort(),
+      }))
+      .sort((a, b) => (a.timestamp === b.timestamp
+        ? a.id.localeCompare(b.id)
+        : a.timestamp - b.timestamp));
+  } catch {
+    return [];
+  }
+};
+
+const persistAuditLog = (entries: MergeAuditEntry[]): void => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.setItem(AUDIT_LOG_STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // ignore persistence errors
+  }
+};
+
+export const appendAuditEntries = (
+  entries: MergeAuditEntry[],
+): MergeAuditEntry[] => {
+  if (entries.length === 0) {
+    return loadAuditLog();
+  }
+  const current = loadAuditLog();
+  const combined = [...current, ...entries].sort((a, b) => (
+    a.timestamp === b.timestamp
+      ? a.id.localeCompare(b.id)
+      : a.timestamp - b.timestamp
+  ));
+  persistAuditLog(combined);
+  return combined;
+};
+
+export const clearAuditLog = (): void => {
+  if (!safeLocalStorage) return;
+  try {
+    safeLocalStorage.removeItem(AUDIT_LOG_STORAGE_KEY);
+  } catch {
+    // ignore removal errors
+  }
+};
+

--- a/utils/backupService.ts
+++ b/utils/backupService.ts
@@ -1,0 +1,78 @@
+import { exportSettings, importSettings } from './settingsStore';
+import {
+  getProgress,
+  setProgress,
+  getKeybinds,
+  setKeybinds,
+  getReplays,
+  setReplays,
+  ProgressData,
+  Keybinds,
+  Replay,
+} from './storage';
+import { BackupBuckets } from './backupMerge';
+
+const clone = <T>(value: T): T => {
+  if (Array.isArray(value)) {
+    return value.map((item) => clone(item)) as T;
+  }
+  if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = clone(nested);
+    }
+    return result as T;
+  }
+  return value;
+};
+
+const normalizeSettings = (json: string): Record<string, unknown> => {
+  try {
+    const parsed = JSON.parse(json);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+};
+
+export const getLocalBackupBuckets = async (): Promise<BackupBuckets> => {
+  const [settingsJson, progress, keybinds, replays] = await Promise.all([
+    exportSettings(),
+    getProgress(),
+    getKeybinds(),
+    getReplays(),
+  ]);
+
+  return {
+    settings: normalizeSettings(settingsJson),
+    progress: clone(progress) as ProgressData,
+    keybinds: clone(keybinds) as Keybinds,
+    replays: clone(replays) as Replay[],
+  };
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const applyBackupBuckets = async (buckets: BackupBuckets): Promise<void> => {
+  const tasks: Promise<void>[] = [];
+
+  if ('settings' in buckets && isRecord(buckets.settings)) {
+    tasks.push(importSettings(JSON.stringify(buckets.settings)));
+  }
+
+  if ('progress' in buckets && isRecord(buckets.progress)) {
+    tasks.push(setProgress(buckets.progress as ProgressData));
+  }
+
+  if ('keybinds' in buckets && isRecord(buckets.keybinds)) {
+    tasks.push(setKeybinds(buckets.keybinds as Keybinds));
+  }
+
+  if ('replays' in buckets && Array.isArray(buckets.replays)) {
+    tasks.push(setReplays(buckets.replays as Replay[]));
+  }
+
+  await Promise.all(tasks);
+};
+

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -35,6 +35,11 @@ export const getReplays = async (): Promise<Replay[]> =>
     ? []
     : (await get<Replay[]>(REPLAYS_KEY)) || []);
 
+export const setReplays = async (replays: Replay[]): Promise<void> => {
+  if (typeof window === 'undefined') return;
+  await set(REPLAYS_KEY, replays);
+};
+
 export const saveReplay = async (replay: Replay): Promise<void> => {
   if (typeof window === 'undefined') return;
   await update<Replay[]>(REPLAYS_KEY, (replays = []) => [...replays, replay]);
@@ -51,6 +56,7 @@ const storage = {
   getKeybinds,
   setKeybinds,
   getReplays,
+  setReplays,
   saveReplay,
   clearReplays,
 };


### PR DESCRIPTION
## Summary
- add a reusable BackupMerge component with per-bucket conflict previews
- implement deterministic backup merge logic, storage helpers, and audit logging
- extend settings privacy tools with backup merge UI, undo support, and activity log

## Testing
- yarn lint
- yarn test backupMerge

------
https://chatgpt.com/codex/tasks/task_e_68dccad65ba88328843b6796284b21a0