### PR TITLE
[desktop] enforce safe window drag bounds

### DIFF
--- a/utils/windowLayout.js
+++ b/utils/windowLayout.js
@@ -1,11 +1,41 @@
+import { SNAP_BOTTOM_INSET } from './uiConstants';
+
 const NAVBAR_SELECTOR = '.main-navbar-vp';
 const DEFAULT_NAVBAR_HEIGHT = 48;
 const WINDOW_TOP_MARGIN = 16;
+const MIN_VISIBLE_WINDOW_EDGE = 40;
 const SAFE_AREA_PROPERTIES = {
   top: '--safe-area-top',
   right: '--safe-area-right',
   bottom: '--safe-area-bottom',
   left: '--safe-area-left',
+};
+
+const clampNumber = (value, min, max) => {
+  if (!Number.isFinite(value)) {
+    if (Number.isFinite(min)) return min;
+    if (Number.isFinite(max)) return max;
+    return 0;
+  }
+  if (Number.isFinite(min) && value < min) return min;
+  if (Number.isFinite(max) && value > max) return max;
+  return value;
+};
+
+const resolveMinVisible = (value) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return MIN_VISIBLE_WINDOW_EDGE;
+  return Math.max(value, 0);
+};
+
+const resolveViewportSize = () => {
+  if (typeof window === 'undefined') {
+    return { width: 0, height: 0 };
+  }
+
+  const width = Number.isFinite(window.innerWidth) ? window.innerWidth : 0;
+  const height = Number.isFinite(window.innerHeight) ? window.innerHeight : 0;
+
+  return { width, height };
 };
 
 const parseSafeAreaValue = (value) => {
@@ -65,4 +95,61 @@ export const clampWindowTopPosition = (value, topOffset) => {
     return safeOffset;
   }
   return Math.max(value, safeOffset);
+};
+
+export const measureWindowSafeArea = (options = {}) => {
+  const minVisible = resolveMinVisible(options.minVisible);
+  const insets = getSafeAreaInsets();
+  const viewport = resolveViewportSize();
+  const topInset = measureWindowTopOffset();
+
+  const top = Math.max(topInset, minVisible);
+  const left = Math.max(insets.left || 0, minVisible);
+  const right = Math.max(insets.right || 0, minVisible);
+  const bottom = Math.max((insets.bottom || 0) + SNAP_BOTTOM_INSET, minVisible);
+
+  return {
+    top,
+    right,
+    bottom,
+    left,
+    viewportWidth: viewport.width,
+    viewportHeight: viewport.height,
+  };
+};
+
+export const computeWindowDragBounds = (width, height, options = {}) => {
+  const safeArea = measureWindowSafeArea(options);
+  const windowWidth = Number.isFinite(width) ? width : 0;
+  const windowHeight = Number.isFinite(height) ? height : 0;
+
+  const minX = safeArea.left - windowWidth;
+  const maxX = safeArea.viewportWidth - safeArea.right;
+  const minY = safeArea.top - windowHeight;
+  const maxY = safeArea.viewportHeight - safeArea.bottom;
+
+  const resolvedMinX = Number.isFinite(minX) ? minX : 0;
+  const resolvedMaxX = Number.isFinite(maxX) ? Math.max(resolvedMinX, maxX || 0) : resolvedMinX;
+  const resolvedMinY = Number.isFinite(minY) ? minY : safeArea.top;
+  const resolvedMaxY = Number.isFinite(maxY) ? Math.max(resolvedMinY, maxY || resolvedMinY) : resolvedMinY;
+
+  return {
+    minX: resolvedMinX,
+    maxX: resolvedMaxX,
+    minY: resolvedMinY,
+    maxY: resolvedMaxY,
+    safeArea,
+  };
+};
+
+export const clampWindowPositionToSafeArea = (x, y, width, height, options = {}) => {
+  const bounds = computeWindowDragBounds(width, height, options);
+  const clampedX = clampNumber(x, bounds.minX, bounds.maxX);
+  const clampedY = clampNumber(y, bounds.minY, bounds.maxY);
+
+  return {
+    x: clampedX,
+    y: clampedY,
+    bounds,
+  };
 };


### PR DESCRIPTION
## Summary
- expose reusable helpers that calculate safe drag bounds with a 40px visible margin in `windowLayout`
- clamp saved window positions in the desktop manager using the new safe-area utilities
- update the window component to honour the safe bounds during drag/resize and report clamped positions

## Testing
- yarn lint *(fails: existing `react/display-name` errors in __tests__/navbar-running-apps.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8d932a2883289ada6392d2640622