### PR TITLE
[theme] Refresh Hangman icon

### DIFF
--- a/public/themes/Yaru/apps/hangman.svg
+++ b/public/themes/Yaru/apps/hangman.svg
@@ -1,13 +1,28 @@
-<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" fill="#2e3436"/>
-  <line x1="16" y1="56" x2="48" y2="56" stroke="#ffffff" stroke-width="4"/>
-  <line x1="24" y1="56" x2="24" y2="8" stroke="#ffffff" stroke-width="4"/>
-  <line x1="24" y1="8" x2="40" y2="8" stroke="#ffffff" stroke-width="4"/>
-  <line x1="40" y1="8" x2="40" y2="16" stroke="#ffffff" stroke-width="4"/>
-  <circle cx="40" cy="22" r="6" stroke="#ffffff" stroke-width="4" fill="none"/>
-  <line x1="40" y1="28" x2="40" y2="40" stroke="#ffffff" stroke-width="4"/>
-  <line x1="40" y1="32" x2="34" y2="36" stroke="#ffffff" stroke-width="4"/>
-  <line x1="40" y1="32" x2="46" y2="36" stroke="#ffffff" stroke-width="4"/>
-  <line x1="40" y1="40" x2="34" y2="48" stroke="#ffffff" stroke-width="4"/>
-  <line x1="40" y1="40" x2="46" y2="48" stroke="#ffffff" stroke-width="4"/>
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Hangman icon">
+  <title>Hangman icon</title>
+  <!-- Original hangman icon created for Kali Linux Portfolio (2025). Released under CC0 1.0 Universal. -->
+  <defs>
+    <linearGradient id="hangman-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3e4c5a"/>
+      <stop offset="100%" stop-color="#27313a"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="10" ry="10" fill="url(#hangman-bg)"/>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M18 48h28" stroke="#0f1a23" stroke-width="4"/>
+    <path d="M22 48V16h18" stroke="#f5f7fa" stroke-width="4"/>
+    <path d="M34 16l-8 8" stroke="#b3beca" stroke-width="3"/>
+    <path d="M40 16v6" stroke="#f5f7fa" stroke-width="3"/>
+    <circle cx="40" cy="26" r="6" stroke="#f5f7fa" stroke-width="3"/>
+    <path d="M40 32v10" stroke="#f5f7fa" stroke-width="3"/>
+    <path d="M40 36l-5 5" stroke="#f5f7fa" stroke-width="3"/>
+    <path d="M40 36l5 5" stroke="#f5f7fa" stroke-width="3"/>
+    <path d="M40 42l-5 7" stroke="#f5f7fa" stroke-width="3"/>
+    <path d="M40 42l5 7" stroke="#f5f7fa" stroke-width="3"/>
+  </g>
+  <g fill="#c6d2df">
+    <rect x="18" y="51" width="8" height="2" rx="1"/>
+    <rect x="28" y="51" width="8" height="2" rx="1"/>
+    <rect x="38" y="51" width="8" height="2" rx="1"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the Hangman app icon with a custom CC0 gallows illustration to improve clarity
- embed licensing context in the SVG comment so downstream reuse is documented

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e029f6f1c48328b33afc9a140d3153