### PR TITLE
[assets] Refresh word search icon

### DIFF
--- a/public/themes/Yaru/apps/word-search.svg
+++ b/public/themes/Yaru/apps/word-search.svg
@@ -1,13 +1,44 @@
-<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" fill="#2e3436"/>
-  <line x1="16" y1="0" x2="16" y2="64" stroke="#ffffff" stroke-width="2"/>
-  <line x1="32" y1="0" x2="32" y2="64" stroke="#ffffff" stroke-width="2"/>
-  <line x1="48" y1="0" x2="48" y2="64" stroke="#ffffff" stroke-width="2"/>
-  <line x1="0" y1="16" x2="64" y2="16" stroke="#ffffff" stroke-width="2"/>
-  <line x1="0" y1="32" x2="64" y2="32" stroke="#ffffff" stroke-width="2"/>
-  <line x1="0" y1="48" x2="64" y2="48" stroke="#ffffff" stroke-width="2"/>
-  <text x="4" y="12" fill="#ffffff" font-size="12" font-family="monospace">W</text>
-  <text x="20" y="28" fill="#ffffff" font-size="12" font-family="monospace">O</text>
-  <text x="36" y="44" fill="#ffffff" font-size="12" font-family="monospace">R</text>
-  <text x="52" y="60" fill="#ffffff" font-size="12" font-family="monospace">D</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Word search icon</title>
+  <desc id="desc">A word search grid with a magnifying glass</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f2527"/>
+      <stop offset="100%" stop-color="#2f3638"/>
+    </linearGradient>
+    <linearGradient id="glass" x1="30%" y1="30%" x2="70%" y2="70%">
+      <stop offset="0%" stop-color="#eef6ff" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#cdd8e6" stop-opacity="0.9"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="8" fill="url(#bg)"/>
+  <g stroke="#4a555a" stroke-width="1.5">
+    <path d="M16 12v40M28 12v40M40 12v40M52 12v40"/>
+    <path d="M12 16h40M12 28h40M12 40h40M12 52h40"/>
+  </g>
+  <rect x="12" y="12" width="40" height="40" fill="none" stroke="#96a6ad" stroke-width="1.5" rx="3"/>
+  <g fill="#dfe6ea" font-family="'Ubuntu Mono', monospace" font-size="7.5" font-weight="600">
+    <text x="16" y="20">W</text>
+    <text x="28" y="20">O</text>
+    <text x="40" y="20">R</text>
+    <text x="52" y="20">D</text>
+    <text x="16" y="32">S</text>
+    <text x="28" y="32">E</text>
+    <text x="40" y="32">A</text>
+    <text x="52" y="32">R</text>
+    <text x="16" y="44">C</text>
+    <text x="28" y="44">H</text>
+    <text x="40" y="44">Q</text>
+    <text x="52" y="44">L</text>
+    <text x="16" y="56">T</text>
+    <text x="28" y="56">M</text>
+    <text x="40" y="56">N</text>
+    <text x="52" y="56">E</text>
+  </g>
+  <g transform="translate(32 32)">
+    <circle cx="12" cy="12" r="9" fill="url(#glass)" stroke="#f7fbff" stroke-width="1.5"/>
+    <circle cx="12" cy="12" r="6" fill="none" stroke="#94a7b4" stroke-width="1.25"/>
+    <rect x="19" y="19" width="10" height="2.6" rx="1.3" transform="rotate(45 24 20.3)" fill="#c2ccd6"/>
+    <rect x="19" y="19" width="10" height="1.3" rx="0.65" transform="rotate(45 24 20.3)" fill="#7d8c9a"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the word search app icon with a grid-and-magnifier illustration for better clarity
- verified the catalog still references the updated asset in `apps.config.js`

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e02a0b98088328b03a780ca692f0c3