### PR TITLE
[trash] Improve restore conflict handling

### DIFF
--- a/__tests__/trashState.test.ts
+++ b/__tests__/trashState.test.ts
@@ -1,13 +1,20 @@
 import { act, renderHook } from '@testing-library/react';
-import useTrashState, { TrashItem } from '../apps/trash/state';
+import useTrashState, {
+  ConflictResolver,
+  OperationSummary,
+  TrashItem,
+} from '../apps/trash/state';
 
-describe('useTrashState restoreFromHistory', () => {
+describe('useTrashState conflict handling', () => {
   beforeEach(() => {
     window.localStorage.clear();
   });
 
-  test('renames on conflict when confirmed', () => {
-    const { result } = renderHook(() => useTrashState());
+  test('keeps both with automatic rename when requested', async () => {
+    const resolver: ConflictResolver = jest
+      .fn()
+      .mockResolvedValue({ action: 'keep-both' });
+    const { result } = renderHook(() => useTrashState({ resolveConflict: resolver }));
     const existing: TrashItem = { id: '1', title: 'App', closedAt: 1 };
     const fromHistory: TrashItem = { id: '2', title: 'App', closedAt: 2 };
 
@@ -16,26 +23,22 @@ describe('useTrashState restoreFromHistory', () => {
       result.current.pushHistory(fromHistory);
     });
 
-    const confirm = jest.spyOn(window, 'confirm').mockReturnValue(false);
-    const prompt = jest
-      .spyOn(window, 'prompt')
-      .mockReturnValue('App (1)');
-
-    act(() => {
-      result.current.restoreFromHistory(0);
+    await act(async () => {
+      await result.current.restoreFromHistory(0);
     });
 
     expect(result.current.items).toEqual([
       existing,
       { ...fromHistory, title: 'App (1)' },
     ]);
-
-    confirm.mockRestore();
-    prompt.mockRestore();
+    expect(resolver).toHaveBeenCalledTimes(1);
   });
 
-  test('replaces on confirm', () => {
-    const { result } = renderHook(() => useTrashState());
+  test('replaces existing entry when replace is selected', async () => {
+    const resolver: ConflictResolver = jest
+      .fn()
+      .mockResolvedValue({ action: 'replace' });
+    const { result } = renderHook(() => useTrashState({ resolveConflict: resolver }));
     const existing: TrashItem = { id: '1', title: 'App', closedAt: 1 };
     const fromHistory: TrashItem = { id: '2', title: 'App', closedAt: 2 };
 
@@ -44,15 +47,97 @@ describe('useTrashState restoreFromHistory', () => {
       result.current.pushHistory(fromHistory);
     });
 
-    const confirm = jest.spyOn(window, 'confirm').mockReturnValue(true);
-
-    act(() => {
-      result.current.restoreFromHistory(0);
+    await act(async () => {
+      await result.current.restoreFromHistory(0);
     });
 
     expect(result.current.items).toEqual([{ ...fromHistory }]);
+    expect(resolver).toHaveBeenCalledTimes(1);
+  });
 
-    confirm.mockRestore();
+  test('skips conflict and keeps history entry when skip is chosen', async () => {
+    const resolver: ConflictResolver = jest
+      .fn()
+      .mockResolvedValue({ action: 'skip' });
+    const { result } = renderHook(() => useTrashState({ resolveConflict: resolver }));
+    const existing: TrashItem = { id: '1', title: 'App', closedAt: 1 };
+    const fromHistory: TrashItem = { id: '2', title: 'App', closedAt: 2 };
+
+    act(() => {
+      result.current.setItems([existing]);
+      result.current.pushHistory(fromHistory);
+    });
+
+    await act(async () => {
+      await result.current.restoreFromHistory(0);
+    });
+
+    expect(result.current.items).toEqual([existing]);
+    expect(result.current.history).toEqual([fromHistory]);
+  });
+
+  test('apply to all reuses the selected action across a batch restore', async () => {
+    const resolver: ConflictResolver = jest
+      .fn()
+      .mockResolvedValueOnce({ action: 'keep-both', applyToAll: true });
+    const { result } = renderHook(() => useTrashState({ resolveConflict: resolver }));
+    const existing: TrashItem = { id: '1', title: 'Doc', closedAt: 1 };
+    const fromHistory: TrashItem[] = [
+      { id: '2', title: 'Doc', closedAt: 2 },
+      { id: '3', title: 'Doc', closedAt: 3 },
+    ];
+
+    act(() => {
+      result.current.setItems([existing]);
+      result.current.pushHistory(fromHistory);
+    });
+
+    let summary: OperationSummary | undefined;
+    await act(async () => {
+      summary = await result.current.restoreAllFromHistory();
+    });
+
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(result.current.items.map(item => item.title)).toEqual([
+      'Doc',
+      'Doc (1)',
+      'Doc (2)',
+    ]);
+    expect(summary?.keptBoth).toHaveLength(2);
+    expect(result.current.history).toEqual([]);
+  });
+
+  test('restoreAllFromHistory returns a detailed summary', async () => {
+    const resolver: ConflictResolver = jest
+      .fn()
+      .mockResolvedValueOnce({ action: 'replace' })
+      .mockResolvedValueOnce({ action: 'skip' });
+    const { result } = renderHook(() => useTrashState({ resolveConflict: resolver }));
+    const existing: TrashItem = { id: '1', title: 'Doc', closedAt: 1 };
+    const conflicts: TrashItem[] = [
+      { id: '2', title: 'Doc', closedAt: 2 },
+      { id: '3', title: 'Doc', closedAt: 3 },
+      { id: '4', title: 'Report', closedAt: 4 },
+    ];
+
+    act(() => {
+      result.current.setItems([existing]);
+      result.current.pushHistory(conflicts);
+    });
+
+    let summary: OperationSummary | undefined;
+    await act(async () => {
+      summary = await result.current.restoreAllFromHistory();
+    });
+
+    expect(summary).toEqual({
+      restored: [{ ...conflicts[2] }],
+      replaced: [{ ...conflicts[0] }],
+      skipped: [{ ...conflicts[1] }],
+      keptBoth: [],
+    });
+    expect(result.current.history).toEqual([conflicts[1]]);
+    expect(result.current.items).toEqual([{ ...conflicts[0] }, conflicts[2]]);
   });
 });
 

--- a/apps/trash/components/ConflictResolutionModal.tsx
+++ b/apps/trash/components/ConflictResolutionModal.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Modal from '../../../components/base/Modal';
+import {
+  ConflictAction,
+  ConflictResolutionRequest,
+} from '../state';
+
+interface Props {
+  isOpen: boolean;
+  request: ConflictResolutionRequest | null;
+  onDecision: (action: ConflictAction, applyToAll: boolean) => void;
+}
+
+const ACTION_LABELS: Record<ConflictAction, string> = {
+  replace: 'Replace existing',
+  skip: 'Skip this item',
+  'keep-both': 'Keep both (auto-rename)',
+};
+
+const ActionDescription: Record<ConflictAction, string> = {
+  replace: 'Overwrite the existing window snapshot with the version from history.',
+  skip: 'Leave the existing window untouched and keep this item in history.',
+  'keep-both': 'Restore with a unique name so both copies stay available.',
+};
+
+const formatDateTime = (value: number) =>
+  new Date(value).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+
+export default function ConflictResolutionModal({
+  isOpen,
+  request,
+  onDecision,
+}: Props) {
+  const [applyToAll, setApplyToAll] = useState<Record<ConflictAction, boolean>>({
+    replace: false,
+    skip: false,
+    'keep-both': false,
+  });
+
+  const diffAvailable = useMemo(() => {
+    if (!request) return false;
+    return Boolean(request.existing.image || request.restored.image);
+  }, [request]);
+
+  const handleDecision = (action: ConflictAction) => {
+    onDecision(action, applyToAll[action]);
+    setApplyToAll({ replace: false, skip: false, 'keep-both': false });
+  };
+
+  const handleClose = () => {
+    if (!request) return;
+    onDecision('skip', false);
+    setApplyToAll({ replace: false, skip: false, 'keep-both': false });
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 p-4">
+        <div className="w-full max-w-3xl rounded-lg bg-ub-cool-grey text-white shadow-xl border border-ub-warm-grey">
+          <div className="border-b border-ub-warm-grey px-5 py-3">
+            <h2 className="text-lg font-bold">Name conflict detected</h2>
+            {request && (
+              <p className="mt-1 text-sm text-ubt-grey">
+                &ldquo;{request.restored.title}&rdquo; already exists in Trash. Choose how you would like to proceed.
+              </p>
+            )}
+          </div>
+          {request && (
+            <div className="px-5 py-4 space-y-4">
+              <div className="rounded bg-black bg-opacity-40 p-4">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-ub-orange">
+                  Conflict preview
+                </h3>
+                <div className="mt-3 grid gap-4 md:grid-cols-2">
+                  <div className="rounded border border-ub-warm-grey bg-black bg-opacity-30 p-3">
+                    <div className="text-xs font-semibold uppercase tracking-wider text-ubt-grey">
+                      Existing
+                    </div>
+                    {request.existing.image ? (
+                      <img
+                        src={request.existing.image}
+                        alt="Existing window preview"
+                        className="mt-2 h-32 w-full rounded object-contain bg-black bg-opacity-40"
+                      />
+                    ) : (
+                      <div className="mt-2 h-32 w-full rounded bg-black bg-opacity-40 flex items-center justify-center text-xs text-ubt-grey">
+                        No preview available
+                      </div>
+                    )}
+                    <dl className="mt-3 text-xs space-y-1">
+                      <div className="flex justify-between">
+                        <dt className="text-ubt-grey">Title</dt>
+                        <dd className="font-mono">{request.existing.title}</dd>
+                      </div>
+                      <div className="flex justify-between">
+                        <dt className="text-ubt-grey">Closed</dt>
+                        <dd>{formatDateTime(request.existing.closedAt)}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                  <div className="rounded border border-ub-warm-grey bg-black bg-opacity-30 p-3">
+                    <div className="text-xs font-semibold uppercase tracking-wider text-ubt-grey">
+                      Restoring from history
+                    </div>
+                    {request.restored.image ? (
+                      <img
+                        src={request.restored.image}
+                        alt="Restored window preview"
+                        className="mt-2 h-32 w-full rounded object-contain bg-black bg-opacity-40"
+                      />
+                    ) : (
+                      <div className="mt-2 h-32 w-full rounded bg-black bg-opacity-40 flex items-center justify-center text-xs text-ubt-grey">
+                        No preview available
+                      </div>
+                    )}
+                    <dl className="mt-3 text-xs space-y-1">
+                      <div className="flex justify-between">
+                        <dt className="text-ubt-grey">Title</dt>
+                        <dd className="font-mono">{request.restored.title}</dd>
+                      </div>
+                      <div className="flex justify-between">
+                        <dt className="text-ubt-grey">Captured</dt>
+                        <dd>{formatDateTime(request.restored.closedAt)}</dd>
+                      </div>
+                    </dl>
+                    <div className="mt-3 rounded bg-black bg-opacity-40 px-2 py-1 text-xs">
+                      Suggested new name: <span className="font-mono">{request.suggestedName}</span>
+                    </div>
+                  </div>
+                </div>
+                {!diffAvailable && (
+                  <p className="mt-3 text-xs text-ubt-grey">
+                    A visual preview is not available for one of the entries. You can still choose an action below.
+                  </p>
+                )}
+              </div>
+              <div className="space-y-3">
+                {(Object.keys(ACTION_LABELS) as ConflictAction[]).map(action => {
+                  const checkboxId = `apply-${action}`;
+                  return (
+                    <div
+                      key={action}
+                      className="flex flex-col gap-2 rounded border border-ub-warm-grey bg-black bg-opacity-30 p-3 md:flex-row md:items-center md:justify-between"
+                    >
+                      <div>
+                        <p className="font-semibold">{ACTION_LABELS[action]}</p>
+                        <p className="text-xs text-ubt-grey">{ActionDescription[action]}</p>
+                        {action === 'keep-both' && (
+                          <p className="mt-1 text-xs text-ub-orange">
+                            Restored entry will be renamed to <span className="font-mono">{request.suggestedName}</span>.
+                          </p>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-4">
+                        <label htmlFor={checkboxId} className="flex items-center gap-2 text-xs">
+                          <input
+                            id={checkboxId}
+                            type="checkbox"
+                            className="h-4 w-4"
+                            checked={applyToAll[action]}
+                            aria-label={`Apply ${ACTION_LABELS[action]} to all conflicts`}
+                            onChange={e =>
+                              setApplyToAll(prev => ({ ...prev, [action]: e.target.checked }))
+                            }
+                          />
+                          Apply to all
+                        </label>
+                        <button
+                          className="rounded bg-ub-orange px-3 py-1 text-sm font-semibold text-black hover:bg-orange-400 focus:outline-none focus:ring-2 focus:ring-ub-orange"
+                          onClick={() => handleDecision(action)}
+                        >
+                          {ACTION_LABELS[action].split('(')[0].trim()}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/trash/components/HistoryList.tsx
+++ b/apps/trash/components/HistoryList.tsx
@@ -4,8 +4,8 @@ import { TrashItem } from '../state';
 
 interface Props {
   history: TrashItem[];
-  onRestore: (index: number) => void;
-  onRestoreAll: () => void;
+  onRestore: (index: number) => Promise<void> | void;
+  onRestoreAll: () => Promise<void> | void;
 }
 
 export default function HistoryList({ history, onRestore, onRestoreAll }: Props) {
@@ -16,8 +16,10 @@ export default function HistoryList({ history, onRestore, onRestoreAll }: Props)
       <div className="flex items-center justify-between mb-2">
         <span className="font-bold">Recently Deleted</span>
         <button
-          onClick={() => {
-            if (window.confirm('Restore all windows?')) onRestoreAll();
+          onClick={async () => {
+            if (window.confirm('Restore all windows?')) {
+              await onRestoreAll();
+            }
           }}
           className="border border-black bg-black bg-opacity-50 px-2 py-1 rounded hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-ub-orange"
         >
@@ -31,8 +33,10 @@ export default function HistoryList({ history, onRestore, onRestoreAll }: Props)
               {item.title}
             </span>
             <button
-              onClick={() => {
-                if (window.confirm(`Restore ${item.title}?`)) onRestore(idx);
+              onClick={async () => {
+                if (window.confirm(`Restore ${item.title}?`)) {
+                  await onRestore(idx);
+                }
               }}
               className="text-ub-orange hover:underline"
             >

--- a/apps/trash/index.tsx
+++ b/apps/trash/index.tsx
@@ -1,14 +1,22 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
-import useTrashState from './state';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import useTrashState, {
+  ConflictAction,
+  ConflictResolutionRequest,
+  ConflictResolutionResponse,
+  OperationSummary,
+} from './state';
 import HistoryList from './components/HistoryList';
+import ConflictResolutionModal from './components/ConflictResolutionModal';
 
 const DEFAULT_ICON = '/themes/Yaru/system/folder.png';
 const EMPTY_ICON = '/themes/Yaru/status/user-trash-symbolic.svg';
 const FULL_ICON = '/themes/Yaru/status/user-trash-full-symbolic.svg';
 
 export default function Trash({ openApp }: { openApp: (id: string) => void }) {
+  const pendingDecision = useRef<((response: ConflictResolutionResponse) => void) | null>(null);
+  const [conflictRequest, setConflictRequest] = useState<ConflictResolutionRequest | null>(null);
   const {
     items,
     setItems,
@@ -16,11 +24,24 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     pushHistory,
     restoreFromHistory,
     restoreAllFromHistory,
-  } = useTrashState();
+  } = useTrashState({
+    resolveConflict: request =>
+      new Promise<ConflictResolutionResponse>(resolve => {
+        pendingDecision.current = resolve;
+        setConflictRequest(request);
+      }),
+  });
   const [selected, setSelected] = useState<number | null>(null);
   const [purgeDays, setPurgeDays] = useState(30);
   const [emptyCountdown, setEmptyCountdown] = useState<number | null>(null);
   const [, setTick] = useState(0);
+  const [summary, setSummary] = useState<OperationSummary | null>(null);
+  const historyCounts = {
+    restored: summary?.restored.length ?? 0,
+    replaced: summary?.replaced.length ?? 0,
+    skipped: summary?.skipped.length ?? 0,
+    keptBoth: summary?.keptBoth.length ?? 0,
+  };
   const daysLeft = useCallback(
     (closedAt: number) =>
       Math.max(
@@ -41,7 +62,25 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
     return () => clearInterval(id);
   }, []);
 
+  useEffect(() => {
+    if (history.length === 0) {
+      setSummary(null);
+    }
+  }, [history.length]);
+
   const notifyChange = () => window.dispatchEvent(new Event('trash-change'));
+
+  const handleConflictDecision = useCallback(
+    (action: ConflictAction, applyToAll: boolean) => {
+      const resolver = pendingDecision.current;
+      pendingDecision.current = null;
+      if (resolver) {
+        resolver({ action, applyToAll });
+      }
+      setConflictRequest(null);
+    },
+    [],
+  );
 
   const restore = useCallback(() => {
     if (selected === null) return;
@@ -124,15 +163,25 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
   }, [handleKey]);
 
   const handleRestoreFromHistory = useCallback(
-    (idx: number) => {
-      restoreFromHistory(idx);
+    async (idx: number) => {
+      await restoreFromHistory(idx);
       notifyChange();
     },
     [restoreFromHistory],
   );
 
-  const handleRestoreAllFromHistory = useCallback(() => {
-    restoreAllFromHistory();
+  const handleRestoreAllFromHistory = useCallback(async () => {
+    const result = await restoreAllFromHistory();
+    if (
+      result.restored.length ||
+      result.replaced.length ||
+      result.skipped.length ||
+      result.keptBoth.length
+    ) {
+      setSummary(result);
+    } else {
+      setSummary(null);
+    }
     notifyChange();
   }, [restoreAllFromHistory]);
 
@@ -221,7 +270,52 @@ export default function Trash({ openApp }: { openApp: (id: string) => void }) {
           </ul>
         )}
       </div>
-      <HistoryList history={history} onRestore={handleRestoreFromHistory} onRestoreAll={handleRestoreAllFromHistory} />
+      <HistoryList
+        history={history}
+        onRestore={handleRestoreFromHistory}
+        onRestoreAll={handleRestoreAllFromHistory}
+      />
+      {summary && (
+        <div className="border-t border-black border-opacity-50 bg-black bg-opacity-30 px-4 py-3 text-xs">
+          <div className="flex items-center justify-between">
+            <span className="font-bold text-sm">Restore summary</span>
+            <button
+              onClick={() => setSummary(null)}
+              className="rounded border border-ub-orange px-2 py-1 text-ub-orange hover:bg-ub-orange hover:text-black focus:outline-none focus:ring-2 focus:ring-ub-orange"
+            >
+              Dismiss
+            </button>
+          </div>
+          <div className="mt-2 grid gap-2 sm:grid-cols-4">
+            <div>Restored: {historyCounts.restored}</div>
+            <div>Replaced: {historyCounts.replaced}</div>
+            <div>Skipped: {historyCounts.skipped}</div>
+            <div>Kept both: {historyCounts.keptBoth}</div>
+          </div>
+          {summary.keptBoth.length > 0 && (
+            <div className="mt-3">
+              <p className="font-semibold text-ub-orange">Renamed items</p>
+              <ul className="mt-1 space-y-1">
+                {summary.keptBoth.map(({ original, renamed }) => (
+                  <li key={`${original.closedAt}-${renamed.title}`} className="font-mono">
+                    {original.title} → {renamed.title}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {summary.skipped.length > 0 && (
+            <p className="mt-3 text-ubt-grey">
+              Skipped items remain available in history for future restores.
+            </p>
+          )}
+        </div>
+      )}
+      <ConflictResolutionModal
+        isOpen={Boolean(conflictRequest)}
+        request={conflictRequest}
+        onDecision={handleConflictDecision}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a conflict resolution modal with replace/skip/keep both actions, diff preview, and apply-to-all toggles
- update Trash restore flows to respect batch decisions and show post-operation summaries
- extend trash state logic and tests to cover all conflict paths and summary reporting

## Testing
- yarn test trashState --runInBand
- yarn lint apps/trash

------
https://chatgpt.com/codex/tasks/task_e_68dcdea57b18832889e783962da5ce70