### PR TITLE
[docs] add mobile task stubs helpers

### DIFF
--- a/docs/TASKS_MOBILE.md
+++ b/docs/TASKS_MOBILE.md
@@ -1,0 +1,45 @@
+# Mobile Task Stubs — Desktop Optimizations
+
+This document captures upcoming work focused on ensuring the desktop shell translates cleanly to mobile and small viewports. Each entry mirrors the structure used by `docs/TASKS_UI_POLISH.md`: acceptance criteria, file hints, and any helper code that already exists to accelerate the change.
+
+## A) Shell & Window Manager
+
+1. **Safe-area aware dock padding**
+   - **Accept:** Dock respects `env(safe-area-inset-*)` values and never collides with device notches or gesture areas while keeping icons centered.
+   - **Where:** `components/screen/desktop.js`, `styles/index.css`, and the dock layout helpers in `components/base/dock/*`.
+   - **Code stub:** See `scripts/examples/mobile-task-stubs.ts` (`createSafeAreaStyle`) for a helper that merges measured safe-area values with existing Tailwind classes.
+
+2. **Portrait window sizing preset**
+   - **Accept:** On viewports with height ≥ width, newly spawned windows default to 90% width, clamp to 720 px max, and vertically center inside the safe viewport.
+   - **Where:** `components/base/window/index.tsx`, window positioning utilities in `hooks/useWindowManager.ts`.
+   - **Code stub:** `scripts/examples/mobile-task-stubs.ts` exports `getPortraitBounds` demonstrating how to derive the target rectangle using the desktop metrics store.
+
+3. **Gesture-to-shortcut bridge**
+   - **Accept:** Swiping left/right on the focused window dispatches the same events as Super+Arrow and temporarily reduces shadow blur during the animation.
+   - **Where:** `hooks/useGestureBindings.ts`, `components/base/window/ShadowLayer.tsx`.
+   - **Code stub:** `scripts/examples/mobile-task-stubs.ts` shows `registerSwipeShortcut` to normalize pointer events into shell shortcuts.
+
+## B) Launcher & Menus
+
+4. **Whisker menu reach mode**
+   - **Accept:** A toggle in Settings mirrors the "One-handed mode" spec and repositions launch actions toward the bottom on mobile screens ≤ 480 px wide.
+   - **Where:** `components/menu/WhiskerMenu.tsx`, `components/apps/settings/stores/menuPreferences.ts`.
+   - **Code stub:** Use `applyReachModeLayout` in `scripts/examples/mobile-task-stubs.ts` for a layout skeleton that swaps flex direction and spacing tokens.
+
+5. **Pinned search input on small screens**
+   - **Accept:** Search input remains pinned while results scroll underneath; focus and escape key handling continue to work with screen readers.
+   - **Where:** `components/menu/WhiskerMenu.tsx`, `styles/menu.css`.
+   - **Code stub:** `scripts/examples/mobile-task-stubs.ts` exports `createStickySearchProps` that memoizes inline style objects for pinned headers.
+
+## C) Performance & Perception
+
+6. **Idle prefetch budget for mobile**
+   - **Accept:** When `navigator.connection.saveData` is true or effective connection type is `3g`, idle prefetch is capped at one app and defers heavy bundles to interaction.
+   - **Where:** `hooks/useIdlePrefetch.ts`, app registry utilities in `apps.config.js`.
+   - **Code stub:** Reference `limitMobilePrefetch` from `scripts/examples/mobile-task-stubs.ts` which includes a guard for the Network Information API fallback path.
+
+---
+
+### How to use these stubs
+
+Each stub in `scripts/examples/mobile-task-stubs.ts` exports a strongly typed helper with inline documentation. Import the relevant helper into your work branch, adapt it to production code, and add Jest coverage mirroring `__tests__/components/menu/WhiskerMenu.mobile.test.tsx` for regressions.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,6 +1,7 @@
 # Application Task List
 
 This document tracks planned improvements and new features for the desktop portfolio apps.
+For mobile-specific shell and launcher polish, see `docs/TASKS_MOBILE.md` which now contains stubbed helper code for responsive work.
 
 ## Foundation
 - Add dynamic app factory at `utils/createDynamicApp.js` to unify dynamic imports and GA events.

--- a/scripts/examples/mobile-task-stubs.ts
+++ b/scripts/examples/mobile-task-stubs.ts
@@ -1,0 +1,283 @@
+import type { CSSProperties } from 'react';
+
+type SafeAreaInsets = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+type PartialSafeAreaInsets = Partial<SafeAreaInsets>;
+
+type DockAlignment = 'bottom' | 'left' | 'right';
+
+type SafeAreaStyleInput = {
+  basePadding: number;
+  insets?: PartialSafeAreaInsets;
+  alignment?: DockAlignment;
+};
+
+export function createSafeAreaStyle({
+  basePadding,
+  insets,
+  alignment = 'bottom',
+}: SafeAreaStyleInput): CSSProperties {
+  const resolvedInsets: SafeAreaInsets = {
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    ...insets,
+  };
+
+  const verticalPadding = Math.max(0, resolvedInsets.bottom);
+  const horizontalPadding = Math.max(0, alignment === 'left' ? resolvedInsets.left : resolvedInsets.right);
+
+  const style: CSSProperties = {
+    paddingInlineStart: `calc(${basePadding}px + ${resolvedInsets.left}px)`,
+    paddingInlineEnd: `calc(${basePadding}px + ${resolvedInsets.right}px)`,
+    paddingBlockEnd: `calc(${basePadding}px + ${verticalPadding}px)`,
+  };
+
+  if (alignment === 'left' || alignment === 'right') {
+    style.paddingBlockStart = `calc(${basePadding}px + ${resolvedInsets.top}px)`;
+    style.paddingBlockEnd = `calc(${basePadding}px + ${resolvedInsets.bottom}px)`;
+    if (alignment === 'left') {
+      style.transform = `translateX(${horizontalPadding}px)`;
+    } else {
+      style.transform = `translateX(-${horizontalPadding}px)`;
+    }
+  }
+
+  return style;
+}
+
+export interface DesktopMetrics {
+  viewportWidth: number;
+  viewportHeight: number;
+  minMargin: number;
+  defaultWidth: number;
+  defaultHeight: number;
+  safeArea?: PartialSafeAreaInsets;
+}
+
+export interface Bounds {
+  width: number;
+  height: number;
+  top: number;
+  left: number;
+}
+
+export function getPortraitBounds(metrics: DesktopMetrics): Bounds {
+  const {
+    viewportWidth,
+    viewportHeight,
+    minMargin,
+    defaultWidth,
+    defaultHeight,
+    safeArea,
+  } = metrics;
+
+  const resolvedSafeArea: SafeAreaInsets = {
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    ...safeArea,
+  };
+
+  const width = Math.min(Math.round(viewportWidth * 0.9), 720);
+  const maxHeight = viewportHeight - resolvedSafeArea.top - resolvedSafeArea.bottom - minMargin * 2;
+  const height = Math.min(Math.max(Math.round(maxHeight), 360), defaultHeight);
+
+  const left = Math.round((viewportWidth - width) / 2);
+  const top = Math.max(
+    resolvedSafeArea.top + minMargin,
+    Math.round((viewportHeight - height) / 2),
+  );
+
+  return { width, height, top, left };
+}
+
+export type SwipeDirection = 'left' | 'right';
+
+export interface SwipeShortcutOptions {
+  threshold?: number;
+  onSwipe: (direction: SwipeDirection) => void;
+}
+
+export function registerSwipeShortcut(
+  element: HTMLElement,
+  { threshold = 48, onSwipe }: SwipeShortcutOptions,
+): () => void {
+  let pointerId: number | null = null;
+  let startX = 0;
+  let startY = 0;
+  let isTracking = false;
+
+  const onPointerDown = (event: PointerEvent) => {
+    if (event.pointerType !== 'touch' || pointerId !== null) {
+      return;
+    }
+    pointerId = event.pointerId;
+    startX = event.clientX;
+    startY = event.clientY;
+    isTracking = true;
+  };
+
+  const onPointerMove = (event: PointerEvent) => {
+    if (!isTracking || pointerId !== event.pointerId) {
+      return;
+    }
+
+    const deltaX = event.clientX - startX;
+    const deltaY = event.clientY - startY;
+
+    if (Math.abs(deltaY) > Math.abs(deltaX)) {
+      return;
+    }
+
+    if (Math.abs(deltaX) >= threshold) {
+      onSwipe(deltaX > 0 ? 'right' : 'left');
+      reset();
+    }
+  };
+
+  const onPointerUp = (event: PointerEvent) => {
+    if (pointerId === event.pointerId) {
+      reset();
+    }
+  };
+
+  const reset = () => {
+    pointerId = null;
+    startX = 0;
+    startY = 0;
+    isTracking = false;
+  };
+
+  element.addEventListener('pointerdown', onPointerDown);
+  element.addEventListener('pointermove', onPointerMove);
+  element.addEventListener('pointerup', onPointerUp);
+  element.addEventListener('pointercancel', onPointerUp);
+
+  return () => {
+    element.removeEventListener('pointerdown', onPointerDown);
+    element.removeEventListener('pointermove', onPointerMove);
+    element.removeEventListener('pointerup', onPointerUp);
+    element.removeEventListener('pointercancel', onPointerUp);
+  };
+}
+
+export interface ReachModeLayout {
+  container: string;
+  actions: string;
+  footer: string;
+}
+
+export function applyReachModeLayout(
+  isReachMode: boolean,
+  base: ReachModeLayout,
+): ReachModeLayout {
+  if (!isReachMode) {
+    return base;
+  }
+
+  return {
+    container: `${base.container} flex-col-reverse gap-3`,
+    actions: `${base.actions} flex-row flex-wrap gap-2`,
+    footer: `${base.footer} justify-center`,
+  };
+}
+
+export function createStickySearchProps(
+  height: number,
+  zIndex = 10,
+  safeAreaTop = 0,
+): CSSProperties {
+  return {
+    position: 'sticky',
+    top: `calc(${safeAreaTop}px)`,
+    zIndex,
+    minHeight: `${height}px`,
+    paddingTop: `calc(${safeAreaTop}px)`,
+    background: 'var(--menu-surface, rgba(16, 20, 24, 0.9))',
+    backdropFilter: 'blur(12px)',
+  };
+}
+
+export interface PrefetchCandidate {
+  id: string;
+  weight: number;
+}
+
+export interface NetworkInformationLike {
+  saveData?: boolean;
+  effectiveType?: string;
+}
+
+export function limitMobilePrefetch(
+  candidates: PrefetchCandidate[],
+  networkInfo?: NetworkInformationLike,
+): PrefetchCandidate[] {
+  if (!candidates.length) {
+    return candidates;
+  }
+
+  const saveData = Boolean(networkInfo?.saveData);
+  const effectiveType = networkInfo?.effectiveType ?? '4g';
+  const isSlowConnection = ['slow-2g', '2g', '3g'].includes(effectiveType);
+
+  if (!saveData && !isSlowConnection) {
+    return candidates.slice(0, 3);
+  }
+
+  const sorted = [...candidates].sort((a, b) => b.weight - a.weight);
+  return sorted.slice(0, 1);
+}
+
+export interface MobileTaskStub {
+  id: string;
+  summary: string;
+  paths: string[];
+  helper: string;
+}
+
+export const mobileTaskStubs: MobileTaskStub[] = [
+  {
+    id: 'safe-area-dock-padding',
+    summary: 'Pad the dock using safe-area insets so icons stay centered and tappable.',
+    paths: ['components/screen/desktop.js', 'components/base/dock'],
+    helper: 'createSafeAreaStyle',
+  },
+  {
+    id: 'portrait-window-bounds',
+    summary: 'Derive portrait window defaults with safe-area aware centering.',
+    paths: ['components/base/window/index.tsx', 'hooks/useWindowManager.ts'],
+    helper: 'getPortraitBounds',
+  },
+  {
+    id: 'swipe-shortcuts',
+    summary: 'Translate horizontal swipes into Super+Arrow shortcuts with minimal shadow work.',
+    paths: ['hooks/useGestureBindings.ts', 'components/base/window/ShadowLayer.tsx'],
+    helper: 'registerSwipeShortcut',
+  },
+  {
+    id: 'menu-reach-mode',
+    summary: 'Offer a reach-friendly layout for launcher actions on narrow screens.',
+    paths: ['components/menu/WhiskerMenu.tsx', 'components/apps/settings/stores/menuPreferences.ts'],
+    helper: 'applyReachModeLayout',
+  },
+  {
+    id: 'sticky-search',
+    summary: 'Keep the launcher search pinned while list content scrolls underneath.',
+    paths: ['components/menu/WhiskerMenu.tsx', 'styles/menu.css'],
+    helper: 'createStickySearchProps',
+  },
+  {
+    id: 'idle-prefetch-mobile-budget',
+    summary: 'Reduce idle prefetching on constrained connections to avoid mobile jank.',
+    paths: ['hooks/useIdlePrefetch.ts', 'apps.config.js'],
+    helper: 'limitMobilePrefetch',
+  },
+];


### PR DESCRIPTION
## Summary
- document a focused set of mobile-first desktop optimization tasks in `docs/TASKS_MOBILE.md`
- add reusable helper stubs in `scripts/examples/mobile-task-stubs.ts` for safe-area, gestures, reach mode, and prefetch tuning work
- link the main application task list to the new mobile-specific checklist

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e633c79944832891e338fd03974f36