### PR TITLE
[desktop] Add taskbar progress indicators

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -87,4 +87,35 @@ describe('Navbar running apps tray', () => {
     expect(button).toHaveAttribute('data-active', 'false');
     expect(button.querySelector('[data-testid="running-indicator"]')).toBeFalsy();
   });
+
+  it('renders progress metadata with accessible status updates', () => {
+    render(<Navbar />);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('workspace-state', {
+          detail: {
+            ...workspaceEventDetail,
+            runningApps: [
+              {
+                ...workspaceEventDetail.runningApps[0],
+                progress: {
+                  status: 'determinate',
+                  value: 0.5,
+                  label: 'Processing 50 percent',
+                },
+              },
+            ],
+          },
+        }),
+      );
+    });
+
+    const button = screen.getByRole('button', { name: /app one/i });
+    expect(button.querySelector('[data-testid="taskbar-progress-track"]')).toBeTruthy();
+    expect(button.querySelector('[data-testid="taskbar-progress-indicator"]')).toHaveStyle({ width: '50%' });
+    expect(
+      screen.getByRole('status', { name: /processing 50 percent/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/components/apps/hashcat/index.js
+++ b/components/apps/hashcat/index.js
@@ -227,6 +227,44 @@ function HashcatApp() {
     return () => mediaQuery.removeEventListener('change', handleChange);
   }, []);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const appId = 'hashcat';
+    const target = Math.max(progressInfo.progress || 0, 1);
+    if (isCracking) {
+      const normalized = Math.max(0, Math.min(progress / target, 1));
+      if (normalized >= 1) {
+        window.dispatchEvent(
+          new CustomEvent('app-progress', { detail: { appId, reset: true } }),
+        );
+      } else {
+        window.dispatchEvent(
+          new CustomEvent('app-progress', {
+            detail: {
+              appId,
+              value: normalized,
+              label: `Hashcat cracking ${Math.round(normalized * 100)} percent`,
+            },
+          }),
+        );
+      }
+    } else {
+      window.dispatchEvent(
+        new CustomEvent('app-progress', { detail: { appId, reset: true } }),
+      );
+    }
+  }, [isCracking, progress]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return () => {};
+    const appId = 'hashcat';
+    return () => {
+      window.dispatchEvent(
+        new CustomEvent('app-progress', { detail: { appId, reset: true } }),
+      );
+    };
+  }, []);
+
   const startCracking = () => {
     if (isCracking) return;
     const expected = selected.output;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -75,6 +75,25 @@ html[data-theme='matrix'] {
 
 }
 
+@keyframes shell-taskbar-progress-indeterminate {
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(-20%);
+  }
+  100% {
+    transform: translateX(120%);
+  }
+}
+
+.shell-taskbar-progress-indeterminate {
+  width: 40%;
+  min-width: 2rem;
+  animation: shell-taskbar-progress-indeterminate 1.2s ease-in-out infinite;
+  will-change: transform;
+}
+
 ::selection {
   background: color-mix(in srgb, var(--color-primary) 65%, var(--kali-bg));
   color: var(--kali-text);


### PR DESCRIPTION
## Summary
- track per-app progress metadata in the desktop workspace state and broadcast it to the taskbar
- render determinate and indeterminate taskbar progress bars with accessible status messaging and animation
- emit hashcat cracking progress to the shell and cover the new UI with dedicated unit tests

## Testing
- yarn test --runTestsByPath __tests__/navbar-running-apps.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd8da0c70483288983ede80bca083c