### PR TITLE
[desktop] Add milestone-driven boot progress

### DIFF
--- a/components/screen/booting_screen.js
+++ b/components/screen/booting_screen.js
@@ -1,14 +1,29 @@
 import React from 'react'
 import Image from 'next/image'
 
-const bootMessages = [
-    'Securing environment',
-    'Loading offensive simulations',
-    'Calibrating desktop widgets',
+const defaultBootMessages = [
+    {
+        id: 'boot-default-1',
+        label: 'Securing environment',
+        status: 'pending',
+    },
+    {
+        id: 'boot-default-2',
+        label: 'Loading offensive simulations',
+        status: 'pending',
+    },
+    {
+        id: 'boot-default-3',
+        label: 'Calibrating desktop widgets',
+        status: 'pending',
+    },
 ]
 
 function BootingScreen(props) {
     const isVisible = props.visible || props.isShutDown
+    const steps = props.progressSteps && props.progressSteps.length > 0 ? props.progressSteps : defaultBootMessages
+    const completedSteps = steps.filter((step) => step.status === 'complete')
+    const latestAnnouncement = completedSteps.length > 0 ? completedSteps[completedSteps.length - 1]?.label : undefined
 
     return (
         <div
@@ -66,14 +81,40 @@ function BootingScreen(props) {
                         )}
                     </button>
 
-                    <ul className="flex flex-col gap-2 text-sm text-slate-300">
-                        {bootMessages.map((message) => (
-                            <li key={message} className="flex items-center gap-3">
-                                <span className="inline-flex h-2 w-2 rounded-full bg-sky-400/70 shadow-[0_0_12px_rgba(56,189,248,0.7)] animate-[pulse_2s_ease-in-out_infinite]" aria-hidden />
-                                <span>{message}</span>
-                            </li>
-                        ))}
-                    </ul>
+                    <div className="flex flex-col gap-2 text-sm text-slate-300" aria-live="polite">
+                        {latestAnnouncement ? <span className="sr-only">{latestAnnouncement}</span> : null}
+                        <ul className="flex flex-col gap-2 text-sm text-slate-300">
+                            {steps.map((step) => {
+                                const isComplete = step.status === 'complete'
+                                return (
+                                    <li key={step.id} className="flex items-center gap-3">
+                                        <span
+                                            className={`inline-flex h-3 w-3 items-center justify-center rounded-full border border-sky-400/70 transition ${
+                                                isComplete
+                                                    ? 'bg-sky-400/80 text-slate-900'
+                                                    : 'border-dashed border-sky-400/40 text-slate-400'
+                                            }`}
+                                            aria-hidden
+                                        >
+                                            {isComplete ? (
+                                                <svg viewBox="0 0 20 20" className="h-2.5 w-2.5" focusable="false" aria-hidden>
+                                                    <path
+                                                        d="M5 10.5l3 3 7-7"
+                                                        fill="none"
+                                                        stroke="currentColor"
+                                                        strokeWidth="2"
+                                                        strokeLinecap="round"
+                                                        strokeLinejoin="round"
+                                                    />
+                                                </svg>
+                                            ) : null}
+                                        </span>
+                                        <span className={isComplete ? 'text-slate-100' : 'text-slate-400'}>{step.label}</span>
+                                    </li>
+                                )
+                            })}
+                        </ul>
+                    </div>
                 </div>
 
                 <div className="relative mb-6 flex gap-4 text-xs uppercase tracking-[0.4em] text-slate-500">

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -8,128 +8,271 @@ import Navbar from './screen/navbar';
 import Layout from './desktop/Layout';
 import ReactGA from 'react-ga4';
 import { safeLocalStorage } from '../utils/safeStorage';
+import { loadAppRegistry } from '../lib/appRegistry';
+
+const BOOT_PROGRESS_TEMPLATE = [
+  { id: 'fonts', label: 'Loading system fonts', status: 'pending' },
+  { id: 'window', label: 'Finalizing desktop environment', status: 'pending' },
+  { id: 'apps', label: 'Preparing app catalog', status: 'pending' },
+];
+
+const cloneBootProgress = () => BOOT_PROGRESS_TEMPLATE.map((step) => ({ ...step }));
+
+const getNow = () =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+
+const waitForFontsReady = () => {
+  if (typeof document === 'undefined') {
+    return Promise.resolve();
+  }
+  const fontSet = document.fonts;
+  if (!fontSet) {
+    return Promise.resolve();
+  }
+  if (fontSet.status === 'loaded') {
+    return Promise.resolve();
+  }
+  return fontSet.ready.catch(() => undefined);
+};
+
+const waitForWindowLoad = () =>
+  new Promise((resolve) => {
+    if (typeof window === 'undefined') {
+      resolve();
+      return;
+    }
+    if (document.readyState === 'complete') {
+      resolve();
+      return;
+    }
+    const handler = () => {
+      window.removeEventListener('load', handler);
+      resolve();
+    };
+    window.addEventListener('load', handler, { once: true });
+  });
+
+let sharedAppRegistryPromise;
+
+const waitForAppRegistry = () => {
+  if (!sharedAppRegistryPromise) {
+    sharedAppRegistryPromise = loadAppRegistry().catch((error) => {
+      console.error('Failed to preload app registry', error);
+      return null;
+    });
+  }
+  return sharedAppRegistryPromise.then(() => undefined);
+};
 
 export default class Ubuntu extends Component {
-	constructor() {
-		super();
-		this.state = {
-			screen_locked: false,
-			bg_image_name: 'wall-2',
-			booting_screen: true,
-			shutDownScreen: false
-		};
-	}
+  constructor() {
+    super();
+    this.state = {
+      screen_locked: false,
+      bg_image_name: 'wall-2',
+      booting_screen: true,
+      shutDownScreen: false,
+      bootProgress: cloneBootProgress(),
+    };
+    this.bootHideTimer = null;
+    this.unmounted = false;
+  }
 
-	componentDidMount() {
-		this.getLocalData();
-	}
+  componentDidMount() {
+    const localData = this.getLocalData();
+    this.setState(
+      {
+        bg_image_name: localData.bgImageName,
+        screen_locked: localData.screenLocked,
+        shutDownScreen: localData.wasShutDown,
+        bootProgress: cloneBootProgress(),
+      },
+      () => {
+        if (!localData.wasShutDown) {
+          this.startBootSequence({ warmBoot: localData.visitedBefore });
+        }
+      }
+    );
+  }
 
-	setTimeOutBootScreen = () => {
-		setTimeout(() => {
-			this.setState({ booting_screen: false });
-		}, 2000);
-	};
+  componentWillUnmount() {
+    this.unmounted = true;
+    if (this.bootHideTimer) {
+      clearTimeout(this.bootHideTimer);
+      this.bootHideTimer = null;
+    }
+  }
 
-	getLocalData = () => {
-		// Get Previously selected Background Image
-                let bg_image_name = safeLocalStorage?.getItem('bg-image');
-		if (bg_image_name !== null && bg_image_name !== undefined) {
-			this.setState({ bg_image_name });
-		}
+  getLocalData = () => {
+    let bgImageName = this.state.bg_image_name;
+    const storedBackground = safeLocalStorage?.getItem('bg-image');
+    if (storedBackground !== null && storedBackground !== undefined) {
+      bgImageName = storedBackground;
+    }
 
-                let booting_screen = safeLocalStorage?.getItem('booting_screen');
-		if (booting_screen !== null && booting_screen !== undefined) {
-			// user has visited site before
-			this.setState({ booting_screen: false });
-		} else {
-			// user is visiting site for the first time
-                        safeLocalStorage?.setItem('booting_screen', false);
-			this.setTimeOutBootScreen();
-		}
+    const bootingScreenFlag = safeLocalStorage?.getItem('booting_screen');
+    const visitedBefore = bootingScreenFlag !== null && bootingScreenFlag !== undefined;
+    if (!visitedBefore) {
+      safeLocalStorage?.setItem('booting_screen', 'false');
+    }
 
-		// get shutdown state
-                let shut_down = safeLocalStorage?.getItem('shut-down');
-		if (shut_down !== null && shut_down !== undefined && shut_down === 'true') this.shutDown();
-		else {
-			// Get previous lock screen state
-                        let screen_locked = safeLocalStorage?.getItem('screen-locked');
-			if (screen_locked !== null && screen_locked !== undefined) {
-				this.setState({ screen_locked: screen_locked === 'true' ? true : false });
-			}
-		}
-	};
+    const shutDown = safeLocalStorage?.getItem('shut-down');
+    const wasShutDown = shutDown !== null && shutDown !== undefined && shutDown === 'true';
 
-	lockScreen = () => {
-		// google analytics
-		ReactGA.send({ hitType: "pageview", page: "/lock-screen", title: "Lock Screen" });
-		ReactGA.event({
-			category: `Screen Change`,
-			action: `Set Screen to Locked`
-		});
+    let screenLocked = this.state.screen_locked;
+    if (!wasShutDown) {
+      const storedScreenLocked = safeLocalStorage?.getItem('screen-locked');
+      if (storedScreenLocked !== null && storedScreenLocked !== undefined) {
+        screenLocked = storedScreenLocked === 'true';
+      }
+    }
 
-                const statusBar = document.getElementById('status-bar');
-                // Consider using a React ref if the status bar element lives within this component tree
-                statusBar?.blur();
-		setTimeout(() => {
-			this.setState({ screen_locked: true });
-		}, 100); // waiting for all windows to close (transition-duration)
-                safeLocalStorage?.setItem('screen-locked', true);
-	};
+    return {
+      bgImageName,
+      screenLocked,
+      visitedBefore,
+      wasShutDown,
+    };
+  };
 
-	unLockScreen = () => {
-		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+  startBootSequence = async ({ warmBoot = false } = {}) => {
+    if (this.unmounted) {
+      return;
+    }
+    this.setState({ booting_screen: true, bootProgress: cloneBootProgress() });
 
-		window.removeEventListener('click', this.unLockScreen);
-		window.removeEventListener('keypress', this.unLockScreen);
+    const startTime = getNow();
+    const sequence = [
+      { id: 'fonts', waitFor: waitForFontsReady },
+      { id: 'window', waitFor: waitForWindowLoad },
+      { id: 'apps', waitFor: waitForAppRegistry },
+    ];
 
-		this.setState({ screen_locked: false });
-                safeLocalStorage?.setItem('screen-locked', false);
-	};
+    for (const step of sequence) {
+      try {
+        await step.waitFor();
+      } catch (error) {
+        console.error(`Boot step ${step.id} failed`, error);
+      } finally {
+        this.markBootStepComplete(step.id);
+      }
+    }
 
-	changeBackgroundImage = (img_name) => {
-		this.setState({ bg_image_name: img_name });
-                safeLocalStorage?.setItem('bg-image', img_name);
-	};
+    const elapsed = getNow() - startTime;
+    const minimumVisible = warmBoot ? 0 : 2000;
+    const remaining = Math.max(minimumVisible - elapsed, 0);
 
-	shutDown = () => {
-		ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
+    const finish = () => {
+      if (this.unmounted) {
+        return;
+      }
+      this.setState({ booting_screen: false });
+    };
 
-		ReactGA.event({
-			category: `Screen Change`,
-			action: `Switched off the Ubuntu`
-		});
+    if (remaining > 0) {
+      this.bootHideTimer = setTimeout(finish, remaining);
+    } else {
+      finish();
+    }
+  };
 
-                const statusBar = document.getElementById('status-bar');
-                // Consider using a React ref if the status bar element lives within this component tree
-                statusBar?.blur();
-		this.setState({ shutDownScreen: true });
-                safeLocalStorage?.setItem('shut-down', true);
-	};
+  markBootStepComplete = (id) => {
+    if (this.unmounted) {
+      return;
+    }
+    this.setState((prev) => ({
+      bootProgress: prev.bootProgress.map((step) =>
+        step.id === id
+          ? {
+              ...step,
+              status: 'complete',
+            }
+          : step
+      ),
+    }));
+  };
 
-	turnOn = () => {
-		ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+  lockScreen = () => {
+    // google analytics
+    ReactGA.send({ hitType: "pageview", page: "/lock-screen", title: "Lock Screen" });
+    ReactGA.event({
+      category: `Screen Change`,
+      action: `Set Screen to Locked`,
+    });
 
-		this.setState({ shutDownScreen: false, booting_screen: true });
-		this.setTimeOutBootScreen();
-                safeLocalStorage?.setItem('shut-down', false);
-	};
+    const statusBar = document.getElementById('status-bar');
+    // Consider using a React ref if the status bar element lives within this component tree
+    statusBar?.blur();
+    setTimeout(() => {
+      this.setState({ screen_locked: true });
+    }, 100); // waiting for all windows to close (transition-duration)
+    safeLocalStorage?.setItem('screen-locked', true);
+  };
 
-	render() {
-        return (
-                <Layout id="monitor-screen">
-                                <LockScreen
-                                        isLocked={this.state.screen_locked}
-                                        bgImgName={this.state.bg_image_name}
-                                        unLockScreen={this.unLockScreen}
-                                />
-				<BootingScreen
-					visible={this.state.booting_screen}
-					isShutDown={this.state.shutDownScreen}
-					turnOn={this.turnOn}
-				/>
-                                <Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
-                                <Desktop bg_image_name={this.state.bg_image_name} changeBackgroundImage={this.changeBackgroundImage} />
-                </Layout>
-        );
-	}
+  unLockScreen = () => {
+    ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+
+    window.removeEventListener('click', this.unLockScreen);
+    window.removeEventListener('keypress', this.unLockScreen);
+
+    this.setState({ screen_locked: false });
+    safeLocalStorage?.setItem('screen-locked', false);
+  };
+
+  changeBackgroundImage = (img_name) => {
+    this.setState({ bg_image_name: img_name });
+    safeLocalStorage?.setItem('bg-image', img_name);
+  };
+
+  shutDown = () => {
+    ReactGA.send({ hitType: "pageview", page: "/switch-off", title: "Custom Title" });
+
+    ReactGA.event({
+      category: `Screen Change`,
+      action: `Switched off the Ubuntu`,
+    });
+
+    const statusBar = document.getElementById('status-bar');
+    // Consider using a React ref if the status bar element lives within this component tree
+    statusBar?.blur();
+    this.setState({ shutDownScreen: true, bootProgress: cloneBootProgress() });
+    safeLocalStorage?.setItem('shut-down', 'true');
+  };
+
+  turnOn = () => {
+    ReactGA.send({ hitType: "pageview", page: "/desktop", title: "Custom Title" });
+
+    this.setState(
+      { shutDownScreen: false, booting_screen: true, bootProgress: cloneBootProgress() },
+      () => {
+        this.startBootSequence({ warmBoot: true });
+      }
+    );
+    safeLocalStorage?.setItem('shut-down', 'false');
+  };
+
+  render() {
+    return (
+      <Layout id="monitor-screen">
+        <LockScreen
+          isLocked={this.state.screen_locked}
+          bgImgName={this.state.bg_image_name}
+          unLockScreen={this.unLockScreen}
+        />
+        <BootingScreen
+          visible={this.state.booting_screen}
+          isShutDown={this.state.shutDownScreen}
+          turnOn={this.turnOn}
+          progressSteps={this.state.bootProgress}
+        />
+        <Navbar lockScreen={this.lockScreen} shutDown={this.shutDown} />
+        <Desktop
+          bg_image_name={this.state.bg_image_name}
+          changeBackgroundImage={this.changeBackgroundImage}
+        />
+      </Layout>
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- replace the boot overlay messages with a milestone list that marks each step as it finishes
- orchestrate boot completion via document.fonts, window load, and the app registry promise while keeping warm boots under two seconds
- reset boot progress when powering off so the UI reflects the next startup sequence

## Testing
- `yarn lint` *(fails: pre-existing display-name rule violations in __tests__/navbar-running-apps.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8db1ec208328843276450074ec8e