### PR TITLE
[desktop] add listener cleanup tests

### DIFF
--- a/__tests__/desktop.listeners.test.tsx
+++ b/__tests__/desktop.listeners.test.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Desktop } from '../components/screen/desktop';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+jest.mock('html-to-image', () => ({ toPng: jest.fn().mockResolvedValue('data:image/png;base64,') }));
+jest.mock('../components/util-components/background-image', () => () => <div data-testid="background" />);
+jest.mock('../components/base/window', () => () => <div data-testid="window" />);
+jest.mock('../components/base/ubuntu_app', () => () => <div data-testid="ubuntu-app" />);
+jest.mock('../components/screen/all-applications', () => () => <div data-testid="all-apps" />);
+jest.mock('../components/screen/shortcut-selector', () => () => <div data-testid="shortcut-selector" />);
+jest.mock('../components/screen/window-switcher', () => () => <div data-testid="window-switcher" />);
+jest.mock('../components/context-menus/desktop-menu', () => ({
+  __esModule: true,
+  default: () => <div data-testid="desktop-menu" />,
+}));
+jest.mock('../components/context-menus/default', () => ({
+  __esModule: true,
+  default: () => <div data-testid="default-menu" />,
+}));
+jest.mock('../components/context-menus/app-menu', () => ({
+  __esModule: true,
+  default: () => <div data-testid="app-menu" />,
+}));
+jest.mock('../components/context-menus/taskbar-menu', () => ({
+  __esModule: true,
+  default: () => <div data-testid="taskbar-menu" />,
+}));
+jest.mock('../utils/recentStorage', () => ({ addRecentApp: jest.fn() }));
+
+describe('Desktop event listeners', () => {
+  let originalMatchMedia: typeof window.matchMedia | undefined;
+  let matchMediaMock: jest.Mock;
+  let mediaQueryMock: {
+    matches: boolean;
+    addEventListener: jest.Mock;
+    removeEventListener: jest.Mock;
+    addListener: jest.Mock;
+    removeListener: jest.Mock;
+  };
+  let openSettingsButton: HTMLButtonElement;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+    mediaQueryMock = {
+      matches: false,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    };
+    matchMediaMock = jest.fn().mockReturnValue(mediaQueryMock);
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: matchMediaMock,
+    });
+
+    openSettingsButton = document.createElement('button');
+    openSettingsButton.id = 'open-settings';
+    document.body.appendChild(openSettingsButton);
+  });
+
+  afterEach(() => {
+    if (originalMatchMedia) {
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      });
+    } else {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error matchMedia can be removed for the test cleanup
+      delete window.matchMedia;
+    }
+    document.body.innerHTML = '';
+    jest.restoreAllMocks();
+  });
+
+  it('cleans up listeners on unmount', () => {
+    const winAddSpy = jest.spyOn(window, 'addEventListener');
+    const winRemoveSpy = jest.spyOn(window, 'removeEventListener');
+    const docAddSpy = jest.spyOn(document, 'addEventListener');
+    const docRemoveSpy = jest.spyOn(document, 'removeEventListener');
+    const openSettingsRemoveSpy = jest.spyOn(openSettingsButton, 'removeEventListener');
+
+    const desktopRef = React.createRef<Desktop>();
+    const { unmount } = render(
+      <Desktop
+        ref={desktopRef}
+        clearSession={() => {}}
+        changeBackgroundImage={() => {}}
+        bg_image_name="aurora"
+        snapEnabled
+      />
+    );
+
+    const instance = desktopRef.current!;
+    const gestureRoot = instance.desktopRef.current!;
+    const gestureRemoveSpy = jest.spyOn(gestureRoot, 'removeEventListener');
+    const pointerListener = instance.pointerMediaListener;
+
+    expect(winAddSpy).toHaveBeenCalled();
+    expect(docAddSpy).toHaveBeenCalled();
+    expect(pointerListener).toEqual(expect.any(Function));
+
+    unmount();
+
+    expect(winRemoveSpy.mock.calls).toEqual(
+      expect.arrayContaining([
+        ['trash-change', instance.updateTrashIcon],
+        ['open-app', instance.handleOpenAppEvent],
+        ['resize', instance.handleViewportResize],
+        ['workspace-select', instance.handleExternalWorkspaceSelect],
+        ['workspace-request', instance.broadcastWorkspaceState],
+        ['taskbar-command', instance.handleExternalTaskbarCommand],
+      ])
+    );
+    expect(docRemoveSpy.mock.calls).toEqual(
+      expect.arrayContaining([
+        ['keydown', instance.handleGlobalShortcut],
+        ['contextmenu', instance.checkContextMenu],
+        ['click', instance.hideAllContextMenu],
+        ['keydown', instance.handleContextKey],
+      ])
+    );
+    expect(gestureRemoveSpy.mock.calls).toEqual(
+      expect.arrayContaining([
+        ['pointerdown', instance.handleShellPointerDown],
+        ['pointermove', instance.handleShellPointerMove],
+        ['pointerup', instance.handleShellPointerUp],
+        ['pointercancel', instance.handleShellPointerCancel],
+        ['touchstart', instance.handleShellTouchStart],
+        ['touchmove', instance.handleShellTouchMove],
+        ['touchend', instance.handleShellTouchEnd],
+        ['touchcancel', instance.handleShellTouchCancel],
+      ])
+    );
+    expect(mediaQueryMock.removeEventListener).toHaveBeenCalledWith('change', pointerListener);
+    expect(openSettingsRemoveSpy).toHaveBeenCalledWith('click', instance.openSettingsClickHandler);
+  });
+});
+
+describe('Desktop gesture handlers', () => {
+  it('releases pointer and touch references after interactions', () => {
+    const desktop = new Desktop();
+    desktop.dispatchWindowCommand = jest.fn().mockReturnValue(false);
+    desktop.focus = jest.fn();
+    // prevent state updates from throwing warnings
+    desktop.setState = jest.fn();
+    desktop.setWorkspaceState = jest.fn();
+
+    const node = document.createElement('div');
+    desktop.desktopRef.current = node;
+    const removeSpy = jest.spyOn(node, 'removeEventListener');
+    const addSpy = jest.spyOn(node, 'addEventListener');
+
+    desktop.setupGestureListeners();
+    expect(addSpy).toHaveBeenCalled();
+
+    const windowElement = document.createElement('div');
+    windowElement.id = 'win-gesture';
+    windowElement.classList.add('opened-window');
+    document.body.appendChild(windowElement);
+
+    desktop.handleShellPointerDown({
+      pointerType: 'touch',
+      isPrimary: true,
+      pointerId: 1,
+      clientX: 10,
+      clientY: 10,
+      target: windowElement,
+    } as PointerEvent);
+    expect(desktop.gestureState.pointer).not.toBeNull();
+
+    desktop.handleShellPointerMove({ pointerId: 1, clientX: 20, clientY: 25 } as PointerEvent);
+    expect(desktop.gestureState.pointer?.lastX).toBe(20);
+
+    desktop.handleShellPointerUp({ pointerId: 1, clientX: 150, clientY: 15 } as PointerEvent);
+    expect(desktop.gestureState.pointer).toBeNull();
+
+    desktop.handleShellPointerDown({
+      pointerType: 'touch',
+      isPrimary: true,
+      pointerId: 2,
+      clientX: 5,
+      clientY: 5,
+      target: windowElement,
+    } as PointerEvent);
+    desktop.handleShellPointerCancel({ pointerId: 2 } as PointerEvent);
+    expect(desktop.gestureState.pointer).toBeNull();
+
+    const touches = [
+      { clientX: 0, clientY: 100 },
+      { clientX: 10, clientY: 110 },
+      { clientX: 20, clientY: 120 },
+    ];
+    desktop.handleShellTouchStart({ touches } as TouchEvent);
+    expect(desktop.gestureState.overview).not.toBeNull();
+
+    const movedTouches = [
+      { clientX: 0, clientY: 60 },
+      { clientX: 10, clientY: 70 },
+      { clientX: 20, clientY: 80 },
+    ];
+    desktop.handleShellTouchMove({ touches: movedTouches } as TouchEvent);
+    desktop.handleShellTouchEnd({ touches: [] } as TouchEvent);
+    expect(desktop.gestureState.overview).toBeNull();
+
+    desktop.handleShellTouchStart({ touches } as TouchEvent);
+    desktop.handleShellTouchCancel();
+    expect(desktop.gestureState.overview).toBeNull();
+
+    desktop.gestureState.pointer = { pointerId: 3 } as any;
+    desktop.gestureState.overview = { startY: 10 } as any;
+    desktop.teardownGestureListeners();
+    expect(removeSpy).toHaveBeenCalledWith('pointerdown', desktop.handleShellPointerDown);
+    expect(desktop.gestureState.pointer).toBeNull();
+    expect(desktop.gestureState.overview).toBeNull();
+
+    document.body.innerHTML = '';
+  });
+});

--- a/__tests__/window.listeners.test.tsx
+++ b/__tests__/window.listeners.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Window from '../components/base/window';
+
+jest.mock('react-ga4', () => ({ send: jest.fn(), event: jest.fn() }));
+jest.mock('react-draggable', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+jest.mock('../components/apps/terminal', () => ({ displayTerminal: jest.fn() }));
+
+describe('Window event listeners', () => {
+  it('detaches global and node listeners on unmount', () => {
+    const winAddSpy = jest.spyOn(window, 'addEventListener');
+    const winRemoveSpy = jest.spyOn(window, 'removeEventListener');
+    let nodeRemoveSpy: jest.SpyInstance | null = null;
+    let superArrowHandler: ((event: Event) => void) | undefined;
+
+    try {
+      const windowRef = React.createRef<Window>();
+      const { unmount } = render(
+        <Window
+          id="listener-window"
+          title="Test"
+          screen={() => <div>content</div>}
+          focus={() => {}}
+          hasMinimised={() => {}}
+          closed={() => {}}
+          openApp={() => {}}
+          ref={windowRef}
+        />
+      );
+
+      const resizeHandler = winAddSpy.mock.calls.find(([type]) => type === 'resize')?.[1];
+      const contextOpenHandler = winAddSpy.mock.calls.find(([type]) => type === 'context-menu-open')?.[1];
+      const contextCloseHandler = winAddSpy.mock.calls.find(([type]) => type === 'context-menu-close')?.[1];
+
+      expect(resizeHandler).toBeDefined();
+      expect(contextOpenHandler).toBeDefined();
+      expect(contextCloseHandler).toBeDefined();
+
+      const node = document.getElementById('listener-window');
+      expect(node).not.toBeNull();
+      nodeRemoveSpy = node ? jest.spyOn(node, 'removeEventListener') : null;
+      superArrowHandler = windowRef.current?.handleSuperArrow;
+      expect(superArrowHandler).toBeDefined();
+
+      unmount();
+
+      expect(winRemoveSpy.mock.calls).toContainEqual(['resize', resizeHandler]);
+      expect(winRemoveSpy.mock.calls).toContainEqual(['context-menu-open', contextOpenHandler]);
+      expect(winRemoveSpy.mock.calls).toContainEqual(['context-menu-close', contextCloseHandler]);
+      expect(nodeRemoveSpy?.mock.calls).toContainEqual(['super-arrow', superArrowHandler]);
+    } finally {
+      winAddSpy.mockRestore();
+      winRemoveSpy.mockRestore();
+      nodeRemoveSpy?.mockRestore();
+    }
+  });
+});

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -94,6 +94,10 @@ export class Desktop extends Component {
 
         this.validAppIds = new Set(apps.map((app) => app.id));
 
+        this.openSettingsTarget = null;
+        this.openSettingsClickHandler = null;
+        this.openSettingsListenerAttached = false;
+
     }
 
     createEmptyWorkspaceState = () => ({
@@ -263,6 +267,8 @@ export class Desktop extends Component {
         node.removeEventListener('touchend', this.handleShellTouchEnd);
         node.removeEventListener('touchcancel', this.handleShellTouchCancel);
         this.gestureRoot = null;
+        this.gestureState.pointer = null;
+        this.gestureState.overview = null;
     };
 
     handleShellPointerDown = (event) => {
@@ -880,6 +886,7 @@ export class Desktop extends Component {
     }
 
     componentWillUnmount() {
+        this.removeEventListeners();
         this.removeContextListeners();
         document.removeEventListener('keydown', this.handleGlobalShortcut);
         window.removeEventListener('trash-change', this.updateTrashIcon);
@@ -1011,11 +1018,36 @@ export class Desktop extends Component {
 
     setEventListeners = () => {
         const openSettings = document.getElementById("open-settings");
-        if (openSettings) {
-            openSettings.addEventListener("click", () => {
-                this.openApp("settings");
-            });
+        if (!openSettings) {
+            this.removeEventListeners();
+            return;
         }
+
+        if (!this.openSettingsClickHandler) {
+            this.openSettingsClickHandler = () => {
+                this.openApp("settings");
+            };
+        }
+
+        if (this.openSettingsTarget && this.openSettingsTarget !== openSettings && this.openSettingsClickHandler) {
+            this.openSettingsTarget.removeEventListener('click', this.openSettingsClickHandler);
+            this.openSettingsListenerAttached = false;
+        }
+
+        this.openSettingsTarget = openSettings;
+
+        if (!this.openSettingsListenerAttached && this.openSettingsClickHandler) {
+            this.openSettingsTarget.addEventListener('click', this.openSettingsClickHandler);
+            this.openSettingsListenerAttached = true;
+        }
+    }
+
+    removeEventListeners = () => {
+        if (this.openSettingsTarget && this.openSettingsClickHandler) {
+            this.openSettingsTarget.removeEventListener('click', this.openSettingsClickHandler);
+        }
+        this.openSettingsTarget = null;
+        this.openSettingsListenerAttached = false;
     }
 
     setContextListeners = () => {


### PR DESCRIPTION
## Summary
- ensure the desktop shell releases its gesture state and removes the open settings click handler when unmounting
- add focused Jest coverage for desktop gesture cleanup and global listener removal
- add a window listener cleanup test to guard against add/remove mismatches

## Testing
- yarn test desktop.listeners
- yarn test window.listeners

------
https://chatgpt.com/codex/tasks/task_e_68e5e7be99a08328bc4dc315f3ccf9da