### PR TITLE
[deps] dedupe lockfile to fix deployment check failures

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4111,7 +4111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:5.3.0, aria-query@npm:^5.0.0":
+"aria-query@npm:5.3.0":
   version: 5.3.0
   resolution: "aria-query@npm:5.3.0"
   dependencies:
@@ -4120,7 +4120,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:^5.3.2":
+"aria-query@npm:^5.0.0, aria-query@npm:^5.3.2":
   version: 5.3.2
   resolution: "aria-query@npm:5.3.2"
   checksum: 10c0/003c7e3e2cff5540bf7a7893775fc614de82b0c5dde8ae823d47b7a28a9d4da1f7ed85f340bdb93d5649caa927755f0e31ecc7ab63edfdfc00c8ef07e505e03e
@@ -11032,7 +11032,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.6.3, semver@npm:^7.5.3, semver@npm:^7.5.4":
+"semver@npm:7.6.3":
   version: 7.6.3
   resolution: "semver@npm:7.6.3"
   bin:
@@ -11050,21 +11050,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5":
+"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.1, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:~7.7.1":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
     semver: bin/semver.js
   checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.7.1, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:~7.7.1":
-  version: 7.7.3
-  resolution: "semver@npm:7.7.3"
-  bin:
-    semver: bin/semver.js
-  checksum: 10c0/4afe5c986567db82f44c8c6faef8fe9df2a9b1d98098fc1721f57c696c4c21cebd572f297fc21002f81889492345b8470473bc6f4aff5fb032a6ea59ea2bc45e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Motivation
- CI and deploy workflows run `yarn dedupe --check` before building, and the lockfile previously contained multiple resolutions for packages (notably `aria-query` and `semver`) which caused the dedupe check to fail and prevented deployment.

### Description
- Updated `yarn.lock` to consolidate and deduplicate dependency resolutions so the dedupe check succeeds, resolving drift in `aria-query` and `semver` entries; no application source files were modified.
- Ensured the build/export flow remains unchanged and that PWA/vendor assets required by the build are still produced by the pipeline.

### Testing
- Ran `yarn dedupe:check` and it passed successfully.
- Ran `yarn lint` and `yarn build` (and `yarn export`) and the build completed with static pages generated.
- Ran the repository verification flow with `yarn verify:all` where the dedupe, lint, and typecheck phases passed and the unit test suite executed successfully (tests passed while a small number of console warnings from test environment hooks were observed but did not fail the run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a66ec553648328b29d618a518aad53)