### PR TITLE
[apps] Add hashcat keyspace heatmap visualization

### DIFF
--- a/__tests__/components/apps/hashcat/KeyspaceHeatmap.test.tsx
+++ b/__tests__/components/apps/hashcat/KeyspaceHeatmap.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import KeyspaceHeatmap, {
+  DEFAULT_CHARSETS,
+} from '../../../../components/apps/hashcat/KeyspaceHeatmap';
+
+type MockContext = CanvasRenderingContext2D & {
+  fillStyle: string;
+  strokeStyle: string;
+  lineWidth: number;
+  font: string;
+};
+
+const createMockContext = (): MockContext => {
+  let fillStyle = '';
+  let strokeStyle = '';
+  let lineWidth = 1;
+  let font = '';
+  return {
+    canvas: document.createElement('canvas'),
+    clearRect: jest.fn(),
+    fillRect: jest.fn(),
+    strokeRect: jest.fn(),
+    beginPath: jest.fn(),
+    rect: jest.fn(),
+    stroke: jest.fn(),
+    save: jest.fn(),
+    restore: jest.fn(),
+    setTransform: jest.fn(),
+    scale: jest.fn(),
+    fillText: jest.fn(),
+    measureText: jest.fn().mockReturnValue({ width: 0 }),
+    translate: jest.fn(),
+    transform: jest.fn(),
+    getTransform: jest.fn(),
+    resetTransform: jest.fn(),
+    get fillStyle() {
+      return fillStyle;
+    },
+    set fillStyle(value: string) {
+      fillStyle = value;
+    },
+    get strokeStyle() {
+      return strokeStyle;
+    },
+    set strokeStyle(value: string) {
+      strokeStyle = value;
+    },
+    get lineWidth() {
+      return lineWidth;
+    },
+    set lineWidth(value: number) {
+      lineWidth = value;
+    },
+    get font() {
+      return font;
+    },
+    set font(value: string) {
+      font = value;
+    },
+    drawImage: jest.fn(),
+    createPattern: jest.fn(),
+    createLinearGradient: jest.fn(),
+    createRadialGradient: jest.fn(),
+    clip: jest.fn(),
+    quadraticCurveTo: jest.fn(),
+    bezierCurveTo: jest.fn(),
+    arc: jest.fn(),
+    arcTo: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    closePath: jest.fn(),
+    fill: jest.fn(),
+    strokeText: jest.fn(),
+    isPointInPath: jest.fn(),
+    isPointInStroke: jest.fn(),
+    rotate: jest.fn(),
+    globalAlpha: 1,
+    globalCompositeOperation: 'source-over',
+    shadowBlur: 0,
+    shadowColor: '',
+    shadowOffsetX: 0,
+    shadowOffsetY: 0,
+    textAlign: 'left',
+    textBaseline: 'alphabetic',
+    getImageData: jest.fn(),
+    putImageData: jest.fn(),
+    imageSmoothingEnabled: true,
+    imageSmoothingQuality: 'low',
+    direction: 'ltr',
+    filter: 'none',
+  } as unknown as MockContext;
+};
+
+let getContextSpy: jest.SpyInstance;
+
+describe('KeyspaceHeatmap', () => {
+  beforeEach(() => {
+    getContextSpy = jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(() => createMockContext());
+  });
+
+  afterEach(() => {
+    getContextSpy.mockRestore();
+  });
+
+  it('updates mask input and notifies parent handler', () => {
+    const handleMaskChange = jest.fn();
+    const { getByLabelText } = render(
+      <KeyspaceHeatmap mask="?d" onMaskChange={handleMaskChange} />
+    );
+    const input = getByLabelText('Mask') as HTMLInputElement;
+    expect(input.value).toBe('?d');
+    fireEvent.change(input, { target: { value: '?d?l' } });
+    expect(handleMaskChange).toHaveBeenCalledWith('?d?l');
+  });
+
+  it('propagates charset size adjustments', () => {
+    const handleCharsetsChange = jest.fn();
+    const { getByLabelText } = render(
+      <KeyspaceHeatmap
+        mask="?d"
+        charsets={DEFAULT_CHARSETS}
+        onCharsetsChange={handleCharsetsChange}
+      />
+    );
+    const digitsInput = getByLabelText('Digits (?d) size') as HTMLInputElement;
+    fireEvent.change(digitsInput, { target: { value: '15' } });
+    expect(handleCharsetsChange).toHaveBeenCalled();
+    const latest = handleCharsetsChange.mock.calls.pop()?.[0] as {
+      id: string;
+      size: number;
+    }[];
+    expect(latest).toBeDefined();
+    expect(latest?.find((set) => set.id === '?d')?.size).toBe(15);
+  });
+
+  it('renders efficiently for large datasets', () => {
+    const largeCharsets = Array.from({ length: 200 }, (_, index) => ({
+      id: `?c${index}`,
+      label: `Set ${index}`,
+      size: index + 1,
+    }));
+    const longMask = Array.from({ length: 120 }, () => '?a').join('');
+    const { container } = render(
+      <KeyspaceHeatmap mask={longMask} charsets={largeCharsets} />
+    );
+    const canvases = container.querySelectorAll('canvas');
+    expect(canvases).toHaveLength(1);
+    expect(getContextSpy).toHaveBeenCalledWith('2d');
+    const width = canvases[0].style.width;
+    expect(width.endsWith('px')).toBe(true);
+    expect(parseFloat(width)).toBeGreaterThan(0);
+  });
+});

--- a/components/apps/hashcat/KeyspaceHeatmap.tsx
+++ b/components/apps/hashcat/KeyspaceHeatmap.tsx
@@ -1,0 +1,450 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+type CharsetDefinition = {
+  id: string;
+  label: string;
+  size: number;
+};
+
+type HoveredCell = {
+  row: number;
+  col: number;
+};
+
+type KeyspaceHeatmapProps = {
+  mask?: string;
+  onMaskChange?: (value: string) => void;
+  charsets?: CharsetDefinition[];
+  onCharsetsChange?: (next: CharsetDefinition[]) => void;
+  className?: string;
+  cellSize?: number;
+};
+
+const parseMask = (mask: string): string[] => {
+  if (!mask) return [];
+  const tokens: string[] = [];
+  for (let i = 0; i < mask.length; i += 1) {
+    if (mask[i] === '?' && i < mask.length - 1) {
+      tokens.push(mask.slice(i, i + 2));
+      i += 1;
+    } else {
+      tokens.push(mask[i]);
+    }
+  }
+  return tokens;
+};
+
+const formatCount = (value: number): string => {
+  if (value < 1_000) return value.toLocaleString();
+  if (value < 1_000_000) return `${(value / 1_000).toFixed(2)}K`;
+  if (value < 1_000_000_000) return `${(value / 1_000_000).toFixed(2)}M`;
+  if (value < 1_000_000_000_000) return `${(value / 1_000_000_000).toFixed(2)}B`;
+  return `${(value / 1_000_000_000_000).toFixed(2)}T`;
+};
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const usePrefersReducedMotion = () => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return true;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return undefined;
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+};
+
+export const DEFAULT_CHARSETS: CharsetDefinition[] = [
+  { id: '?l', label: 'Lowercase (?l)', size: 26 },
+  { id: '?u', label: 'Uppercase (?u)', size: 26 },
+  { id: '?d', label: 'Digits (?d)', size: 10 },
+  { id: '?s', label: 'Symbols (?s)', size: 33 },
+  { id: '?a', label: 'Printable (?a)', size: 95 },
+];
+
+const buildCharsetMap = (sets: CharsetDefinition[]) => {
+  const map = new Map<string, number>();
+  sets.forEach((set) => {
+    map.set(set.id, set.size);
+  });
+  return map;
+};
+
+const KeyspaceHeatmap: React.FC<KeyspaceHeatmapProps> = ({
+  mask = '',
+  onMaskChange,
+  charsets,
+  onCharsetsChange,
+  className,
+  cellSize = 32,
+}) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const isMaskControlled = typeof onMaskChange === 'function';
+  const isCharsetControlled = typeof onCharsetsChange === 'function';
+  const [internalMask, setInternalMask] = useState(mask);
+  const [internalCharsets, setInternalCharsets] = useState<CharsetDefinition[]>(
+    () => charsets ?? DEFAULT_CHARSETS
+  );
+
+  useEffect(() => {
+    if (!isMaskControlled) {
+      setInternalMask(mask);
+    }
+  }, [mask, isMaskControlled]);
+
+  useEffect(() => {
+    if (!isCharsetControlled && charsets) {
+      setInternalCharsets(charsets);
+    }
+  }, [charsets, isCharsetControlled]);
+
+  const maskValue = isMaskControlled ? mask : internalMask;
+  const charsetList = isCharsetControlled
+    ? charsets ?? DEFAULT_CHARSETS
+    : internalCharsets;
+
+  const setMaskValue = (value: string) => {
+    if (onMaskChange) {
+      onMaskChange(value);
+    }
+    if (!isMaskControlled) {
+      setInternalMask(value);
+    }
+  };
+
+  const setCharsetList = (value: CharsetDefinition[]) => {
+    if (onCharsetsChange) {
+      onCharsetsChange(value);
+    }
+    if (!isCharsetControlled) {
+      setInternalCharsets(value);
+    }
+  };
+
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const contextRef = useRef<CanvasRenderingContext2D | null>(null);
+  const drawRef = useRef<number | null>(null);
+  const dprRef = useRef(1);
+  const progressRef = useRef(0);
+  const [hoveredCell, setHoveredCell] = useState<HoveredCell | null>(null);
+  const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
+
+  const tokens = useMemo(() => {
+    const parsed = parseMask(maskValue);
+    if (parsed.length > 0) return parsed;
+    return ['?l'];
+  }, [maskValue]);
+
+  const charsetMap = useMemo(() => buildCharsetMap(charsetList), [
+    charsetList,
+  ]);
+
+  const positionProduct = useMemo(() => {
+    return tokens.map((_, index) => {
+      return tokens.reduce((acc, token, tokenIndex) => {
+        if (tokenIndex === index) return acc;
+        const size = charsetMap.get(token) ?? 1;
+        return acc * clamp(size, 1, Number.MAX_SAFE_INTEGER);
+      }, 1);
+    });
+  }, [tokens, charsetMap]);
+
+  const counts = useMemo(() => {
+    return charsetList.map((charset) =>
+      tokens.map((_, index) =>
+        clamp(
+          charset.size * positionProduct[index],
+          0,
+          Number.MAX_SAFE_INTEGER
+        )
+      )
+    );
+  }, [charsetList, tokens, positionProduct]);
+
+  const maxCount = useMemo(() => {
+    let max = 0;
+    counts.forEach((row) => {
+      row.forEach((value) => {
+        if (value > max) max = value;
+      });
+    });
+    return max || 1;
+  }, [counts]);
+
+  const highlightRows = useMemo(() => {
+    const map = new Map<string, number>();
+    charsetList.forEach((set, index) => map.set(set.id, index));
+    return tokens.map((token) => map.get(token));
+  }, [charsetList, tokens]);
+
+  const positionCount = tokens.length;
+  const rowCount = charsetList.length;
+  const width = Math.max(positionCount * cellSize, cellSize);
+  const height = Math.max(rowCount * cellSize, cellSize);
+
+  const drawHeatmap = useCallback(() => {
+    const canvas = canvasRef.current;
+    const context = contextRef.current;
+    if (!canvas || !context) return;
+    const dpr = dprRef.current;
+    context.save();
+    context.setTransform(1, 0, 0, 1, 0, 0);
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.scale(dpr, dpr);
+
+    const totalCells = Math.max(positionCount * rowCount, 1);
+    const progressedCells = clamp(progressRef.current, 0, totalCells);
+
+    for (let row = 0; row < rowCount; row += 1) {
+      for (let col = 0; col < positionCount; col += 1) {
+        const value = counts[row][col];
+        const ratio = Math.log(value + 1) / Math.log(maxCount + 1);
+        const hue = 220 - ratio * 160;
+        const lightness = 20 + ratio * 40;
+        context.fillStyle = `hsl(${hue}, 70%, ${lightness}%)`;
+        context.fillRect(col * cellSize, row * cellSize, cellSize, cellSize);
+
+        const cellIndex = row * positionCount + col;
+        if (cellIndex < progressedCells) {
+          context.fillStyle = 'rgba(14, 165, 233, 0.35)';
+          context.fillRect(col * cellSize, row * cellSize, cellSize, cellSize);
+        }
+      }
+    }
+
+    highlightRows.forEach((rowIndex, colIndex) => {
+      if (rowIndex == null) return;
+      context.strokeStyle = 'rgba(255, 255, 255, 0.7)';
+      context.lineWidth = 2;
+      context.strokeRect(
+        colIndex * cellSize + 1,
+        rowIndex * cellSize + 1,
+        cellSize - 2,
+        cellSize - 2
+      );
+    });
+
+    if (hoveredCell) {
+      context.strokeStyle = 'rgba(255, 255, 255, 0.9)';
+      context.lineWidth = 2;
+      context.strokeRect(
+        hoveredCell.col * cellSize + 0.5,
+        hoveredCell.row * cellSize + 0.5,
+        cellSize - 1,
+        cellSize - 1
+      );
+    }
+
+    context.restore();
+  }, [
+    counts,
+    maxCount,
+    positionCount,
+    rowCount,
+    cellSize,
+    highlightRows,
+    hoveredCell,
+  ]);
+
+  const scheduleDraw = useCallback(() => {
+    if (drawRef.current != null) {
+      cancelAnimationFrame(drawRef.current);
+    }
+    drawRef.current = requestAnimationFrame(() => {
+      drawRef.current = null;
+      drawHeatmap();
+    });
+  }, [drawHeatmap]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const dpr =
+      typeof window !== 'undefined' && window.devicePixelRatio
+        ? window.devicePixelRatio
+        : 1;
+    dprRef.current = dpr;
+    canvas.width = Math.max(width * dpr, 1);
+    canvas.height = Math.max(height * dpr, 1);
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    contextRef.current = canvas.getContext('2d');
+    scheduleDraw();
+  }, [width, height, scheduleDraw]);
+
+  useEffect(() => {
+    scheduleDraw();
+  }, [scheduleDraw]);
+
+  useEffect(() => {
+    progressRef.current = 0;
+    const totalCells = Math.max(positionCount * rowCount, 1);
+    if (prefersReducedMotion) {
+      progressRef.current = totalCells;
+      scheduleDraw();
+      return;
+    }
+    let frame: number;
+    const step = () => {
+      const increment = Math.max(Math.floor(totalCells / 180), 1);
+      progressRef.current = (progressRef.current + increment) % (totalCells + 1);
+      scheduleDraw();
+      frame = requestAnimationFrame(step);
+    };
+    frame = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(frame);
+  }, [positionCount, rowCount, prefersReducedMotion, scheduleDraw]);
+
+  useEffect(() => {
+    return () => {
+      if (drawRef.current != null) {
+        cancelAnimationFrame(drawRef.current);
+      }
+    };
+  }, []);
+
+  const handleMaskChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setMaskValue(event.target.value);
+  };
+
+  const handleSizeChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    index: number
+  ) => {
+    const nextSize = clamp(Number(event.target.value) || 0, 1, 10_000);
+    const next = charsetList.map((set, idx) =>
+      idx === index ? { ...set, size: nextSize } : set
+    );
+    setCharsetList(next);
+  };
+
+  const handleMouseMove = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const col = Math.floor(x / cellSize);
+    const row = Math.floor(y / cellSize);
+    if (col < 0 || col >= positionCount || row < 0 || row >= rowCount) {
+      setHoveredCell(null);
+      return;
+    }
+    setHoveredCell({ row, col });
+    setTooltipPosition({ x, y });
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredCell(null);
+  };
+
+  const tooltipData = useMemo(() => {
+    if (!hoveredCell) return null;
+    const charset = charsetList[hoveredCell.row];
+    const value = counts[hoveredCell.row]?.[hoveredCell.col] ?? 0;
+    return {
+      charset: charset?.label ?? 'Unknown set',
+      token: tokens[hoveredCell.col],
+      value,
+    };
+  }, [hoveredCell, counts, charsetList, tokens]);
+
+  return (
+    <div
+      className={
+        className ??
+        'w-full bg-black/40 border border-white/10 rounded-lg p-4 space-y-4'
+      }
+    >
+      <div className="flex flex-col gap-2">
+        <label htmlFor="heatmap-mask-input" className="text-sm font-semibold">
+          Mask
+        </label>
+        <input
+          id="heatmap-mask-input"
+          type="text"
+          className="px-2 py-1 text-black rounded"
+          value={maskValue}
+          onChange={handleMaskChange}
+          aria-label="Mask"
+          placeholder="e.g. ?l?l?d"
+        />
+        <p className="text-xs text-gray-300">
+          Adjust the mask to see how each position interacts with the configured
+          character sets.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-sm font-semibold">Charset sizes</div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {charsetList.map((set, index) => (
+            <label key={set.id} className="flex flex-col gap-1 text-xs">
+              <span className="font-medium text-gray-200">{set.label}</span>
+              <input
+                type="number"
+                min={1}
+                max={10000}
+                className="px-2 py-1 text-black rounded"
+                value={set.size}
+                onChange={(event) => handleSizeChange(event, index)}
+                aria-label={`${set.label} size`}
+              />
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="relative border border-white/10 rounded overflow-auto">
+        <canvas
+          ref={canvasRef}
+          role="img"
+          aria-label="Mask position to charset heatmap"
+          onMouseMove={handleMouseMove}
+          onMouseLeave={handleMouseLeave}
+          tabIndex={0}
+        />
+        {tooltipData && (
+          <div
+            className="pointer-events-none absolute z-10 bg-black/80 text-xs text-white px-2 py-1 rounded shadow-lg"
+            style={{
+              left: clamp(tooltipPosition.x + 12, 0, width - 120),
+              top: clamp(tooltipPosition.y + 12, 0, height - 60),
+            }}
+            role="status"
+            aria-live="polite"
+          >
+            <div>
+              Position {hoveredCell.col + 1} • {tooltipData.token || 'literal'}
+            </div>
+            <div>{tooltipData.charset}</div>
+            <div>Combinations: {formatCount(tooltipData.value)}</div>
+          </div>
+        )}
+      </div>
+
+      <p className="text-xs text-gray-300">
+        Progress overlay animates through the grid to simulate keyspace
+        exploration without performing any cracking work.
+      </p>
+    </div>
+  );
+};
+
+export default KeyspaceHeatmap;

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -1,6 +1,9 @@
 import React, { useState, useEffect, useRef } from 'react';
 import progressInfo from './progress.json';
 import StatsChart from '../../StatsChart';
+import KeyspaceHeatmap, {
+  DEFAULT_CHARSETS as HEATMAP_DEFAULT_CHARSETS,
+} from './KeyspaceHeatmap';
 
 export const hashTypes = [
   {
@@ -172,6 +175,9 @@ function HashcatApp() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const [attackMode, setAttackMode] = useState('0');
   const [mask, setMask] = useState('');
+  const [charsets, setCharsets] = useState(() => [
+    ...HEATMAP_DEFAULT_CHARSETS,
+  ]);
   const appendMask = (token) => setMask((m) => m + token);
   const [maskStats, setMaskStats] = useState({ count: 0, time: 0 });
   const showMask = ['3', '6', '7'].includes(attackMode);
@@ -195,13 +201,13 @@ function HashcatApp() {
       setMaskStats({ count: 0, time: 0 });
       return;
     }
-    const sets = { '?l': 26, '?u': 26, '?d': 10, '?s': 33, '?a': 95 };
+    const sets = new Map(charsets.map((set) => [set.id, set.size]));
     let total = 1;
     for (let i = 0; i < mask.length; i++) {
       if (mask[i] === '?' && i < mask.length - 1) {
         const token = mask.slice(i, i + 2);
-        if (sets[token]) {
-          total *= sets[token];
+        if (sets.has(token)) {
+          total *= sets.get(token);
           i++;
           continue;
         }
@@ -209,7 +215,7 @@ function HashcatApp() {
       total *= 1;
     }
     setMaskStats({ count: total, time: total / 1_000_000 });
-  }, [mask]);
+  }, [mask, charsets]);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -391,29 +397,26 @@ function HashcatApp() {
         </select>
       </div>
       {showMask && (
-        <div>
-          <label className="block" htmlFor="mask-input">
-            Mask
-          </label>
-          <input
-            id="mask-input"
-            type="text"
-            aria-label="Mask pattern"
-            className="text-black px-2 py-1 w-full"
-            value={mask}
-            onChange={(e) => setMask(e.target.value)}
+        <div className="w-full">
+          <KeyspaceHeatmap
+            mask={mask}
+            onMaskChange={setMask}
+            charsets={charsets}
+            onCharsetsChange={setCharsets}
           />
-          <div className="space-x-2 mt-1">
-            {['?l', '?u', '?d', '?s', '?a'].map((t) => (
-              <button
-                key={t}
-                type="button"
-                onClick={() => appendMask(t)}
-                aria-label={`Add ${t} to mask`}
-              >
-                {t}
-              </button>
-            ))}
+          <div className="space-x-2 mt-2">
+            {charsets
+              .filter((set) => set.id.startsWith('?'))
+              .map((set) => (
+                <button
+                  key={set.id}
+                  type="button"
+                  onClick={() => appendMask(set.id)}
+                  aria-label={`Add ${set.id} to mask`}
+                >
+                  {set.id}
+                </button>
+              ))}
           </div>
           {mask && (
             <div className="mt-2">


### PR DESCRIPTION
## Summary
- add a canvas-based KeyspaceHeatmap component that visualizes mask positions versus charset sizes with tooltips and simulated progress
- wire the heatmap into the hashcat simulator so mask and charset adjustments stay in sync with candidate estimates
- add Jest coverage to confirm mask/charset controls work and the heatmap handles large datasets without DOM bloat

## Testing
- yarn test KeyspaceHeatmap


------
https://chatgpt.com/codex/tasks/task_e_68dcdeb199388328b409e55e3d86a43f