### PR TITLE
[apps] fix vscode StackBlitz embed URL

### DIFF
--- a/apps/vscode/index.tsx
+++ b/apps/vscode/index.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 export const STACKBLITZ_EMBED_URL =
-  'https://stackblitz.com/~/github.com/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md';
+  'https://stackblitz.com/edit/github/Alex-Unnippillil/kali-linux-portfolio?embed=1&file=README.md&hideNavigation=1&view=editor';
 const STACKBLITZ_EXTERNAL_URL =
-  'https://stackblitz.com/~/github.com/Alex-Unnippillil/kali-linux-portfolio?file=README.md';
+  'https://stackblitz.com/edit/github/Alex-Unnippillil/kali-linux-portfolio?file=README.md';
 
 const STACKBLITZ_IFRAME_ALLOW =
   'clipboard-read; clipboard-write; fullscreen; geolocation; microphone; camera; display-capture';


### PR DESCRIPTION
### Motivation
- StackBlitz embeds using the `~/github.com` URL were refused to connect in the in-app iframe, so the VS Code app needs an embeddable `edit/github` URL to restore the embedded editor experience.

### Description
- Replaced the StackBlitz URLs in `apps/vscode/index.tsx` to use the `https://stackblitz.com/edit/github/...` pattern with `embed=1` and editor-focused params (`hideNavigation=1&view=editor`).
- Kept the iframe, sandbox/allow attributes, and the external “Open in StackBlitz” link unchanged so UX stays consistent.
- Only `apps/vscode/index.tsx` was modified to update the `STACKBLITZ_EMBED_URL` and `STACKBLITZ_EXTERNAL_URL` constants.

### Testing
- Ran `yarn test --runInBand __tests__/vscode.test.tsx` and the test suite passed (`1 passed`), validating the iframe `src` and external link behavior.
- No feature flags were changed in this PR and no API behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04855cafd4832881de158071bd9868)