### PR TITLE
[icons] Refresh Sudoku app artwork

### DIFF
--- a/public/themes/Yaru/apps/sudoku.svg
+++ b/public/themes/Yaru/apps/sudoku.svg
@@ -1,23 +1,37 @@
-<svg viewBox="0 0 90 90" xmlns="http://www.w3.org/2000/svg">
-  <rect width="90" height="90" fill="#2e3436"/>
-  <g stroke="#ffffff" stroke-width="1">
-    <line x1="10" y1="0" x2="10" y2="90"/>
-    <line x1="20" y1="0" x2="20" y2="90"/>
-    <line x1="40" y1="0" x2="40" y2="90"/>
-    <line x1="50" y1="0" x2="50" y2="90"/>
-    <line x1="70" y1="0" x2="70" y2="90"/>
-    <line x1="80" y1="0" x2="80" y2="90"/>
-    <line x1="0" y1="10" x2="90" y2="10"/>
-    <line x1="0" y1="20" x2="90" y2="20"/>
-    <line x1="0" y1="40" x2="90" y2="40"/>
-    <line x1="0" y1="50" x2="90" y2="50"/>
-    <line x1="0" y1="70" x2="90" y2="70"/>
-    <line x1="0" y1="80" x2="90" y2="80"/>
+<svg viewBox="0 0 90 90" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Sudoku grid icon</title>
+  <desc id="desc">A 3 by 3 Sudoku board with highlighted cells.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#f6f7fb"/>
+      <stop offset="1" stop-color="#d9deec"/>
+    </linearGradient>
+  </defs>
+  <rect width="90" height="90" rx="10" fill="url(#bg)"/>
+  <rect x="13" y="13" width="64" height="64" rx="6" fill="#ffffff" stroke="#2b303b" stroke-width="2"/>
+  <g fill="#cfe2f3">
+    <rect x="35" y="13" width="21" height="21"/>
+    <rect x="57" y="35" width="20" height="21"/>
+    <rect x="13" y="57" width="21" height="20"/>
   </g>
-  <g stroke="#ffffff" stroke-width="3">
-    <line x1="30" y1="0" x2="30" y2="90"/>
-    <line x1="60" y1="0" x2="60" y2="90"/>
-    <line x1="0" y1="30" x2="90" y2="30"/>
-    <line x1="0" y1="60" x2="90" y2="60"/>
+  <g stroke="#2b303b" stroke-width="1.5">
+    <line x1="34" y1="13" x2="34" y2="77"/>
+    <line x1="56" y1="13" x2="56" y2="77"/>
+    <line x1="13" y1="34" x2="77" y2="34"/>
+    <line x1="13" y1="56" x2="77" y2="56"/>
+  </g>
+  <g stroke="#2b303b" stroke-width="3">
+    <line x1="47" y1="13" x2="47" y2="77"/>
+    <line x1="13" y1="47" x2="77" y2="47"/>
+  </g>
+  <g fill="#2b303b" font-family="'Ubuntu', 'Segoe UI', sans-serif" font-size="12" font-weight="600" text-anchor="middle" dominant-baseline="central">
+    <text x="24" y="24">5</text>
+    <text x="47" y="24">1</text>
+    <text x="70" y="24">7</text>
+    <text x="24" y="47">6</text>
+    <text x="70" y="47">3</text>
+    <text x="47" y="70">8</text>
+    <text x="24" y="70">2</text>
+    <text x="70" y="70">9</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the Sudoku app icon with a custom vector board that includes highlighted cells and numbers for better readability

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e02a08383883288d1c7f271811fbef