### PR TITLE
[api] Handle empty quote tag results

### DIFF
--- a/__tests__/quote.api.test.ts
+++ b/__tests__/quote.api.test.ts
@@ -1,0 +1,19 @@
+import handler from '../pages/api/quote';
+import { createMocks } from 'node-mocks-http';
+
+describe('quote api', () => {
+  it('returns 404 with error payload when no quotes match the requested tag', () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: { tag: 'nonexistent-tag' },
+    });
+
+    handler(req as any, res as any);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: 'No quotes found for the provided tag.',
+      tag: 'nonexistent-tag',
+    });
+  });
+});

--- a/pages/api/quote.ts
+++ b/pages/api/quote.ts
@@ -15,7 +15,20 @@ export default function handler(
 ) {
   const tag = Array.isArray(req.query.tag) ? req.query.tag[0] : req.query.tag;
   const pool = tag ? quotes.filter((q) => q.tags?.includes(tag)) : quotes;
-  const quote = pool[Math.floor(Math.random() * pool.length)];
+
+  if (pool.length === 0) {
+    res
+      .status(404)
+      .json({
+        error: 'No quotes found for the provided tag.',
+        tag,
+      });
+    return;
+  }
+
+  const index = Math.floor(Math.random() * pool.length);
+  const quote = pool[index];
+
   res.setHeader('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=3600');
   res.status(200).json(quote);
 }


### PR DESCRIPTION
## Summary
- return a clear 404 response when the filtered quote pool is empty
- guard random selection to avoid NaN indexing
- add an API test covering the no matching tag scenario

## Testing
- yarn test --runTestsByPath __tests__/quote.api.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5e89b57bc8328924197ee5a080f82