### PR TITLE
[desktop] add focused window keyboard shortcuts

### DIFF
--- a/apps/settings/keymapRegistry.ts
+++ b/apps/settings/keymapRegistry.ts
@@ -8,6 +8,9 @@ export interface Shortcut {
 const DEFAULT_SHORTCUTS: Shortcut[] = [
   { description: 'Show keyboard shortcuts', keys: '?' },
   { description: 'Open settings', keys: 'Ctrl+,' },
+  { description: 'Open focused window menu', keys: 'Alt+Space' },
+  { description: 'Snap focused window', keys: 'Win+Arrow Keys' },
+  { description: 'Close focused window', keys: 'Alt+F4' },
 ];
 
 const validator = (value: unknown): value is Record<string, string> => {


### PR DESCRIPTION
## Summary
- gate focused-window shortcuts in the desktop controller so Alt+Space, Win+Arrow, and Alt+F4 only affect the active window
- stop propagating those shortcuts and reuse the app menu for the Alt+Space window menu invocation
- record the new window shortcuts in the settings keymap registry for user reference

## Testing
- yarn lint *(fails: existing react/display-name violations in __tests__/navbar-running-apps.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8d96979c83289a739835ff1d1df6