### PR TITLE
[icons] Refresh dsniff packet-sniffer art

### DIFF
--- a/public/themes/Yaru/apps/dsniff.svg
+++ b/public/themes/Yaru/apps/dsniff.svg
@@ -1,5 +1,32 @@
-<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" fill="#2e3440"/>
-  <circle cx="32" cy="32" r="20" fill="#4c566a"/>
-  <path d="M16 32h32M32 16v32" stroke="#88c0d0" stroke-width="4"/>
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">dsniff icon</title>
+  <desc id="desc">Magnifying glass inspecting stylised network packets to represent packet sniffing.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1d2536" />
+      <stop offset="100%" stop-color="#25324a" />
+    </linearGradient>
+    <linearGradient id="glass" x1="30%" y1="20%" x2="80%" y2="80%">
+      <stop offset="0%" stop-color="#7ad1ff" />
+      <stop offset="100%" stop-color="#3aa9f0" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="12" fill="url(#bg)" />
+  <g stroke="#9bb7ff" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M16 22h18" />
+    <path d="M16 32h14" />
+    <path d="M16 42h10" />
+  </g>
+  <g fill="#67f0c2">
+    <rect x="20" y="20" width="5" height="4" rx="1" />
+    <rect x="26" y="30" width="6" height="4" rx="1" />
+    <rect x="22" y="40" width="5" height="4" rx="1" />
+  </g>
+  <g transform="translate(6 6)">
+    <circle cx="34" cy="32" r="12" fill="url(#glass)" stroke="#d7f3ff" stroke-width="2" />
+    <path d="M43.5 41.5l7 7" stroke="#5fb6f7" stroke-width="4" stroke-linecap="round" />
+    <path d="M28 26c2.5-3 7.5-3 10 0" stroke="#dff7ff" stroke-width="2" stroke-linecap="round" />
+    <path d="M29 36.5c3 3 8 3 11 0" stroke="#dff7ff" stroke-width="2" stroke-linecap="round" />
+  </g>
+  <path d="M32 14c3 0 5 2 5 4.5S35 23 32 23s-5-2.5-5-4.5S29 14 32 14z" fill="#2f3a52" opacity="0.35" />
 </svg>


### PR DESCRIPTION
## Summary
- replace the dsniff app icon with a custom illustration themed around inspecting network packets

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e02a14e76c8328bd7a980d41d323fa