### PR TITLE
[shell] add persistent quick settings flyout

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,37 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock', () => {
+  const MockClock = () => <div data-testid="clock" />;
+  MockClock.displayName = 'MockClock';
+  return MockClock;
+});
+
+jest.mock('../components/util-components/status', () => {
+  const MockStatus = () => <div data-testid="status" />;
+  MockStatus.displayName = 'MockStatus';
+  return MockStatus;
+});
+
+jest.mock('../components/ui/QuickSettings', () => {
+  const MockQuickSettings = ({ open }: { open: boolean }) => (
+    <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
+  );
+  MockQuickSettings.displayName = 'MockQuickSettings';
+  return MockQuickSettings;
+});
+
+jest.mock('../components/menu/WhiskerMenu', () => {
+  const MockWhisker = () => <button type="button">Menu</button>;
+  MockWhisker.displayName = 'MockWhiskerMenu';
+  return MockWhisker;
+});
+
+jest.mock('../components/ui/PerformanceGraph', () => {
+  const MockPerformance = () => <div data-testid="performance" />;
+  MockPerformance.displayName = 'MockPerformanceGraph';
+  return MockPerformance;
+});
 
 const workspaceEventDetail = {
   workspaces: [

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -22,11 +22,34 @@
   --color-control-accent: var(--color-accent);
   --kali-text: #f5f5f5;
   accent-color: var(--color-control-accent);
+  --screen-brightness: 100;
+  --system-volume: 100;
 }
 
 body {
   background: var(--kali-bg);
   color: var(--kali-text);
+  filter: brightness(calc(var(--screen-brightness, 100) * 1%));
+  transition: filter var(--motion-medium, 300ms) ease;
+}
+
+body.muted {
+  --system-volume: 0;
+}
+
+/* Light theme */
+html[data-theme='light'] {
+  --color-bg: #0f1317;
+  --color-text: #f5f5f5;
+  --color-primary: #1793d1;
+  --color-secondary: #1a1f26;
+  --color-accent: #1793d1;
+  --color-muted: #2a2e36;
+  --color-surface: #1a1f26;
+  --color-inverse: #000000;
+  --color-border: #2a2e36;
+  --color-terminal: #00ff00;
+  --color-dark: #0c0f12;
 }
 
 /* Dark theme */


### PR DESCRIPTION
## Summary
- add a client quick settings flyout in the navbar with brightness, volume, and theme controls backed by persistent storage
- propagate the selected settings across the shell via CSS variables, data attributes, and class toggles for brightness, volume, and high-contrast modes
- update navbar test mocks with display names to satisfy lint rules after the flyout changes

## Testing
- yarn lint


------
https://chatgpt.com/codex/tasks/task_e_68dd8da53acc8328a6816aea4825b29b