### PR TITLE
[screen-recorder] Add input overlay timeline and export flow

### DIFF
--- a/__tests__/overlay.test.ts
+++ b/__tests__/overlay.test.ts
@@ -1,0 +1,55 @@
+import {
+  computeFrameIndex,
+  formatKeyCombo,
+  sanitizeIgnoreList,
+  shouldIgnoreKey,
+  shouldRecordEvent,
+} from '../utils/overlay';
+
+const mockEvent = (overrides: Partial<KeyboardEvent> = {}) =>
+  ({
+    key: 'a',
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    metaKey: false,
+    ...overrides,
+  }) as KeyboardEvent;
+
+describe('overlay utilities', () => {
+  it('formats key combos with consistent ordering', () => {
+    const combo = formatKeyCombo(
+      mockEvent({ key: 's', ctrlKey: true, altKey: true, shiftKey: true }),
+    );
+    expect(combo).toEqual(['Ctrl', 'Alt', 'Shift', 'S']);
+  });
+
+  it('computes frame index relative to recording start', () => {
+    const start = 1000;
+    const now = start + 166;
+    expect(computeFrameIndex(now, start, 60)).toBe(10);
+  });
+
+  it('prevents noisy duplicates within threshold', () => {
+    const map = new Map<string, number>();
+    const threshold = 200;
+    const first = shouldRecordEvent('Ctrl + S', 1000, threshold, map);
+    const second = shouldRecordEvent('Ctrl + S', 1100, threshold, map);
+    const third = shouldRecordEvent('Ctrl + S', 1400, threshold, map);
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    expect(third).toBe(true);
+  });
+
+  it('sanitises ignore lists case-insensitively', () => {
+    const list = sanitizeIgnoreList(['Meta', ' meta ', 'Shift']);
+    expect(list).toEqual(['meta', 'shift']);
+  });
+
+  it('matches ignored keys regardless of case', () => {
+    const ignore = new Set(['meta', 'shift']);
+    expect(shouldIgnoreKey('Meta', ignore)).toBe(true);
+    expect(shouldIgnoreKey('Shift', ignore)).toBe(true);
+    expect(shouldIgnoreKey('Alt', ignore)).toBe(false);
+  });
+});

--- a/components/apps/screen-recorder.tsx
+++ b/components/apps/screen-recorder.tsx
@@ -1,119 +1,401 @@
-import React, { useEffect, useRef, useState } from 'react';
+'use client';
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import InputOverlay from './screen-recorder/InputOverlay';
+import { FrameMarker, OverlayEvent } from '../../types/overlay';
+import { sanitizeIgnoreList } from '../../utils/overlay';
+import { renderOverlayOnVideo } from '../../utils/overlayExport';
+
+const DEFAULT_FRAME_RATE = 30;
+const OVERLAY_DOWNLOAD = 'recording-overlay.webm';
+const METADATA_DOWNLOAD = 'recording-overlay.json';
+
+const downloadBlob = (blob: Blob, filename: string) => {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+};
 
 function ScreenRecorder() {
-    const [recording, setRecording] = useState(false);
-    const [videoUrl, setVideoUrl] = useState<string | null>(null);
-    const recorderRef = useRef<MediaRecorder | null>(null);
-    const chunksRef = useRef<Blob[]>([]);
-    const streamRef = useRef<MediaStream | null>(null);
+  const [recording, setRecording] = useState(false);
+  const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  const [videoBlob, setVideoBlob] = useState<Blob | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const videoUrlRef = useRef<string | null>(null);
 
-    const startRecording = async () => {
-        try {
-            const stream = await navigator.mediaDevices.getDisplayMedia({
-                video: true,
-                audio: true,
-            });
-            streamRef.current = stream;
-            const recorder = new MediaRecorder(stream);
-            chunksRef.current = [];
-            recorder.ondataavailable = (e: BlobEvent) => {
-                if (e.data.size > 0) chunksRef.current.push(e.data);
-            };
-            recorder.onstop = () => {
-                const blob = new Blob(chunksRef.current, { type: 'video/webm' });
-                const url = URL.createObjectURL(blob);
-                setVideoUrl(url);
-                stream.getTracks().forEach((t) => t.stop());
-            };
-            recorder.start();
-            recorderRef.current = recorder;
-            setRecording(true);
-        } catch {
-            // ignore
+  const [overlayEvents, setOverlayEvents] = useState<OverlayEvent[]>([]);
+  const overlayEventsRef = useRef<OverlayEvent[]>([]);
+  const [overlayOpacity, setOverlayOpacity] = useState(0.85);
+  const [noiseThreshold, setNoiseThreshold] = useState(120);
+  const [ignoredKeysInput, setIgnoredKeysInput] = useState('Meta');
+  const [showKeyboard, setShowKeyboard] = useState(true);
+  const [showMouse, setShowMouse] = useState(true);
+  const [overlayStart, setOverlayStart] = useState<number | null>(null);
+  const overlayStartRef = useRef<number | null>(null);
+  const [frameRate, setFrameRate] = useState(DEFAULT_FRAME_RATE);
+  const frameRateRef = useRef(DEFAULT_FRAME_RATE);
+  const [frameTimeline, setFrameTimeline] = useState<FrameMarker[]>([]);
+  const frameTimelineRef = useRef<FrameMarker[]>([]);
+  const frameLoopRef = useRef<number>();
+  const [recordingStartedAt, setRecordingStartedAt] = useState<number | null>(null);
+  const [exportStatus, setExportStatus] = useState('');
+
+  const ignoreKeys = useMemo(
+    () =>
+      sanitizeIgnoreList(
+        ignoredKeysInput
+          .split(',')
+          .map((key) => key.trim())
+          .filter(Boolean),
+      ),
+    [ignoredKeysInput],
+  );
+
+  useEffect(() => {
+    frameRateRef.current = frameRate;
+  }, [frameRate]);
+
+  const stopFrameLoop = useCallback(() => {
+    if (frameLoopRef.current) {
+      cancelAnimationFrame(frameLoopRef.current);
+      frameLoopRef.current = undefined;
+    }
+  }, []);
+
+  const startFrameLoop = useCallback(() => {
+    frameTimelineRef.current = [];
+    const loop = () => {
+      if (overlayStartRef.current !== null) {
+        const now = performance.now();
+        const elapsed = now - overlayStartRef.current;
+        const frameIndex = Math.round((elapsed / 1000) * frameRateRef.current);
+        const last = frameTimelineRef.current[frameTimelineRef.current.length - 1];
+        if (!last || last.frame !== frameIndex) {
+          frameTimelineRef.current.push({ frame: frameIndex, time: elapsed });
         }
+      }
+      frameLoopRef.current = requestAnimationFrame(loop);
     };
+    frameLoopRef.current = requestAnimationFrame(loop);
+  }, []);
 
-    const stopRecording = () => {
-        recorderRef.current?.stop();
-        setRecording(false);
-    };
+  const resetRecordingState = useCallback(() => {
+    overlayEventsRef.current = [];
+    setOverlayEvents([]);
+    frameTimelineRef.current = [];
+    setFrameTimeline([]);
+    setExportStatus('');
+    if (videoUrlRef.current) {
+      URL.revokeObjectURL(videoUrlRef.current);
+      videoUrlRef.current = null;
+    }
+    setVideoUrl(null);
+    setVideoBlob(null);
+  }, []);
 
-    const saveRecording = async () => {
-        if (!videoUrl) return;
+  const handleOverlayRecord = useCallback((event: OverlayEvent) => {
+    overlayEventsRef.current = [...overlayEventsRef.current, event];
+    setOverlayEvents(overlayEventsRef.current);
+  }, []);
+
+  const startRecording = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        video: true,
+        audio: true,
+      });
+      streamRef.current = stream;
+      const track = stream.getVideoTracks()[0];
+      const settings = track?.getSettings?.() ?? {};
+      const rate =
+        typeof settings.frameRate === 'number' && settings.frameRate > 0
+          ? Math.round(settings.frameRate)
+          : DEFAULT_FRAME_RATE;
+      setFrameRate(rate);
+      frameRateRef.current = rate;
+
+      const recorder = new MediaRecorder(stream);
+      chunksRef.current = [];
+      recorder.ondataavailable = (event: BlobEvent) => {
+        if (event.data.size > 0) {
+          chunksRef.current.push(event.data);
+        }
+      };
+      recorder.onstop = () => {
         const blob = new Blob(chunksRef.current, { type: 'video/webm' });
-        if ('showSaveFilePicker' in window) {
-            try {
-                const handle = await (window as any).showSaveFilePicker({
-                    suggestedName: 'recording.webm',
-                    types: [
-                        {
-                            description: 'WebM video',
-                            accept: { 'video/webm': ['.webm'] },
-                        },
-                    ],
-                });
-                const writable = await handle.createWritable();
-                await writable.write(blob);
-                await writable.close();
-            } catch {
-                // ignore
-            }
-        } else {
-            const a = document.createElement('a');
-            a.href = videoUrl;
-            a.download = 'recording.webm';
-            document.body.appendChild(a);
-            a.click();
-            a.remove();
+        setVideoBlob(blob);
+        if (videoUrlRef.current) {
+          URL.revokeObjectURL(videoUrlRef.current);
         }
+        const url = URL.createObjectURL(blob);
+        videoUrlRef.current = url;
+        setVideoUrl(url);
+        stream.getTracks().forEach((trackItem) => trackItem.stop());
+        overlayStartRef.current = null;
+        setOverlayStart(null);
+        stopFrameLoop();
+        setFrameTimeline([...frameTimelineRef.current]);
+        setRecording(false);
+      };
+      recorder.start();
+      recorderRef.current = recorder;
+      resetRecordingState();
+      const start = performance.now();
+      overlayStartRef.current = start;
+      setOverlayStart(start);
+      startFrameLoop();
+      setRecordingStartedAt(Date.now());
+      setRecording(true);
+    } catch {
+      // ignore permission denials or unsupported environments
+    }
+  };
+
+  const stopRecording = useCallback(() => {
+    recorderRef.current?.stop();
+    setRecording(false);
+  }, []);
+
+  const saveRecording = async () => {
+    if (!videoBlob || !videoUrl) return;
+    if ('showSaveFilePicker' in window) {
+      try {
+        const handle = await (window as any).showSaveFilePicker({
+          suggestedName: 'recording.webm',
+          types: [
+            {
+              description: 'WebM video',
+              accept: { 'video/webm': ['.webm'] },
+            },
+          ],
+        });
+        const writable = await handle.createWritable();
+        await writable.write(videoBlob);
+        await writable.close();
+      } catch {
+        // ignore user cancellation
+      }
+    } else {
+      downloadBlob(videoBlob, 'recording.webm');
+    }
+  };
+
+  const exportOverlayVideo = async () => {
+    if (!videoBlob || overlayEventsRef.current.length === 0) return;
+    setExportStatus('Rendering overlay…');
+    try {
+      const rendered = await renderOverlayOnVideo(videoBlob, overlayEventsRef.current, {
+        frameRate: frameRateRef.current,
+        opacity: overlayOpacity,
+      });
+      downloadBlob(rendered, OVERLAY_DOWNLOAD);
+      setExportStatus('Overlay baked into exported video.');
+    } catch (error) {
+      console.error(error);
+      downloadBlob(videoBlob, 'recording.webm');
+      setExportStatus('Overlay rendering unavailable. Exported original recording.');
+    }
+  };
+
+  const exportOverlayMetadata = () => {
+    if (overlayEventsRef.current.length === 0) return;
+    const payload = {
+      recordedAt: recordingStartedAt,
+      frameRate: frameRateRef.current,
+      overlay: overlayEventsRef.current,
+      frames: frameTimelineRef.current,
+      settings: {
+        opacity: overlayOpacity,
+        noiseThreshold,
+        ignoreKeys,
+        showKeyboard,
+        showMouse,
+      },
     };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: 'application/json',
+    });
+    downloadBlob(blob, METADATA_DOWNLOAD);
+    setExportStatus('Overlay metadata exported.');
+  };
 
-    useEffect(() => {
-        return () => {
-            streamRef.current?.getTracks().forEach((t) => t.stop());
-            recorderRef.current?.stop();
-        };
-    }, []);
+  useEffect(() => {
+    return () => {
+      streamRef.current?.getTracks().forEach((track) => track.stop());
+      stopFrameLoop();
+      if (videoUrlRef.current) {
+        URL.revokeObjectURL(videoUrlRef.current);
+      }
+    };
+  }, [stopFrameLoop]);
 
-    return (
-        <div className="h-full w-full flex flex-col items-center justify-center bg-ub-cool-grey text-white space-y-4 p-4">
-            {!recording && (
-                <button
-                    type="button"
-                    onClick={startRecording}
-                    className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
-                >
-                    Start Recording
-                </button>
-            )}
-            {recording && (
-                <button
-                    type="button"
-                    onClick={stopRecording}
-                    className="px-4 py-2 rounded bg-red-600 hover:bg-red-700"
-                >
-                    Stop Recording
-                </button>
-            )}
-            {videoUrl && !recording && (
-                <>
-                    <video src={videoUrl} controls className="max-w-full" />
-                    <button
-                        type="button"
-                        onClick={saveRecording}
-                        className="px-4 py-2 rounded bg-ub-dracula hover:bg-ub-dracula-dark"
-                    >
-                        Save Recording
-                    </button>
-                </>
-            )}
+  return (
+    <div className="relative flex h-full w-full flex-col items-center justify-start space-y-6 bg-ub-cool-grey p-6 text-white">
+      <InputOverlay
+        recording={recording}
+        frameRate={frameRate}
+        startTime={overlayStart}
+        opacity={overlayOpacity}
+        ignoreKeys={ignoreKeys}
+        noiseThreshold={noiseThreshold}
+        showKeyboard={showKeyboard}
+        showMouse={showMouse}
+        onRecord={handleOverlayRecord}
+      />
+      <div className="flex flex-col items-center space-y-4">
+        {!recording && (
+          <button
+            type="button"
+            onClick={startRecording}
+            className="rounded bg-ub-dracula px-4 py-2 hover:bg-ub-dracula-dark"
+          >
+            Start Recording
+          </button>
+        )}
+        {recording && (
+          <button
+            type="button"
+            onClick={stopRecording}
+            className="rounded bg-red-600 px-4 py-2 hover:bg-red-700"
+          >
+            Stop Recording
+          </button>
+        )}
+        {videoUrl && !recording && (
+          <>
+            <video src={videoUrl} controls className="max-w-full rounded border border-gray-700" />
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <button
+                type="button"
+                onClick={saveRecording}
+                className="rounded bg-ub-dracula px-3 py-1 text-sm hover:bg-ub-dracula-dark"
+              >
+                Save Recording
+              </button>
+              <button
+                type="button"
+                onClick={exportOverlayVideo}
+                disabled={overlayEvents.length === 0}
+                className="rounded bg-blue-600 px-3 py-1 text-sm hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-600/50"
+              >
+                Export With Overlay
+              </button>
+              <button
+                type="button"
+                onClick={exportOverlayMetadata}
+                disabled={overlayEvents.length === 0}
+                className="rounded bg-slate-600 px-3 py-1 text-sm hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-600/50"
+              >
+                Export Overlay Metadata
+              </button>
+            </div>
+            {exportStatus && <p className="text-xs text-gray-300">{exportStatus}</p>}
+          </>
+        )}
+      </div>
+
+      <section className="w-full max-w-xl space-y-4 rounded-lg bg-black/40 p-4">
+        <header>
+          <h2 className="text-lg font-semibold">Overlay Settings</h2>
+          <p className="text-xs text-gray-300">
+            Adjust how keyboard combos and mouse clicks are displayed while recording.
+          </p>
+        </header>
+        <div className="space-y-2">
+          <label className="flex flex-col text-sm">
+            <span className="mb-1">Overlay opacity ({overlayOpacity.toFixed(2)})</span>
+            <input
+              type="range"
+              min={0.2}
+              max={1}
+              step={0.05}
+              value={overlayOpacity}
+              onChange={(e) => setOverlayOpacity(parseFloat(e.target.value))}
+            />
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="mb-1">Noise filter window (ms)</span>
+            <input
+              type="number"
+              min={0}
+              max={1000}
+              step={10}
+              value={noiseThreshold}
+              onChange={(e) => setNoiseThreshold(Math.max(0, Number(e.target.value) || 0))}
+              className="rounded border border-gray-700 bg-gray-800 p-2"
+            />
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="mb-1">Ignore keys (comma separated)</span>
+            <input
+              type="text"
+              value={ignoredKeysInput}
+              onChange={(e) => setIgnoredKeysInput(e.target.value)}
+              className="rounded border border-gray-700 bg-gray-800 p-2"
+              placeholder="Meta, PrintScreen"
+            />
+          </label>
+          <div className="flex flex-col gap-2 text-sm">
+            <label className="inline-flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={showKeyboard}
+                onChange={(e) => setShowKeyboard(e.target.checked)}
+              />
+              Show keyboard combos
+            </label>
+            <label className="inline-flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={showMouse}
+                onChange={(e) => setShowMouse(e.target.checked)}
+              />
+              Show mouse clicks
+            </label>
+          </div>
         </div>
-    );
+      </section>
+
+      {overlayEvents.length > 0 && (
+        <section className="w-full max-w-xl rounded-lg bg-black/30 p-4 text-xs">
+          <header className="mb-2 flex items-center justify-between">
+            <h3 className="text-sm font-semibold">Overlay timeline</h3>
+            <span className="text-gray-300">{overlayEvents.length} events</span>
+          </header>
+          <div className="max-h-48 overflow-y-auto space-y-1">
+            {overlayEvents.slice(-20).map((event) => (
+              <div key={event.id} className="flex justify-between gap-2">
+                <span className="font-mono text-gray-100">{event.label}</span>
+                <span className="text-gray-400">{(event.timestamp / 1000).toFixed(2)}s · f{event.frame}</span>
+              </div>
+            ))}
+          </div>
+          {frameTimeline.length > 0 && (
+            <p className="mt-2 text-gray-400">
+              Captured {frameTimeline.length} frame markers at approximately {frameRate} fps.
+            </p>
+          )}
+        </section>
+      )}
+    </div>
+  );
 }
 
 export default ScreenRecorder;
 
 export const displayScreenRecorder = () => {
-    return <ScreenRecorder />;
+  return <ScreenRecorder />;
 };
-

--- a/components/apps/screen-recorder/InputOverlay.tsx
+++ b/components/apps/screen-recorder/InputOverlay.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  computeFrameIndex,
+  formatKeyCombo,
+  shouldIgnoreKey,
+  shouldRecordEvent,
+} from '../../../utils/overlay';
+import { OverlayEvent } from '../../../types/overlay';
+
+interface InputOverlayProps {
+  recording: boolean;
+  frameRate: number;
+  startTime: number | null;
+  opacity: number;
+  ignoreKeys: string[];
+  noiseThreshold: number;
+  showKeyboard: boolean;
+  showMouse: boolean;
+  onRecord: (event: OverlayEvent) => void;
+}
+
+interface DisplayEvent extends OverlayEvent {
+  until: number;
+}
+
+const DISPLAY_DURATION = 900; // ms each entry remains visible
+const MAX_VISIBLE = 6;
+
+const mouseLabel = (button: number): string => {
+  switch (button) {
+    case 0:
+      return 'Left Click';
+    case 1:
+      return 'Middle Click';
+    case 2:
+      return 'Right Click';
+    default:
+      return `Button ${button}`;
+  }
+};
+
+const InputOverlay: React.FC<InputOverlayProps> = ({
+  recording,
+  frameRate,
+  startTime,
+  opacity,
+  ignoreKeys,
+  noiseThreshold,
+  showKeyboard,
+  showMouse,
+  onRecord,
+}) => {
+  const [displayEvents, setDisplayEvents] = useState<DisplayEvent[]>([]);
+  const lastEventsRef = useRef<Map<string, number>>(new Map());
+  const startRef = useRef<number | null>(null);
+  const ignoreSet = useMemo(() => new Set(ignoreKeys.map((key) => key.toLowerCase())), [ignoreKeys]);
+
+  useEffect(() => {
+    if (recording && startTime !== null) {
+      startRef.current = startTime;
+      lastEventsRef.current.clear();
+    } else if (!recording) {
+      startRef.current = null;
+      lastEventsRef.current.clear();
+    }
+  }, [recording, startTime]);
+
+  useEffect(() => {
+    const cleanup = window.setInterval(() => {
+      const now = performance.now();
+      setDisplayEvents((events) => events.filter((event) => event.until > now));
+    }, 120);
+    return () => window.clearInterval(cleanup);
+  }, []);
+
+  const pushDisplayEvent = (event: OverlayEvent, now: number) => {
+    setDisplayEvents((events) => {
+      const filtered = events.filter((entry) => entry.until > now);
+      const next: DisplayEvent[] = [...filtered, { ...event, until: now + DISPLAY_DURATION }];
+      return next.slice(-MAX_VISIBLE);
+    });
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!showKeyboard) return;
+      const now = performance.now();
+      const parts = formatKeyCombo(e);
+      if (parts.length === 0) return;
+      if (parts.some((part) => shouldIgnoreKey(part, ignoreSet))) return;
+      const label = parts.join(' + ');
+      if (!shouldRecordEvent(label, now, noiseThreshold, lastEventsRef.current)) {
+        return;
+      }
+      const start = startRef.current;
+      const overlayEvent: OverlayEvent = {
+        id: `${now}-${label}`,
+        type: 'key',
+        label,
+        combo: parts,
+        timestamp: start !== null ? now - start : 0,
+        frame: computeFrameIndex(now, start, frameRate),
+      };
+      pushDisplayEvent(overlayEvent, now);
+      if (recording && start !== null) {
+        onRecord(overlayEvent);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [frameRate, ignoreSet, noiseThreshold, onRecord, recording, showKeyboard]);
+
+  useEffect(() => {
+    const handleMouse = (e: MouseEvent) => {
+      if (!showMouse) return;
+      const now = performance.now();
+      const label = mouseLabel(e.button);
+      if (!shouldRecordEvent(label, now, noiseThreshold, lastEventsRef.current)) {
+        return;
+      }
+      const start = startRef.current;
+      const overlayEvent: OverlayEvent = {
+        id: `${now}-${label}`,
+        type: 'mouse',
+        label,
+        button: label,
+        timestamp: start !== null ? now - start : 0,
+        frame: computeFrameIndex(now, start, frameRate),
+      };
+      pushDisplayEvent(overlayEvent, now);
+      if (recording && start !== null) {
+        onRecord(overlayEvent);
+      }
+    };
+
+    window.addEventListener('mousedown', handleMouse);
+    return () => {
+      window.removeEventListener('mousedown', handleMouse);
+    };
+  }, [frameRate, noiseThreshold, onRecord, recording, showMouse]);
+
+  if (displayEvents.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-none fixed bottom-8 right-8 z-50 flex max-w-sm flex-col space-y-2 text-sm"
+      style={{ opacity }}
+      aria-live="polite"
+    >
+      {displayEvents.map((event) => (
+        <div
+          key={event.id}
+          className="rounded bg-black/70 px-3 py-2 text-white shadow-lg backdrop-blur"
+          data-event-type={event.type}
+        >
+          <span className="font-semibold">{event.label}</span>
+          <span className="ml-2 text-xs text-gray-300">
+            {`${(event.timestamp / 1000).toFixed(2)}s • f${event.frame}`}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default InputOverlay;

--- a/types/overlay.ts
+++ b/types/overlay.ts
@@ -1,0 +1,25 @@
+export type OverlayEventType = 'key' | 'mouse';
+
+export interface OverlayEvent {
+  id: string;
+  type: OverlayEventType;
+  /** Human readable label for the event (e.g. "Ctrl + S" or "Left Click") */
+  label: string;
+  /** Parts of the key combo when the event is keyboard driven */
+  combo?: string[];
+  /** Mouse button label when the event is a mouse click */
+  button?: string;
+  /**
+   * Timestamp in milliseconds relative to the start of the recording.
+   * Consumers can pair this with `frame` to align with captured footage.
+   */
+  timestamp: number;
+  /** Frame index calculated using the active frame rate at capture time */
+  frame: number;
+}
+
+export interface FrameMarker {
+  frame: number;
+  /** Timestamp in milliseconds relative to the start of the recording */
+  time: number;
+}

--- a/utils/overlay.ts
+++ b/utils/overlay.ts
@@ -1,0 +1,114 @@
+import { FrameMarker, OverlayEvent } from '../types/overlay';
+
+const MODIFIER_ORDER: Array<{ key: keyof KeyboardEvent; label: string }> = [
+  { key: 'ctrlKey', label: 'Ctrl' },
+  { key: 'altKey', label: 'Alt' },
+  { key: 'shiftKey', label: 'Shift' },
+  { key: 'metaKey', label: 'Meta' },
+];
+
+/**
+ * Normalises a keyboard event into ordered, human readable combo parts.
+ */
+export const formatKeyCombo = (
+  event: Pick<
+    KeyboardEvent,
+    'key' | 'ctrlKey' | 'altKey' | 'shiftKey' | 'metaKey'
+  >,
+): string[] => {
+  const parts: string[] = [];
+  MODIFIER_ORDER.forEach(({ key, label }) => {
+    if (event[key]) {
+      parts.push(label);
+    }
+  });
+  const base = event.key.length === 1 ? event.key.toUpperCase() : event.key;
+  const normalised = base === ' ' ? 'Space' : base;
+  if (normalised) {
+    parts.push(normalised);
+  }
+  return parts;
+};
+
+/**
+ * Calculates the video frame index for a timestamp relative to the start of a
+ * recording session. Returns 0 when information is incomplete.
+ */
+export const computeFrameIndex = (
+  now: number,
+  startTime: number | null,
+  frameRate: number,
+): number => {
+  if (!startTime || frameRate <= 0) return 0;
+  const elapsed = Math.max(0, now - startTime);
+  return Math.round((elapsed / 1000) * frameRate);
+};
+
+/**
+ * Keeps track of previous events to reduce noisy repeats. Returns `true` when
+ * the event should be recorded and updates the internal map with the latest
+ * timestamp.
+ */
+export const shouldRecordEvent = (
+  label: string,
+  timestamp: number,
+  threshold: number,
+  lastEvents: Map<string, number>,
+): boolean => {
+  if (threshold <= 0) {
+    lastEvents.set(label, timestamp);
+    return true;
+  }
+  const last = lastEvents.get(label);
+  if (last !== undefined && timestamp - last < threshold) {
+    return false;
+  }
+  lastEvents.set(label, timestamp);
+  return true;
+};
+
+/**
+ * Case-insensitive check to see if a combo part should be ignored.
+ */
+export const shouldIgnoreKey = (
+  part: string,
+  ignoreList: Iterable<string>,
+): boolean => {
+  const normalised = part.trim().toLowerCase();
+  for (const item of ignoreList) {
+    if (item.trim().toLowerCase() === normalised) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Sanitises a list of ignore entries into a unique, lower case array.
+ */
+export const sanitizeIgnoreList = (list: string[]): string[] => {
+  const seen = new Set<string>();
+  list
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .forEach((item) => {
+      seen.add(item.toLowerCase());
+    });
+  return Array.from(seen);
+};
+
+/**
+ * Converts a list of frame markers to overlay events, useful when generating
+ * placeholder events for testing sync logic.
+ */
+export const mapFramesToEvents = (
+  frames: FrameMarker[],
+  labelFactory: (frame: FrameMarker, index: number) => string,
+): OverlayEvent[] =>
+  frames.map((frame, index) => ({
+    id: `${frame.frame}-${index}`,
+    type: 'mouse',
+    label: labelFactory(frame, index),
+    timestamp: frame.time,
+    frame: frame.frame,
+  }));

--- a/utils/overlayExport.ts
+++ b/utils/overlayExport.ts
@@ -1,0 +1,125 @@
+import { OverlayEvent } from '../types/overlay';
+
+interface OverlayRenderOptions {
+  frameRate: number;
+  opacity: number;
+  /** Duration in milliseconds for each event to stay visible */
+  displayDuration?: number;
+}
+
+/**
+ * Attempts to render overlay events on top of the recorded video by replaying
+ * the media inside an offscreen canvas and recording the composed frames.
+ */
+export const renderOverlayOnVideo = async (
+  videoBlob: Blob,
+  events: OverlayEvent[],
+  options: OverlayRenderOptions,
+): Promise<Blob> => {
+  if (typeof window === 'undefined') {
+    throw new Error('Overlay rendering requires a browser environment.');
+  }
+  if (!('MediaRecorder' in window) || typeof HTMLCanvasElement.prototype.captureStream !== 'function') {
+    throw new Error('Current environment does not support media composition.');
+  }
+
+  const { frameRate, opacity, displayDuration = 900 } = options;
+
+  const video = document.createElement('video');
+  video.src = URL.createObjectURL(videoBlob);
+  video.muted = true;
+  video.playsInline = true;
+
+  await new Promise<void>((resolve, reject) => {
+    video.onloadedmetadata = () => resolve();
+    video.onerror = () => reject(new Error('Unable to load recorded video.'));
+  });
+
+  const canvas = document.createElement('canvas');
+  canvas.width = video.videoWidth;
+  canvas.height = video.videoHeight;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Failed to create drawing context.');
+  }
+
+  const stream = canvas.captureStream(frameRate || 30);
+  const recorder = new MediaRecorder(stream, {
+    mimeType: 'video/webm;codecs=vp9',
+  });
+  const chunks: BlobPart[] = [];
+
+  recorder.ondataavailable = (event) => {
+    if (event.data.size > 0) {
+      chunks.push(event.data);
+    }
+  };
+
+  const result = new Promise<Blob>((resolve, reject) => {
+    recorder.onstop = () => {
+      resolve(new Blob(chunks, { type: 'video/webm' }));
+    };
+    recorder.onerror = (e) => {
+      reject(e.error || e);
+    };
+  });
+
+  const visibleWindow = displayDuration;
+
+  const drawOverlay = (currentMs: number) => {
+    const active = events.filter((event) => {
+      const startMs = (event.frame / frameRate) * 1000;
+      return currentMs >= startMs && currentMs <= startMs + visibleWindow;
+    });
+
+    const padding = 12;
+    const lineHeight = 24;
+    active.slice(-6).forEach((event, index) => {
+      const top = canvas.height - padding - (active.length - index) * (lineHeight + 8);
+      const label = `${event.label}`;
+      const meta = `${(event.timestamp / 1000).toFixed(2)}s • f${event.frame}`;
+      ctx.font = '14px "Ubuntu", sans-serif';
+      const labelWidth = ctx.measureText(label).width;
+      ctx.font = '11px "Ubuntu", sans-serif';
+      const metaWidth = ctx.measureText(meta).width;
+      const width = Math.max(labelWidth, metaWidth) + padding * 2;
+      const left = canvas.width - width - padding;
+      ctx.fillStyle = `rgba(0,0,0,${0.7 * opacity})`;
+      ctx.fillRect(left, top, width, lineHeight + 24);
+      ctx.fillStyle = `rgba(255,255,255,${opacity})`;
+      ctx.font = '14px "Ubuntu", sans-serif';
+      ctx.fillText(label, left + padding, top + 18);
+      ctx.fillStyle = `rgba(209,213,219,${opacity})`;
+      ctx.font = '11px "Ubuntu", sans-serif';
+      ctx.fillText(meta, left + padding, top + 32);
+    });
+  };
+
+  const renderLoop = () => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    drawOverlay(video.currentTime * 1000);
+    if (!video.paused && !video.ended) {
+      requestAnimationFrame(renderLoop);
+    }
+  };
+
+  recorder.start();
+
+  await video.play();
+  renderLoop();
+
+  await new Promise<void>((resolve) => {
+    const stop = () => {
+      recorder.stop();
+      resolve();
+    };
+    video.onended = stop;
+    if (video.ended) {
+      stop();
+    }
+  });
+
+  URL.revokeObjectURL(video.src);
+  return result;
+};


### PR DESCRIPTION
## Summary
- add a reusable input overlay component that captures key combos and mouse clicks with debouncing
- enhance the screen recorder to sync overlay events with captured frames and export baked-in or metadata tracks
- expose settings for overlay opacity, noise filtering, and ignored keys to customise the display

## Testing
- yarn test -- __tests__/overlay.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dcdec147ec8328926313b972248278