### PR TITLE
[ui] Align window motion timing

### DIFF
--- a/components/base/window.module.css
+++ b/components/base/window.module.css
@@ -4,7 +4,17 @@
   border-radius: var(--radius-6);
   box-shadow: var(--shadow-2);
   overflow: hidden;
-  transition: filter var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+  --window-motion-transform-duration: var(--window-motion-duration-restore);
+  --window-motion-transform-easing: var(--window-motion-ease-restore);
+  --window-motion-opacity-duration: var(--window-motion-duration-minimize);
+  --window-motion-opacity-easing: var(--window-motion-ease-minimize);
+  transition:
+    transform var(--window-motion-transform-duration) var(--window-motion-transform-easing),
+    filter var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease,
+    opacity var(--window-motion-opacity-duration) var(--window-motion-opacity-easing),
+    visibility 0s linear;
+  transition-delay: 0s, 0s, 0s, 0s, 0s;
 }
 
 .windowFrame::before {
@@ -33,10 +43,23 @@
 
 .windowFrameMaximized {
   border-radius: 0;
+  --window-motion-transform-duration: var(--window-motion-duration-maximize);
+  --window-motion-transform-easing: var(--window-motion-ease-maximize);
 }
 
 .windowFrameMaximized::before {
   border-radius: 0;
+}
+
+.windowFrameMinimized {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition-delay: 0s, 0s, 0s, 0s, var(--window-motion-opacity-duration);
+}
+
+.snapPreview {
+  transition: opacity var(--window-motion-duration-snap-preview) var(--window-motion-ease-snap-preview);
 }
 
 .windowTitlebar {

--- a/styles/animation.css
+++ b/styles/animation.css
@@ -1,0 +1,12 @@
+:root {
+  --window-motion-duration-minimize: 200ms;
+  --window-motion-ease-minimize: cubic-bezier(0.4, 0, 0.2, 1);
+  --window-motion-duration-restore: 300ms;
+  --window-motion-ease-restore: cubic-bezier(0.2, 0.8, 0.4, 1);
+  --window-motion-duration-snap: 240ms;
+  --window-motion-ease-snap: cubic-bezier(0.2, 0.8, 0.4, 1);
+  --window-motion-duration-maximize: 320ms;
+  --window-motion-ease-maximize: cubic-bezier(0.2, 0.8, 0.4, 1);
+  --window-motion-duration-snap-preview: var(--window-motion-duration-snap);
+  --window-motion-ease-snap-preview: var(--window-motion-ease-snap);
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,5 @@
 @import './globals.css';
+@import './animation.css';
 
 html {
     font-size: clamp(12px, calc(16px * var(--font-multiplier)), 24px);


### PR DESCRIPTION
## Summary
- add shared CSS variables for window motion states
- refactor the window component to use the shared timing presets
- apply consistent timing to snap preview and minimize transitions

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e5e7b483388328ba05ef6b89dea420