### PR TITLE
[icons] Refresh Checkers app artwork

### DIFF
--- a/public/themes/Yaru/apps/checkers.svg
+++ b/public/themes/Yaru/apps/checkers.svg
@@ -1,16 +1,86 @@
-<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" fill="#2e3436"/>
-  <rect x="8" y="8" width="48" height="48" fill="#8b4513"/>
-  <g fill="#b22222">
-    <rect x="8" y="8" width="12" height="12"/>
-    <rect x="32" y="8" width="12" height="12"/>
-    <rect x="20" y="20" width="12" height="12"/>
-    <rect x="44" y="20" width="12" height="12"/>
-    <rect x="8" y="32" width="12" height="12"/>
-    <rect x="32" y="32" width="12" height="12"/>
-    <rect x="20" y="44" width="12" height="12"/>
-    <rect x="44" y="44" width="12" height="12"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Checkers board icon</title>
+  <desc id="desc">Stylised checkers board with red and navy pieces arranged for play.</desc>
+  <defs>
+    <radialGradient id="boardGlow" cx="50%" cy="35%" r="75%">
+      <stop offset="0%" stop-color="#fbe6c7" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#d6a46a" stop-opacity="0.2" />
+    </radialGradient>
+    <radialGradient id="pieceRed" cx="48%" cy="32%" r="60%">
+      <stop offset="0%" stop-color="#f8bbb3" />
+      <stop offset="65%" stop-color="#d65a50" />
+      <stop offset="100%" stop-color="#b4453d" />
+    </radialGradient>
+    <radialGradient id="pieceNavy" cx="48%" cy="32%" r="60%">
+      <stop offset="0%" stop-color="#9aa8c9" />
+      <stop offset="65%" stop-color="#445170" />
+      <stop offset="100%" stop-color="#2c3349" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="8" fill="#15191f" />
+  <rect x="5" y="5" width="54" height="54" rx="6" fill="#2b1a11" />
+  <rect x="8" y="8" width="48" height="48" rx="2.5" fill="#f2d8a8" stroke="#8a5c2e" stroke-width="1.5" />
+  <rect x="8" y="8" width="48" height="48" rx="2.5" fill="url(#boardGlow)" opacity="0.55" />
+  <g fill="#b87143">
+    <rect x="14" y="8" width="6" height="6" />
+    <rect x="26" y="8" width="6" height="6" />
+    <rect x="38" y="8" width="6" height="6" />
+    <rect x="50" y="8" width="6" height="6" />
+    <rect x="8" y="14" width="6" height="6" />
+    <rect x="20" y="14" width="6" height="6" />
+    <rect x="32" y="14" width="6" height="6" />
+    <rect x="44" y="14" width="6" height="6" />
+    <rect x="14" y="20" width="6" height="6" />
+    <rect x="26" y="20" width="6" height="6" />
+    <rect x="38" y="20" width="6" height="6" />
+    <rect x="50" y="20" width="6" height="6" />
+    <rect x="8" y="26" width="6" height="6" />
+    <rect x="20" y="26" width="6" height="6" />
+    <rect x="32" y="26" width="6" height="6" />
+    <rect x="44" y="26" width="6" height="6" />
+    <rect x="14" y="32" width="6" height="6" />
+    <rect x="26" y="32" width="6" height="6" />
+    <rect x="38" y="32" width="6" height="6" />
+    <rect x="50" y="32" width="6" height="6" />
+    <rect x="8" y="38" width="6" height="6" />
+    <rect x="20" y="38" width="6" height="6" />
+    <rect x="32" y="38" width="6" height="6" />
+    <rect x="44" y="38" width="6" height="6" />
+    <rect x="14" y="44" width="6" height="6" />
+    <rect x="26" y="44" width="6" height="6" />
+    <rect x="38" y="44" width="6" height="6" />
+    <rect x="50" y="44" width="6" height="6" />
+    <rect x="8" y="50" width="6" height="6" />
+    <rect x="20" y="50" width="6" height="6" />
+    <rect x="32" y="50" width="6" height="6" />
+    <rect x="44" y="50" width="6" height="6" />
   </g>
-  <circle cx="20" cy="20" r="6" fill="#ffffff"/>
-  <circle cx="44" cy="44" r="6" fill="#000000"/>
+  <g fill="url(#pieceRed)" stroke="#611d1b" stroke-width="0.4">
+    <circle cx="17" cy="11" r="2.35" />
+    <circle cx="29" cy="11" r="2.35" />
+    <circle cx="41" cy="11" r="2.35" />
+    <circle cx="53" cy="11" r="2.35" />
+    <circle cx="11" cy="17" r="2.35" />
+    <circle cx="23" cy="17" r="2.35" />
+    <circle cx="35" cy="17" r="2.35" />
+    <circle cx="47" cy="17" r="2.35" />
+    <circle cx="17" cy="23" r="2.35" />
+    <circle cx="29" cy="23" r="2.35" />
+    <circle cx="41" cy="23" r="2.35" />
+    <circle cx="53" cy="23" r="2.35" />
+  </g>
+  <g fill="url(#pieceNavy)" stroke="#182134" stroke-width="0.4">
+    <circle cx="11" cy="41" r="2.35" />
+    <circle cx="23" cy="41" r="2.35" />
+    <circle cx="35" cy="41" r="2.35" />
+    <circle cx="47" cy="41" r="2.35" />
+    <circle cx="17" cy="47" r="2.35" />
+    <circle cx="29" cy="47" r="2.35" />
+    <circle cx="41" cy="47" r="2.35" />
+    <circle cx="53" cy="47" r="2.35" />
+    <circle cx="11" cy="53" r="2.35" />
+    <circle cx="23" cy="53" r="2.35" />
+    <circle cx="35" cy="53" r="2.35" />
+    <circle cx="47" cy="53" r="2.35" />
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the Checkers app icon with a newly drawn SVG board and pieces
- verified the existing app configuration still points at the refreshed artwork

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e029f1f7ac8328a0e7cf954d377065