### PR TITLE
[tests] add narrow-layout coverage for project gallery

### DIFF
--- a/__tests__/apps/project-gallery/index.test.tsx
+++ b/__tests__/apps/project-gallery/index.test.tsx
@@ -11,6 +11,7 @@ const useRouterMock = useRouter as unknown as jest.Mock;
 
 describe('ProjectGalleryPage', () => {
   const originalFetch = global.fetch;
+  const originalMatchMedia = window.matchMedia;
 
   const projects = [
     {
@@ -49,6 +50,19 @@ describe('ProjectGalleryPage', () => {
   ];
 
   beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 1280 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: 800 });
+    window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+      matches: query.includes('min-width') ? window.innerWidth >= 640 : false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+
     useRouterMock.mockReturnValue({
       pathname: '/apps/project-gallery',
       query: {},
@@ -64,11 +78,11 @@ describe('ProjectGalleryPage', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    window.matchMedia = originalMatchMedia;
     if (originalFetch) {
       global.fetch = originalFetch;
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      delete (global as any).fetch;
+      delete (globalThis as { fetch?: typeof fetch }).fetch;
     }
   });
 
@@ -102,5 +116,35 @@ describe('ProjectGalleryPage', () => {
     expect(
       screen.getByText(/Use the filter chips above to add or remove stacks, tags, or years/i),
     ).toBeInTheDocument();
+  });
+
+  it('keeps narrow-window toolbar and helper copy on compact readable classes', async () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 420 });
+
+    render(<ProjectGalleryPage />);
+
+    const activeFiltersLabel = await screen.findByText('Active filters');
+    const toolbarRow = activeFiltersLabel.closest('div');
+    expect(toolbarRow).toHaveClass('flex-wrap');
+
+    const emptyHelper = screen.getByText(/No filters selected\. Use the chips below/i);
+    expect(emptyHelper).toHaveClass('text-sm');
+    expect(emptyHelper).toHaveClass('text-white/70');
+  });
+
+  it('renders card overflow containers for narrow layouts', async () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 390 });
+
+    render(<ProjectGalleryPage />);
+
+    const title = await screen.findByRole('heading', { name: 'Terminal Dashboard' });
+    const cardBody = title.closest('div[class*="overflow-hidden"]');
+    expect(cardBody).toBeInTheDocument();
+    expect(cardBody).toHaveClass('overflow-hidden');
+
+    const thumbnail = screen.getByAltText('Terminal Dashboard');
+    const imageFrame = thumbnail.closest('div');
+    expect(imageFrame).toHaveClass('overflow-hidden');
+    expect(imageFrame).toHaveClass('rounded-lg');
   });
 });


### PR DESCRIPTION
### Motivation

- Add deterministic, fast component tests that assert layout behavior in narrow viewport contexts (toolbar wrapping, readable compact classes, and overflow containers).
- Prefer structural assertions over pixel snapshots to keep tests stable across environments.
- Reuse existing test patterns for viewport/matchMedia stubbing and component-level coverage to improve confidence in responsive behavior.

### Description

- Extended `__tests__/apps/project-gallery/index.test.tsx` with viewport stubbing (`window.innerWidth`/`innerHeight`) and a `matchMedia` mock to make narrow/compact layout assertions deterministic. 
- Added tests that assert the active-filters toolbar row uses `flex-wrap`, that helper copy retains `text-sm` and `text-white/70` classes in narrow mode, and that project cards/thumbnails render `overflow-hidden` containers for constrained widths. 
- Replaced a loose `any` teardown with a typed deletion `delete (globalThis as { fetch?: typeof fetch }).fetch` to satisfy lint rules. 
- Committed under the message: `[tests] add narrow-layout coverage for project gallery`.

### Testing

- Ran `yarn test __tests__/apps/project-gallery/index.test.tsx` and the suite passed (4 tests, 0 failures). Note: tests emitted a worker exit warning about open handles but completed successfully. 
- Ran `yarn lint` after the teardown typing fix and it passed with no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e380b3026c8328aaf6a256eef43450)