### PR TITLE
[desktop] add window open telemetry

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,33 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock', () => {
+  const MockClock = () => <div data-testid="clock" />;
+  MockClock.displayName = 'MockClock';
+  return MockClock;
+});
+jest.mock('../components/util-components/status', () => {
+  const MockStatus = () => <div data-testid="status" />;
+  MockStatus.displayName = 'MockStatus';
+  return MockStatus;
+});
+jest.mock('../components/ui/QuickSettings', () => {
+  const MockQuickSettings = ({ open }: { open: boolean }) => (
+    <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
+  );
+  MockQuickSettings.displayName = 'MockQuickSettings';
+  return MockQuickSettings;
+});
+jest.mock('../components/menu/WhiskerMenu', () => {
+  const MockWhiskerMenu = () => <button type="button">Menu</button>;
+  MockWhiskerMenu.displayName = 'MockWhiskerMenu';
+  return MockWhiskerMenu;
+});
+jest.mock('../components/ui/PerformanceGraph', () => {
+  const MockPerformanceGraph = () => <div data-testid="performance" />;
+  MockPerformanceGraph.displayName = 'MockPerformanceGraph';
+  return MockPerformanceGraph;
+});
 
 const workspaceEventDetail = {
   workspaces: [

--- a/components/base/window.js
+++ b/components/base/window.js
@@ -86,6 +86,10 @@ export class Window extends Component {
         // google analytics
         ReactGA.send({ hitType: "pageview", page: `/${this.id}`, title: "Custom Title" });
 
+        if (typeof this.props.onTelemetryMount === 'function') {
+            this.props.onTelemetryMount(this.id);
+        }
+
         // on window resize, resize boundary
         window.addEventListener('resize', this.resizeBoundries);
         // Listen for context menu events to toggle inert background

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,3 +7,12 @@ The project is a desktop-style portfolio built with Next.js.
 - **pages/api/** exposes serverless functions for backend features.
 
 For setup instructions, see the [Getting Started](./getting-started.md) guide.
+
+## Window open telemetry
+
+Desktop window launches now record light-weight metrics on the client so we can identify slow apps quickly:
+
+- `windowPerformance.pending` — `Map<appId, { start, title, workspace }>` that stores the `performance.now()` timestamp when `openApp` begins spawning a window. Entries are cleared when the window mounts or closes.
+- `windowPerformance.samples` — `Array<{ id, title, duration, startedAt, completedAt, workspace, context }>` containing completed launch measurements. `duration` reflects the milliseconds between the open request and the window mount/hydration callback.
+
+In non-production builds, every new sample prints an aggregated summary (`console.groupCollapsed('🖥️ Window open performance')`) with per-app counts plus min/avg/max/last durations. Engineers can watch the console while opening windows to immediately spot regressions or unusually slow screens.


### PR DESCRIPTION
## Summary
- capture performance.now() timings when opening desktop windows and log aggregated metrics outside production builds
- notify windows when mounting so telemetry can complete and be summarized
- document the windowPerformance telemetry structures for faster diagnostics

## Testing
- [x] yarn lint
- [ ] yarn test

------
https://chatgpt.com/codex/tasks/task_e_68dd8d9c401c8328b183824b5760d589