### PR TITLE
[notifications] aggregate notifications by app

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,31 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock', () =>
+  function MockClock() {
+    return <div data-testid="clock" />;
+  },
+);
+jest.mock('../components/util-components/status', () =>
+  function MockStatus() {
+    return <div data-testid="status" />;
+  },
+);
+jest.mock('../components/ui/QuickSettings', () =>
+  function MockQuickSettings({ open }: { open: boolean }) {
+    return <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>;
+  },
+);
+jest.mock('../components/menu/WhiskerMenu', () =>
+  function MockWhiskerMenu() {
+    return <button type="button">Menu</button>;
+  },
+);
+jest.mock('../components/ui/PerformanceGraph', () =>
+  function MockPerformanceGraph() {
+    return <div data-testid="performance" />;
+  },
+);
 
 const workspaceEventDetail = {
   workspaces: [


### PR DESCRIPTION
## Summary
- group notification items by application with collapsible headers that persist user state and mark items read when expanded
- add per-app clear actions and unread badges while keeping dismiss-all support
- name navbar test mocks to satisfy display name linting

## Testing
- [x] yarn lint
- [x] yarn test navbar-running-apps.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd8db4b5cc8328b6c6475b4fb30043