### PR TITLE
[ui] move CommandPalette modifier hint detection to component runtime

### DIFF
--- a/components/ui/CommandPalette.tsx
+++ b/components/ui/CommandPalette.tsx
@@ -40,8 +40,6 @@ const isMacLike = (): boolean => {
   return /Mac|iPhone|iPad|iPod/i.test(platform || userAgent);
 };
 
-const modifierHint = isMacLike() ? '⌘' : 'Ctrl';
-
 const normalizeIconPath = (icon?: string): string | undefined => {
   if (!icon || typeof icon !== 'string') return undefined;
   if (/^(https?:|data:)/i.test(icon)) return icon;
@@ -72,6 +70,7 @@ export default function CommandPalette({
   onSelect,
   onClose,
 }: CommandPaletteProps) {
+  const modifierHint = useMemo(() => (isMacLike() ? '⌘' : 'Ctrl'), []);
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
   const searchInputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
### Motivation
- Avoid module-time access to `navigator` and ensure platform modifier detection happens on the client at component runtime while preserving the existing shortcut hint UI.

### Description
- Compute `modifierHint` inside `components/ui/CommandPalette.tsx` using `useMemo(() => isMacLike() ? '⌘' : 'Ctrl', [])` and remove the top-level `modifierHint` constant while keeping the existing `isMacLike` helper and unchanged rendering of the hint.

### Testing
- Ran `yarn lint` which completed successfully; commands executed: `yarn lint`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40fdfdb808328a842d6b00acee9da)