### PR TITLE
[pdfviewer] Virtualized thumbnail sidebar

### DIFF
--- a/__tests__/navbar-running-apps.test.tsx
+++ b/__tests__/navbar-running-apps.test.tsx
@@ -2,13 +2,37 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import Navbar from '../components/screen/navbar';
 
-jest.mock('../components/util-components/clock', () => () => <div data-testid="clock" />);
-jest.mock('../components/util-components/status', () => () => <div data-testid="status" />);
-jest.mock('../components/ui/QuickSettings', () => ({ open }: { open: boolean }) => (
-  <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
-));
-jest.mock('../components/menu/WhiskerMenu', () => () => <button type="button">Menu</button>);
-jest.mock('../components/ui/PerformanceGraph', () => () => <div data-testid="performance" />);
+jest.mock('../components/util-components/clock', () => {
+  const MockClock = () => <div data-testid="clock" />;
+  MockClock.displayName = 'MockClock';
+  return MockClock;
+});
+
+jest.mock('../components/util-components/status', () => {
+  const MockStatus = () => <div data-testid="status" />;
+  MockStatus.displayName = 'MockStatus';
+  return MockStatus;
+});
+
+jest.mock('../components/ui/QuickSettings', () => {
+  const MockQuickSettings = ({ open }: { open: boolean }) => (
+    <div data-testid="quick-settings">{open ? 'open' : 'closed'}</div>
+  );
+  MockQuickSettings.displayName = 'MockQuickSettings';
+  return MockQuickSettings;
+});
+
+jest.mock('../components/menu/WhiskerMenu', () => {
+  const MockWhiskerMenu = () => <button type="button">Menu</button>;
+  MockWhiskerMenu.displayName = 'MockWhiskerMenu';
+  return MockWhiskerMenu;
+});
+
+jest.mock('../components/ui/PerformanceGraph', () => {
+  const MockPerformanceGraph = () => <div data-testid="performance" />;
+  MockPerformanceGraph.displayName = 'MockPerformanceGraph';
+  return MockPerformanceGraph;
+});
 
 const workspaceEventDetail = {
   workspaces: [

--- a/__tests__/pdfviewer.test.tsx
+++ b/__tests__/pdfviewer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PdfViewer from '../components/common/PdfViewer';
 
@@ -26,15 +26,16 @@ describe('PdfViewer', () => {
     expect(canvas).toBeInTheDocument();
     await user.type(screen.getByPlaceholderText(/search/i), 'hello');
     await user.click(screen.getByText('Search'));
-    expect(await screen.findByText('Page 1')).toBeInTheDocument();
+    const results = await screen.findByTestId('search-results');
+    expect(within(results).getAllByText(/Page \d/)).toHaveLength(3);
   });
 
   it('supports keyboard navigation through thumbnails', async () => {
     const user = userEvent.setup();
     render(<PdfViewer url="/sample.pdf" />);
     const options = await screen.findAllByRole('option');
-    options[0].focus();
-    await user.keyboard('{ArrowRight}');
+    await user.click(options[0]);
+    await user.keyboard('{ArrowDown}');
     const updated = await screen.findAllByRole('option');
     expect(updated[1]).toHaveFocus();
     expect(updated[1]).toHaveAttribute('aria-selected', 'true');

--- a/components/common/PdfViewer/index.tsx
+++ b/components/common/PdfViewer/index.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import useRovingTabIndex from '../../../hooks/useRovingTabIndex';
 import type { PDFDocumentProxy } from 'pdfjs-dist';
 import type { TextItem } from 'pdfjs-dist/types/src/display/api';
@@ -9,20 +15,30 @@ interface PdfViewerProps {
   url: string;
 }
 
+type ThumbMeta = {
+  pageNumber: number;
+  width: number;
+  height: number;
+  scale: number;
+};
+
+type ThumbMetaWithPosition = ThumbMeta & { top: number };
+
+const THUMB_WIDTH = 120;
+const THUMB_GAP = 12;
+
 const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const thumbListRef = useRef<HTMLDivElement | null>(null);
+  const thumbCacheRef = useRef<Map<number, HTMLCanvasElement>>(new Map());
   const [pdf, setPdf] = useState<PDFDocumentProxy | null>(null);
   const [page, setPage] = useState(1);
-  const [thumbs, setThumbs] = useState<HTMLCanvasElement[]>([]);
+  const [thumbMeta, setThumbMeta] = useState<ThumbMeta[]>([]);
   const [query, setQuery] = useState('');
   const [matches, setMatches] = useState<number[]>([]);
-  const thumbListRef = useRef<HTMLDivElement | null>(null);
-
-  useRovingTabIndex(
-    thumbListRef as React.RefObject<HTMLElement>,
-    thumbs.length > 0,
-    'horizontal',
-  );
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
 
   useEffect(() => {
     let mounted = true;
@@ -43,42 +59,195 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
   }, [url]);
 
   useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const query = window.matchMedia('(max-width: 768px)');
+    const updateFromQuery = (event: MediaQueryList | MediaQueryListEvent) => {
+      const matches = 'matches' in event ? event.matches : event.currentTarget?.matches;
+      if (matches === undefined) return;
+      setIsSidebarOpen(!matches);
+    };
+
+    updateFromQuery(query);
+    const handler = (event: MediaQueryListEvent) => updateFromQuery(event);
+    query.addEventListener('change', handler);
+    return () => {
+      query.removeEventListener('change', handler);
+    };
+  }, []);
+
+  useEffect(() => {
+    thumbCacheRef.current.clear();
+  }, [pdf]);
+
+  useEffect(() => {
     if (!pdf) return;
     const render = async () => {
       const pg = await pdf.getPage(page);
       const viewport = pg.getViewport({ scale: 1.5 });
-      const canvas = canvasRef.current!;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
       canvas.height = viewport.height;
       canvas.width = viewport.width;
       await pg
         .render({ canvasContext: canvas.getContext('2d')!, viewport, canvas })
         .promise;
-
-
     };
     render();
   }, [pdf, page]);
 
   useEffect(() => {
     if (!pdf) return;
-    const loadThumbs = async () => {
-      const arr: HTMLCanvasElement[] = [];
+    let cancelled = false;
+    const loadThumbMeta = async () => {
+      const meta: ThumbMeta[] = [];
       for (let i = 1; i <= pdf.numPages; i++) {
         const pg = await pdf.getPage(i);
-        const viewport = pg.getViewport({ scale: 0.2 });
-        const canvas = document.createElement('canvas');
-        canvas.height = viewport.height;
-        canvas.width = viewport.width;
-        await pg
-          .render({ canvasContext: canvas.getContext('2d')!, viewport, canvas })
-          .promise;
-
-        arr.push(canvas);
+        const viewport = pg.getViewport({ scale: 1 });
+        const scale = THUMB_WIDTH / viewport.width;
+        meta.push({
+          pageNumber: i,
+          width: Math.round(viewport.width * scale),
+          height: Math.round(viewport.height * scale),
+          scale,
+        });
       }
-      setThumbs(arr);
+      if (!cancelled) setThumbMeta(meta);
     };
-    loadThumbs();
+    loadThumbMeta();
+    return () => {
+      cancelled = true;
+    };
   }, [pdf]);
+
+  useEffect(() => {
+    const node = thumbListRef.current;
+    if (!node || !isSidebarOpen) return;
+    const handleScroll = () => setScrollTop(node.scrollTop);
+    handleScroll();
+    setContainerHeight(node.clientHeight);
+
+    node.addEventListener('scroll', handleScroll);
+
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver((entries) => {
+        const entry = entries[0];
+        if (entry) setContainerHeight(entry.contentRect.height);
+      });
+      resizeObserver.observe(node);
+    }
+
+    return () => {
+      node.removeEventListener('scroll', handleScroll);
+      resizeObserver?.disconnect();
+    };
+  }, [isSidebarOpen]);
+
+  const thumbPositions = useMemo<ThumbMetaWithPosition[]>(() => {
+    let offset = 0;
+    return thumbMeta.map((meta) => {
+      const item = {
+        ...meta,
+        top: offset,
+      };
+      offset += meta.height + THUMB_GAP;
+      return item;
+    });
+  }, [thumbMeta]);
+
+  const totalThumbHeight = useMemo(() => {
+    if (thumbPositions.length === 0) return 0;
+    const last = thumbPositions[thumbPositions.length - 1];
+    return last.top + last.height;
+  }, [thumbPositions]);
+
+  const visibleThumbs = useMemo<ThumbMetaWithPosition[]>(() => {
+    if (thumbPositions.length === 0) return [];
+    if (!isSidebarOpen) return [];
+    if (containerHeight === 0) {
+      return thumbPositions.slice(0, Math.min(thumbPositions.length, 12));
+    }
+    const viewBottom = scrollTop + containerHeight;
+    let start = 0;
+    while (
+      start < thumbPositions.length &&
+      thumbPositions[start].top + thumbPositions[start].height < scrollTop
+    ) {
+      start += 1;
+    }
+    let end = start;
+    while (end < thumbPositions.length && thumbPositions[end].top < viewBottom) {
+      end += 1;
+    }
+    const overscan = 2;
+    start = Math.max(0, start - overscan);
+    end = Math.min(thumbPositions.length, end + overscan);
+    return thumbPositions.slice(start, end);
+  }, [thumbPositions, containerHeight, scrollTop, isSidebarOpen]);
+
+  const rovingKey = useMemo(
+    () => visibleThumbs.map((item) => item.pageNumber).join('-'),
+    [visibleThumbs]
+  );
+
+  useRovingTabIndex(
+    thumbListRef as React.RefObject<HTMLElement>,
+    isSidebarOpen && visibleThumbs.length > 0,
+    'vertical',
+    rovingKey
+  );
+
+  const renderThumbnail = useCallback(
+    async (pageNumber: number, scale: number) => {
+      if (!pdf) return null;
+      const cache = thumbCacheRef.current;
+      if (cache.has(pageNumber)) return cache.get(pageNumber)!;
+      const pg = await pdf.getPage(pageNumber);
+      const viewport = pg.getViewport({ scale });
+      const canvas = document.createElement('canvas');
+      canvas.width = viewport.width;
+      canvas.height = viewport.height;
+      const context = canvas.getContext('2d');
+      if (!context) return null;
+      await pg
+        .render({ canvasContext: context, viewport, canvas })
+        .promise;
+      cache.set(pageNumber, canvas);
+      return canvas;
+    },
+    [pdf]
+  );
+
+  const handleThumbCanvasRef = useCallback(
+    (meta: ThumbMeta) =>
+      (canvas: HTMLCanvasElement | null) => {
+        if (!canvas) return;
+        canvas.width = meta.width;
+        canvas.height = meta.height;
+        renderThumbnail(meta.pageNumber, meta.scale).then((source) => {
+          if (!source) return;
+          const ctx = canvas.getContext('2d');
+          if (!ctx) return;
+          ctx.clearRect(0, 0, meta.width, meta.height);
+          ctx.drawImage(source, 0, 0, meta.width, meta.height);
+        });
+      },
+    [renderThumbnail]
+  );
+
+  useEffect(() => {
+    const node = thumbListRef.current;
+    if (!node || !isSidebarOpen) return;
+    const active = thumbPositions.find((item) => item.pageNumber === page);
+    if (!active) return;
+    const top = active.top;
+    const bottom = active.top + active.height;
+    if (top < node.scrollTop) {
+      node.scrollTop = top;
+    } else if (bottom > node.scrollTop + node.clientHeight) {
+      node.scrollTop = bottom - node.clientHeight;
+    }
+  }, [page, thumbPositions, isSidebarOpen]);
 
   const search = async () => {
     if (!pdf) return;
@@ -96,41 +265,109 @@ const PdfViewer: React.FC<PdfViewerProps> = ({ url }) => {
   };
 
   return (
-    <div>
-      <div className="flex gap-2 mb-2">
+    <div className="flex h-full flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="sr-only" htmlFor="pdf-search">
+          Search document
+        </label>
         <input
+          id="pdf-search"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search"
+          aria-label="Search document"
+          className="min-w-[200px] flex-1 rounded border border-slate-600 bg-transparent px-3 py-2 text-sm text-slate-100 placeholder-slate-400 focus:border-sky-400 focus:outline-none"
         />
-        <button onClick={search}>Search</button>
+        <button
+          onClick={search}
+          type="button"
+          className="rounded bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300"
+        >
+          Search
+        </button>
+        <button
+          type="button"
+          className="ml-auto rounded border border-slate-600 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200 transition hover:border-sky-500 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300"
+          onClick={() => setIsSidebarOpen((prev) => !prev)}
+          aria-expanded={isSidebarOpen}
+          aria-controls="pdf-thumbnail-sidebar"
+        >
+          {isSidebarOpen ? 'Hide thumbnails' : 'Show thumbnails'}
+        </button>
       </div>
-      <canvas ref={canvasRef} data-testid="pdf-canvas" />
-      <div
-        className="flex gap-2 overflow-x-auto mt-2"
-        role="listbox"
-        aria-orientation="horizontal"
-        ref={thumbListRef}
-      >
-        {thumbs.map((t, i) => (
+      <div className="flex min-h-[400px] flex-1 overflow-hidden rounded-lg border border-slate-700 bg-black/30">
+        <aside
+          id="pdf-thumbnail-sidebar"
+          className={`relative flex h-full flex-col border-r border-slate-700 bg-slate-900/60 transition-[width,opacity] duration-200 ${
+            isSidebarOpen ? 'w-48 sm:w-56 opacity-100' : 'w-0 opacity-0'
+          }`}
+          aria-hidden={!isSidebarOpen}
+        >
+          <div className="flex items-center justify-between px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">
+            <span>Pages</span>
+          </div>
+          <div className="relative flex-1 overflow-hidden">
+            <div
+              ref={thumbListRef}
+              role="listbox"
+              aria-label="Document pages"
+              aria-orientation="vertical"
+              className="h-full overflow-y-auto focus:outline-none"
+              tabIndex={-1}
+            >
+              <div
+                style={{ height: totalThumbHeight, position: 'relative' }}
+                className="pr-2"
+              >
+                {visibleThumbs.map((thumb) => (
+                  <div
+                    key={thumb.pageNumber}
+                    style={{ position: 'absolute', top: thumb.top, left: 0, right: 0 }}
+                    className="px-2"
+                  >
+                    <button
+                      type="button"
+                      role="option"
+                      tabIndex={page === thumb.pageNumber ? 0 : -1}
+                      aria-selected={page === thumb.pageNumber}
+                      data-testid={`thumb-${thumb.pageNumber}`}
+                      onClick={() => setPage(thumb.pageNumber)}
+                      onFocus={() => setPage(thumb.pageNumber)}
+                      className={`group flex w-full flex-col items-center gap-2 rounded-md border px-2 py-3 text-xs font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300 ${
+                        page === thumb.pageNumber
+                          ? 'border-sky-500 bg-sky-500/20 text-sky-100'
+                          : 'border-transparent bg-slate-800/60 text-slate-200 hover:border-slate-500 hover:bg-slate-800'
+                      }`}
+                    >
+                      <canvas
+                        ref={handleThumbCanvasRef(thumb)}
+                        width={thumb.width}
+                        height={thumb.height}
+                        className="w-full rounded shadow-sm"
+                        aria-hidden="true"
+                      />
+                      <span className="w-full text-center text-[11px] uppercase tracking-wide text-slate-300">
+                        Page {thumb.pageNumber}
+                      </span>
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </aside>
+        <div className="relative flex flex-1 justify-center overflow-auto bg-slate-950/70 p-4">
           <canvas
-            key={i + 1}
-            role="option"
-            tabIndex={page === i + 1 ? 0 : -1}
-            aria-selected={page === i + 1}
-            data-testid={`thumb-${i + 1}`}
-            onClick={() => setPage(i + 1)}
-            onFocus={() => setPage(i + 1)}
-            ref={(el) => {
-              if (el) el.getContext('2d')?.drawImage(t, 0, 0);
-            }}
-            width={t.width}
-            height={t.height}
+            ref={canvasRef}
+            data-testid="pdf-canvas"
+            className="max-h-full w-auto max-w-full"
+            role="img"
+            aria-label={`Page ${page} preview`}
           />
-        ))}
+        </div>
       </div>
       {matches.length > 0 && (
-        <div data-testid="search-results">
+        <div data-testid="search-results" className="space-y-1 text-sm text-slate-100">
           {matches.map((m) => (
             <div key={m}>Page {m}</div>
           ))}

--- a/hooks/useRovingTabIndex.ts
+++ b/hooks/useRovingTabIndex.ts
@@ -9,7 +9,8 @@ import { useEffect } from 'react';
 export default function useRovingTabIndex(
   ref: React.RefObject<HTMLElement>,
   active: boolean = true,
-  orientation: 'horizontal' | 'vertical' = 'horizontal'
+  orientation: 'horizontal' | 'vertical' = 'horizontal',
+  refresh?: unknown
 ) {
   useEffect(() => {
     const node = ref.current;
@@ -46,5 +47,5 @@ export default function useRovingTabIndex(
     return () => {
       node.removeEventListener('keydown', handleKey);
     };
-  }, [ref, active, orientation]);
+  }, [ref, active, orientation, refresh]);
 }


### PR DESCRIPTION
## Summary
- add a collapsible thumbnail sidebar to the PDF viewer with virtualization and responsive controls
- expose a refresh key in the roving tab index hook so listboxes re-initialize when their items change
- update related unit tests and jest mocks for accessibility-focused changes

## Testing
- yarn lint
- yarn test --runTestsByPath __tests__/pdfviewer.test.tsx
- yarn test --runTestsByPath __tests__/navbar-running-apps.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd8dbca8b08328b4a32c33e264eda4