### PR TITLE
[apps] Replace chess icon

### DIFF
--- a/public/themes/Yaru/apps/chess.svg
+++ b/public/themes/Yaru/apps/chess.svg
@@ -1,8 +1,31 @@
-<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" fill="#2e3436"/>
-  <!-- Simple chess rook icon -->
-  <rect x="24" y="12" width="16" height="8" fill="#ffffff"/>
-  <rect x="20" y="20" width="24" height="12" fill="#ffffff"/>
-  <rect x="16" y="32" width="32" height="16" fill="#ffffff"/>
-  <rect x="12" y="48" width="40" height="8" fill="#ffffff"/>
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Chess rook icon</title>
+  <desc id="desc">Detailed rook chess piece on a dark gradient square.</desc>
+  <!-- Original vector artwork created for the Kali Linux Portfolio project. Released under CC0 1.0. -->
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2e3436"/>
+      <stop offset="100%" stop-color="#1b1f21"/>
+    </linearGradient>
+    <linearGradient id="stone" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f5f7f7"/>
+      <stop offset="45%" stop-color="#d9ddde"/>
+      <stop offset="100%" stop-color="#b7bdc1"/>
+    </linearGradient>
+    <linearGradient id="shadow" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0b0d0e" stop-opacity="0.45"/>
+      <stop offset="100%" stop-color="#0b0d0e" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#bg)"/>
+  <g fill="url(#stone)" stroke="#0d1114" stroke-width="1.25" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M18 50h28l-1.6 6H19.6z"/>
+    <path d="M20 44h24l-2 6H22z"/>
+    <path d="M23.5 22h17l-2 12h5l-3 10h4l-2.5 8H22l-2.5-8h4l-3-10h5z"/>
+    <path d="M18 12h28v8h-5v-4h-4v4h-6v-4h-4v4h-5z"/>
+  </g>
+  <path d="M22 44h20l-1 3H23z" fill="#9da3a6" opacity="0.45"/>
+  <path d="M24 24h16l-1.4 8h-13.2z" fill="#ffffff" opacity="0.35"/>
+  <path d="M16 44h32l3 9H13z" fill="url(#shadow)"/>
+  <path d="M18 12h28" stroke="#ffffff" stroke-opacity="0.35" stroke-width="1.25" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
## Summary
- replace the chess app icon with an original CC0-licensed rook illustration to better match the themed set

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e029f304048328b384fa758012d4d0