### PR TITLE
[firefox] add simulation overlay controls

### DIFF
--- a/__tests__/firefox.test.tsx
+++ b/__tests__/firefox.test.tsx
@@ -1,7 +1,50 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Firefox from '../components/apps/firefox';
+import { SettingsContext } from '../hooks/useSettings';
+
+const DEFAULT_GRID_COLOR = '#38bdf8';
+
+const renderFirefox = (options: { highContrast?: boolean } = {}) =>
+  render(
+    <Firefox />,
+    {
+      wrapper: ({ children }) => (
+        <SettingsContext.Provider
+          value={{
+            accent: '#1793d1',
+            wallpaper: 'wall-2',
+            bgImageName: 'wall-2',
+            useKaliWallpaper: false,
+            density: 'regular',
+            reducedMotion: false,
+            fontScale: 1,
+            highContrast: options.highContrast ?? false,
+            largeHitAreas: false,
+            pongSpin: true,
+            allowNetwork: false,
+            haptics: true,
+            theme: 'default',
+            setAccent: () => {},
+            setWallpaper: () => {},
+            setUseKaliWallpaper: () => {},
+            setDensity: () => {},
+            setReducedMotion: () => {},
+            setFontScale: () => {},
+            setHighContrast: () => {},
+            setLargeHitAreas: () => {},
+            setPongSpin: () => {},
+            setAllowNetwork: () => {},
+            setHaptics: () => {},
+            setTheme: () => {},
+          }}
+        >
+          {children}
+        </SettingsContext.Provider>
+      ),
+    }
+  );
 
 describe('Firefox app', () => {
   beforeEach(() => {
@@ -10,7 +53,7 @@ describe('Firefox app', () => {
   });
 
   it('renders the default address with a simulation fallback', () => {
-    render(<Firefox />);
+    renderFirefox();
     const input = screen.getByLabelText('Address');
     expect(input).toHaveValue('https://www.kali.org/docs/');
     expect(screen.getByRole('heading', { name: 'Kali Linux Documentation' })).toBeInTheDocument();
@@ -22,7 +65,7 @@ describe('Firefox app', () => {
 
   it('navigates to entered urls', async () => {
     const user = userEvent.setup();
-    render(<Firefox />);
+    renderFirefox();
     const input = screen.getByLabelText('Address');
     await user.clear(input);
     await user.type(input, 'example.com');
@@ -34,12 +77,51 @@ describe('Firefox app', () => {
 
   it('opens bookmarks when clicked and shows their simulations', async () => {
     const user = userEvent.setup();
-    render(<Firefox />);
+    renderFirefox();
     const bookmark = await screen.findByRole('button', { name: 'Kali NetHunter' });
     await user.click(bookmark);
     await waitFor(() =>
       expect(screen.getByRole('heading', { name: 'Kali NetHunter & Downloads' })).toBeInTheDocument()
     );
     expect(localStorage.getItem('firefox:last-url')).toBe('https://www.kali.org/get-kali/#kali-platforms');
+  });
+
+  it('allows overlays to be toggled via settings and keyboard shortcuts', async () => {
+    const user = userEvent.setup();
+    renderFirefox();
+
+    await user.click(screen.getByRole('button', { name: /overlay settings/i }));
+    const gridToggle = screen.getByRole('checkbox', { name: 'Grid overlay' });
+    expect(gridToggle).toBeChecked();
+    await user.click(gridToggle);
+    expect(screen.queryByTestId('firefox-grid-overlay')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'g', shiftKey: true });
+    expect(screen.getByTestId('firefox-grid-overlay')).toBeInTheDocument();
+
+    const flexToggle = screen.getByRole('checkbox', { name: 'Flex outlines' });
+    const overlayContainer = screen.getByTestId('firefox-overlay-container');
+    expect(overlayContainer).toHaveAttribute('data-flex-overlay', 'false');
+    await user.click(flexToggle);
+    expect(overlayContainer).toHaveAttribute('data-flex-overlay', 'true');
+
+    fireEvent.keyDown(window, { key: 'f', shiftKey: true });
+    expect(overlayContainer).toHaveAttribute('data-flex-overlay', 'false');
+
+    const guideColorInput = screen.getByLabelText('Guides overlay color');
+    fireEvent.change(guideColorInput, { target: { value: '#ff0000' } });
+    expect(overlayContainer).toHaveAttribute('data-guide-color', '#ff0000');
+  });
+
+  it('adapts overlay colors when high contrast mode is enabled', async () => {
+    renderFirefox({ highContrast: true });
+
+    await screen.findByRole('heading', { name: 'Kali Linux Documentation' });
+    const overlayContainer = screen.getByTestId('firefox-overlay-container');
+    expect(overlayContainer).toHaveAttribute('data-high-contrast', 'true');
+
+    const gridOverlay = screen.getByTestId('firefox-grid-overlay');
+    expect(gridOverlay).toHaveAttribute('data-grid-color');
+    expect(gridOverlay.getAttribute('data-grid-color')).not.toBe(DEFAULT_GRID_COLOR);
   });
 });

--- a/components/apps/firefox/simulations.tsx
+++ b/components/apps/firefox/simulations.tsx
@@ -1,4 +1,86 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSettings } from '../../../hooks/useSettings';
+
+type OverlaySettingsState = {
+  showGrid: boolean;
+  showFlex: boolean;
+  showRulers: boolean;
+  showGuides: boolean;
+  gridColor: string;
+  flexColor: string;
+  guideColor: string;
+};
+
+type OverlayToggleKey = 'showGrid' | 'showFlex' | 'showRulers' | 'showGuides';
+type OverlayColorKey = 'gridColor' | 'flexColor' | 'guideColor';
+
+const DEFAULT_OVERLAY_COLORS = {
+  grid: '#38bdf8',
+  flex: '#f97316',
+  guide: '#22c55e',
+} as const;
+
+const HIGH_CONTRAST_FALLBACK = {
+  grid: '#ffffff',
+  flex: '#facc15',
+  guide: '#22d3ee',
+} as const;
+
+type RGB = { r: number; g: number; b: number };
+
+const clampColorValue = (value: number) => Math.max(0, Math.min(255, value));
+
+const hexToRgb = (hex: string): RGB => {
+  const normalized = hex.replace('#', '').trim();
+  if (![3, 6].includes(normalized.length)) {
+    return { r: 0, g: 0, b: 0 };
+  }
+  const value =
+    normalized.length === 3
+      ? normalized
+          .split('')
+          .map((char) => `${char}${char}`)
+          .join('')
+      : normalized;
+  const intValue = parseInt(value, 16);
+  return {
+    r: (intValue >> 16) & 255,
+    g: (intValue >> 8) & 255,
+    b: intValue & 255,
+  };
+};
+
+const rgbToHex = ({ r, g, b }: RGB) =>
+  `#${clampColorValue(r).toString(16).padStart(2, '0')}${clampColorValue(g)
+    .toString(16)
+    .padStart(2, '0')}${clampColorValue(b).toString(16).padStart(2, '0')}`.toLowerCase();
+
+const mixHexColors = (color: string, fallback: string, ratio: number) => {
+  const base = hexToRgb(color);
+  const target = hexToRgb(fallback);
+  const blend = {
+    r: Math.round(base.r * (1 - ratio) + target.r * ratio),
+    g: Math.round(base.g * (1 - ratio) + target.g * ratio),
+    b: Math.round(base.b * (1 - ratio) + target.b * ratio),
+  };
+  return rgbToHex(blend);
+};
+
+const hexToRgba = (color: string, alpha: number) => {
+  const { r, g, b } = hexToRgb(color);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+const isEditableTarget = (target: EventTarget | null) => {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tagName = target.tagName.toLowerCase();
+  if (['input', 'textarea', 'select'].includes(tagName)) {
+    return true;
+  }
+  return target.isContentEditable;
+};
 
 export type SimulationLink = {
   label: string;
@@ -528,47 +610,347 @@ export const SIMULATIONS = Object.fromEntries([
   }),
 ]) as Record<string, FirefoxSimulation>;
 
-export const FirefoxSimulationView: React.FC<{ simulation: FirefoxSimulation }> = ({ simulation }) => (
-  <div className="flex h-full flex-col overflow-hidden bg-gray-950 text-gray-100">
-    <header className="border-b border-gray-800 px-6 py-5">
-      <h1 className="text-2xl font-semibold text-white">{simulation.heading}</h1>
-      <p className="mt-2 max-w-3xl text-sm text-gray-300">{simulation.description}</p>
-      <a
-        href={simulation.externalUrl}
-        target="_blank"
-        rel="noreferrer"
-        className="mt-4 inline-flex items-center gap-2 rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
-      >
-        {simulation.ctaLabel ?? 'Open official site'}
-        <span aria-hidden="true" className="text-xs">↗</span>
-      </a>
-    </header>
-    <div className="flex-1 overflow-y-auto px-6 py-6">
-      <div className="grid gap-6 lg:grid-cols-2">
-        {simulation.sections.map((section) => (
-          <section key={section.title} className="rounded-lg border border-gray-800 bg-gray-900/60 p-5 shadow-inner">
-            <h2 className="text-lg font-semibold text-white">{section.title}</h2>
-            {section.body ? <p className="mt-2 text-sm text-gray-300">{section.body}</p> : null}
-            {section.links ? (
-              <ul className="mt-4 space-y-3 text-sm">
-                {section.links.map((link) => (
-                  <li key={link.href} className="rounded-md bg-gray-900/80 p-3 transition hover:bg-gray-800/80">
-                    <a
-                      href={link.href}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="font-medium text-blue-300 hover:text-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
-                    >
-                      {link.label}
-                    </a>
-                    {link.description ? <p className="mt-1 text-xs text-gray-400">{link.description}</p> : null}
-                  </li>
-                ))}
-              </ul>
+export const FirefoxSimulationView: React.FC<{ simulation: FirefoxSimulation }> = ({ simulation }) => {
+  const { highContrast } = useSettings();
+  const [overlaySettings, setOverlaySettings] = useState<OverlaySettingsState>(() => ({
+    showGrid: true,
+    showFlex: false,
+    showRulers: true,
+    showGuides: true,
+    gridColor: DEFAULT_OVERLAY_COLORS.grid,
+    flexColor: DEFAULT_OVERLAY_COLORS.flex,
+    guideColor: DEFAULT_OVERLAY_COLORS.guide,
+  }));
+  const [panelOpen, setPanelOpen] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const overlayPalette = useMemo(
+    () => ({
+      grid: mixHexColors(overlaySettings.gridColor, HIGH_CONTRAST_FALLBACK.grid, highContrast ? 0.65 : 0),
+      flex: mixHexColors(overlaySettings.flexColor, HIGH_CONTRAST_FALLBACK.flex, highContrast ? 0.55 : 0),
+      guide: mixHexColors(overlaySettings.guideColor, HIGH_CONTRAST_FALLBACK.guide, highContrast ? 0.55 : 0),
+    }),
+    [overlaySettings.gridColor, overlaySettings.flexColor, overlaySettings.guideColor, highContrast]
+  );
+
+  const toggleOverlay = useCallback((key: OverlayToggleKey) => {
+    setOverlaySettings((prev) => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+
+  const updateColor = useCallback((key: OverlayColorKey, value: string) => {
+    setOverlaySettings((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const handleKeyboardToggle = useCallback(
+    (event: KeyboardEvent) => {
+      if (!event.shiftKey || isEditableTarget(event.target)) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      if (key === 'g') {
+        event.preventDefault();
+        toggleOverlay('showGrid');
+      } else if (key === 'f') {
+        event.preventDefault();
+        toggleOverlay('showFlex');
+      } else if (key === 'r') {
+        event.preventDefault();
+        toggleOverlay('showRulers');
+      } else if (key === 'l') {
+        event.preventDefault();
+        toggleOverlay('showGuides');
+      }
+    },
+    [toggleOverlay]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyboardToggle);
+    return () => window.removeEventListener('keydown', handleKeyboardToggle);
+  }, [handleKeyboardToggle]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-gray-950 text-gray-100">
+      <header className="border-b border-gray-800 px-6 py-5">
+        <h1 className="text-2xl font-semibold text-white">{simulation.heading}</h1>
+        <p className="mt-2 max-w-3xl text-sm text-gray-300">{simulation.description}</p>
+        <a
+          href={simulation.externalUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-4 inline-flex items-center gap-2 rounded bg-blue-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300"
+        >
+          {simulation.ctaLabel ?? 'Open official site'}
+          <span aria-hidden="true" className="text-xs">
+            ↗
+          </span>
+        </a>
+      </header>
+      <div className="flex-1 overflow-y-auto px-6 py-6">
+        <div className="space-y-4">
+          <section className="rounded-lg border border-gray-800 bg-gray-900/60 p-4 shadow-inner">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 id="overlay-settings-heading" className="text-sm font-semibold text-white">
+                  Layout overlay controls
+                </h2>
+                <p className="mt-1 max-w-xl text-xs text-gray-400">
+                  Use <kbd className="rounded bg-gray-800 px-1">Shift</kbd> + <kbd className="rounded bg-gray-800 px-1">G</kbd> for
+                  grids, <kbd className="rounded bg-gray-800 px-1">Shift</kbd> + <kbd className="rounded bg-gray-800 px-1">F</kbd> for flex outlines,{' '}
+                  <kbd className="rounded bg-gray-800 px-1">Shift</kbd> + <kbd className="rounded bg-gray-800 px-1">R</kbd> for rulers, and{' '}
+                  <kbd className="rounded bg-gray-800 px-1">Shift</kbd> + <kbd className="rounded bg-gray-800 px-1">L</kbd> for guides.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setPanelOpen((value) => !value)}
+                aria-expanded={panelOpen}
+                aria-controls="firefox-overlay-settings"
+                className="self-start rounded border border-gray-700 bg-gray-800 px-3 py-2 text-xs font-medium text-gray-100 transition hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
+              >
+                {panelOpen ? 'Hide overlay settings' : 'Show overlay settings'}
+              </button>
+            </div>
+            {panelOpen ? (
+              <div
+                id="firefox-overlay-settings"
+                role="group"
+                aria-labelledby="overlay-settings-heading"
+                className="mt-4 grid gap-4 text-xs sm:grid-cols-2 sm:text-sm"
+              >
+                <label className="flex items-center justify-between gap-2 text-gray-200">
+                  <span>Grid overlay</span>
+                  <input
+                    type="checkbox"
+                    checked={overlaySettings.showGrid}
+                    onChange={() => toggleOverlay('showGrid')}
+                    aria-describedby="overlay-grid-hint"
+                    className="h-4 w-4"
+                  />
+                </label>
+                <label className="flex items-center justify-between gap-2 text-gray-200">
+                  <span>Flex outlines</span>
+                  <input
+                    type="checkbox"
+                    checked={overlaySettings.showFlex}
+                    onChange={() => toggleOverlay('showFlex')}
+                    aria-describedby="overlay-flex-hint"
+                    className="h-4 w-4"
+                  />
+                </label>
+                <label className="flex items-center justify-between gap-2 text-gray-200">
+                  <span>Rulers</span>
+                  <input
+                    type="checkbox"
+                    checked={overlaySettings.showRulers}
+                    onChange={() => toggleOverlay('showRulers')}
+                    className="h-4 w-4"
+                  />
+                </label>
+                <label className="flex items-center justify-between gap-2 text-gray-200">
+                  <span>Guides</span>
+                  <input
+                    type="checkbox"
+                    checked={overlaySettings.showGuides}
+                    onChange={() => toggleOverlay('showGuides')}
+                    className="h-4 w-4"
+                  />
+                </label>
+                <div className="flex items-center justify-between gap-2 text-gray-200">
+                  <label htmlFor="grid-color" className="text-gray-200">
+                    Grid color
+                  </label>
+                  <input
+                    id="grid-color"
+                    type="color"
+                    value={overlaySettings.gridColor}
+                    onChange={(event) => updateColor('gridColor', event.target.value)}
+                    className="h-8 w-16 cursor-pointer"
+                    aria-label="Grid overlay color"
+                  />
+                </div>
+                <div className="flex items-center justify-between gap-2 text-gray-200">
+                  <label htmlFor="flex-color" className="text-gray-200">
+                    Flex color
+                  </label>
+                  <input
+                    id="flex-color"
+                    type="color"
+                    value={overlaySettings.flexColor}
+                    onChange={(event) => updateColor('flexColor', event.target.value)}
+                    className="h-8 w-16 cursor-pointer"
+                    aria-label="Flex overlay color"
+                  />
+                </div>
+                <div className="flex items-center justify-between gap-2 text-gray-200">
+                  <label htmlFor="guide-color" className="text-gray-200">
+                    Guides & rulers color
+                  </label>
+                  <input
+                    id="guide-color"
+                    type="color"
+                    value={overlaySettings.guideColor}
+                    onChange={(event) => updateColor('guideColor', event.target.value)}
+                    className="h-8 w-16 cursor-pointer"
+                    aria-label="Guides overlay color"
+                  />
+                </div>
+                <p id="overlay-grid-hint" className="text-[11px] text-gray-400 sm:col-span-2">
+                  Grid and ruler overlays are color-blind safe and never capture pointer events so the simulation remains
+                  interactive.
+                </p>
+                <p id="overlay-flex-hint" className="text-[11px] text-gray-400 sm:col-span-2">
+                  Flex outlines hug the cards using high-contrast dashed borders for rapid layout auditing.
+                </p>
+              </div>
             ) : null}
           </section>
-        ))}
+
+          <div
+            ref={contentRef}
+            className="relative"
+            data-testid="firefox-overlay-container"
+            data-high-contrast={highContrast ? 'true' : 'false'}
+            data-flex-overlay={overlaySettings.showFlex ? 'true' : 'false'}
+            data-grid-color={overlayPalette.grid}
+            data-flex-color={overlayPalette.flex}
+            data-guide-color={overlayPalette.guide}
+          >
+            <div className="grid gap-6 lg:grid-cols-2">
+              {simulation.sections.map((section) => (
+                <section
+                  key={section.title}
+                  data-firefox-overlay="section"
+                  className="rounded-lg border border-gray-800 bg-gray-900/60 p-5 shadow-inner transition"
+                  style={
+                    overlaySettings.showFlex
+                      ? {
+                          outline: `2px dashed ${overlayPalette.flex}`,
+                          outlineOffset: '4px',
+                          boxShadow: `inset 0 0 0 1px ${hexToRgba(overlayPalette.flex, highContrast ? 0.9 : 0.5)}`,
+                        }
+                      : undefined
+                  }
+                >
+                  <h2 className="text-lg font-semibold text-white">{section.title}</h2>
+                  {section.body ? <p className="mt-2 text-sm text-gray-300">{section.body}</p> : null}
+                  {section.links ? (
+                    <ul className="mt-4 space-y-3 text-sm">
+                      {section.links.map((link) => (
+                        <li
+                          key={link.href}
+                          className="rounded-md bg-gray-900/80 p-3 transition hover:bg-gray-800/80"
+                          style={
+                            overlaySettings.showFlex
+                              ? {
+                                  outline: `1px dashed ${overlayPalette.flex}`,
+                                  outlineOffset: '2px',
+                                }
+                              : undefined
+                          }
+                        >
+                          <a
+                            href={link.href}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="font-medium text-blue-300 hover:text-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
+                          >
+                            {link.label}
+                          </a>
+                          {link.description ? <p className="mt-1 text-xs text-gray-400">{link.description}</p> : null}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </section>
+              ))}
+            </div>
+
+            <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+              {overlaySettings.showGrid ? (
+                <div
+                  data-testid="firefox-grid-overlay"
+                  data-grid-color={overlayPalette.grid}
+                  className="absolute inset-0 rounded-lg"
+                  style={{
+                    backgroundImage: `linear-gradient(to right, ${hexToRgba(overlayPalette.grid, highContrast ? 0.85 : 0.6)} 1px, transparent 1px), linear-gradient(to bottom, ${hexToRgba(
+                      overlayPalette.grid,
+                      highContrast ? 0.85 : 0.6
+                    )} 1px, transparent 1px)`,
+                    backgroundSize: '48px 48px',
+                    mixBlendMode: highContrast ? 'screen' : 'normal',
+                  }}
+                />
+              ) : null}
+              {overlaySettings.showRulers ? (
+                <div data-testid="firefox-rulers-overlay" className="absolute inset-0">
+                  <div
+                    className="absolute left-0 right-0 top-0 h-8 rounded-t-lg border-b border-gray-800/60 bg-gray-900/80"
+                    style={{
+                      backgroundImage: `repeating-linear-gradient(to right, transparent 0, transparent 39px, ${hexToRgba(
+                        overlayPalette.guide,
+                        0.75
+                      )} 39px, ${hexToRgba(overlayPalette.guide, 0.75)} 40px)`,
+                    }}
+                    aria-hidden="true"
+                  />
+                  <div
+                    className="absolute bottom-0 left-0 top-0 w-8 rounded-l-lg border-r border-gray-800/60 bg-gray-900/80"
+                    style={{
+                      backgroundImage: `repeating-linear-gradient(to bottom, transparent 0, transparent 39px, ${hexToRgba(
+                        overlayPalette.guide,
+                        0.75
+                      )} 39px, ${hexToRgba(overlayPalette.guide, 0.75)} 40px)`,
+                    }}
+                    aria-hidden="true"
+                  />
+                </div>
+              ) : null}
+              {overlaySettings.showGuides ? (
+                <div data-testid="firefox-guides-overlay" className="absolute inset-0">
+                  <div
+                    className="absolute top-1/2 left-0 right-0 h-0.5"
+                    style={{
+                      backgroundImage: `repeating-linear-gradient(to right, ${hexToRgba(
+                        overlayPalette.guide,
+                        0.9
+                      )} 0, ${hexToRgba(overlayPalette.guide, 0.9)} 6px, transparent 6px, transparent 12px)`,
+                    }}
+                  />
+                  <div
+                    className="absolute top-0 bottom-0 left-1/2 w-0.5"
+                    style={{
+                      backgroundImage: `repeating-linear-gradient(to bottom, ${hexToRgba(
+                        overlayPalette.guide,
+                        0.9
+                      )} 0, ${hexToRgba(overlayPalette.guide, 0.9)} 6px, transparent 6px, transparent 12px)`,
+                    }}
+                  />
+                  <div
+                    className="absolute top-0 bottom-0 left-[25%] w-0.5"
+                    style={{
+                      backgroundImage: `repeating-linear-gradient(to bottom, ${hexToRgba(
+                        overlayPalette.grid,
+                        0.75
+                      )} 0, ${hexToRgba(overlayPalette.grid, 0.75)} 4px, transparent 4px, transparent 8px)`,
+                    }}
+                  />
+                  <div
+                    className="absolute top-[35%] left-0 right-0 h-0.5"
+                    style={{
+                      backgroundImage: `repeating-linear-gradient(to right, ${hexToRgba(
+                        overlayPalette.flex,
+                        0.75
+                      )} 0, ${hexToRgba(overlayPalette.flex, 0.75)} 4px, transparent 4px, transparent 8px)`,
+                    }}
+                  />
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};


### PR DESCRIPTION
## Summary
- add keyboard-toggleable grid, flex, ruler, and guide overlays to the Firefox simulation
- provide color-customizable overlay controls that remain pointer transparent and color-blind friendly
- extend unit tests to cover overlay interactions and high-contrast accessibility behavior

## Testing
- yarn test firefox

------
https://chatgpt.com/codex/tasks/task_e_68dcdeaeb2b483289789b83d863055f1