### PR TITLE
[desktop] Improve Alt+Tab switcher keyboard flow

### DIFF
--- a/components/screen/window-switcher.js
+++ b/components/screen/window-switcher.js
@@ -1,59 +1,170 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 
 export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(0);
   const inputRef = useRef(null);
+  const filteredRef = useRef([]);
+  const selectedRef = useRef(0);
+  const closedRef = useRef(false);
 
-  const filtered = windows.filter((w) =>
-    w.title.toLowerCase().includes(query.toLowerCase())
+  const filtered = useMemo(
+    () => windows.filter((w) => w.title.toLowerCase().includes(query.toLowerCase())),
+    [windows, query]
+  );
+
+  filteredRef.current = filtered;
+
+  useEffect(() => {
+    const len = filtered.length;
+    if (!len && selected !== 0) {
+      setSelected(0);
+      selectedRef.current = 0;
+      return;
+    }
+    if (len && selected >= len) {
+      const next = len - 1;
+      setSelected(next);
+      selectedRef.current = next;
+    }
+  }, [filtered, selected]);
+
+  useEffect(() => {
+    selectedRef.current = selected;
+  }, [selected]);
+
+  useEffect(() => {
+    closedRef.current = false;
+    inputRef.current?.focus();
+    return () => {
+      closedRef.current = true;
+    };
+  }, []);
+
+  const close = useCallback(() => {
+    if (closedRef.current) return;
+    closedRef.current = true;
+    setQuery('');
+    setSelected(0);
+    selectedRef.current = 0;
+    if (typeof onClose === 'function') {
+      onClose();
+    }
+  }, [onClose]);
+
+  const commitSelection = useCallback(() => {
+    if (closedRef.current) return;
+    const current = filteredRef.current;
+    const win = current[selectedRef.current];
+    closedRef.current = true;
+    setQuery('');
+    setSelected(0);
+    selectedRef.current = 0;
+    if (win && typeof onSelect === 'function') {
+      onSelect(win.id);
+    } else if (typeof onClose === 'function') {
+      onClose();
+    }
+  }, [onSelect, onClose]);
+
+  const updateSelected = useCallback((updater) => {
+    setSelected((prev) => {
+      const len = filteredRef.current.length;
+      const next = updater(prev, len);
+      selectedRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const cycleSelection = useCallback(
+    (direction) => {
+      updateSelected((prev, len) => {
+        if (!len) return 0;
+        return (prev + direction + len) % len;
+      });
+    },
+    [updateSelected]
+  );
+
+  const moveSelection = useCallback(
+    (direction) => {
+      updateSelected((prev, len) => {
+        if (!len) return 0;
+        const next = prev + direction;
+        if (next < 0) return len - 1;
+        if (next >= len) return 0;
+        return next;
+      });
+    },
+    [updateSelected]
   );
 
   useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
+    const handleKeyDown = (e) => {
+      if (closedRef.current) return;
 
-  useEffect(() => {
-    const handleKeyUp = (e) => {
       if (e.key === 'Alt') {
-        const win = filtered[selected];
-        if (win && typeof onSelect === 'function') {
-          onSelect(win.id);
-        } else if (typeof onClose === 'function') {
-          onClose();
-        }
+        return;
+      }
+
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+        return;
+      }
+
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        cycleSelection(e.shiftKey ? -1 : 1);
+        return;
+      }
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        moveSelection(1);
+        return;
+      }
+
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        moveSelection(-1);
+        return;
+      }
+
+      if (e.altKey && (e.key === 'Backspace' || e.key === 'Delete')) {
+        e.preventDefault();
+        setQuery((prev) => prev.slice(0, -1));
+        updateSelected(() => 0);
+        return;
+      }
+
+      if (e.altKey && e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        const nextChar = e.key === ' ' ? ' ' : e.key;
+        setQuery((prev) => `${prev}${nextChar}`);
+        updateSelected(() => 0);
       }
     };
-    window.addEventListener('keyup', handleKeyUp);
-    return () => window.removeEventListener('keyup', handleKeyUp);
-  }, [filtered, selected, onSelect, onClose]);
 
-  const handleKeyDown = (e) => {
-    if (e.key === 'Tab') {
-      e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      const dir = e.shiftKey ? -1 : 1;
-      setSelected((selected + dir + len) % len);
-    } else if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      setSelected((selected + 1) % len);
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      const len = filtered.length;
-      if (!len) return;
-      setSelected((selected - 1 + len) % len);
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      if (typeof onClose === 'function') onClose();
-    }
-  };
+    const handleKeyUp = (e) => {
+      if (closedRef.current) return;
+      if (e.key === 'Alt') {
+        e.preventDefault();
+        commitSelection();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [close, cycleSelection, moveSelection, commitSelection, updateSelected]);
 
   const handleChange = (e) => {
     setQuery(e.target.value);
-    setSelected(0);
+    updateSelected(() => 0);
   };
 
   return (
@@ -63,7 +174,7 @@ export default function WindowSwitcher({ windows = [], onSelect, onClose }) {
           ref={inputRef}
           value={query}
           onChange={handleChange}
-          onKeyDown={handleKeyDown}
+          aria-label="Search windows"
           className="w-full mb-4 px-2 py-1 rounded bg-black bg-opacity-20 focus:outline-none"
           placeholder="Search windows"
         />


### PR DESCRIPTION
## Summary
- rewrite the window switcher overlay keyboard handling to keep it open while Alt is held
- allow Alt-modified typing to filter windows, clamp selection safely, and clear the query on close
- ensure Escape dismisses without selection and commit the highlighted window on modifier release

## Testing
- yarn lint *(fails: react/display-name errors in __tests__/navbar-running-apps.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8da5c1e08328b454a8f11539ad3d