### PR TITLE
[context-menu] replace index-based keys with deterministic item IDs

### DIFF
--- a/components/common/ContextMenu.tsx
+++ b/components/common/ContextMenu.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 import useFocusTrap from '../../hooks/useFocusTrap';
 import useRovingTabIndex from '../../hooks/useRovingTabIndex';
 
 export interface MenuItem {
+  id?: string;
   label: React.ReactNode;
   onSelect: () => void;
 }
@@ -68,6 +69,35 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
     }
   }, [open]);
 
+  const keyedItems = useMemo(() => {
+    const labelCounts = new Map<string, number>();
+
+    return items.map((item) => {
+      if (item.id) {
+        return { ...item, key: item.id };
+      }
+
+      const derivedLabel =
+        typeof item.label === 'string' || typeof item.label === 'number'
+          ? String(item.label)
+          : 'menu-item';
+
+      const normalizedLabel = derivedLabel
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, '-')
+        .replace(/[^a-z0-9-]/g, '') || 'menu-item';
+
+      const count = (labelCounts.get(normalizedLabel) ?? 0) + 1;
+      labelCounts.set(normalizedLabel, count);
+
+      return {
+        ...item,
+        key: count === 1 ? normalizedLabel : `${normalizedLabel}-${count}`,
+      };
+    });
+  }, [items]);
+
   useEffect(() => {
     if (!open) return;
 
@@ -101,9 +131,9 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
       className={(open ? 'block ' : 'hidden ') +
         'cursor-default w-52 context-menu-bg border text-left border-gray-900 rounded text-white py-4 absolute z-50 text-sm'}
     >
-      {items.map((item, i) => (
+      {keyedItems.map((item) => (
         <button
-          key={i}
+          key={item.key}
           role="menuitem"
           tabIndex={-1}
           onClick={() => {
@@ -120,4 +150,3 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ targetRef, items }) => {
 };
 
 export default ContextMenu;
-


### PR DESCRIPTION
### Motivation

- Avoid non-deterministic React keys coming from array indices which can cause unstable renders and make updates brittle when menu item arrays change.
- Allow call sites to provide stable identifiers so context menus render consistently across re-renders and preserve focus/DOM identity for accessibility.

### Description

- Extended `MenuItem` in `components/common/ContextMenu.tsx` with an optional `id?: string` so callers can provide deterministic IDs.
- Added a memoized `keyedItems` list that prefers `item.id` and otherwise derives a normalized key from `item.label` with duplicate-safe suffixing, and replaced `key={i}` with `key={item.key}` in the rendered menu buttons.
- Kept existing focus/keyboard integration intact by preserving the `useRovingTabIndex(...)` and `useFocusTrap(...)` usage and not changing DOM structure or tab-index behavior.
- Scanned the repo for `ContextMenu` usage and did not find other in-repo call sites that needed updating, so no call-site changes were required.

### Testing

- Ran `yarn lint` and it completed successfully on the changed files.
- Ran `yarn test -- aboutAccessibility.test.tsx` and the accessibility roving-tab test passed.
- Performed a code search (`rg`) for `ContextMenu`/`MenuItem` usages to confirm call sites; no additional menu arrays needed changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40fdde9b08328944b8e44a537c295)