### PR TITLE
[ubuntu] switch unlock listener cleanup to keydown

### DIFF
--- a/__tests__/ubuntu.unlock.test.tsx
+++ b/__tests__/ubuntu.unlock.test.tsx
@@ -1,0 +1,36 @@
+import React, { act } from 'react';
+import { render } from '@testing-library/react';
+import Ubuntu from '../components/ubuntu';
+
+jest.mock('../components/screen/desktop', () => function DesktopMock() {
+  return <div data-testid="desktop" />;
+});
+
+jest.mock('../components/screen/navbar', () => function NavbarMock() {
+  return <div data-testid="navbar" />;
+});
+
+describe('Ubuntu unlock behavior', () => {
+  it('unlocks the screen when Enter is pressed', () => {
+    let instance: Ubuntu | null = null;
+    render(<Ubuntu ref={(component) => (instance = component)} />);
+
+    expect(instance).not.toBeNull();
+
+    act(() => {
+      instance!.setState({
+        screen_locked: true,
+        booting_screen: false,
+        desktopMounted: true,
+      });
+    });
+
+    expect(instance!.state.screen_locked).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+
+    expect(instance!.state.screen_locked).toBe(false);
+  });
+});

--- a/components/ubuntu.js
+++ b/components/ubuntu.js
@@ -191,7 +191,7 @@ export default class Ubuntu extends Component {
                 logPageView('/desktop', 'Custom Title');
 
                 window.removeEventListener('click', this.unLockScreen);
-                window.removeEventListener('keypress', this.unLockScreen);
+                window.removeEventListener('keydown', this.unLockScreen);
 
                 this.setState({ screen_locked: false });
                 safeLocalStorage?.setItem('screen-locked', false);


### PR DESCRIPTION
### Motivation
- Align the `Ubuntu` component's unlock cleanup with the lock screen's keyboard handling by using the same `keydown` event, preserving the existing unlock flow and avoiding a stale `keypress` listener.

### Description
- Replace `window.removeEventListener('keypress', this.unLockScreen)` with `window.removeEventListener('keydown', this.unLockScreen)` in `components/ubuntu.js` so cleanup matches the `LockScreen` implementation.
- Add a focused unit test `__tests__/ubuntu.unlock.test.tsx` that mounts `Ubuntu`, sets `screen_locked` to `true`, dispatches a `KeyboardEvent('keydown', { key: 'Enter' })`, and asserts the screen is unlocked.

### Testing
- Ran `yarn test __tests__/ubuntu.test.tsx __tests__/ubuntu.unlock.test.tsx` and both test files passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40fdc99c08328bbcae50129e24274)