### PR TITLE
[desktop] fix window focus and persistence

### DIFF
--- a/components/base/window.js
+++ b/components/base/window.js
@@ -236,7 +236,8 @@ export class Window extends Component {
     notifySizeChange = () => {
         if (typeof this.props.onSizeChange === 'function') {
             const { width, height } = this.state;
-            this.props.onSizeChange(width, height);
+            const targetId = this.id ?? this.props.id;
+            this.props.onSizeChange(targetId, width, height);
         }
     }
 
@@ -266,6 +267,10 @@ export class Window extends Component {
     }
 
     componentDidUpdate(prevProps) {
+        if (!prevProps.isFocused && this.props.isFocused) {
+            this.focusWindow();
+        }
+
         if (prevProps.minWidth === this.props.minWidth && prevProps.minHeight === this.props.minHeight) {
             return;
         }
@@ -1026,7 +1031,8 @@ export class Window extends Component {
         this.updatePositionState(roundedX, roundedY);
 
         if (this.props.onPositionChange) {
-            this.props.onPositionChange(absoluteX, absoluteY);
+            const targetId = this.id ?? this.props.id;
+            this.props.onPositionChange(targetId, roundedX, roundedY);
         }
 
         this.notifySizeChange();

--- a/components/screen/desktop.js
+++ b/components/screen/desktop.js
@@ -5147,6 +5147,7 @@ export class Desktop extends Component {
                 onSizeChange: this.updateWindowSize,
                 snapEnabled: this.props.snapEnabled,
                 snapGrid,
+                zIndex: 100 + index,
                 context: this.state.window_context[id],
             };
 
@@ -5500,8 +5501,7 @@ export class Desktop extends Component {
                 this.focus(objId);
                 var r = document.querySelector("#" + objId);
                 r.style.transform = `translate(${r.style.getPropertyValue("--window-transform-x")},${r.style.getPropertyValue("--window-transform-y")}) scale(1)`;
-                let minimized_windows = this.state.minimized_windows;
-                minimized_windows[objId] = false;
+                const minimized_windows = { ...this.state.minimized_windows, [objId]: false };
                 this.setWorkspaceState({ minimized_windows }, this.saveSession);
 
             }
@@ -5512,9 +5512,8 @@ export class Desktop extends Component {
                     this.focus(objId);
                     var r = document.querySelector("#" + objId);
                     r.style.transform = `translate(${r.style.getPropertyValue("--window-transform-x")},${r.style.getPropertyValue("--window-transform-y")}) scale(1)`;
-                    let minimized_windows = this.state.minimized_windows;
-                    minimized_windows[objId] = false;
-                    this.setState({ minimized_windows: minimized_windows }, this.saveSession);
+                    const minimized_windows = { ...this.state.minimized_windows, [objId]: false };
+                    this.setWorkspaceState({ minimized_windows }, this.saveSession);
                 } else {
                     this.focus(objId);
                     this.saveSession();


### PR DESCRIPTION
### Motivation

- Fix unreliable DOM focus when a window is promoted in the stack so keyboard interactions target the active window. 
- Ensure window position/size persistence writes are attributed to the correct window id so bounds are restored reliably. 
- Prevent accidental mutation of minimized-window state when restoring already-open windows and ensure deterministic z-ordering.

### Description

- Call `focusWindow()` when a window's `isFocused` prop transitions to true in `componentDidUpdate` so the DOM element receives focus. 
- Include the window id when calling `onSizeChange` and `onPositionChange` from the `Window` component so the desktop stores sizes/positions under the correct key. 
- Provide an explicit `zIndex` (stack-derived) to each rendered `Window` so layer ordering follows the active stack. 
- Replace in-place mutation of `minimized_windows` with immutable updates via `setWorkspaceState` when reopening/restoring already-open apps.

### Testing

- Ran `yarn lint` and the linter completed successfully. 
- Ran `yarn test` and the full test suite completed (tests passed, with expected test warnings logged by tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62105a5cdc832889bd77bed915d430)