### PR TITLE
[contact] Dim wallpaper when form focused

### DIFF
--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import FormError from "../../components/ui/FormError";
 import Toast from "../../components/ui/Toast";
 import { processContactForm } from "../../components/apps/contact";
@@ -8,6 +8,7 @@ import { contactSchema } from "../../utils/contactSchema";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openMailto } from "../../utils/mailto";
 import { trackEvent } from "@/lib/analytics-client";
+import { useWallpaperDimmer } from "@/hooks/useWallpaperDimmer";
 
 const DRAFT_KEY = "contact-draft";
 const EMAIL = "alex.unnippillil@hotmail.com";
@@ -34,6 +35,25 @@ const ContactApp: React.FC = () => {
   const [submitting, setSubmitting] = useState(false);
   const [emailError, setEmailError] = useState("");
   const [messageError, setMessageError] = useState("");
+  const { dimWallpaper, restoreWallpaper } = useWallpaperDimmer();
+
+  const handleFormFocus = useCallback(() => {
+    dimWallpaper();
+  }, [dimWallpaper]);
+
+  const handleFormBlur = useCallback(
+    (event: React.FocusEvent<HTMLFormElement>) => {
+      const nextTarget = event.relatedTarget as Node | null;
+      if (!event.currentTarget.contains(nextTarget)) {
+        restoreWallpaper();
+      }
+    },
+    [restoreWallpaper],
+  );
+
+  useEffect(() => () => {
+    restoreWallpaper();
+  }, [restoreWallpaper]);
 
   useEffect(() => {
     const saved = localStorage.getItem(DRAFT_KEY);
@@ -139,7 +159,12 @@ const ContactApp: React.FC = () => {
           Open email app
         </button>
       </p>
-      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-4 max-w-md"
+        onFocusCapture={handleFormFocus}
+        onBlurCapture={handleFormBlur}
+      >
         <div>
           <label
             htmlFor="contact-name"

--- a/hooks/useWallpaperDimmer.ts
+++ b/hooks/useWallpaperDimmer.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const WALLPAPER_DIM_CLASS = 'wallpaper-dimmed';
+let activeDimRequests = 0;
+
+const getRootElement = () =>
+  typeof document === 'undefined' ? null : document.documentElement;
+
+const applyDimClass = () => {
+  const root = getRootElement();
+  if (!root) return;
+  root.classList.add(WALLPAPER_DIM_CLASS);
+};
+
+const removeDimClass = () => {
+  const root = getRootElement();
+  if (!root) return;
+  root.classList.remove(WALLPAPER_DIM_CLASS);
+};
+
+export function useWallpaperDimmer() {
+  const hasActiveRequest = useRef(false);
+
+  const dimWallpaper = useCallback(() => {
+    if (hasActiveRequest.current) return;
+    const root = getRootElement();
+    if (!root) return;
+
+    hasActiveRequest.current = true;
+    activeDimRequests += 1;
+    if (activeDimRequests === 1) {
+      applyDimClass();
+    }
+  }, []);
+
+  const restoreWallpaper = useCallback(() => {
+    if (!hasActiveRequest.current) return;
+    if (activeDimRequests === 0) {
+      hasActiveRequest.current = false;
+      return;
+    }
+
+    hasActiveRequest.current = false;
+    activeDimRequests = Math.max(0, activeDimRequests - 1);
+    if (activeDimRequests === 0) {
+      removeDimClass();
+    }
+  }, []);
+
+  useEffect(() => () => {
+    if (!hasActiveRequest.current) return;
+    hasActiveRequest.current = false;
+    activeDimRequests = Math.max(0, activeDimRequests - 1);
+    if (activeDimRequests === 0) {
+      removeDimClass();
+    }
+  }, []);
+
+  return {
+    dimWallpaper,
+    restoreWallpaper,
+  };
+}
+
+export default useWallpaperDimmer;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -99,3 +99,18 @@ html {
   background-color: var(--kali-border, var(--color-border));
   border-radius: 6px;
 }
+
+.bg-ubuntu-img {
+  transition: opacity 240ms ease, filter 240ms ease;
+}
+
+html.wallpaper-dimmed .bg-ubuntu-img {
+  opacity: 0.75;
+  filter: brightness(0.8);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bg-ubuntu-img {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable wallpaper dimmer hook to toggle a shared CSS class
- dim the desktop wallpaper while the contact form owns focus and restore it on blur
- animate the wallpaper brightness change while honoring prefers-reduced-motion

## Testing
- yarn lint *(fails: pre-existing react/display-name errors in __tests__/navbar-running-apps.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8dac24288328a1afa2162afe9bc7