### PR TITLE
[desktop] Improve window resize affordances

### DIFF
--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -51,12 +51,10 @@
   height: 28px;
 }
 
-.windowYBorder {
-  height: calc(100% - 10px);
-  width: calc(100% + 10px);
-}
-
-.windowXBorder {
-  height: calc(100% + 10px);
-  width: calc(100% - 10px);
+.resizeHandle {
+  position: absolute;
+  pointer-events: auto;
+  touch-action: none;
+  z-index: 10;
+  background: transparent;
 }


### PR DESCRIPTION
## Summary
- add invisible resize overlays for window edges and corners with appropriate cursors
- implement pointer-driven resize logic that updates transforms and respects bounds
- clean up legacy drag resize stubs and expose new handle styles in the module CSS

## Testing
- yarn lint *(fails: existing __tests__/navbar-running-apps.test.tsx missing display-name lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8d94775c8328ae8afd92fcce0097