### PR TITLE
[hydra] Send resume action to API

### DIFF
--- a/components/apps/hydra/index.js
+++ b/components/apps/hydra/index.js
@@ -129,11 +129,11 @@ const HydraApp = () => {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
+            action: 'resume',
             target: session.target,
             service: session.service,
             userList: user.content,
             passList: pass.content,
-            resume: true,
           }),
         });
         const data = await res.json();


### PR DESCRIPTION
## Summary
- include `action: "resume"` in the Hydra session resume request payload
- update the Hydra session restore test to assert the resume call uses the resume action

## Testing
- yarn test hydra

------
https://chatgpt.com/codex/tasks/task_e_68e634aa091c8328975f255a412bbc82