### PR TITLE
[serial-terminal] Enhance signal probing and encoding hints

### DIFF
--- a/__tests__/serial-detection.test.ts
+++ b/__tests__/serial-detection.test.ts
@@ -1,0 +1,59 @@
+import {
+  analyzeXonXoff,
+  createXonSuggestion,
+  detectEncoding,
+  evaluateHardwareSignals,
+  type HardwareSignals,
+  type XonXoffStats,
+} from '../utils/serial/detection';
+
+describe('serial detection heuristics', () => {
+  it('detects UTF-8 text with multi-byte sequences', () => {
+    const bytes = new TextEncoder().encode('Hello π and café');
+    const suggestion = detectEncoding(bytes);
+    expect(suggestion.encoding).toBe('utf-8');
+    expect(suggestion.confidence).toBeGreaterThan(0.6);
+  });
+
+  it('falls back to Latin-1 when invalid UTF-8 bytes are encountered', () => {
+    const bytes = Uint8Array.from([0xff, 0xfe, 0xf1]);
+    const suggestion = detectEncoding(bytes);
+    expect(suggestion.encoding).toBe('latin1');
+    expect(suggestion.confidence).toBeGreaterThan(0.6);
+  });
+
+  it('recommends Latin-1 when high-bit bytes lack UTF-8 structure', () => {
+    const latin1Buffer = Uint8Array.from(Buffer.from('\xff\xfa\xf1', 'binary'));
+    const suggestion = detectEncoding(latin1Buffer);
+    expect(suggestion.encoding).toBe('latin1');
+  });
+
+  it('counts XON/XOFF bytes and toggles recommendation', () => {
+    const sample = Uint8Array.from([0x11, 0x13, 0x41, 0x11]);
+    const stats = analyzeXonXoff(sample);
+    const aggregated: XonXoffStats = {
+      xon: stats.xon,
+      xoff: stats.xoff,
+      totalBytes: sample.length,
+    };
+    const suggestion = createXonSuggestion(aggregated);
+    expect(suggestion.type).toBe('XON/XOFF');
+    expect(suggestion.state).toBe('enabled');
+    expect(suggestion.confidence).toBeGreaterThan(0.6);
+  });
+
+  it('keeps software flow control disabled when no markers seen', () => {
+    const aggregated: XonXoffStats = { xon: 0, xoff: 0, totalBytes: 400 };
+    const suggestion = createXonSuggestion(aggregated);
+    expect(suggestion.state).toBe('disabled');
+  });
+
+  it('mirrors available hardware signal telemetry', () => {
+    const signals: HardwareSignals = { clearToSend: true, requestToSend: false };
+    const results = evaluateHardwareSignals(signals);
+    const cts = results.find((item) => item.type === 'CTS');
+    const rts = results.find((item) => item.type === 'RTS');
+    expect(cts?.state).toBe('enabled');
+    expect(rts?.state).toBe('disabled');
+  });
+});

--- a/__tests__/serial-terminal.test.tsx
+++ b/__tests__/serial-terminal.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, within, waitFor } from '@testing-library/react';
+import SerialTerminalApp from '../components/apps/serial-terminal';
+
+describe('SerialTerminalApp session integration', () => {
+  const requestPort = jest.fn();
+  const addEventListener = jest.fn();
+  const removeEventListener = jest.fn();
+  let mockPort: {
+    readable: ReadableStream<Uint8Array>;
+    open: jest.Mock;
+    close: jest.Mock;
+    getSignals: jest.Mock;
+    setSignals: jest.Mock;
+  };
+
+  class MockReader {
+    private chunks: Uint8Array[];
+
+    constructor(chunks: Uint8Array[]) {
+      this.chunks = [...chunks];
+    }
+
+    async read(): Promise<{ value: Uint8Array | undefined; done: boolean }> {
+      if (this.chunks.length === 0) {
+        return { value: undefined, done: true };
+      }
+      const value = this.chunks.shift();
+      return { value: value as Uint8Array, done: false };
+    }
+
+    async cancel() {
+      this.chunks = [];
+    }
+
+    releaseLock() {
+      this.chunks = [];
+    }
+  }
+
+  const mockReadable = (chunks: Uint8Array[]): ReadableStream<Uint8Array> =>
+    ({
+      getReader() {
+        return new MockReader(chunks);
+      },
+    } as unknown as ReadableStream<Uint8Array>);
+
+  beforeEach(() => {
+    const stream = mockReadable([Uint8Array.from([0xff, 0xfa, 0xf1])]);
+
+    mockPort = {
+      readable: stream,
+      open: jest.fn(() => Promise.resolve()),
+      close: jest.fn(() => Promise.resolve()),
+      getSignals: jest.fn(() => Promise.resolve({ clearToSend: false })),
+      setSignals: jest.fn(() => Promise.resolve()),
+    };
+
+    requestPort.mockResolvedValue(mockPort);
+
+    const nav = navigator as Navigator & { serial?: unknown };
+    Object.defineProperty(nav, 'serial', {
+      configurable: true,
+      value: {
+        requestPort,
+        addEventListener,
+        removeEventListener,
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('applies detection suggestions to the active session', async () => {
+    render(<SerialTerminalApp />);
+
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+    await waitFor(() => expect(requestPort).toHaveBeenCalled());
+
+    await screen.findByText(/Suggested: LATIN1/i);
+    const applyEncoding = await screen.findByRole('button', { name: /apply encoding/i });
+    fireEvent.click(applyEncoding);
+    await screen.findByText(/Active encoding: LATIN1/i);
+
+    const rtsLabel = await screen.findByText('RTS');
+    const rtsEntry = rtsLabel.closest('li') as HTMLElement;
+    const applySignal = within(rtsEntry).getByRole('button', { name: /apply/i });
+    fireEvent.click(applySignal);
+    await waitFor(() => expect(applySignal).toHaveTextContent(/applied/i));
+
+    expect(mockPort.setSignals).toHaveBeenCalledWith({ requestToSend: false });
+  });
+});

--- a/components/apps/serial-terminal.tsx
+++ b/components/apps/serial-terminal.tsx
@@ -1,10 +1,29 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import FormError from '../ui/FormError';
+import {
+  analyzeXonXoff,
+  createXonSuggestion,
+  detectEncoding,
+  evaluateHardwareSignals,
+  type EncodingOption,
+  type EncodingSuggestion,
+  type SignalSuggestion,
+  type XonXoffStats,
+} from '../../utils/serial/detection';
+
+interface SerialSignals {
+  readonly clearToSend?: boolean;
+  readonly dataCarrierDetect?: boolean;
+  readonly ringIndicator?: boolean;
+  readonly requestToSend?: boolean;
+}
 
 interface SerialPort {
   readonly readable: ReadableStream<Uint8Array> | null;
   open(options: { baudRate: number }): Promise<void>;
   close(): Promise<void>;
+  getSignals?(): Promise<SerialSignals>;
+  setSignals?(signals: { requestToSend?: boolean; dataTerminalReady?: boolean }): Promise<void>;
 }
 
 interface Serial {
@@ -15,12 +34,54 @@ interface Serial {
 
 type NavigatorSerial = Navigator & { serial: Serial };
 
+const signalOrder: Record<SignalSuggestion['type'], number> = {
+  CTS: 0,
+  RTS: 1,
+  'XON/XOFF': 2,
+};
+
+const decodeBuffer = (encoding: EncodingOption, buffer: number[]) => {
+  if (buffer.length === 0) return '';
+  const decoder = new TextDecoder(encoding, { fatal: false });
+  return decoder.decode(new Uint8Array(buffer));
+};
+
 const SerialTerminalApp: React.FC = () => {
   const supported = typeof navigator !== 'undefined' && 'serial' in navigator;
   const [port, setPort] = useState<SerialPort | null>(null);
   const [logs, setLogs] = useState('');
   const [error, setError] = useState('');
-  const readerRef = useRef<ReadableStreamDefaultReader<string> | null>(null);
+  const [signalSuggestions, setSignalSuggestions] = useState<SignalSuggestion[]>([]);
+  const [appliedSignals, setAppliedSignals] = useState<SignalSuggestion['type'][]>([]);
+  const [encoding, setEncoding] = useState<EncodingOption>('utf-8');
+  const [encodingSuggestion, setEncodingSuggestion] = useState<EncodingSuggestion | null>(null);
+  const readerRef = useRef<ReadableStreamDefaultReader<Uint8Array> | null>(null);
+  const rawBufferRef = useRef<number[]>([]);
+  const encodingRef = useRef<EncodingOption>('utf-8');
+  const xonStatsRef = useRef<XonXoffStats>({ xon: 0, xoff: 0, totalBytes: 0 });
+
+  const sortedSuggestions = useMemo(
+    () => [...signalSuggestions].sort((a, b) => signalOrder[a.type] - signalOrder[b.type]),
+    [signalSuggestions],
+  );
+
+  const updateSignalSuggestion = (suggestion: SignalSuggestion) => {
+    setSignalSuggestions((prev) => {
+      const filtered = prev.filter((item) => item.type !== suggestion.type);
+      return [...filtered, suggestion];
+    });
+  };
+
+  const resetSessionState = () => {
+    rawBufferRef.current = [];
+    xonStatsRef.current = { xon: 0, xoff: 0, totalBytes: 0 };
+    setLogs('');
+    setEncoding('utf-8');
+    encodingRef.current = 'utf-8';
+    setEncodingSuggestion(null);
+    setSignalSuggestions([]);
+    setAppliedSignals([]);
+  };
 
   useEffect(() => {
     if (!supported) return;
@@ -28,6 +89,7 @@ const SerialTerminalApp: React.FC = () => {
       if (e.target === port) {
         setError('Device disconnected.');
         setPort(null);
+        resetSessionState();
       }
     };
     const nav = navigator as NavigatorSerial;
@@ -38,21 +100,34 @@ const SerialTerminalApp: React.FC = () => {
   }, [supported, port]);
 
   const readLoop = async (p: SerialPort) => {
-    const textDecoder = new TextDecoderStream();
-    const readableClosed = p.readable?.pipeTo(textDecoder.writable as WritableStream<Uint8Array>);
-    const reader = textDecoder.readable.getReader();
+    const reader = p.readable?.getReader();
+    if (!reader) return;
     readerRef.current = reader;
     try {
       while (true) {
         const { value, done } = await reader.read();
         if (done) break;
-        if (value) setLogs((l) => l + value);
+        if (value) {
+          rawBufferRef.current.push(...value);
+          const stats = analyzeXonXoff(value);
+          xonStatsRef.current = {
+            xon: xonStatsRef.current.xon + stats.xon,
+            xoff: xonStatsRef.current.xoff + stats.xoff,
+            totalBytes: xonStatsRef.current.totalBytes + value.length,
+          };
+          updateSignalSuggestion(createXonSuggestion(xonStatsRef.current));
+
+          const activeEncoding = encodingRef.current;
+          setLogs(decodeBuffer(activeEncoding, rawBufferRef.current));
+
+          const sample = rawBufferRef.current.slice(-4096);
+          setEncodingSuggestion(detectEncoding(new Uint8Array(sample)));
+        }
       }
     } catch {
       // ignored
     } finally {
       reader.releaseLock();
-      await readableClosed?.catch(() => {});
     }
   };
 
@@ -63,6 +138,19 @@ const SerialTerminalApp: React.FC = () => {
       const p = await (navigator as NavigatorSerial).serial.requestPort();
       await p.open({ baudRate: 9600 });
       setPort(p);
+      const hardwareSuggestions = await (async () => {
+        try {
+          const signals = await p.getSignals?.();
+          return evaluateHardwareSignals({
+            clearToSend: signals?.clearToSend,
+            requestToSend: signals?.requestToSend,
+          });
+        } catch {
+          return evaluateHardwareSignals({});
+        }
+      })();
+      hardwareSuggestions.forEach(updateSignalSuggestion);
+      updateSignalSuggestion(createXonSuggestion(xonStatsRef.current));
       readLoop(p);
     } catch (err) {
       const e = err as DOMException;
@@ -84,38 +172,117 @@ const SerialTerminalApp: React.FC = () => {
       // ignore
     } finally {
       setPort(null);
+      resetSessionState();
     }
   };
 
+  const applySignalSuggestion = async (suggestion: SignalSuggestion) => {
+    if (suggestion.type === 'RTS' && port?.setSignals) {
+      try {
+        await port.setSignals({ requestToSend: suggestion.state === 'enabled' });
+      } catch {
+        setError('Failed to update RTS line on the active session.');
+        return;
+      }
+    }
+    setAppliedSignals((prev) => (prev.includes(suggestion.type) ? prev : [...prev, suggestion.type]));
+  };
+
+  const applyEncoding = (suggestion: EncodingSuggestion) => {
+    encodingRef.current = suggestion.encoding;
+    setEncoding(suggestion.encoding);
+  };
+
+  useEffect(() => {
+    encodingRef.current = encoding;
+    setLogs(decodeBuffer(encoding, rawBufferRef.current));
+  }, [encoding]);
+
   return (
-    <div className="relative h-full w-full bg-black p-4 text-green-400 font-mono">
-      <div className="mb-4 flex gap-2">
-        {!port ? (
-          <button
-            onClick={connect}
-            disabled={!supported}
-            className="rounded bg-gray-700 px-2 py-1 text-white disabled:opacity-50"
-          >
-            Connect
-          </button>
-        ) : (
-          <button
-            onClick={disconnect}
-            className="rounded bg-red-700 px-2 py-1 text-white"
-          >
-            Disconnect
-          </button>
-        )}
+    <div className="relative h-full w-full bg-black p-4 font-mono text-green-400">
+      <div className="grid h-full gap-4 md:grid-cols-[2fr_1fr]">
+        <div className="flex h-full flex-col">
+          <div className="mb-4 flex gap-2">
+            {!port ? (
+              <button
+                onClick={connect}
+                disabled={!supported}
+                className="rounded bg-gray-700 px-2 py-1 text-white disabled:opacity-50"
+              >
+                Connect
+              </button>
+            ) : (
+              <button onClick={disconnect} className="rounded bg-red-700 px-2 py-1 text-white">
+                Disconnect
+              </button>
+            )}
+          </div>
+          {!supported && (
+            <p className="mb-2 text-sm text-yellow-400">Web Serial API not supported in this browser.</p>
+          )}
+          {error && <FormError className="mb-2 mt-0">{error}</FormError>}
+          <pre className="flex-1 overflow-auto whitespace-pre-wrap break-words rounded border border-green-700/40 bg-black/60 p-3">
+            {logs || 'No data'}
+          </pre>
+        </div>
+        <aside className="flex h-full flex-col gap-4 rounded border border-green-700/40 bg-gray-900/60 p-4 text-xs text-green-200">
+          <div>
+            <h2 className="mb-2 text-sm font-semibold text-green-300">Signal recommendations</h2>
+            <ul className="space-y-3">
+              {sortedSuggestions.map((suggestion) => {
+                const applied = appliedSignals.includes(suggestion.type);
+                return (
+                  <li key={suggestion.type} className="rounded border border-green-800/40 bg-black/40 p-2">
+                    <div className="flex items-center justify-between">
+                      <span className="font-semibold text-green-100">{suggestion.type}</span>
+                      <span className="text-green-400">{suggestion.state.toUpperCase()}</span>
+                    </div>
+                    <p className="mt-1 text-[0.7rem] text-green-300">{suggestion.reason}</p>
+                    <div className="mt-2 flex items-center justify-between text-[0.7rem]">
+                      <span>Confidence: {(suggestion.confidence * 100).toFixed(0)}%</span>
+                      <button
+                        onClick={() => applySignalSuggestion(suggestion)}
+                        disabled={applied}
+                        className="rounded bg-green-700 px-2 py-1 text-black disabled:cursor-not-allowed disabled:bg-green-900 disabled:text-green-500"
+                      >
+                        {applied ? 'Applied' : 'Apply'}
+                      </button>
+                    </div>
+                  </li>
+                );
+              })}
+              {sortedSuggestions.length === 0 && (
+                <li className="rounded border border-green-800/40 bg-black/40 p-2 text-[0.7rem] text-green-300">
+                  No signal telemetry collected yet.
+                </li>
+              )}
+            </ul>
+          </div>
+          <div>
+            <h2 className="mb-2 text-sm font-semibold text-green-300">Encoding insight</h2>
+            {encodingSuggestion ? (
+              <div className="rounded border border-green-800/40 bg-black/40 p-2">
+                <div className="flex items-center justify-between">
+                  <span className="font-semibold text-green-100">Suggested: {encodingSuggestion.encoding.toUpperCase()}</span>
+                  <span className="text-green-400">{(encodingSuggestion.confidence * 100).toFixed(0)}%</span>
+                </div>
+                <p className="mt-1 text-[0.7rem] text-green-300">{encodingSuggestion.reason}</p>
+                <button
+                  onClick={() => applyEncoding(encodingSuggestion)}
+                  className="mt-2 w-full rounded bg-green-700 px-2 py-1 text-black"
+                >
+                  Apply encoding
+                </button>
+              </div>
+            ) : (
+              <p className="rounded border border-green-800/40 bg-black/40 p-2 text-[0.7rem] text-green-300">
+                Waiting for data to analyse character encoding.
+              </p>
+            )}
+            <p className="mt-2 text-[0.7rem] text-green-200">Active encoding: {encoding.toUpperCase()}</p>
+          </div>
+        </aside>
       </div>
-      {!supported && (
-        <p className="mb-2 text-sm text-yellow-400">
-          Web Serial API not supported in this browser.
-        </p>
-      )}
-      {error && <FormError className="mb-2 mt-0">{error}</FormError>}
-      <pre className="h-[calc(100%-4rem)] overflow-auto whitespace-pre-wrap break-words">
-        {logs || 'No data'}
-      </pre>
     </div>
   );
 };

--- a/utils/serial/detection.ts
+++ b/utils/serial/detection.ts
@@ -1,0 +1,223 @@
+export type FlowControlState = 'enabled' | 'disabled';
+export type SignalType = 'CTS' | 'RTS' | 'XON/XOFF';
+
+export interface SignalSuggestion {
+  type: SignalType;
+  state: FlowControlState;
+  confidence: number;
+  reason: string;
+}
+
+export type EncodingOption = 'utf-8' | 'latin1';
+
+export interface EncodingSuggestion {
+  encoding: EncodingOption;
+  confidence: number;
+  reason: string;
+}
+
+export interface XonXoffStats {
+  xon: number;
+  xoff: number;
+  totalBytes: number;
+}
+
+export interface HardwareSignals {
+  clearToSend?: boolean;
+  requestToSend?: boolean;
+}
+
+export function analyzeXonXoff(bytes: Uint8Array): XonXoffStats {
+  let xon = 0;
+  let xoff = 0;
+  for (const value of bytes) {
+    if (value === 0x11) xon += 1;
+    if (value === 0x13) xoff += 1;
+  }
+  return {
+    xon,
+    xoff,
+    totalBytes: bytes.length,
+  };
+}
+
+export function createXonSuggestion(stats: XonXoffStats): SignalSuggestion {
+  const totalControl = stats.xon + stats.xoff;
+  if (stats.totalBytes === 0) {
+    return {
+      type: 'XON/XOFF',
+      state: 'disabled',
+      confidence: 0.4,
+      reason: 'No bytes captured yet to analyse software flow control.',
+    };
+  }
+
+  if (totalControl === 0) {
+    const confidence = Math.max(0.4, 1 - Math.min(0.6, stats.totalBytes / 2048));
+    return {
+      type: 'XON/XOFF',
+      state: 'disabled',
+      confidence,
+      reason: `Inspected ${stats.totalBytes} byte(s) with no XON/XOFF markers detected.`,
+    };
+  }
+
+  const ratio = totalControl / stats.totalBytes;
+  const confidence = Math.min(0.95, 0.6 + ratio * 2);
+  return {
+    type: 'XON/XOFF',
+    state: 'enabled',
+    confidence,
+    reason: `Observed ${stats.xon} XON and ${stats.xoff} XOFF control character(s) within ${stats.totalBytes} byte(s).`,
+  };
+}
+
+export function evaluateHardwareSignals(signals: HardwareSignals): SignalSuggestion[] {
+  const suggestions: SignalSuggestion[] = [];
+  if (typeof signals.clearToSend === 'boolean') {
+    suggestions.push({
+      type: 'CTS',
+      state: signals.clearToSend ? 'enabled' : 'disabled',
+      confidence: signals.clearToSend ? 0.9 : 0.6,
+      reason: signals.clearToSend
+        ? 'Port reports clear-to-send high; hardware handshake is active.'
+        : 'Port reports clear-to-send low; hardware handshake appears inactive.',
+    });
+  } else {
+    suggestions.push({
+      type: 'CTS',
+      state: 'enabled',
+      confidence: 0.4,
+      reason: 'CTS state unavailable from port; keeping handshake enabled unless issues occur.',
+    });
+  }
+
+  if (typeof signals.requestToSend === 'boolean') {
+    suggestions.push({
+      type: 'RTS',
+      state: signals.requestToSend ? 'enabled' : 'disabled',
+      confidence: 0.7,
+      reason: signals.requestToSend
+        ? 'Request-to-send output is asserted; peers likely expect RTS.'
+        : 'Request-to-send output is low; RTS handshake may be unused.',
+    });
+  } else if (typeof signals.clearToSend === 'boolean') {
+    suggestions.push({
+      type: 'RTS',
+      state: signals.clearToSend ? 'enabled' : 'disabled',
+      confidence: 0.55,
+      reason: 'Mirroring CTS reading because RTS state is unavailable.',
+    });
+  } else {
+    suggestions.push({
+      type: 'RTS',
+      state: 'enabled',
+      confidence: 0.4,
+      reason: 'Signal telemetry missing; defaulting to RTS enabled.',
+    });
+  }
+
+  return suggestions;
+}
+
+interface Utf8PatternStats {
+  multiByteSequences: number;
+  strayContinuation: number;
+  highBytes: number;
+}
+
+function analyseUtf8Patterns(buffer: Uint8Array): Utf8PatternStats {
+  let multiByteSequences = 0;
+  let strayContinuation = 0;
+  let highBytes = 0;
+
+  for (let i = 0; i < buffer.length; i += 1) {
+    const byte = buffer[i];
+    if (byte >= 0x80) highBytes += 1;
+
+    if (byte >> 5 === 0b110 && i + 1 < buffer.length && buffer[i + 1] >> 6 === 0b10) {
+      multiByteSequences += 1;
+      i += 1;
+      continue;
+    }
+    if (byte >> 4 === 0b1110 && i + 2 < buffer.length && buffer[i + 1] >> 6 === 0b10 && buffer[i + 2] >> 6 === 0b10) {
+      multiByteSequences += 1;
+      i += 2;
+      continue;
+    }
+    if (byte >> 3 === 0b11110 && i + 3 < buffer.length && buffer[i + 1] >> 6 === 0b10 && buffer[i + 2] >> 6 === 0b10 && buffer[i + 3] >> 6 === 0b10) {
+      multiByteSequences += 1;
+      i += 3;
+      continue;
+    }
+    if (byte >> 6 === 0b10) {
+      strayContinuation += 1;
+      continue;
+    }
+    if (byte >= 0x80) {
+      strayContinuation += 1;
+    }
+  }
+
+  return { multiByteSequences, strayContinuation, highBytes };
+}
+
+export function detectEncoding(buffer: Uint8Array): EncodingSuggestion {
+  if (buffer.length === 0) {
+    return {
+      encoding: 'utf-8',
+      confidence: 0.5,
+      reason: 'No input received; defaulting to UTF-8 until data arrives.',
+    };
+  }
+
+  let utf8Valid = true;
+  try {
+    new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+  } catch {
+    utf8Valid = false;
+  }
+
+  const { multiByteSequences, strayContinuation, highBytes } = analyseUtf8Patterns(buffer);
+
+  if (!utf8Valid) {
+    const ratio = highBytes / buffer.length;
+    return {
+      encoding: 'latin1',
+      confidence: Math.min(0.95, 0.6 + ratio * 0.5),
+      reason: 'Encountered invalid UTF-8 byte patterns; Latin-1 preserves raw high-bit values.',
+    };
+  }
+
+  if (highBytes === 0) {
+    return {
+      encoding: 'utf-8',
+      confidence: 0.6,
+      reason: 'All bytes are ASCII; UTF-8 is safe for mixed-language streams.',
+    };
+  }
+
+  if (multiByteSequences > strayContinuation) {
+    const ratio = multiByteSequences / Math.max(1, highBytes);
+    return {
+      encoding: 'utf-8',
+      confidence: Math.min(0.95, 0.65 + ratio * 0.3),
+      reason: `Detected ${multiByteSequences} multi-byte UTF-8 sequence(s) without errors.`,
+    };
+  }
+
+  if (strayContinuation > 0) {
+    const ratio = strayContinuation / buffer.length;
+    return {
+      encoding: 'latin1',
+      confidence: Math.min(0.9, 0.5 + ratio * 1.5),
+      reason: `Observed ${strayContinuation} isolated high-bit byte(s); Latin-1 keeps them verbatim.`,
+    };
+  }
+
+  return {
+    encoding: 'latin1',
+    confidence: 0.55,
+    reason: 'High-bit bytes lacked UTF-8 continuation structure; falling back to Latin-1.',
+  };
+}


### PR DESCRIPTION
## Summary
- surface flow-control telemetry in the serial terminal, including CTS/RTS probing and XON/XOFF heuristics with apply actions
- add automatic UTF-8 vs Latin-1 detection that can retune the active session decoding from the UI
- extract reusable detection helpers with dedicated unit tests plus an integration test covering session updates

## Testing
- yarn lint
- yarn test serial-terminal
- yarn test serial-detection

------
https://chatgpt.com/codex/tasks/task_e_68dcdec3bab88328bb95d68df3102907