### PR TITLE
[clock] add preferences popover

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,37 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock-preferences-button', () => {
+  const MockClockPreferencesButton = () => <div data-testid="clock" />;
+  MockClockPreferencesButton.displayName = 'MockClockPreferencesButton';
+  return MockClockPreferencesButton;
+});
+
+jest.mock('../components/util-components/status', () => {
+  const MockStatus = () => <div data-testid="status" />;
+  MockStatus.displayName = 'MockStatus';
+  return MockStatus;
+});
+
+jest.mock('../components/ui/QuickSettings', () => {
+  const MockQuickSettings = ({ open }: { open: boolean }) => (
+    <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
+  );
+  MockQuickSettings.displayName = 'MockQuickSettings';
+  return MockQuickSettings;
+});
+
+jest.mock('../components/menu/WhiskerMenu', () => {
+  const MockWhiskerMenu = () => <button type="button">Menu</button>;
+  MockWhiskerMenu.displayName = 'MockWhiskerMenu';
+  return MockWhiskerMenu;
+});
+
+jest.mock('../components/ui/PerformanceGraph', () => {
+  const MockPerformanceGraph = () => <div data-testid="performance" />;
+  MockPerformanceGraph.displayName = 'MockPerformanceGraph';
+  return MockPerformanceGraph;
+});
 
 const workspaceEventDetail = {
   workspaces: [

--- a/components/screen/lock_screen.js
+++ b/components/screen/lock_screen.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import Clock from '../util-components/clock';
 import { useSettings } from '../../hooks/useSettings';
+import { useClockPreferences } from '../../hooks/useClockPreferences';
 import KaliWallpaper from '../util-components/kali-wallpaper';
 
 export default function LockScreen(props) {
 
     const { bgImageName, useKaliWallpaper } = useSettings();
+    const { hour12, timeZone, locale } = useClockPreferences();
     const useKaliTheme = useKaliWallpaper || bgImageName === 'kali-gradient';
 
     if (props.isLocked) {
@@ -31,10 +33,10 @@ export default function LockScreen(props) {
             )}
             <div className="w-full h-full z-50 overflow-hidden relative flex flex-col justify-center items-center text-white">
                 <div className=" text-7xl">
-                    <Clock onlyTime={true} />
+                    <Clock onlyTime={true} hour12={hour12} timeZone={timeZone} locale={locale} />
                 </div>
                 <div className="mt-4 text-xl font-medium">
-                    <Clock onlyDay={true} />
+                    <Clock onlyDay={true} hour12={hour12} timeZone={timeZone} locale={locale} />
                 </div>
                 <div className=" mt-16 text-base">
                     Click or Press a key to unlock

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import Image from 'next/image';
-import Clock from '../util-components/clock';
+import ClockPreferencesButton from '../util-components/clock-preferences-button';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
 import WhiskerMenu from '../menu/WhiskerMenu';
@@ -205,7 +205,7 @@ export default class Navbar extends PureComponent {
                                                 <PerformanceGraph />
                                         </div>
                                         <div className="flex items-center gap-4 text-xs md:text-sm">
-                                                <Clock onlyTime={true} showCalendar={true} hour12={false} variant="minimal" />
+                                                <ClockPreferencesButton />
                                                 <div
                                                         id="status-bar"
                                                         role="button"

--- a/components/util-components/clock-preferences-button.js
+++ b/components/util-components/clock-preferences-button.js
@@ -1,0 +1,186 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import Clock from './clock'
+import { useClockPreferences } from '../../hooks/useClockPreferences'
+
+const BUTTON_BASE_CLASSES =
+    'group flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-left text-sm font-medium text-white shadow-sm transition-colors duration-200 hover:border-white/20 hover:bg-white/15 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900'
+
+const BUTTON_MINIMAL_CLASSES =
+    'group flex items-center gap-1 rounded px-0 py-0 text-right text-sm font-semibold text-white/80 transition-colors duration-150 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/80 focus-visible:ring-offset-0'
+
+const PREFS_TITLE = 'Clock preferences'
+
+const ClockPreferencesButton = ({
+    variant = 'minimal',
+    clockProps = { onlyTime: true },
+    align = 'right'
+}) => {
+    const { hour12, timeZone, locale, setHour12, setTimeZone, timeZoneOptions } = useClockPreferences()
+    const [isOpen, setIsOpen] = useState(false)
+    const [canUsePortal, setCanUsePortal] = useState(false)
+    const buttonRef = useRef(null)
+    const popoverRef = useRef(null)
+    const popoverId = useId()
+    const hour12Id = `${popoverId}-format-12`
+    const hour24Id = `${popoverId}-format-24`
+    const timeZoneSelectId = `${popoverId}-timezone`
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return undefined
+        setCanUsePortal(true)
+        return undefined
+    }, [])
+
+    useEffect(() => {
+        if (!isOpen) return undefined
+        const handleClickOutside = (event) => {
+            if (popoverRef.current?.contains(event.target)) return
+            if (buttonRef.current?.contains(event.target)) return
+            setIsOpen(false)
+        }
+        const handleEscape = (event) => {
+            if (event.key === 'Escape') {
+                setIsOpen(false)
+                buttonRef.current?.focus({ preventScroll: true })
+            }
+        }
+        document.addEventListener('mousedown', handleClickOutside)
+        document.addEventListener('touchstart', handleClickOutside)
+        document.addEventListener('keydown', handleEscape)
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside)
+            document.removeEventListener('touchstart', handleClickOutside)
+            document.removeEventListener('keydown', handleEscape)
+        }
+    }, [isOpen])
+
+    useEffect(() => {
+        if (!isOpen) return undefined
+        const { current } = popoverRef
+        current?.focus({ preventScroll: true })
+        return undefined
+    }, [isOpen])
+
+    const handleToggle = () => {
+        setIsOpen((prev) => !prev)
+    }
+
+    const handleHourFormatChange = (event) => {
+        setHour12(event.target.value)
+    }
+
+    const handleTimeZoneChange = (event) => {
+        setTimeZone(event.target.value)
+    }
+
+    const popoverPosition = useMemo(() => {
+        if (!isOpen || typeof window === 'undefined') return {}
+        const button = buttonRef.current
+        if (!button) return {}
+        const rect = button.getBoundingClientRect()
+        const width = 280
+        const margin = 12
+        const top = rect.bottom + margin
+        const left = align === 'left' ? rect.left : rect.right - width
+        return {
+            position: 'fixed',
+            top,
+            left: Math.max(margin, left),
+            width,
+            zIndex: 60
+        }
+    }, [align, isOpen])
+
+    const popover = (
+        <div
+            ref={popoverRef}
+            role="dialog"
+            aria-modal="false"
+            tabIndex={-1}
+            aria-label={PREFS_TITLE}
+            id={popoverId}
+            className="fixed rounded-2xl border border-white/10 bg-slate-950/95 p-4 text-sm text-white shadow-2xl ring-1 ring-cyan-300/20 backdrop-blur-2xl"
+            style={popoverPosition}
+        >
+            <h2 className="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-200/80">{PREFS_TITLE}</h2>
+            <div className="mt-3 space-y-4">
+                <fieldset className="space-y-2">
+                    <legend className="text-[0.65rem] uppercase tracking-[0.2em] text-white/60">Hour format</legend>
+                    <div className="flex items-center gap-2 text-sm text-white/90">
+                        <input
+                            id={hour12Id}
+                            type="radio"
+                            name={`${popoverId}-clock-hour-format`}
+                            value="12"
+                            checked={hour12 === true}
+                            onChange={handleHourFormatChange}
+                            aria-label="12-hour format"
+                            className="h-3.5 w-3.5 rounded-full border-white/40 bg-slate-900 text-cyan-400 focus:ring-cyan-300"
+                        />
+                        <label htmlFor={hour12Id} className="cursor-pointer">
+                            12-hour (AM/PM)
+                        </label>
+                    </div>
+                    <div className="flex items-center gap-2 text-sm text-white/90">
+                        <input
+                            id={hour24Id}
+                            type="radio"
+                            name={`${popoverId}-clock-hour-format`}
+                            value="24"
+                            checked={hour12 === false}
+                            onChange={handleHourFormatChange}
+                            aria-label="24-hour format"
+                            className="h-3.5 w-3.5 rounded-full border-white/40 bg-slate-900 text-cyan-400 focus:ring-cyan-300"
+                        />
+                        <label htmlFor={hour24Id} className="cursor-pointer">
+                            24-hour
+                        </label>
+                    </div>
+                </fieldset>
+                <label className="flex flex-col gap-2 text-sm text-white/90" htmlFor={timeZoneSelectId}>
+                    <span className="text-[0.65rem] uppercase tracking-[0.2em] text-white/60">Time zone</span>
+                    <select
+                        id={timeZoneSelectId}
+                        value={timeZone}
+                        onChange={handleTimeZoneChange}
+                        className="w-full rounded-xl border border-white/10 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-400/50"
+                    >
+                        {timeZoneOptions.map((zone) => (
+                            <option key={zone} value={zone}>
+                                {zone}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+            </div>
+        </div>
+    )
+
+    const buttonClassName = variant === 'minimal' ? BUTTON_MINIMAL_CLASSES : BUTTON_BASE_CLASSES
+
+    const renderedPopover = isOpen
+        ? canUsePortal && typeof document !== 'undefined'
+            ? createPortal(popover, document.body)
+            : popover
+        : null
+
+    return (
+        <div className="relative inline-flex items-center" suppressHydrationWarning>
+            <button
+                type="button"
+                ref={buttonRef}
+                onClick={handleToggle}
+                className={buttonClassName}
+                aria-haspopup="dialog"
+                aria-expanded={isOpen}
+                aria-controls={popoverId}
+            >
+                <Clock {...clockProps} hour12={hour12} timeZone={timeZone} locale={locale} variant={variant} />
+            </button>
+            {renderedPopover}
+        </div>
+    )
+}
+
+export default ClockPreferencesButton

--- a/hooks/useClockPreferences.js
+++ b/hooks/useClockPreferences.js
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { safeLocalStorage } from '../utils/safeStorage'
+
+const HOUR_FORMAT_KEY = 'clock-hour-format'
+const TIME_ZONE_KEY = 'clock-time-zone'
+
+const resolveDefaultTimeZone = () => {
+    try {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+    } catch (error) {
+        return 'UTC'
+    }
+}
+
+const normalizeLocale = (value) => {
+    if (!value) return undefined
+    const normalized = value.replace(/_/g, '-').split('@')[0]
+    try {
+        // Validate locale support
+        new Intl.DateTimeFormat(normalized)
+        return normalized
+    } catch (error) {
+        return undefined
+    }
+}
+
+const resolveDefaultLocale = () => {
+    const fallback = 'en-US'
+    if (typeof navigator !== 'undefined' && navigator.language) {
+        const normalized = normalizeLocale(navigator.language)
+        if (normalized) {
+            return normalized
+        }
+    }
+    try {
+        const resolved = normalizeLocale(Intl.DateTimeFormat().resolvedOptions().locale)
+        return resolved || fallback
+    } catch (error) {
+        return fallback
+    }
+}
+
+const parseStoredHourFormat = (value) => {
+    if (value === '12') return true
+    if (value === '24') return false
+    return undefined
+}
+
+export const useClockPreferences = () => {
+    const [hour12, setHour12State] = useState(() => {
+        const stored = safeLocalStorage?.getItem(HOUR_FORMAT_KEY)
+        const parsed = parseStoredHourFormat(stored)
+        return typeof parsed === 'boolean' ? parsed : false
+    })
+
+    const [timeZone, setTimeZoneState] = useState(() => {
+        const stored = safeLocalStorage?.getItem(TIME_ZONE_KEY)
+        return stored || resolveDefaultTimeZone()
+    })
+
+    const [locale, setLocale] = useState(() => resolveDefaultLocale())
+
+    useEffect(() => {
+        if (typeof navigator === 'undefined') return
+        if (!navigator.language) return
+        const normalized = normalizeLocale(navigator.language)
+        if (normalized) {
+            setLocale(normalized)
+        }
+    }, [])
+
+    useEffect(() => {
+        if (!safeLocalStorage) return
+        safeLocalStorage.setItem(HOUR_FORMAT_KEY, hour12 ? '12' : '24')
+    }, [hour12])
+
+    useEffect(() => {
+        if (!safeLocalStorage) return
+        if (!timeZone) return
+        safeLocalStorage.setItem(TIME_ZONE_KEY, timeZone)
+    }, [timeZone])
+
+    const setHour12 = useCallback((value) => {
+        if (typeof value === 'string') {
+            setHour12State(value === '12')
+            return
+        }
+        setHour12State(Boolean(value))
+    }, [])
+
+    const setTimeZone = useCallback((value) => {
+        if (!value) return
+        setTimeZoneState(value)
+    }, [])
+
+    const timeZoneOptions = useMemo(() => {
+        const options = new Set()
+        if (typeof Intl !== 'undefined' && typeof Intl.supportedValuesOf === 'function') {
+            try {
+                Intl.supportedValuesOf('timeZone').forEach((zone) => options.add(zone))
+            } catch (error) {
+                // noop
+            }
+        }
+        options.add(resolveDefaultTimeZone())
+        if (timeZone) options.add(timeZone)
+        options.add('UTC')
+        let comparer
+        try {
+            comparer = new Intl.Collator(locale || undefined).compare
+        } catch (error) {
+            comparer = undefined
+        }
+        return Array.from(options).sort((a, b) => {
+            if (comparer) return comparer(a, b)
+            return a.localeCompare(b)
+        })
+    }, [locale, timeZone])
+
+    return {
+        hour12,
+        timeZone,
+        locale,
+        setHour12,
+        setTimeZone,
+        timeZoneOptions
+    }
+}
+
+export default useClockPreferences


### PR DESCRIPTION
## Summary
- add a reusable clock preferences button with hour-format and time zone controls
- persist clock preferences and apply locale-aware formatting across clock displays
- update navbar and lock screen to use the shared preferences hook and adjust tests

## Testing
- yarn lint
- yarn test __tests__/navbar-running-apps.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd8da2d4848328a5db49087ad17a4a