### PR TITLE
[screen] sync desktop focus styling

### DIFF
--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -4,7 +4,7 @@
   border-radius: var(--radius-6);
   box-shadow: var(--shadow-2);
   overflow: hidden;
-  transition: filter var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+  transition: filter var(--motion-fast) ease, box-shadow var(--motion-fast) ease, outline var(--motion-fast) ease;
 }
 
 .windowFrame::before {
@@ -59,4 +59,24 @@
 .windowXBorder {
   height: calc(100% + 10px);
   width: calc(100% - 10px);
+}
+
+:global {
+  .opened-window {
+    outline: none;
+  }
+
+  .opened-window.is-focused {
+    outline: none;
+  }
+
+  .opened-window.is-focused:focus-visible {
+    outline: 3px solid var(--color-focus-ring);
+    outline-offset: -2px;
+  }
+
+  .opened-window.is-focused :focus-visible {
+    outline: none;
+    box-shadow: none;
+  }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -80,9 +80,13 @@ html[data-theme='matrix'] {
   color: var(--kali-text);
 }
 
-*:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
-  outline-offset: 2px;
+#desktop :focus {
+  outline: none;
+}
+
+#desktop :focus-visible {
+  outline: none;
+  box-shadow: none;
 }
 
 html {


### PR DESCRIPTION
## Summary
- ensure the desktop manager toggles a shared `.is-focused` class and programmatically focuses the active window
- update global and window styles to remove generic outlines and show a dedicated focus border for active windows

## Testing
- [ ] yarn lint *(fails: existing react/display-name errors in __tests__/navbar-running-apps.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8d8f0b208328a9190decc53d8bc3