### PR TITLE
[file-explorer] add duplicate scanner with safe delete

### DIFF
--- a/__tests__/fileExplorerHashUtils.test.ts
+++ b/__tests__/fileExplorerHashUtils.test.ts
@@ -1,0 +1,27 @@
+import { createDuplicateGroups } from '../modules/fileExplorer/hashUtils';
+
+const toBuffer = (text: string) => new TextEncoder().encode(text).buffer;
+
+describe('createDuplicateGroups', () => {
+  it('groups identical content by hash', () => {
+    const records = [
+      { hash: 'abc', size: 4, segments: ['a.txt'], name: 'a.txt', content: toBuffer('test') },
+      { hash: 'abc', size: 4, segments: ['b.txt'], name: 'b.txt', content: toBuffer('test') },
+      { hash: 'def', size: 4, segments: ['c.txt'], name: 'c.txt', content: toBuffer('demo') },
+    ];
+
+    const groups = createDuplicateGroups(records);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].files.map((f) => f.path)).toEqual(expect.arrayContaining(['a.txt', 'b.txt']));
+  });
+
+  it('ignores hash collisions with different content', () => {
+    const records = [
+      { hash: 'same', size: 3, segments: ['one.txt'], name: 'one.txt', content: toBuffer('foo') },
+      { hash: 'same', size: 3, segments: ['two.txt'], name: 'two.txt', content: toBuffer('bar') },
+    ];
+
+    const groups = createDuplicateGroups(records);
+    expect(groups).toHaveLength(0);
+  });
+});

--- a/__tests__/fileExplorerUndo.test.ts
+++ b/__tests__/fileExplorerUndo.test.ts
@@ -1,0 +1,40 @@
+import { RecycleBinUndoManager, restoreDeletion } from '../modules/fileExplorer/undoManager';
+
+const toBuffer = (text: string) => new TextEncoder().encode(text).buffer;
+
+describe('RecycleBinUndoManager', () => {
+  it('restores files through the provided restorer', async () => {
+    const manager = new RecycleBinUndoManager();
+    const operation = {
+      files: [
+        {
+          name: 'file.txt',
+          segments: ['folder', 'file.txt'],
+          path: 'folder/file.txt',
+          data: toBuffer('payload'),
+          recycleName: 'file.txt.restore',
+        },
+      ],
+      groupSnapshot: {
+        id: 'hash-1',
+        hash: 'hash-1',
+        size: 7,
+        files: [
+          { path: 'folder/file.txt', segments: ['folder', 'file.txt'], name: 'file.txt', size: 7, type: '' },
+        ],
+      },
+    };
+
+    manager.push(operation);
+    const popped = manager.pop();
+    expect(popped).toBeTruthy();
+
+    const restoredFiles = new Map<string, number>();
+    const restored = await restoreDeletion(popped!, async (entry) => {
+      restoredFiles.set(entry.path || entry.segments.join('/'), new Uint8Array(entry.data).length);
+    });
+
+    expect(restored).toBe(true);
+    expect(restoredFiles.get('folder/file.txt')).toBe(7);
+  });
+});

--- a/components/apps/file-explorer.hash.worker.js
+++ b/components/apps/file-explorer.hash.worker.js
@@ -1,0 +1,96 @@
+import { createDuplicateGroups } from '../../modules/fileExplorer/hashUtils';
+
+const state = {
+  cancelled: false,
+};
+
+const resetState = () => {
+  state.cancelled = false;
+};
+
+const traverseFiles = async (directoryHandle, path = [], collection = []) => {
+  if (!directoryHandle || state.cancelled) return collection;
+  for await (const [name, handle] of directoryHandle.entries()) {
+    if (state.cancelled) return collection;
+    if (handle.kind === 'file') {
+      collection.push({ path: [...path, name], handle });
+    } else if (handle.kind === 'directory') {
+      await traverseFiles(handle, [...path, name], collection);
+      if (state.cancelled) return collection;
+    }
+  }
+  return collection;
+};
+
+const hashBuffer = async (buffer) => {
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  const view = new Uint8Array(digest);
+  let hash = '';
+  for (let i = 0; i < view.length; i += 1) {
+    const hex = view[i].toString(16).padStart(2, '0');
+    hash += hex;
+  }
+  return hash;
+};
+
+self.onmessage = async (event) => {
+  const { type } = event.data || {};
+  if (type === 'cancel') {
+    state.cancelled = true;
+    return;
+  }
+
+  if (type !== 'start') return;
+
+  resetState();
+
+  const { directoryHandle } = event.data;
+  if (!directoryHandle) {
+    self.postMessage({ type: 'error', message: 'No directory handle provided' });
+    return;
+  }
+
+  try {
+    const files = await traverseFiles(directoryHandle);
+    if (state.cancelled) {
+      self.postMessage({ type: 'cancelled' });
+      return;
+    }
+
+    const total = files.length;
+    if (total === 0) {
+      self.postMessage({ type: 'complete', groups: [] });
+      return;
+    }
+
+    const records = [];
+    for (let index = 0; index < files.length; index += 1) {
+      if (state.cancelled) {
+        self.postMessage({ type: 'cancelled' });
+        return;
+      }
+      const fileEntry = files[index];
+      const file = await fileEntry.handle.getFile();
+      const arrayBuffer = await file.arrayBuffer();
+      const hash = await hashBuffer(arrayBuffer);
+      records.push({
+        hash,
+        size: file.size,
+        segments: fileEntry.path,
+        name: file.name,
+        type: file.type,
+        content: arrayBuffer,
+      });
+      self.postMessage({
+        type: 'progress',
+        processed: index + 1,
+        total,
+      });
+    }
+
+    const groups = createDuplicateGroups(records);
+    self.postMessage({ type: 'complete', groups });
+  } catch (error) {
+    self.postMessage({ type: 'error', message: error?.message || 'Scan failed' });
+  }
+};

--- a/components/apps/file-explorer.js
+++ b/components/apps/file-explorer.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import useOPFS from '../../hooks/useOPFS';
 import { getDb } from '../../utils/safeIDB';
 import Breadcrumbs from '../ui/Breadcrumbs';
+import { RecycleBinUndoManager, restoreDeletion } from '../../modules/fileExplorer/undoManager';
 
 export async function openFileDialog(options = {}) {
   if (typeof window !== 'undefined' && window.showOpenFilePicker) {
@@ -91,6 +92,22 @@ async function addRecentDir(handle) {
   } catch {}
 }
 
+const makeFileKey = (groupId, file) => `${groupId}:${file.path}`;
+
+const formatBytes = (value) => {
+  const size = typeof value === 'number' && Number.isFinite(value) ? value : 0;
+  if (size <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let unitIndex = 0;
+  let display = size;
+  while (display >= 1024 && unitIndex < units.length - 1) {
+    display /= 1024;
+    unitIndex += 1;
+  }
+  const precision = display >= 10 || unitIndex === 0 ? 0 : 1;
+  return `${display.toFixed(precision)} ${units[unitIndex]}`;
+};
+
 export default function FileExplorer({ context, initialPath, path: pathProp } = {}) {
   const [supported, setSupported] = useState(true);
   const [dirHandle, setDirHandle] = useState(null);
@@ -105,6 +122,16 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
   const workerRef = useRef(null);
   const fallbackInputRef = useRef(null);
   const [locationError, setLocationError] = useState(null);
+  const [scanState, setScanState] = useState({ status: 'idle', progress: 0, message: null, processed: 0, total: 0 });
+  const [duplicateGroups, setDuplicateGroups] = useState([]);
+  const [selection, setSelection] = useState({});
+  const [undoPrompt, setUndoPrompt] = useState(null);
+  const [actionError, setActionError] = useState(null);
+  const scanWorkerRef = useRef(null);
+  const scanRootRef = useRef(null);
+  const recycleDirRef = useRef(null);
+  const undoManagerRef = useRef(new RecycleBinUndoManager());
+  const shellRef = useRef(context?.shell);
 
   const hasWorker = typeof Worker !== 'undefined';
   const {
@@ -116,6 +143,21 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
     deleteFile: opfsDelete,
   } = useOPFS();
   const [unsavedDir, setUnsavedDir] = useState(null);
+
+  useEffect(() => {
+    shellRef.current = context?.shell;
+  }, [context]);
+
+  useEffect(
+    () => () => {
+      shellRef.current?.clearBadge?.();
+      if (scanWorkerRef.current) {
+        scanWorkerRef.current.terminate();
+        scanWorkerRef.current = null;
+      }
+    },
+    []
+  );
 
   useEffect(() => {
     const ok = !!window.showDirectoryPicker;
@@ -146,6 +188,93 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
     if (unsavedDir) await opfsDelete(name, unsavedDir);
   };
 
+  const resetScanner = useCallback(() => {
+    setScanState({ status: 'idle', progress: 0, message: null, processed: 0, total: 0 });
+    setDuplicateGroups([]);
+    setSelection({});
+    setUndoPrompt(null);
+    setActionError(null);
+    undoManagerRef.current.clear();
+    scanRootRef.current = null;
+    recycleDirRef.current = null;
+    if (scanWorkerRef.current) {
+      scanWorkerRef.current.terminate();
+      scanWorkerRef.current = null;
+    }
+    shellRef.current?.clearBadge?.();
+  }, []);
+
+  const resolveDirectory = useCallback(async (segments = [], options = { create: false }) => {
+    let current = scanRootRef.current;
+    if (!current) throw new Error('No directory selected');
+    for (let i = 0; i < segments.length; i += 1) {
+      current = await current.getDirectoryHandle(segments[i], options);
+    }
+    return current;
+  }, []);
+
+  const ensureRecycleDir = useCallback(async () => {
+    if (recycleDirRef.current) return recycleDirRef.current;
+    const rootHandle = scanRootRef.current;
+    if (!rootHandle || typeof rootHandle.getDirectoryHandle !== 'function') return null;
+    try {
+      recycleDirRef.current = await rootHandle.getDirectoryHandle('.recycle-bin', { create: true });
+      return recycleDirRef.current;
+    } catch (error) {
+      return null;
+    }
+  }, []);
+
+  const restoreFileEntry = useCallback(
+    async (entry) => {
+      if (!entry) return;
+      const parentSegments = Array.isArray(entry.segments) ? entry.segments.slice(0, -1) : [];
+      const parent = await resolveDirectory(parentSegments, { create: true });
+      const fileHandle = await parent.getFileHandle(entry.name, { create: true });
+      const writable = await fileHandle.createWritable();
+      await writable.write(entry.data);
+      await writable.close();
+      if (recycleDirRef.current && entry.recycleName) {
+        try {
+          await recycleDirRef.current.removeEntry(entry.recycleName);
+        } catch {}
+      }
+    },
+    [resolveDirectory]
+  );
+
+  const moveFileToRecycleBin = useCallback(
+    async (groupId, file) => {
+      const segments = Array.isArray(file?.segments) ? file.segments : [];
+      const parentSegments = segments.slice(0, -1);
+      const parent = await resolveDirectory(parentSegments);
+      const fileHandle = await parent.getFileHandle(file.name);
+      const fileBlob = await fileHandle.getFile();
+      const buffer = await fileBlob.arrayBuffer();
+      const recycleDir = await ensureRecycleDir();
+      let recycleName = null;
+      if (recycleDir) {
+        recycleName = `${file.name}.${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const recycleHandle = await recycleDir.getFileHandle(recycleName, { create: true });
+        const writable = await recycleHandle.createWritable();
+        await writable.write(buffer);
+        await writable.close();
+      }
+      await parent.removeEntry(file.name);
+      return {
+        groupId,
+        segments: [...segments],
+        name: file.name,
+        path: file.path,
+        type: fileBlob.type,
+        data: buffer,
+        recycleName,
+        fileInfo: { ...file },
+      };
+    },
+    [ensureRecycleDir, resolveDirectory]
+  );
+
   const openFallback = async (e) => {
     const file = e.target.files[0];
     if (!file) return;
@@ -158,6 +287,7 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
     try {
       const handle = await window.showDirectoryPicker();
       setDirHandle(handle);
+      resetScanner();
       addRecentDir(handle);
       setRecent(await getRecentDirs());
       setPath([{ name: handle.name || '/', handle }]);
@@ -171,6 +301,7 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
       const perm = await entry.handle.requestPermission({ mode: 'readwrite' });
       if (perm !== 'granted') return;
       setDirHandle(entry.handle);
+      resetScanner();
       setPath([{ name: entry.name, handle: entry.handle }]);
       await readDir(entry.handle);
       setLocationError(null);
@@ -215,6 +346,7 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
       try {
         if (!sanitized) {
           if (!active) return;
+          resetScanner();
           setDirHandle(root);
           setPath([{ name: root.name || '/', handle: root }]);
           await readDir(root);
@@ -232,6 +364,7 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
           crumbs.push({ name: segment, handle: current });
         }
         if (!active) return;
+        resetScanner();
         setDirHandle(current);
         setPath(crumbs);
         await readDir(current);
@@ -249,6 +382,7 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
 
   const openDir = async (dir) => {
     setDirHandle(dir.handle);
+    resetScanner();
     setPath((p) => [...p, { name: dir.name, handle: dir.handle }]);
     await readDir(dir.handle);
     setLocationError(null);
@@ -258,6 +392,7 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
     const target = path[index];
     if (!target || !target.handle) return;
     setDirHandle(target.handle);
+    resetScanner();
     setPath(path.slice(0, index + 1));
     await readDir(target.handle);
     setLocationError(null);
@@ -270,10 +405,206 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
     setPath(newPath);
     if (prev?.handle) {
       setDirHandle(prev.handle);
+      resetScanner();
       await readDir(prev.handle);
       setLocationError(null);
     }
   };
+
+  const startScan = useCallback(async () => {
+    if (!dirHandle) return;
+    if (!hasWorker || typeof Worker !== 'function') {
+      setScanState({ status: 'error', progress: 0, message: 'Background workers are not supported in this browser.', processed: 0, total: 0 });
+      return;
+    }
+    try {
+      if (typeof dirHandle.requestPermission === 'function') {
+        const permission = await dirHandle.requestPermission({ mode: 'readwrite' });
+        if (permission && permission !== 'granted') {
+          setScanState({ status: 'error', progress: 0, message: 'Permission to modify files was denied.', processed: 0, total: 0 });
+          return;
+        }
+      }
+    } catch (error) {
+      setScanState({ status: 'error', progress: 0, message: error?.message || 'Unable to request permissions.', processed: 0, total: 0 });
+      return;
+    }
+
+    if (scanWorkerRef.current) {
+      scanWorkerRef.current.terminate();
+      scanWorkerRef.current = null;
+    }
+
+    const worker = new Worker(new URL('./file-explorer.hash.worker.js', import.meta.url));
+    scanWorkerRef.current = worker;
+    scanRootRef.current = dirHandle;
+    recycleDirRef.current = null;
+    undoManagerRef.current.clear();
+    setDuplicateGroups([]);
+    setSelection({});
+    setUndoPrompt(null);
+    setActionError(null);
+    setScanState({ status: 'scanning', progress: 0, message: null, processed: 0, total: 0 });
+
+    worker.onmessage = (event) => {
+      const { type } = event.data || {};
+      if (type === 'progress') {
+        const processed = Number(event.data.processed) || 0;
+        const total = Number(event.data.total) || 0;
+        const progress = total > 0 ? processed / total : 0;
+        setScanState({ status: 'scanning', progress, message: null, processed, total });
+        shellRef.current?.setBadge?.({ progress, text: `${Math.round(progress * 100)}%` });
+      } else if (type === 'complete') {
+        worker.terminate();
+        scanWorkerRef.current = null;
+        shellRef.current?.clearBadge?.();
+        setScanState((prev) => ({ ...prev, status: 'completed', progress: 1, message: null, processed: prev.total || prev.processed, total: prev.total || prev.processed }));
+        const groups = Array.isArray(event.data.groups) ? event.data.groups : [];
+        groups.sort((a, b) => (b.files?.length || 0) - (a.files?.length || 0) || (b.size || 0) - (a.size || 0));
+        setDuplicateGroups(groups);
+        setSelection(() => {
+          const defaults = {};
+          groups.forEach((group) => {
+            (group.files || []).forEach((file, index) => {
+              defaults[makeFileKey(group.id, file)] = index > 0;
+            });
+          });
+          return defaults;
+        });
+      } else if (type === 'cancelled') {
+        worker.terminate();
+        scanWorkerRef.current = null;
+        shellRef.current?.clearBadge?.();
+        setScanState({ status: 'cancelled', progress: 0, message: null, processed: 0, total: 0 });
+      } else if (type === 'error') {
+        worker.terminate();
+        scanWorkerRef.current = null;
+        shellRef.current?.clearBadge?.();
+        setScanState({ status: 'error', progress: 0, message: event.data.message || 'Scan failed.', processed: 0, total: 0 });
+      }
+    };
+
+    worker.postMessage({ type: 'start', directoryHandle: dirHandle });
+  }, [dirHandle, hasWorker]);
+
+  const cancelScan = useCallback(() => {
+    if (!scanWorkerRef.current) return;
+    scanWorkerRef.current.postMessage({ type: 'cancel' });
+    setScanState((prev) => ({ ...prev, status: 'cancelling' }));
+  }, []);
+
+  const toggleSelection = useCallback((groupId, file) => {
+    const key = makeFileKey(groupId, file);
+    setSelection((prev) => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+
+  const handleSelectAll = useCallback(
+    (groupId, value) => {
+      setSelection((prev) => {
+        const next = { ...prev };
+        const group = duplicateGroups.find((g) => g.id === groupId);
+        if (!group) return prev;
+        group.files.forEach((file, index) => {
+          next[makeFileKey(groupId, file)] = typeof value === 'boolean' ? value : index > 0;
+        });
+        return next;
+      });
+    },
+    [duplicateGroups]
+  );
+
+  const handleDeleteSelected = useCallback(
+    async (group) => {
+      if (!group || !dirHandle) return;
+      const selectedFiles = (group.files || []).filter((file) => selection[makeFileKey(group.id, file)]);
+      if (selectedFiles.length === 0) return;
+      const targetKeys = new Set(selectedFiles.map((file) => makeFileKey(group.id, file)));
+      const deletedEntries = [];
+      setActionError(null);
+      try {
+        for (let i = 0; i < selectedFiles.length; i += 1) {
+          const entry = await moveFileToRecycleBin(group.id, selectedFiles[i]);
+          deletedEntries.push(entry);
+        }
+      } catch (error) {
+        setActionError(error?.message || 'Unable to move files to recycle bin.');
+        if (deletedEntries.length > 0) {
+          await restoreDeletion({ files: deletedEntries }, restoreFileEntry);
+        }
+        return;
+      }
+
+      const snapshot = {
+        ...group,
+        files: (group.files || []).map((file) => ({ ...file })),
+      };
+      undoManagerRef.current.push({ files: deletedEntries, groupSnapshot: snapshot });
+      setUndoPrompt({
+        count: deletedEntries.length,
+        groupId: group.id,
+        message: `${deletedEntries.length} file${deletedEntries.length === 1 ? '' : 's'} moved to recycle bin.`,
+      });
+
+      setSelection((prev) => {
+        const next = { ...prev };
+        targetKeys.forEach((key) => {
+          delete next[key];
+        });
+        return next;
+      });
+
+      setDuplicateGroups((prev) => {
+        const next = prev
+          .map((item) => {
+            if (item.id !== group.id) return item;
+            const remaining = (item.files || []).filter((file) => !targetKeys.has(makeFileKey(group.id, file)));
+            return { ...item, files: remaining };
+          })
+          .filter((item) => (item.files?.length || 0) > 1);
+        next.sort((a, b) => (b.files?.length || 0) - (a.files?.length || 0) || (b.size || 0) - (a.size || 0));
+        return next;
+      });
+
+      await readDir(dirHandle);
+    },
+    [dirHandle, moveFileToRecycleBin, readDir, restoreFileEntry, selection]
+  );
+
+  const applySnapshot = useCallback((snapshot) => {
+    if (!snapshot) return;
+    const sanitized = {
+      ...snapshot,
+      files: Array.isArray(snapshot.files) ? snapshot.files.map((file) => ({ ...file })) : [],
+    };
+    setDuplicateGroups((prev) => {
+      const next = prev.filter((group) => group.id !== sanitized.id);
+      if (sanitized.files.length > 1) {
+        next.push(sanitized);
+      }
+      next.sort((a, b) => (b.files?.length || 0) - (a.files?.length || 0) || (b.size || 0) - (a.size || 0));
+      return next;
+    });
+    setSelection((prev) => {
+      const next = { ...prev };
+      Object.keys(next).forEach((key) => {
+        if (key.startsWith(`${sanitized.id}:`)) delete next[key];
+      });
+      sanitized.files.forEach((file, index) => {
+        next[makeFileKey(sanitized.id, file)] = index > 0;
+      });
+      return next;
+    });
+  }, []);
+
+  const handleUndo = useCallback(async () => {
+    const operation = undoManagerRef.current.pop();
+    if (!operation) return;
+    await restoreDeletion(operation, restoreFileEntry);
+    applySnapshot(operation.groupSnapshot);
+    setUndoPrompt(null);
+    setActionError(null);
+    if (dirHandle) await readDir(dirHandle);
+  }, [applySnapshot, dirHandle, readDir, restoreFileEntry]);
 
   const saveFile = async () => {
     if (!currentFile) return;
@@ -408,22 +739,135 @@ export default function FileExplorer({ context, initialPath, path: pathProp } = 
           {currentFile && (
             <textarea className="flex-1 p-2 bg-ub-cool-grey outline-none" value={content} onChange={onChange} />
           )}
-          <div className="p-2 border-t border-gray-600">
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Find in files"
-              className="px-1 py-0.5 text-black"
-            />
-            <button onClick={runSearch} className="ml-2 px-2 py-1 bg-black bg-opacity-50 rounded">
-              Search
-            </button>
-            <div className="max-h-40 overflow-auto mt-2">
-              {results.map((r, i) => (
-                <div key={i}>
-                  <span className="font-bold">{r.file}:{r.line}</span> {r.text}
+          <div className="p-2 border-t border-gray-600 space-y-4">
+            <div>
+              <div className="flex items-center">
+                <input
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Find in files"
+                  className="px-1 py-0.5 text-black flex-1"
+                />
+                <button onClick={runSearch} className="ml-2 px-2 py-1 bg-black bg-opacity-50 rounded">
+                  Search
+                </button>
+              </div>
+              <div className="max-h-40 overflow-auto mt-2">
+                {results.map((r, i) => (
+                  <div key={i}>
+                    <span className="font-bold">{r.file}:{r.line}</span> {r.text}
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="font-semibold">Duplicate Scanner</div>
+                  <div className="text-xs text-gray-300">
+                    Identify duplicate files by content hash and manage safe deletions.
+                  </div>
                 </div>
-              ))}
+                <div className="flex items-center space-x-2">
+                  {(scanState.status === 'scanning' || scanState.status === 'cancelling') && (
+                    <button onClick={cancelScan} className="px-2 py-1 bg-black bg-opacity-50 rounded">
+                      Cancel
+                    </button>
+                  )}
+                  {scanState.status !== 'scanning' && scanState.status !== 'cancelling' && (
+                    <button
+                      onClick={startScan}
+                      className="px-2 py-1 bg-black bg-opacity-50 rounded"
+                      disabled={!dirHandle || !hasWorker}
+                    >
+                      Scan
+                    </button>
+                  )}
+                </div>
+              </div>
+              {(scanState.status === 'scanning' || scanState.status === 'cancelling') && (
+                <div className="flex items-center space-x-2" role="status">
+                  <progress className="flex-1" value={scanState.progress} max={1} />
+                  <span className="text-xs">{`${Math.round((scanState.progress || 0) * 100)}%`}</span>
+                </div>
+              )}
+              {scanState.status === 'error' && scanState.message && (
+                <div className="text-xs text-red-400">{scanState.message}</div>
+              )}
+              {scanState.status === 'cancelled' && (
+                <div className="text-xs text-yellow-300">Scan cancelled.</div>
+              )}
+              {duplicateGroups.length > 0 ? (
+                <div className="space-y-3 max-h-60 overflow-auto pr-1">
+                  {duplicateGroups.map((group) => {
+                    const selectedFiles = (group.files || []).filter((file) => selection[makeFileKey(group.id, file)]);
+                    return (
+                      <div key={group.id} className="border border-gray-700 rounded p-2 bg-black bg-opacity-20">
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <div className="font-semibold">
+                              Hash {group.hash.slice(0, 8)} · {group.files.length} file{group.files.length === 1 ? '' : 's'}
+                            </div>
+                            <div className="text-xs text-gray-300">Size: {formatBytes(group.size)}</div>
+                          </div>
+                          <div className="flex items-center space-x-2">
+                            <button
+                              onClick={() => handleSelectAll(group.id, true)}
+                              className="px-2 py-1 bg-black bg-opacity-50 rounded"
+                            >
+                              Select all
+                            </button>
+                            <button
+                              onClick={() => handleSelectAll(group.id, false)}
+                              className="px-2 py-1 bg-black bg-opacity-50 rounded"
+                            >
+                              Clear
+                            </button>
+                            <button
+                              onClick={() => handleDeleteSelected(group)}
+                              disabled={selectedFiles.length === 0}
+                              className="px-2 py-1 bg-ub-orange bg-opacity-80 text-black rounded disabled:opacity-40"
+                            >
+                              Delete selected
+                            </button>
+                          </div>
+                        </div>
+                        <ul className="mt-2 space-y-1 text-xs">
+                          {(group.files || []).map((file, index) => {
+                            const key = makeFileKey(group.id, file);
+                            return (
+                              <li key={key} className="flex items-center">
+                                <input
+                                  type="checkbox"
+                                  className="mr-2"
+                                  checked={Boolean(selection[key])}
+                                  onChange={() => toggleSelection(group.id, file)}
+                                />
+                                <span className="truncate" title={file.path}>
+                                  {index === 0 ? 'Keep' : 'Duplicate'} · {file.path}
+                                </span>
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                scanState.status === 'completed' && (
+                  <div className="text-xs text-gray-300">No duplicate files detected.</div>
+                )
+              )}
+              {actionError && <div className="text-xs text-red-400">{actionError}</div>}
+              {undoPrompt && (
+                <div className="flex items-center justify-between bg-black bg-opacity-30 border border-gray-700 rounded px-2 py-2 text-xs">
+                  <span>{undoPrompt.message}</span>
+                  <button onClick={handleUndo} className="px-2 py-1 bg-black bg-opacity-50 rounded">
+                    Undo
+                  </button>
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 
 export default function Taskbar(props) {
     const runningApps = props.apps.filter(app => props.closed_windows[app.id] === false);
+    const badges = props.badges || {};
 
     const handleClick = (app) => {
         const id = app.id;
@@ -36,12 +37,20 @@ export default function Taskbar(props) {
                     const isMinimized = Boolean(props.minimized_windows[app.id]);
                     const isFocused = Boolean(props.focused_windows[app.id]);
                     const isActive = !isMinimized;
+                    const badge = badges[app.id] || null;
+                    const hasText = badge && typeof badge.text === 'string' && badge.text.trim();
+                    const progressValue = typeof badge?.progress === 'number' && Number.isFinite(badge.progress)
+                        ? Math.min(1, Math.max(0, badge.progress))
+                        : null;
+                    const badgeText = hasText ? badge.text.trim() : null;
+                    const badgeLabel = badgeText || (progressValue !== null ? `${Math.round(progressValue * 100)}%` : null);
+                    const ariaLabel = badgeLabel ? `${app.title} (${badgeLabel})` : app.title;
 
                     return (
                         <button
                             key={app.id}
                             type="button"
-                            aria-label={app.title}
+                            aria-label={ariaLabel}
                             data-context="taskbar"
                             data-app-id={app.id}
                             data-active={isActive ? 'true' : 'false'}
@@ -73,17 +82,37 @@ export default function Taskbar(props) {
                             >
                                 {app.title}
                             </span>
-                            {isActive && (
+                            {badgeLabel && (
                                 <span
                                     aria-hidden="true"
-                                    data-testid="running-indicator"
-                                    className="absolute bottom-1 left-1/2 -translate-x-1/2 rounded"
-                                    style={{
-                                        width: '0.5rem',
-                                        height: '0.25rem',
-                                        background: 'currentColor',
-                                    }}
-                                />
+                                    className="absolute -top-1 -right-1 rounded-full bg-ub-orange px-1 py-0.5 text-[0.6rem] font-semibold text-black"
+                                >
+                                    {badgeLabel}
+                                </span>
+                            )}
+                            {progressValue !== null ? (
+                                <span
+                                    aria-hidden="true"
+                                    className="absolute left-2 right-2 bottom-1 h-1 rounded bg-white/20 overflow-hidden"
+                                >
+                                    <span
+                                        className="block h-full bg-ub-orange"
+                                        style={{ width: `${Math.max(0, Math.min(100, progressValue * 100))}%` }}
+                                    />
+                                </span>
+                            ) : (
+                                isActive && (
+                                    <span
+                                        aria-hidden="true"
+                                        data-testid="running-indicator"
+                                        className="absolute bottom-1 left-1/2 -translate-x-1/2 rounded"
+                                        style={{
+                                            width: '0.5rem',
+                                            height: '0.25rem',
+                                            background: 'currentColor',
+                                        }}
+                                    />
+                                )
                             )}
                         </button>
                     );

--- a/modules/fileExplorer/hashUtils.js
+++ b/modules/fileExplorer/hashUtils.js
@@ -1,0 +1,93 @@
+const toUint8 = (buffer) => {
+  if (!buffer) return new Uint8Array();
+  if (buffer instanceof Uint8Array) return buffer;
+  if (buffer.buffer instanceof ArrayBuffer && buffer.byteLength !== undefined) {
+    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  }
+  return new Uint8Array(buffer);
+};
+
+export const buffersEqual = (a, b) => {
+  if (a === b) return true;
+  const viewA = toUint8(a);
+  const viewB = toUint8(b);
+  if (viewA.byteLength !== viewB.byteLength) return false;
+  for (let i = 0; i < viewA.byteLength; i += 1) {
+    if (viewA[i] !== viewB[i]) return false;
+  }
+  return true;
+};
+
+export const createDuplicateGroups = (records = []) => {
+  const byHash = new Map();
+  records.forEach((record) => {
+    if (!record || !record.hash) return;
+    const existing = byHash.get(record.hash) || [];
+    existing.push(record);
+    byHash.set(record.hash, existing);
+  });
+
+  const groups = [];
+  let counter = 0;
+
+  byHash.forEach((items, hash) => {
+    if (!Array.isArray(items) || items.length < 2) return;
+
+    const partitions = [];
+
+    items.forEach((item) => {
+      if (!item) return;
+      const size = item.size ?? (item.content ? toUint8(item.content).byteLength : 0);
+      const segments = Array.isArray(item.segments)
+        ? item.segments
+        : Array.isArray(item.path)
+        ? item.path
+        : [];
+      const pathString = item.pathString || segments.join('/');
+      const name = item.name || segments[segments.length - 1] || pathString;
+      const candidate = {
+        hash,
+        size,
+        segments,
+        path: pathString,
+        name,
+        type: item.type || '',
+        content: item.content,
+      };
+
+      let matched = false;
+      for (let i = 0; i < partitions.length; i += 1) {
+        const part = partitions[i];
+        if (part.size !== size) continue;
+        if (buffersEqual(part.content, candidate.content)) {
+          part.items.push(candidate);
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) {
+        partitions.push({ size, content: candidate.content, items: [candidate] });
+      }
+    });
+
+    partitions.forEach((partition) => {
+      if (!partition || partition.items.length < 2) return;
+      const files = partition.items.map((entry) => ({
+        path: entry.path,
+        segments: [...entry.segments],
+        name: entry.name,
+        size: entry.size,
+        type: entry.type,
+      }));
+      counter += 1;
+      groups.push({
+        id: `${hash}-${counter}`,
+        hash,
+        size: partition.size,
+        files,
+      });
+    });
+  });
+
+  return groups;
+};

--- a/modules/fileExplorer/undoManager.js
+++ b/modules/fileExplorer/undoManager.js
@@ -1,0 +1,45 @@
+export class RecycleBinUndoManager {
+  constructor() {
+    this.stack = [];
+  }
+
+  push(operation) {
+    if (!operation || !Array.isArray(operation.files) || operation.files.length === 0) return;
+    const snapshot = operation.groupSnapshot
+      ? {
+          ...operation.groupSnapshot,
+          files: Array.isArray(operation.groupSnapshot.files)
+            ? operation.groupSnapshot.files.map((file) => ({ ...file }))
+            : [],
+        }
+      : undefined;
+    const safeOperation = {
+      ...operation,
+      groupSnapshot: snapshot,
+      files: operation.files.map((file) => ({ ...file })),
+    };
+    this.stack.push(safeOperation);
+  }
+
+  pop() {
+    if (this.stack.length === 0) return null;
+    return this.stack.pop() || null;
+  }
+
+  clear() {
+    this.stack = [];
+  }
+
+  get size() {
+    return this.stack.length;
+  }
+}
+
+export const restoreDeletion = async (operation, restorer) => {
+  if (!operation || typeof restorer !== 'function') return false;
+  const entries = Array.isArray(operation.files) ? operation.files : [];
+  for (let i = 0; i < entries.length; i += 1) {
+    await restorer(entries[i]);
+  }
+  return entries.length > 0;
+};


### PR DESCRIPTION
## Summary
- integrate a worker-based content hash scanner into File Explorer and surface progress as taskbar badges
- add duplicate grouping UI with cancel, select helpers, and a recycle-bin backed safe delete with undo support
- introduce hash/undo utilities and unit tests covering hash collisions and undo restoration

## Testing
- yarn test fileExplorerHashUtils
- yarn test fileExplorerUndo

------
https://chatgpt.com/codex/tasks/task_e_68dccad8ac0c8328a0d992bec8bbfb2e