### PR TITLE
[apps] improve horizontal scroll discoverability in security app tables

### DIFF
--- a/components/apps/dsniff/index.js
+++ b/components/apps/dsniff/index.js
@@ -3,6 +3,7 @@ import urlsnarfFixture from '../../../public/demo-data/dsniff/urlsnarf.json';
 import arpspoofFixture from '../../../public/demo-data/dsniff/arpspoof.json';
 import pcapFixture from '../../../public/demo-data/dsniff/pcap.json';
 import TerminalOutput from '../../TerminalOutput';
+import HorizontalScrollAffordance from '../shared/HorizontalScrollAffordance';
 
 // Simple parser that attempts to extract protocol, host and remaining details
 // Each parsed line is also given a synthetic timestamp for display purposes
@@ -481,7 +482,11 @@ const Dsniff = () => {
             Suite tools
           </h2>
           <div className="overflow-hidden rounded-2xl border border-slate-800/80 bg-slate-950/50 shadow-sm">
-            <table className="w-full table-fixed text-left text-xs md:text-sm">
+            <HorizontalScrollAffordance
+              className="overflow-x-auto"
+              regionLabel="Dsniff suite tools table"
+            >
+              <table className="w-full min-w-[42rem] table-fixed text-left text-xs md:text-sm">
               <thead className="bg-slate-900/60 text-[11px] uppercase tracking-[0.25em] text-slate-400">
                 <tr>
                   <th className="px-4 py-3">Tool</th>
@@ -509,7 +514,8 @@ const Dsniff = () => {
                   </tr>
                 ))}
               </tbody>
-            </table>
+              </table>
+            </HorizontalScrollAffordance>
           </div>
         </section>
 
@@ -594,7 +600,11 @@ const Dsniff = () => {
             ))}
           </div>
           <div className="overflow-hidden rounded-2xl border border-slate-800/80 bg-slate-950/50 shadow-sm">
-            <table className="w-full text-left text-xs md:text-sm">
+            <HorizontalScrollAffordance
+              className="overflow-x-auto"
+              regionLabel="PCAP credential leakage table"
+            >
+              <table className="w-full min-w-[42rem] text-left text-xs md:text-sm">
               <thead className="bg-slate-900/60 text-[11px] uppercase tracking-[0.25em] text-slate-400">
                 <tr>
                   <th className="px-4 py-3">Src</th>
@@ -632,7 +642,8 @@ const Dsniff = () => {
                   </tr>
                 ))}
               </tbody>
-            </table>
+              </table>
+            </HorizontalScrollAffordance>
           </div>
           <div className="flex flex-wrap items-center justify-between gap-3">
             <button
@@ -687,7 +698,11 @@ const Dsniff = () => {
             </div>
           </div>
           <div className="overflow-hidden rounded-2xl border border-slate-800/80 bg-slate-950/50 shadow-sm">
-            <table className="w-full text-left text-xs md:text-sm">
+            <HorizontalScrollAffordance
+              className="overflow-x-auto"
+              regionLabel="Parsed credentials by domain table"
+            >
+              <table className="w-full min-w-[44rem] text-left text-xs md:text-sm">
               <thead className="bg-slate-900/60 text-[11px] uppercase tracking-[0.25em] text-slate-400">
                 <tr>
                   <th className="px-4 py-3">Domain</th>
@@ -726,7 +741,8 @@ const Dsniff = () => {
                   </tr>
                 ))}
               </tbody>
-            </table>
+              </table>
+            </HorizontalScrollAffordance>
             {!filteredDomainSummary.length && (
               <div className="border-t border-slate-800/80 px-4 py-6 text-center text-xs text-slate-400">
                 No domains match the current risk filter.
@@ -871,12 +887,16 @@ const Dsniff = () => {
         </div>
 
         <div
-          className="h-56 overflow-auto rounded-2xl border border-slate-800/80 bg-black/70 text-emerald-300 shadow-inner"
+          className="rounded-2xl border border-slate-800/80 bg-black/70 text-emerald-300 shadow-inner"
           aria-live="polite"
           role="log"
         >
           {filteredLogs.length ? (
-            <table className="w-full text-left text-sm">
+            <HorizontalScrollAffordance
+              className="h-56 overflow-auto"
+              regionLabel="Captured traffic log table"
+            >
+              <table className="w-full min-w-[44rem] text-left text-sm">
               <thead className="sticky top-0 bg-black/80 text-[11px] uppercase tracking-[0.25em] text-slate-500">
                 <tr>
                   <th className="px-3 py-2">Time</th>
@@ -894,9 +914,10 @@ const Dsniff = () => {
                   />
                 ))}
               </tbody>
-            </table>
+              </table>
+            </HorizontalScrollAffordance>
           ) : (
-            <div className="flex h-full items-center justify-center text-sm text-slate-400">
+            <div className="flex h-56 items-center justify-center text-sm text-slate-400">
               No data
             </div>
           )}

--- a/components/apps/openvas/index.js
+++ b/components/apps/openvas/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import TaskOverview from './task-overview';
 import PolicySettings from './policy-settings';
+import HorizontalScrollAffordance from '../shared/HorizontalScrollAffordance';
 import pciProfile from './templates/pci.json';
 import hipaaProfile from './templates/hipaa.json';
 import demoReport from './fixtures/demo-report.json';
@@ -740,17 +741,22 @@ const OpenVASApp = () => {
         {announce}
       </div>
       {output && (
-        <div className="overflow-auto rounded-lg border border-white/10 bg-kali-surface-muted text-xs font-mono text-white">
-          {output.split('\n').map((line, i) => (
-            <div
-              key={i}
-              className={`px-2 py-1 ${
-                i % 2 ? 'bg-kali-surface' : 'bg-kali-surface-muted/80'
-              }`}
-            >
-              {line || '\u00A0'}
-            </div>
-          ))}
+        <div className="rounded-lg border border-white/10 bg-kali-surface-muted text-xs font-mono text-white">
+          <HorizontalScrollAffordance
+            className="overflow-auto"
+            regionLabel="OpenVAS scan output table-style log"
+          >
+            {output.split('\n').map((line, i) => (
+              <div
+                key={i}
+                className={`px-2 py-1 ${
+                  i % 2 ? 'bg-kali-surface' : 'bg-kali-surface-muted/80'
+                }`}
+              >
+                {line || '\u00A0'}
+              </div>
+            ))}
+          </HorizontalScrollAffordance>
         </div>
       )}
       {summaryUrl && (

--- a/components/apps/shared/HorizontalScrollAffordance.js
+++ b/components/apps/shared/HorizontalScrollAffordance.js
@@ -1,0 +1,77 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+const EDGE_BASE =
+  'pointer-events-none absolute inset-y-0 z-10 w-5 transition-opacity duration-200';
+
+const HorizontalScrollAffordance = ({
+  children,
+  className = '',
+  regionLabel,
+  hint = 'Scroll horizontally for more',
+  showHint = true,
+}) => {
+  const scrollRef = useRef(null);
+  const [canScroll, setCanScroll] = useState(false);
+  const [showLeft, setShowLeft] = useState(false);
+  const [showRight, setShowRight] = useState(false);
+
+  const evaluateScroll = () => {
+    const node = scrollRef.current;
+    if (!node) return;
+    const hasOverflow = node.scrollWidth > node.clientWidth + 1;
+    const atStart = node.scrollLeft <= 1;
+    const atEnd = node.scrollLeft + node.clientWidth >= node.scrollWidth - 1;
+    setCanScroll(hasOverflow);
+    setShowLeft(hasOverflow && !atStart);
+    setShowRight(hasOverflow && !atEnd);
+  };
+
+  useEffect(() => {
+    evaluateScroll();
+    if (typeof window === 'undefined') return undefined;
+    window.addEventListener('resize', evaluateScroll);
+    return () => window.removeEventListener('resize', evaluateScroll);
+  }, []);
+
+  const ariaLabel = useMemo(() => {
+    if (!regionLabel) return undefined;
+    return canScroll ? `${regionLabel}. ${hint}.` : regionLabel;
+  }, [canScroll, hint, regionLabel]);
+
+  return (
+    <div className="relative">
+      <div
+        ref={scrollRef}
+        onScroll={evaluateScroll}
+        className={className}
+        aria-label={ariaLabel}
+      >
+        {children}
+      </div>
+
+      <div
+        aria-hidden="true"
+        className={`${EDGE_BASE} left-0 bg-gradient-to-r from-[color:color-mix(in_srgb,var(--kali-panel)_95%,#060b14)] to-transparent ${
+          showLeft ? 'opacity-100' : 'opacity-0'
+        }`}
+      />
+      <div
+        aria-hidden="true"
+        className={`${EDGE_BASE} right-0 bg-gradient-to-l from-[color:color-mix(in_srgb,var(--kali-panel)_95%,#060b14)] to-transparent ${
+          showRight ? 'opacity-100' : 'opacity-0'
+        }`}
+      />
+
+      {showHint && canScroll && !showLeft && showRight && (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-1 right-2 rounded-full border border-[color:color-mix(in_srgb,var(--kali-panel-border)_65%,transparent)] bg-[color:color-mix(in_srgb,var(--kali-panel)_90%,rgba(15,148,210,0.18))] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[color:color-mix(in_srgb,var(--kali-terminal-text)_70%,rgba(148,210,255,0.4))]"
+        >
+          Scroll →
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HorizontalScrollAffordance;

--- a/components/apps/volatility/index.js
+++ b/components/apps/volatility/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import MemoryHeatmap from './MemoryHeatmap';
 import PluginBrowser from './PluginBrowser';
 import PluginWalkthrough from '../../../apps/volatility/components/PluginWalkthrough';
+import HorizontalScrollAffordance from '../shared/HorizontalScrollAffordance';
 import memoryFixture from '../../../public/demo-data/volatility/memory.json';
 import pslistJson from '../../../public/demo-data/volatility/pslist.json';
 import netscanJson from '../../../public/demo-data/volatility/netscan.json';
@@ -109,7 +110,11 @@ const SortableTable = ({ columns, data, onRowClick, rowClassName }) => {
 
   return (
     <div className="overflow-hidden rounded-lg border border-[color:var(--kali-border)] bg-[color:var(--kali-panel)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-      <table className="min-w-full table-auto text-xs text-[color:var(--color-text)]">
+      <HorizontalScrollAffordance
+        className="overflow-x-auto"
+        regionLabel="Volatility plugin results table"
+      >
+        <table className="min-w-full table-auto text-xs text-[color:var(--color-text)]">
         <thead className="bg-[color:color-mix(in_srgb,var(--kali-panel)_88%,rgba(15,148,210,0.18))] text-[10px] uppercase tracking-wide text-[color:color-mix(in_srgb,var(--kali-terminal-text)_70%,rgba(148,210,255,0.32))]">
           <tr>
             {columns.map((col) => (
@@ -150,7 +155,8 @@ const SortableTable = ({ columns, data, onRowClick, rowClassName }) => {
             </tr>
           ))}
         </tbody>
-      </table>
+        </table>
+      </HorizontalScrollAffordance>
     </div>
   );
 };


### PR DESCRIPTION
### Motivation

- Improve discoverability of horizontally overflowing table content without changing existing table markup or data logic.  
- Provide a subtle, theme-consistent visual cue and accessible hint so users notice scrollable columns in security app views.  

### Description

- Added a reusable `HorizontalScrollAffordance` component that detects horizontal overflow and renders subtle Kali-themed left/right edge fades plus an optional inline "Scroll →" hint and contextual `aria-label` text (`components/apps/shared/HorizontalScrollAffordance.js`).  
- Wrapped Volatility sortable results table with the affordance while keeping the original table structure and sorting behavior unchanged (`components/apps/volatility/index.js`).  
- Applied the affordance to multiple Dsniff table regions (suite tools, PCAP summary, parsed domain summary, and captured log table) by wrapping the existing table containers and adding small `min-w-` adjustments so the visual hint appears only when needed (`components/apps/dsniff/index.js`).  
- Wrapped OpenVAS scan output (table-style log rows) in the affordance so long output lines surface horizontal scroll affordances and accessibility hints (`components/apps/openvas/index.js`).  

### Testing

- Ran linter with `yarn lint` and it completed with no reported errors.  
- Ran unit tests with `yarn test --watch=false` and all automated suites completed with no failures (test suites: 261 passed, 4 skipped; tests: 923 passed, 144 skipped, 0 failed).  
- No feature flags or network/behavior changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e380b184e483288458183a8d6fb26c)