### PR TITLE
[hydra] align api validation with http ui options

### DIFF
--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -5,7 +5,15 @@ import { promisify } from 'util';
 import path from 'path';
 
 const execFileAsync = promisify(execFile);
-const allowed = new Set(['http', 'https', 'ssh', 'ftp', 'smtp']);
+const allowed = new Set([
+  'http',
+  'https',
+  'ssh',
+  'ftp',
+  'smtp',
+  'http-get',
+  'http-post-form',
+]);
 
 export default async function handler(req, res) {
   if (


### PR DESCRIPTION
## Summary
- allow the Hydra API stub to accept the http-get and http-post-form services surfaced in the UI
- extend the API tests to cover acceptance of http variants and rejection of unknown protocols

## Testing
- yarn test hydra.api.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e6338f1d28832893f1a93a69706f46