### PR TITLE
[apps] Refresh Breakout icon

### DIFF
--- a/public/themes/Yaru/apps/breakout.svg
+++ b/public/themes/Yaru/apps/breakout.svg
@@ -1,6 +1,45 @@
-<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" fill="#2e3436"/>
-  <rect x="12" y="8" width="40" height="12" fill="#ffffff"/>
-  <rect x="20" y="54" width="24" height="4" fill="#ffffff"/>
-  <circle cx="32" cy="40" r="4" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <!-- Original artwork created for the Kali Linux Portfolio project (2024). Licensed under Apache-2.0. -->
+  <title>Breakout arcade icon</title>
+  <desc>A glowing paddle deflects a ball toward a wall of bricks.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1e1f29"/>
+      <stop offset="1" stop-color="#272a36"/>
+    </linearGradient>
+    <linearGradient id="brick" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ff6f61"/>
+      <stop offset="1" stop-color="#d13d5a"/>
+    </linearGradient>
+    <linearGradient id="brick2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffd166"/>
+      <stop offset="1" stop-color="#f77f00"/>
+    </linearGradient>
+    <linearGradient id="paddle" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#4cc9f0"/>
+      <stop offset="1" stop-color="#4895ef"/>
+    </linearGradient>
+    <radialGradient id="ball" cx="0.35" cy="0.35" r="0.75">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#d1e9ff"/>
+    </radialGradient>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="1.6" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="64" height="64" rx="8" ry="8" fill="url(#bg)"/>
+  <g transform="translate(8 10)">
+    <rect width="48" height="8" rx="2" fill="url(#brick)"/>
+    <rect y="10" width="48" height="8" rx="2" fill="url(#brick2)"/>
+    <rect y="20" width="48" height="6" rx="2" fill="#4cc9f0" opacity="0.25"/>
+  </g>
+  <g filter="url(#glow)">
+    <circle cx="40" cy="30" r="5" fill="url(#ball)"/>
+    <path d="M34 38c6-4 14-7 20-12" fill="none" stroke="#9be1ff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.6"/>
+  </g>
+  <rect x="20" y="50" width="24" height="6" rx="3" fill="url(#paddle)" filter="url(#glow)"/>
 </svg>


### PR DESCRIPTION
## Summary
- replace the Breakout app icon with a custom breakout illustration that includes bricks, ball trail, and paddle glow
- confirm the Breakout registry entry continues to point at the updated asset

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e029ef47a08328a8950d9a1be954dd