### PR TITLE
[pinball] polish table lighting and playfield art

### DIFF
--- a/apps/pinball/index.tsx
+++ b/apps/pinball/index.tsx
@@ -500,24 +500,25 @@ export default function Pinball({ windowMeta }: PinballProps) {
           </span>
         </div>
       </div>
-      <div className="relative">
+      <div className="relative rounded-2xl border border-slate-700/70 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.14),rgba(15,23,42,0.86)_45%,rgba(2,6,23,0.96)_100%)] p-3 shadow-[0_20px_50px_rgba(2,6,23,0.55)]">
+        <div className="pointer-events-none absolute inset-x-8 top-2 h-8 rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.24),transparent_75%)] opacity-70" />
         <canvas
           ref={canvasRef}
           width={constants.WIDTH}
           height={constants.HEIGHT}
           aria-label="Pinball playfield"
-          className="border"
+          className="rounded-md border border-slate-500/55 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.25),0_0_22px_rgba(14,165,233,0.22)]"
         />
-        <div className="absolute top-3 left-3 rounded bg-[var(--kali-overlay)] px-2 py-1 font-mono text-xs text-[var(--kali-text)]">
+        <div className="absolute top-6 left-6 rounded border border-slate-400/35 bg-[color-mix(in_srgb,var(--kali-overlay)_85%,rgba(2,6,23,0.75))] px-2 py-1 font-mono text-xs text-[var(--kali-text)] shadow">
           Balls: {ballsRemaining}
         </div>
-        <div className="absolute top-3 left-1/2 -translate-x-1/2 font-mono text-2xl text-[var(--kali-text)]">
+        <div className="absolute top-6 left-1/2 -translate-x-1/2 rounded bg-[color-mix(in_srgb,var(--kali-overlay)_64%,transparent)] px-3 py-1 font-mono text-2xl text-[var(--kali-text)] shadow">
           {formatScore(score)}
         </div>
-        <div className="absolute top-12 left-1/2 -translate-x-1/2 font-mono text-xs tracking-widest text-[color-mix(in_srgb,var(--kali-text)_85%,transparent)]">
+        <div className="absolute top-16 left-1/2 -translate-x-1/2 font-mono text-xs tracking-[0.2em] text-[color-mix(in_srgb,var(--kali-text)_85%,transparent)]">
           HI {formatScore(highScore)}
         </div>
-        <div className="absolute top-3 right-3 flex flex-col items-end space-y-2">
+        <div className="absolute top-6 right-6 flex flex-col items-end space-y-2">
           <div>{overlay}</div>
           <button
             type="button"

--- a/apps/pinball/physics.ts
+++ b/apps/pinball/physics.ts
@@ -53,6 +53,14 @@ interface Spark {
   hue: number;
 }
 
+interface InsertLamp {
+  x: number;
+  y: number;
+  radius: number;
+  hue: number;
+  phase: number;
+}
+
 interface LaneGlow {
   left: boolean;
   right: boolean;
@@ -217,6 +225,13 @@ export function createPinballWorld(
   const glowTimers: Partial<Record<Lane, number>> = {};
   const bumperTimers = new Map<Matter.Body, number>();
   const targetStates = new Map<Matter.Body, boolean>();
+  const tableLights: InsertLamp[] = [
+    { x: 70, y: 110, radius: 8, hue: 210, phase: 0.2 },
+    { x: WIDTH / 2, y: 140, radius: 9, hue: 180, phase: 1.1 },
+    { x: WIDTH - 70, y: 110, radius: 8, hue: 210, phase: 2.3 },
+    { x: 70, y: HEIGHT - 170, radius: 7, hue: 145, phase: 0.7 },
+    { x: WIDTH - 70, y: HEIGHT - 170, radius: 7, hue: 145, phase: 2.0 },
+  ];
   let locked = true;
 
   const lightLane = (lane: Lane) => {
@@ -300,6 +315,52 @@ export function createPinballWorld(
 
   const handleAfterRender = () => {
     const ctx = render.context;
+    const now = performance.now();
+
+    const playfieldGradient = ctx.createLinearGradient(0, 0, 0, HEIGHT);
+    playfieldGradient.addColorStop(0, "rgba(255,255,255,0.08)");
+    playfieldGradient.addColorStop(0.35, "rgba(255,255,255,0.02)");
+    playfieldGradient.addColorStop(1, "rgba(0,0,0,0.24)");
+    ctx.fillStyle = playfieldGradient;
+    ctx.fillRect(16, 16, WIDTH - 32, HEIGHT - 32);
+
+    ctx.save();
+    ctx.globalAlpha = 0.42;
+    ctx.strokeStyle = "rgba(255,255,255,0.18)";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(46, 96);
+    ctx.quadraticCurveTo(WIDTH / 2, 46, WIDTH - 46, 96);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(46, HEIGHT - 136);
+    ctx.quadraticCurveTo(WIDTH / 2, HEIGHT - 176, WIDTH - 46, HEIGHT - 136);
+    ctx.stroke();
+    ctx.restore();
+
+    tableLights.forEach((light) => {
+      const pulse = 0.48 + Math.sin(now * 0.003 + light.phase) * 0.22;
+      const halo = ctx.createRadialGradient(
+        light.x,
+        light.y,
+        0,
+        light.x,
+        light.y,
+        light.radius * 3.4,
+      );
+      halo.addColorStop(0, `hsla(${light.hue}, 100%, 74%, ${Math.max(pulse, 0.2)})`);
+      halo.addColorStop(1, `hsla(${light.hue}, 100%, 60%, 0)`);
+      ctx.fillStyle = halo;
+      ctx.beginPath();
+      ctx.arc(light.x, light.y, light.radius * 3.4, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.fillStyle = `hsla(${light.hue}, 96%, 78%, 0.9)`;
+      ctx.beginPath();
+      ctx.arc(light.x, light.y, light.radius, 0, Math.PI * 2);
+      ctx.fill();
+    });
+
     const { x, y } = ball.position;
     const gradient = ctx.createRadialGradient(
       x - 4,
@@ -324,9 +385,12 @@ export function createPinballWorld(
         ctx.shadowBlur = 20;
         ctx.fillStyle = "#ff0";
       } else {
-        ctx.fillStyle = "#555";
+        ctx.fillStyle = "#64748b";
       }
       ctx.fillRect(lx - 20, ly - 5, 40, 10);
+      ctx.strokeStyle = "rgba(226,232,240,0.6)";
+      ctx.lineWidth = 1;
+      ctx.strokeRect(lx - 20, ly - 5, 40, 10);
       ctx.restore();
     };
 
@@ -334,9 +398,18 @@ export function createPinballWorld(
     drawLane(rightLane, glow.right);
 
     bumpers.forEach((bumper) => {
-      const angle = bumper.render.fillStyle === "#fde68a" ? 0.6 : 0.3;
+      const active = bumper.render.fillStyle === "#fde68a";
       ctx.save();
       ctx.translate(bumper.position.x, bumper.position.y);
+      if (active) {
+        const glow = ctx.createRadialGradient(0, 0, BUMPER_RADIUS * 0.35, 0, 0, BUMPER_RADIUS * 2);
+        glow.addColorStop(0, "rgba(254,240,138,0.65)");
+        glow.addColorStop(1, "rgba(254,240,138,0)");
+        ctx.fillStyle = glow;
+        ctx.beginPath();
+        ctx.arc(0, 0, BUMPER_RADIUS * 2, 0, Math.PI * 2);
+        ctx.fill();
+      }
       const gradientBumper = ctx.createRadialGradient(0, 0, 6, 0, 0, BUMPER_RADIUS);
       gradientBumper.addColorStop(0, "rgba(255,255,255,0.9)");
       gradientBumper.addColorStop(1, bumper.render.fillStyle || "#f59e0b");
@@ -346,6 +419,11 @@ export function createPinballWorld(
       ctx.fill();
       ctx.strokeStyle = "rgba(255,255,255,0.4)";
       ctx.lineWidth = 2;
+      ctx.stroke();
+      ctx.strokeStyle = "rgba(15,23,42,0.6)";
+      ctx.lineWidth = 4;
+      ctx.beginPath();
+      ctx.arc(0, 0, BUMPER_RADIUS + 2, 0, Math.PI * 2);
       ctx.stroke();
       ctx.restore();
     });

--- a/components/apps/pinball.js
+++ b/components/apps/pinball.js
@@ -284,7 +284,51 @@ const Pinball = () => {
 
     Events.on(render, 'afterRender', () => {
       const ctx = render.context;
+      const time = performance.now();
       ctx.save();
+      const playfieldGlow = ctx.createLinearGradient(0, 0, 0, HEIGHT);
+      playfieldGlow.addColorStop(0, 'rgba(59,130,246,0.16)');
+      playfieldGlow.addColorStop(0.55, 'rgba(15,23,42,0.04)');
+      playfieldGlow.addColorStop(1, 'rgba(2,6,23,0.24)');
+      ctx.fillStyle = playfieldGlow;
+      ctx.fillRect(18, 18, WIDTH - 36, HEIGHT - 36);
+
+      lanes.forEach((lane, index) => {
+        const pulse = 0.35 + Math.sin(time * 0.005 + index * 1.3) * 0.2;
+        const halo = ctx.createRadialGradient(
+          lane.position.x,
+          lane.position.y,
+          0,
+          lane.position.x,
+          lane.position.y,
+          30
+        );
+        halo.addColorStop(0, `rgba(56,189,248,${Math.max(pulse, 0.12)})`);
+        halo.addColorStop(1, 'rgba(56,189,248,0)');
+        ctx.fillStyle = halo;
+        ctx.beginPath();
+        ctx.arc(lane.position.x, lane.position.y, 30, 0, Math.PI * 2);
+        ctx.fill();
+      });
+
+      bumpersRef.current.forEach(({ body, lit }) => {
+        if (!lit || !lightsRef.current) return;
+        const ring = ctx.createRadialGradient(
+          body.position.x,
+          body.position.y,
+          body.circleRadius * 0.3,
+          body.position.x,
+          body.position.y,
+          body.circleRadius * 1.8
+        );
+        ring.addColorStop(0, 'rgba(250,204,21,0.45)');
+        ring.addColorStop(1, 'rgba(250,204,21,0)');
+        ctx.fillStyle = ring;
+        ctx.beginPath();
+        ctx.arc(body.position.x, body.position.y, body.circleRadius * 1.8, 0, Math.PI * 2);
+        ctx.fill();
+      });
+
       ballsRef.current.forEach((b) => {
         ctx.fillStyle = 'rgba(0,0,0,0.3)';
         ctx.beginPath();

--- a/components/apps/pinball.tsx
+++ b/components/apps/pinball.tsx
@@ -1,1 +1,9 @@
-export { default } from '../../apps/pinball';
+import Pinball, { type PinballProps } from "../../apps/pinball";
+
+export default function PinballApp(props: PinballProps) {
+  return (
+    <div className="h-full w-full bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.08),transparent_42%),linear-gradient(180deg,rgba(15,23,42,0.95),rgba(2,6,23,0.95))] p-2">
+      <Pinball {...props} />
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Improve the visual polish of the pinball table and HUD to make the playfield feel more layered and lively while keeping the simulation deterministic. 
- Preserve all gameplay behavior by not touching physics constants, tilt thresholds, or scoring rules.

### Description
- Add playfield sheen, decorative lane arcs, pulsing insert lamps, refined lane styling, and stronger bumper glow/ring treatment in the TypeScript renderer (`apps/pinball/physics.ts`).
- Refresh the table shell and HUD styling with a subtle bezel, score panel treatment, and adjusted HUD placement (`apps/pinball/index.tsx`).
- Wrap the exported app in a lightweight visual backdrop so routed usage inherits the updated presentation (`components/apps/pinball.tsx`).
- Enhance the legacy canvas renderer with soft playfield lighting, lane halos, and lit-bumper glow rings to match the TypeScript changes (`components/apps/pinball.js`).
- No changes were made to gameplay constants, tilt logic, or scoring code in `apps/pinball/physics.ts` or `apps/pinball/tilt.ts`.

### Testing
- Ran `yarn test __tests__/pinballScore.test.tsx` and it passed.
- Ran `yarn test __tests__/pinballTilt.test.ts` and it passed.
- Ran `yarn test __tests__/pinballFocus.test.tsx` and it passed.
- Note: test runs emitted a worker-exit warning about open handles but all targeted tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59ddc55108328a6bc0cc4cfbd53c5)