### PR TITLE
[desktop] Add touch hold context menu support

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,37 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock', () => {
+  const MockClock = () => <div data-testid="clock" />;
+  MockClock.displayName = 'MockClock';
+  return MockClock;
+});
+
+jest.mock('../components/util-components/status', () => {
+  const MockStatus = () => <div data-testid="status" />;
+  MockStatus.displayName = 'MockStatus';
+  return MockStatus;
+});
+
+jest.mock('../components/ui/QuickSettings', () => {
+  const MockQuickSettings = ({ open }: { open: boolean }) => (
+    <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
+  );
+  MockQuickSettings.displayName = 'MockQuickSettings';
+  return MockQuickSettings;
+});
+
+jest.mock('../components/menu/WhiskerMenu', () => {
+  const MockWhiskerMenu = () => <button type="button">Menu</button>;
+  MockWhiskerMenu.displayName = 'MockWhiskerMenu';
+  return MockWhiskerMenu;
+});
+
+jest.mock('../components/ui/PerformanceGraph', () => {
+  const MockPerformanceGraph = () => <div data-testid="performance" />;
+  MockPerformanceGraph.displayName = 'MockPerformanceGraph';
+  return MockPerformanceGraph;
+});
 
 const workspaceEventDetail = {
   workspaces: [

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -94,6 +94,11 @@ export class Desktop extends Component {
 
         this.validAppIds = new Set(apps.map((app) => app.id));
 
+        this.touchContextHold = null;
+        this.touchContextHoldTimeout = null;
+        this.touchFeedbackTimeout = null;
+        this.ignoreNextContextClick = false;
+
     }
 
     createEmptyWorkspaceState = () => ({
@@ -876,6 +881,11 @@ export class Desktop extends Component {
         window.removeEventListener('open-app', this.handleOpenAppEvent);
         window.removeEventListener('resize', this.handleViewportResize);
         this.detachIconKeyboardListeners();
+        this.cancelTouchContextHold();
+        if (this.touchFeedbackTimeout) {
+            clearTimeout(this.touchFeedbackTimeout);
+            this.touchFeedbackTimeout = null;
+        }
         if (typeof window !== 'undefined') {
             window.removeEventListener('workspace-select', this.handleExternalWorkspaceSelect);
             window.removeEventListener('workspace-request', this.broadcastWorkspaceState);
@@ -1011,15 +1021,130 @@ export class Desktop extends Component {
     setContextListeners = () => {
         document.addEventListener('contextmenu', this.checkContextMenu);
         // on click, anywhere, hide all menus
-        document.addEventListener('click', this.hideAllContextMenu);
+        document.addEventListener('click', this.handleContextMenuClickDismiss, true);
         // allow keyboard activation of context menus
         document.addEventListener('keydown', this.handleContextKey);
+        document.addEventListener('pointerdown', this.handleContextPointerDown, { passive: true });
+        document.addEventListener('pointermove', this.handleContextPointerMove, { passive: true });
+        document.addEventListener('pointerup', this.handleContextPointerUp, { passive: true });
+        document.addEventListener('pointercancel', this.handleContextPointerCancel, { passive: true });
     }
 
     removeContextListeners = () => {
         document.removeEventListener("contextmenu", this.checkContextMenu);
-        document.removeEventListener("click", this.hideAllContextMenu);
+        document.removeEventListener('click', this.handleContextMenuClickDismiss, true);
         document.removeEventListener('keydown', this.handleContextKey);
+        document.removeEventListener('pointerdown', this.handleContextPointerDown);
+        document.removeEventListener('pointermove', this.handleContextPointerMove);
+        document.removeEventListener('pointerup', this.handleContextPointerUp);
+        document.removeEventListener('pointercancel', this.handleContextPointerCancel);
+    }
+
+    handleContextMenuClickDismiss = () => {
+        if (this.ignoreNextContextClick) {
+            this.ignoreNextContextClick = false;
+            return;
+        }
+        this.hideAllContextMenu();
+    }
+
+    cancelTouchContextHold = () => {
+        if (this.touchContextHoldTimeout) {
+            clearTimeout(this.touchContextHoldTimeout);
+            this.touchContextHoldTimeout = null;
+        }
+        this.touchContextHold = null;
+    }
+
+    handleContextPointerDown = (event) => {
+        if (event.pointerType !== 'touch' || event.isPrimary === false) return;
+        const target = event.target?.closest?.('[data-context]');
+        if (!target) {
+            this.cancelTouchContextHold();
+            return;
+        }
+        this.cancelTouchContextHold();
+        const { clientX, clientY, pageX, pageY, pointerId } = event;
+        this.touchContextHold = {
+            pointerId,
+            target,
+            startX: clientX,
+            startY: clientY,
+            pageX,
+            pageY,
+            clientX,
+            clientY,
+        };
+        this.touchContextHoldTimeout = setTimeout(() => {
+            this.touchContextHoldTimeout = null;
+            if (!this.touchContextHold || this.touchContextHold.pointerId !== pointerId) return;
+            this.triggerTouchContextMenu();
+        }, 550);
+    }
+
+    handleContextPointerMove = (event) => {
+        const hold = this.touchContextHold;
+        if (!hold || hold.pointerId !== event.pointerId) return;
+        const { clientX, clientY, pageX, pageY } = event;
+        const deltaX = clientX - hold.startX;
+        const deltaY = clientY - hold.startY;
+        if (Math.hypot(deltaX, deltaY) > 10) {
+            this.cancelTouchContextHold();
+            return;
+        }
+        hold.pageX = pageX;
+        hold.pageY = pageY;
+        hold.clientX = clientX;
+        hold.clientY = clientY;
+    }
+
+    handleContextPointerUp = (event) => {
+        if (this.touchContextHold && this.touchContextHold.pointerId === event.pointerId) {
+            this.cancelTouchContextHold();
+        }
+    }
+
+    handleContextPointerCancel = (event) => {
+        if (this.touchContextHold && this.touchContextHold.pointerId === event.pointerId) {
+            this.cancelTouchContextHold();
+        }
+    }
+
+    triggerTouchContextMenu = () => {
+        const hold = this.touchContextHold;
+        if (!hold) return;
+        const target = hold.target;
+        const fakeEvent = {
+            preventDefault: () => { },
+            target,
+            pageX: hold.pageX,
+            pageY: hold.pageY,
+            clientX: hold.clientX ?? hold.pageX,
+            clientY: hold.clientY ?? hold.pageY,
+        };
+        this.ignoreNextContextClick = true;
+        this.checkContextMenu(fakeEvent);
+        this.provideTouchContextFeedback(target);
+        this.cancelTouchContextHold();
+    }
+
+    provideTouchContextFeedback = (target) => {
+        if (!target || !target.classList) return;
+        if (typeof window !== 'undefined' && window.navigator?.vibrate) {
+            try {
+                window.navigator.vibrate(15);
+            } catch (_error) {
+                // ignore vibration errors
+            }
+        }
+        target.classList.add('context-touch-feedback');
+        if (this.touchFeedbackTimeout) {
+            clearTimeout(this.touchFeedbackTimeout);
+        }
+        this.touchFeedbackTimeout = setTimeout(() => {
+            target.classList.remove('context-touch-feedback');
+            this.touchFeedbackTimeout = null;
+        }, 250);
     }
 
     handleGlobalShortcut = (e) => {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -99,3 +99,10 @@ html {
   background-color: var(--kali-border, var(--color-border));
   border-radius: 6px;
 }
+
+.context-touch-feedback {
+  box-shadow: 0 0 0 6px rgba(96, 165, 250, 0.25);
+  outline: 2px solid rgba(59, 130, 246, 0.45);
+  outline-offset: 2px;
+  transition: box-shadow 120ms ease, outline-color 120ms ease;
+}


### PR DESCRIPTION
## Summary
- add long-press detection on touch pointers to surface desktop context menus without triggering accidental opens while scrolling
- provide mobile feedback for touch-activated menus and guard against immediate dismissal taps
- fix display name warnings in navbar running apps test mocks and add a highlight style used by the new feedback

## Testing
- [x] yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dd8dbb24988328ab2b27e6baeb3658