### PR TITLE
[desktop] Clamp window positions on resize

### DIFF
--- a/__tests__/desktopViewportResize.test.ts
+++ b/__tests__/desktopViewportResize.test.ts
@@ -1,0 +1,104 @@
+import { Desktop } from '../components/screen/desktop';
+import { SNAP_BOTTOM_INSET } from '../utils/uiConstants';
+import { measureSafeAreaInset, measureWindowTopOffset } from '../utils/windowLayout';
+
+const setViewport = (width: number, height: number) => {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: width });
+  Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: height });
+};
+
+describe('Desktop viewport resize handling', () => {
+  beforeEach(() => {
+    setViewport(1440, 900);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('clamps saved window positions within the new viewport bounds', () => {
+    setViewport(800, 600);
+    const desktop = new Desktop({});
+    desktop.props = desktop.props || {};
+    desktop.configureTouchTargets = jest.fn();
+    desktop.realignIconPositions = jest.fn();
+    desktop.saveSession = jest.fn();
+    desktop.commitWorkspacePartial = jest.fn();
+
+    desktop.state = {
+      closed_windows: { app1: false, app2: false },
+      minimized_windows: {},
+      focused_windows: {},
+      window_positions: {
+        app1: { x: 1400, y: 900 },
+        app2: { x: -120, y: 20 },
+      },
+    } as any;
+
+    const nodes: Record<string, any> = {
+      app1: {
+        getBoundingClientRect: () => ({
+          left: 0,
+          top: 0,
+          right: 420,
+          bottom: 320,
+          width: 420,
+          height: 320,
+          x: 0,
+          y: 0,
+          toJSON: () => {},
+        }),
+        style: {
+          getPropertyValue: jest.fn(() => ''),
+          transform: '',
+        },
+      },
+      app2: {
+        getBoundingClientRect: () => ({
+          left: 0,
+          top: 0,
+          right: 300,
+          bottom: 200,
+          width: 300,
+          height: 200,
+          x: 0,
+          y: 0,
+          toJSON: () => {},
+        }),
+        style: {
+          getPropertyValue: jest.fn(() => ''),
+          transform: '',
+        },
+      },
+    };
+
+    const getElementSpy = jest
+      .spyOn(document, 'getElementById')
+      .mockImplementation((id: string) => nodes[id] || null);
+
+    const updates: any[] = [];
+    desktop.setWorkspaceState = jest.fn((updater: any, callback?: () => void) => {
+      let partial = updater;
+      if (typeof updater === 'function') {
+        partial = updater(desktop.state);
+      }
+      desktop.state = { ...desktop.state, ...partial };
+      updates.push(partial);
+      if (typeof callback === 'function') {
+        callback();
+      }
+    });
+
+    desktop.handleViewportResize();
+
+    expect(updates).toHaveLength(1);
+    const positions = desktop.state.window_positions;
+    const topOffset = measureWindowTopOffset();
+    const safeBottom = Math.max(0, measureSafeAreaInset('bottom'));
+    const expectedApp1Y = topOffset + Math.max(600 - topOffset - SNAP_BOTTOM_INSET - safeBottom - 320, 0);
+    expect(positions.app1).toEqual({ x: 380, y: expectedApp1Y });
+    expect(positions.app2).toEqual({ x: 0, y: topOffset });
+
+    getElementSpy.mockRestore();
+  });
+});

--- a/components/desktop/Window.tsx
+++ b/components/desktop/Window.tsx
@@ -1,0 +1,122 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import BaseWindow from "../base/window";
+import {
+  clampWindowPositionWithinViewport,
+  clampWindowTopPosition,
+  measureWindowTopOffset,
+} from "../../utils/windowLayout";
+
+type BaseWindowProps = React.ComponentProps<typeof BaseWindow>;
+// BaseWindow is a class component, so the instance type exposes helper methods.
+type BaseWindowInstance = InstanceType<typeof BaseWindow> | null;
+
+type MutableRef<T> = React.MutableRefObject<T>;
+
+const parsePx = (value?: string | null): number | null => {
+  if (typeof value !== "string") return null;
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const readNodePosition = (node: HTMLElement): { x: number; y: number } | null => {
+  const style = node.style as CSSStyleDeclaration | undefined;
+  if (!style) {
+    return null;
+  }
+
+  if (typeof style.getPropertyValue === "function") {
+    const x = parsePx(style.getPropertyValue("--window-transform-x"));
+    const y = parsePx(style.getPropertyValue("--window-transform-y"));
+    if (x !== null && y !== null) {
+      return { x, y };
+    }
+  }
+
+  const transform = style.transform;
+  if (typeof transform === "string" && transform.length) {
+    const match = /translate\(([-\d.]+)px,\s*([-\d.]+)px\)/.exec(transform);
+    if (match) {
+      const parsedX = parseFloat(match[1]);
+      const parsedY = parseFloat(match[2]);
+      if (Number.isFinite(parsedX) && Number.isFinite(parsedY)) {
+        return { x: parsedX, y: parsedY };
+      }
+    }
+  }
+
+  return null;
+};
+
+const DesktopWindow = React.forwardRef<BaseWindowInstance, BaseWindowProps>(
+  (props, forwardedRef) => {
+    const innerRef = useRef<BaseWindowInstance>(null);
+
+    const assignRef = useCallback(
+      (instance: BaseWindowInstance) => {
+        innerRef.current = instance;
+        if (!forwardedRef) return;
+        if (typeof forwardedRef === "function") {
+          forwardedRef(instance);
+        } else {
+          (forwardedRef as MutableRef<BaseWindowInstance>).current = instance;
+        }
+      },
+      [forwardedRef],
+    );
+
+    const clampToViewport = useCallback(() => {
+      if (typeof window === "undefined") return;
+      const instance = innerRef.current;
+      const node = instance && typeof instance.getWindowNode === "function"
+        ? instance.getWindowNode()
+        : null;
+      if (!node || typeof node.getBoundingClientRect !== "function") return;
+
+      const rect = node.getBoundingClientRect();
+      const topOffset = measureWindowTopOffset();
+      const storedPosition = readNodePosition(node);
+      const fallbackPosition = {
+        x: typeof props.initialX === "number" ? props.initialX : 0,
+        y: clampWindowTopPosition(props.initialY, topOffset),
+      };
+      const currentPosition = storedPosition || fallbackPosition;
+      const clamped = clampWindowPositionWithinViewport(currentPosition, rect, {
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+        topOffset,
+      });
+      if (!clamped) return;
+      if (clamped.x === currentPosition.x && clamped.y === currentPosition.y) {
+        return;
+      }
+
+      node.style.transform = `translate(${clamped.x}px, ${clamped.y}px)`;
+      if (typeof node.style.setProperty === "function") {
+        node.style.setProperty("--window-transform-x", `${clamped.x}px`);
+        node.style.setProperty("--window-transform-y", `${clamped.y}px`);
+      } else {
+        (node.style as unknown as Record<string, string>)["--window-transform-x"] = `${clamped.x}px`;
+        (node.style as unknown as Record<string, string>)["--window-transform-y"] = `${clamped.y}px`;
+      }
+
+      if (typeof props.onPositionChange === "function") {
+        props.onPositionChange(clamped.x, clamped.y);
+      }
+    }, [props.initialX, props.initialY, props.onPositionChange]);
+
+    useEffect(() => {
+      if (typeof window === "undefined") return undefined;
+      const handler = () => clampToViewport();
+      window.addEventListener("resize", handler);
+      return () => {
+        window.removeEventListener("resize", handler);
+      };
+    }, [clampToViewport]);
+
+    return <BaseWindow ref={assignRef} {...props} />;
+  },
+);
+
+DesktopWindow.displayName = "DesktopWindow";
+
+export default DesktopWindow;


### PR DESCRIPTION
## Summary
- clamp saved desktop window positions against the resized viewport using the new bounds helper
- add a forwardRef desktop window wrapper that adjusts DOM transforms when the viewport changes
- cover the new behaviour with unit tests that shrink the viewport and confirm windows remain reachable

## Testing
- yarn test window.test.tsx desktopViewportResize.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e5e7bb19c483289933e02f6df2d663