### PR TITLE
[desktop] sync menu accelerators with shortcut registry

### DIFF
--- a/components/context-menus/MenuRow.tsx
+++ b/components/context-menus/MenuRow.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+type MenuRowProps = {
+  icon?: React.ReactNode;
+  label: React.ReactNode;
+  accel?: string | null;
+};
+
+const MenuRow: React.FC<MenuRowProps> = ({ icon, label, accel }) => {
+  return (
+    <span className="flex w-full items-center justify-between gap-3 px-4">
+      <span className="flex min-w-0 items-center gap-2 text-sm text-current">
+        {icon ? <span className="shrink-0" aria-hidden>{icon}</span> : null}
+        <span className="truncate">{label}</span>
+      </span>
+      {accel ? (
+        <span
+          className="ml-4 shrink-0 text-[11px] font-medium tabular-nums"
+          style={{ color: 'var(--color-text)', opacity: 0.75 }}
+        >
+          {accel}
+        </span>
+      ) : null}
+    </span>
+  );
+};
+
+export default MenuRow;

--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import MenuRow from './MenuRow'
 
 function AppMenu(props) {
     const menuRef = useRef(null)
@@ -37,7 +38,7 @@ function AppMenu(props) {
                 aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
-                <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
+                <MenuRow label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'} />
             </button>
         </div>
     )

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import MenuRow from './MenuRow'
 
 function DefaultMenu(props) {
     const menuRef = useRef(null)
@@ -32,7 +33,7 @@ function DefaultMenu(props) {
                 aria-label="Follow on Linkedin"
                 className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
-                <span className="ml-5">🙋‍♂️</span> <span className="ml-2">Follow on <strong>Linkedin</strong></span>
+                <MenuRow icon={<span>🙋‍♂️</span>} label={<>Follow on <strong>Linkedin</strong></>} />
             </a>
             <a
                 rel="noopener noreferrer"
@@ -42,7 +43,7 @@ function DefaultMenu(props) {
                 aria-label="Follow on Github"
                 className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
-                <span className="ml-5">🤝</span> <span className="ml-2">Follow on <strong>Github</strong></span>
+                <MenuRow icon={<span>🤝</span>} label={<>Follow on <strong>Github</strong></>} />
             </a>
             <a
                 rel="noopener noreferrer"
@@ -52,7 +53,7 @@ function DefaultMenu(props) {
                 aria-label="Contact Me"
                 className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
-                <span className="ml-5">📥</span> <span className="ml-2">Contact Me</span>
+                <MenuRow icon={<span>📥</span>} label="Contact Me" />
             </a>
             <Devider />
             <button
@@ -62,7 +63,7 @@ function DefaultMenu(props) {
                 aria-label="Reset Kali Linux"
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
-                <span className="ml-5">🧹</span> <span className="ml-2">Reset Kali Linux</span>
+                <MenuRow icon={<span>🧹</span>} label="Reset Kali Linux" />
             </button>
         </div>
     )

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,9 +1,13 @@
 import React, { useState, useEffect } from 'react'
 import logger from '../../utils/logger'
+import MenuRow from './MenuRow'
+import useKeymap from '../../apps/settings/keymapRegistry'
 
 function DesktopMenu(props) {
 
     const [isFullScreen, setIsFullScreen] = useState(false)
+    const { shortcuts } = useKeymap()
+    const openSettingsShortcut = shortcuts.find((s) => s.description === 'Open settings')?.keys || null
 
     useEffect(() => {
         document.addEventListener('fullscreenchange', checkFullScreen);
@@ -57,7 +61,7 @@ function DesktopMenu(props) {
                 aria-label="New Folder"
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
-                <span className="ml-5">New Folder</span>
+                <MenuRow label="New Folder" />
             </button>
             <button
                 onClick={props.openShortcutSelector}
@@ -66,15 +70,15 @@ function DesktopMenu(props) {
                 aria-label="Create Shortcut"
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
-                <span className="ml-5">Create Shortcut...</span>
+                <MenuRow label="Create Shortcut..." />
             </button>
             <Devider />
             <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Paste</span>
+                <MenuRow label="Paste" />
             </div>
             <Devider />
             <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Show Desktop in Files</span>
+                <MenuRow label="Show Desktop in Files" />
             </div>
             <button
                 onClick={openTerminal}
@@ -83,7 +87,7 @@ function DesktopMenu(props) {
                 aria-label="Open in Terminal"
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
-                <span className="ml-5">Open in Terminal</span>
+                <MenuRow label="Open in Terminal" />
             </button>
             <Devider />
             <button
@@ -93,11 +97,11 @@ function DesktopMenu(props) {
                 aria-label="Change Background"
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
-                <span className="ml-5">Change Background...</span>
+                <MenuRow label="Change Background..." />
             </button>
             <Devider />
             <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Display Settings</span>
+                <MenuRow label="Display Settings" />
             </div>
             <button
                 onClick={openSettings}
@@ -106,7 +110,7 @@ function DesktopMenu(props) {
                 aria-label="Settings"
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
-                <span className="ml-5">Settings</span>
+                <MenuRow label="Settings" accel={openSettingsShortcut} />
             </button>
             <Devider />
             <button
@@ -116,7 +120,7 @@ function DesktopMenu(props) {
                 aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
-                <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
+                <MenuRow label={`${isFullScreen ? "Exit" : "Enter"} Full Screen`} />
             </button>
             <Devider />
             <button
@@ -126,7 +130,7 @@ function DesktopMenu(props) {
                 aria-label="Clear Session"
                 className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
             >
-                <span className="ml-5">Clear Session</span>
+                <MenuRow label="Clear Session" />
             </button>
         </div>
     )

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+import MenuRow from './MenuRow';
 
 function TaskbarMenu(props) {
     const menuRef = useRef(null);
@@ -39,7 +40,7 @@ function TaskbarMenu(props) {
                 aria-label={props.minimized ? 'Restore Window' : 'Minimize Window'}
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
-                <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
+                <MenuRow label={props.minimized ? 'Restore' : 'Minimize'} />
             </button>
             <button
                 type="button"
@@ -48,7 +49,7 @@ function TaskbarMenu(props) {
                 aria-label="Close Window"
                 className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
             >
-                <span className="ml-5">Close</span>
+                <MenuRow label="Close" />
             </button>
         </div>
     );

--- a/components/ui/AppTooltipContent.tsx
+++ b/components/ui/AppTooltipContent.tsx
@@ -1,4 +1,7 @@
-import React from 'react';
+"use client";
+
+import React, { useMemo } from 'react';
+import useKeymap from '../../apps/settings/keymapRegistry';
 
 type AppTooltipContentProps = {
   meta?: {
@@ -9,31 +12,111 @@ type AppTooltipContentProps = {
   } | null;
 };
 
+const splitHint = (hint: string): { key: string | null; description: string } => {
+  const parts = hint.split(' — ');
+  if (parts.length >= 2) {
+    const [key, ...rest] = parts;
+    return { key: key.trim(), description: rest.join(' — ').trim() };
+  }
+  return { key: null, description: hint };
+};
+
 const AppTooltipContent: React.FC<AppTooltipContentProps> = ({ meta }) => {
+  const { shortcuts } = useKeymap();
+
+  const shortcutMap = useMemo(() => {
+    const map = new Map<string, string>();
+    shortcuts.forEach(({ description, keys }) => {
+      map.set(description, keys);
+    });
+    return map;
+  }, [shortcuts]);
+
+  const hints = useMemo(() => {
+    if (!meta?.keyboard?.length) {
+      return [] as Array<{ key: string | null; description: string }>;
+    }
+    return meta.keyboard.map((hint) => {
+      const parsed = splitHint(hint);
+      const override = parsed.description
+        ? shortcutMap.get(parsed.description)
+        : null;
+      return {
+        key: override ?? parsed.key,
+        description: parsed.description,
+      };
+    });
+  }, [meta?.keyboard, shortcutMap]);
+
   if (!meta) {
-    return <span className="text-xs text-gray-200">Metadata unavailable.</span>;
+    return (
+      <span
+        className="text-xs opacity-80"
+        style={{ color: 'var(--color-text)' }}
+      >
+        Metadata unavailable.
+      </span>
+    );
   }
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2" style={{ color: 'var(--color-text)' }}>
       {meta.title ? (
-        <p className="text-sm font-semibold text-white">{meta.title}</p>
+        <p className="text-sm font-semibold" style={{ color: 'var(--color-text)' }}>
+          {meta.title}
+        </p>
       ) : null}
       {meta.description ? (
-        <p className="text-xs leading-relaxed text-gray-200">{meta.description}</p>
+        <p className="text-xs leading-relaxed opacity-90">
+          {meta.description}
+        </p>
       ) : null}
       {meta.path ? (
-        <p className="text-[11px] text-gray-300">
-          <span className="font-semibold text-gray-100">Path:</span>{' '}
-          <code className="rounded bg-black/40 px-1 py-0.5 text-[11px] text-ubt-grey">
+        <p className="text-[11px] opacity-80">
+          <span className="font-semibold" style={{ color: 'var(--color-text)' }}>
+            Path:
+          </span>{' '}
+          <code
+            className="rounded px-1 py-0.5 text-[11px] bg-black/40 dark:bg-white/10"
+            style={{
+              color: 'var(--color-text)',
+              backgroundColor: 'color-mix(in srgb, var(--color-muted) 70%, transparent)',
+            }}
+          >
             {meta.path}
           </code>
         </p>
       ) : null}
-      {meta.keyboard?.length ? (
-        <ul className="list-disc space-y-1 pl-4 text-[11px] text-gray-200">
-          {meta.keyboard.map((hint) => (
-            <li key={hint}>{hint}</li>
+      {hints.length ? (
+        <ul className="space-y-1 text-[11px]">
+          {hints.map(({ key, description }) => (
+            <li
+              key={`${description}-${key ?? 'none'}`}
+              className="flex items-center justify-between gap-3 rounded border border-white/10 bg-black/30 px-2 py-1 dark:border-white/10 dark:bg-white/10"
+              style={{
+                color: 'var(--color-text)',
+                backgroundColor:
+                  'color-mix(in srgb, var(--color-muted) 55%, transparent)',
+                borderColor:
+                  'color-mix(in srgb, var(--color-border) 65%, transparent)',
+              }}
+            >
+              <span className="truncate opacity-90">{description}</span>
+              {key ? (
+                <kbd
+                  className="ml-4 shrink-0 rounded border border-white/20 bg-black/40 px-2 py-0.5 text-[11px] font-semibold font-mono dark:border-white/20 dark:bg-white/10"
+                  style={{
+                    color: 'var(--color-text)',
+                    backgroundColor:
+                      'color-mix(in srgb, var(--color-surface) 65%, transparent)',
+                    borderColor:
+                      'color-mix(in srgb, var(--color-border) 70%, transparent)',
+                  }}
+                >
+                  {key}
+                </kbd>
+              ) : null}
+            </li>
           ))}
         </ul>
       ) : null}


### PR DESCRIPTION
## Summary
- add a reusable menu row layout that right-aligns optional accelerators across context menus
- surface the Settings shortcut binding from the keymap registry and clean up menu item rendering
- refresh app tooltips to read live shortcut labels and improve keyboard hint contrast in both themes

## Testing
- yarn test ShortcutOverlay

------
https://chatgpt.com/codex/tasks/task_e_68dd8dba99588328b4ae312d48f503b6