### PR TITLE
[desktop] Clamp window fallback below navbar

### DIFF
--- a/utils/windowLayout.js
+++ b/utils/windowLayout.js
@@ -1,7 +1,8 @@
-import { SNAP_BOTTOM_INSET } from './uiConstants';
+import { NAVBAR_HEIGHT, SNAP_BOTTOM_INSET } from './uiConstants';
 
 const NAVBAR_SELECTOR = '.main-navbar-vp';
-const DEFAULT_NAVBAR_HEIGHT = 48;
+const NAVBAR_VERTICAL_PADDING = 16; // 0.5rem top + 0.5rem bottom
+const DEFAULT_NAVBAR_HEIGHT = NAVBAR_HEIGHT + NAVBAR_VERTICAL_PADDING;
 const WINDOW_TOP_MARGIN = 8;
 const SAFE_AREA_PROPERTIES = {
   top: '--safe-area-top',


### PR DESCRIPTION
## Summary
- reuse the shared navbar height constant for window layout fallbacks
- account for the navbar's fixed padding so default top offsets clear the bar before measurements run

## Testing
- yarn lint
- Manual QA: Desktop view – opening an app at first paint places the window below the navbar

------
https://chatgpt.com/codex/tasks/task_e_68e636d6f1ec8328ad98e6e14cd9ff54