### PR TITLE
[apps] fix registry preview routes

### DIFF
--- a/components/apps/plugin-manager/index.tsx
+++ b/components/apps/plugin-manager/index.tsx
@@ -46,8 +46,27 @@ const formatTimestamp = (timestamp: string) => {
 type FilterOption = 'all' | 'installed' | 'available';
 type SortOption = 'alpha' | 'size';
 
+const DEMO_PLUGINS: PluginInfo[] = [
+  {
+    id: 'demo',
+    file: 'demo.json',
+    sandbox: 'worker',
+    size: 146,
+    description: 'Echoes a static message from a sandboxed worker.',
+  },
+];
+
+const DEMO_MANIFESTS: Record<string, PluginManifest> = {
+  'demo.json': {
+    id: 'demo',
+    sandbox: 'worker',
+    code: "self.postMessage('content');",
+  },
+};
+
 export default function PluginManager() {
   const [plugins, setPlugins] = useState<PluginInfo[]>([]);
+  const [catalogStatus, setCatalogStatus] = useState('Loading plugin catalog…');
   const [installed, setInstalled] = useState<Record<string, PluginManifest>>(
     () => {
       if (typeof window !== 'undefined') {
@@ -92,14 +111,40 @@ export default function PluginManager() {
 
   useEffect(() => {
     fetch('/api/plugins')
-      .then((res) => res.json())
-      .then(setPlugins)
-      .catch(() => setPlugins([]));
+      .then((res) => {
+        if ('ok' in res && !res.ok) throw new Error('Plugin API unavailable');
+        return res.json();
+      })
+      .then((catalog) => {
+        if (Array.isArray(catalog) && catalog.length > 0) {
+          setPlugins(catalog);
+          setCatalogStatus('Server plugin catalog loaded.');
+        } else {
+          setPlugins(DEMO_PLUGINS);
+          setCatalogStatus('No server plugins were returned, so the offline demo catalog is shown.');
+        }
+      })
+      .catch(() => {
+        setPlugins(DEMO_PLUGINS);
+        setCatalogStatus('Plugin API unavailable; using the offline demo catalog.');
+      });
   }, []);
 
   const install = async (plugin: PluginInfo) => {
-    const res = await fetch(`/api/plugins/${plugin.file}`);
-    const manifest: PluginManifest = await res.json();
+    let manifest: PluginManifest;
+    try {
+      const res = await fetch(`/api/plugins/${plugin.file}`);
+      if ('ok' in res && !res.ok) throw new Error('Plugin manifest unavailable');
+      manifest = await res.json();
+    } catch {
+      const fallback = DEMO_MANIFESTS[plugin.file];
+      if (!fallback) {
+        setCatalogStatus(`Unable to install ${plugin.id}; no offline manifest is available.`);
+        return;
+      }
+      manifest = fallback;
+      setCatalogStatus(`Installed ${plugin.id} from the offline demo manifest.`);
+    }
     const updated = { ...installed, [plugin.id]: manifest };
     setInstalled(updated);
     try {
@@ -237,6 +282,9 @@ export default function PluginManager() {
           <h1 className="mb-1 text-2xl font-semibold">Plugin Catalog</h1>
           <p className="text-sm text-[color:color-mix(in_srgb,var(--color-text)_70%,transparent)]">
             Discover sandboxed utilities and keep installed plugins up to date.
+          </p>
+          <p className="mt-2 rounded-lg border border-[color:var(--kali-border)] bg-[color:color-mix(in_srgb,var(--kali-panel)_78%,transparent)] px-3 py-2 text-xs text-[color:color-mix(in_srgb,var(--color-text)_72%,transparent)]" role="status">
+            {catalogStatus}
           </p>
         </div>
         <div className="flex flex-wrap gap-4" role="group" aria-label="Plugin filters">

--- a/pages/apps/[...appId].jsx
+++ b/pages/apps/[...appId].jsx
@@ -1,0 +1,65 @@
+import apps from '../../apps.config';
+
+const appById = new Map(apps.map((app) => [app.id, app]));
+
+const collectExplicitAppRoutes = (fs, path, dir, prefix = '') => {
+  if (!fs.existsSync(dir)) return new Set();
+
+  return fs.readdirSync(dir, { withFileTypes: true }).reduce((routes, entry) => {
+    if (entry.name.startsWith('[') || entry.name === 'index.jsx') return routes;
+
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectExplicitAppRoutes(fs, path, entryPath, `${prefix}${entry.name}/`).forEach((route) => routes.add(route));
+      return routes;
+    }
+
+    if (/\.(jsx|tsx|js|ts)$/.test(entry.name)) {
+      routes.add(`${prefix}${entry.name.replace(/\.(jsx|tsx|js|ts)$/, '')}`);
+    }
+
+    return routes;
+  }, new Set());
+};
+
+export function getStaticPaths() {
+  const fs = require('fs');
+  const path = require('path');
+  const explicitRoutes = collectExplicitAppRoutes(fs, path, path.join(process.cwd(), 'pages/apps'));
+  const paths = apps
+    .filter((app) => !app.disabled && !app.isFolder && !explicitRoutes.has(app.id))
+    .map((app) => ({ params: { appId: app.id.split('/') } }));
+
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+export function getStaticProps({ params }) {
+  return {
+    props: {
+      appId: (params?.appId || []).join('/'),
+    },
+  };
+}
+
+export default function RegistryAppPage({ appId }) {
+  const app = appById.get(appId);
+
+  if (!app?.screen) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-ub-cool-grey p-6 text-white">
+        <div className="max-w-md rounded-lg border border-white/10 bg-black/30 p-6 text-center shadow-2xl">
+          <h1 className="text-xl font-semibold">App unavailable</h1>
+          <p className="mt-2 text-sm text-gray-200">
+            This launcher entry does not have a standalone preview route yet.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const AppScreen = app.screen;
+  return <AppScreen />;
+}

--- a/pages/apps/solitaire.jsx
+++ b/pages/apps/solitaire.jsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 
-const PageSolitaire = dynamic(() => import('../../games/solitaire'), {
+const PageSolitaire = dynamic(() => import('../../apps/solitaire'), {
   ssr: false,
   loading: () => <p>Loading...</p>,
 });


### PR DESCRIPTION
### Motivation

- Provide standalone preview pages for registry-backed apps that lack explicit `pages/apps/*` entries while avoiding static path conflicts with existing routes.
- Prevent build/runtime failures when the site is statically exported or run without API routes by surfacing graceful fallbacks for missing screens and APIs.
- Improve Plugin Manager resiliency in static/offline environments so the catalog remains usable when `/api/plugins` is unavailable.

### Description

- Added a catch-all preview page `pages/apps/[...appId].jsx` that collects explicit `pages/apps/*` routes and generates `getStaticPaths` only for registry entries that do not already have an explicit page, and renders `app.screen` or an "App unavailable" fallback when appropriate.
- Fixed the Solitaire preview import by changing `pages/apps/solitaire.jsx` to import from the existing `apps/solitaire` implementation.
- Updated `components/apps/plugin-manager/index.tsx` to include `DEMO_PLUGINS` and `DEMO_MANIFESTS`, detect when the `/api/plugins` endpoint or manifest is unavailable, fall back to the offline demo catalog/manifest, and display a small status message indicating whether the catalog came from server or offline fallback.

### Testing

- Ran a registry inspection script with `python3` to check for duplicate literal IDs and missing icon paths; the inspection reported no missing icons.
- Ran linting with `yarn lint`, which completed without errors.
- Ran unit tests with `yarn test`; the full suite completed with the test runner reporting 261 passed and 4 skipped, with a non-critical Jest open-handle warning after completion, and the focused `__tests__/pluginManager.test.tsx` run passed.
- Built and exported the site with `yarn build` and `yarn export`; both completed successfully and `next export` emitted the expected note that static export disables API routes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62106ca8fc8328bdd58e2d2d7a69fe)