### PR TITLE
[desktop] Support hold-triggered shortcut overlay

### DIFF
--- a/__tests__/ShortcutOverlay.test.tsx
+++ b/__tests__/ShortcutOverlay.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import ShortcutOverlay from '../components/common/ShortcutOverlay';
+import {
+  SHORTCUT_OVERLAY_EVENT,
+  type ShortcutOverlayEventDetail,
+} from '../components/common/shortcutOverlayEvents';
 
 describe('ShortcutOverlay', () => {
   beforeEach(() => {
@@ -16,7 +20,18 @@ describe('ShortcutOverlay', () => {
       })
     );
     render(<ShortcutOverlay />);
-    fireEvent.keyDown(window, { key: 'a' });
+
+    const openEvent = new CustomEvent<ShortcutOverlayEventDetail>(
+      SHORTCUT_OVERLAY_EVENT,
+      {
+        detail: { action: 'hold', state: 'start', trigger: 'test' },
+      }
+    );
+
+    act(() => {
+      window.dispatchEvent(openEvent);
+    });
+
     expect(
       screen.getByText('Show keyboard shortcuts')
     ).toBeInTheDocument();

--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,24 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
+const MockClock: React.FC = () => <div data-testid="clock" />;
+MockClock.displayName = 'MockClock';
+const MockStatus: React.FC = () => <div data-testid="status" />;
+MockStatus.displayName = 'MockStatus';
+const MockQuickSettings: React.FC<{ open: boolean }> = ({ open }) => (
   <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+);
+MockQuickSettings.displayName = 'MockQuickSettings';
+const MockMenu: React.FC = () => <button type="button">Menu</button>;
+MockMenu.displayName = 'MockWhiskerMenu';
+const MockPerformance: React.FC = () => <div data-testid="performance" />;
+MockPerformance.displayName = 'MockPerformanceGraph';
+
+jest.mock('../components/util-components/clock', () => MockClock);
+jest.mock('../components/util-components/status', () => MockStatus);
+jest.mock('../components/ui/QuickSettings', () => MockQuickSettings);
+jest.mock('../components/menu/WhiskerMenu', () => MockMenu);
+jest.mock('../components/ui/PerformanceGraph', () => MockPerformance);
 
 const workspaceEventDetail = {
   workspaces: [

--- a/components/common/shortcutOverlayEvents.ts
+++ b/components/common/shortcutOverlayEvents.ts
@@ -1,0 +1,20 @@
+export const SHORTCUT_OVERLAY_EVENT = 'shortcut-overlay' as const;
+
+export type ShortcutOverlayHoldState = 'start' | 'end';
+
+export type ShortcutOverlayEventDetail =
+  | {
+      action: 'hold';
+      state: ShortcutOverlayHoldState;
+      trigger?: string;
+    }
+  | { action: 'open' | 'close' };
+
+export type ShortcutOverlayEvent = CustomEvent<ShortcutOverlayEventDetail>;
+
+export const dispatchShortcutOverlayEvent = (
+  detail: ShortcutOverlayEventDetail,
+) => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(SHORTCUT_OVERLAY_EVENT, { detail }));
+};


### PR DESCRIPTION
## Summary
- add Desktop-level key listeners that detect hold gestures for Shift, ? and Ctrl+/ and broadcast shortcut overlay events
- refactor the shortcut overlay to respond to the new events, restore focus after dismissal, and hide itself from assistive tech when closed
- update shortcut overlay tests and fix navbar test mocks so lint passes

## Testing
- yarn lint
- yarn test ShortcutOverlay

------
https://chatgpt.com/codex/tasks/task_e_68dd8d9d6bf88328a16c200d5f0d5da7