### PR TITLE
[icons] Refresh Tetris block artwork

### DIFF
--- a/public/themes/Yaru/apps/tetris.svg
+++ b/public/themes/Yaru/apps/tetris.svg
@@ -1,7 +1,30 @@
-<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" fill="#2e3436"/>
-  <rect x="8" y="8" width="16" height="16" fill="#4caf50"/>
-  <rect x="24" y="8" width="16" height="16" fill="#4caf50"/>
-  <rect x="40" y="8" width="16" height="16" fill="#4caf50"/>
-  <rect x="24" y="24" width="16" height="16" fill="#4caf50"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Tetris Block Icon</title>
+  <desc id="desc">Stylized T shaped Tetris block on a dark grid background.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#1d1f21" />
+      <stop offset="1" stop-color="#121314" />
+    </linearGradient>
+    <linearGradient id="tile" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#7af7ff" />
+      <stop offset="1" stop-color="#0ca0d8" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#001827" flood-opacity="0.4" />
+    </filter>
+  </defs>
+  <rect width="64" height="64" fill="url(#bg)" />
+  <g fill="#161819" opacity="0.35">
+    <path d="M0 12h64v2H0zm0 12h64v2H0zm0 12h64v2H0zm0 12h64v2H0z" />
+    <path d="M12 0v64h-2V0zm12 0v64h-2V0zm12 0v64h-2V0zm12 0v64h-2V0z" />
+  </g>
+  <g filter="url(#shadow)">
+    <rect x="12" y="12" width="40" height="16" rx="2" fill="url(#tile)" stroke="#083f5b" stroke-width="1" />
+    <rect x="28" y="28" width="16" height="24" rx="2" fill="url(#tile)" stroke="#083f5b" stroke-width="1" />
+  </g>
+  <g opacity="0.3">
+    <rect x="16" y="16" width="8" height="8" fill="#ffffff" />
+    <rect x="32" y="32" width="8" height="8" fill="#ffffff" />
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the Tetris application icon with a custom SVG that includes gradients, shadows, and accessibility metadata
- keep the application registry pointed at the refreshed asset

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e02a0374f083288cfdfd6ab34344de