### PR TITLE
[apps] make toolbar action buttons resilient with flexible sizing

### DIFF
--- a/components/apps/bluetooth/index.tsx
+++ b/components/apps/bluetooth/index.tsx
@@ -107,6 +107,7 @@ const BluetoothApp: React.FC = () => {
           placeholder="Min RSSI"
           value={rssiFilter}
           onChange={(e) => setRssiFilter(e.target.value)}
+          aria-label="Minimum RSSI filter"
           className="w-1/3 rounded bg-gray-800 p-2 text-white"
         />
         <input
@@ -114,6 +115,7 @@ const BluetoothApp: React.FC = () => {
           placeholder="Search devices"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
+          aria-label="Search Bluetooth devices"
           className="w-2/3 rounded bg-gray-800 p-2 text-white"
         />
       </div>
@@ -154,13 +156,13 @@ const BluetoothApp: React.FC = () => {
         <div className="absolute inset-0 flex items-center justify-center bg-black/70">
           <div className="w-64 rounded bg-gray-800 p-4 text-center">
             <p className="mb-4">Allow access to Bluetooth devices?</p>
-            <div className="flex justify-end gap-2">
+            <div className="flex flex-wrap justify-end gap-2">
               <button
                 onClick={() => {
                   setShowPermissionModal(false);
                   setError("Permission denied.");
                 }}
-                className="w-[90px] rounded bg-gray-600 px-2 py-1"
+                className="inline-flex min-w-[90px] justify-center rounded bg-gray-600 px-3 py-1"
               >
                 Cancel
               </button>
@@ -170,7 +172,7 @@ const BluetoothApp: React.FC = () => {
                   setShowPermissionModal(false);
                   loadData();
                 }}
-                className="w-[90px] rounded bg-blue-600 px-2 py-1"
+                className="inline-flex min-w-[90px] justify-center rounded bg-blue-600 px-3 py-1"
               >
                 Allow
               </button>
@@ -184,10 +186,10 @@ const BluetoothApp: React.FC = () => {
             <p className="mb-4">
               Pair with {pairingDevice.name || pairingDevice.address}?
             </p>
-            <div className="flex justify-end gap-2">
+            <div className="flex flex-wrap justify-end gap-2">
               <button
                 onClick={() => setPairingDevice(null)}
-                className="w-[90px] rounded bg-gray-600 px-2 py-1"
+                className="inline-flex min-w-[90px] justify-center rounded bg-gray-600 px-3 py-1"
               >
                 Cancel
               </button>
@@ -196,7 +198,7 @@ const BluetoothApp: React.FC = () => {
                   setPairedDevice(pairingDevice.name || pairingDevice.address);
                   setPairingDevice(null);
                 }}
-                className="w-[90px] rounded bg-blue-600 px-2 py-1"
+                className="inline-flex min-w-[90px] justify-center rounded bg-blue-600 px-3 py-1"
               >
                 Pair
               </button>

--- a/components/apps/firefox/index.tsx
+++ b/components/apps/firefox/index.tsx
@@ -138,7 +138,7 @@ const Firefox: React.FC = () => {
     <div className="flex h-full min-h-0 flex-col bg-[var(--kali-surface)] text-[color:var(--kali-text)]">
       <form
         onSubmit={handleSubmit}
-        className="flex flex-col gap-3 border-b border-[color:var(--kali-border)] bg-[var(--kali-overlay)] px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between"
+        className="flex flex-col gap-3 border-b border-[color:var(--kali-border)] bg-[var(--kali-overlay)] px-4 py-3 text-sm sm:flex-row sm:flex-wrap sm:items-center sm:justify-between"
       >
         <label htmlFor="firefox-address" className="sr-only">
           Address
@@ -194,7 +194,7 @@ const Firefox: React.FC = () => {
         </div>
         <button
           type="submit"
-          className="h-10 rounded-md bg-[color:var(--color-primary)] px-4 text-sm font-semibold text-[color:var(--color-inverse)] shadow-[0_12px_32px_-12px_var(--kali-blue-glow)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--color-primary)]"
+          className="inline-flex h-10 min-w-[5.5rem] items-center justify-center rounded-md bg-[color:var(--color-primary)] px-4 text-sm font-semibold text-[color:var(--color-inverse)] shadow-[0_12px_32px_-12px_var(--kali-blue-glow)] transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--color-primary)]"
         >
           Go
         </button>

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -451,7 +451,7 @@ const OpenVASApp = () => {
         </div>
       )}
       <h2 className="mb-2 text-lg font-semibold">OpenVAS Scanner</h2>
-      <div className="mb-4 flex flex-wrap gap-2">
+      <div className="mb-4 flex flex-wrap items-start gap-2">
           <input
             className="flex-1 min-w-[12rem] rounded-lg bg-kali-surface-muted px-3 py-2 text-sm text-white placeholder-white/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kali-focus"
             placeholder="Target (e.g. 192.168.1.1)"
@@ -466,7 +466,7 @@ const OpenVASApp = () => {
             onChange={(e) => setGroup(e.target.value)}
             aria-label="Asset group"
           />
-        <div className="flex items-center gap-2" role="tablist" aria-label="Scan profile">
+        <div className="flex flex-wrap items-center gap-2" role="tablist" aria-label="Scan profile">
           {profileTabs.map((p) => (
             <button
               key={p.id}
@@ -475,7 +475,7 @@ const OpenVASApp = () => {
               aria-selected={profile === p.id}
               aria-label={p.label}
               onClick={() => setProfile(p.id)}
-              className={`flex h-8 w-8 items-center justify-center rounded-md border border-white/10 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kali-focus ${
+              className={`inline-flex min-h-8 min-w-8 items-center justify-center rounded-md border border-white/10 px-2 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kali-focus ${
                 profile === p.id
                   ? 'bg-kali-surface-raised text-kali-control shadow-[0_0_0_1px_rgba(255,255,255,0.12)]'
                   : 'bg-kali-surface-muted text-white/70 hover:text-white'


### PR DESCRIPTION
### Motivation
- Toolbars and modal action rows used fixed button widths which caused overflow and poor wrapping in constrained window sizes; the change makes sizing flexible and wrapping resilient while preserving existing behavior and labels.

### Description
- Replaced fixed-width modal buttons in `components/apps/bluetooth/index.tsx` with wrapping-friendly rows (`flex-wrap`) and buttons using `inline-flex`, `min-w-[90px]`, centered content (`justify-center`) and slightly increased horizontal padding, while preserving labels and behavior.
- Adjusted the OpenVAS scan action cluster in `components/apps/openvas/index.js` to allow wrapping and converted profile icon tabs from fixed `h-8 w-8` to `inline-flex min-h-8 min-w-8 px-2` to retain visual size but avoid hard widths.
- Updated Firefox toolbar in `components/apps/firefox/index.tsx` to allow wrapping at the `sm` row breakpoint and made the `Go` button `inline-flex` with `min-w-[5.5rem]` and centered content for consistent behavior under narrow layouts.
- Preserved keyboard accessibility, ARIA attributes, icons, and labels, and added `aria-label`s to Bluetooth inputs to address accessibility lint warnings; no behavioral logic changes were made.

### Testing
- Ran `yarn lint` and the warnings were addressed; lint completed successfully.
- Ran `yarn test --watch=false` and the test suite completed with all suites passing (261 passed, 4 skipped) and 923 tests passing; no regressions were observed.
- Manual verification focused on ensuring buttons remain focusable and that labels/icons remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e380a9101c8328a0d19e68a0289897)