### PR TITLE
[taskbar] persist and reorder pinned apps

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
+import { getPinnedAppIds, pinApp, unpinApp } from '../utils/taskbar';
 
 jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
 jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
@@ -32,10 +33,18 @@ describe('Navbar running apps tray', () => {
 
   beforeEach(() => {
     dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+    window.localStorage.clear();
+    act(() => {
+      getPinnedAppIds().forEach((id) => unpinApp(id));
+    });
   });
 
   afterEach(() => {
     dispatchSpy.mockRestore();
+    act(() => {
+      getPinnedAppIds().forEach((id) => unpinApp(id));
+    });
+    window.localStorage.clear();
   });
 
   it('dispatches a taskbar command when clicking an open app', () => {
@@ -86,5 +95,18 @@ describe('Navbar running apps tray', () => {
     expect(button).toHaveAttribute('aria-pressed', 'false');
     expect(button).toHaveAttribute('data-active', 'false');
     expect(button.querySelector('[data-testid="running-indicator"]')).toBeFalsy();
+  });
+
+  it('renders pinned apps even when not running', () => {
+    act(() => {
+      pinApp('terminal');
+    });
+
+    render(<Navbar />);
+
+    const button = screen.getByRole('button', { name: /terminal/i });
+    expect(button).toHaveAttribute('data-pinned', 'true');
+    expect(button).toHaveAttribute('data-running', 'false');
+    expect(button).toHaveAttribute('aria-pressed', 'false');
   });
 });

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -13,6 +13,15 @@ function TaskbarMenu(props) {
         }
     };
 
+    const handlePinToggle = () => {
+        if (props.pinned) {
+            props.onUnpin && props.onUnpin();
+        } else {
+            props.onPin && props.onPin();
+        }
+        props.onCloseMenu && props.onCloseMenu();
+    };
+
     const handleMinimize = () => {
         props.onMinimize && props.onMinimize();
         props.onCloseMenu && props.onCloseMenu();
@@ -32,6 +41,15 @@ function TaskbarMenu(props) {
             onKeyDown={handleKeyDown}
             className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
         >
+            <button
+                type="button"
+                onClick={handlePinToggle}
+                role="menuitem"
+                aria-label={props.pinned ? 'Unpin from taskbar' : 'Pin to taskbar'}
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">{props.pinned ? 'Unpin from Taskbar' : 'Pin to Taskbar'}</span>
+            </button>
             <button
                 type="button"
                 onClick={handleMinimize}

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -20,6 +20,7 @@ import TaskbarMenu from '../context-menus/taskbar-menu';
 import ReactGA from 'react-ga4';
 import { toPng } from 'html-to-image';
 import { safeLocalStorage } from '../../utils/safeStorage';
+import { pinApp as pinTaskbarApp, unpinApp as unpinTaskbarApp, isPinned as isTaskbarPinned } from '../../utils/taskbar';
 import { addRecentApp } from '../../utils/recentStorage';
 import { DESKTOP_TOP_PADDING } from '../../utils/uiConstants';
 import { useSnapSetting } from '../../hooks/usePersistentState';
@@ -1870,6 +1871,17 @@ export class Desktop extends Component {
                 <TaskbarMenu
                     active={this.state.context_menus.taskbar}
                     minimized={this.state.context_app ? this.state.minimized_windows[this.state.context_app] : false}
+                    pinned={isTaskbarPinned(this.state.context_app)}
+                    onPin={() => {
+                        const id = this.state.context_app;
+                        if (!id) return;
+                        pinTaskbarApp(id);
+                    }}
+                    onUnpin={() => {
+                        const id = this.state.context_app;
+                        if (!id) return;
+                        unpinTaskbarApp(id);
+                    }}
                     onMinimize={() => {
                         const id = this.state.context_app;
                         if (!id) return;

--- a/components/screen/navbar.js
+++ b/components/screen/navbar.js
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react';
-import Image from 'next/image';
 import Clock from '../util-components/clock';
 import Status from '../util-components/status';
 import QuickSettings from '../ui/QuickSettings';
@@ -7,6 +6,7 @@ import WhiskerMenu from '../menu/WhiskerMenu';
 import PerformanceGraph from '../ui/PerformanceGraph';
 import WorkspaceSwitcher from '../panel/WorkspaceSwitcher';
 import { NAVBAR_HEIGHT } from '../../utils/uiConstants';
+import Taskbar from './taskbar';
 
 const areWorkspacesEqual = (next, prev) => {
         if (next.length !== prev.length) return false;
@@ -92,95 +92,8 @@ export default class Navbar extends PureComponent {
                 window.dispatchEvent(new CustomEvent('taskbar-command', { detail }));
         };
 
-        handleAppButtonClick = (app) => {
-                const detail = { appId: app.id, action: 'toggle' };
-                this.dispatchTaskbarCommand(detail);
-        };
-
-        handleAppButtonKeyDown = (event, app) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                        event.preventDefault();
-                        this.handleAppButtonClick(app);
-                }
-        };
-
-        renderRunningApps = () => {
-                const { runningApps } = this.state;
-                if (!runningApps.length) return null;
-
-                return (
-                        <ul
-                                className="flex max-w-[40vw] items-center gap-2 overflow-x-auto rounded-md border border-white/10 bg-[#1b2231]/90 px-2 py-1"
-                                role="list"
-                                aria-label="Open applications"
-                        >
-                                {runningApps.map((app) => (
-                                        <li key={app.id} className="flex">
-                                                {this.renderRunningAppButton(app)}
-                                        </li>
-                                ))}
-                        </ul>
-                );
-        };
-
-        renderRunningAppButton = (app) => {
-                const isActive = !app.isMinimized;
-                const isFocused = app.isFocused && isActive;
-
-                return (
-                        <button
-                                type="button"
-                                aria-label={app.title}
-                                aria-pressed={isActive}
-                                data-context="taskbar"
-                                data-app-id={app.id}
-                                data-active={isActive ? 'true' : 'false'}
-                                onClick={() => this.handleAppButtonClick(app)}
-                                onKeyDown={(event) => this.handleAppButtonKeyDown(event, app)}
-                                className={`${isFocused ? 'bg-white/20' : 'bg-transparent'} relative flex items-center gap-2 rounded-md px-2 py-1 text-xs text-white/80 transition-colors hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kali-blue)]`}
-                        >
-                                <span className="relative inline-flex items-center justify-center">
-                                        <Image
-                                                src={app.icon}
-                                                alt=""
-                                                width={28}
-                                                height={28}
-                                                className="h-6 w-6"
-                                        />
-                                        {isActive && (
-                                                <span
-                                                        aria-hidden="true"
-                                                        data-testid="running-indicator"
-                                                        className="absolute -bottom-1 left-1/2 h-1 w-2 -translate-x-1/2 rounded-full bg-current"
-                                                />
-                                        )}
-                                </span>
-                                <span className="hidden whitespace-nowrap text-white md:inline">{app.title}</span>
-                        </button>
-                );
-        };
-
-        handleWorkspaceSelect = (workspaceId) => {
-                if (typeof workspaceId !== 'number') return;
-                this.setState({ activeWorkspace: workspaceId });
-                if (typeof window !== 'undefined') {
-                        window.dispatchEvent(new CustomEvent('workspace-select', { detail: { workspaceId } }));
-                }
-        };
-
-        handleStatusToggle = () => {
-                this.setState((state) => ({ status_card: !state.status_card }));
-        };
-
-        handleStatusKeyDown = (event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                        event.preventDefault();
-                        this.handleStatusToggle();
-                }
-        };
-
                 render() {
-                        const { workspaces, activeWorkspace } = this.state;
+                        const { workspaces, activeWorkspace, runningApps } = this.state;
                         return (
                                 <div
                                         className="main-navbar-vp fixed inset-x-0 top-0 z-50 flex w-full items-center justify-between bg-slate-950/80 text-ubt-grey shadow-lg backdrop-blur-md"
@@ -201,7 +114,10 @@ export default class Navbar extends PureComponent {
                                                                 onSelect={this.handleWorkspaceSelect}
                                                         />
                                                 )}
-                                                {this.renderRunningApps()}
+                                                <Taskbar
+                                                        runningApps={runningApps}
+                                                        onTaskbarCommand={this.dispatchTaskbarCommand}
+                                                />
                                                 <PerformanceGraph />
                                         </div>
                                         <div className="flex items-center gap-4 text-xs md:text-sm">

--- a/components/screen/taskbar.js
+++ b/components/screen/taskbar.js
@@ -1,0 +1,279 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Image from 'next/image';
+import { getAppMetadata, getPinnedAppIds, reorderPinnedApps, subscribePinnedApps } from '../../utils/taskbar';
+
+function mergeTaskbarItems(runningApps = [], pinned = []) {
+        const pinnedSet = new Set(pinned);
+        const runningMap = new Map();
+        runningApps.forEach((app) => {
+                runningMap.set(app.id, {
+                        ...app,
+                        icon: app.icon ? app.icon : '',
+                        isPinned: pinnedSet.has(app.id),
+                        isRunning: true,
+                });
+        });
+
+        const merged = [];
+
+        pinned.forEach((id) => {
+                const running = runningMap.get(id);
+                if (running) {
+                        merged.push(running);
+                        runningMap.delete(id);
+                        return;
+                }
+                const meta = getAppMetadata(id);
+                if (!meta) return;
+                merged.push({
+                        id,
+                        title: meta.title,
+                        icon: meta.icon,
+                        isFocused: false,
+                        isMinimized: false,
+                        isPinned: true,
+                        isRunning: false,
+                });
+        });
+
+        runningApps.forEach((app) => {
+                if (pinnedSet.has(app.id)) return;
+                const running = runningMap.get(app.id);
+                if (running) {
+                        merged.push({
+                                ...running,
+                                isPinned: false,
+                                isRunning: true,
+                        });
+                }
+        });
+
+        return merged;
+}
+
+function normalizeIconPath(path = '') {
+        if (!path) return path;
+        return path.startsWith('/') ? path : path.replace('./', '/');
+}
+
+const Taskbar = ({ runningApps = [], onTaskbarCommand }) => {
+        const [pinned, setPinned] = useState(() => getPinnedAppIds());
+        const dragSourceIndex = useRef(null);
+        const pendingFocusId = useRef(null);
+        const buttonRefs = useRef(new Map());
+
+        useEffect(() => {
+                return subscribePinnedApps((nextPinned) => {
+                        setPinned(nextPinned);
+                });
+        }, []);
+
+        useEffect(() => {
+                if (!pendingFocusId.current) return;
+                const node = buttonRefs.current.get(pendingFocusId.current);
+                if (node) {
+                        node.focus();
+                }
+                pendingFocusId.current = null;
+        }, [pinned, runningApps]);
+
+        const items = useMemo(() => {
+                return mergeTaskbarItems(runningApps, pinned).map((item) => ({
+                        ...item,
+                        icon: normalizeIconPath(item.icon),
+                }));
+        }, [runningApps, pinned]);
+
+        const registerButtonRef = useCallback((id, node) => {
+                if (!id) return;
+                if (node) {
+                        buttonRefs.current.set(id, node);
+                } else {
+                        buttonRefs.current.delete(id);
+                }
+        }, []);
+
+        const handleCommand = useCallback(
+                (appId, action = 'toggle') => {
+                        if (typeof onTaskbarCommand === 'function') {
+                                onTaskbarCommand({ appId, action });
+                        }
+                },
+                [onTaskbarCommand],
+        );
+
+        const handleClick = useCallback(
+                (event, item) => {
+                        event.preventDefault();
+                        handleCommand(item.id, 'toggle');
+                },
+                [handleCommand],
+        );
+
+        const handleKeyDown = useCallback(
+                (event, item) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                                event.preventDefault();
+                                handleCommand(item.id, 'toggle');
+                                return;
+                        }
+
+                        if (!item.isPinned) return;
+
+                        if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+                                event.preventDefault();
+                                const pinnedIndex = pinned.indexOf(item.id);
+                                if (pinnedIndex === -1) return;
+                                const direction = event.key === 'ArrowUp' ? -1 : 1;
+                                const targetIndex = pinnedIndex + direction;
+                                if (targetIndex < 0 || targetIndex >= pinned.length) return;
+                                reorderPinnedApps(pinnedIndex, targetIndex);
+                                pendingFocusId.current = item.id;
+                        }
+                },
+                [handleCommand, pinned],
+        );
+
+        const handleDragStart = useCallback(
+                (event, item) => {
+                        if (!item.isPinned) {
+                                event.preventDefault();
+                                return;
+                        }
+                        const pinnedIndex = pinned.indexOf(item.id);
+                        if (pinnedIndex === -1) {
+                                event.preventDefault();
+                                return;
+                        }
+                        dragSourceIndex.current = pinnedIndex;
+                        if (event.dataTransfer) {
+                                event.dataTransfer.setData('text/plain', item.id);
+                                event.dataTransfer.setDragImage(event.currentTarget, 0, 0);
+                                event.dataTransfer.effectAllowed = 'move';
+                        }
+                },
+                [pinned],
+        );
+
+        const handleDragOver = useCallback((event, item) => {
+                if (!item.isPinned) return;
+                event.preventDefault();
+                if (event.dataTransfer) {
+                        event.dataTransfer.dropEffect = 'move';
+                }
+        }, []);
+
+        const handleDrop = useCallback(
+                (event, item) => {
+                        if (!item.isPinned) return;
+                        const targetIndex = pinned.indexOf(item.id);
+                        const sourceIndex = dragSourceIndex.current;
+                        if (sourceIndex == null || targetIndex === -1) return;
+                        event.preventDefault();
+                        reorderPinnedApps(sourceIndex, targetIndex);
+                        if (event.dataTransfer) {
+                                const draggedId = event.dataTransfer.getData('text/plain');
+                                pendingFocusId.current = draggedId || item.id;
+                        } else {
+                                pendingFocusId.current = item.id;
+                        }
+                        dragSourceIndex.current = null;
+                },
+                [pinned],
+        );
+
+        const handleDragEnd = useCallback(() => {
+                dragSourceIndex.current = null;
+        }, []);
+
+        const handleListDragOver = useCallback((event) => {
+                if (dragSourceIndex.current == null) return;
+                event.preventDefault();
+                if (event.dataTransfer) {
+                        event.dataTransfer.dropEffect = 'move';
+                }
+        }, []);
+
+        const handleListDrop = useCallback(
+                (event) => {
+                        const sourceIndex = dragSourceIndex.current;
+                        if (sourceIndex == null) return;
+                        event.preventDefault();
+                        reorderPinnedApps(sourceIndex, pinned.length - 1);
+                        const ordered = getPinnedAppIds();
+                        pendingFocusId.current = ordered[ordered.length - 1] || null;
+                        dragSourceIndex.current = null;
+                },
+                [pinned.length],
+        );
+
+        if (!items.length) {
+                        return null;
+        }
+
+        return (
+                <ul
+                        className="flex max-w-[40vw] items-center gap-2 overflow-x-auto rounded-md border border-white/10 bg-[#1b2231]/90 px-2 py-1"
+                        role="list"
+                        aria-label="Pinned and open applications"
+                        onDragOver={handleListDragOver}
+                        onDrop={handleListDrop}
+                >
+                        {items.map((item) => {
+                                const isActive = item.isRunning && !item.isMinimized;
+                                const isFocused = item.isRunning && item.isFocused && isActive;
+                                const pinnedIndex = pinned.indexOf(item.id);
+                                const draggable = item.isPinned;
+                                const ariaLabel = item.title;
+                                return (
+                                        <li key={item.id} className="flex">
+                                                <button
+                                                        type="button"
+                                                        ref={(node) => registerButtonRef(item.id, node)}
+                                                        aria-label={ariaLabel}
+                                                        aria-pressed={isActive}
+                                                        data-context="taskbar"
+                                                        data-app-id={item.id}
+                                                        data-active={isActive ? 'true' : 'false'}
+                                                        data-pinned={item.isPinned ? 'true' : 'false'}
+                                                        data-running={item.isRunning ? 'true' : 'false'}
+                                                        draggable={draggable}
+                                                        onDragStart={(event) => handleDragStart(event, item)}
+                                                        onDragOver={(event) => handleDragOver(event, item)}
+                                                        onDrop={(event) => handleDrop(event, item)}
+                                                        onDragEnd={handleDragEnd}
+                                                        onClick={(event) => handleClick(event, item)}
+                                                        onKeyDown={(event) => handleKeyDown(event, item)}
+                                                        className={`${isFocused ? 'bg-white/20' : 'bg-transparent'} ${
+                                                                item.isRunning ? 'text-white/80' : 'text-white/50'
+                                                        } relative flex items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kali-blue)]`}
+                                                >
+                                                        <span className="relative inline-flex items-center justify-center">
+                                                                <Image
+                                                                        src={item.icon}
+                                                                        alt=""
+                                                                        width={28}
+                                                                        height={28}
+                                                                        className="h-6 w-6"
+                                                                />
+                                                                {item.isRunning && isActive && (
+                                                                        <span
+                                                                                aria-hidden="true"
+                                                                                data-testid="running-indicator"
+                                                                                className="absolute -bottom-1 left-1/2 h-1 w-2 -translate-x-1/2 rounded-full bg-current"
+                                                                        />
+                                                                )}
+                                                        </span>
+                                                        <span className="hidden whitespace-nowrap text-white md:inline">{item.title}</span>
+                                                        {item.isPinned && typeof pinnedIndex === 'number' && pinnedIndex > -1 && (
+                                                                <span className="sr-only"> pinned app</span>
+                                                        )}
+                                                </button>
+                                        </li>
+                                );
+                        })}
+                </ul>
+        );
+};
+
+export default Taskbar;

--- a/utils/taskbar.js
+++ b/utils/taskbar.js
@@ -1,0 +1,132 @@
+import apps from '../apps.config';
+import { safeLocalStorage } from './safeStorage';
+
+const STORAGE_KEY = 'taskbarPinnedApps';
+
+const appMetadata = new Map(
+        apps.map((app) => [
+                app.id,
+                {
+                        id: app.id,
+                        title: app.title,
+                        icon: app.icon ? app.icon.replace('./', '/') : '',
+                },
+        ]),
+);
+
+let pinned = normalizePinned(loadPinned());
+const subscribers = new Set();
+
+function loadPinned() {
+        if (!safeLocalStorage) return [];
+        try {
+                const stored = safeLocalStorage.getItem(STORAGE_KEY);
+                if (!stored) return [];
+                const parsed = JSON.parse(stored);
+                return Array.isArray(parsed) ? parsed.filter((id) => typeof id === 'string') : [];
+        } catch (error) {
+                return [];
+        }
+}
+
+function persistPinned(next) {
+        if (!safeLocalStorage) return;
+        try {
+                safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        } catch (error) {
+                // Ignore write failures (e.g. storage disabled)
+        }
+}
+
+function emitChange() {
+        const snapshot = getPinnedAppIds();
+        subscribers.forEach((listener) => {
+                try {
+                        listener(snapshot);
+                } catch (error) {
+                        // Fail silently so one bad listener does not break others
+                }
+        });
+}
+
+function normalizePinned(appIds) {
+        if (!Array.isArray(appIds)) return [];
+        const seen = new Set();
+        const normalized = [];
+        appIds.forEach((id) => {
+                if (typeof id !== 'string') return;
+                if (!appMetadata.has(id)) return;
+                if (seen.has(id)) return;
+                seen.add(id);
+                normalized.push(id);
+        });
+        return normalized;
+}
+
+export function getPinnedAppIds() {
+        return Array.from(pinned);
+}
+
+export function subscribePinnedApps(listener) {
+        if (typeof listener !== 'function') return () => {};
+        subscribers.add(listener);
+        listener(getPinnedAppIds());
+        return () => {
+                subscribers.delete(listener);
+        };
+}
+
+function setPinned(next) {
+        const normalized = normalizePinned(next);
+        pinned = normalized;
+        persistPinned(pinned);
+        emitChange();
+}
+
+export function pinApp(appId) {
+        if (typeof appId !== 'string') return;
+        if (pinned.includes(appId)) return;
+        if (!appMetadata.has(appId)) return;
+        setPinned([...pinned, appId]);
+}
+
+export function unpinApp(appId) {
+        if (typeof appId !== 'string') return;
+        if (!pinned.includes(appId)) return;
+        setPinned(pinned.filter((id) => id !== appId));
+}
+
+export function reorderPinnedApps(fromIndex, toIndex) {
+        if (typeof fromIndex !== 'number' || typeof toIndex !== 'number') return;
+        if (fromIndex === toIndex) return;
+        if (fromIndex < 0 || toIndex < 0) return;
+        if (fromIndex >= pinned.length || toIndex >= pinned.length) return;
+        const next = [...pinned];
+        const [item] = next.splice(fromIndex, 1);
+        next.splice(toIndex, 0, item);
+        setPinned(next);
+}
+
+export function movePinnedApp(appId, targetIndex) {
+        if (typeof targetIndex !== 'number') return;
+        const currentIndex = pinned.indexOf(appId);
+        if (currentIndex === -1) return;
+        const clampedIndex = Math.max(0, Math.min(targetIndex, pinned.length - 1));
+        reorderPinnedApps(currentIndex, clampedIndex);
+}
+
+export function isPinned(appId) {
+        return pinned.includes(appId);
+}
+
+export function getAppMetadata(appId) {
+        return appMetadata.get(appId) || null;
+}
+
+if (typeof window !== 'undefined') {
+        window.addEventListener('storage', (event) => {
+                if (event.key !== STORAGE_KEY) return;
+                pinned = normalizePinned(loadPinned());
+                emitChange();
+        });
+}


### PR DESCRIPTION
## Summary
- add a shared taskbar state module that persists pinned app ids and notifies subscribers
- render a dedicated Taskbar component that merges pinned items with running windows and supports drag, drop, and keyboard reordering
- expose pin and unpin actions through the taskbar context menu and cover the new behaviour with unit tests

## Testing
- yarn test __tests__/navbar-running-apps.test.tsx --runTestsByPath


------
https://chatgpt.com/codex/tasks/task_e_68dd8d9f77c8832892ddcf863d9cbdf7