### PR TITLE
[icons] refresh QR utility artwork

### DIFF
--- a/public/themes/Yaru/apps/qr.svg
+++ b/public/themes/Yaru/apps/qr.svg
@@ -1,10 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect width="100" height="100" fill="#fff"/>
-  <rect x="0" y="0" width="30" height="30" fill="#000"/>
-  <rect x="70" y="0" width="30" height="30" fill="#000"/>
-  <rect x="0" y="70" width="30" height="30" fill="#000"/>
-  <rect x="40" y="40" width="10" height="10" fill="#000"/>
-  <rect x="60" y="40" width="10" height="10" fill="#000"/>
-  <rect x="40" y="60" width="10" height="10" fill="#000"/>
-  <rect x="80" y="80" width="20" height="20" fill="#000"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="QR utility icon">
+  <defs>
+    <linearGradient id="qr-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+    <linearGradient id="qr-scan" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0"/>
+      <stop offset="50%" stop-color="#38bdf8" stop-opacity="0.55"/>
+      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#qr-bg)"/>
+  <rect x="24" y="24" width="80" height="80" rx="16" fill="#0b1220"/>
+  <rect x="32" y="32" width="24" height="24" rx="6" fill="#1f2937" stroke="#38bdf8" stroke-width="4"/>
+  <rect x="72" y="32" width="24" height="24" rx="6" fill="#1f2937" stroke="#38bdf8" stroke-width="4"/>
+  <rect x="32" y="72" width="24" height="24" rx="6" fill="#1f2937" stroke="#38bdf8" stroke-width="4"/>
+  <rect x="60" y="60" width="12" height="12" rx="2" fill="#38bdf8"/>
+  <path d="M88 72h8v8h-8z" fill="#38bdf8"/>
+  <path d="M72 88h16v8H72z" fill="#1f2937"/>
+  <path d="M64 96h24v8H64z" fill="#38bdf8"/>
+  <path d="M56 72h8v16h-8z" fill="#1f2937"/>
+  <rect x="40" y="54" width="48" height="20" fill="url(#qr-scan)" opacity="0.8"/>
+  <rect x="40" y="52" width="48" height="2" fill="#38bdf8" opacity="0.65"/>
 </svg>


### PR DESCRIPTION
## Summary
- replace the QR utility icon with a newly created gradient illustration that emphasizes scanning patterns

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e029e3bcf0832882929896923ae1c7