### PR TITLE
[notifications] add do not disturb toggle

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,41 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock', () => {
+  function ClockMock() {
+    return <div data-testid="clock" />;
+  }
+  ClockMock.displayName = 'ClockMock';
+  return ClockMock;
+});
+jest.mock('../components/util-components/status', () => {
+  function StatusMock() {
+    return <div data-testid="status" />;
+  }
+  StatusMock.displayName = 'StatusMock';
+  return StatusMock;
+});
+jest.mock('../components/ui/QuickSettings', () => {
+  function QuickSettingsMock({ open }: { open: boolean }) {
+    return <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>;
+  }
+  QuickSettingsMock.displayName = 'QuickSettingsMock';
+  return QuickSettingsMock;
+});
+jest.mock('../components/menu/WhiskerMenu', () => {
+  function WhiskerMenuMock() {
+    return <button type="button">Menu</button>;
+  }
+  WhiskerMenuMock.displayName = 'WhiskerMenuMock';
+  return WhiskerMenuMock;
+});
+jest.mock('../components/ui/PerformanceGraph', () => {
+  function PerformanceGraphMock() {
+    return <div data-testid="performance" />;
+  }
+  PerformanceGraphMock.displayName = 'PerformanceGraphMock';
+  return PerformanceGraphMock;
+});
 
 const workspaceEventDetail = {
   workspaces: [

--- a/components/ui/NotificationBell.tsx
+++ b/components/ui/NotificationBell.tsx
@@ -78,6 +78,7 @@ const NotificationBell: React.FC = () => {
     unreadCount,
     clearNotifications,
     markAllRead,
+    isDoNotDisturb,
   } = useNotifications();
 
   const [isOpen, setIsOpen] = useState(false);
@@ -188,6 +189,17 @@ const NotificationBell: React.FC = () => {
     }
   }, [isOpen, markAllRead, notifications]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const handleOpenRequest = () => {
+      setIsOpen(true);
+    };
+    window.addEventListener('notification-center-open-request', handleOpenRequest);
+    return () => {
+      window.removeEventListener('notification-center-open-request', handleOpenRequest);
+    };
+  }, []);
+
   const timeFormatter = useMemo(
     () =>
       new Intl.DateTimeFormat(undefined, {
@@ -238,7 +250,11 @@ const NotificationBell: React.FC = () => {
       <button
         type="button"
         ref={buttonRef}
-        aria-label="Open notifications"
+        aria-label={
+          isDoNotDisturb
+            ? 'Open notifications (Do Not Disturb enabled)'
+            : 'Open notifications'
+        }
         aria-haspopup="dialog"
         aria-expanded={isOpen}
         aria-controls={panelId}
@@ -252,9 +268,23 @@ const NotificationBell: React.FC = () => {
           viewBox="0 0 20 20"
           fill="currentColor"
         >
-          <path d="M10 2a4 4 0 00-4 4v1.09c0 .471-.158.93-.45 1.3L4.3 10.2A1 1 0 005 11.8h10a1 1 0 00.7-1.6l-1.25-1.81a2 2 0 01-.45-1.3V6a4 4 0 00-4-4z" />
-          <path d="M7 12a3 3 0 006 0H7z" />
+          {isDoNotDisturb ? (
+            <path d="M4 8c0-.26.017-.517.049-.77l7.722 7.723a33.56 33.56 0 0 1-3.722-.01 2 2 0 0 0 3.862.15l1.134 1.134a3.5 3.5 0 0 1-6.53-1.409 32.91 32.91 0 0 1-3.257-.508.75.75 0 0 1-.515-1.076A11.448 11.448 0 0 0 4 8ZM17.266 13.9a.756.756 0 0 1-.068.116L6.389 3.207A6 6 0 0 1 16 8c.001 1.887.455 3.665 1.258 5.234a.75.75 0 0 1 .01.666ZM3.28 2.22a.75.75 0 0 0-1.06 1.06l14.5 14.5a.75.75 0 1 0 1.06-1.06L3.28 2.22Z" />
+          ) : (
+            <>
+              <path d="M10 2a4 4 0 00-4 4v1.09c0 .471-.158.93-.45 1.3L4.3 10.2A1 1 0 005 11.8h10a1 1 0 00.7-1.6l-1.25-1.81a2 2 0 01-.45-1.3V6a4 4 0 00-4-4z" />
+              <path d="M7 12a3 3 0 006 0H7z" />
+            </>
+          )}
         </svg>
+        {isDoNotDisturb && (
+          <span
+            aria-hidden="true"
+            className="absolute -top-1.5 -left-1.5 rounded-full border border-ubb-orange/60 bg-ubb-orange/10 px-1 text-[0.55rem] font-semibold uppercase tracking-wide text-ubb-orange"
+          >
+            DND
+          </span>
+        )}
         {unreadCount > 0 && (
           <span className="absolute -top-1.5 -right-1.5 min-w-[1.5rem] rounded-full bg-ubb-orange px-1 text-center text-[0.65rem] font-semibold leading-5 text-white">
             {unreadCount > 99 ? '99+' : unreadCount}
@@ -271,6 +301,23 @@ const NotificationBell: React.FC = () => {
           tabIndex={-1}
           className="absolute right-0 z-50 mt-2 w-72 max-h-96 overflow-hidden rounded-md border border-white/10 bg-ub-grey/95 text-ubt-grey shadow-xl backdrop-blur"
         >
+          {isDoNotDisturb && (
+            <div className="flex items-center gap-2 border-b border-white/10 bg-ubb-orange/10 px-4 py-2 text-xs font-medium text-ubb-orange">
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                className="h-4 w-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              >
+                <circle cx="12" cy="12" r="9" />
+                <path d="M8 12h8" strokeLinecap="round" />
+              </svg>
+              <span>Do Not Disturb is on. Toasts stay muted.</span>
+            </div>
+          )}
           <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
             <h2 id={headingId} className="text-sm font-semibold text-white">
               Notifications

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -2,6 +2,7 @@
 
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
+import useNotifications from '../../hooks/useNotifications';
 
 interface Props {
   open: boolean;
@@ -12,6 +13,7 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const { isDoNotDisturb, toggleDoNotDisturb } = useNotifications();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -36,20 +38,47 @@ const QuickSettings = ({ open }: Props) => {
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
+      <div className="px-4 pb-2 flex items-center justify-between gap-2">
+        <label htmlFor="quick-settings-sound">Sound</label>
         <input
+          id="quick-settings-sound"
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+          aria-label="Toggle sound"
+        />
+      </div>
+      <div className="px-4 pb-2 flex items-center justify-between gap-2">
+        <label htmlFor="quick-settings-network">Network</label>
+        <input
+          id="quick-settings-network"
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+          aria-label="Toggle network"
+        />
+      </div>
+      <div className="px-4 pb-2 flex items-center justify-between gap-2">
+        <label htmlFor="quick-settings-dnd">Do Not Disturb</label>
+        <span className="flex items-center gap-2 text-xs text-ubt-grey text-opacity-80">
+          <span aria-hidden="true">{isDoNotDisturb ? 'On' : 'Off'}</span>
+          <input
+            id="quick-settings-dnd"
+            type="checkbox"
+            checked={isDoNotDisturb}
+            onChange={() => toggleDoNotDisturb()}
+            aria-label={isDoNotDisturb ? 'Disable Do Not Disturb' : 'Enable Do Not Disturb'}
+          />
+        </span>
+      </div>
+      <div className="px-4 flex items-center justify-between gap-2 pb-2">
+        <label htmlFor="quick-settings-reduce-motion">Reduced motion</label>
+        <input
+          id="quick-settings-reduce-motion"
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
+          aria-label="Toggle reduced motion"
         />
       </div>
     </div>

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -4,10 +4,12 @@ import { useSettings } from '../../hooks/useSettings';
 import VolumeControl from '../ui/VolumeControl';
 import NetworkIndicator from '../ui/NetworkIndicator';
 import BatteryIndicator from '../ui/BatteryIndicator';
+import useNotifications from "../../hooks/useNotifications";
 
 export default function Status() {
   const { allowNetwork } = useSettings();
   const [online, setOnline] = useState(true);
+  const { isDoNotDisturb } = useNotifications();
 
   useEffect(() => {
     const pingServer = async () => {
@@ -47,6 +49,24 @@ export default function Status() {
       />
       <VolumeControl className="mx-1.5" />
       <BatteryIndicator className="mx-1.5" />
+      {isDoNotDisturb && (
+        <span
+          role="img"
+          aria-label="Do Not Disturb enabled"
+          className="mx-1.5 text-ubb-orange"
+          title="Do Not Disturb enabled"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-4 w-4"
+          >
+            <circle cx="12" cy="12" r="8" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M8 12h8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+        </span>
+      )}
       <span className="mx-1">
         <SmallArrow angle="down" className=" status-symbol" />
       </span>


### PR DESCRIPTION
## Summary
- add a persistent do not disturb toggle in the quick settings panel with notification center integration
- suppress notification toasts while do not disturb is active and broadcast the state to the rest of the shell
- update status indicators, notification bell UI, and related tests for accessibility compliance

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dd8da50ec883288f38c13413c9ce01