### PR TITLE
[theme] Replace Nmap NSE icon

### DIFF
--- a/public/themes/Yaru/apps/nmap-nse.svg
+++ b/public/themes/Yaru/apps/nmap-nse.svg
@@ -1,6 +1,78 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" ry="8" fill="#1e1e1e"/>
-  <circle cx="32" cy="32" r="20" stroke="#0ff" stroke-width="4" fill="none"/>
-  <line x1="32" y1="32" x2="52" y2="32" stroke="#0ff" stroke-width="4"/>
-  <line x1="32" y1="32" x2="44" y2="20" stroke="#0ff" stroke-width="4"/>
+<?xml version="1.0" ?>
+<!-- Source: Kali Linux menu icons (GPL-3.0+), retrieved from https://gitlab.com/kalilinux/packages/kali-menu/-/blob/kali/master/menu-icons/scalable/apps/kali-nmap.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64" height="64" version="1.1" viewBox="0 0 384 384">
+  <defs>
+    <clipPath>
+      <rect width="384" height="384"/>
+    </clipPath>
+    <linearGradient id="a" x1="193.38" x2="193.84" y1="71.815" y2="290.49" gradientTransform="translate(0 15.672)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#80c6ed" offset="0"/>
+      <stop stop-color="#fff" offset=".5"/>
+      <stop stop-color="#80c6ed" offset="1"/>
+    </linearGradient>
+    <linearGradient id="f" x1="45.448" x2="45.448" y1="92.54" y2="7.0165" gradientTransform="scale(1.0059 .99417)" gradientUnits="userSpaceOnUse">
+      <stop offset="0"/>
+      <stop stop-opacity=".58824" offset="1"/>
+    </linearGradient>
+    <filter id="c" x="-.047721" y="-.048282" width="1.0954" height="1.0966" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="1.71"/>
+    </filter>
+    <radialGradient id="e" cx="47.5" cy="59.494" r="37.054" gradientTransform="matrix(1.1227 1.0047e-8 0 1.0388 -5.8315 -6.8641)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#347aa1" offset="0"/>
+      <stop stop-color="#191919" offset="1"/>
+    </radialGradient>
+    <clipPath id="b">
+      <rect x="6" y="6" width="84" height="84" rx="6" ry="6" fill="#fff"/>
+    </clipPath>
+    <filter id="d" x="-.19506" y="-.19506" width="1.3901" height="1.3901" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="5.28"/>
+    </filter>
+    <linearGradient x1="15.594" x2="111.61" y1="61.448" y2="61.448" gradientTransform="matrix(.70315 0 0 .69956 3.1971 4.0472)" gradientUnits="userSpaceOnUse" spreadMethod="reflect">
+      <stop stop-color="#ffc730" stop-opacity="0" offset="0"/>
+      <stop stop-color="#ffc730" offset=".2202"/>
+      <stop stop-color="#ffc730" offset=".56107"/>
+      <stop stop-color="#ffc730" stop-opacity="0" offset="1"/>
+    </linearGradient>
+  </defs>
+  <g transform="matrix(.92741 0 0 .92992 -45.417 -46.061)">
+    <g transform="translate(0,416)" display="none" stroke-width=".78542">
+      <rect x="5" y="7" width="86" height="85" rx="6" ry="6" fill="url(#f)" filter="url(#c)" opacity=".9" stroke-width=".76384"/>
+    </g>
+    <g transform="matrix(4.888,0,0,4.888,23.821,18.322)" stroke-width=".80761">
+      <rect x="10.446" y="11.5" width="74.107" height="74.25" rx="5.5667" ry="5.8378" fill="url(#e)" stroke-width=".80761"/>
+      <path d="m19 13c-3.2894 0-6 2.7106-6 6v58c0 3.2894 2.7106 6 6 6h58c3.2894 0 6-2.7106 6-6v-58c0-3.2894-2.7106-6-6-6zm0 4h58c1.1426 0 2 0.85741 2 2v58c0 1.1426-0.85741 2-2 2h-58c-1.1426 0-2-0.85741-2-2v-58c0-1.1426 0.85741-2 2-2z" color="#000000000" opacity=".15" stroke-width=".78542" style="text-decoration-line:none;text-indent:0;text-transform:none"/>
+      <path d="m17 14c-1.662 0-3 1.338-3 3v62c0 1.662 1.338 3 3 3h62c1.662 0 3-1.338 3-3v-62c0-1.662-1.338-3-3-3zm0 1.9375h62c0.61816 0 1.0625 0.44434 1.0625 1.0625v62c0 0.61816-0.44434 1.0625-1.0625 1.0625h-62c-0.61816 0-1.0625-0.44434-1.0625-1.0625v-62c0-0.61816 0.44434-1.0625 1.0625-1.0625z" color="#000000000" opacity=".3" stroke-width=".78542"/>
+      <path d="m17 14c-1.662 0-3 1.338-3 3v62c0 1.662 1.338 3 3 3h62c1.662 0 3-1.338 3-3v-62c0-1.662-1.338-3-3-3zm0 0.96875h62c1.1401 0 2.0312 0.89117 2.0312 2.0312v62c0 1.1401-0.89117 2.0312-2.0312 2.0312h-62c-1.1401 0-2.0312-0.89117-2.0312-2.0312v-62c0-1.1401 0.89117-2.0312 2.0312-2.0312z" color="#000000000" opacity=".6" stroke-width=".78542"/>
+      <g fill="#4aaee6" stroke="#4aaee6" stroke-width="1.5708">
+        <path d="m73 12v70" opacity=".08"/>
+        <path d="m61 12v70" opacity=".08"/>
+        <path d="m49 12v70" opacity=".08"/>
+        <path d="m37 12v70" opacity=".08"/>
+        <path d="m25 12v70" opacity=".08"/>
+        <path d="m13 71h70" opacity=".08"/>
+        <path d="m13 59h70" opacity=".08"/>
+        <path d="m13 47h70" opacity=".08"/>
+        <path d="m13 35h70" opacity=".08"/>
+        <path d="m13 23h70" opacity=".08"/>
+      </g>
+      <g fill="#4aaee6">
+        <rect x="66" y="36" width="9" height="2" rx=".9" ry=".66667" stroke-width=".80761"/>
+        <rect x="66" y="32" width="9" height="2" rx=".9" ry=".66667" stroke-width=".80761"/>
+        <rect x="66" y="28" width="9" height="2" rx=".9" ry=".66667" opacity=".5" stroke-width=".76384"/>
+        <rect x="66" y="24" width="9" height="2" rx=".9" ry=".66667" opacity=".5" stroke-width=".76384"/>
+        <rect x="66" y="20" width="9" height="2" rx=".9" ry=".66667" opacity=".5" stroke-width=".76384"/>
+      </g>
+    </g>
+    <rect transform="matrix(4.2286 0 0 4.2286 53.026 49.762)" x="15" y="15" width="66" height="66" rx="12" ry="12" clip-path="url(#b)" fill="#4aaee6" filter="url(#d)" opacity=".1" stroke="#fff" stroke-linecap="round" stroke-width=".4038"/>
+  </g>
+  <g transform="matrix(1.0589 0 0 1.0589 -11.305 -11.579)">
+    <path transform="scale(.75)" d="m256 116.3c-80.162 0-172.31 63.67-238.49 163.59a13.252 13.252 0 0 0 2.1504 17.137c75.893 68.725 167.31 121.03 236.34 121.03 68.879 0 163.09-51.092 236.6-121.27a13.252 13.252 0 0 0 1.793-17.061c-71.209-104.23-158.79-163.43-238.39-163.43z" color="#000000" opacity=".3" stroke-linejoin="round" stroke-width="25.028" style="-inkscape-stroke:none"/>
+    <path d="m192 89.66c-54.63 0-122.26 45.281-170.58 118.24 55.745 50.48 124.2 88.199 170.58 88.199s116.88-36.922 170.58-88.199c-52.235-76.458-115.96-118.24-170.58-118.24z" fill="#fff" stroke="#3b8bb8" stroke-linejoin="round" stroke-width="18.771"/>
+    <path d="m192 107.54c-52.745 0-118.04 38.722-164.7 101.12 53.822 43.168 119.91 75.423 164.7 75.423s112.84-31.574 164.7-75.423c-50.433-65.384-111.95-101.12-164.7-101.12z" fill="url(#a)" stroke="#4aaee6" stroke-linejoin="round" stroke-width="18.771"/>
+    <circle cx="192.39" cy="197.77" r="70.134" fill="#4aaee6" fill-opacity=".49804" stroke="#4aaee6" stroke-linecap="round" stroke-linejoin="round" stroke-opacity=".34902" stroke-width="35.415"/>
+    <path d="m192 135.43v122.32" fill="#fff" stroke="#fff" stroke-width="3.5415"/>
+    <path d="m253.16 196.59h-122.32" fill="#fff" stroke="#fff" stroke-width="3.5415"/>
+    <path d="m192 97.6c-57.609 0-124.51 40.727-172.66 105.1a9.939 9.939 0 0 0 1.7402 13.705c55.034 44.141 121.36 77.607 170.92 77.607 49.456 0 117.78-32.673 171.12-77.771a9.939 9.939 0 0 0 1.4512-13.658c-51.75-67.092-115.33-104.98-172.57-104.98zm0 19.875c46.258 0 102.78 30.929 150.65 89.57-49.438 39.365-112.49 67.094-150.65 67.094-38.075 0-99.429-28.244-150.62-67.322 44.684-55.729 104.85-89.342 150.62-89.342z" color="#000000" fill="#4aaee6" stroke-linejoin="round" stroke-width=".94439" style="-inkscape-stroke:none"/>
+    <path d="m192 117.47c-45.771 0-105.94 33.613-150.62 89.342 0.50436 0.385 1.0245 0.75092 1.5308 1.1338 44.521-54.604 103.84-87.476 149.09-87.476 45.766 0 101.57 30.321 149.11 87.756 0.50866-0.40032 1.0366-0.78227 1.5425-1.185-47.867-58.642-104.39-89.571-150.65-89.571zm174.5 92.679a9.939 9.939 0 0 1-3.3823 6.0879c-53.334 45.099-121.66 77.771-171.12 77.771-49.557 0-115.88-33.466-170.92-77.607a9.939 9.939 0 0 1-3.4761-6.0015 9.939 9.939 0 0 0 3.4761 9.0015c55.034 44.141 121.36 77.607 170.92 77.607 49.456 0 117.78-32.673 171.12-77.771a9.939 9.939 0 0 0 3.3823-9.0879z" color="#000000" opacity=".1" stroke-linejoin="round" stroke-width=".94439" style="-inkscape-stroke:none;mix-blend-mode:normal"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the Nmap NSE app icon with the Kali menu SVG asset and embed source attribution for licensing context

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e02a25acac832899a6e39a2129a0db