### PR TITLE
[games] standardize GameLayout control/status spacing

### DIFF
--- a/components/apps/GameLayout.tsx
+++ b/components/apps/GameLayout.tsx
@@ -31,6 +31,7 @@ interface GameLayoutProps {
   pauseHotkeys?: string[];
   restartHotkeys?: string[];
   settingsPanel?: React.ReactNode;
+  statusPanel?: React.ReactNode;
   isFocused?: boolean;
 }
 
@@ -81,6 +82,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
   pauseHotkeys,
   restartHotkeys,
   settingsPanel,
+  statusPanel,
   isFocused = true,
 }) => {
   const [showHelp, setShowHelp] = useState(false);
@@ -290,6 +292,9 @@ const GameLayout: React.FC<GameLayoutProps> = ({
     return () => window.removeEventListener('keydown', handler);
   }, [pauseHotkeys, restartHotkeys, handleRestart, isFocused]);
 
+  const actionButtonClass =
+    'min-h-8 rounded bg-gray-700 px-3 py-1 text-xs font-medium text-white transition hover:bg-gray-600 focus:outline-none focus:ring';
+
   return (
     <RecorderContext.Provider value={contextValue}>
       <div
@@ -314,11 +319,11 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           </button>
         </div>
       )}
-      <div className="absolute top-2 right-2 z-40 flex space-x-2">
+      <div className="absolute right-2 top-2 z-40 flex flex-wrap justify-end gap-2">
         <button
           type="button"
           onClick={() => setPaused((p) => !p)}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className={actionButtonClass}
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
@@ -326,7 +331,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           <button
             type="button"
             onClick={handleRestart}
-            className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className={actionButtonClass}
           >
             Restart
           </button>
@@ -334,21 +339,21 @@ const GameLayout: React.FC<GameLayoutProps> = ({
         <button
           type="button"
           onClick={snapshot}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className={actionButtonClass}
         >
           Snapshot
         </button>
         <button
           type="button"
           onClick={replay}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className={actionButtonClass}
         >
           Replay
         </button>
         <button
           type="button"
           onClick={shareApp}
-          className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+          className={actionButtonClass}
         >
           Share
         </button>
@@ -358,7 +363,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
             aria-label="Settings"
             aria-expanded={showSettings}
             onClick={() => setShowSettings((s) => !s)}
-            className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className={actionButtonClass}
           >
             Settings
           </button>
@@ -367,7 +372,7 @@ const GameLayout: React.FC<GameLayoutProps> = ({
           <button
             type="button"
             onClick={shareScore}
-            className="px-2 py-1 bg-gray-700 text-white rounded focus:outline-none focus:ring"
+            className={actionButtonClass}
           >
             Share Score
           </button>
@@ -389,40 +394,47 @@ const GameLayout: React.FC<GameLayoutProps> = ({
         </div>
       )}
       <div
-        className="absolute top-2 left-2 z-10 text-sm flex flex-col gap-1"
+        className="absolute left-2 top-2 z-10 flex flex-col gap-2 text-sm"
         role="status"
         aria-live="polite"
       >
-        {stage !== undefined && (
-          <div className="rounded px-2 py-1 bg-slate-900/60 border border-slate-700/70 backdrop-blur">
-            Stage: {stage}
-          </div>
-        )}
-        {lives !== undefined && (
-          <div className="rounded px-2 py-1 bg-slate-900/60 border border-slate-700/70 backdrop-blur">
-            Lives: {lives}
-          </div>
-        )}
-        {score !== undefined && (
-          <div
-            className={clsx(
-              'rounded px-2 py-1 bg-slate-900/70 border border-emerald-500/20 backdrop-blur shadow-sm transition-transform duration-300 ease-out',
-              !prefersReducedMotion && scorePulse &&
-                'scale-110 text-emerald-300 shadow-[0_0_18px_rgba(16,185,129,0.45)]',
-            )}
-          >
-            Score: {score}
-          </div>
-        )}
-        {highScore !== undefined && (
-          <div
-            className={clsx(
-              'rounded px-2 py-1 bg-slate-900/70 border border-indigo-400/20 backdrop-blur shadow-sm transition-transform duration-300 ease-out',
-              !prefersReducedMotion && highScorePulse &&
-                'scale-105 text-indigo-300 shadow-[0_0_16px_rgba(129,140,248,0.35)]',
-            )}
-          >
-            {highScoreLabel}: {highScore}
+        <div className="flex flex-col gap-1.5">
+          {stage !== undefined && (
+            <div className="rounded border border-slate-700/70 bg-slate-900/60 px-2 py-1 backdrop-blur">
+              Stage: {stage}
+            </div>
+          )}
+          {lives !== undefined && (
+            <div className="rounded border border-slate-700/70 bg-slate-900/60 px-2 py-1 backdrop-blur">
+              Lives: {lives}
+            </div>
+          )}
+          {score !== undefined && (
+            <div
+              className={clsx(
+                'rounded border border-emerald-500/20 bg-slate-900/70 px-2 py-1 backdrop-blur shadow-sm transition-transform duration-300 ease-out',
+                !prefersReducedMotion && scorePulse &&
+                  'scale-110 text-emerald-300 shadow-[0_0_18px_rgba(16,185,129,0.45)]',
+              )}
+            >
+              Score: {score}
+            </div>
+          )}
+          {highScore !== undefined && (
+            <div
+              className={clsx(
+                'rounded border border-indigo-400/20 bg-slate-900/70 px-2 py-1 backdrop-blur shadow-sm transition-transform duration-300 ease-out',
+                !prefersReducedMotion && highScorePulse &&
+                  'scale-105 text-indigo-300 shadow-[0_0_16px_rgba(129,140,248,0.35)]',
+              )}
+            >
+              {highScoreLabel}: {highScore}
+            </div>
+          )}
+        </div>
+        {statusPanel && (
+          <div className="rounded border border-slate-700/70 bg-slate-900/60 p-2 backdrop-blur">
+            {statusPanel}
           </div>
         )}
       </div>

--- a/components/apps/pacman.tsx
+++ b/components/apps/pacman.tsx
@@ -846,6 +846,42 @@ const Pacman: React.FC<{ windowMeta?: { isFocused?: boolean } }> = ({
     </div>
   );
 
+  const statusPanel = (
+    <div className="grid min-w-[13rem] grid-cols-1 gap-1 text-xs text-slate-200 sm:min-w-[16rem]">
+      <div className="rounded border border-slate-600/70 bg-slate-900/70 px-2 py-1">
+        Mode:{' '}
+        <span className="text-cyan-300">
+          {mode === 'fright' ? 'Frightened' : mode}
+        </span>
+      </div>
+      <div className="rounded border border-slate-600/70 bg-slate-900/70 px-2 py-1">
+        Dots: <span className="text-amber-200">{pellets}</span>
+      </div>
+      <div className="rounded border border-slate-600/70 bg-slate-900/70 px-2 py-1">
+        {powerMode ? (
+          <>
+            Power: <span className="text-fuchsia-300">{powerMode}</span>{' '}
+            <span className="text-slate-400">({Math.ceil(powerTimer)}s)</span>
+          </>
+        ) : (
+          <>
+            Power: <span className="text-slate-400">none</span>
+          </>
+        )}
+      </div>
+      {paused && (
+        <div className="rounded bg-slate-800/80 px-2 py-1 text-slate-300">
+          Paused - press Escape to resume
+        </div>
+      )}
+      {statusMessage && (
+        <div className="rounded bg-amber-500/80 px-2 py-1 text-center text-slate-900">
+          {statusMessage}
+        </div>
+      )}
+    </div>
+  );
+
   const renderStartScreen = () => (
     <div
       className="absolute inset-0 flex flex-col items-center justify-center bg-black/70 text-white gap-4"
@@ -933,6 +969,7 @@ const Pacman: React.FC<{ windowMeta?: { isFocused?: boolean } }> = ({
       pauseHotkeys={['Escape', 'p']}
       restartHotkeys={['r']}
       settingsPanel={settingsPanel}
+      statusPanel={statusPanel}
       isFocused={isFocused}
       editor={
         showEditor ? (
@@ -943,22 +980,6 @@ const Pacman: React.FC<{ windowMeta?: { isFocused?: boolean } }> = ({
       }
     >
       <div className="relative h-full w-full flex flex-col bg-ub-cool-grey text-white">
-        <div className="mx-4 mt-2 rounded-md border border-blue-500/40 bg-black/70 px-3 py-2 text-[11px] uppercase tracking-[0.18em] text-yellow-300">
-          <div className="grid grid-cols-3 items-center gap-2 text-center">
-            <div>
-              <div className="text-[10px] text-slate-300">1UP</div>
-              <div className="font-bold text-lg leading-none text-yellow-200">{score.toString().padStart(6, '0')}</div>
-            </div>
-            <div>
-              <div className="text-[10px] text-slate-300">HIGH SCORE</div>
-              <div className="font-bold text-lg leading-none text-red-300">{highScore.toString().padStart(6, '0')}</div>
-            </div>
-            <div>
-              <div className="text-[10px] text-slate-300">LEVEL</div>
-              <div className="font-bold text-lg leading-none text-sky-300">{(customLevel ? 1 : activeLevelIndex + 1).toString().padStart(2, '0')}</div>
-            </div>
-          </div>
-        </div>
         <div className="relative flex-1 w-full min-h-0 flex items-center justify-center">
           <canvas
             ref={canvasRef}
@@ -995,39 +1016,9 @@ const Pacman: React.FC<{ windowMeta?: { isFocused?: boolean } }> = ({
             </div>
           )}
         </div>
-        <div className="mt-3 mx-3 mb-2 grid grid-cols-2 gap-2 text-xs text-slate-200 sm:grid-cols-4">
-          <div className="rounded border border-slate-600/70 bg-slate-900/70 px-2 py-1">
-            Mode: <span className="text-cyan-300">{mode === 'fright' ? 'Frightened' : mode}</span>
-          </div>
-          <div className="rounded border border-slate-600/70 bg-slate-900/70 px-2 py-1">
-            Dots: <span className="text-amber-200">{pellets}</span>
-          </div>
-          <div className="rounded border border-slate-600/70 bg-slate-900/70 px-2 py-1">
-            Lives: <span className="text-yellow-300">{'● '.repeat(Math.max(0, lives)).trim() || '0'}</span>
-          </div>
-          <div className="rounded border border-slate-600/70 bg-slate-900/70 px-2 py-1">
-            {powerMode ? (
-              <>
-                Power: <span className="text-fuchsia-300">{powerMode}</span> <span className="text-slate-400">({Math.ceil(powerTimer)}s)</span>
-              </>
-            ) : (
-              <>Power: <span className="text-slate-400">none</span></>
-            )}
-          </div>
-          {statusMessage && (
-            <div className="col-span-full rounded bg-amber-500/80 px-2 py-1 text-center text-slate-900">
-              {statusMessage}
-            </div>
-          )}
-        </div>
         {isTouch && (
           <div className="mt-4">
             <VirtualPad onDirection={setBufferedDirection} />
-          </div>
-        )}
-        {paused && (
-          <div className="mt-3 text-xs text-slate-300">
-            Paused - press Escape to resume
           </div>
         )}
         <div className="sr-only" aria-live="polite">


### PR DESCRIPTION
### Motivation
- Reduce duplicated presentational header/status UI across game apps by centralizing layout and spacing in `GameLayout`.
- Normalize top-right action controls (Pause/Restart/Snapshot/Replay/Share/Settings) so sizing and spacing are consistent across games.
- Move non-logic, visual-only status chips (mode/dots/power/paused text) out of app components and into a shared slot to keep game logic untouched.

### Description
- Added a new `statusPanel?: React.ReactNode` prop to `GameLayout` and render slot for it next to the shared stage/lives/score stack. (components/apps/GameLayout.tsx)
- Introduced a shared `actionButtonClass` and adjusted the top-right controls wrapper to `flex-wrap`/`gap` for consistent action button sizing and spacing. (components/apps/GameLayout.tsx)
- Normalized left status stack spacing and styling inside `GameLayout` (score/high-score/stage/lives) and made it accept `statusPanel` content. (components/apps/GameLayout.tsx)
- Updated `pacman.tsx` to supply a `statusPanel` containing the previous local presentational chips (mode, dots, power timer, paused/status text) and removed the duplicated header/status markup from the component. (components/apps/pacman.tsx)

### Testing
- Ran linting with `yarn lint` and it completed successfully.
- Ran the test suite with `yarn test --watch=false`, which completed successfully with test suites: 265 total (261 passed, 4 skipped) and tests: 1067 total (923 passed, 144 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e380b1d48c83288d94a3c588e9ce37)