### PR TITLE
[apps] add shared presentational wrappers for volatility, dsniff, and openvas

### DIFF
--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -3,6 +3,7 @@ import urlsnarfFixture from '../../../public/demo-data/dsniff/urlsnarf.json';
 import arpspoofFixture from '../../../public/demo-data/dsniff/arpspoof.json';
 import pcapFixture from '../../../public/demo-data/dsniff/pcap.json';
 import TerminalOutput from '../../TerminalOutput';
+import { AppPanel, AppToolbar } from '../shared';
 
 // Simple parser that attempts to extract protocol, host and remaining details
 // Each parsed line is also given a synthetic timestamp for display purposes
@@ -440,9 +441,9 @@ const Dsniff = () => {
   }, [arpspoofLogs.length, domainSummary, filters.length, pcapSummary.length, protocolFilter.length, search, urlsnarfLogs.length]);
 
   return (
-    <div className="h-full w-full overflow-auto bg-ub-cool-grey text-white">
+    <AppPanel className="h-full w-full overflow-auto rounded-none bg-ub-cool-grey text-white" tone="subtle">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-6 md:px-6">
-        <div className="flex flex-wrap items-start justify-between gap-4">
+        <AppToolbar className="items-start rounded-xl border">
           <div className="space-y-1">
             <h1 className="text-xl font-semibold text-slate-100 md:text-2xl">dsniff capture console</h1>
             <p className="max-w-xl text-sm leading-relaxed text-slate-300/90">
@@ -455,10 +456,11 @@ const Dsniff = () => {
           >
             <span>Export summary</span>
           </button>
-        </div>
+        </AppToolbar>
 
-        <div
-          className="rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100 shadow-inner"
+        <AppPanel
+          className="px-4 py-3 text-sm text-amber-100 shadow-inner"
+          tone="warning"
           role="alert"
         >
           <div className="flex items-start gap-3">
@@ -474,13 +476,13 @@ const Dsniff = () => {
               </p>
             </div>
           </div>
-        </div>
+        </AppPanel>
 
         <section className="space-y-3" data-testid="suite-tools">
           <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-300">
             Suite tools
           </h2>
-          <div className="overflow-hidden rounded-2xl border border-slate-800/80 bg-slate-950/50 shadow-sm">
+          <AppPanel className="overflow-hidden rounded-2xl border-slate-800/80 bg-slate-950/50 shadow-sm">
             <table className="w-full table-fixed text-left text-xs md:text-sm">
               <thead className="bg-slate-900/60 text-[11px] uppercase tracking-[0.25em] text-slate-400">
                 <tr>
@@ -510,7 +512,7 @@ const Dsniff = () => {
                 ))}
               </tbody>
             </table>
-          </div>
+          </AppPanel>
         </section>
 
         <section className="space-y-3" data-testid="triage-dashboard">
@@ -593,7 +595,7 @@ const Dsniff = () => {
               <SessionTile key={`tile-${i}`} session={pkt} onView={() => setSelectedPacket(i)} />
             ))}
           </div>
-          <div className="overflow-hidden rounded-2xl border border-slate-800/80 bg-slate-950/50 shadow-sm">
+          <AppPanel className="overflow-hidden rounded-2xl border-slate-800/80 bg-slate-950/50 shadow-sm">
             <table className="w-full text-left text-xs md:text-sm">
               <thead className="bg-slate-900/60 text-[11px] uppercase tracking-[0.25em] text-slate-400">
                 <tr>
@@ -633,7 +635,7 @@ const Dsniff = () => {
                 ))}
               </tbody>
             </table>
-          </div>
+          </AppPanel>
           <div className="flex flex-wrap items-center justify-between gap-3">
             <button
               onClick={copySelectedPacket}
@@ -686,7 +688,7 @@ const Dsniff = () => {
               </button>
             </div>
           </div>
-          <div className="overflow-hidden rounded-2xl border border-slate-800/80 bg-slate-950/50 shadow-sm">
+          <AppPanel className="overflow-hidden rounded-2xl border-slate-800/80 bg-slate-950/50 shadow-sm">
             <table className="w-full text-left text-xs md:text-sm">
               <thead className="bg-slate-900/60 text-[11px] uppercase tracking-[0.25em] text-slate-400">
                 <tr>
@@ -732,7 +734,7 @@ const Dsniff = () => {
                 No domains match the current risk filter.
               </div>
             )}
-          </div>
+          </AppPanel>
         </section>
 
         <section className="space-y-3" data-testid="capture-timeline">
@@ -902,7 +904,7 @@ const Dsniff = () => {
           )}
         </div>
       </div>
-    </div>
+    </AppPanel>
   );
 };
 

--- a/components/apps/openvas/task-overview.js
+++ b/components/apps/openvas/task-overview.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import FeedStatusCard from './feed-status-card';
 import TaskRunChart from './task-run-chart';
+import { AppPanel, AppToolbar, StatusChip } from '../shared';
 
 const TaskOverview = () => {
   const tasks = [
@@ -12,10 +13,12 @@ const TaskOverview = () => {
   return (
     <div className="mb-4">
       <FeedStatusCard />
-      <div className="rounded-xl border border-white/10 bg-kali-surface-muted/80 p-4 text-white shadow-kali-panel backdrop-blur">
-        <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-kali-control">
-          Demo Task Overview
-        </h3>
+      <AppPanel className="border-white/10 bg-kali-surface-muted/80 p-4 text-white shadow-kali-panel backdrop-blur">
+        <AppToolbar className="mb-2 rounded-lg border-white/10 bg-kali-surface-raised/60 px-3 py-2">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-kali-control">
+            Demo Task Overview
+          </h3>
+        </AppToolbar>
         <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-kali-muted">
           Run History
         </h4>
@@ -24,16 +27,16 @@ const TaskOverview = () => {
           {tasks.map((t) => (
             <li key={t.name} className="flex items-center justify-between">
               <span>{t.name}</span>
-              <span className="rounded-full bg-kali-surface-raised/70 px-2 py-0.5 text-xs font-medium text-white/70">
+              <StatusChip className="border-white/15 bg-kali-surface-raised/70 text-white/70">
                 {t.status}
-              </span>
+              </StatusChip>
             </li>
           ))}
         </ul>
         <p className="mt-2 text-xs text-white/60">
           All task data is canned for demonstration purposes.
         </p>
-      </div>
+      </AppPanel>
     </div>
   );
 };

--- a/components/apps/shared/AppPanel.js
+++ b/components/apps/shared/AppPanel.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+/**
+ * Shared app chrome note:
+ * - Use AppPanel/AppToolbar/StatusChip for visual wrappers only.
+ * - Keep each app's behavior and layout logic unchanged; pass className for app-specific spacing.
+ * - Prefer existing Kali CSS variables to preserve global theming across apps.
+ */
+const panelToneClasses = {
+  default:
+    'border border-[color:var(--kali-border)] bg-[color:var(--kali-panel)] text-[color:var(--kali-terminal-text)]',
+  muted:
+    'border border-[color:var(--kali-border)] bg-[color:color-mix(in_srgb,var(--kali-panel)_92%,rgba(4,24,36,0.32))] text-[color:var(--kali-terminal-text)]',
+  subtle:
+    'border border-[color:var(--kali-border)] bg-[color:color-mix(in_srgb,var(--kali-panel)_96%,rgba(4,12,20,0.35))] text-[color:var(--kali-terminal-text)]',
+  terminal:
+    'border border-[color:var(--kali-border)] bg-[color:color-mix(in_srgb,var(--kali-panel)_88%,rgba(2,20,14,0.35))] text-[color:var(--kali-terminal-text)]',
+  warning:
+    'border border-amber-500/40 bg-amber-500/10 text-amber-100',
+};
+
+const AppPanel = ({
+  as: Component = 'div',
+  tone = 'default',
+  className = '',
+  children,
+  ...rest
+}) => {
+  const toneClass = panelToneClasses[tone] || panelToneClasses.default;
+
+  return (
+    <Component className={`rounded-xl ${toneClass} ${className}`.trim()} {...rest}>
+      {children}
+    </Component>
+  );
+};
+
+export default AppPanel;

--- a/components/apps/shared/AppToolbar.js
+++ b/components/apps/shared/AppToolbar.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const AppToolbar = ({
+  as: Component = 'div',
+  className = '',
+  children,
+  ...rest
+}) => {
+  return (
+    <Component
+      className={`flex flex-wrap items-center justify-between gap-3 border-b border-[color:var(--kali-border)] bg-[color:color-mix(in_srgb,var(--kali-panel)_88%,rgba(15,148,210,0.14))] px-4 py-3 ${className}`.trim()}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+};
+
+export default AppToolbar;

--- a/components/apps/shared/StatusChip.js
+++ b/components/apps/shared/StatusChip.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const statusStyles = {
+  neutral:
+    'border border-[color:var(--kali-border)] bg-[color:color-mix(in_srgb,var(--kali-panel)_88%,transparent)] text-[color:var(--kali-terminal-text)]',
+  info:
+    'border border-[color:color-mix(in_srgb,var(--kali-blue)_50%,transparent)] bg-[color:color-mix(in_srgb,var(--kali-panel)_86%,rgba(15,148,210,0.2))] text-[color:var(--kali-terminal-text)]',
+  success:
+    'border border-emerald-500/60 bg-emerald-900/50 text-emerald-100',
+  warning:
+    'border border-amber-500/40 bg-amber-500/10 text-amber-100',
+};
+
+const StatusChip = ({
+  as: Component = 'span',
+  tone = 'neutral',
+  className = '',
+  children,
+  ...rest
+}) => {
+  const toneClass = statusStyles[tone] || statusStyles.neutral;
+
+  return (
+    <Component
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${toneClass} ${className}`.trim()}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+};
+
+export default StatusChip;

--- a/components/apps/shared/index.js
+++ b/components/apps/shared/index.js
@@ -1,0 +1,3 @@
+export { default as AppPanel } from './AppPanel';
+export { default as AppToolbar } from './AppToolbar';
+export { default as StatusChip } from './StatusChip';

--- a/components/apps/volatility/index.js
+++ b/components/apps/volatility/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import MemoryHeatmap from './MemoryHeatmap';
 import PluginBrowser from './PluginBrowser';
 import PluginWalkthrough from '../../../apps/volatility/components/PluginWalkthrough';
+import { AppPanel, AppToolbar } from '../shared';
 import memoryFixture from '../../../public/demo-data/volatility/memory.json';
 import pslistJson from '../../../public/demo-data/volatility/pslist.json';
 import netscanJson from '../../../public/demo-data/volatility/netscan.json';
@@ -219,8 +220,8 @@ const VolatilityApp = () => {
   ];
 
   return (
-    <div className="flex h-full w-full flex-col gap-4 rounded-2xl border border-[color:var(--kali-border)] bg-[color:color-mix(in_srgb,var(--kali-panel)_96%,rgba(4,12,20,0.35))] text-white shadow-xl shadow-black/40">
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[color:var(--kali-border)] bg-[color:color-mix(in_srgb,var(--kali-panel)_92%,rgba(4,24,36,0.35))] px-4 py-3">
+    <AppPanel className="flex h-full w-full flex-col gap-4 rounded-2xl text-white shadow-xl shadow-black/40" tone="subtle">
+      <AppToolbar className="bg-[color:color-mix(in_srgb,var(--kali-panel)_92%,rgba(4,24,36,0.35))]">
         <div>
           <h1 className="text-lg font-semibold uppercase tracking-wide text-gray-100">
             Volatility analyzer
@@ -246,13 +247,13 @@ const VolatilityApp = () => {
             </>
           )}
         </button>
-      </div>
+      </AppToolbar>
       <div className="px-4 pt-2">
         <MemoryHeatmap data={heatmapData} />
       </div>
       <div className="flex flex-1 flex-col gap-4 px-4 pb-4 text-[color:var(--kali-terminal-text)]">
         <div className="flex flex-col gap-4 lg:flex-row">
-          <div className="flex-1 overflow-hidden rounded-xl border border-[color:var(--kali-border)] bg-[color:var(--kali-panel)] shadow-[0_20px_40px_rgba(5,12,20,0.45)]">
+          <AppPanel className="flex-1 overflow-hidden shadow-[0_20px_40px_rgba(5,12,20,0.45)]">
             <div className="flex flex-wrap items-center gap-2 border-b border-[color:var(--kali-border)] bg-[color:color-mix(in_srgb,var(--kali-panel)_88%,rgba(15,148,210,0.16))] px-3 py-2 text-[11px] uppercase tracking-wide text-[color:color-mix(in_srgb,var(--kali-terminal-text)_70%,rgba(148,210,255,0.28))]">
               {tabs.map((tab) => (
                 <button
@@ -380,9 +381,9 @@ const VolatilityApp = () => {
               {activeTab === 'plugins' && <PluginBrowser />}
               {activeTab === 'walkthrough' && <PluginWalkthrough />}
             </div>
-          </div>
+          </AppPanel>
           {finding && (
-            <aside className="w-full rounded-xl border border-[color:var(--kali-border)] bg-[color:var(--kali-panel)] p-4 text-xs shadow-inner lg:w-72">
+            <AppPanel as="aside" className="w-full p-4 text-xs shadow-inner lg:w-72">
               <h3 className="text-sm font-semibold text-white">Explain this finding</h3>
               <p className="mt-2 text-[11px] text-gray-300">{finding.description}</p>
               <a
@@ -400,12 +401,12 @@ const VolatilityApp = () => {
                 <span aria-hidden="true">✕</span>
                 Close
               </button>
-            </aside>
+            </AppPanel>
           )}
         </div>
       </div>
       {output && (
-        <div className="mx-4 mb-4 overflow-auto rounded-xl border border-[color:var(--kali-border)] bg-[color:color-mix(in_srgb,var(--kali-panel)_88%,rgba(2,20,14,0.35))] text-xs font-mono text-[color:var(--kali-terminal-text)] shadow-inner shadow-[0_0_18px_color-mix(in_srgb,var(--kali-terminal-green)_20%,transparent)]">
+        <AppPanel className="mx-4 mb-4 overflow-auto text-xs font-mono shadow-inner shadow-[0_0_18px_color-mix(in_srgb,var(--kali-terminal-green)_20%,transparent)]" tone="terminal">
           {output.split('\n').map((line, i) => (
             <div
               key={i}
@@ -418,9 +419,9 @@ const VolatilityApp = () => {
               {line || '\u00A0'}
             </div>
           ))}
-        </div>
+        </AppPanel>
       )}
-    </div>
+    </AppPanel>
   );
 };
 


### PR DESCRIPTION
### Motivation

- Introduce a small set of shared presentational primitives to unify panel/toolbar/status visuals across security-themed apps while preserving each app's existing behavior and layout logic. 
- Reuse the repo's existing Kali CSS variables (for example `--kali-panel`, `--kali-border`, etc.) so theming remains consistent without visual regressions. 
- Apply the change incrementally to a narrow slice of high‑usage apps to reduce risk and provide a pattern for future migrations.

### Description

- Added a new shared module `components/apps/shared/` that exports `AppPanel`, `AppToolbar`, and `StatusChip` with documented usage guidance in the file header to keep them visual-only. 
- Replaced local panel/toolbar/chip markup in `components/apps/volatility/index.js`, `components/apps/dsniff/index.js`, and `components/apps/openvas/task-overview.js` with the shared wrappers while preserving existing classNames and behavior (no logic or state changes). 
- Implemented tone variants on `AppPanel` (`default`, `muted`, `subtle`, `terminal`, `warning`) and status tones on `StatusChip` and kept Tailwind/CSS-variable-driven styles so existing themes are preserved. 
- Added barrel exports in `components/apps/shared/index.js` to simplify imports for future uses.

### Testing

- Ran linting with `yarn lint` and resolved initial JSX parse issue during the migration; result: lint passed. 
- Ran the full test suite with `yarn test --watch=false` and all suites completed successfully (tests passed; there are unrelated console warnings from test environment utilities that pre-existed). 
- No feature flags were toggled for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e380b17bcc83289bfa7d25ca0273c9)