### PR TITLE
[theme] Refresh Wordle icon

### DIFF
--- a/public/themes/Yaru/apps/wordle.svg
+++ b/public/themes/Yaru/apps/wordle.svg
@@ -1,8 +1,16 @@
-<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" fill="#2e3436"/>
-  <rect x="4" y="26" width="10" height="10" fill="#3a3f41" stroke="#ffffff" stroke-width="2"/>
-  <rect x="16" y="26" width="10" height="10" fill="#3a3f41" stroke="#ffffff" stroke-width="2"/>
-  <rect x="28" y="26" width="10" height="10" fill="#3a3f41" stroke="#ffffff" stroke-width="2"/>
-  <rect x="40" y="26" width="10" height="10" fill="#3a3f41" stroke="#ffffff" stroke-width="2"/>
-  <rect x="52" y="26" width="10" height="10" fill="#3a3f41" stroke="#ffffff" stroke-width="2"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Wordle inspired tile</title>
+  <desc id="desc">A green game tile with the letter W on a dark background</desc>
+  <defs>
+    <linearGradient id="tile" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#7ac46d" />
+      <stop offset="100%" stop-color="#4c8c47" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" fill="#121214" rx="8" />
+  <rect x="10" y="10" width="44" height="44" rx="8" fill="url(#tile)" stroke="#2d4f2c" stroke-width="2" />
+  <path
+    d="M18 20h6l3.2 16.5L32 28l4.8 8.5L40 20h6l-5 24h-6l-3-13-4 7-4-7-3 13h-6z"
+    fill="#f5f7f8"
+  />
 </svg>


### PR DESCRIPTION
## Summary
- replace the Wordle app icon with a custom Wordle-inspired tile that includes accessibility metadata
- confirmed the apps configuration continues to point at the refreshed asset

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e02a0742108328b0c6d4bb1d051a74