### PR TITLE
[desktop] Preserve maximized window position clamp

### DIFF
--- a/components/desktop/Window.tsx
+++ b/components/desktop/Window.tsx
@@ -10,6 +10,10 @@ type BaseWindowProps = React.ComponentProps<typeof BaseWindow>;
 // BaseWindow is a class component, so the instance type exposes helper methods.
 type BaseWindowInstance = InstanceType<typeof BaseWindow> | null;
 
+type BaseWindowState = {
+  maximized?: boolean;
+};
+
 type MutableRef<T> = React.MutableRefObject<T>;
 
 const parsePx = (value?: string | null): number | null => {
@@ -71,6 +75,15 @@ const DesktopWindow = React.forwardRef<BaseWindowInstance, BaseWindowProps>(
         ? instance.getWindowNode()
         : null;
       if (!node || typeof node.getBoundingClientRect !== "function") return;
+
+      const instanceState =
+        instance && typeof instance === "object" && "state" in instance
+          ? (instance as { state?: BaseWindowState }).state ?? null
+          : null;
+
+      if (instanceState?.maximized) {
+        return;
+      }
 
       const rect = node.getBoundingClientRect();
       const topOffset = measureWindowTopOffset();


### PR DESCRIPTION
## Summary
- skip viewport clamping when a window is maximized so the stored position is preserved
- add a maximized state guard inside the DesktopWindow wrapper before adjusting transforms

## Testing
- yarn test window.test.tsx desktopViewportResize.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e62b02195483289e259750d3cbe1ec