### PR TITLE
[public] refresh Connect Four icon

### DIFF
--- a/public/themes/Yaru/apps/connect-four.svg
+++ b/public/themes/Yaru/apps/connect-four.svg
@@ -1,13 +1,101 @@
-<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" fill="#2e3436"/>
-  <rect x="8" y="8" width="48" height="48" fill="#204a87"/>
-  <circle cx="20" cy="20" r="6" fill="#ef2929"/>
-  <circle cx="32" cy="20" r="6" fill="#fce94f"/>
-  <circle cx="44" cy="20" r="6" fill="#ef2929"/>
-  <circle cx="20" cy="32" r="6" fill="#fce94f"/>
-  <circle cx="32" cy="32" r="6" fill="#ef2929"/>
-  <circle cx="44" cy="32" r="6" fill="#fce94f"/>
-  <circle cx="20" cy="44" r="6" fill="#ef2929"/>
-  <circle cx="32" cy="44" r="6" fill="#fce94f"/>
-  <circle cx="44" cy="44" r="6" fill="#ef2929"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Connect Four board</title>
+  <desc id="desc">A blue Connect Four game board with red and yellow discs forming a diagonal.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#181c20"/>
+      <stop offset="1" stop-color="#0d1013"/>
+    </linearGradient>
+    <linearGradient id="board" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#3a6ec8"/>
+      <stop offset="1" stop-color="#1e4d92"/>
+    </linearGradient>
+    <linearGradient id="boardStroke" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#6aa0ff" stop-opacity="0.9"/>
+      <stop offset="1" stop-color="#123268" stop-opacity="0.9"/>
+    </linearGradient>
+    <radialGradient id="discRed" cx="0.3" cy="0.3" r="0.9">
+      <stop offset="0" stop-color="#ffb0b0"/>
+      <stop offset="0.6" stop-color="#f14c45"/>
+      <stop offset="1" stop-color="#b71c1c"/>
+    </radialGradient>
+    <radialGradient id="discYellow" cx="0.35" cy="0.35" r="0.9">
+      <stop offset="0" stop-color="#fff5bf"/>
+      <stop offset="0.6" stop-color="#ffdd3a"/>
+      <stop offset="1" stop-color="#c28700"/>
+    </radialGradient>
+    <linearGradient id="boardHighlight" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.35"/>
+      <stop offset="0.4" stop-color="#ffffff" stop-opacity="0.1"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+    <mask id="boardHoles">
+      <rect x="6" y="8" width="52" height="46" rx="5" ry="5" fill="#fff"/>
+      <g fill="#000">
+        <circle cx="12" cy="50" r="4.4"/>
+        <circle cx="18.6667" cy="50" r="4.4"/>
+        <circle cx="25.3333" cy="50" r="4.4"/>
+        <circle cx="32" cy="50" r="4.4"/>
+        <circle cx="38.6667" cy="50" r="4.4"/>
+        <circle cx="45.3333" cy="50" r="4.4"/>
+        <circle cx="52" cy="50" r="4.4"/>
+        <circle cx="12" cy="42.8" r="4.4"/>
+        <circle cx="18.6667" cy="42.8" r="4.4"/>
+        <circle cx="25.3333" cy="42.8" r="4.4"/>
+        <circle cx="32" cy="42.8" r="4.4"/>
+        <circle cx="38.6667" cy="42.8" r="4.4"/>
+        <circle cx="45.3333" cy="42.8" r="4.4"/>
+        <circle cx="52" cy="42.8" r="4.4"/>
+        <circle cx="12" cy="35.6" r="4.4"/>
+        <circle cx="18.6667" cy="35.6" r="4.4"/>
+        <circle cx="25.3333" cy="35.6" r="4.4"/>
+        <circle cx="32" cy="35.6" r="4.4"/>
+        <circle cx="38.6667" cy="35.6" r="4.4"/>
+        <circle cx="45.3333" cy="35.6" r="4.4"/>
+        <circle cx="52" cy="35.6" r="4.4"/>
+        <circle cx="12" cy="28.4" r="4.4"/>
+        <circle cx="18.6667" cy="28.4" r="4.4"/>
+        <circle cx="25.3333" cy="28.4" r="4.4"/>
+        <circle cx="32" cy="28.4" r="4.4"/>
+        <circle cx="38.6667" cy="28.4" r="4.4"/>
+        <circle cx="45.3333" cy="28.4" r="4.4"/>
+        <circle cx="52" cy="28.4" r="4.4"/>
+        <circle cx="12" cy="21.2" r="4.4"/>
+        <circle cx="18.6667" cy="21.2" r="4.4"/>
+        <circle cx="25.3333" cy="21.2" r="4.4"/>
+        <circle cx="32" cy="21.2" r="4.4"/>
+        <circle cx="38.6667" cy="21.2" r="4.4"/>
+        <circle cx="45.3333" cy="21.2" r="4.4"/>
+        <circle cx="52" cy="21.2" r="4.4"/>
+        <circle cx="12" cy="14" r="4.4"/>
+        <circle cx="18.6667" cy="14" r="4.4"/>
+        <circle cx="25.3333" cy="14" r="4.4"/>
+        <circle cx="32" cy="14" r="4.4"/>
+        <circle cx="38.6667" cy="14" r="4.4"/>
+        <circle cx="45.3333" cy="14" r="4.4"/>
+        <circle cx="52" cy="14" r="4.4"/>
+      </g>
+    </mask>
+  </defs>
+  <rect width="64" height="64" rx="6" ry="6" fill="url(#bg)"/>
+  <g>
+    <g opacity="0.94">
+      <circle cx="12" cy="50" r="4.1" fill="url(#discYellow)"/>
+      <circle cx="18.6667" cy="42.8" r="4.1" fill="url(#discYellow)"/>
+      <circle cx="25.3333" cy="35.6" r="4.1" fill="url(#discYellow)"/>
+      <circle cx="32" cy="28.4" r="4.1" fill="url(#discYellow)"/>
+      <circle cx="18.6667" cy="50" r="4.1" fill="url(#discRed)"/>
+      <circle cx="25.3333" cy="42.8" r="4.1" fill="url(#discRed)"/>
+      <circle cx="32" cy="35.6" r="4.1" fill="url(#discRed)"/>
+      <circle cx="38.6667" cy="28.4" r="4.1" fill="url(#discRed)"/>
+      <circle cx="45.3333" cy="21.2" r="4.1" fill="url(#discRed)"/>
+      <circle cx="38.6667" cy="42.8" r="4.1" fill="url(#discYellow)"/>
+    </g>
+    <g mask="url(#boardHoles)">
+      <rect x="6" y="8" width="52" height="46" rx="5" ry="5" fill="url(#board)"/>
+      <rect x="6" y="8" width="52" height="18" rx="5" ry="5" fill="url(#boardHighlight)"/>
+    </g>
+    <rect x="6" y="8" width="52" height="46" rx="5" ry="5" fill="none" stroke="url(#boardStroke)" stroke-width="1.4"/>
+    <path d="M6 50h52v4.5c0 2.761-2.239 5-5 5H11c-2.761 0-5-2.239-5-5z" fill="#0b1323" opacity="0.55"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the Connect Four app icon with a reusable SVG board that includes gradients, masking, and descriptive metadata

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e029f363e08328ba2dba48835cce62