### PR TITLE
[icons] Refresh Ettercap icon

### DIFF
--- a/public/themes/Yaru/apps/ettercap.svg
+++ b/public/themes/Yaru/apps/ettercap.svg
@@ -1,8 +1,28 @@
-<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="32" cy="12" r="6" fill="#4ade80"/>
-  <circle cx="12" cy="52" r="6" fill="#4ade80"/>
-  <circle cx="52" cy="52" r="6" fill="#4ade80"/>
-  <line x1="32" y1="18" x2="12" y2="46" stroke="#ffffff" stroke-width="4"/>
-  <line x1="32" y1="18" x2="52" y2="46" stroke="#ffffff" stroke-width="4"/>
-  <line x1="12" y1="52" x2="52" y2="52" stroke="#ffffff" stroke-width="4"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title>Ettercap network spider icon</title>
+  <desc>A stylized spider over a network node grid, representing Ettercap packet capturing.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#1e293b"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#bg)"/>
+  <g fill="none" stroke="#38bdf8" stroke-width="2" stroke-linecap="round">
+    <path d="M16 22h12m8 0h12m-36 20h12m8 0h12" opacity=".5"/>
+    <path d="M16 22v20m16-20v20m16-20v20" opacity=".5"/>
+    <circle cx="16" cy="22" r="3" fill="#0f172a" stroke="#38bdf8"/>
+    <circle cx="32" cy="22" r="3" fill="#0f172a" stroke="#38bdf8"/>
+    <circle cx="48" cy="22" r="3" fill="#0f172a" stroke="#38bdf8"/>
+    <circle cx="16" cy="42" r="3" fill="#0f172a" stroke="#38bdf8"/>
+    <circle cx="32" cy="42" r="3" fill="#0f172a" stroke="#38bdf8"/>
+    <circle cx="48" cy="42" r="3" fill="#0f172a" stroke="#38bdf8"/>
+  </g>
+  <g stroke="#f8fafc" stroke-width="2" stroke-linecap="round">
+    <ellipse cx="32" cy="34" rx="7" ry="9" fill="#38bdf8"/>
+    <circle cx="32" cy="25" r="4" fill="#bae6fd"/>
+    <path d="M22 26l6 6m-6 8 6-3M42 26l-6 6m6 8-6-3" fill="none"/>
+    <path d="M26 20l4 5m8-5-4 5" fill="none"/>
+    <path d="M24 44l4-4m12 4-4-4" fill="none"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the Ettercap app icon with a custom spider-and-network SVG compatible with the Yaru theme
- verified existing menu and app config continue pointing at `/themes/Yaru/apps/ettercap.svg`

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e02a1692248328b67526d4fd38ae49