### PR TITLE
[common] add error help knowledge base

### DIFF
--- a/__tests__/ErrorHelp.test.tsx
+++ b/__tests__/ErrorHelp.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import ErrorHelp from '../components/common/ErrorHelp';
+
+describe('ErrorHelp component', () => {
+  it('shows the error summary and default article', () => {
+    render(<ErrorHelp code="ERR_NETWORK_TIMEOUT" />);
+
+    expect(screen.getByText('ERR_NETWORK_TIMEOUT')).toBeInTheDocument();
+    expect(
+      screen.getByText('Network request timed out while contacting the server.')
+    ).toBeInTheDocument();
+
+    const article = screen.getByRole('article');
+    expect(
+      within(article).getByText(
+        'Fix connectivity issues when the desktop cannot reach API endpoints or background services.'
+      )
+    ).toBeInTheDocument();
+    expect(within(article).getByText('Quick checks')).toBeInTheDocument();
+  });
+
+  it('falls back to the unknown error article when the code is not registered', () => {
+    render(<ErrorHelp code="ERR_NOT_REAL" message="Custom failure message" />);
+
+    expect(screen.getByText('ERR_UNKNOWN')).toBeInTheDocument();
+    expect(screen.getByText('Custom failure message')).toBeInTheDocument();
+
+    const article = screen.getByRole('article');
+    expect(
+      within(article).getByText('Baseline recovery steps for unknown or unexpected application errors.')
+    ).toBeInTheDocument();
+  });
+
+  it('updates the article when a search result is selected', async () => {
+    render(<ErrorHelp code="ERR_NETWORK_TIMEOUT" />);
+
+    const searchInput = screen.getByLabelText(/Search knowledge base/i);
+    fireEvent.change(searchInput, { target: { value: 'integrity' } });
+
+    const resultButton = await screen.findByRole('button', {
+      name: /Investigate data integrity warnings/i,
+    });
+    fireEvent.click(resultButton);
+
+    await waitFor(() => {
+      const article = screen.getByRole('article');
+      expect(
+        within(article).getByText(
+          'Steps to follow when checksum or replay protections detect unexpected changes.'
+        )
+      ).toBeInTheDocument();
+      expect(within(article).getByText('Checklist')).toBeInTheDocument();
+      expect(searchInput).toHaveValue('');
+    });
+  });
+});

--- a/__tests__/errors.test.ts
+++ b/__tests__/errors.test.ts
@@ -1,0 +1,46 @@
+import {
+  ERROR_CODES,
+  getErrorDefinition,
+  getErrorHelpArticle,
+  searchHelpArticles,
+} from '../utils/errors';
+
+describe('error metadata', () => {
+  it('maps every error code to a help article', () => {
+    for (const code of ERROR_CODES) {
+      const definition = getErrorDefinition(code);
+      expect(definition.articleSlug).toBeTruthy();
+      const article = getErrorHelpArticle(code);
+      expect(article?.slug).toBe(definition.articleSlug);
+    }
+  });
+
+  it('falls back to ERR_UNKNOWN for unknown codes', () => {
+    const definition = getErrorDefinition('ERR_NOT_REAL');
+    expect(definition.code).toBe('ERR_UNKNOWN');
+    const article = getErrorHelpArticle('ERR_NOT_REAL');
+    expect(article?.slug).toBe('troubleshooting-basics');
+  });
+});
+
+describe('offline help search', () => {
+  it('matches keywords and content across articles', () => {
+    const networkResults = searchHelpArticles('offline retry');
+    expect(networkResults.map((article) => article.slug)).toContain('network-timeout');
+
+    const accessResults = searchHelpArticles('permission role');
+    expect(accessResults.map((article) => article.slug)).toContain('access-denied');
+  });
+
+  it('requires non-empty query', () => {
+    expect(searchHelpArticles('')).toHaveLength(0);
+    expect(searchHelpArticles('   ')).toHaveLength(0);
+  });
+
+  it('returns unique matches even when keywords overlap', () => {
+    const results = searchHelpArticles('error');
+    const slugs = results.map((article) => article.slug);
+    const uniqueSlugs = new Set(slugs);
+    expect(uniqueSlugs.size).toBe(slugs.length);
+  });
+});

--- a/components/common/ErrorHelp.tsx
+++ b/components/common/ErrorHelp.tsx
@@ -1,0 +1,231 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  ERROR_CODES,
+  getAllHelpArticles,
+  getErrorDefinition,
+  getErrorHelpArticle,
+  type ErrorCode,
+  type ErrorDefinition,
+  type ErrorSeverity,
+  type HelpArticle,
+  searchHelpArticles,
+} from '../../utils/errors';
+
+interface ErrorHelpProps {
+  code: ErrorCode | string;
+  message?: string;
+}
+
+const severityLabels: Record<ErrorSeverity, string> = {
+  info: 'Info',
+  warning: 'Warning',
+  error: 'Error',
+  critical: 'Critical',
+};
+
+function formatArticleContent(article: HelpArticle): React.ReactNode {
+  return article.content.map((segment, index) => {
+    const trimmed = segment.trim();
+    if (!trimmed) {
+      return <hr key={`divider-${article.slug}-${index}`} className="border-neutral-700/70" />;
+    }
+
+    if (trimmed.startsWith('- ')) {
+      const items = trimmed
+        .split(/\n+/)
+        .filter(Boolean)
+        .map((item) => item.replace(/^[-*]\s*/, ''));
+      return (
+        <ul key={`list-${article.slug}-${index}`} className="ml-5 list-disc space-y-1 text-sm leading-6 text-neutral-200">
+          {items.map((item, itemIndex) => (
+            <li key={`list-item-${article.slug}-${index}-${itemIndex}`}>{item}</li>
+          ))}
+        </ul>
+      );
+    }
+
+    if (/^\d+\.\s/.test(trimmed)) {
+      const items = trimmed
+        .split(/\n+/)
+        .filter(Boolean)
+        .map((item) => item.replace(/^\d+\.\s*/, ''));
+      return (
+        <ol key={`ordered-${article.slug}-${index}`} className="ml-5 list-decimal space-y-1 text-sm leading-6 text-neutral-200">
+          {items.map((item, itemIndex) => (
+            <li key={`ordered-item-${article.slug}-${index}-${itemIndex}`}>{item}</li>
+          ))}
+        </ol>
+      );
+    }
+
+    if (trimmed.startsWith('## ')) {
+      return (
+        <h3 key={`subheading-${article.slug}-${index}`} className="text-base font-semibold text-neutral-50">
+          {trimmed.replace(/^##\s+/, '')}
+        </h3>
+      );
+    }
+
+    if (trimmed.startsWith('# ')) {
+      return (
+        <h2 key={`heading-${article.slug}-${index}`} className="text-lg font-bold text-neutral-50">
+          {trimmed.replace(/^#\s+/, '')}
+        </h2>
+      );
+    }
+
+    return (
+      <p key={`paragraph-${article.slug}-${index}`} className="text-sm leading-6 text-neutral-200">
+        {trimmed}
+      </p>
+    );
+  });
+}
+
+function ErrorSummary({ definition, message }: { definition: ErrorDefinition; message: string }) {
+  return (
+    <div className="rounded-md border border-neutral-700 bg-neutral-900/70 p-4 text-neutral-100">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-neutral-400">Error code</p>
+          <p className="text-lg font-semibold text-sky-300">{definition.code}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs uppercase tracking-wide text-neutral-400">Severity</p>
+          <p className="text-base font-semibold text-amber-300">{severityLabels[definition.severity]}</p>
+        </div>
+      </div>
+      <p className="mt-3 text-sm leading-6 text-neutral-200">{message}</p>
+    </div>
+  );
+}
+
+function ArticlePanel({ article }: { article: HelpArticle }) {
+  return (
+    <article
+      id={`knowledge-base-${article.slug}`}
+      className="space-y-3 rounded-md border border-neutral-700 bg-neutral-900/50 p-4 shadow-inner"
+      aria-live="polite"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-neutral-400">Knowledge base</p>
+          <h2 className="text-lg font-semibold text-neutral-50">{article.title}</h2>
+        </div>
+        <a
+          className="text-sm font-semibold text-sky-300 underline"
+          href={`#knowledge-base-${article.slug}`}
+        >
+          View article
+        </a>
+      </div>
+      <p className="text-sm text-neutral-200">{article.summary}</p>
+      <div className="space-y-2">{formatArticleContent(article)}</div>
+    </article>
+  );
+}
+
+function SearchPanel({
+  query,
+  onQueryChange,
+  onSelectArticle,
+  articles,
+  selectedSlug,
+}: {
+  query: string;
+  onQueryChange: (value: string) => void;
+  onSelectArticle: (article: HelpArticle) => void;
+  articles: readonly HelpArticle[];
+  selectedSlug?: string | null;
+}) {
+  const trimmedQuery = query.trim();
+  const results = useMemo(() => {
+    if (!trimmedQuery) {
+      return [] as HelpArticle[];
+    }
+    return searchHelpArticles(trimmedQuery, 8);
+  }, [trimmedQuery]);
+
+  const displayedResults = trimmedQuery ? results : articles.slice(0, 3);
+
+  return (
+    <div className="space-y-2 rounded-md border border-neutral-700 bg-neutral-900/50 p-4">
+      <div className="flex flex-col gap-1">
+        <label htmlFor="kb-search" className="text-sm font-semibold text-neutral-100">
+          Search knowledge base (offline)
+        </label>
+        <input
+          id="kb-search"
+          type="search"
+          value={query}
+          onChange={(event) => onQueryChange(event.target.value)}
+          placeholder="Search by keyword or symptom"
+          className="rounded border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm text-neutral-100 outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-500/60"
+        />
+      </div>
+      <ul className="space-y-2" aria-live="polite">
+        {trimmedQuery && displayedResults.length === 0 ? (
+          <li className="text-sm text-neutral-400">No articles found. Try a different search phrase.</li>
+        ) : (
+          displayedResults.map((article) => {
+            const isActive = selectedSlug === article.slug;
+            return (
+              <li key={article.slug}>
+                <button
+                  type="button"
+                  onClick={() => onSelectArticle(article)}
+                  className={`w-full rounded border px-3 py-2 text-left text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60 ${
+                    isActive
+                      ? 'border-sky-400 bg-sky-900/40 text-neutral-50'
+                      : 'border-neutral-700 bg-neutral-950 text-neutral-100 hover:border-sky-400/80 hover:text-neutral-50'
+                  }`}
+                >
+                  <span className="block font-semibold">{article.title}</span>
+                  <span className="mt-1 block text-xs text-neutral-300">{article.summary}</span>
+                </button>
+              </li>
+            );
+          })
+        )}
+      </ul>
+    </div>
+  );
+}
+
+const ErrorHelp: React.FC<ErrorHelpProps> = ({ code, message }) => {
+  const definition = useMemo(() => getErrorDefinition(code), [code]);
+  const defaultArticle = useMemo(() => getErrorHelpArticle(definition.code), [definition.code]);
+  const [selectedArticle, setSelectedArticle] = useState<HelpArticle | undefined>(defaultArticle);
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    const fallback = getErrorHelpArticle(code);
+    setSelectedArticle(fallback);
+    setQuery('');
+  }, [code]);
+
+  const availableArticles = useMemo(() => getAllHelpArticles(), []);
+  const displayMessage = message ?? definition.defaultMessage;
+
+  return (
+    <div className="space-y-4" data-error-code={definition.code}>
+      <ErrorSummary definition={definition} message={displayMessage} />
+      {selectedArticle && <ArticlePanel article={selectedArticle} />}
+      <SearchPanel
+        query={query}
+        onQueryChange={setQuery}
+        onSelectArticle={(article) => {
+          setSelectedArticle(article);
+          setQuery('');
+        }}
+        articles={availableArticles}
+        selectedSlug={selectedArticle?.slug}
+      />
+      <p className="text-xs text-neutral-500">
+        Supported error codes: {ERROR_CODES.join(', ')}
+      </p>
+    </div>
+  );
+};
+
+export default ErrorHelp;

--- a/data/help/articles.json
+++ b/data/help/articles.json
@@ -1,0 +1,58 @@
+[
+  {
+    "slug": "network-timeout",
+    "title": "Resolve network timeouts",
+    "summary": "Fix connectivity issues when the desktop cannot reach API endpoints or background services.",
+    "keywords": ["network", "timeout", "offline", "api", "retry", "connectivity"],
+    "content": [
+      "# Resolve network timeouts",
+      "Network timeouts normally indicate that the browser could not reach the API within the allowed time window.",
+      "## Quick checks",
+      "- Confirm your device still has an active connection and that airplane mode is disabled.\n- Verify that VPN or proxy settings are not blocking requests to the application domain.\n- Retry the action after a short pause. Transient outages are often resolved automatically.",
+      "## Advanced steps",
+      "1. Open the network inspector and confirm the failing request URL.\n2. If you are working offline, enable demo data or use cached content exposed in the settings panel.\n3. Clear the service worker cache from the desktop settings and relaunch the application."
+    ]
+  },
+  {
+    "slug": "access-denied",
+    "title": "Understand access denied errors",
+    "summary": "Learn why permission failures occur and how to unblock secure actions.",
+    "keywords": ["access", "denied", "permission", "auth", "policy", "login"],
+    "content": [
+      "# Understand access denied errors",
+      "An access denied error means the current profile does not meet the security policy required for the request.",
+      "## Why this happens",
+      "- The session expired or was revoked by an administrator.\n- You attempted to reach a restricted workspace or app without the correct role.\n- Multi-factor authentication requirements were not completed in time.",
+      "## What to do",
+      "1. Sign out and sign back in to refresh credentials.\n2. Review the access control matrix in the admin console to verify your role assignments.\n3. Contact the maintainer listed in the About window if additional access is needed."
+    ]
+  },
+  {
+    "slug": "data-integrity",
+    "title": "Investigate data integrity warnings",
+    "summary": "Steps to follow when checksum or replay protections detect unexpected changes.",
+    "keywords": ["data", "integrity", "checksum", "cache", "validation", "replay"],
+    "content": [
+      "# Investigate data integrity warnings",
+      "Integrity warnings help prevent cached or replayed content from corrupting saved work.",
+      "## Checklist",
+      "- Confirm the local clock matches the network time service.\n- Clear the affected cache from the maintenance tools window.\n- Re-import the dataset or configuration from a trusted backup.",
+      "## Need more help?",
+      "Send the integrity report (without personal data) to support so they can compare hashes."
+    ]
+  },
+  {
+    "slug": "troubleshooting-basics",
+    "title": "General troubleshooting steps",
+    "summary": "Baseline recovery steps for unknown or unexpected application errors.",
+    "keywords": ["troubleshooting", "basics", "unknown", "error", "reset"],
+    "content": [
+      "# General troubleshooting steps",
+      "When the application reports an unknown error, follow these baseline recovery steps.",
+      "## Reset the workspace",
+      "- Close unused windows and relaunch the affected module.\n- Check the notifications center for maintenance announcements.\n- Use the reset layout option in desktop settings to clear stale state.",
+      "## Capture diagnostics",
+      "1. Record the steps taken before the failure occurred.\n2. Capture a screenshot of the error dialog for maintainers.\n3. Include logs exported from the diagnostics pane when opening a ticket."
+    ]
+  }
+]

--- a/data/help/index.ts
+++ b/data/help/index.ts
@@ -1,0 +1,83 @@
+import rawArticles from './articles.json';
+
+export interface HelpArticle {
+  slug: string;
+  title: string;
+  summary: string;
+  keywords: string[];
+  content: string[];
+}
+
+type IndexedHelpArticle = HelpArticle & { searchText: string };
+
+const HELP_ARTICLES_INTERNAL: IndexedHelpArticle[] = (rawArticles as HelpArticle[]).map((article) => {
+  const keywords = [...article.keywords];
+  const content = [...article.content];
+  const searchText = [article.title, article.summary, keywords.join(' '), content.join(' ')]
+    .join(' ')
+    .toLowerCase();
+  return {
+    slug: article.slug,
+    title: article.title,
+    summary: article.summary,
+    keywords,
+    content,
+    searchText,
+  };
+});
+
+HELP_ARTICLES_INTERNAL.forEach((article) => {
+  Object.freeze(article.keywords);
+  Object.freeze(article.content);
+});
+
+Object.freeze(HELP_ARTICLES_INTERNAL);
+
+const HELP_ARTICLE_INDEX = new Map<string, IndexedHelpArticle>(
+  HELP_ARTICLES_INTERNAL.map((article) => [article.slug, article])
+);
+
+export const HELP_ARTICLES: readonly HelpArticle[] = HELP_ARTICLES_INTERNAL;
+
+export function listHelpArticles(): readonly HelpArticle[] {
+  return HELP_ARTICLES;
+}
+
+export function getHelpArticle(slug: string): HelpArticle | undefined {
+  return HELP_ARTICLE_INDEX.get(slug);
+}
+
+export function searchHelpArticles(query: string, limit = 5): HelpArticle[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const matches: HelpArticle[] = [];
+
+  for (const article of HELP_ARTICLES_INTERNAL) {
+    if (article.searchText.includes(normalized) || article.keywords.some((keyword) => keyword.toLowerCase().includes(normalized))) {
+      if (!seen.has(article.slug)) {
+        seen.add(article.slug);
+        matches.push(article);
+        if (matches.length >= limit) {
+          break;
+        }
+      }
+      continue;
+    }
+
+    const words = normalized.split(/\s+/);
+    const allWordsPresent = words.every((word) => article.searchText.includes(word));
+    if (allWordsPresent && !seen.has(article.slug)) {
+      seen.add(article.slug);
+      matches.push(article);
+      if (matches.length >= limit) {
+        break;
+      }
+    }
+  }
+
+  return matches;
+}

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -1,0 +1,81 @@
+import { getHelpArticle, listHelpArticles, searchHelpArticles } from '../data/help';
+import type { HelpArticle } from '../data/help';
+
+export type ErrorSeverity = 'info' | 'warning' | 'error' | 'critical';
+
+export type ErrorCode =
+  | 'ERR_NETWORK_TIMEOUT'
+  | 'ERR_ACCESS_DENIED'
+  | 'ERR_DATA_INTEGRITY'
+  | 'ERR_UNKNOWN';
+
+export interface ErrorDefinition {
+  code: ErrorCode;
+  defaultMessage: string;
+  severity: ErrorSeverity;
+  articleSlug: string;
+  shortTitle: string;
+}
+
+const ERROR_DEFINITIONS = {
+  ERR_NETWORK_TIMEOUT: {
+    code: 'ERR_NETWORK_TIMEOUT',
+    defaultMessage: 'Network request timed out while contacting the server.',
+    severity: 'warning',
+    articleSlug: 'network-timeout',
+    shortTitle: 'Network timeout',
+  },
+  ERR_ACCESS_DENIED: {
+    code: 'ERR_ACCESS_DENIED',
+    defaultMessage: 'You do not have permission to complete this action.',
+    severity: 'error',
+    articleSlug: 'access-denied',
+    shortTitle: 'Access denied',
+  },
+  ERR_DATA_INTEGRITY: {
+    code: 'ERR_DATA_INTEGRITY',
+    defaultMessage: 'Integrity safeguards detected inconsistent cached data.',
+    severity: 'error',
+    articleSlug: 'data-integrity',
+    shortTitle: 'Integrity warning',
+  },
+  ERR_UNKNOWN: {
+    code: 'ERR_UNKNOWN',
+    defaultMessage: 'An unexpected error occurred. Try again or review troubleshooting steps.',
+    severity: 'critical',
+    articleSlug: 'troubleshooting-basics',
+    shortTitle: 'Unexpected error',
+  },
+} as const satisfies Record<ErrorCode, ErrorDefinition>;
+
+export const ERROR_CODES: readonly ErrorCode[] = Object.freeze(
+  Object.keys(ERROR_DEFINITIONS) as ErrorCode[]
+);
+
+export function isErrorCode(value: string): value is ErrorCode {
+  return value in ERROR_DEFINITIONS;
+}
+
+export function getErrorDefinition(code: ErrorCode | string): ErrorDefinition {
+  if (isErrorCode(code)) {
+    return ERROR_DEFINITIONS[code];
+  }
+
+  return ERROR_DEFINITIONS.ERR_UNKNOWN;
+}
+
+export function getErrorHelpArticle(code: ErrorCode | string): HelpArticle | undefined {
+  const definition = getErrorDefinition(code);
+  return getHelpArticle(definition.articleSlug);
+}
+
+export function getHelpArticleBySlug(slug: string): HelpArticle | undefined {
+  return getHelpArticle(slug);
+}
+
+export function getAllHelpArticles(): readonly HelpArticle[] {
+  return listHelpArticles();
+}
+
+export { searchHelpArticles };
+export type { HelpArticle };


### PR DESCRIPTION
## Summary
- add structured error definitions tied to knowledge base articles
- surface an offline-friendly ErrorHelp component with contextual search
- seed local knowledge base content for network, access, integrity, and unknown issues

## Testing
- yarn test --runTestsByPath __tests__/errors.test.ts __tests__/ErrorHelp.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dcde99aac08328afc05b25df94f426