### PR TITLE
[ui] Add taskbar window previews

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,37 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock', () => {
+  const MockClock = () => <div data-testid="clock" />;
+  MockClock.displayName = 'MockClock';
+  return MockClock;
+});
+
+jest.mock('../components/util-components/status', () => {
+  const MockStatus = () => <div data-testid="status" />;
+  MockStatus.displayName = 'MockStatus';
+  return MockStatus;
+});
+
+jest.mock('../components/ui/QuickSettings', () => {
+  const MockQuickSettings = ({ open }: { open: boolean }) => (
+    <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
+  );
+  MockQuickSettings.displayName = 'MockQuickSettings';
+  return MockQuickSettings;
+});
+
+jest.mock('../components/menu/WhiskerMenu', () => {
+  const MockWhiskerMenu = () => <button type="button">Menu</button>;
+  MockWhiskerMenu.displayName = 'MockWhiskerMenu';
+  return MockWhiskerMenu;
+});
+
+jest.mock('../components/ui/PerformanceGraph', () => {
+  const MockPerformanceGraph = () => <div data-testid="performance" />;
+  MockPerformanceGraph.displayName = 'MockPerformanceGraph';
+  return MockPerformanceGraph;
+});
 
 const workspaceEventDetail = {
   workspaces: [

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -37,6 +37,8 @@ const areRunningAppsEqual = (next = [], prev = []) => {
         return true;
 };
 
+const PREVIEW_REFRESH_INTERVAL = 500;
+
 export default class Navbar extends PureComponent {
         constructor() {
                 super();
@@ -46,13 +48,22 @@ export default class Navbar extends PureComponent {
                         placesMenuOpen: false,
                         workspaces: [],
                         activeWorkspace: 0,
-                        runningApps: []
+                        runningApps: [],
+                        previewVisible: false,
+                        previewAppId: null,
+                        previewImage: null,
+                        previewAnchor: null,
+                        previewTitle: '',
+                        previewAnnouncement: ''
                 };
+
+                this.previewTimer = null;
         }
 
         componentDidMount() {
                 if (typeof window !== 'undefined') {
                         window.addEventListener('workspace-state', this.handleWorkspaceStateUpdate);
+                        window.addEventListener('taskbar-preview-response', this.handlePreviewResponse);
                         window.dispatchEvent(new CustomEvent('workspace-request'));
                 }
         }
@@ -60,7 +71,9 @@ export default class Navbar extends PureComponent {
         componentWillUnmount() {
                 if (typeof window !== 'undefined') {
                         window.removeEventListener('workspace-state', this.handleWorkspaceStateUpdate);
+                        window.removeEventListener('taskbar-preview-response', this.handlePreviewResponse);
                 }
+                this.clearPreviewTimer();
         }
 
         handleWorkspaceStateUpdate = (event) => {
@@ -84,12 +97,54 @@ export default class Navbar extends PureComponent {
                                 activeWorkspace: nextActiveWorkspace,
                                 runningApps: runningAppsChanged ? nextRunningApps : previousState.runningApps
                         };
+                }, () => {
+                        if (!this.state.previewVisible) return;
+                        const stillRunning = nextRunningApps.some(
+                                (app) => app.id === this.state.previewAppId && app.isMinimized === false
+                        );
+                        if (!stillRunning) {
+                                this.stopPreview();
+                        }
                 });
         };
 
         dispatchTaskbarCommand = (detail) => {
                 if (typeof window === 'undefined') return;
                 window.dispatchEvent(new CustomEvent('taskbar-command', { detail }));
+        };
+
+        clearPreviewTimer = () => {
+                if (this.previewTimer) {
+                        clearInterval(this.previewTimer);
+                        this.previewTimer = null;
+                }
+        };
+
+        requestPreview = (windowId) => {
+                if (typeof window === 'undefined' || !windowId) return;
+                window.dispatchEvent(new CustomEvent('taskbar-preview-request', { detail: { windowId } }));
+        };
+
+        handlePreviewResponse = (event) => {
+                const detail = event?.detail || {};
+                const windowId = detail.windowId;
+                const image = detail.image || null;
+                this.setState((previousState) => {
+                        if (!previousState.previewVisible || previousState.previewAppId !== windowId) {
+                                return null;
+                        }
+                        if (previousState.previewImage === image) {
+                                return null;
+                        }
+                        const now = new Date().toLocaleTimeString();
+                        const message = image
+                                ? `Preview refreshed for ${previousState.previewTitle} at ${now}`
+                                : `Preview unavailable for ${previousState.previewTitle} at ${now}`;
+                        return {
+                                previewImage: image,
+                                previewAnnouncement: message,
+                        };
+                });
         };
 
         handleAppButtonClick = (app) => {
@@ -104,39 +159,131 @@ export default class Navbar extends PureComponent {
                 }
         };
 
+        handleAppButtonEnter = (event, app) => {
+                if (!app || app.isMinimized) return;
+                const target = event?.currentTarget;
+                const rect = typeof target?.getBoundingClientRect === 'function'
+                        ? target.getBoundingClientRect()
+                        : null;
+                const anchor = rect
+                        ? {
+                                top: rect.bottom + 8,
+                                left: rect.left + rect.width / 2,
+                        }
+                        : null;
+                const keepImage = this.state.previewVisible && this.state.previewAppId === app.id
+                        ? this.state.previewImage
+                        : null;
+
+                this.clearPreviewTimer();
+                this.setState({
+                        previewVisible: true,
+                        previewAppId: app.id,
+                        previewAnchor: anchor,
+                        previewTitle: app.title,
+                        previewImage: keepImage,
+                        previewAnnouncement: `Preview opened for ${app.title} at ${new Date().toLocaleTimeString()}`,
+                }, () => {
+                        this.requestPreview(app.id);
+                        if (typeof window !== 'undefined') {
+                                this.previewTimer = window.setInterval(
+                                        () => this.requestPreview(app.id),
+                                        PREVIEW_REFRESH_INTERVAL
+                                );
+                        }
+                });
+        };
+
+        stopPreview = () => {
+                if (!this.state.previewVisible) return;
+                const title = this.state.previewTitle;
+                this.clearPreviewTimer();
+                this.setState({
+                        previewVisible: false,
+                        previewAppId: null,
+                        previewAnchor: null,
+                        previewImage: null,
+                        previewAnnouncement: title
+                                ? `Preview closed for ${title} at ${new Date().toLocaleTimeString()}`
+                                : `Preview closed at ${new Date().toLocaleTimeString()}`,
+                });
+        };
+
+        handleAppButtonLeave = () => {
+                this.stopPreview();
+        };
+
+        renderPreviewPopover = () => {
+                const { previewVisible, previewAnchor, previewImage, previewTitle } = this.state;
+                if (!previewVisible || !previewAnchor) return null;
+
+                return (
+                        <div
+                                id="taskbar-preview-popover"
+                                role="dialog"
+                                aria-label={`${previewTitle} window preview`}
+                                className="pointer-events-none fixed z-[60] mt-2 max-w-[18rem] -translate-x-1/2 rounded-lg border border-white/10 bg-slate-900/95 p-3 text-white shadow-xl backdrop-blur-md"
+                                style={{ top: previewAnchor.top, left: previewAnchor.left }}
+                        >
+                                <p className="mb-2 text-xs font-medium text-white/80">{previewTitle}</p>
+                                <div className="flex h-32 w-48 max-w-full items-center justify-center overflow-hidden rounded-md border border-white/10 bg-black/60">
+                                        {previewImage ? (
+                                                <img
+                                                        src={previewImage}
+                                                        alt={`Live preview of ${previewTitle}`}
+                                                        className="h-full w-full object-contain"
+                                                />
+                                        ) : (
+                                                <span className="text-xs text-white/60">Preview unavailable</span>
+                                        )}
+                                </div>
+                        </div>
+                );
+        };
+
         renderRunningApps = () => {
                 const { runningApps } = this.state;
                 if (!runningApps.length) return null;
 
                 return (
-                        <ul
-                                className="flex max-w-[40vw] items-center gap-2 overflow-x-auto rounded-md border border-white/10 bg-[#1b2231]/90 px-2 py-1"
-                                role="list"
-                                aria-label="Open applications"
-                        >
-                                {runningApps.map((app) => (
-                                        <li key={app.id} className="flex">
-                                                {this.renderRunningAppButton(app)}
-                                        </li>
-                                ))}
-                        </ul>
+                        <>
+                                <ul
+                                        className="flex max-w-[40vw] items-center gap-2 overflow-x-auto rounded-md border border-white/10 bg-[#1b2231]/90 px-2 py-1"
+                                        role="list"
+                                        aria-label="Open applications"
+                                >
+                                        {runningApps.map((app) => (
+                                                <li key={app.id} className="flex">
+                                                        {this.renderRunningAppButton(app)}
+                                                </li>
+                                        ))}
+                                </ul>
+                                {this.renderPreviewPopover()}
+                        </>
                 );
         };
 
         renderRunningAppButton = (app) => {
                 const isActive = !app.isMinimized;
                 const isFocused = app.isFocused && isActive;
+                const { previewVisible, previewAppId } = this.state;
+                const describedBy = previewVisible && previewAppId === app.id ? 'taskbar-preview-popover' : undefined;
 
                 return (
                         <button
                                 type="button"
                                 aria-label={app.title}
                                 aria-pressed={isActive}
+                                aria-describedby={describedBy}
                                 data-context="taskbar"
                                 data-app-id={app.id}
                                 data-active={isActive ? 'true' : 'false'}
                                 onClick={() => this.handleAppButtonClick(app)}
                                 onKeyDown={(event) => this.handleAppButtonKeyDown(event, app)}
+                                onMouseEnter={(event) => this.handleAppButtonEnter(event, app)}
+                                onMouseLeave={this.handleAppButtonLeave}
+                                onFocus={(event) => this.handleAppButtonEnter(event, app)}
+                                onBlur={this.handleAppButtonLeave}
                                 className={`${isFocused ? 'bg-white/20' : 'bg-transparent'} relative flex items-center gap-2 rounded-md px-2 py-1 text-xs text-white/80 transition-colors hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kali-blue)]`}
                         >
                                 <span className="relative inline-flex items-center justify-center">
@@ -222,9 +369,12 @@ export default class Navbar extends PureComponent {
                                                         <QuickSettings open={this.state.status_card} />
                                                 </div>
                                         </div>
+                                        <div className="sr-only" aria-live="polite">
+                                                {this.state.previewAnnouncement}
+                                        </div>
                                 </div>
-			);
-		}
+                        );
+                }
 
 
 }


### PR DESCRIPTION
## Summary
- reuse the desktop window snapshot logic to serve preview requests and clean up cached thumbnails when windows close
- add a hover/focus-driven taskbar preview popover with live updates, aria announcements, and throttled refreshes for performance
- update navbar unit test mocks with display names to satisfy the lint configuration

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dd8da0eebc8328bc584379cb5be175