### PR TITLE
[ui] Add modular type scale slider

### DIFF
--- a/__tests__/typeScale.test.tsx
+++ b/__tests__/typeScale.test.tsx
@@ -1,0 +1,110 @@
+jest.mock('../utils/settingsStore', () => {
+  const defaults = {
+    accent: '#1793d1',
+    wallpaper: 'wall-2',
+    useKaliWallpaper: false,
+    density: 'regular',
+    reducedMotion: false,
+    fontScale: 1,
+    highContrast: false,
+    largeHitAreas: false,
+    pongSpin: true,
+    allowNetwork: false,
+    haptics: true,
+  } as const;
+
+  type Defaults = typeof defaults;
+  const state: { [K in keyof Defaults]: Defaults[K] } = { ...defaults };
+
+  const makeGetter = <K extends keyof Defaults>(key: K) =>
+    jest.fn(async () => state[key]);
+
+  const makeSetter = <K extends keyof Defaults>(key: K) =>
+    jest.fn(async (value: Defaults[K]) => {
+      state[key] = value;
+    });
+
+  return {
+    __esModule: true,
+    defaults,
+    getAccent: makeGetter('accent'),
+    setAccent: makeSetter('accent'),
+    getWallpaper: makeGetter('wallpaper'),
+    setWallpaper: makeSetter('wallpaper'),
+    getUseKaliWallpaper: makeGetter('useKaliWallpaper'),
+    setUseKaliWallpaper: makeSetter('useKaliWallpaper'),
+    getDensity: makeGetter('density'),
+    setDensity: makeSetter('density'),
+    getReducedMotion: makeGetter('reducedMotion'),
+    setReducedMotion: makeSetter('reducedMotion'),
+    getFontScale: makeGetter('fontScale'),
+    setFontScale: makeSetter('fontScale'),
+    getHighContrast: makeGetter('highContrast'),
+    setHighContrast: makeSetter('highContrast'),
+    getLargeHitAreas: makeGetter('largeHitAreas'),
+    setLargeHitAreas: makeSetter('largeHitAreas'),
+    getPongSpin: makeGetter('pongSpin'),
+    setPongSpin: makeSetter('pongSpin'),
+    getAllowNetwork: makeGetter('allowNetwork'),
+    setAllowNetwork: makeSetter('allowNetwork'),
+    getHaptics: makeGetter('haptics'),
+    setHaptics: makeSetter('haptics'),
+    __resetMockState: () => {
+      Object.assign(state, defaults);
+    },
+  };
+});
+
+import { renderHook, act } from '@testing-library/react';
+import { SettingsProvider, useSettings, TYPE_SCALE_RANGE } from '../hooks/useSettings';
+import * as settingsStore from '../utils/settingsStore';
+
+const getRootStyleValue = (property: string) =>
+  document.documentElement.style.getPropertyValue(property);
+
+describe('type scale settings', () => {
+  beforeEach(async () => {
+    (settingsStore as any).__resetMockState();
+    document.documentElement.style.removeProperty('--font-multiplier');
+    document.documentElement.style.removeProperty('--type-factor');
+  });
+
+  test('persists selected type scale across sessions', async () => {
+    const { result, unmount } = renderHook(() => useSettings(), {
+      wrapper: SettingsProvider,
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.setFontScale(TYPE_SCALE_RANGE.max);
+    });
+
+    await expect(settingsStore.getFontScale()).resolves.toBe(
+      TYPE_SCALE_RANGE.max,
+    );
+
+    unmount();
+  });
+
+  test('updates CSS variables when type scale changes', async () => {
+    const { result, unmount } = renderHook(() => useSettings(), {
+      wrapper: SettingsProvider,
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.setFontScale(1.1);
+    });
+
+    expect(getRootStyleValue('--font-multiplier')).toBe('1.1');
+    expect(getRootStyleValue('--type-factor')).toBe('1.1');
+
+    unmount();
+  });
+});

--- a/apps/settings/index.tsx
+++ b/apps/settings/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useRef } from "react";
-import { useSettings, ACCENT_OPTIONS } from "../../hooks/useSettings";
+import { useState, useRef, useId } from "react";
+import { useSettings, ACCENT_OPTIONS, TYPE_SCALE_RANGE } from "../../hooks/useSettings";
 import BackgroundSlideshow from "./components/BackgroundSlideshow";
 import {
   resetSettings,
@@ -36,6 +36,8 @@ export default function Settings() {
     setTheme,
   } = useSettings();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const wallpaperToggleId = useId();
+  const typeScaleSliderId = useId();
 
   const tabs = [
     { id: "appearance", label: "Appearance" },
@@ -156,14 +158,20 @@ export default function Settings() {
               ))}
             </div>
           </div>
-          <div className="flex justify-center my-4">
-            <label className="mr-2 text-ubt-grey flex items-center">
-              <input
-                type="checkbox"
-                checked={useKaliWallpaper}
-                onChange={(e) => setUseKaliWallpaper(e.target.checked)}
-                className="mr-2"
-              />
+          <div className="flex justify-center my-4 items-center">
+            <input
+              id={wallpaperToggleId}
+              type="checkbox"
+              checked={useKaliWallpaper}
+              onChange={(e) => setUseKaliWallpaper(e.target.checked)}
+              className="mr-2"
+              aria-labelledby={`${wallpaperToggleId}-label`}
+            />
+            <label
+              id={`${wallpaperToggleId}-label`}
+              htmlFor={wallpaperToggleId}
+              className="text-ubt-grey"
+            >
               Kali Gradient Wallpaper
             </label>
           </div>
@@ -233,19 +241,26 @@ export default function Settings() {
       )}
       {activeTab === "accessibility" && (
         <>
-          <div className="flex justify-center my-4">
-            <label htmlFor="font-scale" className="mr-2 text-ubt-grey">Icon Size:</label>
+          <div className="flex flex-col items-center my-4">
+            <label htmlFor={typeScaleSliderId} className="mb-2 text-ubt-grey">
+              Type scale
+            </label>
             <input
-              id="font-scale"
+              id={typeScaleSliderId}
               type="range"
-              min="0.75"
-              max="1.5"
-              step="0.05"
+              min={TYPE_SCALE_RANGE.min}
+              max={TYPE_SCALE_RANGE.max}
+              step={TYPE_SCALE_RANGE.step}
               value={fontScale}
               onChange={(e) => setFontScale(parseFloat(e.target.value))}
               className="ubuntu-slider"
-              aria-label="Icon size"
+              aria-label="Type scale"
             />
+            <div className="mt-2 flex w-full max-w-xs justify-between text-xs text-ubt-grey">
+              <span>{Math.round(TYPE_SCALE_RANGE.min * 100)}%</span>
+              <span aria-live="polite">{Math.round(fontScale * 100)}%</span>
+              <span>{Math.round(TYPE_SCALE_RANGE.max * 100)}%</span>
+            </div>
           </div>
           <div className="flex justify-center my-4">
             <label className="mr-2 text-ubt-grey">Density:</label>

--- a/components/SettingsDrawer.tsx
+++ b/components/SettingsDrawer.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { getUnlockedThemes } from '../utils/theme';
-import { useSettings, ACCENT_OPTIONS } from '../hooks/useSettings';
+import { useSettings, ACCENT_OPTIONS, TYPE_SCALE_RANGE } from '../hooks/useSettings';
 
 interface Props {
   highScore?: number;
@@ -9,7 +9,10 @@ interface Props {
 const SettingsDrawer = ({ highScore = 0 }: Props) => {
   const [open, setOpen] = useState(false);
   const unlocked = getUnlockedThemes(highScore);
-  const { accent, setAccent, theme, setTheme } = useSettings();
+  const { accent, setAccent, theme, setTheme, fontScale, setFontScale } = useSettings();
+  const typeScaleId = useId();
+  const typeScaleLabelId = useId();
+  const typeScaleDescriptionId = useId();
 
   return (
     <div>
@@ -52,6 +55,37 @@ const SettingsDrawer = ({ highScore = 0 }: Props) => {
               ))}
             </div>
           </label>
+          <div className="mt-4">
+            <label id={typeScaleLabelId} htmlFor={typeScaleId} className="block">
+              Type scale
+            </label>
+            <input
+              id={typeScaleId}
+              type="range"
+              min={TYPE_SCALE_RANGE.min}
+              max={TYPE_SCALE_RANGE.max}
+              step={TYPE_SCALE_RANGE.step}
+              value={fontScale}
+              onChange={(event) => setFontScale(parseFloat(event.target.value))}
+              className="ubuntu-slider mt-2 w-full"
+              aria-describedby={typeScaleDescriptionId}
+              aria-labelledby={typeScaleLabelId}
+              aria-valuetext={`${Math.round(fontScale * 100)} percent`}
+            />
+            <div
+              id={typeScaleDescriptionId}
+              className="mt-2 flex w-full justify-between text-xs text-gray-300"
+            >
+              <span>{Math.round(TYPE_SCALE_RANGE.min * 100)}%</span>
+              <span aria-live="polite">
+                {Math.round(fontScale * 100)}%
+              </span>
+              <span>{Math.round(TYPE_SCALE_RANGE.max * 100)}%</span>
+            </div>
+            <p className="mt-2 text-xs text-gray-400" aria-live="polite" aria-atomic="true">
+              Preview text grows and shrinks based on this scale factor.
+            </p>
+          </div>
         </div>
       )}
     </div>

--- a/components/apps/settings.js
+++ b/components/apps/settings.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { useSettings, ACCENT_OPTIONS } from '../../hooks/useSettings';
+import React, { useEffect, useRef, useState, useCallback, useId } from 'react';
+import { useSettings, ACCENT_OPTIONS, TYPE_SCALE_RANGE } from '../../hooks/useSettings';
 import { resetSettings, defaults, exportSettings as exportSettingsData, importSettings as importSettingsData } from '../../utils/settingsStore';
 import KaliWallpaper from '../util-components/kali-wallpaper';
 
@@ -8,6 +8,14 @@ export function Settings() {
     const [contrast, setContrast] = useState(0);
     const liveRegion = useRef(null);
     const fileInput = useRef(null);
+    const wallpaperToggleId = useId();
+    const typeScaleId = useId();
+    const reducedMotionId = useId();
+    const largeHitAreasId = useId();
+    const highContrastId = useId();
+    const allowNetworkId = useId();
+    const hapticsId = useId();
+    const pongSpinId = useId();
 
     const wallpapers = ['wall-1', 'wall-2', 'wall-3', 'wall-4', 'wall-5', 'wall-6', 'wall-7', 'wall-8'];
 
@@ -82,14 +90,16 @@ export function Settings() {
                     <option value="matrix">Matrix</option>
                 </select>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={useKaliWallpaper}
-                        onChange={(e) => setUseKaliWallpaper(e.target.checked)}
-                        className="mr-2"
-                    />
+            <div className="flex justify-center my-4 items-center">
+                <input
+                    id={wallpaperToggleId}
+                    type="checkbox"
+                    checked={useKaliWallpaper}
+                    onChange={(e) => setUseKaliWallpaper(e.target.checked)}
+                    className="mr-2"
+                    aria-labelledby={`${wallpaperToggleId}-label`}
+                />
+                <label id={`${wallpaperToggleId}-label`} htmlFor={wallpaperToggleId} className="text-ubt-grey">
                     Kali Gradient Wallpaper
                 </label>
             </div>
@@ -125,81 +135,100 @@ export function Settings() {
                     <option value="compact">Compact</option>
                 </select>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey">Font Size:</label>
+            <div className="flex flex-col items-center my-4">
+                <label htmlFor={typeScaleId} className="mb-2 text-ubt-grey">Type scale</label>
                 <input
+                    id={typeScaleId}
                     type="range"
-                    min="0.75"
-                    max="1.5"
-                    step="0.05"
+                    min={TYPE_SCALE_RANGE.min}
+                    max={TYPE_SCALE_RANGE.max}
+                    step={TYPE_SCALE_RANGE.step}
                     value={fontScale}
                     onChange={(e) => setFontScale(parseFloat(e.target.value))}
                     className="ubuntu-slider"
+                    aria-label="Type scale"
                 />
+                <div className="mt-2 flex w-full max-w-xs justify-between text-xs text-ubt-grey">
+                    <span>{Math.round(TYPE_SCALE_RANGE.min * 100)}%</span>
+                    <span aria-live="polite">{Math.round(fontScale * 100)}%</span>
+                    <span>{Math.round(TYPE_SCALE_RANGE.max * 100)}%</span>
+                </div>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={reducedMotion}
-                        onChange={(e) => setReducedMotion(e.target.checked)}
-                        className="mr-2"
-                    />
+            <div className="flex justify-center my-4 items-center">
+                <input
+                    id={reducedMotionId}
+                    type="checkbox"
+                    checked={reducedMotion}
+                    onChange={(e) => setReducedMotion(e.target.checked)}
+                    className="mr-2"
+                    aria-labelledby={`${reducedMotionId}-label`}
+                />
+                <label id={`${reducedMotionId}-label`} htmlFor={reducedMotionId} className="text-ubt-grey">
                     Reduced Motion
                 </label>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={largeHitAreas}
-                        onChange={(e) => setLargeHitAreas(e.target.checked)}
-                        className="mr-2"
-                    />
+            <div className="flex justify-center my-4 items-center">
+                <input
+                    id={largeHitAreasId}
+                    type="checkbox"
+                    checked={largeHitAreas}
+                    onChange={(e) => setLargeHitAreas(e.target.checked)}
+                    className="mr-2"
+                    aria-labelledby={`${largeHitAreasId}-label`}
+                />
+                <label id={`${largeHitAreasId}-label`} htmlFor={largeHitAreasId} className="text-ubt-grey">
                     Large Hit Areas
                 </label>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={highContrast}
-                        onChange={(e) => setHighContrast(e.target.checked)}
-                        className="mr-2"
-                    />
+            <div className="flex justify-center my-4 items-center">
+                <input
+                    id={highContrastId}
+                    type="checkbox"
+                    checked={highContrast}
+                    onChange={(e) => setHighContrast(e.target.checked)}
+                    className="mr-2"
+                    aria-labelledby={`${highContrastId}-label`}
+                />
+                <label id={`${highContrastId}-label`} htmlFor={highContrastId} className="text-ubt-grey">
                     High Contrast
                 </label>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={allowNetwork}
-                        onChange={(e) => setAllowNetwork(e.target.checked)}
-                        className="mr-2"
-                    />
+            <div className="flex justify-center my-4 items-center">
+                <input
+                    id={allowNetworkId}
+                    type="checkbox"
+                    checked={allowNetwork}
+                    onChange={(e) => setAllowNetwork(e.target.checked)}
+                    className="mr-2"
+                    aria-labelledby={`${allowNetworkId}-label`}
+                />
+                <label id={`${allowNetworkId}-label`} htmlFor={allowNetworkId} className="text-ubt-grey">
                     Allow Network Requests
                 </label>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={haptics}
-                        onChange={(e) => setHaptics(e.target.checked)}
-                        className="mr-2"
-                    />
+            <div className="flex justify-center my-4 items-center">
+                <input
+                    id={hapticsId}
+                    type="checkbox"
+                    checked={haptics}
+                    onChange={(e) => setHaptics(e.target.checked)}
+                    className="mr-2"
+                    aria-labelledby={`${hapticsId}-label`}
+                />
+                <label id={`${hapticsId}-label`} htmlFor={hapticsId} className="text-ubt-grey">
                     Haptics
                 </label>
             </div>
-            <div className="flex justify-center my-4">
-                <label className="mr-2 text-ubt-grey flex items-center">
-                    <input
-                        type="checkbox"
-                        checked={pongSpin}
-                        onChange={(e) => setPongSpin(e.target.checked)}
-                        className="mr-2"
-                    />
+            <div className="flex justify-center my-4 items-center">
+                <input
+                    id={pongSpinId}
+                    type="checkbox"
+                    checked={pongSpin}
+                    onChange={(e) => setPongSpin(e.target.checked)}
+                    className="mr-2"
+                    aria-labelledby={`${pongSpinId}-label`}
+                />
+                <label id={`${pongSpinId}-label`} htmlFor={pongSpinId} className="text-ubt-grey">
                     Pong Spin
                 </label>
             </div>
@@ -307,6 +336,7 @@ export function Settings() {
                     }
                     e.target.value = '';
                 }}
+                aria-label="Import settings"
                 className="hidden"
             />
         </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,15 +1,5 @@
 @import './globals.css';
-
-html {
-    font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);
-}
-
-body{
-    font-family: var(--font-family-base);
-    font-display: swap;
-    background-color: var(--color-bg);
-    color: var(--color-text);
-}
+@import './typography.css';
 
 :root {
     /* Stack utility defaults */

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -1,0 +1,115 @@
+:root {
+  --font-family-sans: var(--font-family-base, 'Ubuntu', sans-serif);
+  --font-family-display: var(--font-family-sans);
+  --font-family-mono: 'Fira Code', 'Source Code Pro', 'Ubuntu Mono', ui-monospace,
+    SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  --font-family-code: var(--font-family-mono);
+
+  --type-base-size: clamp(15px, calc(15px + 0.35vw), 18px);
+  --type-ratio: 1.25;
+  --type-factor: var(--font-multiplier, 1);
+
+  --font-size-body: 1rem;
+  --font-size-small: calc(var(--font-size-body) / var(--type-ratio));
+  --font-size-xs: calc(var(--font-size-small) / var(--type-ratio));
+  --font-size-h6: calc(var(--font-size-body) * var(--type-ratio));
+  --font-size-h5: calc(var(--font-size-h6) * var(--type-ratio));
+  --font-size-h4: calc(var(--font-size-h5) * var(--type-ratio));
+  --font-size-h3: calc(var(--font-size-h4) * var(--type-ratio));
+  --font-size-h2: calc(var(--font-size-h3) * var(--type-ratio));
+  --font-size-h1: calc(var(--font-size-h2) * var(--type-ratio));
+  --font-size-display: calc(var(--font-size-h1) * var(--type-ratio));
+  --font-size-code: calc(var(--font-size-body) / 1.05);
+
+  --line-height-body: 1.6;
+  --line-height-heading: 1.2;
+  --line-height-code: 1.45;
+  --font-weight-heading: 700;
+}
+
+html {
+  font-size: calc(var(--type-base-size) * var(--type-factor));
+}
+
+body {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-body);
+  line-height: var(--line-height-body);
+  color: var(--color-text);
+  background-color: var(--color-bg);
+}
+
+p,
+li,
+dd {
+  font-size: var(--font-size-body);
+  line-height: var(--line-height-body);
+}
+
+small,
+.caption,
+figcaption {
+  font-size: var(--font-size-small);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-family-display);
+  line-height: var(--line-height-heading);
+  font-weight: var(--font-weight-heading);
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+h1 {
+  font-size: var(--font-size-h1);
+}
+
+h2 {
+  font-size: var(--font-size-h2);
+}
+
+h3 {
+  font-size: var(--font-size-h3);
+}
+
+h4 {
+  font-size: var(--font-size-h4);
+}
+
+h5 {
+  font-size: var(--font-size-h5);
+}
+
+h6 {
+  font-size: var(--font-size-h6);
+}
+
+.display-title {
+  font-size: var(--font-size-display);
+  font-weight: var(--font-weight-heading);
+  line-height: calc(var(--line-height-heading) * 0.95);
+}
+
+code,
+pre,
+kbd,
+samp {
+  font-family: var(--font-family-code);
+  font-size: var(--font-size-code);
+  line-height: var(--line-height-code);
+}
+
+pre {
+  overflow-x: auto;
+}
+
+@media (max-width: 480px) {
+  :root {
+    --type-base-size: clamp(14px, calc(14px + 0.5vw), 16px);
+  }
+}


### PR DESCRIPTION
## Summary
- establish a modular typography scale with responsive CSS variables and import it into the global stylesheet
- expose the font scale controls in both desktop settings UIs and persist updates through the settings hook
- add unit coverage to verify the type scale persistence behaviour

## Testing
- yarn lint
- yarn test typeScale

------
https://chatgpt.com/codex/tasks/task_e_68dcde8b7e8c8328ab8cf66e3a17e288