### PR TITLE
[theme] refresh quote icon art

### DIFF
--- a/public/themes/Yaru/apps/quote.svg
+++ b/public/themes/Yaru/apps/quote.svg
@@ -1,4 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" ry="8" fill="#4a5568"/>
-  <path d="M20 24h10v16H16V36c0-7 5-12 10-12zm24 0h10v16H40V36c0-7 5-12 10-12z" fill="#fff"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Quotation mark badge</title>
+  <desc id="desc">Rounded tile with stylized double quotation marks inspired by a CC0 asset from Wikimedia Commons.</desc>
+  <defs>
+    <linearGradient id="quoteBackground" x1="4" x2="60" y1="60" y2="4" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1f2937"/>
+      <stop offset="0.5" stop-color="#3b4a6b"/>
+      <stop offset="1" stop-color="#5665a5"/>
+    </linearGradient>
+    <linearGradient id="quoteHighlight" x1="12" x2="52" y1="12" y2="44" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" ry="14" fill="url(#quoteBackground)"/>
+  <rect x="8" y="10" width="48" height="44" rx="12" ry="12" fill="url(#quoteHighlight)"/>
+  <g opacity="0.28" transform="translate(6.1 19.8) scale(0.85) translate(279.9 -381.5)">
+    <path d="M-260.7,408.9c-5.1-5.7-1.6-15.7,2.7-19.5c3.6-3.3,9.6-6,10.2-5c0.9,1.5-2.6,2.5-5.3,4.9c-3.3,3.6-4.4,5.2,0.2,7.2c4.9,2.2,5,4.4,5.2,7.2C-247.4,410.6-255.7,413.8-260.7,408.9z"/>
+    <path d="M-279.9,408.8c-5.1-5.7-1.6-15.7,2.7-19.5c3.6-3.3,9.6-6,10.2-5c0.9,1.5-2.6,2.5-5.3,4.9c-3.3,3.6-4.4,5.2,0.2,7.2c4.9,2.2,5,4.4,5.2,7.2C-266.6,410.5-274.9,413.7-279.9,408.8z"/>
+    <path d="M-213.5,386.6c5.1,5.7,1.6,15.7-2.7,19.5c-3.6,3.3-9.6,6-10.2,5c-0.9-1.5,2.6-2.5,5.3-4.9c3.3-3.6,4.4-5.2-0.2-7.2c-4.9-2.2-5-4.4-5.2-7.2C-226.8,384.9-218.5,381.6-213.5,386.6z"/>
+    <path d="M-232.7,386.5c5.1,5.7,1.6,15.7-2.7,19.5c-3.6,3.3-9.6,6-10.2,5c-0.9-1.5,2.6-2.5,5.3-4.9c3.3-3.6,4.4-5.2-0.2-7.2c-4.9-2.2-5-4.4-5.2-7.2C-245.9,384.8-237.7,381.5-232.7,386.5z"/>
+  </g>
+  <g transform="translate(3.8 17) scale(0.85) translate(279.9 -381.5)" fill="#dde2ff">
+    <path d="M-260.7,408.9c-5.1-5.7-1.6-15.7,2.7-19.5c3.6-3.3,9.6-6,10.2-5c0.9,1.5-2.6,2.5-5.3,4.9c-3.3,3.6-4.4,5.2,0.2,7.2c4.9,2.2,5,4.4,5.2,7.2C-247.4,410.6-255.7,413.8-260.7,408.9z"/>
+    <path d="M-279.9,408.8c-5.1-5.7-1.6-15.7,2.7-19.5c3.6-3.3,9.6-6,10.2-5c0.9,1.5-2.6,2.5-5.3,4.9c-3.3,3.6-4.4,5.2,0.2,7.2c4.9,2.2,5,4.4,5.2,7.2C-266.6,410.5-274.9,413.7-279.9,408.8z"/>
+    <path d="M-213.5,386.6c5.1,5.7,1.6,15.7-2.7,19.5c-3.6,3.3-9.6,6-10.2,5c-0.9-1.5,2.6-2.5,5.3-4.9c3.3-3.6,4.4-5.2-0.2-7.2c-4.9-2.2-5-4.4-5.2-7.2C-226.8,384.9-218.5,381.6-213.5,386.6z"/>
+    <path d="M-232.7,386.5c5.1,5.7,1.6,15.7-2.7,19.5c-3.6,3.3-9.6,6-10.2,5c-0.9-1.5,2.6-2.5,5.3-4.9c3.3-3.6,4.4-5.2-0.2-7.2c-4.9-2.2-5-4.4-5.2-7.2C-245.9,384.8-237.7,381.5-232.7,386.5z"/>
+  </g>
+  <circle cx="18" cy="22" r="2" fill="#9aa5ff" opacity="0.45"/>
+  <circle cx="46" cy="16" r="1.6" fill="#f4f7ff" opacity="0.7"/>
 </svg>


### PR DESCRIPTION
## Summary
- replace the Yaru quote app icon with a layered badge using CC0 quotation marks from Wikimedia Commons
- add gradients, highlights, and metadata to keep the tile detailed and accessible

## Testing
- [x] yarn lint


------
https://chatgpt.com/codex/tasks/task_e_68e029e3b744832885c0f345b02518d2