### PR TITLE
[ui] share context menu item contract

### DIFF
--- a/components/context-menus/app-menu.js
+++ b/components/context-menus/app-menu.js
@@ -1,6 +1,9 @@
 import React, { useRef } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import { MenuItemsList } from '../common/ContextMenu'
+
+/** @typedef {import('../common/ContextMenu').MenuItem} MenuItem */
 
 function AppMenu(props) {
     const menuRef = useRef(null)
@@ -21,6 +24,19 @@ function AppMenu(props) {
         }
     }
 
+    /** @type {MenuItem[]} */
+    const items = [
+        {
+            id: 'toggle-pin',
+            label: props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites',
+            onSelect: handlePin,
+        },
+    ]
+
+    const handleItemSelect = () => {
+        props.onClose && props.onClose()
+    }
+
     return (
         <div
             id="app-menu"
@@ -30,15 +46,7 @@ function AppMenu(props) {
             onKeyDown={handleKeyDown}
             className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
         >
-            <button
-                type="button"
-                onClick={handlePin}
-                role="menuitem"
-                aria-label={props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
-            >
-                <span className="ml-5">{props.pinned ? 'Unpin from Favorites' : 'Pin to Favorites'}</span>
-            </button>
+            <MenuItemsList items={items} onItemSelect={handleItemSelect} />
         </div>
     )
 }

--- a/components/context-menus/default.js
+++ b/components/context-menus/default.js
@@ -1,6 +1,9 @@
-import React, { useRef } from 'react'
+import React, { useMemo, useRef } from 'react'
 import useFocusTrap from '../../hooks/useFocusTrap'
 import useRovingTabIndex from '../../hooks/useRovingTabIndex'
+import { MenuItemsList } from '../common/ContextMenu'
+
+/** @typedef {import('../common/ContextMenu').MenuItem} MenuItem */
 
 function DefaultMenu(props) {
     const menuRef = useRef(null)
@@ -11,6 +14,46 @@ function DefaultMenu(props) {
         if (e.key === 'Escape') {
             props.onClose && props.onClose()
         }
+    }
+
+    const followLinks = useMemo(
+        () => /** @type {MenuItem[]} */ ([
+            {
+                id: 'follow-linkedin',
+                icon: '🙋‍♂️',
+                label: 'Follow on Linkedin',
+                onSelect: () => window.open('https://www.linkedin.com/in/unnippillil/', '_blank', 'noopener,noreferrer'),
+            },
+            {
+                id: 'follow-github',
+                icon: '🤝',
+                label: 'Follow on Github',
+                onSelect: () => window.open('https://github.com/Alex-Unnippillil', '_blank', 'noopener,noreferrer'),
+            },
+            {
+                id: 'contact-email',
+                icon: '📥',
+                label: 'Contact Me',
+                onSelect: () => window.open('mailto:alex.j.unnippillil@gmail.com', '_self'),
+            },
+        ]),
+        [],
+    )
+
+    const systemItems = useMemo(
+        () => /** @type {MenuItem[]} */ ([
+            {
+                id: 'reset-session',
+                icon: '🧹',
+                label: 'Reset Kali Linux',
+                onSelect: () => { localStorage.clear(); window.location.reload() },
+            },
+        ]),
+        [],
+    )
+
+    const handleItemSelect = () => {
+        props.onClose && props.onClose()
     }
 
     return (
@@ -24,46 +67,15 @@ function DefaultMenu(props) {
         >
 
             <Devider />
-            <a
-                rel="noopener noreferrer"
-                href="https://www.linkedin.com/in/unnippillil/"
-                target="_blank"
-                role="menuitem"
-                aria-label="Follow on Linkedin"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
-            >
-                <span className="ml-5">🙋‍♂️</span> <span className="ml-2">Follow on <strong>Linkedin</strong></span>
-            </a>
-            <a
-                rel="noopener noreferrer"
-                href="https://github.com/Alex-Unnippillil"
-                target="_blank"
-                role="menuitem"
-                aria-label="Follow on Github"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
-            >
-                <span className="ml-5">🤝</span> <span className="ml-2">Follow on <strong>Github</strong></span>
-            </a>
-            <a
-                rel="noopener noreferrer"
-                href="mailto:alex.j.unnippillil@gmail.com"
-                target="_blank"
-                role="menuitem"
-                aria-label="Contact Me"
-                className="w-full block cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
-            >
-                <span className="ml-5">📥</span> <span className="ml-2">Contact Me</span>
-            </a>
+            <MenuItemsList
+                items={followLinks}
+                onItemSelect={handleItemSelect}
+            />
             <Devider />
-            <button
-                type="button"
-                onClick={() => { localStorage.clear(); window.location.reload() }}
-                role="menuitem"
-                aria-label="Reset Kali Linux"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
-            >
-                <span className="ml-5">🧹</span> <span className="ml-2">Reset Kali Linux</span>
-            </button>
+            <MenuItemsList
+                items={systemItems}
+                onItemSelect={handleItemSelect}
+            />
         </div>
     )
 }

--- a/components/context-menus/desktop-menu.js
+++ b/components/context-menus/desktop-menu.js
@@ -1,5 +1,8 @@
 import React, { useState, useEffect } from 'react'
 import logger from '../../utils/logger'
+import { MenuItemsList } from '../common/ContextMenu'
+
+/** @typedef {import('../common/ContextMenu').MenuItem} MenuItem */
 
 function DesktopMenu(props) {
 
@@ -43,6 +46,87 @@ function DesktopMenu(props) {
         }
     }
 
+    /** @type {MenuItem[]} */
+    const mainActions = [
+        {
+            id: 'new-folder',
+            label: 'New Folder',
+            onSelect: props.addNewFolder,
+        },
+        {
+            id: 'create-shortcut',
+            label: 'Create Shortcut...',
+            onSelect: props.openShortcutSelector,
+        },
+    ]
+
+    /** @type {MenuItem[]} */
+    const clipboardActions = [
+        {
+            id: 'paste',
+            label: 'Paste',
+            disabled: true,
+            onSelect: () => { },
+        },
+    ]
+
+    /** @type {MenuItem[]} */
+    const terminalActions = [
+        {
+            id: 'show-desktop',
+            label: 'Show Desktop in Files',
+            disabled: true,
+            onSelect: () => { },
+        },
+        {
+            id: 'open-terminal',
+            label: 'Open in Terminal',
+            onSelect: openTerminal,
+        },
+    ]
+
+    /** @type {MenuItem[]} */
+    const appearanceActions = [
+        {
+            id: 'change-background',
+            label: 'Change Background...',
+            onSelect: openSettings,
+        },
+    ]
+
+    /** @type {MenuItem[]} */
+    const settingsActions = [
+        {
+            id: 'display-settings',
+            label: 'Display Settings',
+            disabled: true,
+            onSelect: () => { },
+        },
+        {
+            id: 'settings',
+            label: 'Settings',
+            onSelect: openSettings,
+        },
+    ]
+
+    /** @type {MenuItem[]} */
+    const screenActions = [
+        {
+            id: 'toggle-fullscreen',
+            label: `${isFullScreen ? 'Exit' : 'Enter'} Full Screen`,
+            onSelect: goFullScreen,
+        },
+    ]
+
+    /** @type {MenuItem[]} */
+    const sessionActions = [
+        {
+            id: 'clear-session',
+            label: 'Clear Session',
+            onSelect: props.clearSession,
+        },
+    ]
+
     return (
         <div
             id="desktop-menu"
@@ -50,84 +134,19 @@ function DesktopMenu(props) {
             aria-label="Desktop context menu"
             className={(props.active ? " block " : " hidden ") + " cursor-default w-52 context-menu-bg border text-left font-light border-gray-900 rounded text-white py-4 absolute z-50 text-sm"}
         >
-            <button
-                onClick={props.addNewFolder}
-                type="button"
-                role="menuitem"
-                aria-label="New Folder"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">New Folder</span>
-            </button>
-            <button
-                onClick={props.openShortcutSelector}
-                type="button"
-                role="menuitem"
-                aria-label="Create Shortcut"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Create Shortcut...</span>
-            </button>
+            <MenuItemsList items={mainActions} itemClassName='hover:bg-ub-warm-grey hover:bg-opacity-20' />
             <Devider />
-            <div role="menuitem" aria-label="Paste" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Paste</span>
-            </div>
+            <MenuItemsList items={clipboardActions} itemClassName='hover:bg-ub-warm-grey hover:bg-opacity-20' />
             <Devider />
-            <div role="menuitem" aria-label="Show Desktop in Files" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Show Desktop in Files</span>
-            </div>
-            <button
-                onClick={openTerminal}
-                type="button"
-                role="menuitem"
-                aria-label="Open in Terminal"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Open in Terminal</span>
-            </button>
+            <MenuItemsList items={terminalActions} itemClassName='hover:bg-ub-warm-grey hover:bg-opacity-20' />
             <Devider />
-            <button
-                onClick={openSettings}
-                type="button"
-                role="menuitem"
-                aria-label="Change Background"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Change Background...</span>
-            </button>
+            <MenuItemsList items={appearanceActions} itemClassName='hover:bg-ub-warm-grey hover:bg-opacity-20' />
             <Devider />
-            <div role="menuitem" aria-label="Display Settings" aria-disabled="true" className="w-full py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5 text-gray-400">
-                <span className="ml-5">Display Settings</span>
-            </div>
-            <button
-                onClick={openSettings}
-                type="button"
-                role="menuitem"
-                aria-label="Settings"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Settings</span>
-            </button>
+            <MenuItemsList items={settingsActions} itemClassName='hover:bg-ub-warm-grey hover:bg-opacity-20' />
             <Devider />
-            <button
-                onClick={goFullScreen}
-                type="button"
-                role="menuitem"
-                aria-label={isFullScreen ? "Exit Full Screen" : "Enter Full Screen"}
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">{isFullScreen ? "Exit" : "Enter"} Full Screen</span>
-            </button>
+            <MenuItemsList items={screenActions} itemClassName='hover:bg-ub-warm-grey hover:bg-opacity-20' />
             <Devider />
-            <button
-                onClick={props.clearSession}
-                type="button"
-                role="menuitem"
-                aria-label="Clear Session"
-                className="w-full text-left py-0.5 hover:bg-ub-warm-grey hover:bg-opacity-20 mb-1.5"
-            >
-                <span className="ml-5">Clear Session</span>
-            </button>
+            <MenuItemsList items={sessionActions} itemClassName='hover:bg-ub-warm-grey hover:bg-opacity-20' />
         </div>
     )
 }

--- a/components/context-menus/taskbar-menu.js
+++ b/components/context-menus/taskbar-menu.js
@@ -1,6 +1,9 @@
 import React, { useRef } from 'react';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';
+import { MenuItemsList } from '../common/ContextMenu';
+
+/** @typedef {import('../common/ContextMenu').MenuItem} MenuItem */
 
 function TaskbarMenu(props) {
     const menuRef = useRef(null);
@@ -23,6 +26,20 @@ function TaskbarMenu(props) {
         props.onCloseMenu && props.onCloseMenu();
     };
 
+    /** @type {MenuItem[]} */
+    const items = [
+        {
+            id: 'toggle-minimize',
+            label: props.minimized ? 'Restore' : 'Minimize',
+            onSelect: handleMinimize,
+        },
+        {
+            id: 'close-window',
+            label: 'Close',
+            onSelect: handleClose,
+        },
+    ];
+
     return (
         <div
             id="taskbar-menu"
@@ -32,24 +49,7 @@ function TaskbarMenu(props) {
             onKeyDown={handleKeyDown}
             className={(props.active ? ' block ' : ' hidden ') + ' cursor-default w-40 context-menu-bg border text-left border-gray-900 rounded text-white py-2 absolute z-50 text-sm'}
         >
-            <button
-                type="button"
-                onClick={handleMinimize}
-                role="menuitem"
-                aria-label={props.minimized ? 'Restore Window' : 'Minimize Window'}
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
-            >
-                <span className="ml-5">{props.minimized ? 'Restore' : 'Minimize'}</span>
-            </button>
-            <button
-                type="button"
-                onClick={handleClose}
-                role="menuitem"
-                aria-label="Close Window"
-                className="w-full text-left cursor-default py-0.5 hover:bg-gray-700 mb-1.5"
-            >
-                <span className="ml-5">Close</span>
-            </button>
+            <MenuItemsList items={items} />
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- define a reusable MenuItem interface with optional icon, accelerator, and disabled states in the shared ContextMenu renderer
- refactor desktop, default, app, and taskbar context menus to build their layouts from typed MenuItem collections
- export a reusable MenuItemsList helper to keep styling consistent while allowing custom hover treatments

## Testing
- yarn lint *(fails: existing react/display-name errors in __tests__/navbar-running-apps.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8db82fbc8328a7a4b40ae6433fc5