### PR TITLE
[api] allow hydra http services

### DIFF
--- a/__tests__/hydra-api.test.js
+++ b/__tests__/hydra-api.test.js
@@ -1,7 +1,8 @@
-const randomUUIDMock = jest
-  .fn()
-  .mockReturnValueOnce('u')
-  .mockReturnValueOnce('p');
+let uuidCounter = 0;
+const randomUUIDMock = jest.fn(() => {
+  uuidCounter += 1;
+  return `id-${uuidCounter}`;
+});
 
 jest.mock('crypto', () => ({
   randomUUID: randomUUIDMock,
@@ -10,19 +11,35 @@ jest.mock('crypto', () => ({
 process.env.FEATURE_TOOL_APIS = 'enabled';
 process.env.FEATURE_HYDRA = 'enabled';
 
+const util = require('util');
+
+const execFileMock = jest.fn((cmd, args, options, callback) => {
+  if (typeof options === 'function') {
+    callback = options;
+  }
+  callback(null, 'done', '');
+});
+
+execFileMock[util.promisify.custom] = (cmd) => {
+  if (cmd === 'which') {
+    return Promise.resolve({ stdout: '/usr/bin/hydra', stderr: '' });
+  }
+  return Promise.resolve({ stdout: 'done', stderr: '' });
+};
+
 jest.mock('child_process', () => ({
-  execFile: (cmd, args, options, callback) => {
-    if (typeof options === 'function') {
-      callback = options;
-    }
-    callback(null, 'done', '');
-  },
+  execFile: execFileMock,
 }));
 
 const handler = require('../pages/api/hydra').default;
 const path = require('path');
 const fs = require('fs').promises;
 const sessionDir = path.join(process.cwd(), 'hydra');
+
+beforeEach(() => {
+  uuidCounter = 0;
+  randomUUIDMock.mockClear();
+});
 
 test('removes temp files after hydra execution', async () => {
   const req = {
@@ -34,13 +51,56 @@ test('removes temp files after hydra execution', async () => {
     json: jest.fn(),
   };
 
-  const userPath = '/tmp/hydra-users-u.txt';
-  const passPath = '/tmp/hydra-pass-p.txt';
-
   await handler(req, res);
+
+  const [userResult, passResult] = randomUUIDMock.mock.results;
+  const userPath = `/tmp/hydra-users-${userResult.value}.txt`;
+  const passPath = `/tmp/hydra-pass-${passResult.value}.txt`;
 
   await expect(fs.access(userPath)).rejects.toBeTruthy();
   await expect(fs.access(passPath)).rejects.toBeTruthy();
+});
+
+test('accepts http-get service names exposed in the UI', async () => {
+  const req = {
+    method: 'POST',
+    body: {
+      target: 'target',
+      service: 'http-get',
+      userList: 'u',
+      passList: 'p',
+    },
+  };
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+
+  await handler(req, res);
+
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ output: 'done' });
+});
+
+test('rejects unsupported hydra services', async () => {
+  const req = {
+    method: 'POST',
+    body: {
+      target: 'target',
+      service: 'unknown-service',
+      userList: 'u',
+      passList: 'p',
+    },
+  };
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+
+  await handler(req, res);
+
+  expect(res.status).toHaveBeenCalledWith(400);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Unsupported service' });
 });
 afterAll(async () => {
   await fs.rm(sessionDir, { recursive: true, force: true });

--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -5,7 +5,15 @@ import { promisify } from 'util';
 import path from 'path';
 
 const execFileAsync = promisify(execFile);
-const allowed = new Set(['http', 'https', 'ssh', 'ftp', 'smtp']);
+const allowed = new Set([
+  'http',
+  'https',
+  'ssh',
+  'ftp',
+  'smtp',
+  'http-get',
+  'http-post-form',
+]);
 
 export default async function handler(req, res) {
   if (


### PR DESCRIPTION
## Summary
- allow the Hydra API to accept the http-get and http-post-form service keys exposed in the UI
- extend the Hydra API unit test to cover the new service names and ensure unknown services remain blocked

## Testing
- yarn test hydra-api

------
https://chatgpt.com/codex/tasks/task_e_68e634ab472483288a31105171b52802