### PR TITLE
[desktop] add loading skeleton

### DIFF
--- a/components/screen/desktop-skeleton.js
+++ b/components/screen/desktop-skeleton.js
@@ -1,0 +1,62 @@
+"use client";
+
+import React from 'react';
+import { DESKTOP_TOP_PADDING } from '../../utils/uiConstants';
+
+const PLACEHOLDER_COUNT = 6;
+
+function DesktopSkeleton() {
+    return (
+        <main
+            id="desktop"
+            role="main"
+            aria-busy="true"
+            aria-label="Loading desktop"
+            className="min-h-screen h-full w-full flex flex-col items-end justify-start content-start flex-wrap-reverse bg-transparent relative overflow-hidden overscroll-none window-parent"
+            style={{ paddingTop: DESKTOP_TOP_PADDING, minHeight: '100dvh' }}
+        >
+            <div className="pointer-events-none absolute inset-0">
+                <div className="absolute inset-0 bg-gradient-to-b from-slate-900/90 via-slate-900/80 to-slate-900/95" aria-hidden />
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.12),_transparent_55%)]" aria-hidden />
+            </div>
+
+            <div className="relative z-10 flex h-full w-full flex-col animate-pulse">
+                <header className="flex items-center justify-between px-6 pt-8">
+                    <div className="h-12 w-48 rounded-lg bg-slate-700/60" />
+                    <div className="flex items-center gap-3">
+                        <div className="h-5 w-32 rounded bg-slate-700/50" />
+                        <div className="h-5 w-20 rounded bg-slate-700/40" />
+                        <div className="h-5 w-16 rounded bg-slate-700/40" />
+                    </div>
+                </header>
+
+                <div className="flex-1 px-6 pb-24 pt-10">
+                    <div className="grid h-full w-full max-w-5xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                        {Array.from({ length: PLACEHOLDER_COUNT }).map((_, index) => (
+                            <div
+                                key={index}
+                                className="flex h-36 flex-col justify-between rounded-xl border border-slate-700/40 bg-slate-800/60 p-5 shadow-lg shadow-slate-900/40"
+                            >
+                                <div className="h-12 w-12 rounded-lg bg-slate-700/60" />
+                                <div className="space-y-3">
+                                    <div className="h-4 w-24 rounded bg-slate-700/50" />
+                                    <div className="h-3 w-32 rounded bg-slate-700/40" />
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                <footer className="flex items-center justify-center gap-4 pb-8">
+                    <div className="h-14 w-14 rounded-full bg-slate-700/60" />
+                    <div className="h-14 w-14 rounded-full bg-slate-700/50" />
+                    <div className="h-14 w-14 rounded-full bg-slate-700/40" />
+                </footer>
+            </div>
+
+            <div id="window-area" className="absolute inset-0" aria-hidden="true" />
+        </main>
+    );
+}
+
+export default DesktopSkeleton;

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -28,11 +28,12 @@ import {
     getSafeAreaInsets,
     measureWindowTopOffset,
 } from '../../utils/windowLayout';
+import DesktopSkeleton from './desktop-skeleton';
 
 
 export class Desktop extends Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.workspaceCount = 4;
         this.workspaceStacks = Array.from({ length: this.workspaceCount }, () => []);
         this.workspaceSnapshots = Array.from({ length: this.workspaceCount }, () => this.createEmptyWorkspaceState());
@@ -72,6 +73,7 @@ export class Desktop extends Component {
                 label: `Workspace ${index + 1}`,
             })),
             draggingIconId: null,
+            isReady: Boolean(props?.appReady),
         }
 
         this.desktopRef = React.createRef();
@@ -95,6 +97,12 @@ export class Desktop extends Component {
         this.validAppIds = new Set(apps.map((app) => app.id));
 
     }
+
+    markDesktopReady = () => {
+        if (!this.state.isReady) {
+            this.setState({ isReady: true });
+        }
+    };
 
     createEmptyWorkspaceState = () => ({
         focused_windows: {},
@@ -843,6 +851,7 @@ export class Desktop extends Component {
             } else {
                 this.openApp('about');
             }
+            this.markDesktopReady();
         });
         this.setContextListeners();
         this.setEventListeners();
@@ -857,7 +866,10 @@ export class Desktop extends Component {
         this.setupGestureListeners();
     }
 
-    componentDidUpdate(_prevProps, prevState) {
+    componentDidUpdate(prevProps, prevState) {
+        if (!prevProps?.appReady && this.props.appReady && !this.state.isReady) {
+            this.setState({ isReady: true });
+        }
         if (
             prevState.activeWorkspace !== this.state.activeWorkspace ||
             prevState.closed_windows !== this.state.closed_windows ||
@@ -1826,6 +1838,10 @@ export class Desktop extends Component {
     };
 
     render() {
+        const isDesktopReady = this.state.isReady || Boolean(this.props.appReady);
+        if (!isDesktopReady) {
+            return <DesktopSkeleton />;
+        }
         return (
             <main
                 id="desktop"


### PR DESCRIPTION
## Summary
- add a themed desktop skeleton placeholder that mimics the shell layout
- gate the desktop render until internal state or an optional appReady prop signals readiness

## Testing
- yarn lint *(fails: existing react/display-name violations in __tests__/navbar-running-apps.test.tsx)*
- yarn eslint components/screen/desktop.js components/screen/desktop-skeleton.js


------
https://chatgpt.com/codex/tasks/task_e_68dd8d99821883288e5a4f33a8c30ea4