### PR TITLE
[menu] Add Alt+F1 fallback for launcher

### DIFF
--- a/__tests__/whiskerMenu.test.tsx
+++ b/__tests__/whiskerMenu.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import WhiskerMenu from '../components/menu/WhiskerMenu';
+
+beforeAll(() => {
+  if (!window.requestAnimationFrame) {
+    // @ts-expect-error - assigning to allow the component to schedule animations in tests
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      const getNow = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+      return window.setTimeout(() => callback(getNow()), 0);
+    };
+  }
+});
+
+describe('WhiskerMenu keyboard shortcuts', () => {
+  it('opens the menu when the Alt+F1 fallback shortcut is pressed', () => {
+    render(<WhiskerMenu />);
+
+    expect(screen.queryByText('Categories')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'F1', altKey: true });
+
+    expect(screen.getByText('Categories')).toBeInTheDocument();
+  });
+});

--- a/components/menu/WhiskerMenu.tsx
+++ b/components/menu/WhiskerMenu.tsx
@@ -310,7 +310,12 @@ const WhiskerMenu: React.FC = () => {
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Meta' && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+      const metaShortcut =
+        e.key === 'Meta' && !e.ctrlKey && !e.shiftKey && !e.altKey;
+      const altF1Shortcut =
+        e.key === 'F1' && e.altKey && !e.metaKey && !e.ctrlKey && !e.shiftKey;
+
+      if (metaShortcut || altF1Shortcut) {
         e.preventDefault();
         toggleMenu();
         return;
@@ -398,6 +403,7 @@ const WhiskerMenu: React.FC = () => {
         ref={buttonRef}
         type="button"
         onClick={toggleMenu}
+        aria-keyshortcuts="Meta Alt+F1"
         className="pl-3 pr-3 outline-none transition duration-100 ease-in-out border-b-2 border-transparent py-1"
       >
         <Image

--- a/pages/keyboard-reference.tsx
+++ b/pages/keyboard-reference.tsx
@@ -13,6 +13,10 @@ const KeyboardReference = () => (
       </thead>
       <tbody>
         <tr>
+          <td className="p-2 border border-ubt-grey">Meta / Alt + F1</td>
+          <td className="p-2 border border-ubt-grey">Open the applications menu</td>
+        </tr>
+        <tr>
           <td className="p-2 border border-ubt-grey">Ctrl + C</td>
           <td className="p-2 border border-ubt-grey">Copy selected text</td>
         </tr>


### PR DESCRIPTION
## Summary
- add an Alt+F1 fallback shortcut alongside Meta for toggling the Whisker menu
- expose both shortcuts on the Applications button and in the keyboard reference page
- cover the new shortcut with a Jest test to ensure it opens the launcher

## Testing
- [x] yarn lint
- [x] yarn test whiskerMenu.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68e62b91cda4832889805ae9c9a46d39