### PR TITLE
[desktop] Cache window switcher thumbnails

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,33 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock', () => {
+  const MockClock = () => <div data-testid="clock" />;
+  MockClock.displayName = 'MockClock';
+  return MockClock;
+});
+jest.mock('../components/util-components/status', () => {
+  const MockStatus = () => <div data-testid="status" />;
+  MockStatus.displayName = 'MockStatus';
+  return MockStatus;
+});
+jest.mock('../components/ui/QuickSettings', () => {
+  const MockQuickSettings = ({ open }: { open: boolean }) => (
+    <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
+  );
+  MockQuickSettings.displayName = 'MockQuickSettings';
+  return MockQuickSettings;
+});
+jest.mock('../components/menu/WhiskerMenu', () => {
+  const MockWhiskerMenu = () => <button type="button">Menu</button>;
+  MockWhiskerMenu.displayName = 'MockWhiskerMenu';
+  return MockWhiskerMenu;
+});
+jest.mock('../components/ui/PerformanceGraph', () => {
+  const MockPerformanceGraph = () => <div data-testid="performance" />;
+  MockPerformanceGraph.displayName = 'MockPerformanceGraph';
+  return MockPerformanceGraph;
+});
 
 const workspaceEventDetail = {
   workspaces: [

--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -1,13 +1,98 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ensureWindowThumbnail,
+  getWindowThumbnail,
+  subscribeWindowThumbnail,
+} from '../../utils/windowThumbnails';
+
+function useWindowThumbnail(windowId) {
+  const [snapshot, setSnapshot] = useState(() =>
+    windowId ? getWindowThumbnail(windowId) : null
+  );
+
+  useEffect(() => {
+    if (!windowId) return undefined;
+    setSnapshot(getWindowThumbnail(windowId));
+    return subscribeWindowThumbnail(windowId, setSnapshot);
+  }, [windowId]);
+
+  return snapshot;
+}
+
+function WindowThumbnail({ windowId, icon, title }) {
+  const canvasRef = useRef(null);
+  const snapshot = useWindowThumbnail(windowId);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const context = canvas.getContext('2d');
+    if (!context) return;
+    if (!snapshot || !snapshot.bitmap) {
+      context.clearRect(0, 0, canvas.width, canvas.height);
+      canvas.width = 0;
+      canvas.height = 0;
+      return;
+    }
+    canvas.width = snapshot.width;
+    canvas.height = snapshot.height;
+    context.clearRect(0, 0, snapshot.width, snapshot.height);
+    context.drawImage(snapshot.bitmap, 0, 0, snapshot.width, snapshot.height);
+  }, [snapshot]);
+
+  return (
+    <div className="relative flex aspect-video items-center justify-center overflow-hidden rounded-md bg-black bg-opacity-40">
+      <canvas
+        ref={canvasRef}
+        aria-hidden="true"
+        className={`h-full w-full object-cover transition-opacity duration-150 ${
+          snapshot && snapshot.bitmap ? 'opacity-100' : 'opacity-0'
+        }`}
+      />
+      {!(snapshot && snapshot.bitmap) && (
+        <div className="flex h-full w-full items-center justify-center text-center text-sm text-white text-opacity-80">
+          {icon ? (
+            <img
+              src={icon}
+              alt=""
+              className="h-12 w-12"
+              aria-hidden="true"
+            />
+          ) : (
+            <span>{title}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(0);
   const inputRef = useRef(null);
 
-  const filtered = windows.filter((w) =>
-    w.title.toLowerCase().includes(query.toLowerCase())
+  const filtered = useMemo(
+    () =>
+      windows.filter((w) =>
+        w.title.toLowerCase().includes(query.toLowerCase())
+      ),
+    [query, windows]
   );
+
+  useEffect(() => {
+    windows.forEach((win) => ensureWindowThumbnail(win.id));
+  }, [windows]);
+
+  useEffect(() => {
+    if (filtered.length === 0) {
+      setSelected(0);
+      return;
+    }
+    if (selected >= filtered.length) {
+      setSelected(filtered.length - 1);
+    }
+  }, [filtered, selected]);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -48,6 +133,12 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
     } else if (e.key === 'Escape') {
       e.preventDefault();
       if (typeof onClose === 'function') onClose();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const win = filtered[selected];
+      if (win && typeof onSelect === 'function') {
+        onSelect(win.id);
+      }
     }
   };
 
@@ -56,27 +147,55 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
     setSelected(0);
   };
 
+  const handleItemFocus = (index) => {
+    setSelected(index);
+  };
+
+  const handleItemSelect = (win) => {
+    if (typeof onSelect === 'function') {
+      onSelect(win.id);
+    }
+  };
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 text-white">
-      <div className="bg-ub-grey p-4 rounded w-3/4 md:w-1/3">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 px-4 py-6 text-white">
+      <div className="w-full max-w-5xl rounded-lg bg-ub-grey/95 p-4 shadow-2xl">
         <input
           ref={inputRef}
           value={query}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
+          className="mb-4 w-full rounded-md bg-black bg-opacity-30 px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ub-orange"
           placeholder="Search windows"
+          aria-label="Search open windows"
         />
-        <ul>
-          {filtered.map((w, i) => (
-            <li
-              key={w.id}
-              className={`px-2 py-1 rounded ${i === selected ? 'bg-ub-orange text-black' : ''}`}
-            >
-              {w.title}
-            </li>
-          ))}
-        </ul>
+        {filtered.length === 0 ? (
+          <p className="text-sm text-white text-opacity-70">No windows match your search.</p>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {filtered.map((win, index) => (
+              <button
+                key={win.id}
+                type="button"
+                onClick={() => handleItemSelect(win)}
+                onMouseEnter={() => handleItemFocus(index)}
+                onFocus={() => handleItemFocus(index)}
+                className={`flex flex-col rounded-lg border border-transparent bg-black bg-opacity-20 p-3 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-ub-orange ${
+                  index === selected
+                    ? 'border-ub-orange bg-black bg-opacity-40 text-white'
+                    : 'hover:border-white/40 hover:bg-black hover:bg-opacity-30'
+                }`}
+                aria-pressed={index === selected}
+              >
+                <WindowThumbnail windowId={win.id} icon={win.icon} title={win.title} />
+                <div className="mt-3 flex items-center justify-between">
+                  <span className="truncate text-sm font-semibold">{win.title}</span>
+                  <span className="ml-2 text-xs uppercase text-white text-opacity-60">{win.id}</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/utils/windowThumbnails.js
+++ b/utils/windowThumbnails.js
@@ -1,0 +1,196 @@
+const cache = new Map();
+const listeners = new Map();
+const pendingCaptures = new Map();
+
+const getWindowObject = () => (typeof window !== 'undefined' ? window : null);
+
+const requestIdle = (cb) => {
+  const win = getWindowObject();
+  if (!win) return null;
+  if (typeof win.requestIdleCallback === 'function') {
+    return win.requestIdleCallback(cb, { timeout: 1000 });
+  }
+  return win.setTimeout(() => {
+    cb({ didTimeout: false, timeRemaining: () => 0 });
+  }, 120);
+};
+
+const cancelIdle = (handle) => {
+  const win = getWindowObject();
+  if (!win || handle == null) return;
+  if (typeof win.cancelIdleCallback === 'function') {
+    win.cancelIdleCallback(handle);
+  } else {
+    win.clearTimeout(handle);
+  }
+};
+
+const disposeBitmap = (entry) => {
+  if (entry && entry.bitmap && typeof entry.bitmap.close === 'function') {
+    try {
+      entry.bitmap.close();
+    } catch (e) {
+      // ignore
+    }
+  }
+};
+
+const notify = (id) => {
+  const callbacks = listeners.get(id);
+  if (!callbacks) return;
+  const snapshot = cache.get(id) || null;
+  callbacks.forEach((callback) => {
+    try {
+      callback(snapshot);
+    } catch (e) {
+      // ignore listener errors
+    }
+  });
+};
+
+const MAX_DIMENSION = 320;
+
+export const getWindowThumbnail = (id) => cache.get(id) || null;
+
+export const subscribeWindowThumbnail = (id, callback) => {
+  if (!listeners.has(id)) {
+    listeners.set(id, new Set());
+  }
+  const callbacks = listeners.get(id);
+  callbacks.add(callback);
+  return () => {
+    const current = listeners.get(id);
+    if (!current) return;
+    current.delete(callback);
+    if (current.size === 0) {
+      listeners.delete(id);
+    }
+  };
+};
+
+const scheduleCapture = (id, element, force = false) => {
+  if (!element || typeof element !== 'object') return;
+  const win = getWindowObject();
+  if (!win) return;
+  if (pendingCaptures.has(id)) {
+    cancelIdle(pendingCaptures.get(id));
+    pendingCaptures.delete(id);
+  }
+  const handle = requestIdle(async () => {
+    pendingCaptures.delete(id);
+    if (!element.isConnected) return;
+    if (typeof element.getBoundingClientRect === 'function') {
+      const rect = element.getBoundingClientRect();
+      if (!rect.width || !rect.height) {
+        return;
+      }
+    }
+    const existing = cache.get(id);
+    if (existing && !force && !existing.stale) {
+      return;
+    }
+    try {
+      const { toCanvas } = await import('html-to-image');
+      const pixelRatio = Math.min(win.devicePixelRatio || 1, 1.5);
+      const baseCanvas = await toCanvas(element, {
+        cacheBust: false,
+        skipFonts: false,
+        pixelRatio,
+      });
+      const width = baseCanvas.width;
+      const height = baseCanvas.height;
+      if (!width || !height) {
+        return;
+      }
+      const maxSourceDimension = Math.max(width, height);
+      const scale = maxSourceDimension > MAX_DIMENSION
+        ? MAX_DIMENSION / maxSourceDimension
+        : 1;
+      const targetWidth = Math.max(1, Math.round(width * scale));
+      const targetHeight = Math.max(1, Math.round(height * scale));
+      let bitmapSource = baseCanvas;
+      if (scale !== 1) {
+        const doc = win.document;
+        if (!doc) {
+          return;
+        }
+        const scaledCanvas = doc.createElement('canvas');
+        scaledCanvas.width = targetWidth;
+        scaledCanvas.height = targetHeight;
+        const ctx = scaledCanvas.getContext('2d');
+        if (!ctx) {
+          return;
+        }
+        ctx.drawImage(baseCanvas, 0, 0, targetWidth, targetHeight);
+        bitmapSource = scaledCanvas;
+      }
+      if (typeof win.createImageBitmap !== 'function') {
+        return;
+      }
+      const bitmap = await win.createImageBitmap(bitmapSource, 0, 0, targetWidth, targetHeight);
+      const entry = {
+        bitmap,
+        width: targetWidth,
+        height: targetHeight,
+        updatedAt: Date.now(),
+        stale: false,
+      };
+      if (existing) {
+        disposeBitmap(existing);
+      }
+      cache.set(id, entry);
+      notify(id);
+    } catch (error) {
+      // ignore capture errors
+    }
+  });
+  if (handle != null) {
+    pendingCaptures.set(id, handle);
+  }
+};
+
+export const queueWindowThumbnailCapture = (id, element, options = {}) => {
+  if (!id || !element) return;
+  scheduleCapture(id, element, options.force === true);
+};
+
+export const invalidateWindowThumbnail = (id) => {
+  if (!id) return;
+  const entry = cache.get(id);
+  if (entry) {
+    entry.stale = true;
+    cache.set(id, entry);
+    notify(id);
+  }
+};
+
+export const removeWindowThumbnail = (id) => {
+  if (!id) return;
+  const existing = cache.get(id);
+  if (existing) {
+    disposeBitmap(existing);
+    cache.delete(id);
+    notify(id);
+  }
+  if (pendingCaptures.has(id)) {
+    cancelIdle(pendingCaptures.get(id));
+    pendingCaptures.delete(id);
+  }
+};
+
+export const ensureWindowThumbnail = (id) => {
+  if (!id) return;
+  if (cache.has(id) && !cache.get(id)?.stale) {
+    return;
+  }
+  const win = getWindowObject();
+  if (!win) return;
+  const element = win.document ? win.document.getElementById(id) : null;
+  if (element) {
+    scheduleCapture(id, element, true);
+  }
+};
+
+export const clearWindowThumbnails = () => {
+  Array.from(cache.keys()).forEach((id) => removeWindowThumbnail(id));
+};


### PR DESCRIPTION
## Summary
- add a shared imageBitmap cache and idle capture pipeline for window previews
- render cached thumbnails in the window switcher with refreshed layout and keyboard support
- update navbar mocks to satisfy linting in the affected test suite

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dd8da7bc408328b4c6d30bb623a126