### PR TITLE
[desktop] add find overlay for window content

### DIFF
--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -1032,6 +1032,14 @@ export class Desktop extends Component {
             e.preventDefault();
             this.openApp('clipboard-manager');
         }
+        else if (e.ctrlKey && !e.altKey && !e.metaKey && e.key.toLowerCase() === 'f') {
+            e.preventDefault();
+            const id = this.getFocusedWindowId();
+            if (id) {
+                const node = document.getElementById(id);
+                node?.dispatchEvent(new CustomEvent('window-find-open', { detail: {} }));
+            }
+        }
         else if (e.altKey && e.key === 'Tab') {
             e.preventDefault();
             this.cycleApps(e.shiftKey ? -1 : 1);

--- a/styles/index.css
+++ b/styles/index.css
@@ -582,6 +582,27 @@ textarea:focus-visible {
     scroll-snap-align: start;
 }
 
+/* Highlighted search results within windows */
+.window-find-highlight {
+    background-color: rgba(217, 119, 6, 0.35);
+    color: inherit;
+    border-radius: 3px;
+    padding: 0 0.2rem;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.window-find-highlight-active {
+    background-color: rgba(234, 179, 8, 0.85);
+    color: #0f1317;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
+}
+
+.high-contrast .window-find-highlight,
+.high-contrast .window-find-highlight-active {
+    background-color: #ffff00;
+    color: #000;
+}
+
 /* High contrast overrides */
 .high-contrast .bg-ub-orange {
     color: #000 !important;


### PR DESCRIPTION
## Summary
- add a window-level find bar with keyboard navigation and result highlighting
- wire Ctrl+F to open the find overlay for the focused window
- style highlighted matches for normal and high-contrast themes

## Testing
- yarn lint *(fails: existing `react/display-name` errors in `__tests__/navbar-running-apps.test.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8dbdcd5c83289ced0698c6eee1cc