### PR TITLE
[icons] Update radare2 Yaru asset

### DIFF
--- a/public/themes/Yaru/apps/radare2.svg
+++ b/public/themes/Yaru/apps/radare2.svg
@@ -1,5 +1,65 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="45" fill="#fff" stroke="#000" stroke-width="5"/>
-  <line x1="50" y1="5" x2="50" y2="95" stroke="#000" stroke-width="5"/>
-  <line x1="5" y1="50" x2="95" y2="50" stroke="#000" stroke-width="5"/>
-</svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Source: https://github.com/radareorg/radare2/blob/master/doc/images/r2.svg (LGPL-3.0-or-later) -->
+<!-- Created with Inkscape (https://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="https://purl.org/dc/elements/1.1/"
+   xmlns:cc="https://creativecommons.org/ns#"
+   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="https://www.w3.org/2000/svg"
+   xmlns="https://www.w3.org/2000/svg"
+   xmlns:sodipodi="https://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="https://www.inkscape.org/namespaces/inkscape"
+   id="svg3004"
+   version="1.1"
+   inkscape:version="0.48.2 r9819"
+   width="500"
+   height="300"
+   xml:space="preserve"
+   sodipodi:docname="r2.svg"><metadata
+     id="metadata3010"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="https://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs
+     id="defs3008"><clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3018"><path
+         d="m 0,841.89 1190.55,0 L 1190.55,0 0,0 0,841.89 z"
+         id="path3020"
+         inkscape:connector-curvature="0" /></clipPath></defs><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="791"
+     inkscape:window-height="818"
+     id="namedview3006"
+     showgrid="false"
+     inkscape:zoom="0.39912236"
+     inkscape:cx="715.69007"
+     inkscape:cy="676.77258"
+     inkscape:window-x="2687"
+     inkscape:window-y="256"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g3012" /><g
+     id="g3012"
+     inkscape:groupmode="layer"
+     inkscape:label="radare primeros bocetos"
+     transform="matrix(1.25,0,0,-1.25,0,299.99995)"><g
+       id="g4037"
+       transform="translate(-574.48081,-692.03162)"><path
+         d="m 717.48563,860.61081 0,-95.251 11.881,0 0,-5.379 -82.928,0 0,5.379 15.912,0 0,51.547 c 0,9.188 0.673,17.258 -2.463,25.998 -0.673,2.241 -7.394,15.015 -10.758,9.413 0.898,-3.363 1.346,-7.172 1.346,-10.536 0,-15.013 -10.311,-24.65 -25.102,-24.65 -15.464,0 -26.221,10.757 -26.221,26.221 0,16.136 14.12,24.875 28.911,24.875 15.909,0 28.683,-8.514 36.085,-22.186 l 0.444,0 0,22.637 c 21.513,-0.673 43.254,-2.69 64.774,-2.69 l 0,-5.378 -11.881,0 z"
+         style="fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path3492-8"
+         inkscape:connector-curvature="0" /><path
+         d="m 717.30203,814.96091 109.965,54.98 0,-109.96 -109.965,54.98 z"
+         style="fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path3496-8"
+         inkscape:connector-curvature="0" /><path
+         d="m 827.26683,814.96091 109.959,54.98 0,-109.96 -109.959,54.98 z"
+         style="fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path3500-9"
+         inkscape:connector-curvature="0" /></g></g></svg>


### PR DESCRIPTION
## Summary
- replace the Yaru radare2 icon with the official radare2 SVG sourced from the upstream repository

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e02a27f9588328a6c99765427f1692