### PR TITLE
[icons] Refresh autopsy app artwork

### DIFF
--- a/public/themes/Yaru/apps/autopsy.svg
+++ b/public/themes/Yaru/apps/autopsy.svg
@@ -1,5 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" fill="#333"/>
-  <circle cx="28" cy="28" r="14" stroke="#fff" stroke-width="4" fill="none"/>
-  <line x1="38" y1="38" x2="50" y2="50" stroke="#fff" stroke-width="4" stroke-linecap="round"/>
+  <defs>
+    <linearGradient id="bg" x1="12" y1="14" x2="52" y2="50" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#273043"/>
+      <stop offset="1" stop-color="#1b2334"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="8" fill="#101827"/>
+  <rect x="10" y="12" width="44" height="40" rx="7" fill="url(#bg)"/>
+  <rect x="14" y="16" width="36" height="12" rx="5" fill="#3f4a63" opacity="0.65"/>
+  <circle cx="32" cy="20" r="6" fill="#f8fafc" opacity="0.95"/>
+  <path d="M24 26h16c2.2 0 4 1.8 4 4v3.5c0 1.7-1.3 3-3 3h-1v13.5l4.6 3.7a3 3 0 0 1 1 2.3V54a3 3 0 0 1-3 3H21.4a3 3 0 0 1-3-3v-1.5a3 3 0 0 1 1-2.3L24 50V36.5h-1a3 3 0 0 1-3-3V30c0-2.2 1.8-4 4-4z" fill="#e5ecf5"/>
+  <path d="M30.5 34.5h3a1.5 1.5 0 0 1 1.5 1.5v8.5h-6v-8.5a1.5 1.5 0 0 1 1.5-1.5z" fill="#ced7e8"/>
+  <rect x="28" y="48" width="8" height="5" rx="1.5" fill="#c6d0e3"/>
+  <path d="M32 50.5 30 56a1 1 0 0 0 .94 1.3h2.12A1 1 0 0 0 34 56l-2-5.5z" fill="#9ca9c4"/>
+  <path d="M18 38.5V34a4 4 0 0 1 4-4" fill="none" stroke="#9aa5be" stroke-width="2" stroke-linecap="round"/>
+  <path d="M46 38.5V34a4 4 0 0 0-4-4" fill="none" stroke="#9aa5be" stroke-width="2" stroke-linecap="round"/>
+  <path d="M47.5 22.5 53 20l-2.5-5.5-5.6 2.5a2 2 0 0 0-.9 2.7l1.2 2.8a2 2 0 0 0 2.8 1z" fill="#d0e4ff"/>
+  <path d="m50.6 19.6-2.7-6.2" stroke="#8cb7f2" stroke-width="1.5" stroke-linecap="round"/>
+  <circle cx="50.8" cy="19.2" r="1.2" fill="#4f82c9"/>
 </svg>


### PR DESCRIPTION
## Summary
- replace the Autopsy app icon with an original forensic table illustration while keeping the existing asset path

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e02a0c943483288b1bf789ef097db3