### PR TITLE
[notifications] Add quiet hours controls and toast muting

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,33 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock', () => {
+  const MockClock = () => <div data-testid="clock" />;
+  MockClock.displayName = 'MockClock';
+  return MockClock;
+});
+jest.mock('../components/util-components/status', () => {
+  const MockStatus = () => <div data-testid="status" />;
+  MockStatus.displayName = 'MockStatus';
+  return MockStatus;
+});
+jest.mock('../components/ui/QuickSettings', () => {
+  const MockQuickSettings = ({ open }: { open: boolean }) => (
+    <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
+  );
+  MockQuickSettings.displayName = 'MockQuickSettings';
+  return MockQuickSettings;
+});
+jest.mock('../components/menu/WhiskerMenu', () => {
+  const MockMenu = () => <button type="button">Menu</button>;
+  MockMenu.displayName = 'MockWhiskerMenu';
+  return MockMenu;
+});
+jest.mock('../components/ui/PerformanceGraph', () => {
+  const MockPerformance = () => <div data-testid="performance" />;
+  MockPerformance.displayName = 'MockPerformanceGraph';
+  return MockPerformance;
+});
 
 const workspaceEventDetail = {
   workspaces: [

--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -8,6 +8,7 @@ import { contactSchema } from "../../utils/contactSchema";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openMailto } from "../../utils/mailto";
 import { trackEvent } from "@/lib/analytics-client";
+import { useToastNotifications } from "../../hooks/useToastNotifications";
 
 const DRAFT_KEY = "contact-draft";
 const EMAIL = "alex.unnippillil@hotmail.com";
@@ -29,11 +30,14 @@ const ContactApp: React.FC = () => {
   const [message, setMessage] = useState("");
   const [honeypot, setHoneypot] = useState("");
   const [error, setError] = useState("");
-  const [toast, setToast] = useState("");
   const [csrfToken, setCsrfToken] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [emailError, setEmailError] = useState("");
   const [messageError, setMessageError] = useState("");
+  const { toast, showToast, dismissToast } = useToastNotifications({
+    appId: "contact",
+    notificationTitle: "Contact message",
+  });
 
   useEffect(() => {
     const saved = localStorage.getItem(DRAFT_KEY);
@@ -101,7 +105,7 @@ const ContactApp: React.FC = () => {
         recaptchaToken,
       });
       if (result.success) {
-        setToast("Message sent");
+        showToast("Message sent", { notificationTitle: "Contact message sent" });
         setName("");
         setEmail("");
         setMessage("");
@@ -274,7 +278,15 @@ const ContactApp: React.FC = () => {
           )}
         </button>
       </form>
-      {toast && <Toast message={toast} onClose={() => setToast("")} />}
+      {toast && (
+        <Toast
+          message={toast.message}
+          actionLabel={toast.actionLabel}
+          onAction={toast.onAction}
+          duration={toast.duration}
+          onClose={dismissToast}
+        />
+      )}
     </div>
   );
 };

--- a/apps/metasploit/index.tsx
+++ b/apps/metasploit/index.tsx
@@ -4,6 +4,7 @@ import React, { useState, useMemo, useRef, useEffect } from 'react';
 import modulesData from '../../components/apps/metasploit/modules.json';
 import MetasploitApp from '../../components/apps/metasploit';
 import Toast from '../../components/ui/Toast';
+import { useToastNotifications } from '../../hooks/useToastNotifications';
 
 interface Module {
   name: string;
@@ -47,9 +48,12 @@ const MetasploitPage: React.FC = () => {
   const [split, setSplit] = useState(60);
   const splitRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
-  const [toast, setToast] = useState('');
   const [query, setQuery] = useState('');
   const [tag, setTag] = useState('');
+  const { toast, showToast, dismissToast } = useToastNotifications({
+    appId: 'metasploit',
+    notificationTitle: 'Metasploit update',
+  });
 
   const allTags = useMemo(
     () =>
@@ -99,7 +103,11 @@ const MetasploitPage: React.FC = () => {
     };
   }, []);
 
-  const handleGenerate = () => setToast('Payload generated');
+  const handleGenerate = () => {
+    showToast('Payload generated', {
+      notificationTitle: 'Payload generated',
+    });
+  };
 
   const renderTree = (node: TreeNode) => (
     <ul className="ml-2">
@@ -223,7 +231,15 @@ const MetasploitPage: React.FC = () => {
           </div>
         </div>
       </div>
-      {toast && <Toast message={toast} onClose={() => setToast('')} />}
+      {toast && (
+        <Toast
+          message={toast.message}
+          actionLabel={toast.actionLabel}
+          onAction={toast.onAction}
+          duration={toast.duration}
+          onClose={dismissToast}
+        />
+      )}
     </div>
   );
 };

--- a/components/ui/QuickSettings.tsx
+++ b/components/ui/QuickSettings.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import usePersistentState from '../../hooks/usePersistentState';
-import { useEffect } from 'react';
+import { useEffect, ChangeEvent } from 'react';
+import { useNotifications } from '../../hooks/useNotifications';
 
 interface Props {
   open: boolean;
@@ -12,6 +13,57 @@ const QuickSettings = ({ open }: Props) => {
   const [sound, setSound] = usePersistentState('qs-sound', true);
   const [online, setOnline] = usePersistentState('qs-online', true);
   const [reduceMotion, setReduceMotion] = usePersistentState('qs-reduce-motion', false);
+  const {
+    doNotDisturb,
+    setDoNotDisturb,
+    quietHours,
+    setQuietHours,
+    quietHoursActive,
+    notificationsMuted,
+    mutingReason,
+  } = useNotifications();
+
+  const toggleQuietHoursEnabled = () => {
+    setQuietHours(prev => ({
+      ...prev,
+      enabled: !prev.enabled,
+    }));
+  };
+
+  const handleQuietHoursChange = (key: 'start' | 'end') =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      if (!/^\d{2}:\d{2}$/.test(value)) return;
+      setQuietHours(prev => ({
+        ...prev,
+        [key]: value,
+      }));
+    };
+
+  const formatTime = (time: string) => {
+    const [hours, minutes] = time.split(':').map(Number);
+    if (Number.isNaN(hours) || Number.isNaN(minutes)) return time;
+    const reference = new Date();
+    reference.setHours(hours, minutes, 0, 0);
+    return new Intl.DateTimeFormat(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(reference);
+  };
+
+  const mutingSummary = notificationsMuted
+    ? mutingReason === 'both'
+      ? 'Do Not Disturb and quiet hours'
+      : mutingReason === 'do-not-disturb'
+        ? 'Do Not Disturb'
+        : 'Quiet hours'
+    : 'Notifications on';
+
+  const quietHoursSummary = quietHours.enabled
+    ? `${formatTime(quietHours.start)} – ${formatTime(quietHours.end)}${
+        quietHoursActive ? ' (active)' : ''
+      }`
+    : 'Quiet hours disabled';
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -36,21 +88,101 @@ const QuickSettings = ({ open }: Props) => {
           <span>{theme === 'light' ? 'Light' : 'Dark'}</span>
         </button>
       </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Sound</span>
-        <input type="checkbox" checked={sound} onChange={() => setSound(!sound)} />
-      </div>
-      <div className="px-4 pb-2 flex justify-between">
-        <span>Network</span>
-        <input type="checkbox" checked={online} onChange={() => setOnline(!online)} />
-      </div>
-      <div className="px-4 flex justify-between">
-        <span>Reduced motion</span>
+      <div className="px-4 pb-2 flex items-center justify-between">
+        <label htmlFor="qs-sound-toggle" className="cursor-pointer">
+          Sound
+        </label>
         <input
+          id="qs-sound-toggle"
+          type="checkbox"
+          checked={sound}
+          onChange={() => setSound(!sound)}
+          aria-label="Toggle sound"
+        />
+      </div>
+      <div className="px-4 pb-2 flex items-center justify-between">
+        <label htmlFor="qs-network-toggle" className="cursor-pointer">
+          Network
+        </label>
+        <input
+          id="qs-network-toggle"
+          type="checkbox"
+          checked={online}
+          onChange={() => setOnline(!online)}
+          aria-label="Toggle simulated network"
+        />
+      </div>
+      <div className="px-4 flex items-center justify-between">
+        <label htmlFor="qs-reduce-motion-toggle" className="cursor-pointer">
+          Reduced motion
+        </label>
+        <input
+          id="qs-reduce-motion-toggle"
           type="checkbox"
           checked={reduceMotion}
           onChange={() => setReduceMotion(!reduceMotion)}
+          aria-label="Toggle reduced motion"
         />
+      </div>
+      <div className="mt-3 border-t border-white/10 px-4 pt-3 text-sm text-white/90">
+        <div className="flex items-center justify-between">
+          <label htmlFor="qs-dnd-toggle" className="cursor-pointer">
+            Do Not Disturb
+          </label>
+          <input
+            id="qs-dnd-toggle"
+            type="checkbox"
+            checked={doNotDisturb}
+            onChange={() => setDoNotDisturb(prev => !prev)}
+            aria-label="Toggle Do Not Disturb"
+          />
+        </div>
+        <p className="mt-2 text-xs text-white/70">
+          {notificationsMuted
+            ? `Notifications muted (${mutingSummary}).`
+            : 'Notifications allowed.'}
+        </p>
+        <div className="mt-3 flex items-center justify-between">
+          <label htmlFor="qs-quiet-hours-toggle" className="cursor-pointer">
+            Quiet hours
+          </label>
+          <input
+            id="qs-quiet-hours-toggle"
+            type="checkbox"
+            checked={quietHours.enabled}
+            onChange={toggleQuietHoursEnabled}
+            aria-label="Toggle quiet hours"
+          />
+        </div>
+        <div className={`mt-2 grid grid-cols-2 gap-2 text-xs ${quietHours.enabled ? '' : 'opacity-50'}`}>
+          <label className="flex flex-col gap-1" htmlFor="qs-quiet-hours-start">
+            <span>Start</span>
+            <input
+              id="qs-quiet-hours-start"
+              type="time"
+              value={quietHours.start}
+              onChange={handleQuietHoursChange('start')}
+              disabled={!quietHours.enabled}
+              className="rounded border border-white/10 bg-black/20 px-2 py-1 text-white"
+              aria-label="Quiet hours start time"
+            />
+          </label>
+          <label className="flex flex-col gap-1" htmlFor="qs-quiet-hours-end">
+            <span>End</span>
+            <input
+              id="qs-quiet-hours-end"
+              type="time"
+              value={quietHours.end}
+              onChange={handleQuietHoursChange('end')}
+              disabled={!quietHours.enabled}
+              className="rounded border border-white/10 bg-black/20 px-2 py-1 text-white"
+              aria-label="Quiet hours end time"
+            />
+          </label>
+        </div>
+        <p className="mt-2 text-xs text-white/60">
+          {quietHoursSummary}
+        </p>
       </div>
     </div>
   );

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -5,6 +5,8 @@ export type {
   AppNotification,
   PushNotificationInput,
   NotificationPriority,
+  QuietHoursConfig,
+  NotificationMutingReason,
 } from '../components/common/NotificationCenter';
 export type {
   ClassificationResult,

--- a/hooks/useToastNotifications.ts
+++ b/hooks/useToastNotifications.ts
@@ -1,0 +1,118 @@
+"use client";
+
+import { useCallback, useContext, useEffect, useState } from 'react';
+import {
+  NotificationsContext,
+  NotificationPriority,
+  NotificationHints,
+  NotificationMutingReason,
+} from '../components/common/NotificationCenter';
+
+export interface ToastPayload {
+  id: string;
+  message: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  duration?: number;
+}
+
+export interface UseToastNotificationsConfig {
+  appId: string;
+  notificationTitle?: string;
+  priority?: NotificationPriority;
+  hints?: NotificationHints;
+}
+
+export interface ShowToastOptions {
+  actionLabel?: string;
+  onAction?: () => void;
+  duration?: number;
+  priority?: NotificationPriority;
+  notificationTitle?: string;
+  hints?: NotificationHints;
+  body?: string;
+  appId?: string;
+}
+
+export interface ShowToastResult {
+  muted: boolean;
+  reason: NotificationMutingReason;
+}
+
+const createToastId = () => `toast-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+export const useToastNotifications = ({
+  appId,
+  notificationTitle,
+  priority: defaultPriority,
+  hints: defaultHints,
+}: UseToastNotificationsConfig) => {
+  const context = useContext(NotificationsContext);
+  const pushNotification = context?.pushNotification;
+  const notificationsMuted = context?.notificationsMuted ?? false;
+  const mutingReason = context?.mutingReason ?? null;
+
+  const [toast, setToast] = useState<ToastPayload | null>(null);
+
+  useEffect(() => {
+    if (notificationsMuted && toast) {
+      setToast(null);
+    }
+  }, [notificationsMuted, toast]);
+
+  const showToast = useCallback(
+    (message: string, options?: ShowToastOptions): ShowToastResult => {
+      if (notificationsMuted) {
+        const reasonLabel =
+          mutingReason === 'both'
+            ? 'Do Not Disturb & quiet hours'
+            : mutingReason === 'do-not-disturb'
+              ? 'Do Not Disturb'
+              : mutingReason === 'quiet-hours'
+                ? 'quiet hours'
+                : 'notification preferences';
+        const mergedHints: NotificationHints | undefined = (() => {
+          const base = { ...(defaultHints ?? {}) } as NotificationHints;
+          const override = options?.hints ?? {};
+          const combined: NotificationHints = { ...base, ...override };
+          combined['x-kali-muted'] = true;
+          if (mutingReason) {
+            combined['x-kali-muted-reason'] = mutingReason;
+          }
+          return combined;
+        })();
+
+        pushNotification?.({
+          appId: options?.appId ?? appId,
+          title: options?.notificationTitle ?? notificationTitle ?? 'Notification silenced',
+          body:
+            options?.body ??
+            `${message}${reasonLabel ? ` (muted by ${reasonLabel})` : ''}`,
+          priority: options?.priority ?? defaultPriority ?? 'normal',
+          hints: mergedHints,
+        });
+
+        return { muted: true, reason: mutingReason };
+      }
+
+      setToast({
+        id: createToastId(),
+        message,
+        actionLabel: options?.actionLabel,
+        onAction: options?.onAction,
+        duration: options?.duration,
+      });
+
+      return { muted: false, reason: null };
+    },
+    [appId, defaultHints, defaultPriority, mutingReason, notificationTitle, notificationsMuted, pushNotification],
+  );
+
+  const dismissToast = useCallback(() => {
+    setToast(null);
+  }, []);
+
+  return { toast, showToast, dismissToast };
+};
+
+export default useToastNotifications;


### PR DESCRIPTION
## Summary
- extend the notification context with quiet hours scheduling, Do Not Disturb state, and derived muting status helpers
- introduce a shared toast delivery hook that suppresses banners during mute windows while still logging them to the notification center
- update desktop quick settings and affected apps to respect the new mute logic and surface quiet hour controls, and patch dependent tests

## Testing
- yarn lint
- yarn test metasploitPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd8db6da3c83288d84efb34d7ef360