### PR TITLE
[desktop] broaden window re-clamp event coverage

### DIFF
--- a/components/desktop/Window.tsx
+++ b/components/desktop/Window.tsx
@@ -175,6 +175,7 @@ const DesktopWindow = React.memo(
       useEffect(() => {
         if (typeof window === "undefined") return undefined;
         let rafId: number | null = null;
+        const visualViewport = window.visualViewport;
 
         const performClamp = () => {
           rafId = null;
@@ -187,8 +188,12 @@ const DesktopWindow = React.memo(
         };
 
         window.addEventListener("resize", handler);
+        visualViewport?.addEventListener("resize", handler);
+        visualViewport?.addEventListener("scroll", handler);
         return () => {
           window.removeEventListener("resize", handler);
+          visualViewport?.removeEventListener("resize", handler);
+          visualViewport?.removeEventListener("scroll", handler);
           if (rafId) window.cancelAnimationFrame(rafId);
         };
       }, [clampToViewport]);


### PR DESCRIPTION
### Motivation

- Ensure window positions are re-clamped when the visual viewport changes (for example on mobile pinch-zoom or visual viewport scrolling) in addition to the existing `window.resize` updates.
- Prevent event listener leaks by cleaning up all added listeners and keeping reflow scheduling centralized.

### Description

- Updated the `useEffect` in `components/desktop/Window.tsx` to capture `window.visualViewport` and attach `resize` and `scroll` listeners when available.
- Reused the existing RAF-throttled `handler`/`performClamp` flow so all viewport-triggered clamps go through a single scheduling path.
- Removed listeners for both `window` and `visualViewport` on unmount and preserved canceling any pending animation frame to avoid leaks.

### Testing

- Ran `yarn lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40fe0a5e083289ba8daa93ceab474)