### PR TITLE
[a11y] Improve notification semantics

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,37 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock', () => {
+  const MockClock = () => <div data-testid="clock" />;
+  MockClock.displayName = 'MockClock';
+  return MockClock;
+});
+
+jest.mock('../components/util-components/status', () => {
+  const MockStatus = () => <div data-testid="status" />;
+  MockStatus.displayName = 'MockStatus';
+  return MockStatus;
+});
+
+jest.mock('../components/ui/QuickSettings', () => {
+  const MockQuickSettings = ({ open }: { open: boolean }) => (
+    <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
+  );
+  MockQuickSettings.displayName = 'MockQuickSettings';
+  return MockQuickSettings;
+});
+
+jest.mock('../components/menu/WhiskerMenu', () => {
+  const MockWhiskerMenu = () => <button type="button">Menu</button>;
+  MockWhiskerMenu.displayName = 'MockWhiskerMenu';
+  return MockWhiskerMenu;
+});
+
+jest.mock('../components/ui/PerformanceGraph', () => {
+  const MockPerformanceGraph = () => <div data-testid="performance" />;
+  MockPerformanceGraph.displayName = 'MockPerformanceGraph';
+  return MockPerformanceGraph;
+});
 
 const workspaceEventDetail = {
   workspaces: [

--- a/apps/contact/index.tsx
+++ b/apps/contact/index.tsx
@@ -274,7 +274,13 @@ const ContactApp: React.FC = () => {
           )}
         </button>
       </form>
-      {toast && <Toast message={toast} onClose={() => setToast("")} />}
+      {toast && (
+        <Toast
+          message={toast}
+          onClose={() => setToast("")}
+          priority="normal"
+        />
+      )}
     </div>
   );
 };

--- a/apps/metasploit/index.tsx
+++ b/apps/metasploit/index.tsx
@@ -223,7 +223,13 @@ const MetasploitPage: React.FC = () => {
           </div>
         </div>
       </div>
-      {toast && <Toast message={toast} onClose={() => setToast('')} />}
+      {toast && (
+        <Toast
+          message={toast}
+          onClose={() => setToast('')}
+          priority="normal"
+        />
+      )}
     </div>
   );
 };

--- a/components/apps/Games/common/Overlay.tsx
+++ b/components/apps/Games/common/Overlay.tsx
@@ -101,6 +101,7 @@ export default function Overlay({
           message={toast}
           onClose={() => setToast('')}
           duration={1000000}
+          priority="critical"
         />
       )}
     </>

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { NotificationPriority } from '../../utils/notifications/ruleEngine';
 
 interface ToastProps {
   message: string;
@@ -6,6 +7,7 @@ interface ToastProps {
   onAction?: () => void;
   onClose?: () => void;
   duration?: number;
+  priority?: NotificationPriority;
 }
 
 const Toast: React.FC<ToastProps> = ({
@@ -14,27 +16,65 @@ const Toast: React.FC<ToastProps> = ({
   onAction,
   onClose,
   duration = 6000,
+  priority = 'normal',
 }) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const [visible, setVisible] = useState(false);
+  const messageId = useId();
+
+  const handleClose = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setVisible(false);
+    onClose?.();
+  }, [onClose]);
 
   useEffect(() => {
     setVisible(true);
     timeoutRef.current = setTimeout(() => {
-      onClose && onClose();
+      handleClose();
     }, duration);
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-  }, [duration, onClose]);
+  }, [duration, handleClose]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        handleClose();
+      }
+    };
+
+    const node = containerRef.current;
+    node?.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      node?.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleClose]);
+
+  const isCritical = priority === 'critical';
+  const role = isCritical ? 'alertdialog' : 'status';
+  const ariaLive = isCritical ? 'assertive' : 'polite';
 
   return (
     <div
-      role="status"
-      aria-live="polite"
+      ref={containerRef}
+      role={role}
+      aria-live={ariaLive}
+      aria-atomic="true"
+      aria-labelledby={isCritical ? messageId : undefined}
+      tabIndex={isCritical ? -1 : undefined}
       className={`fixed top-4 left-1/2 -translate-x-1/2 transform bg-gray-900 text-white border border-gray-700 px-4 py-3 rounded-md shadow-md flex items-center transition-transform duration-150 ease-in-out ${visible ? 'translate-y-0' : '-translate-y-full'}`}
     >
-      <span>{message}</span>
+      <span id={messageId}>{message}</span>
       {onAction && actionLabel && (
         <button
           onClick={onAction}


### PR DESCRIPTION
## Summary
- update toast popovers to assign ARIA roles based on urgency and close on Escape
- add keyboard navigation and roving focus behaviours to the notification center list and actions
- name mocked components in navbar running apps test to satisfy display-name lint rule

## Testing
- yarn lint
- yarn a11y *(fails: missing libatk shared library in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8db744488328be38e8f3bd729475