### PR TITLE
[theme] Refresh car racer icon asset

### DIFF
--- a/public/themes/Yaru/apps/car-racer.svg
+++ b/public/themes/Yaru/apps/car-racer.svg
@@ -1,6 +1,41 @@
-<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <rect x="8" y="24" width="48" height="16" fill="#2e3436"/>
-  <rect x="16" y="16" width="32" height="16" fill="#555753"/>
-  <circle cx="20" cy="44" r="6" fill="#000"/>
-  <circle cx="44" cy="44" r="6" fill="#000"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="64" height="64" role="img" aria-labelledby="carRacerTitle carRacerDesc">
+  <title id="carRacerTitle">Car racer icon</title>
+  <desc id="carRacerDesc">Stylized racing car derived from the Ionicons car-sport-outline glyph.</desc>
+  <!--
+    Adapted from the "car-sport-outline" icon by the Ionic Team (Ionicons).
+    Ionicons is licensed under the MIT License: https://github.com/ionic-team/ionicons/blob/main/LICENSE
+  -->
+  <g stroke-linecap="round" stroke-linejoin="round">
+    <path
+      d="M469.71,234.6c-7.33-9.73-34.56-16.43-46.08-33.94s-20.95-55.43-50.27-70S288,112,256,112s-88,4-117.36,18.63-38.75,52.52-50.27,70S49.62,224.87,42.29,234.6,29.8,305.84,32.94,336s9,48,9,48h86c14.08,0,18.66-5.29,47.46-8C207,373,238,372,256,372s50,1,81.58,4c28.8,2.73,33.53,8,47.46,8h85s5.86-17.84,9-48S477,244.33,469.71,234.6Z"
+      fill="#f04b4b"
+      stroke="#2e3436"
+      stroke-width="28"
+    />
+    <path
+      d="M364.47,309.16c-5.91-6.83-25.17-12.53-50.67-16.35S279,288,256.2,288s-33.17,1.64-57.61,4.81-42.79,8.81-50.66,16.35C136.12,320.6,153.42,333.44,167,335c13.16,1.5,39.47.95,89.31.95s76.15.55,89.31-.95C359.18,333.35,375.24,321.4,364.47,309.16Z"
+      fill="#fefefe"
+      stroke="#2e3436"
+      stroke-width="20"
+    />
+    <path
+      d="M431.57,243.05a3.23,3.23,0,0,0-3.1-3c-11.81-.42-23.8.42-45.07,6.69a93.88,93.88,0,0,0-30.08,15.06c-2.28,1.78-1.47,6.59,1.39,7.1A455.32,455.32,0,0,0,407.53,272c10.59,0,21.52-3,23.55-12.44A52.41,52.41,0,0,0,431.57,243.05Z"
+      fill="#ffce51"
+      stroke="#2e3436"
+      stroke-width="16"
+    />
+    <path
+      d="M80.43,243.05a3.23,3.23,0,0,1,3.1-3c11.81-.42,23.8.42,45.07,6.69a93.88,93.88,0,0,1,30.08,15.06c2.28,1.78,1.47,6.59-1.39,7.1A455.32,455.32,0,0,1,104.47,272c-10.59,0-21.52-3-23.55-12.44A52.41,52.41,0,0,1,80.43,243.05Z"
+      fill="#ffce51"
+      stroke="#2e3436"
+      stroke-width="16"
+    />
+  </g>
+  <rect x="400" y="384" width="56" height="16" rx="6" fill="#2e3436"/>
+  <rect x="56" y="384" width="56" height="16" rx="6" fill="#2e3436"/>
+  <g fill="none" stroke="#2e3436" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="432" y1="192" x2="448" y2="192" stroke-width="20"/>
+    <line x1="64" y1="192" x2="80" y2="192" stroke-width="20"/>
+    <path d="M78,211s46.35-12,178-12,178,12,178,12" stroke-width="20"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- swap the car racer app icon for a detailed Ionicons-derived SVG that documents the MIT license and adds accessible metadata

## Testing
- [x] yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e029f12d088328afa48da9e01341d3