### PR TITLE
[devtools] add repro export/import bundle

### DIFF
--- a/__tests__/reproBundle.test.ts
+++ b/__tests__/reproBundle.test.ts
@@ -1,0 +1,187 @@
+import type { AppNotification } from '../components/common/NotificationCenter';
+import type { SettingsContextValue } from '../hooks/useSettings';
+import {
+  REPRO_BUNDLE_VERSION,
+  buildReproBundle,
+  collectLocalState,
+  applyReproBundle,
+  type ReproBundle,
+} from '../utils/dev/reproBundle';
+import {
+  clearRecorder,
+  recordLog,
+  recordStep,
+  getRecorderSnapshot,
+} from '../utils/dev/reproRecorder';
+
+const createSettingsStub = (): SettingsContextValue => ({
+  accent: '#1793d1',
+  wallpaper: 'wall-2',
+  bgImageName: 'wall-2',
+  useKaliWallpaper: false,
+  density: 'regular',
+  reducedMotion: false,
+  fontScale: 1,
+  highContrast: false,
+  largeHitAreas: false,
+  pongSpin: true,
+  allowNetwork: false,
+  haptics: true,
+  theme: 'default',
+  setAccent: jest.fn(),
+  setWallpaper: jest.fn(),
+  setUseKaliWallpaper: jest.fn(),
+  setDensity: jest.fn(),
+  setReducedMotion: jest.fn(),
+  setFontScale: jest.fn(),
+  setHighContrast: jest.fn(),
+  setLargeHitAreas: jest.fn(),
+  setPongSpin: jest.fn(),
+  setAllowNetwork: jest.fn(),
+  setHaptics: jest.fn(),
+  setTheme: jest.fn(),
+});
+
+describe('repro bundle', () => {
+  beforeEach(() => {
+    clearRecorder();
+    localStorage.clear();
+  });
+
+  test('buildReproBundle captures sanitized snapshot', () => {
+    const settings = createSettingsStub();
+    const notificationsByApp: Record<string, AppNotification[]> = {
+      audit: [
+        {
+          id: 'n-1',
+          appId: 'audit',
+          title: 'Alert for user@example.com',
+          body: 'token=secret123456',
+          timestamp: 1700000000,
+          read: false,
+          priority: 'high',
+          hints: { source: 'qa' },
+          classification: { priority: 'high', matchedRuleId: 'rule-1', source: 'rule' },
+        },
+      ],
+    };
+    localStorage.setItem(
+      'desktop_icon_positions',
+      JSON.stringify({ terminal: { x: 100, y: 200 } }),
+    );
+
+    recordStep('Clicked user@example.com login', { email: 'user@example.com' });
+    recordLog('warn', 'Token token=abcdef123456', { secret: 'value' });
+
+    const bundle = buildReproBundle(settings, notificationsByApp, {
+      recentApps: ['terminal'],
+      storage: collectLocalState(localStorage, ['desktop_icon_positions']),
+    });
+
+    expect(bundle.version).toBe(REPRO_BUNDLE_VERSION);
+    expect(bundle.state.settings.accent).toBe(settings.accent);
+    expect(bundle.state.local.recentApps).toEqual(['terminal']);
+    expect(bundle.state.local.storage.desktop_icon_positions).toBeDefined();
+    expect(bundle.state.notifications.audit[0].title).toContain('<redacted-email>');
+    expect(bundle.state.notifications.audit[0].body).toContain('<redacted>');
+
+    const snapshot = getRecorderSnapshot();
+    expect(snapshot.steps[0].label).toContain('<redacted-email>');
+    expect(snapshot.logs[0].message).toContain('<redacted>');
+  });
+
+  test('applyReproBundle hydrates settings, notifications, and storage', () => {
+    const settings = createSettingsStub();
+    const hydrateNotifications = jest.fn();
+    const writeRecentApps = jest.fn();
+
+    const bundle: ReproBundle = {
+      version: REPRO_BUNDLE_VERSION,
+      exportedAt: new Date().toISOString(),
+      state: {
+        settings: {
+          accent: '#ffffff',
+          wallpaper: 'wall-4',
+          bgImageName: 'wall-4',
+          useKaliWallpaper: true,
+          density: 'compact',
+          reducedMotion: true,
+          fontScale: 1.25,
+          highContrast: true,
+          largeHitAreas: true,
+          pongSpin: false,
+          allowNetwork: true,
+          haptics: false,
+          theme: 'matrix',
+        },
+        notifications: {
+          tools: [
+            {
+              id: 'log-1',
+              appId: 'tools',
+              title: 'Job finished',
+              body: 'All good',
+              timestamp: 1710000000,
+              read: false,
+              priority: 'normal',
+              hints: { source: 'import' },
+              classification: { priority: 'normal', matchedRuleId: null, source: 'default' },
+            },
+          ],
+        },
+        local: {
+          recentApps: ['tools'],
+          storage: {
+            'desktop_icon_positions': { analyzer: { x: 10, y: 20 } },
+          },
+        },
+      },
+      steps: [
+        {
+          id: 'step-1',
+          timestamp: 1,
+          label: 'Imported run',
+        },
+      ],
+      logs: [
+        {
+          id: 'log-1',
+          timestamp: 2,
+          level: 'info',
+          message: 'Import complete',
+        },
+      ],
+    };
+
+    applyReproBundle(
+      bundle,
+      { settings, notifications: { hydrateNotifications } },
+      {
+        storage: localStorage,
+        writeRecentApps,
+      },
+    );
+
+    expect(settings.setAccent).toHaveBeenCalledWith('#ffffff');
+    expect(settings.setWallpaper).toHaveBeenCalledWith('wall-4');
+    expect(settings.setUseKaliWallpaper).toHaveBeenCalledWith(true);
+    expect(settings.setDensity).toHaveBeenCalledWith('compact');
+    expect(settings.setReducedMotion).toHaveBeenCalledWith(true);
+    expect(settings.setFontScale).toHaveBeenCalledWith(1.25);
+    expect(settings.setHighContrast).toHaveBeenCalledWith(true);
+    expect(settings.setLargeHitAreas).toHaveBeenCalledWith(true);
+    expect(settings.setPongSpin).toHaveBeenCalledWith(false);
+    expect(settings.setAllowNetwork).toHaveBeenCalledWith(true);
+    expect(settings.setHaptics).toHaveBeenCalledWith(false);
+    expect(settings.setTheme).toHaveBeenCalledWith('matrix');
+    expect(hydrateNotifications).toHaveBeenCalled();
+    expect(writeRecentApps).toHaveBeenCalledWith(['tools']);
+    expect(JSON.parse(localStorage.getItem('desktop_icon_positions') ?? '{}')).toEqual({
+      analyzer: { x: 10, y: 20 },
+    });
+
+    const snapshot = getRecorderSnapshot();
+    expect(snapshot.steps[0].label).toBe('Imported run');
+    expect(snapshot.logs[0].message).toBe('Import complete');
+  });
+});

--- a/components/dev/ReproExporter.tsx
+++ b/components/dev/ReproExporter.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { useSettings } from '../../hooks/useSettings';
+import { useNotifications } from '../../hooks/useNotifications';
+import { safeLocalStorage } from '../../utils/safeStorage';
+import { readRecentAppIds, writeRecentAppIds } from '../../utils/recentStorage';
+import {
+  REPRO_BUNDLE_VERSION,
+  buildReproBundle,
+  collectLocalState,
+  applyReproBundle,
+  type SettingsHydrator,
+  type NotificationsHydrator,
+} from '../../utils/dev/reproBundle';
+import { recordLog, recordStep } from '../../utils/dev/reproRecorder';
+
+const buttonBaseClass =
+  'inline-flex items-center justify-center rounded border border-slate-600 bg-slate-900 px-3 py-1.5 text-xs font-medium text-slate-100 transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-60';
+
+const ReproExporter: React.FC = () => {
+  const settings = useSettings();
+  const notifications = useNotifications();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const settingsHydrator: SettingsHydrator = useMemo(
+    () => ({
+      setAccent: settings.setAccent,
+      setWallpaper: settings.setWallpaper,
+      setUseKaliWallpaper: settings.setUseKaliWallpaper,
+      setDensity: settings.setDensity,
+      setReducedMotion: settings.setReducedMotion,
+      setFontScale: settings.setFontScale,
+      setHighContrast: settings.setHighContrast,
+      setLargeHitAreas: settings.setLargeHitAreas,
+      setPongSpin: settings.setPongSpin,
+      setAllowNetwork: settings.setAllowNetwork,
+      setHaptics: settings.setHaptics,
+      setTheme: settings.setTheme,
+    }),
+    [
+      settings.setAccent,
+      settings.setWallpaper,
+      settings.setUseKaliWallpaper,
+      settings.setDensity,
+      settings.setReducedMotion,
+      settings.setFontScale,
+      settings.setHighContrast,
+      settings.setLargeHitAreas,
+      settings.setPongSpin,
+      settings.setAllowNetwork,
+      settings.setHaptics,
+      settings.setTheme,
+    ],
+  );
+
+  const notificationsHydrator: NotificationsHydrator = useMemo(
+    () => ({ hydrateNotifications: notifications.hydrateNotifications }),
+    [notifications.hydrateNotifications],
+  );
+
+  const resetFileInput = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleExport = useCallback(() => {
+    if (busy) return;
+    setBusy(true);
+    setStatus(null);
+    try {
+      const localState = {
+        recentApps: readRecentAppIds(),
+        storage: collectLocalState(safeLocalStorage ?? undefined),
+      };
+      const bundle = buildReproBundle(settings, notifications.notificationsByApp, localState);
+      const json = JSON.stringify(bundle, null, 2);
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const timestamp = bundle.exportedAt.replace(/[:.]/g, '-');
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `kali-repro-${timestamp}.json`;
+      anchor.rel = 'noopener';
+      anchor.click();
+      URL.revokeObjectURL(url);
+      recordStep('dev:repro-export', { version: bundle.version });
+      recordLog('info', 'repro:export-success', { version: bundle.version });
+      setStatus(`Exported reproduction bundle v${bundle.version}`);
+    } catch (error) {
+      console.error('Failed to export reproduction bundle', error);
+      recordLog('error', 'repro:export-failure', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      setStatus('Failed to export reproduction bundle');
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, notifications.notificationsByApp, settings]);
+
+  const handleImport = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+      setBusy(true);
+      setStatus(null);
+      try {
+        const text = await file.text();
+        const parsed = JSON.parse(text);
+        const result = applyReproBundle(
+          parsed,
+          { settings: settingsHydrator, notifications: notificationsHydrator },
+          {
+            storage: safeLocalStorage ?? undefined,
+            writeRecentApps: writeRecentAppIds,
+          },
+        );
+        recordStep('dev:repro-import', { version: result.version });
+        recordLog('info', 'repro:import-success', { version: result.version });
+        setStatus(`Imported reproduction bundle v${result.version}`);
+        if (typeof window !== 'undefined') {
+          window.dispatchEvent(new CustomEvent('kali:repro-imported', { detail: { version: result.version } }));
+        }
+      } catch (error) {
+        console.error('Failed to import reproduction bundle', error);
+        recordLog('error', 'repro:import-failure', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        setStatus('Failed to import reproduction bundle');
+      } finally {
+        resetFileInput();
+        setBusy(false);
+      }
+    },
+    [notificationsHydrator, settingsHydrator],
+  );
+
+  return (
+    <section className="rounded-lg border border-dashed border-slate-700 bg-slate-950/80 p-4 text-slate-100">
+      <header className="mb-2 flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wide">Reproduction bundle</h2>
+        <span className="text-[0.65rem] uppercase text-slate-400">v{REPRO_BUNDLE_VERSION}</span>
+      </header>
+      <p className="mb-4 text-xs text-slate-300">
+        Export anonymized UI state, QA steps, and logs to help debug reports. Importing will replace current settings and desktop
+        session data with the bundle snapshot.
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        <button type="button" className={buttonBaseClass} onClick={handleExport} disabled={busy}>
+          Export bundle
+        </button>
+        <label className={`${buttonBaseClass} cursor-pointer relative overflow-hidden`}>
+          <span>Import bundle</span>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json"
+            className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+            aria-label="Import reproduction bundle"
+            onChange={handleImport}
+            disabled={busy}
+          />
+        </label>
+        <button
+          type="button"
+          className={`${buttonBaseClass} border-slate-500 bg-slate-900/80 hover:bg-slate-800/80`}
+          onClick={() => {
+            recordStep('dev:repro-reset-status', {});
+            setStatus(null);
+            resetFileInput();
+          }}
+          disabled={busy}
+        >
+          Clear status
+        </button>
+      </div>
+      {status && <p className="mt-3 text-xs text-slate-300" role="status">{status}</p>}
+    </section>
+  );
+};
+
+export default ReproExporter;

--- a/hooks/useSettings.tsx
+++ b/hooks/useSettings.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState, ReactNode, useRef } from 'react';
+import { createContext, useContext, useEffect, useState, ReactNode, useRef, useCallback } from 'react';
 import {
   getAccent as loadAccent,
   setAccent as saveAccent,
@@ -25,6 +25,7 @@ import {
   defaults,
 } from '../utils/settingsStore';
 import { getTheme as loadTheme, setTheme as saveTheme } from '../utils/theme';
+import { recordStep } from '../utils/dev/reproRecorder';
 type Density = 'regular' | 'compact';
 
 // Predefined accent palette exposed to settings UI
@@ -53,7 +54,7 @@ const shadeColor = (color: string, percent: number): string => {
     .slice(1)}`;
 };
 
-interface SettingsContextValue {
+export interface SettingsContextValue {
   accent: string;
   wallpaper: string;
   bgImageName: string;
@@ -110,34 +111,89 @@ export const SettingsContext = createContext<SettingsContextValue>({
 });
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
-  const [accent, setAccent] = useState<string>(defaults.accent);
-  const [wallpaper, setWallpaper] = useState<string>(defaults.wallpaper);
-  const [useKaliWallpaper, setUseKaliWallpaper] = useState<boolean>(defaults.useKaliWallpaper);
-  const [density, setDensity] = useState<Density>(defaults.density as Density);
-  const [reducedMotion, setReducedMotion] = useState<boolean>(defaults.reducedMotion);
-  const [fontScale, setFontScale] = useState<number>(defaults.fontScale);
-  const [highContrast, setHighContrast] = useState<boolean>(defaults.highContrast);
-  const [largeHitAreas, setLargeHitAreas] = useState<boolean>(defaults.largeHitAreas);
-  const [pongSpin, setPongSpin] = useState<boolean>(defaults.pongSpin);
-  const [allowNetwork, setAllowNetwork] = useState<boolean>(defaults.allowNetwork);
-  const [haptics, setHaptics] = useState<boolean>(defaults.haptics);
-  const [theme, setTheme] = useState<string>(() => loadTheme());
+  const [accent, setAccentState] = useState<string>(defaults.accent);
+  const [wallpaper, setWallpaperState] = useState<string>(defaults.wallpaper);
+  const [useKaliWallpaper, setUseKaliWallpaperState] = useState<boolean>(defaults.useKaliWallpaper);
+  const [density, setDensityState] = useState<Density>(defaults.density as Density);
+  const [reducedMotion, setReducedMotionState] = useState<boolean>(defaults.reducedMotion);
+  const [fontScale, setFontScaleState] = useState<number>(defaults.fontScale);
+  const [highContrast, setHighContrastState] = useState<boolean>(defaults.highContrast);
+  const [largeHitAreas, setLargeHitAreasState] = useState<boolean>(defaults.largeHitAreas);
+  const [pongSpin, setPongSpinState] = useState<boolean>(defaults.pongSpin);
+  const [allowNetwork, setAllowNetworkState] = useState<boolean>(defaults.allowNetwork);
+  const [haptics, setHapticsState] = useState<boolean>(defaults.haptics);
+  const [theme, setThemeState] = useState<string>(() => loadTheme());
   const fetchRef = useRef<typeof fetch | null>(null);
+
+  const updateSetting = useCallback(
+    <T,>(
+      setter: (value: T) => void,
+      label: string,
+      value: T,
+    ) => {
+      setter(value);
+      recordStep(`settings:${label}`, { value });
+    },
+    [],
+  );
+
+  const setAccent = useCallback((value: string) => updateSetting(setAccentState, 'accent', value), [updateSetting]);
+  const setWallpaper = useCallback(
+    (value: string) => updateSetting(setWallpaperState, 'wallpaper', value),
+    [updateSetting],
+  );
+  const setUseKaliWallpaper = useCallback(
+    (value: boolean) => updateSetting(setUseKaliWallpaperState, 'use-kali-wallpaper', value),
+    [updateSetting],
+  );
+  const setDensity = useCallback(
+    (value: Density) => updateSetting(setDensityState, 'density', value),
+    [updateSetting],
+  );
+  const setReducedMotion = useCallback(
+    (value: boolean) => updateSetting(setReducedMotionState, 'reduced-motion', value),
+    [updateSetting],
+  );
+  const setFontScale = useCallback(
+    (value: number) => updateSetting(setFontScaleState, 'font-scale', value),
+    [updateSetting],
+  );
+  const setHighContrast = useCallback(
+    (value: boolean) => updateSetting(setHighContrastState, 'high-contrast', value),
+    [updateSetting],
+  );
+  const setLargeHitAreas = useCallback(
+    (value: boolean) => updateSetting(setLargeHitAreasState, 'large-hit-areas', value),
+    [updateSetting],
+  );
+  const setPongSpin = useCallback(
+    (value: boolean) => updateSetting(setPongSpinState, 'pong-spin', value),
+    [updateSetting],
+  );
+  const setAllowNetwork = useCallback(
+    (value: boolean) => updateSetting(setAllowNetworkState, 'allow-network', value),
+    [updateSetting],
+  );
+  const setHaptics = useCallback(
+    (value: boolean) => updateSetting(setHapticsState, 'haptics', value),
+    [updateSetting],
+  );
+  const setTheme = useCallback((value: string) => updateSetting(setThemeState, 'theme', value), [updateSetting]);
 
   useEffect(() => {
     (async () => {
-      setAccent(await loadAccent());
-      setWallpaper(await loadWallpaper());
-      setUseKaliWallpaper(await loadUseKaliWallpaper());
-      setDensity((await loadDensity()) as Density);
-      setReducedMotion(await loadReducedMotion());
-      setFontScale(await loadFontScale());
-      setHighContrast(await loadHighContrast());
-      setLargeHitAreas(await loadLargeHitAreas());
-      setPongSpin(await loadPongSpin());
-      setAllowNetwork(await loadAllowNetwork());
-      setHaptics(await loadHaptics());
-      setTheme(loadTheme());
+      setAccentState(await loadAccent());
+      setWallpaperState(await loadWallpaper());
+      setUseKaliWallpaperState(await loadUseKaliWallpaper());
+      setDensityState((await loadDensity()) as Density);
+      setReducedMotionState(await loadReducedMotion());
+      setFontScaleState(await loadFontScale());
+      setHighContrastState(await loadHighContrast());
+      setLargeHitAreasState(await loadLargeHitAreas());
+      setPongSpinState(await loadPongSpin());
+      setAllowNetworkState(await loadAllowNetwork());
+      setHapticsState(await loadHaptics());
+      setThemeState(loadTheme());
     })();
   }, []);
 

--- a/utils/dev/reproBundle.ts
+++ b/utils/dev/reproBundle.ts
@@ -1,0 +1,267 @@
+import type { AppNotification } from '../../components/common/NotificationCenter';
+import type { SettingsContextValue } from '../../hooks/useSettings';
+import { anonymizeValue, getRecorderSnapshot, replaceRecorderSnapshot, type ReproLog, type ReproStep } from './reproRecorder';
+
+export const REPRO_BUNDLE_VERSION = 1;
+
+export type SerializedNotification = Pick<
+  AppNotification,
+  'id' | 'appId' | 'title' | 'body' | 'timestamp' | 'read' | 'priority'
+> & {
+  hints?: Record<string, unknown>;
+  classification?: {
+    matchedRuleId: string | null;
+    priority: AppNotification['priority'];
+    source: string;
+  };
+};
+
+export interface SettingsSnapshot {
+  accent: string;
+  wallpaper: string;
+  bgImageName: string;
+  useKaliWallpaper: boolean;
+  density: SettingsContextValue['density'];
+  reducedMotion: boolean;
+  fontScale: number;
+  highContrast: boolean;
+  largeHitAreas: boolean;
+  pongSpin: boolean;
+  allowNetwork: boolean;
+  haptics: boolean;
+  theme: string;
+}
+
+export interface LocalStateSnapshot {
+  recentApps: string[];
+  storage: Record<string, unknown>;
+}
+
+export interface ReproState {
+  settings: SettingsSnapshot;
+  notifications: Record<string, SerializedNotification[]>;
+  local: LocalStateSnapshot;
+}
+
+export interface ReproBundle {
+  version: number;
+  exportedAt: string;
+  state: ReproState;
+  steps: ReproStep[];
+  logs: ReproLog[];
+}
+
+export const LOCAL_STORAGE_KEYS = [
+  'desktop_icon_positions',
+  'pinnedApps',
+  'frequentApps',
+  'app_shortcuts',
+  'window-trash',
+  'new_folders',
+  'trash-purge-days',
+  'lab-mode',
+  'lab-mode:auto',
+  'lab-mode:persist',
+  'snap-enabled',
+  'screen-locked',
+  'booting_screen',
+  'shut-down',
+  'kali-recent',
+];
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+const ensurePlainObject = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+
+export const extractSettingsSnapshot = (settings: SettingsContextValue): SettingsSnapshot => ({
+  accent: settings.accent,
+  wallpaper: settings.wallpaper,
+  bgImageName: settings.bgImageName,
+  useKaliWallpaper: settings.useKaliWallpaper,
+  density: settings.density,
+  reducedMotion: settings.reducedMotion,
+  fontScale: settings.fontScale,
+  highContrast: settings.highContrast,
+  largeHitAreas: settings.largeHitAreas,
+  pongSpin: settings.pongSpin,
+  allowNetwork: settings.allowNetwork,
+  haptics: settings.haptics,
+  theme: settings.theme,
+});
+
+export const collectLocalState = (
+  storage: StorageLike | undefined,
+  keys: string[] = LOCAL_STORAGE_KEYS,
+): Record<string, unknown> => {
+  if (!storage) return {};
+  const result: Record<string, unknown> = {};
+  keys.forEach((key) => {
+    try {
+      const value = storage.getItem(key);
+      if (value !== null) {
+        try {
+          result[key] = anonymizeValue(JSON.parse(value));
+        } catch {
+          result[key] = anonymizeValue(value);
+        }
+      }
+    } catch {
+      // ignore storage read errors
+    }
+  });
+  return result;
+};
+
+export const serializeNotifications = (
+  notificationsByApp: Record<string, AppNotification[]>,
+): Record<string, SerializedNotification[]> => {
+  const snapshot: Record<string, SerializedNotification[]> = {};
+  Object.entries(notificationsByApp).forEach(([appId, list]) => {
+    snapshot[appId] = list.map((notification) => ({
+      id: notification.id,
+      appId,
+      title:
+        typeof notification.title === 'string'
+          ? (anonymizeValue(notification.title) as string)
+          : '',
+      body: notification.body ? (anonymizeValue(String(notification.body)) as string) : undefined,
+      timestamp: notification.timestamp,
+      read: Boolean(notification.read),
+      priority: notification.priority,
+      hints: notification.hints ? ensurePlainObject(anonymizeValue(notification.hints)) : undefined,
+      classification: notification.classification
+        ? {
+            matchedRuleId: notification.classification.matchedRuleId,
+            priority: notification.classification.priority,
+            source: notification.classification.source,
+          }
+        : undefined,
+    }));
+  });
+  return snapshot;
+};
+
+export const buildReproBundle = (
+  settings: SettingsContextValue,
+  notificationsByApp: Record<string, AppNotification[]>,
+  localState: LocalStateSnapshot,
+): ReproBundle => {
+  const { steps, logs } = getRecorderSnapshot();
+  return {
+    version: REPRO_BUNDLE_VERSION,
+    exportedAt: new Date().toISOString(),
+    state: {
+      settings: extractSettingsSnapshot(settings),
+      notifications: serializeNotifications(notificationsByApp),
+      local: {
+        recentApps: [...localState.recentApps],
+        storage: anonymizeValue(localState.storage) as Record<string, unknown>,
+      },
+    },
+    steps,
+    logs,
+  };
+};
+
+export interface SettingsHydrator {
+  setAccent: (value: string) => void;
+  setWallpaper: (value: string) => void;
+  setUseKaliWallpaper: (value: boolean) => void;
+  setDensity: (value: SettingsContextValue['density']) => void;
+  setReducedMotion: (value: boolean) => void;
+  setFontScale: (value: number) => void;
+  setHighContrast: (value: boolean) => void;
+  setLargeHitAreas: (value: boolean) => void;
+  setPongSpin: (value: boolean) => void;
+  setAllowNetwork: (value: boolean) => void;
+  setHaptics: (value: boolean) => void;
+  setTheme: (value: string) => void;
+}
+
+export interface NotificationsHydrator {
+  hydrateNotifications: (snapshot: Record<string, SerializedNotification[]>) => void;
+}
+
+export interface HydrationOptions {
+  storage?: StorageLike;
+  writeRecentApps?: (ids: string[]) => void;
+}
+
+export const applyReproBundle = (
+  bundle: unknown,
+  handlers: {
+    settings: SettingsHydrator;
+    notifications: NotificationsHydrator;
+  },
+  options: HydrationOptions = {},
+): ReproBundle => {
+  if (!bundle || typeof bundle !== 'object') {
+    throw new Error('Invalid bundle');
+  }
+  const parsed = bundle as Partial<ReproBundle>;
+  if (typeof parsed.version !== 'number') {
+    throw new Error('Bundle missing version');
+  }
+  if (!parsed.state) {
+    throw new Error('Bundle missing state');
+  }
+  if (parsed.version > REPRO_BUNDLE_VERSION) {
+    throw new Error(`Unsupported bundle version ${parsed.version}`);
+  }
+
+  const state = parsed.state as ReproState;
+  const { settings, notifications, local } = state;
+
+  if (settings) {
+    if (settings.accent) handlers.settings.setAccent(settings.accent);
+    if (settings.wallpaper) handlers.settings.setWallpaper(settings.wallpaper);
+    if (settings.useKaliWallpaper !== undefined) handlers.settings.setUseKaliWallpaper(Boolean(settings.useKaliWallpaper));
+    if (settings.density) handlers.settings.setDensity(settings.density);
+    if (settings.reducedMotion !== undefined) handlers.settings.setReducedMotion(Boolean(settings.reducedMotion));
+    if (typeof settings.fontScale === 'number') handlers.settings.setFontScale(settings.fontScale);
+    if (settings.highContrast !== undefined) handlers.settings.setHighContrast(Boolean(settings.highContrast));
+    if (settings.largeHitAreas !== undefined) handlers.settings.setLargeHitAreas(Boolean(settings.largeHitAreas));
+    if (settings.pongSpin !== undefined) handlers.settings.setPongSpin(Boolean(settings.pongSpin));
+    if (settings.allowNetwork !== undefined) handlers.settings.setAllowNetwork(Boolean(settings.allowNetwork));
+    if (settings.haptics !== undefined) handlers.settings.setHaptics(Boolean(settings.haptics));
+    if (settings.theme) handlers.settings.setTheme(settings.theme);
+  }
+
+  if (notifications) {
+    handlers.notifications.hydrateNotifications(notifications);
+  }
+
+  if (local) {
+    if (options.storage) {
+      Object.entries(local.storage || {}).forEach(([key, value]) => {
+        try {
+          if (value === undefined || value === null) {
+            options.storage!.removeItem(key);
+            return;
+          }
+          const serialized = typeof value === 'string' ? value : JSON.stringify(value);
+          options.storage!.setItem(key, serialized);
+        } catch {
+          // ignore storage failures
+        }
+      });
+    }
+    if (options.writeRecentApps && Array.isArray(local.recentApps)) {
+      options.writeRecentApps(local.recentApps.filter((id): id is string => typeof id === 'string'));
+    }
+  }
+
+  replaceRecorderSnapshot(parsed.steps ?? [], parsed.logs ?? []);
+  return {
+    version: parsed.version,
+    exportedAt: parsed.exportedAt ?? new Date().toISOString(),
+    state,
+    steps: parsed.steps ?? [],
+    logs: parsed.logs ?? [],
+  };
+};

--- a/utils/dev/reproRecorder.ts
+++ b/utils/dev/reproRecorder.ts
@@ -1,0 +1,138 @@
+export type ReproStep = {
+  id: string;
+  timestamp: number;
+  label: string;
+  meta?: Record<string, unknown>;
+};
+
+export type ReproLogLevel = 'info' | 'warn' | 'error';
+
+export type ReproLog = {
+  id: string;
+  timestamp: number;
+  level: ReproLogLevel;
+  message: string;
+  context?: Record<string, unknown>;
+};
+
+const EMAIL_REGEX = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const UUID_REGEX = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const DIGIT_SEQUENCE_REGEX = /\b\d{6,}\b/g;
+const TOKEN_REGEX = /(api|session|auth|secret|token|key)=([^\s&]+)/gi;
+
+const MAX_STEPS = 300;
+const MAX_LOGS = 300;
+
+let steps: ReproStep[] = [];
+let logs: ReproLog[] = [];
+
+const clampHistory = <T>(list: T[], limit: number) =>
+  list.length > limit ? list.slice(list.length - limit) : list;
+
+export const anonymizeText = (value: string): string =>
+  value
+    .replace(EMAIL_REGEX, '<redacted-email>')
+    .replace(UUID_REGEX, '<redacted-id>')
+    .replace(DIGIT_SEQUENCE_REGEX, '<redacted-number>')
+    .replace(TOKEN_REGEX, (_, prefix) => `${prefix}=<redacted>`);
+
+const sanitizePrimitive = (value: unknown): unknown => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    const normalized = anonymizeText(trimmed);
+    return normalized.length > 500 ? `${normalized.slice(0, 497)}...` : normalized;
+  }
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    return 0;
+  }
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (value && typeof value === 'object' && 'toString' in value) {
+    try {
+      return sanitizePrimitive((value as { toString(): string }).toString());
+    } catch {
+      return '[object]';
+    }
+  }
+  return value;
+};
+
+export const anonymizeValue = (value: unknown): unknown => {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) {
+    return value.map(item => anonymizeValue(item));
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    const result: Record<string, unknown> = {};
+    entries.forEach(([key, val]) => {
+      if (key.toLowerCase().includes('token') || key.toLowerCase().includes('secret')) {
+        result[key] = '<redacted>';
+      } else {
+        result[key] = anonymizeValue(val);
+      }
+    });
+    return result;
+  }
+  return sanitizePrimitive(value);
+};
+
+const createEntryId = (prefix: string) => `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+export const recordStep = (label: string, meta?: Record<string, unknown>): void => {
+  const step: ReproStep = {
+    id: createEntryId('step'),
+    timestamp: Date.now(),
+    label: anonymizeText(label),
+    meta: meta ? (anonymizeValue(meta) as Record<string, unknown>) : undefined,
+  };
+  steps = clampHistory([...steps, step], MAX_STEPS);
+};
+
+export const recordLog = (
+  level: ReproLogLevel,
+  message: string,
+  context?: Record<string, unknown>,
+): void => {
+  const log: ReproLog = {
+    id: createEntryId('log'),
+    timestamp: Date.now(),
+    level,
+    message: anonymizeText(message),
+    context: context ? (anonymizeValue(context) as Record<string, unknown>) : undefined,
+  };
+  logs = clampHistory([...logs, log], MAX_LOGS);
+};
+
+export const getRecorderSnapshot = () => ({
+  steps: [...steps],
+  logs: [...logs],
+});
+
+export const clearRecorder = () => {
+  steps = [];
+  logs = [];
+};
+
+export const replaceRecorderSnapshot = (nextSteps: ReproStep[] = [], nextLogs: ReproLog[] = []): void => {
+  steps = clampHistory(
+    nextSteps.map(step => ({
+      ...step,
+      label: anonymizeText(step.label),
+      meta: step.meta ? (anonymizeValue(step.meta) as Record<string, unknown>) : undefined,
+    })),
+    MAX_STEPS,
+  );
+  logs = clampHistory(
+    nextLogs.map(log => ({
+      ...log,
+      message: anonymizeText(log.message),
+      context: log.context ? (anonymizeValue(log.context) as Record<string, unknown>) : undefined,
+    })),
+    MAX_LOGS,
+  );
+};


### PR DESCRIPTION
## Summary
- add a developer ReproExporter component that bundles sanitized state, steps, and logs
- extend settings and notifications managers to record QA steps and hydrate from imports
- provide reusable repro bundle helpers and unit tests covering export completeness and import hydration

## Testing
- yarn lint
- yarn test reproBundle

------
https://chatgpt.com/codex/tasks/task_e_68dcde9a900c83289ba633febbfc9063