### PR TITLE
[app] Refresh subnet calculator icon

### DIFF
--- a/public/themes/Yaru/apps/subnet-calculator.svg
+++ b/public/themes/Yaru/apps/subnet-calculator.svg
@@ -1,23 +1,47 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">Subnet calculator icon</title>
+  <desc id="desc">Stylised network diagram with an IP address block and highlighted subnet lines.</desc>
   <defs>
-    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
-      <stop offset="0" stop-color="#0f172a" />
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#0b1b3a" />
       <stop offset="1" stop-color="#111827" />
     </linearGradient>
+    <linearGradient id="panel" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#1f2937" />
+      <stop offset="1" stop-color="#0f172a" />
+    </linearGradient>
+    <linearGradient id="highlight" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0" stop-color="#38bdf8" />
+      <stop offset="1" stop-color="#22d3ee" />
+    </linearGradient>
+    <clipPath id="grid">
+      <rect x="18" y="20" width="92" height="88" rx="16" ry="16" />
+    </clipPath>
   </defs>
-  <rect width="128" height="128" rx="18" fill="url(#bg)" />
-  <rect x="18" y="26" width="92" height="76" rx="14" fill="#1f2937" stroke="#38bdf8" stroke-width="4" />
-  <path
-    d="M34 54h60M34 74h60M64 26v18M64 102V88"
-    stroke="#38bdf8"
-    stroke-width="4"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    opacity="0.6"
-  />
-  <circle cx="40" cy="46" r="8" fill="#1d4ed8" />
-  <circle cx="88" cy="46" r="8" fill="#1d4ed8" />
-  <circle cx="40" cy="86" r="8" fill="#22d3ee" />
-  <circle cx="88" cy="86" r="8" fill="#22d3ee" />
-  <circle cx="64" cy="66" r="10" fill="#0ea5e9" stroke="#38bdf8" stroke-width="4" />
+  <rect width="128" height="128" rx="20" fill="url(#bg)" />
+  <rect x="18" y="20" width="92" height="88" rx="16" ry="16" fill="url(#panel)" stroke="#38bdf8" stroke-width="3" />
+  <g clip-path="url(#grid)">
+    <g stroke="#1d4ed8" stroke-width="3" opacity="0.35">
+      <path d="M18 44h92M18 68h92M18 92h92" />
+      <path d="M42 20v88M66 20v88M90 20v88" />
+    </g>
+    <rect x="24" y="48" width="80" height="28" rx="8" fill="#0f172a" stroke="url(#highlight)" stroke-width="3" />
+    <g fill="#38bdf8">
+      <circle cx="40" cy="36" r="7" />
+      <circle cx="88" cy="36" r="7" />
+      <circle cx="40" cy="100" r="7" />
+      <circle cx="88" cy="100" r="7" />
+    </g>
+    <path d="M40 36h48M40 100h48" stroke="url(#highlight)" stroke-width="3" stroke-linecap="round" opacity="0.65" />
+    <g fill="none" stroke="url(#highlight)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M52 62h24" />
+      <path d="M38 62h6" />
+      <path d="M84 62h6" />
+    </g>
+  </g>
+  <g font-family="'Fira Mono', 'Menlo', 'DejaVu Sans Mono', monospace" font-size="14" font-weight="600" letter-spacing="0.8" fill="#e0f2fe">
+    <text x="64" y="67" text-anchor="middle">192.168</text>
+    <text x="64" y="81" text-anchor="middle" font-size="12" fill="#38bdf8">/24</text>
+  </g>
+  <path d="M64 94l8 8-8 8-8-8z" fill="url(#highlight)" opacity="0.85" />
 </svg>


### PR DESCRIPTION
## Summary
- replace the subnet calculator app icon with a custom SVG illustrating IP and subnet concepts
- keep the dynamic app registry pointing at the same asset path

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e029e9ae488328a320f917c981086f