### PR TITLE
[desktop] add taskbar pinning and app visibility controls

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,33 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock', () => {
+  const MockClock = () => <div data-testid="clock" />;
+  MockClock.displayName = 'MockClock';
+  return MockClock;
+});
+jest.mock('../components/util-components/status', () => {
+  const MockStatus = () => <div data-testid="status" />;
+  MockStatus.displayName = 'MockStatus';
+  return MockStatus;
+});
+jest.mock('../components/ui/QuickSettings', () => {
+  const MockQuickSettings = ({ open }: { open: boolean }) => (
+    <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
+  );
+  MockQuickSettings.displayName = 'MockQuickSettings';
+  return MockQuickSettings;
+});
+jest.mock('../components/menu/WhiskerMenu', () => {
+  const MockMenu = () => <button type="button">Menu</button>;
+  MockMenu.displayName = 'MockWhiskerMenu';
+  return MockMenu;
+});
+jest.mock('../components/ui/PerformanceGraph', () => {
+  const MockPerformanceGraph = () => <div data-testid="performance" />;
+  MockPerformanceGraph.displayName = 'MockPerformanceGraph';
+  return MockPerformanceGraph;
+});
 
 const workspaceEventDetail = {
   workspaces: [

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -21,6 +21,22 @@ function AppMenu(props) {
         }
     }
 
+    const handleTaskbarPin = () => {
+        if (props.taskbarPinned) {
+            props.unpinFromTaskbar && props.unpinFromTaskbar()
+        } else {
+            props.pinToTaskbar && props.pinToTaskbar()
+        }
+    }
+
+    const handleVisibilityToggle = () => {
+        if (props.isHidden) {
+            props.restoreApp && props.restoreApp()
+        } else {
+            props.removeApp && props.removeApp()
+        }
+    }
+
     return (
         <div
             id="app-menu"
@@ -38,6 +54,24 @@ function AppMenu(props) {
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
                 <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
+            </button>
+            <button
+                type="button"
+                onClick={handleTaskbarPin}
+                role="menuitem"
+                aria-label={props.taskbarPinned ? 'Unpin from Taskbar' : 'Pin to Taskbar'}
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">{props.taskbarPinned ? 'Unpin from Taskbar' : 'Pin to Taskbar'}</span>
+            </button>
+            <button
+                type="button"
+                onClick={handleVisibilityToggle}
+                role="menuitem"
+                aria-label={props.isHidden ? 'Restore application to list' : 'Remove application from list'}
+                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
+            >
+                <span className="ml-5">{props.isHidden ? 'Restore to List' : 'Remove from List'}</span>
             </button>
         </div>
     )


### PR DESCRIPTION
## Summary
- add pin-to-taskbar and remove/restore actions to the app context menu
- persist taskbar and hidden-app state in the desktop shell and surface pinned entries on the taskbar UI
- hide removed apps across launchers while providing restoration flows in the All Apps overlay and Settings

## Testing
- yarn lint
- yarn test --watch=false *(fails: multiple pre-existing suite issues; see console output for details)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8db18c4c83288fb0ffda58a7f0de