### PR TITLE
[workspace] Add reactive env management panel

### DIFF
--- a/__tests__/envStore.test.ts
+++ b/__tests__/envStore.test.ts
@@ -1,0 +1,84 @@
+import {
+  __resetEnvStoreForTests,
+  EnvEntry,
+  deleteKey,
+  getEntries,
+  getValue,
+  setValue,
+  subscribe,
+  validateKey,
+} from '../utils/envStore';
+
+const findEntry = (entries: EnvEntry[], key: string) =>
+  entries.find((entry) => entry.key === key);
+
+describe('envStore', () => {
+  beforeEach(() => {
+    __resetEnvStoreForTests();
+  });
+
+  it('validates keys and prevents reserved overrides', () => {
+    const invalid = setValue(0, 'bad key', 'value');
+    expect(invalid.success).toBe(false);
+    expect(invalid.error).toMatch(/uppercase/i);
+
+    const tooLongKey = 'A'.repeat(70);
+    const tooLong = validateKey(tooLongKey);
+    expect(tooLong.valid).toBe(false);
+    expect(tooLong.message).toMatch(/fewer/i);
+
+    const reserved = setValue(0, 'PATH', '/tmp');
+    expect(reserved.success).toBe(false);
+    expect(reserved.warning).toBeDefined();
+  });
+
+  it('notifies subscribers when values change', () => {
+    const updates: EnvEntry[][] = [];
+    const unsubscribe = subscribe(0, (entries) => {
+      updates.push(entries);
+    });
+
+    expect(updates.length).toBe(1);
+    expect(findEntry(updates[0], 'PATH')).toBeDefined();
+
+    const created = setValue(0, 'API_URL', 'https://example.local');
+    expect(created.success).toBe(true);
+    expect(updates.length).toBeGreaterThan(1);
+
+    const latest = updates[updates.length - 1];
+    const stored = findEntry(latest, 'API_URL');
+    expect(stored).toBeDefined();
+    expect(stored?.value).toBe('https://example.local');
+
+    unsubscribe();
+  });
+
+  it('isolates values per workspace and supports deletion', () => {
+    setValue(0, 'TOKEN', 'ws0-token');
+    setValue(1, 'TOKEN', 'ws1-token');
+
+    expect(getValue(0, 'TOKEN')).toBe('ws0-token');
+    expect(getValue(1, 'TOKEN')).toBe('ws1-token');
+
+    const workspaceOneUpdates: EnvEntry[][] = [];
+    const unsubscribe = subscribe(1, (entries) => {
+      workspaceOneUpdates.push(entries);
+    });
+
+    const initialCount = workspaceOneUpdates.length;
+    setValue(0, 'API_KEY', 'abc');
+    expect(workspaceOneUpdates.length).toBe(initialCount);
+
+    setValue(1, 'API_KEY', 'def');
+    expect(workspaceOneUpdates.length).toBeGreaterThan(initialCount);
+    const latest = workspaceOneUpdates[workspaceOneUpdates.length - 1];
+    expect(findEntry(latest, 'API_KEY')?.value).toBe('def');
+
+    const removal = deleteKey(1, 'TOKEN');
+    expect(removal.success).toBe(true);
+    const afterRemoval = getEntries(1);
+    expect(findEntry(afterRemoval, 'TOKEN')).toBeUndefined();
+
+    unsubscribe();
+  });
+});

--- a/components/workspaces/EnvPanel.tsx
+++ b/components/workspaces/EnvPanel.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import useWorkspaceEnv from '../../hooks/useWorkspaceEnv';
+import type { EnvEntry, EnvMutationResult } from '../../utils/envStore';
+
+interface EditableRowProps {
+  entry: EnvEntry;
+  onSave: (key: string, value: string, previousKey: string) => EnvMutationResult;
+  onDelete: (key: string) => EnvMutationResult;
+  validateKey: (key: string) => { valid: boolean; normalizedKey: string; message?: string; reserved?: boolean };
+}
+
+function EditableRow({ entry, onSave, onDelete, validateKey }: EditableRowProps) {
+  const [draftKey, setDraftKey] = useState(entry.key);
+  const [draftValue, setDraftValue] = useState(entry.value);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(entry.warning ?? null);
+
+  useEffect(() => {
+    setDraftKey(entry.key);
+    setDraftValue(entry.value);
+    setStatus(entry.warning ?? null);
+    setError(null);
+  }, [entry.key, entry.value, entry.warning]);
+
+  const resetMessages = () => {
+    setError(null);
+    setStatus(entry.warning ?? null);
+  };
+
+  const persistChanges = () => {
+    if (entry.readonly) {
+      resetMessages();
+      return;
+    }
+
+    const trimmedValue = draftValue;
+    const validation = validateKey(draftKey);
+    if (!validation.valid) {
+      setError(validation.message ?? 'Invalid key.');
+      return;
+    }
+
+    if (validation.normalizedKey === entry.key && trimmedValue === entry.value) {
+      resetMessages();
+      return;
+    }
+
+    const result = onSave(validation.normalizedKey, trimmedValue, entry.key);
+    if (!result.success) {
+      setError(result.error ?? 'Unable to save variable.');
+      if (result.warning) setStatus(result.warning);
+      return;
+    }
+
+    setError(null);
+    setStatus(result.warning ?? entry.warning ?? null);
+  };
+
+  const handleDelete = () => {
+    const result = onDelete(entry.key);
+    if (!result.success) {
+      setError(result.error ?? 'Unable to remove variable.');
+      if (result.warning) setStatus(result.warning);
+    }
+  };
+
+  const readOnlyBadge = entry.reserved ? (
+    <span className="rounded-full border border-white/20 bg-white/10 px-2 py-0.5 text-[10px] uppercase tracking-wider text-white/70">
+      Reserved
+    </span>
+  ) : null;
+
+  return (
+    <div className="flex flex-col gap-1 rounded-md border border-white/10 bg-slate-900/40 p-3 transition-colors hover:border-white/20">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center">
+        <label className="flex flex-1 flex-col gap-1">
+          <span className="text-xs font-semibold uppercase tracking-wider text-white/60">Key</span>
+          <input
+            id={`env-key-${entry.key}`}
+            value={draftKey}
+            onChange={(event) => {
+              setDraftKey(event.target.value);
+              if (error) setError(null);
+            }}
+            onBlur={persistChanges}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                persistChanges();
+              }
+            }}
+            readOnly={entry.readonly}
+            aria-label="Environment variable key"
+            className={`w-full rounded border px-3 py-2 font-mono text-sm text-white/90 outline-none transition ${
+              entry.readonly
+                ? 'cursor-not-allowed border-white/10 bg-white/5'
+                : 'border-white/10 bg-[#131a26] focus:border-[var(--kali-blue)] focus:ring-2 focus:ring-[var(--kali-blue)]/40'
+            }`}
+            aria-readonly={entry.readonly}
+          />
+        </label>
+        <label className="flex flex-1 flex-col gap-1">
+          <span className="text-xs font-semibold uppercase tracking-wider text-white/60">Value</span>
+          <input
+            id={`env-value-${entry.key}`}
+            value={draftValue}
+            onChange={(event) => {
+              setDraftValue(event.target.value);
+              if (error) setError(null);
+            }}
+            onBlur={persistChanges}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                persistChanges();
+              }
+            }}
+            readOnly={entry.readonly}
+            aria-label="Environment variable value"
+            className={`w-full rounded border px-3 py-2 font-mono text-sm text-white/90 outline-none transition ${
+              entry.readonly
+                ? 'cursor-not-allowed border-white/10 bg-white/5'
+                : 'border-white/10 bg-[#131a26] focus:border-[var(--kali-blue)] focus:ring-2 focus:ring-[var(--kali-blue)]/40'
+            }`}
+            aria-readonly={entry.readonly}
+          />
+        </label>
+        <div className="flex items-center gap-2 self-start pt-6 md:self-center">
+          {readOnlyBadge}
+          {!entry.readonly && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              className="rounded border border-red-500/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-red-200 transition hover:border-red-400 hover:text-red-100"
+            >
+              Remove
+            </button>
+          )}
+        </div>
+      </div>
+      {error && <p className="text-xs text-red-300">{error}</p>}
+      {!error && status && <p className="text-xs text-white/60">{status}</p>}
+    </div>
+  );
+}
+
+export default function EnvPanel() {
+  const { workspaceId, entries, setEntry, deleteEntry, validateKey } = useWorkspaceEnv();
+  const [newKey, setNewKey] = useState('');
+  const [newValue, setNewValue] = useState('');
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [feedbackType, setFeedbackType] = useState<'error' | 'info' | null>(null);
+
+  const editableEntries = useMemo(() => entries.filter((entry) => !entry.reserved), [entries]);
+  const reservedEntries = useMemo(() => entries.filter((entry) => entry.reserved), [entries]);
+
+  const handleCreate = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFeedback(null);
+    setFeedbackType(null);
+
+    const validation = validateKey(newKey);
+    if (!validation.valid) {
+      setFeedback(validation.message ?? 'Invalid key.');
+      setFeedbackType('error');
+      return;
+    }
+    if (validation.reserved) {
+      setFeedback(validation.message ?? 'Reserved variable.');
+      setFeedbackType('error');
+      return;
+    }
+
+    const result = setEntry(validation.normalizedKey, newValue);
+    if (!result.success) {
+      setFeedback(result.error ?? 'Unable to add variable.');
+      setFeedbackType('error');
+      return;
+    }
+
+    setNewKey('');
+    setNewValue('');
+    setFeedback('Variable added to workspace.');
+    setFeedbackType('info');
+  };
+
+  const renderRow = (entry: EnvEntry) => (
+    <EditableRow
+      key={`env-row-${entry.key}`}
+      entry={entry}
+      onSave={(key, value, previousKey) => setEntry(key, value, { previousKey })}
+      onDelete={deleteEntry}
+      validateKey={validateKey}
+    />
+  );
+
+  return (
+    <section className="space-y-4">
+      <header className="flex flex-col gap-1">
+        <h2 className="text-lg font-semibold text-white">Environment Variables</h2>
+        <p className="text-xs text-white/60">
+          Active workspace: <span className="font-mono">{workspaceId + 1}</span>
+        </p>
+        <p className="text-xs text-white/50">
+          Reserved variables mirror the desktop environment and cannot be edited.
+        </p>
+      </header>
+
+      <div className="space-y-3">
+        {reservedEntries.length > 0 && (
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-white/70">System variables</h3>
+            <div className="space-y-2">
+              {reservedEntries.map((entry) => renderRow(entry))}
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-white/70">Workspace variables</h3>
+          {editableEntries.length === 0 ? (
+            <p className="rounded border border-dashed border-white/20 bg-white/5 px-3 py-4 text-sm text-white/60">
+              No custom variables yet. Use the form below to define one.
+            </p>
+          ) : (
+            <div className="space-y-2">{editableEntries.map((entry) => renderRow(entry))}</div>
+          )}
+        </div>
+      </div>
+
+      <form onSubmit={handleCreate} className="space-y-3 rounded-md border border-white/10 bg-slate-900/60 p-4">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-white/70">Add variable</h3>
+        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] md:items-end">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-semibold uppercase tracking-wider text-white/60">Key</span>
+            <input
+              value={newKey}
+              onChange={(event) => setNewKey(event.target.value)}
+              className="rounded border border-white/10 bg-[#131a26] px-3 py-2 font-mono text-sm text-white/90 outline-none transition focus:border-[var(--kali-blue)] focus:ring-2 focus:ring-[var(--kali-blue)]/40"
+              placeholder="API_URL"
+              aria-label="Environment key"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-semibold uppercase tracking-wider text-white/60">Value</span>
+            <input
+              value={newValue}
+              onChange={(event) => setNewValue(event.target.value)}
+              className="rounded border border-white/10 bg-[#131a26] px-3 py-2 font-mono text-sm text-white/90 outline-none transition focus:border-[var(--kali-blue)] focus:ring-2 focus:ring-[var(--kali-blue)]/40"
+              placeholder="https://api.internal"
+              aria-label="Environment value"
+            />
+          </label>
+          <button
+            type="submit"
+            className="h-10 rounded bg-[var(--kali-blue)] px-4 text-xs font-semibold uppercase tracking-wide text-black transition hover:bg-sky-400"
+          >
+            Add variable
+          </button>
+        </div>
+        {feedback && (
+          <p className={`text-xs ${feedbackType === 'error' ? 'text-red-300' : 'text-white/70'}`}>{feedback}</p>
+        )}
+      </form>
+    </section>
+  );
+}

--- a/hooks/useWorkspaceEnv.ts
+++ b/hooks/useWorkspaceEnv.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  EnvEntry,
+  EnvMutationResult,
+  KeyValidationResult,
+  WorkspaceId,
+  deleteKey,
+  getActiveWorkspace,
+  getEntries,
+  getValue,
+  setValue,
+  subscribe,
+  subscribeToWorkspace,
+  validateKey,
+} from '../utils/envStore';
+
+interface UseWorkspaceEnvResult {
+  workspaceId: WorkspaceId;
+  entries: EnvEntry[];
+  setEntry: (
+    key: string,
+    value: string,
+    options?: { previousKey?: string },
+  ) => EnvMutationResult;
+  deleteEntry: (key: string) => EnvMutationResult;
+  validateKey: (key: string) => KeyValidationResult;
+  getEntryValue: (key: string) => string | undefined;
+}
+
+const DEFAULT_WORKSPACE_ID = 0;
+
+export default function useWorkspaceEnv(targetWorkspaceId?: WorkspaceId): UseWorkspaceEnvResult {
+  const [workspaceId, setWorkspaceId] = useState<WorkspaceId>(() => {
+    if (typeof targetWorkspaceId === 'number') {
+      return targetWorkspaceId;
+    }
+    return getActiveWorkspace();
+  });
+
+  const [entries, setEntries] = useState<EnvEntry[]>(() => getEntries(workspaceId));
+
+  useEffect(() => {
+    if (typeof targetWorkspaceId === 'number') {
+      setWorkspaceId(targetWorkspaceId);
+      setEntries(getEntries(targetWorkspaceId));
+      return () => {};
+    }
+
+    const unsubscribe = subscribeToWorkspace((nextId) => {
+      setWorkspaceId(nextId);
+      setEntries(getEntries(nextId));
+    });
+
+    return unsubscribe;
+  }, [targetWorkspaceId]);
+
+  useEffect(() => {
+    const id = typeof targetWorkspaceId === 'number' ? targetWorkspaceId : workspaceId;
+    const unsubscribe = subscribe(id ?? DEFAULT_WORKSPACE_ID, (list) => {
+      setEntries(list);
+    });
+    return unsubscribe;
+  }, [workspaceId, targetWorkspaceId]);
+
+  const setEntry = useMemo(
+    () =>
+      (key: string, value: string, options?: { previousKey?: string }): EnvMutationResult => {
+        const id = typeof targetWorkspaceId === 'number' ? targetWorkspaceId : workspaceId;
+        return setValue(id ?? DEFAULT_WORKSPACE_ID, key, value, options);
+      },
+    [workspaceId, targetWorkspaceId],
+  );
+
+  const deleteEntry = useMemo(
+    () =>
+      (key: string): EnvMutationResult => {
+        const id = typeof targetWorkspaceId === 'number' ? targetWorkspaceId : workspaceId;
+        return deleteKey(id ?? DEFAULT_WORKSPACE_ID, key);
+      },
+    [workspaceId, targetWorkspaceId],
+  );
+
+  const getEntryValue = useMemo(
+    () =>
+      (key: string): string | undefined => {
+        const id = typeof targetWorkspaceId === 'number' ? targetWorkspaceId : workspaceId;
+        return getValue(id ?? DEFAULT_WORKSPACE_ID, key);
+      },
+    [workspaceId, targetWorkspaceId],
+  );
+
+  return {
+    workspaceId,
+    entries,
+    setEntry,
+    deleteEntry,
+    validateKey,
+    getEntryValue,
+  };
+}

--- a/utils/envStore.ts
+++ b/utils/envStore.ts
@@ -1,0 +1,372 @@
+"use client";
+
+import { safeLocalStorage } from './safeStorage';
+
+export type WorkspaceId = number;
+
+export interface EnvEntry {
+  key: string;
+  value: string;
+  readonly: boolean;
+  reserved: boolean;
+  warning?: string;
+}
+
+export interface EnvMutationResult {
+  success: boolean;
+  key?: string;
+  error?: string;
+  warning?: string;
+}
+
+export interface KeyValidationResult {
+  valid: boolean;
+  normalizedKey: string;
+  message?: string;
+  reserved?: boolean;
+}
+
+type EnvSubscriber = (entries: EnvEntry[], meta: { workspaceId: WorkspaceId }) => void;
+type WorkspaceSubscriber = (workspaceId: WorkspaceId) => void;
+
+type StoredEnvRecord = Record<string, string>;
+
+type WorkspaceData = Map<string, string>;
+
+type ReservedDefinition = {
+  key: string;
+  fallback: string;
+  description: string;
+};
+
+const STORAGE_PREFIX = 'workspace-env:';
+const KEY_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
+const MAX_KEY_LENGTH = 64;
+
+const RESERVED_VARIABLES: ReservedDefinition[] = [
+  {
+    key: 'PATH',
+    fallback: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    description: 'System execution path (read-only)',
+  },
+  {
+    key: 'HOME',
+    fallback: '/home/kali',
+    description: 'Home directory (read-only)',
+  },
+  {
+    key: 'USER',
+    fallback: 'kali',
+    description: 'Logged in user (read-only)',
+  },
+  {
+    key: 'SHELL',
+    fallback: '/bin/bash',
+    description: 'Default shell (read-only)',
+  },
+  {
+    key: 'LANG',
+    fallback: 'en_US.UTF-8',
+    description: 'Locale configuration (read-only)',
+  },
+];
+
+const reservedMap = new Map<string, { value: string; description: string }>();
+RESERVED_VARIABLES.forEach(({ key, fallback, description }) => {
+  const envValue = typeof process !== 'undefined' ? process.env?.[key] : undefined;
+  reservedMap.set(key, { value: envValue ?? fallback, description });
+});
+
+const userEnvByWorkspace = new Map<WorkspaceId, WorkspaceData>();
+const envSubscribers = new Map<WorkspaceId, Set<EnvSubscriber>>();
+const workspaceSubscribers = new Set<WorkspaceSubscriber>();
+
+let activeWorkspaceId: WorkspaceId = 0;
+
+function getStorageKey(workspaceId: WorkspaceId): string {
+  return `${STORAGE_PREFIX}${workspaceId}`;
+}
+
+function loadWorkspaceEnv(workspaceId: WorkspaceId): WorkspaceData {
+  const existing = userEnvByWorkspace.get(workspaceId);
+  if (existing) return existing;
+
+  const map: WorkspaceData = new Map();
+  if (safeLocalStorage) {
+    try {
+      const raw = safeLocalStorage.getItem(getStorageKey(workspaceId));
+      if (raw) {
+        const parsed = JSON.parse(raw) as StoredEnvRecord;
+        if (parsed && typeof parsed === 'object') {
+          Object.entries(parsed).forEach(([key, value]) => {
+            if (typeof key === 'string' && typeof value === 'string') {
+              const normalized = key.trim().toUpperCase();
+              if (normalized && !reservedMap.has(normalized)) {
+                map.set(normalized, value);
+              }
+            }
+          });
+        }
+      }
+    } catch {
+      // ignore malformed storage
+    }
+  }
+
+  userEnvByWorkspace.set(workspaceId, map);
+  return map;
+}
+
+function persistWorkspaceEnv(workspaceId: WorkspaceId): void {
+  if (!safeLocalStorage) return;
+  const data = loadWorkspaceEnv(workspaceId);
+  const serialized: StoredEnvRecord = {};
+  data.forEach((value, key) => {
+    serialized[key] = value;
+  });
+  try {
+    safeLocalStorage.setItem(getStorageKey(workspaceId), JSON.stringify(serialized));
+  } catch {
+    // ignore storage failures (quota or disabled storage)
+  }
+}
+
+function buildEntries(workspaceId: WorkspaceId): EnvEntry[] {
+  const data = loadWorkspaceEnv(workspaceId);
+  const entries: EnvEntry[] = [];
+
+  reservedMap.forEach(({ value, description }, key) => {
+    entries.push({
+      key,
+      value,
+      readonly: true,
+      reserved: true,
+      warning: description,
+    });
+  });
+
+  data.forEach((value, key) => {
+    const reserved = reservedMap.has(key);
+    entries.push({
+      key,
+      value,
+      readonly: reserved,
+      reserved,
+      warning: reserved ? reservedMap.get(key)?.description : undefined,
+    });
+  });
+
+  return entries.sort((a, b) => {
+    if (a.reserved !== b.reserved) {
+      return a.reserved ? -1 : 1;
+    }
+    return a.key.localeCompare(b.key);
+  });
+}
+
+function notifyWorkspace(workspaceId: WorkspaceId): void {
+  const subscribers = envSubscribers.get(workspaceId);
+  if (!subscribers || subscribers.size === 0) return;
+  const entries = buildEntries(workspaceId);
+  subscribers.forEach((callback) => callback(entries, { workspaceId }));
+}
+
+function notifyWorkspaceChange(): void {
+  workspaceSubscribers.forEach((callback) => callback(activeWorkspaceId));
+}
+
+function isReservedKey(key: string): boolean {
+  return reservedMap.has(key.trim().toUpperCase());
+}
+
+export function validateKey(key: string): KeyValidationResult {
+  const trimmed = key.trim();
+  const normalizedKey = trimmed.toUpperCase();
+
+  if (!trimmed) {
+    return { valid: false, normalizedKey: '', message: 'Key is required.' };
+  }
+
+  if (trimmed.length > MAX_KEY_LENGTH) {
+    return {
+      valid: false,
+      normalizedKey,
+      message: `Keys must be ${MAX_KEY_LENGTH} characters or fewer.`,
+    };
+  }
+
+  if (!KEY_PATTERN.test(normalizedKey)) {
+    return {
+      valid: false,
+      normalizedKey,
+      message: 'Use uppercase letters, numbers, and underscores. Keys cannot start with a number.',
+    };
+  }
+
+  const reserved = isReservedKey(normalizedKey);
+  return {
+    valid: true,
+    normalizedKey,
+    reserved,
+    message: reserved ? 'Reserved keys are read-only.' : undefined,
+  };
+}
+
+export function getEntries(workspaceId: WorkspaceId): EnvEntry[] {
+  return buildEntries(workspaceId);
+}
+
+export function getValue(workspaceId: WorkspaceId, key: string): string | undefined {
+  const normalized = key.trim().toUpperCase();
+  if (isReservedKey(normalized)) {
+    return reservedMap.get(normalized)?.value;
+  }
+  return loadWorkspaceEnv(workspaceId).get(normalized);
+}
+
+export function setValue(
+  workspaceId: WorkspaceId,
+  key: string,
+  value: string,
+  options: { previousKey?: string } = {},
+): EnvMutationResult {
+  const validation = validateKey(key);
+  if (!validation.valid) {
+    return { success: false, error: validation.message };
+  }
+
+  if (validation.reserved) {
+    return {
+      success: false,
+      error: 'Reserved variables cannot be modified.',
+      warning: validation.message,
+    };
+  }
+
+  const normalized = validation.normalizedKey;
+  const data = loadWorkspaceEnv(workspaceId);
+  const previousKey = options.previousKey?.trim().toUpperCase();
+
+  if (previousKey && previousKey !== normalized) {
+    if (isReservedKey(previousKey)) {
+      return {
+        success: false,
+        error: 'Reserved variables cannot be modified.',
+        warning: 'Reserved keys are immutable.',
+      };
+    }
+    data.delete(previousKey);
+  }
+
+  data.set(normalized, value);
+  persistWorkspaceEnv(workspaceId);
+  notifyWorkspace(workspaceId);
+  return { success: true, key: normalized };
+}
+
+export function deleteKey(workspaceId: WorkspaceId, key: string): EnvMutationResult {
+  const normalized = key.trim().toUpperCase();
+  if (isReservedKey(normalized)) {
+    return {
+      success: false,
+      error: 'Reserved variables cannot be removed.',
+      warning: 'Reserved keys are managed by the system.',
+    };
+  }
+
+  const data = loadWorkspaceEnv(workspaceId);
+  if (!data.has(normalized)) {
+    return { success: false, error: 'Variable not found.' };
+  }
+
+  data.delete(normalized);
+  persistWorkspaceEnv(workspaceId);
+  notifyWorkspace(workspaceId);
+  return { success: true, key: normalized };
+}
+
+export function subscribe(workspaceId: WorkspaceId, callback: EnvSubscriber): () => void {
+  const subscribers = envSubscribers.get(workspaceId) ?? new Set<EnvSubscriber>();
+  if (!envSubscribers.has(workspaceId)) {
+    envSubscribers.set(workspaceId, subscribers);
+  }
+  subscribers.add(callback);
+  callback(buildEntries(workspaceId), { workspaceId });
+
+  return () => {
+    subscribers.delete(callback);
+    if (subscribers.size === 0) {
+      envSubscribers.delete(workspaceId);
+    }
+  };
+}
+
+export function subscribeToWorkspace(callback: WorkspaceSubscriber): () => void {
+  workspaceSubscribers.add(callback);
+  callback(activeWorkspaceId);
+  return () => {
+    workspaceSubscribers.delete(callback);
+  };
+}
+
+export function getActiveWorkspace(): WorkspaceId {
+  return activeWorkspaceId;
+}
+
+export function setActiveWorkspace(workspaceId: WorkspaceId): void {
+  if (typeof workspaceId !== 'number' || Number.isNaN(workspaceId)) return;
+  if (workspaceId === activeWorkspaceId) return;
+  activeWorkspaceId = workspaceId;
+  notifyWorkspaceChange();
+}
+
+export function getReservedKeys(): string[] {
+  return Array.from(reservedMap.keys());
+}
+
+export function getReservedMetadata(key: string): string | undefined {
+  return reservedMap.get(key.trim().toUpperCase())?.description;
+}
+
+type GlobalWithListener = typeof globalThis & {
+  addEventListener?: (type: string, listener: EventListenerOrEventListenerObject) => void;
+};
+
+const globalTarget: GlobalWithListener | undefined =
+  typeof globalThis !== 'undefined' ? (globalThis as GlobalWithListener) : undefined;
+
+if (globalTarget?.addEventListener) {
+  globalTarget.addEventListener('workspace-state', (event: Event) => {
+    const detail = (event as CustomEvent).detail as {
+      activeWorkspace?: unknown;
+    } | undefined;
+    const next = typeof detail?.activeWorkspace === 'number' ? detail.activeWorkspace : undefined;
+    if (typeof next === 'number') {
+      setActiveWorkspace(next);
+    }
+  });
+}
+
+export function __resetEnvStoreForTests(): void {
+  userEnvByWorkspace.clear();
+  envSubscribers.clear();
+  activeWorkspaceId = 0;
+  if (safeLocalStorage) {
+    try {
+      const keys: string[] = [];
+      for (let index = 0; index < safeLocalStorage.length; index += 1) {
+        const key = safeLocalStorage.key(index);
+        if (key && key.startsWith(STORAGE_PREFIX)) {
+          keys.push(key);
+        }
+      }
+      keys.forEach((key) => safeLocalStorage.removeItem(key));
+    } catch {
+      // ignore storage cleanup failures
+    }
+  }
+}
+
+export function __setActiveWorkspaceForTests(workspaceId: WorkspaceId): void {
+  setActiveWorkspace(workspaceId);
+}


### PR DESCRIPTION
## Summary
- add a workspace-scoped environment store with validation, reserved keys, and subscription utilities
- expose a `useWorkspaceEnv` hook plus EnvPanel UI for editing variables and surfacing reserved rows
- add unit tests covering validation failures, subscription updates, and workspace isolation

## Testing
- yarn lint
- yarn test envStore


------
https://chatgpt.com/codex/tasks/task_e_68dcde82fe6c83288bebc0a89e75e187