### PR TITLE
[assets] Refresh 2048 tile icon

### DIFF
--- a/public/themes/Yaru/apps/2048.svg
+++ b/public/themes/Yaru/apps/2048.svg
@@ -1,5 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" ry="8" fill="#edc22e"/>
-  <text x="50%" y="50%" font-family="Arial, Helvetica, sans-serif" font-size="24" fill="#fff"
-    text-anchor="middle" dominant-baseline="middle">2048</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-labelledby="title desc">
+  <title id="title">2048 game tile icon</title>
+  <desc id="desc">A golden rounded square tile with the number 2048 in white, inspired by the official 2048 game tile.</desc>
+  <defs>
+    <linearGradient id="tileGradient" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#f7da72" />
+      <stop offset="1" stop-color="#edc22e" />
+    </linearGradient>
+    <linearGradient id="shineGradient" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#fff" stop-opacity="0.65" />
+      <stop offset="0.45" stop-color="#fff" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <g>
+    <rect x="6" y="6" width="108" height="108" rx="18" fill="#d0a525" />
+    <rect x="10" y="10" width="100" height="100" rx="16" fill="url(#tileGradient)" />
+    <path d="M20 18h80c3.3 0 6 2.7 6 6v10c-24-6-54-7-92 10v-20c0-3.3 2.7-6 6-6z" fill="url(#shineGradient)" />
+    <path d="M20 102c20-6 46-10 80-4v8c0 3.3-2.7 6-6 6H26c-3.3 0-6-2.7-6-6z" fill="#d0a525" opacity="0.35" />
+    <text x="60" y="72" text-anchor="middle" font-family="'Clear Sans','Helvetica Neue',Arial,sans-serif" font-size="52" font-weight="700" fill="#f8f6f1">
+      2048
+    </text>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the 2048 app icon with a refreshed, official-style SVG tile

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e029eb96388328ad514dd3701135c7