### PR TITLE
[navbar] add simulated status controls

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,33 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock', () => {
+  const MockClock = () => <div data-testid="clock" />;
+  MockClock.displayName = 'MockClock';
+  return MockClock;
+});
+jest.mock('../components/util-components/status', () => {
+  const MockStatus = () => <div data-testid="status" />;
+  MockStatus.displayName = 'MockStatus';
+  return MockStatus;
+});
+jest.mock('../components/ui/QuickSettings', () => {
+  const MockQuickSettings = ({ open }: { open: boolean }) => (
+    <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
+  );
+  MockQuickSettings.displayName = 'MockQuickSettings';
+  return MockQuickSettings;
+});
+jest.mock('../components/menu/WhiskerMenu', () => {
+  const MockWhiskerMenu = () => <button type="button">Menu</button>;
+  MockWhiskerMenu.displayName = 'MockWhiskerMenu';
+  return MockWhiskerMenu;
+});
+jest.mock('../components/ui/PerformanceGraph', () => {
+  const MockPerformanceGraph = () => <div data-testid="performance" />;
+  MockPerformanceGraph.displayName = 'MockPerformanceGraph';
+  return MockPerformanceGraph;
+});
 
 const workspaceEventDetail = {
   workspaces: [

--- a/components/ui/NetworkIndicator.tsx
+++ b/components/ui/NetworkIndicator.tsx
@@ -379,9 +379,15 @@ interface NetworkIndicatorProps {
   className?: string;
   allowNetwork: boolean;
   online: boolean;
+  simulationHint?: string;
 }
 
-const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetwork, online }) => {
+const NetworkIndicator: FC<NetworkIndicatorProps> = ({
+  className = "",
+  allowNetwork,
+  online,
+  simulationHint,
+}) => {
 
   const [wifiEnabled, setWifiEnabled] = usePersistentState<boolean>(
     "status-wifi-enabled",
@@ -555,15 +561,17 @@ const NetworkIndicator: FC<NetworkIndicatorProps> = ({ className = "", allowNetw
     }
   }, [appendShareLog, shareTarget]);
 
+  const tooltip = simulationHint ? `${summary.tooltip} • ${simulationHint}` : summary.tooltip;
+
   return (
     <div ref={rootRef} className={classNames("relative flex items-center", className)}>
       <button
         type="button"
         className="flex h-6 w-6 items-center justify-center rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ubt-blue"
-        aria-label={summary.tooltip}
+        aria-label={tooltip}
         aria-haspopup="true"
         aria-expanded={open}
-        title={summary.tooltip}
+        title={tooltip}
         onClick={handleToggle}
         onPointerDown={(event) => event.stopPropagation()}
       >

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -3,14 +3,39 @@
 import usePersistentState from '../../hooks/usePersistentState';
 import { useEffect } from 'react';
 
-interface Props {
-  open: boolean;
+interface StatusSnapshot {
+  online: boolean;
+  isOnlineSimulated: boolean;
+  batteryLevel: number;
+  batteryCharging: boolean;
+  isBatterySimulated: boolean;
 }
 
-const QuickSettings = ({ open }: Props) => {
+interface Props {
+  open: boolean;
+  status: StatusSnapshot;
+  supportsDeviceNetwork: boolean;
+  supportsDeviceBattery: boolean;
+  onNetworkToggle: (online: boolean) => void;
+  onUseDeviceNetwork: () => void;
+  onBatteryLevelChange: (level: number) => void;
+  onBatteryChargingChange: (charging: boolean) => void;
+  onUseDeviceBattery: () => void;
+}
+
+const QuickSettings = ({
+  open,
+  status,
+  supportsDeviceNetwork,
+  supportsDeviceBattery,
+  onNetworkToggle,
+  onUseDeviceNetwork,
+  onBatteryLevelChange,
+  onBatteryChargingChange,
+  onUseDeviceBattery,
+}: Props) => {
   const [theme, setTheme] = usePersistentState('qs-theme', 'light');
   const [sound, setSound] = usePersistentState('qs-sound', true);
-  const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
 
   useEffect(() => {
@@ -20,6 +45,16 @@ const QuickSettings = ({ open }: Props) => {
   useEffect(() => {
     document.documentElement.classList.toggle('reduce-motion', reduceMotion);
   }, [reduceMotion]);
+
+  const batteryPercent = Math.round(Math.max(0, Math.min(1, status.batteryLevel)) * 100);
+  const soundToggleId = 'quick-settings-sound-toggle';
+  const soundLabelId = 'quick-settings-sound-label';
+  const networkToggleId = 'quick-settings-network-toggle';
+  const networkLabelId = 'quick-settings-network-label';
+  const chargingToggleId = 'quick-settings-battery-charging-toggle';
+  const chargingLabelId = 'quick-settings-battery-charging-label';
+  const reduceMotionToggleId = 'quick-settings-reduce-motion-toggle';
+  const reduceMotionLabelId = 'quick-settings-reduce-motion-label';
 
   return (
     <div
@@ -36,19 +71,109 @@ const QuickSettings = ({ open }: Props) => {
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
+      <div className="px-4 pb-2 flex items-center justify-between">
+        <label id={soundLabelId} htmlFor={soundToggleId}>
+          Sound
+        </label>
         <input
+          id={soundToggleId}
+          type="checkbox"
+          checked={sound}
+          aria-labelledby={soundLabelId}
+          onChange={() => setSound(!sound)}
+        />
+      </div>
+      <div className="px-4 pb-3">
+        <div className="flex items-center justify-between">
+          <label id={networkLabelId} htmlFor={networkToggleId}>
+            Network
+          </label>
+          <input
+            id={networkToggleId}
+            type="checkbox"
+            checked={status.online}
+            onChange={(event) => onNetworkToggle(event.target.checked)}
+            aria-label={status.online ? 'Simulate offline mode' : 'Simulate online mode'}
+            aria-describedby="quick-settings-network-hint"
+            aria-labelledby={networkLabelId}
+          />
+        </div>
+        <p
+          id="quick-settings-network-hint"
+          className="mt-1 text-[10px] leading-relaxed text-gray-300"
+        >
+          {status.isOnlineSimulated
+            ? 'Showing simulated connectivity so demos stay predictable.'
+            : 'Live status from browser APIs. Toggle to simulate offline mode.'}
+        </p>
+        <button
+          type="button"
+          className="mt-2 w-full rounded bg-black/30 py-1 text-[11px] text-white transition hover:bg-black/40 disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={onUseDeviceNetwork}
+          disabled={!supportsDeviceNetwork || !status.isOnlineSimulated}
+        >
+          {supportsDeviceNetwork ? 'Use device network' : 'Device network unavailable'}
+        </button>
+      </div>
+      <div className="px-4 pb-3">
+        <div className="flex items-center justify-between">
+          <span>Battery</span>
+          <span className="text-[11px] text-gray-200">{batteryPercent}%</span>
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={100}
+          step={1}
+          value={batteryPercent}
+          className="mt-2 h-1 w-full cursor-pointer accent-ubt-blue"
+          aria-label="Adjust simulated battery level"
+          onChange={(event) => onBatteryLevelChange(Number(event.target.value) / 100)}
+        />
+        <div className="mt-3 flex items-center justify-between text-[11px] uppercase tracking-wide text-gray-200">
+          <label
+            className="text-white normal-case"
+            id={chargingLabelId}
+            htmlFor={chargingToggleId}
+          >
+            Charging
+          </label>
+          <input
+            id={chargingToggleId}
+            type="checkbox"
+            checked={status.batteryCharging}
+            onChange={(event) => onBatteryChargingChange(event.target.checked)}
+            aria-label={status.batteryCharging ? 'Simulate unplugged battery' : 'Simulate charging battery'}
+            aria-describedby="quick-settings-battery-hint"
+            aria-labelledby={chargingLabelId}
+          />
+        </div>
+        <p
+          id="quick-settings-battery-hint"
+          className="mt-1 text-[10px] leading-relaxed text-gray-300"
+        >
+          {status.isBatterySimulated
+            ? 'Status bar is using simulated power data.'
+            : 'Using live battery readings when supported.'}
+        </p>
+        <button
+          type="button"
+          className="mt-2 w-full rounded bg-black/30 py-1 text-[11px] text-white transition hover:bg-black/40 disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={onUseDeviceBattery}
+          disabled={!supportsDeviceBattery || !status.isBatterySimulated}
+        >
+          {supportsDeviceBattery ? 'Use device battery' : 'Device battery unavailable'}
+        </button>
+      </div>
+      <div className="px-4 flex items-center justify-between">
+        <label id={reduceMotionLabelId} htmlFor={reduceMotionToggleId}>
+          Reduced motion
+        </label>
+        <input
+          id={reduceMotionToggleId}
           type="checkbox"
           checked={reduceMotion}
+          aria-labelledby={reduceMotionLabelId}
           onChange={() => setReduceMotion(!reduceMotion)}
         />
       </div>

--- a/components/util-components/status.js
+++ b/components/util-components/status.js
@@ -1,54 +1,61 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import SmallArrow from "./small_arrow";
 import { useSettings } from '../../hooks/useSettings';
 import VolumeControl from '../ui/VolumeControl';
 import NetworkIndicator from '../ui/NetworkIndicator';
 import BatteryIndicator from '../ui/BatteryIndicator';
 
-export default function Status() {
+const FALLBACK_STATUS = {
+  online: true,
+  isOnlineSimulated: true,
+  batteryLevel: 0.75,
+  batteryCharging: true,
+  isBatterySimulated: true,
+};
+
+export default function Status({
+  status = FALLBACK_STATUS,
+  announcement = '',
+  announcementId = 0,
+  onBatteryLevelChange,
+  onBatteryChargingChange,
+}) {
   const { allowNetwork } = useSettings();
-  const [online, setOnline] = useState(true);
+  const resolvedStatus = {
+    ...FALLBACK_STATUS,
+    ...status,
+  };
 
-  useEffect(() => {
-    const pingServer = async () => {
-      if (!window?.location) return;
-      try {
-        const url = new URL('/favicon.ico', window.location.href).toString();
-        await fetch(url, { method: 'HEAD', cache: 'no-store' });
-        setOnline(true);
-      } catch (e) {
-        setOnline(false);
-      }
-    };
-
-    const updateStatus = () => {
-      const isOnline = navigator.onLine;
-      setOnline(isOnline);
-      if (isOnline) {
-        pingServer();
-      }
-    };
-
-    updateStatus();
-    window.addEventListener('online', updateStatus);
-    window.addEventListener('offline', updateStatus);
-    return () => {
-      window.removeEventListener('online', updateStatus);
-      window.removeEventListener('offline', updateStatus);
-    };
-  }, []);
+  const networkHint = resolvedStatus.isOnlineSimulated
+    ? 'Simulated network status'
+    : 'Live network status';
+  const batteryHint = resolvedStatus.isBatterySimulated
+    ? 'Simulated battery level'
+    : 'Live battery level';
 
   return (
     <div className="flex justify-center items-center">
       <NetworkIndicator
         className="mx-1.5"
         allowNetwork={allowNetwork}
-        online={online}
+        online={resolvedStatus.online}
+        simulationHint={networkHint}
       />
       <VolumeControl className="mx-1.5" />
-      <BatteryIndicator className="mx-1.5" />
+      <BatteryIndicator
+        className="mx-1.5"
+        level={resolvedStatus.batteryLevel}
+        charging={resolvedStatus.batteryCharging}
+        isSimulated={resolvedStatus.isBatterySimulated}
+        simulationHint={batteryHint}
+        onLevelChange={onBatteryLevelChange}
+        onChargingChange={onBatteryChargingChange}
+      />
       <span className="mx-1">
         <SmallArrow angle="down" className=" status-symbol" />
+      </span>
+      <span key={announcementId} className="sr-only" aria-live="polite" aria-atomic="true">
+        {announcement}
       </span>
     </div>
   );


### PR DESCRIPTION
## Summary
- add simulated network and battery status tracking to the navbar and announce updates for assistive tech
- pass status details through Status, NetworkIndicator, BatteryIndicator, and QuickSettings to surface tooltips and simulation toggles
- extend tests to accommodate the new props by adding display names to mocked components

## Testing
- yarn lint
- yarn test --runTestsByPath __tests__/navbar-running-apps.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd8da3393c8328963f1d5aa380c368