### PR TITLE
[ui] blur backgrounds during overlays

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,26 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock', () =>
+  Object.assign(() => <div data-testid="clock" />, { displayName: 'MockClock' }),
+);
+jest.mock('../components/util-components/status', () =>
+  Object.assign(() => <div data-testid="status" />, { displayName: 'MockStatus' }),
+);
+jest.mock('../components/ui/QuickSettings', () =>
+  Object.assign(
+    ({ open }: { open: boolean }) => (
+      <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
+    ),
+    { displayName: 'MockQuickSettings' },
+  ),
+);
+jest.mock('../components/menu/WhiskerMenu', () =>
+  Object.assign(() => <button type="button">Menu</button>, { displayName: 'MockWhiskerMenu' }),
+);
+jest.mock('../components/ui/PerformanceGraph', () =>
+  Object.assign(() => <div data-testid="performance" />, { displayName: 'MockPerformanceGraph' }),
+);
 
 const workspaceEventDetail = {
   workspaces: [

--- a/components/base/Modal.tsx
+++ b/components/base/Modal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
+import { setOverlayActive } from '../../utils/overlayState';
 
 interface ModalProps {
     isOpen: boolean;
@@ -32,6 +33,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
     const triggerRef = useRef<HTMLElement | null>(null);
     const portalRef = useRef<HTMLDivElement | null>(null);
     const inertRootRef = useRef<HTMLElement | null>(null);
+    const overlayTokenRef = useRef(`modal-${Math.random().toString(36).slice(2)}`);
 
     if (!portalRef.current && typeof document !== 'undefined') {
         const el = document.createElement('div');
@@ -76,6 +78,14 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, overlayRoot })
         document.addEventListener('keydown', handleKey);
         return () => document.removeEventListener('keydown', handleKey);
     }, [isOpen, onClose]);
+
+    useEffect(() => {
+        const token = overlayTokenRef.current;
+        setOverlayActive(token, isOpen);
+        return () => {
+            setOverlayActive(token, false);
+        };
+    }, [isOpen]);
 
     useEffect(() => {
         return () => {

--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+import { setOverlayActive } from '../../utils/overlayState';
 
 export interface MenuItem {
   label: React.ReactNode;
@@ -24,6 +25,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
   const [open, setOpen] = useState(false);
   const [pos, setPos] = useState({ x: 0, y: 0 });
   const menuRef = useRef<HTMLDivElement>(null);
+  const overlayTokenRef = useRef(`context-menu-${Math.random().toString(36).slice(2)}`);
 
   useFocusTrap(menuRef as React.RefObject<HTMLElement>, open);
   useRovingTabIndex(
@@ -66,6 +68,14 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
     } else {
       window.dispatchEvent(new CustomEvent('context-menu-close'));
     }
+  }, [open]);
+
+  useEffect(() => {
+    const token = overlayTokenRef.current;
+    setOverlayActive(token, open);
+    return () => {
+      setOverlayActive(token, false);
+    };
   }, [open]);
 
   useEffect(() => {

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,33 @@ body{
     color: var(--color-text);
 }
 
+#desktop::before {
+    content: none;
+}
+
+body.ui-overlay-active #desktop::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: 35;
+    pointer-events: none;
+    background: rgba(10, 10, 14, 0.45);
+    background: color-mix(in srgb, var(--color-bg) 60%, rgba(0, 0, 0, 0.65) 40%);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    opacity: 1;
+    transition: opacity 150ms ease;
+}
+
+@media (prefers-reduced-transparency: reduce) {
+    body.ui-overlay-active #desktop::before {
+        content: none;
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
+        background: none;
+    }
+}
+
 :root {
     /* Stack utility defaults */
     --stack-space-0-5: 0.125rem;

--- a/utils/overlayState.ts
+++ b/utils/overlayState.ts
@@ -1,0 +1,39 @@
+const OVERLAY_CLASS = 'ui-overlay-active';
+
+const overlayTokens = new Set<string>();
+
+const getBody = (): HTMLBodyElement | null => {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+    return document.body;
+};
+
+const syncBodyClass = () => {
+    const body = getBody();
+    if (!body) return;
+    if (overlayTokens.size > 0) {
+        body.classList.add(OVERLAY_CLASS);
+        body.dataset.overlayCount = String(overlayTokens.size);
+    } else {
+        body.classList.remove(OVERLAY_CLASS);
+        delete body.dataset.overlayCount;
+    }
+};
+
+export const setOverlayActive = (token: string, active: boolean) => {
+    if (!token) return;
+    if (active) {
+        overlayTokens.add(token);
+    } else {
+        overlayTokens.delete(token);
+    }
+    syncBodyClass();
+};
+
+export const clearOverlayToken = (token: string) => {
+    if (!token) return;
+    overlayTokens.delete(token);
+    syncBodyClass();
+};
+


### PR DESCRIPTION
## Summary
- add a shared overlay state helper to manage the `.ui-overlay-active` body class
- hook desktop overlays, context menus, and modals into the helper so the class is applied and cleared reliably
- blur and dim the desktop background when overlays are active, with a reduced-transparency opt-out

## Testing
- [x] yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dd8d9ba9e883289fc11139dd37b82b