### PR TITLE
[build] fix force graph peer deps warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,17 @@
 yarnPath: .yarn/releases/yarn-4.9.2.cjs
 nodeLinker: node-modules
 
+packageExtensions:
+  "3d-force-graph-ar@*":
+    dependencies:
+      aframe: "^1.5.0"
+  "aframe-forcegraph-component@*":
+    dependencies:
+      three: "^0.179.1"
+  "react-force-graph@*":
+    dependencies:
+      aframe: "^1.5.0"
+
 logFilters:
   - pattern: "deprecated sourcemap-codec@1.4.8"
     level: discard


### PR DESCRIPTION
## Summary
- add Yarn packageExtensions so force-graph packages declare their aframe and three peers

## Testing
- [x] yarn install --immutable --immutable-cache

## Flags
- [ ] Feature flags toggled


------
https://chatgpt.com/codex/tasks/task_e_68e631b2f7b0832887decc3b108ad17a