### PR TITLE
[icons] Refresh HTTP request/response art

### DIFF
--- a/public/themes/Yaru/apps/http.svg
+++ b/public/themes/Yaru/apps/http.svg
@@ -1,4 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">HTTP request and response icon</title>
+  <desc id="desc">Two documents with arrows showing a request and response exchange.</desc>
   <rect width="64" height="64" rx="8" fill="#2e3440"/>
-  <text x="32" y="37" font-size="24" text-anchor="middle" fill="#eceff4" font-family="Arial, Helvetica, sans-serif">HTTP</text>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="11" y="15" width="20" height="28" rx="3" fill="#434c5e" stroke="#88c0d0" stroke-width="1.5"/>
+    <rect x="33" y="21" width="20" height="28" rx="3" fill="#4c566a" stroke="#a3be8c" stroke-width="1.5"/>
+    <rect x="15" y="20" width="12" height="3" fill="#d8dee9" stroke="none"/>
+    <rect x="15" y="26" width="12" height="3" fill="#d8dee9" stroke="none" opacity="0.7"/>
+    <rect x="37" y="26" width="12" height="3" fill="#eceff4" stroke="none"/>
+    <rect x="37" y="32" width="12" height="3" fill="#eceff4" stroke="none" opacity="0.7"/>
+    <path d="M32 24h-6.5" stroke="#88c0d0" stroke-width="2"/>
+    <path d="M26.5 20l-4 4 4 4" fill="none" stroke="#88c0d0" stroke-width="2"/>
+    <path d="M32 36h6.5" stroke="#a3be8c" stroke-width="2"/>
+    <path d="M37.5 40l4-4-4-4" fill="none" stroke="#a3be8c" stroke-width="2"/>
+  </g>
+  <circle cx="24" cy="46" r="3" fill="#88c0d0"/>
+  <circle cx="40" cy="18" r="3" fill="#a3be8c"/>
 </svg>


### PR DESCRIPTION
## Summary
- replace the HTTP app tile graphic with a request/response themed illustration
- keep the existing icon reference path used by the Whisker menu and app registry

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e02a1a63d483289ebb907f659755a8