### PR TITLE
[exports] add export center pipeline and queue tests

### DIFF
--- a/__tests__/exportPipeline.test.ts
+++ b/__tests__/exportPipeline.test.ts
@@ -1,0 +1,188 @@
+import ExportPipeline, {
+  ExportJobRequest,
+  ExportSnapshot,
+  ExportTask,
+} from '../utils/exports/pipeline';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const waitForSnapshot = async (
+  pipeline: ExportPipeline,
+  predicate: (snapshot: ExportSnapshot) => boolean,
+  attempts = 10,
+) => {
+  let snapshot = pipeline.getSnapshot();
+  for (let i = 0; i < attempts; i += 1) {
+    if (predicate(snapshot)) return snapshot;
+    await flush();
+    snapshot = pipeline.getSnapshot();
+  }
+  return snapshot;
+};
+
+describe('ExportPipeline', () => {
+  it('processes queued exports sequentially and updates history', async () => {
+    const history: ExportTask[][] = [];
+    const pipeline = new ExportPipeline({
+      onHistoryChange: (next) => {
+        history.push(next);
+      },
+    });
+
+    let resolveJobA: ((result: { bytesWritten: number }) => void) | undefined;
+    let resolveJobB: ((result: { bytesWritten: number }) => void) | undefined;
+
+    const jobA: ExportJobRequest = {
+      label: 'Recon export',
+      source: 'reports/recon',
+      start: () =>
+        new Promise((resolve) => {
+          resolveJobA = resolve;
+        }),
+    };
+
+    const jobB: ExportJobRequest = {
+      label: 'Loot export',
+      source: 'reports/loot',
+      start: () =>
+        new Promise((resolve) => {
+          resolveJobB = resolve;
+        }),
+    };
+
+    const idA = pipeline.queueExport(jobA);
+    const idB = pipeline.queueExport(jobB);
+
+    const queueSnapshot = await waitForSnapshot(
+      pipeline,
+      (snapshot) =>
+        snapshot.active.some(
+          (task) => task.id === idA && task.status === 'running',
+        ) &&
+        snapshot.active.some((task) => task.id === idB && task.status === 'queued'),
+    );
+
+    expect(queueSnapshot.active.find((task) => task.id === idA)?.status).toBe('running');
+    expect(
+      queueSnapshot.active.some((task) => task.id === idB && task.status === 'queued'),
+    ).toBe(true);
+
+    resolveJobA?.({ bytesWritten: 2_048 });
+
+    const afterFirst = await waitForSnapshot(
+      pipeline,
+      (snapshot) =>
+        snapshot.completed.some(
+          (task) => task.id === idA && task.status === 'completed',
+        ) &&
+        snapshot.active.some((task) => task.id === idB && task.status === 'running'),
+    );
+
+    expect(
+      afterFirst.completed.find((task) => task.id === idA)?.status,
+    ).toBe('completed');
+    expect(
+      afterFirst.active.find((task) => task.id === idB)?.status,
+    ).toBe('running');
+
+    resolveJobB?.({ bytesWritten: 1_024 });
+
+    const finalSnapshot = await waitForSnapshot(
+      pipeline,
+      (snapshot) =>
+        snapshot.active.length === 0 &&
+        snapshot.completed.length === 2 &&
+        snapshot.completed.every((task) => task.status === 'completed'),
+    );
+
+    expect(finalSnapshot.active).toHaveLength(0);
+    expect(finalSnapshot.completed).toHaveLength(2);
+    expect(history.at(-1)?.map((entry) => entry.id)).toEqual([idB, idA]);
+  });
+
+  it('supports cancelling and resuming resumable exports', async () => {
+    const cleanupCalls: string[][] = [];
+    const pipeline = new ExportPipeline();
+
+    let cancelCalled = false;
+    const job: ExportJobRequest = {
+      label: 'Forensics package',
+      source: 'cases/alpha',
+      resumable: true,
+      start: ({ updateProgress, setResumeToken, signal }) => {
+        updateProgress({ bytesTotal: 4_000, bytesCompleted: 2_000, tempFiles: ['tmp-1'] });
+        setResumeToken('resume-token');
+        return new Promise((resolve, reject) => {
+          signal.addEventListener('abort', () => {
+            const abortError = new Error('aborted');
+            abortError.name = 'AbortError';
+            reject(abortError);
+          });
+          // Wait for resume or cancel
+        });
+      },
+      resume: ({ updateProgress, getJob }) => {
+        const snapshot = getJob();
+        expect(snapshot.resumeToken).toBe('resume-token');
+        updateProgress({ bytesCompleted: 4_000 });
+        return Promise.resolve({ bytesWritten: 4_096, redactions: ['credentials'] });
+      },
+      cancel: () => {
+        cancelCalled = true;
+        return Promise.resolve();
+      },
+      cleanup: async (task) => {
+        cleanupCalls.push([...task.tempFiles]);
+      },
+    };
+
+    const exportId = pipeline.queueExport(job);
+    await flush();
+
+    await pipeline.cancelExport(exportId);
+
+    const cancelledSnapshot = await waitForSnapshot(
+      pipeline,
+      (snapshot) =>
+        snapshot.completed.some(
+          (task) => task.id === exportId && task.status === 'cancelled',
+        ),
+    );
+
+    expect(cancelCalled).toBe(true);
+    expect(cleanupCalls).toEqual([['tmp-1']]);
+
+    const cancelled = cancelledSnapshot.completed.find((task) => task.id === exportId);
+    expect(cancelled?.status).toBe('cancelled');
+    expect(cancelled?.tempFiles).toHaveLength(0);
+
+    const resumed = await pipeline.resumeExport(exportId);
+    expect(resumed).toBe(true);
+
+    const runningSnapshot = await waitForSnapshot(
+      pipeline,
+      (snapshot) =>
+        snapshot.active.some(
+          (task) => task.id === exportId && task.status === 'running',
+        ),
+    );
+
+    expect(runningSnapshot.active.find((task) => task.id === exportId)?.status).toBe(
+      'running',
+    );
+
+    const snapshot = await waitForSnapshot(
+      pipeline,
+      (next) =>
+        next.completed.some(
+          (task) => task.id === exportId && task.status === 'completed',
+        ),
+    );
+
+    const completed = snapshot.completed.find((task) => task.id === exportId);
+    expect(completed).toBeDefined();
+    expect(completed?.status).toBe('completed');
+    expect(completed?.redactions).toEqual(['credentials']);
+    expect(completed?.result?.bytesWritten).toBe(4_096);
+  });
+});

--- a/components/common/ExportCenter.tsx
+++ b/components/common/ExportCenter.tsx
@@ -1,0 +1,415 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import usePersistentState from '../../hooks/usePersistentState';
+import ExportPipeline, {
+  ExportJobRequest,
+  ExportSnapshot,
+  ExportTask,
+  ExportTaskView,
+} from '../../utils/exports/pipeline';
+
+const isExportHistory = (value: unknown): value is ExportTask[] =>
+  Array.isArray(value) &&
+  value.every(
+    (entry) =>
+      entry &&
+      typeof entry.id === 'string' &&
+      typeof entry.label === 'string' &&
+      typeof entry.source === 'string' &&
+      typeof entry.status === 'string' &&
+      Array.isArray(entry.redactions) &&
+      Array.isArray(entry.tempFiles),
+  );
+
+export type ExportStatusFilter =
+  | 'all'
+  | 'active'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'running';
+
+interface ExportCenterContextValue {
+  snapshot: ExportSnapshot;
+  enqueueExport: (request: ExportJobRequest) => string;
+  cancelExport: (id: string) => Promise<boolean>;
+  resumeExport: (id: string) => Promise<boolean>;
+  retryExport: (id: string) => boolean;
+  searchTerm: string;
+  setSearchTerm: (value: string) => void;
+  statusFilter: ExportStatusFilter;
+  setStatusFilter: (value: ExportStatusFilter) => void;
+}
+
+const ExportCenterContext = createContext<ExportCenterContextValue | null>(null);
+
+export const useExportCenterContext = () => {
+  const ctx = useContext(ExportCenterContext);
+  if (!ctx) {
+    throw new Error('useExportCenterContext must be used within ExportCenterProvider');
+  }
+  return ctx;
+};
+
+interface ExportCenterProviderProps {
+  children?: React.ReactNode;
+}
+
+export const ExportCenterProvider: React.FC<ExportCenterProviderProps> = ({ children }) => {
+  const [persistedHistory, setPersistedHistory] = usePersistentState<ExportTask[]>(
+    'export-history',
+    [],
+    isExportHistory,
+  );
+
+  const pipelineRef = useRef<ExportPipeline | null>(null);
+  if (!pipelineRef.current) {
+    pipelineRef.current = new ExportPipeline({
+      history: persistedHistory,
+      onHistoryChange: setPersistedHistory,
+    });
+  }
+  const pipeline = pipelineRef.current;
+
+  const [snapshot, setSnapshot] = useState<ExportSnapshot>(() => pipeline.getSnapshot());
+  const [searchTerm, setSearchTerm] = useState('');
+  const [statusFilter, setStatusFilter] = useState<ExportStatusFilter>('all');
+
+  useEffect(() => {
+    const unsubscribe = pipeline.subscribe(setSnapshot);
+    return unsubscribe;
+  }, [pipeline]);
+
+  const enqueueExport = useCallback(
+    (request: ExportJobRequest) => pipeline.queueExport(request),
+    [pipeline],
+  );
+  const cancelExport = useCallback(
+    (id: string) => pipeline.cancelExport(id),
+    [pipeline],
+  );
+  const resumeExport = useCallback(
+    (id: string) => pipeline.resumeExport(id),
+    [pipeline],
+  );
+  const retryExport = useCallback((id: string) => pipeline.retryExport(id), [pipeline]);
+
+  const value = useMemo<ExportCenterContextValue>(
+    () => ({
+      snapshot,
+      enqueueExport,
+      cancelExport,
+      resumeExport,
+      retryExport,
+      searchTerm,
+      setSearchTerm,
+      statusFilter,
+      setStatusFilter,
+    }),
+    [
+      snapshot,
+      enqueueExport,
+      cancelExport,
+      resumeExport,
+      retryExport,
+      searchTerm,
+      setSearchTerm,
+      statusFilter,
+      setStatusFilter,
+    ],
+  );
+
+  return (
+    <ExportCenterContext.Provider value={value}>{children}</ExportCenterContext.Provider>
+  );
+};
+
+export interface ExportCenterProps {
+  className?: string;
+}
+
+const ExportCenter: React.FC<ExportCenterProps> = ({ className }) => {
+  const {
+    snapshot,
+    cancelExport,
+    resumeExport,
+    retryExport,
+    searchTerm,
+    setSearchTerm,
+    statusFilter,
+    setStatusFilter,
+  } = useExportCenterContext();
+
+  const filteredActive = useMemo(() => {
+    return filterTasks(snapshot.active, searchTerm, statusFilter);
+  }, [snapshot.active, searchTerm, statusFilter]);
+
+  const filteredCompleted = useMemo(() => {
+    return filterTasks(snapshot.completed, searchTerm, statusFilter);
+  }, [snapshot.completed, searchTerm, statusFilter]);
+
+  const handleCancel = useCallback(
+    (id: string) => {
+      void cancelExport(id);
+    },
+    [cancelExport],
+  );
+
+  const handleResume = useCallback(
+    (id: string) => {
+      void resumeExport(id);
+    },
+    [resumeExport],
+  );
+
+  const handleRetry = useCallback(
+    (id: string) => {
+      retryExport(id);
+    },
+    [retryExport],
+  );
+
+  return (
+    <div className={className}>
+      <div className="rounded-lg border border-gray-800 bg-gray-900 text-gray-100 shadow-lg">
+        <header className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-800 px-4 py-3">
+          <h2 className="text-lg font-semibold">Export Center</h2>
+          <div className="flex flex-1 flex-wrap items-center justify-end gap-2">
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Search exports"
+              aria-label="Search exports"
+              className="w-full min-w-[180px] flex-1 rounded border border-gray-700 bg-gray-950 px-3 py-1 text-sm text-gray-200 placeholder:text-gray-500 focus:border-blue-500 focus:outline-none"
+            />
+            <select
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value as ExportStatusFilter)}
+              aria-label="Filter exports by status"
+              className="rounded border border-gray-700 bg-gray-950 px-3 py-1 text-sm text-gray-200 focus:border-blue-500 focus:outline-none"
+            >
+              <option value="all">All statuses</option>
+              <option value="active">Active</option>
+              <option value="running">Running</option>
+              <option value="completed">Completed</option>
+              <option value="failed">Failed</option>
+              <option value="cancelled">Cancelled</option>
+            </select>
+          </div>
+        </header>
+        <div className="grid gap-0 divide-y divide-gray-800 md:grid-cols-2 md:divide-x md:divide-y-0">
+          <section className="min-h-[200px]">
+            <h3 className="border-b border-gray-800 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-gray-400">
+              Active exports
+            </h3>
+            {filteredActive.length === 0 ? (
+              <p className="px-4 py-6 text-sm text-gray-500">No active exports</p>
+            ) : (
+              <ul className="divide-y divide-gray-800">
+                {filteredActive.map((task) => (
+                  <li key={task.id} className="px-4 py-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-medium text-gray-100">{task.label}</p>
+                        <p className="text-xs text-gray-500">{formatStatus(task)}</p>
+                      </div>
+                      <div className="text-right text-xs text-gray-400">
+                        {formatProgress(task)}
+                      </div>
+                    </div>
+                    {task.redactions.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-1">
+                        {task.redactions.map((redaction) => (
+                          <span
+                            key={redaction}
+                            className="rounded bg-gray-800 px-2 py-0.5 text-xs text-gray-300"
+                          >
+                            {redaction}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    <div className="mt-3 flex items-center justify-between text-xs text-gray-400">
+                      <span>{formatSizeRange(task.bytesCompleted, task.bytesTotal)}</span>
+                      {task.canCancel && (
+                        <button
+                          type="button"
+                          onClick={() => handleCancel(task.id)}
+                          className="rounded border border-red-500 px-2 py-1 text-xs font-medium text-red-400 transition hover:bg-red-500/10"
+                        >
+                          Cancel
+                        </button>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+          <section className="min-h-[200px]">
+            <h3 className="border-b border-gray-800 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-gray-400">
+              Completed exports
+            </h3>
+            {filteredCompleted.length === 0 ? (
+              <p className="px-4 py-6 text-sm text-gray-500">No export history</p>
+            ) : (
+              <ul className="divide-y divide-gray-800">
+                {filteredCompleted.map((task) => (
+                  <li key={task.id} className="px-4 py-3">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-medium text-gray-100">{task.label}</p>
+                        <p className="text-xs text-gray-500">{formatStatus(task)}</p>
+                        {task.error && (
+                          <p className="mt-1 text-xs text-red-400">{task.error}</p>
+                        )}
+                      </div>
+                      <div className="flex gap-2">
+                        {task.canResume && (
+                          <button
+                            type="button"
+                            onClick={() => handleResume(task.id)}
+                            className="rounded border border-blue-500 px-2 py-1 text-xs font-medium text-blue-300 transition hover:bg-blue-500/10"
+                          >
+                            Resume
+                          </button>
+                        )}
+                        {task.canRetry && (
+                          <button
+                            type="button"
+                            onClick={() => handleRetry(task.id)}
+                            className="rounded border border-yellow-500 px-2 py-1 text-xs font-medium text-yellow-300 transition hover:bg-yellow-500/10"
+                          >
+                            Retry
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                    {task.redactions.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-1">
+                        {task.redactions.map((redaction) => (
+                          <span
+                            key={redaction}
+                            className="rounded bg-gray-800 px-2 py-0.5 text-xs text-gray-300"
+                          >
+                            {redaction}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-gray-400">
+                      <span>{formatSize(task)}</span>
+                      <span>Retries: {task.retries}</span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+function filterTasks(
+  tasks: ExportTaskView[],
+  searchTerm: string,
+  filter: ExportStatusFilter,
+): ExportTaskView[] {
+  const term = searchTerm.trim().toLowerCase();
+  return tasks.filter((task) => {
+    if (filter !== 'all') {
+      if (filter === 'active') {
+        if (!(task.status === 'queued' || task.status === 'running')) return false;
+      } else if (filter === 'running') {
+        if (task.status !== 'running') return false;
+      } else if (task.status !== filter) {
+        return false;
+      }
+    }
+
+    if (!term) return true;
+    const haystack = [
+      task.label,
+      task.source,
+      task.redactions.join(' '),
+      task.result?.downloadUrl ?? '',
+      task.error ?? '',
+    ]
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(term);
+  });
+}
+
+function formatProgress(task: ExportTaskView) {
+  if (task.status === 'queued') return 'Queued';
+  if (task.bytesTotal && task.bytesTotal > 0) {
+    const percent = Math.min(100, Math.round((task.bytesCompleted / task.bytesTotal) * 100));
+    return `${percent}%`; 
+  }
+  if (task.bytesCompleted > 0) {
+    return `${formatBytes(task.bytesCompleted)} exported`;
+  }
+  return 'Starting…';
+}
+
+function formatSize(task: ExportTaskView) {
+  if (task.result?.bytesWritten) {
+    return `Size: ${formatBytes(task.result.bytesWritten)}`;
+  }
+  if (task.bytesCompleted) {
+    return `Size: ${formatBytes(task.bytesCompleted)}`;
+  }
+  return 'Size unknown';
+}
+
+function formatSizeRange(bytesCompleted: number, bytesTotal?: number) {
+  if (bytesTotal && bytesTotal > 0) {
+    return `${formatBytes(bytesCompleted)} / ${formatBytes(bytesTotal)}`;
+  }
+  if (bytesCompleted > 0) {
+    return `${formatBytes(bytesCompleted)} exported`;
+  }
+  return 'Pending';
+}
+
+function formatBytes(value?: number) {
+  if (!value) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let size = value;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+  return `${size.toFixed(size < 10 ? 1 : 0)} ${units[unitIndex]}`;
+}
+
+function formatStatus(task: ExportTaskView) {
+  switch (task.status) {
+    case 'queued':
+      return 'Queued';
+    case 'running':
+      return 'Running';
+    case 'completed':
+      return `Completed ${task.result?.downloadUrl ? '— Ready to download' : ''}`.trim();
+    case 'failed':
+      return 'Failed';
+    case 'cancelled':
+      return 'Cancelled';
+    default:
+      return task.status;
+  }
+}
+
+export default ExportCenter;

--- a/hooks/useExportCenter.ts
+++ b/hooks/useExportCenter.ts
@@ -1,0 +1,5 @@
+import { useExportCenterContext } from '../components/common/ExportCenter';
+
+export const useExportCenter = () => useExportCenterContext();
+
+export default useExportCenter;

--- a/utils/exports/pipeline.ts
+++ b/utils/exports/pipeline.ts
@@ -1,0 +1,482 @@
+export type ExportStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+export interface ExportResult {
+  bytesWritten: number;
+  downloadUrl?: string;
+  redactions?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface ExportProgressUpdate {
+  bytesCompleted?: number;
+  bytesTotal?: number;
+  redactions?: string[];
+  tempFiles?: string[];
+}
+
+export interface ExportJobController {
+  signal: AbortSignal;
+  updateProgress: (update: ExportProgressUpdate) => void;
+  setResumeToken: (token: string | null) => void;
+  getJob: () => ExportTask;
+}
+
+export interface ExportJobRequest {
+  id?: string;
+  label: string;
+  source: string;
+  resumable?: boolean;
+  redactions?: string[];
+  totalBytes?: number;
+  start: (controller: ExportJobController) => Promise<ExportResult>;
+  resume?: (controller: ExportJobController) => Promise<ExportResult>;
+  cancel?: (controller: ExportJobController) => Promise<void>;
+  cleanup?: (task: ExportTask) => Promise<void>;
+}
+
+export interface ExportTask {
+  id: string;
+  label: string;
+  source: string;
+  status: ExportStatus;
+  resumable: boolean;
+  redactions: string[];
+  bytesCompleted: number;
+  bytesTotal?: number;
+  createdAt: number;
+  updatedAt: number;
+  retries: number;
+  error?: string;
+  resumeToken?: string | null;
+  tempFiles: string[];
+  result?: ExportResult;
+}
+
+export interface ExportTaskView extends ExportTask {
+  canCancel: boolean;
+  canResume: boolean;
+  canRetry: boolean;
+  isRunning: boolean;
+  isQueued: boolean;
+}
+
+export interface ExportSnapshot {
+  active: ExportTaskView[];
+  completed: ExportTaskView[];
+}
+
+interface ExportHandlers {
+  start: ExportJobRequest['start'];
+  resume?: ExportJobRequest['resume'];
+  cancel?: ExportJobRequest['cancel'];
+  cleanup?: ExportJobRequest['cleanup'];
+}
+
+interface ExportJobInternal extends ExportTask {
+  pendingResume: boolean;
+  controller?: AbortController;
+}
+
+export interface ExportPipelineOptions {
+  history?: ExportTask[];
+  onHistoryChange?: (history: ExportTask[]) => void;
+}
+
+const DEFAULT_HISTORY: ExportTask[] = [];
+
+const createId = () => `exp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+export class ExportPipeline {
+  private jobs = new Map<string, ExportJobInternal>();
+
+  private handlers = new Map<string, ExportHandlers>();
+
+  private queue: string[] = [];
+
+  private listeners = new Set<(snapshot: ExportSnapshot) => void>();
+
+  private activeId: string | null = null;
+
+  private onHistoryChange?: (history: ExportTask[]) => void;
+
+  constructor(options: ExportPipelineOptions = {}) {
+    this.onHistoryChange = options.onHistoryChange;
+    const history = options.history ?? DEFAULT_HISTORY;
+    history.forEach((entry) => {
+      const job: ExportJobInternal = {
+        ...entry,
+        redactions: [...entry.redactions],
+        tempFiles: [...entry.tempFiles],
+        result: entry.result ? { ...entry.result } : undefined,
+        pendingResume: false,
+        controller: undefined,
+      };
+      this.jobs.set(entry.id, job);
+    });
+  }
+
+  queueExport(request: ExportJobRequest): string {
+    const id = request.id ?? createId();
+    const existing = this.jobs.get(id);
+    if (existing && existing.status !== 'completed') {
+      throw new Error(`Export with id ${id} already exists`);
+    }
+
+    const now = Date.now();
+    const job: ExportJobInternal = {
+      id,
+      label: request.label,
+      source: request.source,
+      status: 'queued',
+      resumable: Boolean(request.resumable),
+      redactions: request.redactions ? [...request.redactions] : [],
+      bytesCompleted: 0,
+      bytesTotal: request.totalBytes,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+      retries: existing?.retries ?? 0,
+      error: undefined,
+      resumeToken: existing?.resumeToken ?? null,
+      tempFiles: [],
+      result: undefined,
+      pendingResume: false,
+      controller: undefined,
+    };
+
+    this.jobs.set(id, job);
+    this.handlers.set(id, {
+      start: request.start,
+      resume: request.resume,
+      cancel: request.cancel,
+      cleanup: request.cleanup,
+    });
+
+    this.enqueue(id);
+    this.emit();
+    return id;
+  }
+
+  async cancelExport(id: string): Promise<boolean> {
+    const job = this.jobs.get(id);
+    if (!job) return false;
+    if (job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') {
+      return false;
+    }
+
+    if (job.status === 'queued') {
+      this.removeFromQueue(id);
+    }
+
+    job.status = 'cancelled';
+    job.updatedAt = Date.now();
+    job.pendingResume = false;
+
+    const handlers = this.handlers.get(id);
+    const controller = job.controller;
+    if (controller && !controller.signal.aborted) controller.abort();
+
+    if (handlers?.cancel) {
+      try {
+        await handlers.cancel(this.createControllerForCancellation(job));
+      } catch (error) {
+        job.error = error instanceof Error ? error.message : String(error);
+      }
+    }
+
+    if (handlers?.cleanup) {
+      try {
+        await handlers.cleanup(this.cloneTask(job));
+      } catch (error) {
+        job.error = error instanceof Error ? error.message : String(error);
+      }
+    }
+
+    job.tempFiles = [];
+    job.controller = undefined;
+    this.persistHistory();
+    this.emit();
+
+    if (this.activeId === id) {
+      this.activeId = null;
+      this.scheduleNext();
+    }
+
+    return true;
+  }
+
+  async resumeExport(id: string): Promise<boolean> {
+    const job = this.jobs.get(id);
+    if (!job) return false;
+    const handlers = this.handlers.get(id);
+    if (!handlers) return false;
+
+    const canResume =
+      job.resumable &&
+      (job.status === 'cancelled' || job.status === 'failed') &&
+      typeof handlers.resume === 'function';
+
+    if (!canResume) return false;
+
+    job.status = 'queued';
+    job.updatedAt = Date.now();
+    job.pendingResume = true;
+    job.error = undefined;
+    job.retries += 1;
+    job.result = undefined;
+    job.tempFiles = [];
+    this.enqueue(id);
+    this.persistHistory();
+    this.emit();
+    return true;
+  }
+
+  retryExport(id: string): boolean {
+    const job = this.jobs.get(id);
+    if (!job) return false;
+    const handlers = this.handlers.get(id);
+    if (!handlers) return false;
+    if (job.status !== 'failed' && job.status !== 'cancelled') return false;
+
+    job.status = 'queued';
+    job.updatedAt = Date.now();
+    job.pendingResume = false;
+    job.error = undefined;
+    job.result = undefined;
+    job.resumeToken = null;
+    job.tempFiles = [];
+    job.bytesCompleted = 0;
+    job.retries += 1;
+    this.enqueue(id);
+    this.persistHistory();
+    this.emit();
+    return true;
+  }
+
+  getSnapshot(): ExportSnapshot {
+    const tasks = Array.from(this.jobs.values()).map((job) => this.toView(job));
+    const active = tasks
+      .filter((task) => task.status === 'queued' || task.status === 'running')
+      .sort((a, b) => a.createdAt - b.createdAt);
+    const completed = tasks
+      .filter((task) => task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled')
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+
+    return { active, completed };
+  }
+
+  subscribe(listener: (snapshot: ExportSnapshot) => void) {
+    this.listeners.add(listener);
+    listener(this.getSnapshot());
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private enqueue(id: string) {
+    if (!this.queue.includes(id)) {
+      this.queue.push(id);
+    }
+    this.scheduleNext();
+  }
+
+  private removeFromQueue(id: string) {
+    this.queue = this.queue.filter((queuedId) => queuedId !== id);
+  }
+
+  private scheduleNext() {
+    if (this.activeId) return;
+
+    while (this.queue.length > 0) {
+      const nextId = this.queue.shift();
+      if (!nextId) break;
+      const job = this.jobs.get(nextId);
+      if (!job || job.status !== 'queued') continue;
+      this.activeId = nextId;
+      this.runJob(job);
+      break;
+    }
+  }
+
+  private runJob(job: ExportJobInternal) {
+    const handlers = this.handlers.get(job.id);
+    if (!handlers) {
+      this.failJob(job, new Error('No export handlers registered'));
+      return;
+    }
+
+    const executor = job.pendingResume && handlers.resume ? handlers.resume : handlers.start;
+    if (!executor) {
+      this.failJob(job, new Error('No available executor for export job'));
+      return;
+    }
+
+    job.status = 'running';
+    job.pendingResume = false;
+    job.updatedAt = Date.now();
+    job.controller = new AbortController();
+    const controller = job.controller;
+
+    const runtime: ExportJobController = {
+      signal: controller.signal,
+      updateProgress: (update) => this.applyProgress(job.id, update),
+      setResumeToken: (token) => this.setResumeToken(job.id, token),
+      getJob: () => this.cloneTask(job),
+    };
+
+    this.emit();
+
+    Promise.resolve()
+      .then(() => executor(runtime))
+      .then((result) => {
+        const current = this.jobs.get(job.id);
+        if (!current || current.status !== 'running') return;
+        this.completeJob(current, result);
+      })
+      .catch((error) => {
+        const current = this.jobs.get(job.id);
+        if (!current) return;
+        if (current.status === 'cancelled') return;
+        if (error instanceof Error && error.name === 'AbortError') {
+          return;
+        }
+        this.failJob(current, error);
+      })
+      .finally(() => {
+        const current = this.jobs.get(job.id);
+        if (current && current.controller === controller) {
+          current.controller = undefined;
+        }
+        if (this.activeId === job.id) {
+          this.activeId = null;
+          this.scheduleNext();
+        }
+      });
+  }
+
+  private completeJob(job: ExportJobInternal, result: ExportResult) {
+    job.status = 'completed';
+    job.updatedAt = Date.now();
+    job.result = result;
+    job.bytesCompleted = result.bytesWritten;
+    job.bytesTotal = result.bytesWritten;
+    if (result.redactions) {
+      job.redactions = [...result.redactions];
+    }
+    job.tempFiles = [];
+    job.resumeToken = null;
+    this.handlers.delete(job.id);
+    this.persistHistory();
+    this.emit();
+  }
+
+  private failJob(job: ExportJobInternal, error: unknown) {
+    job.status = 'failed';
+    job.updatedAt = Date.now();
+    job.error = error instanceof Error ? error.message : String(error);
+    job.controller = undefined;
+    this.persistHistory();
+    this.emit();
+  }
+
+  private applyProgress(id: string, update: ExportProgressUpdate) {
+    const job = this.jobs.get(id);
+    if (!job) return;
+    if (typeof update.bytesCompleted === 'number') {
+      job.bytesCompleted = update.bytesCompleted;
+    }
+    if (typeof update.bytesTotal === 'number') {
+      job.bytesTotal = update.bytesTotal;
+    }
+    if (update.redactions) {
+      job.redactions = [...update.redactions];
+    }
+    if (update.tempFiles) {
+      const unique = new Set([...job.tempFiles, ...update.tempFiles]);
+      job.tempFiles = Array.from(unique);
+    }
+    job.updatedAt = Date.now();
+    this.emit();
+  }
+
+  private setResumeToken(id: string, token: string | null) {
+    const job = this.jobs.get(id);
+    if (!job) return;
+    job.resumeToken = token;
+    job.updatedAt = Date.now();
+    this.emit();
+  }
+
+  private createControllerForCancellation(job: ExportJobInternal): ExportJobController {
+    return {
+      signal: job.controller?.signal ?? new AbortController().signal,
+      updateProgress: (update) => this.applyProgress(job.id, update),
+      setResumeToken: (token) => this.setResumeToken(job.id, token),
+      getJob: () => this.cloneTask(job),
+    };
+  }
+
+  private toView(job: ExportJobInternal): ExportTaskView {
+    const handlers = this.handlers.get(job.id);
+    const canCancel = job.status === 'running' || job.status === 'queued';
+    const canResume =
+      job.resumable &&
+      (job.status === 'cancelled' || job.status === 'failed') &&
+      Boolean(handlers?.resume);
+    const canRetry =
+      (job.status === 'cancelled' || job.status === 'failed') && Boolean(handlers?.start);
+
+    return {
+      ...this.cloneTask(job),
+      canCancel,
+      canResume,
+      canRetry,
+      isRunning: job.status === 'running',
+      isQueued: job.status === 'queued',
+    };
+  }
+
+  private cloneTask(job: ExportJobInternal): ExportTask {
+    return {
+      id: job.id,
+      label: job.label,
+      source: job.source,
+      status: job.status,
+      resumable: job.resumable,
+      redactions: [...job.redactions],
+      bytesCompleted: job.bytesCompleted,
+      bytesTotal: job.bytesTotal,
+      createdAt: job.createdAt,
+      updatedAt: job.updatedAt,
+      retries: job.retries,
+      error: job.error,
+      resumeToken: job.resumeToken ?? null,
+      tempFiles: [...job.tempFiles],
+      result: job.result ? { ...job.result } : undefined,
+    };
+  }
+
+  private persistHistory() {
+    if (!this.onHistoryChange) return;
+    const history = Array.from(this.jobs.values())
+      .filter(
+        (job) =>
+          job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled',
+      )
+      .map((job) => this.cloneTask(job))
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+    this.onHistoryChange(history);
+  }
+
+  private emit() {
+    if (this.listeners.size === 0) return;
+    const snapshot = this.getSnapshot();
+    this.listeners.forEach((listener) => listener(snapshot));
+  }
+}
+
+export default ExportPipeline;


### PR DESCRIPTION
## Summary
- add an export pipeline with resumable queueing, cancellation cleanup, and persisted history updates
- build an Export Center provider and UI surface with filtering, search, and control hooks
- cover the pipeline with queue progression plus cancel/resume unit tests

## Testing
- yarn lint
- yarn test exportPipeline

------
https://chatgpt.com/codex/tasks/task_e_68dcde9db9c483288d9aa7fe0c0a8842