### PR TITLE
[terminal] add app search and open autocomplete

### DIFF
--- a/apps/terminal/commands/index.ts
+++ b/apps/terminal/commands/index.ts
@@ -1,6 +1,21 @@
 import type { CommandContext, CommandDefinition, CommandHandler } from './types';
 import projectsData from '../../../data/projects.json';
+import apps from '../../../apps.config';
 import registry from './registry';
+
+const getAppCatalog = () => (apps || []).map((app) => ({
+  id: app.id,
+  title: app.title,
+  disabled: Boolean(app.disabled),
+}));
+
+const findApps = (query: string) => {
+  const normalized = query.trim().toLowerCase();
+  const catalog = getAppCatalog();
+  if (!normalized) return catalog;
+  return catalog.filter((app) => app.id.toLowerCase().includes(normalized)
+    || String(app.title || '').toLowerCase().includes(normalized));
+};
 
 // Re-export registry for use by Terminal App
 export { default as commandRegistry } from './registry';
@@ -208,16 +223,47 @@ const open: CommandHandler = (args, ctx) => {
   const target = args.trim();
   if (!target) {
     ctx.writeLine('Usage: open <app>');
+    ctx.writeLine('Tip: run "apps" to browse available app IDs.');
     return;
   }
-  // Remove file extension if present (e.g., spotify.app -> spotify) - just in case
-  const appId = target.replace(/\.(app|exe|sh)$/, '');
+
+  const normalized = target.replace(/\.(app|exe|sh)$/, '').trim().toLowerCase();
+  const appMatches = findApps(normalized).filter((app) => !app.disabled);
+
+  if (appMatches.length === 0) {
+    ctx.writeLine(`open: app "${target}" not found.`);
+    const suggestions = findApps(normalized.split('-')[0]).slice(0, 5);
+    if (suggestions.length) {
+      ctx.writeLine(`Did you mean: ${suggestions.map((app) => app.id).join(', ')}?`);
+    }
+    return;
+  }
+
+  const exactMatch = appMatches.find((app) => app.id.toLowerCase() === normalized)
+    || appMatches.find((app) => String(app.title || '').toLowerCase() === normalized);
+  const chosen = exactMatch || appMatches[0];
+  const appId = chosen.id;
 
   if (ctx.openApp) {
     ctx.openApp(appId);
     ctx.writeLine(`Opening ${appId}...`);
   } else {
     ctx.writeLine('Error: Desktop environment not connected (openApp missing).');
+  }
+};
+
+const listAppsCommand: CommandHandler = (args, ctx) => {
+  const results = findApps(args);
+    if (!results.length) {
+      ctx.writeLine('No apps matched your query.');
+      return;
+    }
+  ctx.writeLine(`Applications (${results.length}):`);
+  results
+    .slice(0, 60)
+    .forEach((app) => ctx.writeLine(`- ${app.id}${app.title ? ` (${app.title})` : ''}${app.disabled ? ' [disabled]' : ''}`));
+  if (results.length > 60) {
+    ctx.writeLine(`...and ${results.length - 60} more. Use: apps <search-term>`);
   }
 };
 
@@ -335,6 +381,7 @@ const registerAll = () => {
     { name: 'cat', description: 'Print a file.', usage: 'cat <file>', handler: cat },
     { name: 'clear', description: 'Clear the terminal buffer.', handler: clear },
     { name: 'open', description: 'Open another desktop app.', usage: 'open <app-id>', handler: open },
+    { name: 'apps', description: 'List or search launchable apps.', usage: 'apps [query]', handler: listAppsCommand },
     { name: 'projects', description: 'List the portfolio project catalog.', handler: projects },
     {
       name: 'ssh',

--- a/apps/terminal/commands/types.ts
+++ b/apps/terminal/commands/types.ts
@@ -15,6 +15,7 @@ export interface CommandContext {
   clear: () => void;
   openApp?: (id: string) => void;
   listCommands: () => CommandDefinition[];
+  listApps?: () => Array<{ id: string; title?: string; disabled?: boolean }>;
 }
 
 export type CommandHandler = (args: string, ctx: CommandContext) => void | Promise<void>;

--- a/apps/terminal/index.tsx
+++ b/apps/terminal/index.tsx
@@ -12,6 +12,7 @@ import { FauxFileSystem, TerminalFileSystem, VirtualFileSystem } from './utils/f
 import { createOutputBuffer, stripAnsi } from './utils/outputBuffer';
 import { createWorkerRunner } from './utils/workerRunner';
 import { useTerminalPreferences, type TerminalPrefs } from './hooks/useTerminalPreferences';
+import apps from '../../apps.config';
 
 // --- Polished Icons ---
 const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
@@ -123,6 +124,7 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp, sessio
     },
     openApp,
     listCommands: () => commandRegistry.getAll(),
+    listApps: () => (apps || []).map((app) => ({ id: app.id, title: app.title, disabled: Boolean(app.disabled) })),
   });
 
   // Initialize FS
@@ -442,6 +444,15 @@ const TerminalApp = forwardRef<TerminalHandle, TerminalProps>(({ openApp, sessio
             text: `${buildPromptTextRef.current()} ${command}`,
           });
           schedulePersistRef.current();
+        },
+        getAutocompleteCandidates: (buffer) => {
+          const normalized = buffer.trimStart();
+          if (!normalized.startsWith('open ')) return [];
+          const query = normalized.slice(5).toLowerCase();
+          const catalog = (contextRef.current.listApps?.() || []).filter((app) => !app.disabled);
+          return catalog
+            .filter((app) => app.id.toLowerCase().startsWith(query))
+            .map((app) => `open ${app.id}`);
         },
       });
 

--- a/apps/terminal/utils/sessionManager.ts
+++ b/apps/terminal/utils/sessionManager.ts
@@ -10,6 +10,7 @@ export interface SessionManagerConfig {
   onHistoryUpdate?: (history: string[]) => void;
   onCancelRunning?: () => void;
   onCommand?: (command: string) => void;
+  getAutocompleteCandidates?: (buffer: string) => string[];
 }
 
 export interface SessionManager {
@@ -35,6 +36,7 @@ export function createSessionManager({
   onHistoryUpdate,
   onCancelRunning,
   onCommand,
+  getAutocompleteCandidates,
 }: SessionManagerConfig): SessionManager {
   // Mutable config state
   let currentConfig: SessionManagerConfig = {
@@ -44,7 +46,9 @@ export function createSessionManager({
     write,
     writeLine,
     onHistoryUpdate,
-    onCancelRunning
+    onCancelRunning,
+    onCommand,
+    getAutocompleteCandidates,
   };
 
   const updateConfig = (newConfig: Partial<SessionManagerConfig>) => {
@@ -122,9 +126,23 @@ export function createSessionManager({
   };
 
   const autocomplete = () => {
-    if (/\s/.test(buffer)) {
-      return;
+    const providedCandidates = currentConfig.getAutocompleteCandidates?.(buffer) || [];
+    if (providedCandidates.length > 0) {
+      const uniqueMatches = [...new Set(providedCandidates)].filter((value) => value.startsWith(buffer));
+      if (uniqueMatches.length === 1) {
+        const completion = uniqueMatches[0].slice(buffer.length);
+        if (completion) currentConfig.write(completion);
+        buffer = uniqueMatches[0];
+        return;
+      }
+      if (uniqueMatches.length > 1) {
+        currentConfig.write('\r\n');
+        uniqueMatches.slice(0, 30).forEach((value) => currentConfig.writeLine(value));
+        renderPrompt();
+        return;
+      }
     }
+    if (/\s/.test(buffer)) return;
     const registry = currentConfig.getRegistry();
     const entries = Object.values(registry);
     const matches = entries.filter((c) => c.name.startsWith(buffer));


### PR DESCRIPTION
### Motivation
- Make the terminal more useful for basic desktop workflows by allowing users to discover and open desktop apps from the terminal and by providing argument-level autocomplete for app IDs.

### Description
- Expose the app catalog in the terminal context by adding `listApps` to `CommandContext` and wiring `apps.config` into the terminal runtime (`apps/terminal/commands/types.ts`, `apps/terminal/index.tsx`).
- Implement `findApps` and `getAppCatalog` and improve the `open` command to resolve app ids/titles, refuse disabled apps, and show "did you mean" suggestions when no match is found (`apps/terminal/commands/index.ts`).
- Add a new `apps [query]` command to list or search available applications from the terminal (`apps/terminal/commands/index.ts`).
- Add argument-level autocomplete plumbing (`getAutocompleteCandidates`) to the session manager and use it to provide `open <app-id>` completions from the live app catalog (`apps/terminal/utils/sessionManager.ts`, `apps/terminal/index.tsx`).

### Testing
- Ran `yarn test __tests__/terminal.sessionManager.test.ts __tests__/terminal.test.tsx`, and both suites passed.
- Note: Jest emitted a worker teardown warning about an open handle, but all tests completed successfully and assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0489c426688328a9014705e2c04c26)