### PR TITLE
[hooks] guard daily quote fallback

### DIFF
--- a/__tests__/hooks/useDailyQuote.test.ts
+++ b/__tests__/hooks/useDailyQuote.test.ts
@@ -1,0 +1,60 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import useDailyQuote from '../../hooks/useDailyQuote';
+
+describe('useDailyQuote', () => {
+  const originalLocalStorage = globalThis.localStorage;
+  let setItemMock: jest.Mock;
+
+  beforeEach(() => {
+    let store: Record<string, string> = {};
+
+    setItemMock = jest.fn((key: string, value: string) => {
+      store[key] = value;
+    });
+
+    const mockStorage: Storage = {
+      getItem: jest.fn((key: string) => store[key] ?? null),
+      setItem: setItemMock as unknown as Storage['setItem'],
+      removeItem: jest.fn((key: string) => {
+        delete store[key];
+      }),
+      clear: jest.fn(() => {
+        store = {};
+      }),
+      key: jest.fn(),
+      get length() {
+        return Object.keys(store).length;
+      },
+    };
+
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: mockStorage,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: originalLocalStorage,
+      configurable: true,
+    });
+    jest.clearAllMocks();
+  });
+
+  it('returns a valid quote when filtered pool is empty', async () => {
+    const { result } = renderHook(() => useDailyQuote('non-existent-tag'));
+
+    await waitFor(() => {
+      expect(result.current).not.toBeNull();
+    });
+
+    const quote = result.current;
+
+    expect(quote?.content).toBeTruthy();
+    expect(quote?.author).toBeTruthy();
+    expect(setItemMock).toHaveBeenCalledWith(
+      'dailyQuote',
+      expect.stringContaining('"content"')
+    );
+  });
+});

--- a/hooks/useDailyQuote.ts
+++ b/hooks/useDailyQuote.ts
@@ -84,7 +84,18 @@ export default function useDailyQuote(tag?: string) {
     const pool = tag
       ? offlineQuotes.filter((q) => q.tags.includes(tag))
       : offlineQuotes;
-    const fetched = pool[Math.floor(Math.random() * pool.length)];
+
+    const fallbackPool = pool.length > 0 ? pool : offlineQuotes;
+    const fetched =
+      fallbackPool.length > 0
+        ? fallbackPool[Math.floor(Math.random() * fallbackPool.length)]
+        : undefined;
+
+    if (!fetched) {
+      setQuote(null);
+      return;
+    }
+
     const toStore: Quote = { ...fetched, date: today } as Quote;
     try {
       localStorage.setItem('dailyQuote', JSON.stringify(toStore));


### PR DESCRIPTION
## Summary
- prevent useDailyQuote from selecting undefined when a tag filter has no matches
- store daily quotes only when a valid selection is available and return null otherwise
- add a hook unit test that mocks localStorage and verifies fallback behavior

## Testing
- [x] yarn test useDailyQuote

## Flags
- [ ] None

------
https://chatgpt.com/codex/tasks/task_e_68e5e89d78e88328a2ded9cb474eae4b