### PR TITLE
[workspaces] add template wizard and undo store

### DIFF
--- a/__tests__/workspaceStore.test.ts
+++ b/__tests__/workspaceStore.test.ts
@@ -1,0 +1,72 @@
+import {
+  createWorkspaceFromTemplate,
+  getPendingHistoryAction,
+  getState,
+  getTemplates,
+  resetWorkspaceStore,
+  undoHistoryAction,
+} from '../utils/workspaces/store';
+
+describe('workspace store', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resetWorkspaceStore();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    resetWorkspaceStore();
+  });
+
+  it('seeds workspace with template tabs and settings', () => {
+    const templates = getTemplates();
+    expect(templates.length).toBeGreaterThan(0);
+    const template = templates[0];
+
+    const workspace = createWorkspaceFromTemplate(template.id, { name: `${template.name} Copy` });
+
+    expect(workspace.templateId).toBe(template.id);
+    expect(workspace.tabs).toEqual(template.workspace.tabs);
+    expect(workspace.settings).toEqual(template.workspace.settings);
+    expect(workspace.name).toBe(`${template.name} Copy`);
+
+    const state = getState();
+    expect(state.workspaces).toHaveLength(1);
+    expect(state.workspaces[0].settings).toEqual(template.workspace.settings);
+    expect(state.activeWorkspaceId).toBe(state.workspaces[0].id);
+  });
+
+  it('undo restores prior workspace state when executed before expiry', () => {
+    const templates = getTemplates();
+    createWorkspaceFromTemplate(templates[0].id);
+    const second = createWorkspaceFromTemplate(templates[1].id);
+
+    let state = getState();
+    expect(state.workspaces).toHaveLength(2);
+
+    const history = getPendingHistoryAction();
+    expect(history).not.toBeNull();
+
+    const undone = undoHistoryAction(history!.id);
+    expect(undone).toBe(true);
+
+    state = getState();
+    expect(state.workspaces).toHaveLength(1);
+    expect(state.workspaces[0].id).not.toBe(second.id);
+    expect(getPendingHistoryAction()).toBeNull();
+  });
+
+  it('expires undo after 10 seconds', () => {
+    const templates = getTemplates();
+    createWorkspaceFromTemplate(templates[0].id);
+    const history = getPendingHistoryAction();
+    expect(history).not.toBeNull();
+
+    jest.advanceTimersByTime(10_000);
+    jest.runOnlyPendingTimers();
+
+    expect(getPendingHistoryAction()).toBeNull();
+    expect(undoHistoryAction(history!.id)).toBe(false);
+  });
+});

--- a/components/workspaces/StarterWizard.tsx
+++ b/components/workspaces/StarterWizard.tsx
@@ -1,0 +1,205 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  HistoryPreview,
+  WorkspaceTemplate,
+  createWorkspaceFromTemplate,
+  getPendingHistoryAction,
+  getTemplates,
+  undoHistoryAction,
+} from '../../utils/workspaces/store';
+
+const formatCountdown = (expiresAt: number): string => {
+  const remaining = Math.max(0, expiresAt - Date.now());
+  const seconds = Math.ceil(remaining / 1000);
+  return `${seconds}s`;
+};
+
+const StarterWizard: React.FC = () => {
+  const templates = useMemo<WorkspaceTemplate[]>(() => getTemplates(), []);
+  const [selectedId, setSelectedId] = useState(() => templates[0]?.id ?? '');
+  const [historyPreview, setHistoryPreview] = useState<HistoryPreview | null>(() => getPendingHistoryAction());
+  const [countdownLabel, setCountdownLabel] = useState(() =>
+    historyPreview ? formatCountdown(historyPreview.expiresAt) : '',
+  );
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const selectedTemplate = useMemo(
+    () => templates.find(template => template.id === selectedId) ?? null,
+    [selectedId, templates],
+  );
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const preview = getPendingHistoryAction();
+      setHistoryPreview(preview);
+      setCountdownLabel(preview ? formatCountdown(preview.expiresAt) : '');
+    }, 300);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleCreate = () => {
+    if (!selectedTemplate) return;
+    const workspace = createWorkspaceFromTemplate(selectedTemplate.id);
+    setStatusMessage(`Workspace "${workspace.name}" created.`);
+    const preview = getPendingHistoryAction();
+    setHistoryPreview(preview);
+    setCountdownLabel(preview ? formatCountdown(preview.expiresAt) : '');
+  };
+
+  const handleUndo = () => {
+    if (!historyPreview) return;
+    const undone = undoHistoryAction(historyPreview.id);
+    if (undone) {
+      setStatusMessage('Workspace creation undone.');
+      const preview = getPendingHistoryAction();
+      setHistoryPreview(preview);
+      setCountdownLabel(preview ? formatCountdown(preview.expiresAt) : '');
+    }
+  };
+
+  if (templates.length === 0) {
+    return (
+      <div className="rounded border border-gray-700 bg-ub-grey/80 p-4 text-sm text-gray-300">
+        No workspace templates available.
+      </div>
+    );
+  }
+
+  return (
+    <section className="space-y-4 rounded border border-gray-700 bg-ub-grey/80 p-4 text-white">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold">Workspace Starter Wizard</h2>
+        <p className="text-sm text-gray-300">
+          Pick a template to seed tabs, layout, and tooling for a new workspace. You can undo for 10 seconds
+          after creating one.
+        </p>
+      </header>
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">Templates</h3>
+          <ul className="space-y-2">
+            {templates.map(template => {
+              const isSelected = template.id === selectedId;
+              return (
+                <li key={template.id}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedId(template.id)}
+                    className={`w-full rounded border px-3 py-2 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ub-orange ${
+                      isSelected
+                        ? 'border-ub-orange bg-ub-grey text-white'
+                        : 'border-gray-700 bg-ub-grey/60 text-gray-200 hover:border-gray-500'
+                    }`}
+                    aria-pressed={isSelected}
+                  >
+                    <span className="block text-sm font-semibold">{template.name}</span>
+                    <span className="mt-1 block text-xs text-gray-300">{template.description}</span>
+                    {template.tags.length > 0 && (
+                      <span className="mt-2 block text-[11px] uppercase tracking-wide text-ub-orange">
+                        {template.tags.join(' · ')}
+                      </span>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+        <div className="md:col-span-2 space-y-4">
+          {selectedTemplate && (
+            <div className="rounded border border-gray-700 bg-ub-grey/70 p-4">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">Preview</h3>
+              <div className="mt-3 space-y-3">
+                <div>
+                  <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-400">Tabs</h4>
+                  <ul className="mt-2 space-y-2 text-sm">
+                    {selectedTemplate.workspace.tabs.map(tab => (
+                      <li
+                        key={tab.id}
+                        className="rounded border border-gray-700 bg-black/20 p-2 text-gray-200"
+                      >
+                        <div className="flex items-center justify-between text-xs uppercase tracking-wide text-gray-400">
+                          <span>{tab.type}</span>
+                          {tab.pinned && <span className="text-ub-orange">Pinned</span>}
+                        </div>
+                        <div className="text-sm font-medium text-white">{tab.title}</div>
+                        {tab.data?.command && (
+                          <pre className="mt-2 rounded bg-black/30 p-2 text-xs text-ub-orange">
+                            {tab.data.command}
+                          </pre>
+                        )}
+                        {tab.data?.body && (
+                          <p className="mt-2 text-xs text-gray-300">{tab.data.body}</p>
+                        )}
+                        {tab.data?.dataSource && (
+                          <p className="mt-2 text-xs text-gray-400">Source: {tab.data.dataSource}</p>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-400">Settings</h4>
+                  <dl className="mt-2 grid grid-cols-1 gap-2 text-sm md:grid-cols-2">
+                    <div>
+                      <dt className="text-xs uppercase tracking-wide text-gray-400">Layout</dt>
+                      <dd className="text-white">{selectedTemplate.workspace.settings.layout}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs uppercase tracking-wide text-gray-400">Theme</dt>
+                      <dd className="text-white">{selectedTemplate.workspace.settings.theme}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs uppercase tracking-wide text-gray-400">Telemetry</dt>
+                      <dd className="text-white">
+                        {selectedTemplate.workspace.settings.showTelemetry ? 'Enabled' : 'Disabled'}
+                      </dd>
+                    </div>
+                    {selectedTemplate.workspace.settings.pinnedTools && (
+                      <div className="md:col-span-2">
+                        <dt className="text-xs uppercase tracking-wide text-gray-400">Pinned tools</dt>
+                        <dd className="text-white">
+                          {selectedTemplate.workspace.settings.pinnedTools.join(', ')}
+                        </dd>
+                      </div>
+                    )}
+                    {selectedTemplate.workspace.settings.notebookVisibility && (
+                      <div>
+                        <dt className="text-xs uppercase tracking-wide text-gray-400">Notebook</dt>
+                        <dd className="text-white">
+                          {selectedTemplate.workspace.settings.notebookVisibility}
+                        </dd>
+                      </div>
+                    )}
+                  </dl>
+                </div>
+              </div>
+            </div>
+          )}
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={handleCreate}
+              className="rounded bg-ub-orange px-4 py-2 text-sm font-semibold text-black transition hover:bg-ub-orange/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ub-orange"
+              disabled={!selectedTemplate}
+            >
+              Create workspace
+            </button>
+            {historyPreview && (
+              <button
+                type="button"
+                onClick={handleUndo}
+                className="rounded border border-gray-600 px-3 py-2 text-sm text-gray-200 transition hover:border-ub-orange hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ub-orange"
+              >
+                Undo ({countdownLabel})
+              </button>
+            )}
+            {statusMessage && <span className="text-sm text-gray-300">{statusMessage}</span>}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default StarterWizard;

--- a/data/project-templates/schema.json
+++ b/data/project-templates/schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "WorkspaceTemplateCatalog",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "templates"],
+  "properties": {
+    "version": {
+      "type": "number",
+      "minimum": 1
+    },
+    "templates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/template"
+      }
+    }
+  },
+  "definitions": {
+    "template": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "description", "tags", "workspace"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "badges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "workspace": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["tabs", "settings"],
+          "properties": {
+            "tabs": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/tab"
+              }
+            },
+            "settings": {
+              "$ref": "#/definitions/settings"
+            }
+          }
+        }
+      }
+    },
+    "tab": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "type"],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["terminal", "notes", "report", "visualizer"]
+        },
+        "pinned": {
+          "type": "boolean"
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "type": "string"
+            },
+            "body": {
+              "type": "string"
+            },
+            "dataSource": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "settings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["layout", "theme"],
+      "properties": {
+        "layout": {
+          "type": "string",
+          "enum": ["grid", "focus", "column"]
+        },
+        "theme": {
+          "type": "string",
+          "enum": ["terminal", "midnight", "blueprint"]
+        },
+        "showTelemetry": {
+          "type": "boolean"
+        },
+        "pinnedTools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notebookVisibility": {
+          "type": "string",
+          "enum": ["collapsed", "expanded"]
+        }
+      }
+    }
+  }
+}

--- a/data/project-templates/templates.json
+++ b/data/project-templates/templates.json
@@ -1,0 +1,129 @@
+{
+  "version": 1,
+  "templates": [
+    {
+      "id": "recon-kickoff",
+      "name": "Recon Kickoff",
+      "description": "Launch reconnaissance with terminal commands, observation notes, and a network visualizer ready to populate.",
+      "tags": ["offensive", "recon", "network"],
+      "badges": ["popular", "recommended"],
+      "workspace": {
+        "tabs": [
+          {
+            "id": "terminal-seed",
+            "title": "Terminal",
+            "type": "terminal",
+            "pinned": true,
+            "data": {
+              "command": "nmap -A target.local"
+            }
+          },
+          {
+            "id": "notes-seed",
+            "title": "Recon Notes",
+            "type": "notes",
+            "data": {
+              "body": "Document scope, discovered hosts, and open services."
+            }
+          },
+          {
+            "id": "graph-seed",
+            "title": "Topology",
+            "type": "visualizer",
+            "data": {
+              "dataSource": "network-map"
+            }
+          }
+        ],
+        "settings": {
+          "layout": "grid",
+          "theme": "terminal",
+          "showTelemetry": false,
+          "pinnedTools": ["terminal", "notes"],
+          "notebookVisibility": "expanded"
+        }
+      }
+    },
+    {
+      "id": "blue-team-monitor",
+      "name": "Blue Team Monitor",
+      "description": "Review SIEM timelines, recent alerts, and draft remediation notes in a single workspace.",
+      "tags": ["defensive", "monitoring"],
+      "workspace": {
+        "tabs": [
+          {
+            "id": "timeline-seed",
+            "title": "Event Timeline",
+            "type": "visualizer",
+            "pinned": true,
+            "data": {
+              "dataSource": "siem-timeline"
+            }
+          },
+          {
+            "id": "alerts-seed",
+            "title": "Active Alerts",
+            "type": "report",
+            "data": {
+              "body": "Review endpoint alerts, triage priority, and mark containment status."
+            }
+          },
+          {
+            "id": "notes-remediation",
+            "title": "Remediation Notes",
+            "type": "notes"
+          }
+        ],
+        "settings": {
+          "layout": "focus",
+          "theme": "midnight",
+          "showTelemetry": true,
+          "pinnedTools": ["timeline", "reports"],
+          "notebookVisibility": "collapsed"
+        }
+      }
+    },
+    {
+      "id": "web-app-audit",
+      "name": "Web App Audit",
+      "description": "Organize findings, HTTP captures, and checklist tasks for web assessment workflows.",
+      "tags": ["offensive", "web"],
+      "workspace": {
+        "tabs": [
+          {
+            "id": "findings-seed",
+            "title": "Findings Log",
+            "type": "report",
+            "data": {
+              "body": "Catalog confirmed issues with reproduction steps and severity ratings."
+            }
+          },
+          {
+            "id": "captures-seed",
+            "title": "HTTP Captures",
+            "type": "visualizer",
+            "data": {
+              "dataSource": "burp-history"
+            }
+          },
+          {
+            "id": "checklist-seed",
+            "title": "Checklist",
+            "type": "notes",
+            "pinned": true,
+            "data": {
+              "body": "- [ ] Session management\n- [ ] Input validation\n- [ ] Access control"
+            }
+          }
+        ],
+        "settings": {
+          "layout": "column",
+          "theme": "blueprint",
+          "showTelemetry": false,
+          "pinnedTools": ["notes", "reports", "captures"],
+          "notebookVisibility": "expanded"
+        }
+      }
+    }
+  ]
+}

--- a/pages/module-workspace.tsx
+++ b/pages/module-workspace.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useCallback } from 'react';
 import usePersistentState from '../hooks/usePersistentState';
 import { setValue, getAll } from '../utils/moduleStore';
+import StarterWizard from '../components/workspaces/StarterWizard';
 
 interface ModuleOption {
   name: string;
@@ -113,6 +114,7 @@ const ModuleWorkspace: React.FC = () => {
 
   return (
     <div className="p-4 space-y-4 bg-ub-cool-grey text-white min-h-screen">
+      <StarterWizard />
       <section className="space-y-2">
         <h1 className="text-xl font-semibold">Workspaces</h1>
           <div className="flex gap-2">
@@ -213,6 +215,7 @@ const ModuleWorkspace: React.FC = () => {
                   <div className="flex flex-col gap-2 sm:flex-row">
                     <button
                       onClick={runCommand}
+                      aria-label="Run"
                       className="rounded bg-green-600 px-3 py-2 text-sm font-semibold text-black transition hover:bg-green-500"
                     >
                       Run Command

--- a/utils/workspaces/store.ts
+++ b/utils/workspaces/store.ts
@@ -1,0 +1,449 @@
+import schemaDefinition from '../../data/project-templates/schema.json';
+import templatesCatalog from '../../data/project-templates/templates.json';
+
+export type WorkspaceTabType = 'terminal' | 'notes' | 'report' | 'visualizer';
+
+export interface WorkspaceTabData {
+  command?: string;
+  body?: string;
+  dataSource?: string;
+}
+
+export interface WorkspaceTab {
+  id: string;
+  title: string;
+  type: WorkspaceTabType;
+  pinned?: boolean;
+  data?: WorkspaceTabData;
+}
+
+export type WorkspaceLayout = 'grid' | 'focus' | 'column';
+export type WorkspaceTheme = 'terminal' | 'midnight' | 'blueprint';
+export type NotebookVisibility = 'collapsed' | 'expanded';
+
+export interface WorkspaceSettings {
+  layout: WorkspaceLayout;
+  theme: WorkspaceTheme;
+  showTelemetry?: boolean;
+  pinnedTools?: string[];
+  notebookVisibility?: NotebookVisibility;
+}
+
+export interface WorkspaceTemplate {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  badges?: string[];
+  workspace: {
+    tabs: WorkspaceTab[];
+    settings: WorkspaceSettings;
+  };
+}
+
+export interface WorkspaceTemplateCatalog {
+  version: number;
+  templates: WorkspaceTemplate[];
+}
+
+export interface WorkspaceState {
+  id: string;
+  templateId: string;
+  name: string;
+  createdAt: number;
+  tabs: WorkspaceTab[];
+  settings: WorkspaceSettings;
+}
+
+export interface WorkspaceStoreSnapshot {
+  activeWorkspaceId: string | null;
+  workspaces: WorkspaceState[];
+}
+
+export interface HistoryPreview {
+  id: string;
+  description: string;
+  expiresAt: number;
+}
+
+type Listener = (snapshot: WorkspaceStoreSnapshot) => void;
+
+type SchemaEnum = string[] | undefined;
+
+const ensureArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const getSchemaEnum = (path: string[]): SchemaEnum => {
+  let current: unknown = schemaDefinition as unknown;
+  for (const key of path) {
+    if (!isObject(current) || !(key in current)) {
+      return undefined;
+    }
+    current = current[key];
+  }
+  return Array.isArray(current) ? (current as string[]) : undefined;
+};
+
+const allowedTabTypes = getSchemaEnum(['definitions', 'tab', 'properties', 'type', 'enum']) ?? [
+  'terminal',
+  'notes',
+  'report',
+  'visualizer',
+];
+const allowedLayouts = getSchemaEnum(['definitions', 'settings', 'properties', 'layout', 'enum']) ?? [
+  'grid',
+  'focus',
+  'column',
+];
+const allowedThemes = getSchemaEnum(['definitions', 'settings', 'properties', 'theme', 'enum']) ?? [
+  'terminal',
+  'midnight',
+  'blueprint',
+];
+const allowedNotebookVisibilities = getSchemaEnum([
+  'definitions',
+  'settings',
+  'properties',
+  'notebookVisibility',
+  'enum',
+]) ?? ['collapsed', 'expanded'];
+
+const validateTab = (tab: unknown, index: number, templateId: string): WorkspaceTab => {
+  if (!isObject(tab)) {
+    throw new Error(`Template ${templateId} tab #${index} must be an object`);
+  }
+  const { id, title, type, pinned, data } = tab;
+  if (typeof id !== 'string' || !id) {
+    throw new Error(`Template ${templateId} tab #${index} is missing a string id`);
+  }
+  if (typeof title !== 'string' || !title) {
+    throw new Error(`Template ${templateId} tab ${id} is missing a title`);
+  }
+  if (typeof type !== 'string' || !allowedTabTypes.includes(type)) {
+    throw new Error(`Template ${templateId} tab ${id} has invalid type`);
+  }
+  if (pinned !== undefined && typeof pinned !== 'boolean') {
+    throw new Error(`Template ${templateId} tab ${id} has invalid pinned flag`);
+  }
+  let normalizedData: WorkspaceTabData | undefined;
+  if (data !== undefined) {
+    if (!isObject(data)) {
+      throw new Error(`Template ${templateId} tab ${id} data must be an object`);
+    }
+    const candidate: WorkspaceTabData = {};
+    if ('command' in data) {
+      if (typeof data.command !== 'string') {
+        throw new Error(`Template ${templateId} tab ${id} data.command must be string`);
+      }
+      candidate.command = data.command;
+    }
+    if ('body' in data) {
+      if (typeof data.body !== 'string') {
+        throw new Error(`Template ${templateId} tab ${id} data.body must be string`);
+      }
+      candidate.body = data.body;
+    }
+    if ('dataSource' in data) {
+      if (typeof data.dataSource !== 'string') {
+        throw new Error(`Template ${templateId} tab ${id} data.dataSource must be string`);
+      }
+      candidate.dataSource = data.dataSource;
+    }
+    normalizedData = candidate;
+  }
+  return { id, title, type: type as WorkspaceTabType, pinned, data: normalizedData };
+};
+
+const validateSettings = (templateId: string, settings: unknown): WorkspaceSettings => {
+  if (!isObject(settings)) {
+    throw new Error(`Template ${templateId} settings must be an object`);
+  }
+  const { layout, theme, showTelemetry, pinnedTools, notebookVisibility } = settings;
+  if (typeof layout !== 'string' || !allowedLayouts.includes(layout)) {
+    throw new Error(`Template ${templateId} settings have invalid layout`);
+  }
+  if (typeof theme !== 'string' || !allowedThemes.includes(theme)) {
+    throw new Error(`Template ${templateId} settings have invalid theme`);
+  }
+  if (showTelemetry !== undefined && typeof showTelemetry !== 'boolean') {
+    throw new Error(`Template ${templateId} settings showTelemetry must be boolean`);
+  }
+  let normalizedPinned: string[] | undefined;
+  if (pinnedTools !== undefined) {
+    if (!Array.isArray(pinnedTools)) {
+      throw new Error(`Template ${templateId} settings pinnedTools must be an array`);
+    }
+    pinnedTools.forEach((tool, index) => {
+      if (typeof tool !== 'string') {
+        throw new Error(`Template ${templateId} settings pinnedTools[${index}] must be string`);
+      }
+    });
+    normalizedPinned = [...pinnedTools];
+  }
+  let normalizedNotebookVisibility: NotebookVisibility | undefined;
+  if (notebookVisibility !== undefined) {
+    if (typeof notebookVisibility !== 'string' || !allowedNotebookVisibilities.includes(notebookVisibility)) {
+      throw new Error(`Template ${templateId} settings notebookVisibility is invalid`);
+    }
+    normalizedNotebookVisibility = notebookVisibility as NotebookVisibility;
+  }
+  return {
+    layout: layout as WorkspaceLayout,
+    theme: theme as WorkspaceTheme,
+    showTelemetry: showTelemetry as boolean | undefined,
+    pinnedTools: normalizedPinned,
+    notebookVisibility: normalizedNotebookVisibility,
+  };
+};
+
+const validateTemplate = (template: unknown): WorkspaceTemplate => {
+  if (!isObject(template)) {
+    throw new Error('Template entry must be an object');
+  }
+  const { id, name, description, tags, badges, workspace } = template;
+  if (typeof id !== 'string' || !id) {
+    throw new Error('Template is missing id');
+  }
+  if (typeof name !== 'string' || !name) {
+    throw new Error(`Template ${id} is missing name`);
+  }
+  if (typeof description !== 'string' || !description) {
+    throw new Error(`Template ${id} is missing description`);
+  }
+  if (!Array.isArray(tags)) {
+    throw new Error(`Template ${id} tags must be an array`);
+  }
+  tags.forEach((tag, index) => {
+    if (typeof tag !== 'string') {
+      throw new Error(`Template ${id} tag at index ${index} must be string`);
+    }
+  });
+  let normalizedBadges: string[] | undefined;
+  if (badges !== undefined) {
+    if (!Array.isArray(badges)) {
+      throw new Error(`Template ${id} badges must be an array of strings`);
+    }
+    badges.forEach((badge, index) => {
+      if (typeof badge !== 'string') {
+        throw new Error(`Template ${id} badge at index ${index} must be string`);
+      }
+    });
+    normalizedBadges = [...badges];
+  }
+  if (!isObject(workspace)) {
+    throw new Error(`Template ${id} workspace must be an object`);
+  }
+  const rawTabs = ensureArray(workspace.tabs);
+  if (rawTabs.length === 0) {
+    throw new Error(`Template ${id} must define at least one tab`);
+  }
+  const tabs = rawTabs.map((tab, index) => validateTab(tab, index, id));
+  const settings = validateSettings(id, workspace.settings);
+  return {
+    id,
+    name,
+    description,
+    tags: [...tags],
+    badges: normalizedBadges,
+    workspace: {
+      tabs,
+      settings,
+    },
+  };
+};
+
+const validateCatalog = (catalog: unknown): WorkspaceTemplateCatalog => {
+  if (!isObject(catalog)) {
+    throw new Error('Template catalog must be an object');
+  }
+  const { version, templates } = catalog;
+  if (typeof version !== 'number' || Number.isNaN(version)) {
+    throw new Error('Template catalog version must be a number');
+  }
+  if (!Array.isArray(templates) || templates.length === 0) {
+    throw new Error('Template catalog templates must be a non-empty array');
+  }
+  const normalizedTemplates = templates.map(template => validateTemplate(template));
+  return {
+    version,
+    templates: normalizedTemplates,
+  };
+};
+
+const templateCatalog: WorkspaceTemplateCatalog = validateCatalog(templatesCatalog as unknown);
+
+const listeners = new Set<Listener>();
+
+let workspaceSequence = 0;
+
+const cloneTab = (tab: WorkspaceTab): WorkspaceTab => ({
+  id: tab.id,
+  title: tab.title,
+  type: tab.type,
+  pinned: tab.pinned,
+  data: tab.data ? { ...tab.data } : undefined,
+});
+
+const cloneSettings = (settings: WorkspaceSettings): WorkspaceSettings => ({
+  layout: settings.layout,
+  theme: settings.theme,
+  showTelemetry: settings.showTelemetry,
+  pinnedTools: settings.pinnedTools ? [...settings.pinnedTools] : undefined,
+  notebookVisibility: settings.notebookVisibility,
+});
+
+const cloneWorkspace = (workspace: WorkspaceState): WorkspaceState => ({
+  id: workspace.id,
+  templateId: workspace.templateId,
+  name: workspace.name,
+  createdAt: workspace.createdAt,
+  tabs: workspace.tabs.map(cloneTab),
+  settings: cloneSettings(workspace.settings),
+});
+
+const cloneStore = (store: WorkspaceStoreSnapshot): WorkspaceStoreSnapshot => ({
+  activeWorkspaceId: store.activeWorkspaceId,
+  workspaces: store.workspaces.map(cloneWorkspace),
+});
+
+let storeState: WorkspaceStoreSnapshot = {
+  activeWorkspaceId: null,
+  workspaces: [],
+};
+
+interface HistoryEntryInternal {
+  id: string;
+  description: string;
+  expiresAt: number;
+  timeout: ReturnType<typeof setTimeout> | null;
+  restore: WorkspaceStoreSnapshot;
+}
+
+let pendingHistory: HistoryEntryInternal | null = null;
+
+const emit = () => {
+  const snapshot = getState();
+  listeners.forEach(listener => listener(snapshot));
+};
+
+const scheduleHistory = (description: string, previousState: WorkspaceStoreSnapshot, ttlMs = 10_000) => {
+  if (pendingHistory?.timeout) {
+    clearTimeout(pendingHistory.timeout);
+  }
+  const entry: HistoryEntryInternal = {
+    id: `undo-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    description,
+    expiresAt: Date.now() + ttlMs,
+    timeout: null,
+    restore: cloneStore(previousState),
+  };
+  entry.timeout = setTimeout(() => {
+    pendingHistory = null;
+  }, ttlMs);
+  pendingHistory = entry;
+};
+
+export const getTemplates = (): WorkspaceTemplate[] => templateCatalog.templates.map(template => ({
+  ...template,
+  workspace: {
+    tabs: template.workspace.tabs.map(cloneTab),
+    settings: cloneSettings(template.workspace.settings),
+  },
+}));
+
+export const getState = (): WorkspaceStoreSnapshot => cloneStore(storeState);
+
+export const subscribe = (listener: Listener): (() => void) => {
+  listeners.add(listener);
+  listener(getState());
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const setStore = (nextState: WorkspaceStoreSnapshot) => {
+  storeState = cloneStore(nextState);
+  emit();
+};
+
+export const resetWorkspaceStore = () => {
+  if (pendingHistory?.timeout) {
+    clearTimeout(pendingHistory.timeout);
+  }
+  pendingHistory = null;
+  workspaceSequence = 0;
+  storeState = {
+    activeWorkspaceId: null,
+    workspaces: [],
+  };
+  emit();
+};
+
+export const createWorkspaceFromTemplate = (templateId: string, options?: { name?: string }): WorkspaceState => {
+  const template = templateCatalog.templates.find(entry => entry.id === templateId);
+  if (!template) {
+    throw new Error(`Unknown workspace template: ${templateId}`);
+  }
+  const previousState = getState();
+  workspaceSequence += 1;
+  const workspaceId = `${templateId}-${Date.now()}-${workspaceSequence}`;
+  const name = options?.name?.trim() || template.name;
+  const workspace: WorkspaceState = {
+    id: workspaceId,
+    templateId: template.id,
+    name,
+    createdAt: Date.now(),
+    tabs: template.workspace.tabs.map(cloneTab),
+    settings: cloneSettings(template.workspace.settings),
+  };
+  const nextState: WorkspaceStoreSnapshot = {
+    activeWorkspaceId: workspace.id,
+    workspaces: [...storeState.workspaces.map(cloneWorkspace), workspace],
+  };
+  setStore(nextState);
+  scheduleHistory(`Created workspace \"${workspace.name}\"`, previousState);
+  return cloneWorkspace(workspace);
+};
+
+export const setActiveWorkspace = (workspaceId: string | null) => {
+  if (workspaceId === null) {
+    setStore({
+      ...storeState,
+      activeWorkspaceId: null,
+      workspaces: storeState.workspaces.map(cloneWorkspace),
+    });
+    return;
+  }
+  const exists = storeState.workspaces.some(workspace => workspace.id === workspaceId);
+  if (!exists) return;
+  setStore({
+    ...storeState,
+    activeWorkspaceId: workspaceId,
+    workspaces: storeState.workspaces.map(cloneWorkspace),
+  });
+};
+
+export const getPendingHistoryAction = (): HistoryPreview | null => {
+  if (!pendingHistory) return null;
+  return {
+    id: pendingHistory.id,
+    description: pendingHistory.description,
+    expiresAt: pendingHistory.expiresAt,
+  };
+};
+
+export const undoHistoryAction = (id?: string): boolean => {
+  if (!pendingHistory) return false;
+  if (id && pendingHistory.id !== id) {
+    return false;
+  }
+  if (pendingHistory.timeout) {
+    clearTimeout(pendingHistory.timeout);
+  }
+  const restoreState = cloneStore(pendingHistory.restore);
+  pendingHistory = null;
+  setStore(restoreState);
+  return true;
+};


### PR DESCRIPTION
## Summary
- add project workspace template catalog and validation schema
- implement workspace store with template validation, creation, and timed undo support
- wire the starter wizard into the module workspace page with seeded previews and tests

## Testing
- yarn test workspaceStore --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dcde81a2f88328bd88b8eec6791495