### PR TITLE
[security] harden simulated tool APIs

### DIFF
--- a/__tests__/hydra-api.test.js
+++ b/__tests__/hydra-api.test.js
@@ -61,12 +61,12 @@ test('removes temp files after hydra execution', async () => {
 
   await handler(req, res);
 
-  const [userResult, passResult] = randomUUIDMock.mock.results;
-  const userPath = `/tmp/hydra-users-${userResult.value}.txt`;
-  const passPath = `/tmp/hydra-pass-${passResult.value}.txt`;
-
-  await expect(fs.access(userPath)).rejects.toBeTruthy();
-  await expect(fs.access(passPath)).rejects.toBeTruthy();
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(
+    expect.objectContaining({ output: expect.stringContaining('No sockets were opened') }),
+  );
+  expect(randomUUIDMock).not.toHaveBeenCalled();
+  expect(execFileMock).not.toHaveBeenCalled();
 });
 
 test('accepts http-get service names exposed in the UI', async () => {
@@ -94,7 +94,9 @@ test('accepts http-get service names exposed in the UI', async () => {
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.any(String) }));
   } else {
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ output: 'done' });
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ output: expect.stringContaining('No sockets were opened') }),
+    );
   }
 });
 

--- a/__tests__/hydra.api.test.ts
+++ b/__tests__/hydra.api.test.ts
@@ -118,7 +118,10 @@ describe('Hydra API service validation', () => {
     await handler(req, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(execFileMock).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ output: expect.stringContaining('No sockets were opened') }),
+    );
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   it('rejects unsupported services', async () => {
@@ -179,7 +182,10 @@ describe('Hydra API resume session', () => {
 
     await handler(req, res);
 
-    const hydraCall = execFileMock.mock.calls.find((c) => c[0] === 'hydra');
-    expect(hydraCall[1]).toEqual(['-R']);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ output: expect.stringContaining('No network connections') }),
+    );
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/mimikatz.test.ts
+++ b/__tests__/mimikatz.test.ts
@@ -26,21 +26,23 @@ describe('mimikatz api', () => {
     expect(data.modules.every((module: any) => typeof module.name === 'string')).toBe(true);
   });
 
-  test('executes script template', async () => {
+  test('simulates script template', async () => {
     const req: any = { method: 'POST', body: { script: 'test' } };
     const res: Res = mockRes();
     await handler(req, res);
     expect(res.status).toHaveBeenCalledWith(200);
     const data = res.json.mock.calls[0][0];
-    expect(data.output).toBe('Executed script: test');
+    expect(data.output).toContain('Mimikatz script simulation accepted');
+    expect(data.output).toContain('No commands were executed');
   });
 
-  test('executes ad-hoc command via query parameter', async () => {
+  test('simulates ad-hoc command via query parameter', async () => {
     const req: any = { method: 'GET', query: { command: 'token::elevate' } };
     const res: Res = mockRes();
     await handler(req, res);
     expect(res.status).toHaveBeenCalledWith(200);
     const data = res.json.mock.calls[0][0];
-    expect(data.output).toBe('Executed token::elevate');
+    expect(data.output).toContain('Mimikatz training simulation only');
+    expect(data.output).toContain('No credential access');
   });
 });

--- a/components/apps/nessus/index.js
+++ b/components/apps/nessus/index.js
@@ -4,6 +4,7 @@ import PluginFeedViewer from './PluginFeedViewer';
 import ScanComparison from './ScanComparison';
 import PluginScoreHeatmap from './PluginScoreHeatmap';
 import FormError from '../../ui/FormError';
+import SimulationBanner from '../SimulationBanner';
 
 // helpers for persistent storage of jobs and false positives
 export const loadJobDefinitions = () => {
@@ -75,9 +76,6 @@ export const recordFalsePositive = (findingId, reason) =>
 const findingKeyFor = (finding) => `${finding.host}::${finding.id}`;
 
 const Nessus = () => {
-  const [url, setUrl] = useState('https://localhost:8834');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
   const [token, setToken] = useState('');
   const [scans, setScans] = useState([]);
   const [error, setError] = useState('');
@@ -218,39 +216,15 @@ const Nessus = () => {
     URL.revokeObjectURL(url);
   };
 
-  const login = async (e) => {
+  const login = (e) => {
     e.preventDefault();
     setError('');
-    try {
-      const res = await fetch(`${url}/session`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password }),
-      });
-      if (!res.ok) throw new Error('Authentication failed');
-      const data = await res.json();
-      setToken(data.token);
-      fetchScans(data.token, url);
-    } catch (err) {
-      setError(err.message);
-    }
+    setToken('demo-offline-session');
+    setScans([]);
   };
 
-  const fetchScans = async (tkn = token, baseUrl = url) => {
-    try {
-      const res = await fetch(`${baseUrl}/scans`, {
-        headers: {
-          'X-Cookie': `token=${tkn}`,
-          'Content-Type': 'application/json',
-          'X-Requested-With': 'XMLHttpRequest',
-        },
-      });
-      if (!res.ok) throw new Error('Unable to fetch scans');
-      const data = await res.json();
-      setScans(data.scans || []);
-    } catch (err) {
-      setError(err.message);
-    }
+  const fetchScans = () => {
+    setError('Live Nessus connections are disabled; import a report or use bundled fixtures.');
   };
 
   const addJob = (e) => {
@@ -291,50 +265,16 @@ const Nessus = () => {
   if (!token) {
     return (
       <div className="flex h-full w-full items-center justify-center bg-kali-surface/95 text-kali-text">
-        <form onSubmit={login} className="w-64 space-y-2 p-4">
-          <label htmlFor="nessus-url" className="block text-sm">
-            Nessus URL
-          </label>
-          <input
-            id="nessus-url"
-            className="w-full p-2 rounded text-black"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            aria-invalid={error ? 'true' : undefined}
-            aria-describedby={error ? 'nessus-error' : undefined}
-            placeholder="https://nessus:8834"
-            aria-label="Nessus URL"
-          />
-          <label htmlFor="nessus-username" className="block text-sm">
-            Username
-          </label>
-          <input
-            id="nessus-username"
-            className="w-full p-2 rounded text-black"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            aria-invalid={error ? 'true' : undefined}
-            aria-describedby={error ? 'nessus-error' : undefined}
-            aria-label="Username"
-          />
-          <label htmlFor="nessus-password" className="block text-sm">
-            Password
-          </label>
-          <input
-            id="nessus-password"
-            type="password"
-            className="w-full p-2 rounded text-black"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            aria-invalid={error ? 'true' : undefined}
-            aria-describedby={error ? 'nessus-error' : undefined}
-            aria-label="Password"
-          />
+        <form onSubmit={login} className="w-80 space-y-3 p-4">
+          <SimulationBanner message="Nessus runs in offline demo mode. No scanner login or network requests are performed." />
+          <p className="text-sm text-kali-muted">
+            Start a local demo session, then import a sample report or explore the bundled fixtures.
+          </p>
           <button
             type="submit"
             className="w-full rounded bg-kali-primary py-2 text-kali-inverse transition hover:bg-kali-primary/90"
           >
-            Login
+            Start offline demo
           </button>
           {error && <FormError id="nessus-error">{error}</FormError>}
         </form>

--- a/components/apps/reconng/index.js
+++ b/components/apps/reconng/index.js
@@ -7,7 +7,6 @@ import React, {
 import dynamic from 'next/dynamic';
 import usePersistentState from '../../../hooks/usePersistentState';
 import ReportTemplates from './components/ReportTemplates';
-import { useSettings } from '../../../hooks/useSettings';
 
 const CytoscapeComponent = dynamic(
   async () => {
@@ -19,9 +18,7 @@ const CytoscapeComponent = dynamic(
   { ssr: false },
 );
 
-// Built-in modules with simple schemas and canned demo data. Each schema defines
-// the expected input type, a demo generator for offline usage, and an optional
-// fetchUrl function used when the user opts into live network requests.
+// Built-in modules with simple schemas and canned demo data. Network lookups stay disabled so the tool remains offline-only.
 const moduleSchemas = {
   'DNS Enumeration': {
     input: 'domain',
@@ -188,11 +185,9 @@ const deserializeWorkspaces = (storedWorkspaces = []) => {
 };
 
 const ReconNG = () => {
-  const { allowNetwork } = useSettings();
   const [selectedModule, setSelectedModule] = useState(modules[0]);
   const [target, setTarget] = useState('');
   const [output, setOutput] = useState('');
-  const [useLiveData, setUseLiveData] = useState(false);
   const [view, setView] = useState('run');
   const [marketplace, setMarketplace] = useState([]);
   const [scriptTags, setScriptTags] = usePersistentState('reconng-script-tags', {});
@@ -224,22 +219,6 @@ const ReconNG = () => {
       setActiveWs(safeActiveWs);
     }
   }, [activeWs, safeActiveWs, setActiveWs]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return undefined;
-    if (allowNetwork) return undefined;
-    const originalFetch = window.fetch.bind(window);
-    window.fetch = (input, init) => {
-      const url = typeof input === 'string' ? input : input.url;
-      if (/^https?:/i.test(url) && !url.startsWith(window.location.origin) && !url.startsWith('/')) {
-        return Promise.reject(new Error('Outbound requests blocked'));
-      }
-      return originalFetch(input, init);
-    };
-    return () => {
-      window.fetch = originalFetch;
-    };
-  }, [allowNetwork]);
 
   useEffect(() => {
     fetch('/reconng-marketplace.json')
@@ -370,15 +349,7 @@ const ReconNG = () => {
   const executeModule = async (moduleName, input) => {
     const schema = moduleSchemas[moduleName];
     const demo = schema.demo(input);
-    let text = demo.output;
-    if (useLiveData && schema.fetchUrl) {
-      try {
-        const res = await fetch(schema.fetchUrl(input));
-        text = await res.text();
-      } catch {
-        text = `${demo.output}\n\n(Live fetch failed; showing demo data)`;
-      }
-    }
+    const text = `${demo.output}\n\nDemo mode: outbound reconnaissance requests are disabled; results come from deterministic local data.`;
     return { text, nodes: demo.nodes, edges: demo.edges };
   };
 
@@ -604,15 +575,11 @@ const ReconNG = () => {
               onChange={(e) => setTarget(e.target.value)}
               placeholder="Target"
               className="flex-1 bg-gray-800 px-2 py-1"
+              aria-label="Recon-ng target"
             />
-            <label className="flex items-center gap-1 text-xs">
-              <input
-                type="checkbox"
-                checked={useLiveData}
-                onChange={(e) => setUseLiveData(e.target.checked)}
-              />
-              Live fetch
-            </label>
+            <span className="rounded border border-emerald-400/30 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200">
+              Offline demo data
+            </span>
             <button
               type="button"
               onClick={runModule}
@@ -701,6 +668,7 @@ const ReconNG = () => {
                   onChange={(e) => setApiKeys({ ...apiKeys, [m]: e.target.value })}
                   className="flex-1 bg-gray-800 px-2 py-1"
                   placeholder={`${m} API Key`}
+                  aria-label={`${m} API key`}
                 />
                 <button
                   type="button"

--- a/components/apps/wireshark/index.js
+++ b/components/apps/wireshark/index.js
@@ -191,33 +191,11 @@ const WiresharkApp = ({ initialPackets = [] }) => {
   };
 
   const startCapture = () => {
-    if (socket || typeof window === 'undefined') return;
-    const ws = new WebSocket('ws://localhost:8080');
-    ws.onopen = () => {
-      if (tlsKeys) {
-        ws.send(JSON.stringify({ type: 'tlsKeys', keys: tlsKeys }));
-      }
-    };
-    ws.onmessage = (event) => {
-      try {
-        const pkt = JSON.parse(event.data);
-        setPackets((prev) => [pkt, ...prev].slice(0, 500));
-        if (!pausedRef.current) {
-          workerRef.current?.postMessage(pkt);
-        }
-      } catch (e) {
-        // ignore malformed packets
-      }
-    };
-    ws.onclose = () => setSocket(null);
-    setSocket(ws);
+    setError('Live capture is disabled in this offline simulation. Load a bundled PCAP sample instead.');
   };
 
   const stopCapture = () => {
-    if (socket) {
-      socket.close();
-      setSocket(null);
-    }
+    setSocket(null);
   };
 
   const handlePause = () => {

--- a/pages/api/hydra.js
+++ b/pages/api/hydra.js
@@ -1,11 +1,3 @@
-import { execFile } from 'child_process';
-import { promises as fs } from 'fs';
-import { randomUUID } from 'crypto';
-import { promisify } from 'util';
-import path from 'path';
-import os from 'os';
-
-const execFileAsync = promisify(execFile);
 const allowed = new Set([
   'http',
   'https',
@@ -16,6 +8,17 @@ const allowed = new Set([
   'http-post-form',
 ]);
 
+const MAX_LIST_LINES = 50;
+
+const sanitizeLines = (value) =>
+  String(value || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, MAX_LIST_LINES);
+
+const mask = (value) => `${value.slice(0, 1)}${'*'.repeat(Math.min(Math.max(value.length - 1, 0), 8))}`;
+
 export default async function handler(req, res) {
   if (
     process.env.FEATURE_TOOL_APIS !== 'enabled' ||
@@ -24,45 +27,19 @@ export default async function handler(req, res) {
     res.status(501).json({ error: 'Not implemented' });
     return;
   }
-  // Hydra is an optional external dependency. Environments without the
-  // actual binary may stub this handler for demonstration purposes.
+
   if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }
 
   const { action, target, service, userList, passList } = req.body || {};
 
-  const sessionDir = path.join(process.cwd(), 'hydra');
-  const restoreFile = path.join(sessionDir, 'hydra.restore');
-  const sessionFile = path.join(sessionDir, 'session');
-  await fs.mkdir(sessionDir, { recursive: true });
-
   if (action === 'resume') {
-    try {
-      await fs.copyFile(sessionFile, restoreFile);
-    } catch {
-      res.status(400).json({ error: 'No saved session' });
-      return;
-    }
-    try {
-      await execFileAsync('which', ['hydra']);
-    } catch {
-      res.status(500).json({ error: 'Hydra not installed' });
-      return;
-    }
-    try {
-      const { stdout } = await execFileAsync('hydra', ['-R'], {
-        cwd: sessionDir,
-        timeout: 1000 * 60,
-      });
-      res.status(200).json({ output: stdout.toString() });
-    } catch (error) {
-      const msg = error.stderr?.toString() || error.message;
-      res.status(500).json({ error: msg });
-    } finally {
-      await fs.copyFile(restoreFile, sessionFile).catch(() => { });
-    }
+    res.status(200).json({
+      output: 'Hydra demo session restored. No network connections or brute-force attempts were made.',
+    });
     return;
   }
 
@@ -70,49 +47,37 @@ export default async function handler(req, res) {
     res.status(400).json({ error: 'Missing parameters' });
     return;
   }
+
   if (!allowed.has(service)) {
     res.status(400).json({ error: 'Unsupported service' });
     return;
   }
 
-  const userPath = path.join(os.tmpdir(), `hydra-users-${randomUUID()}.txt`);
-  const passPath = path.join(os.tmpdir(), `hydra-pass-${randomUUID()}.txt`);
+  const users = sanitizeLines(userList);
+  const passwords = sanitizeLines(passList);
 
-  try {
-    await fs.writeFile(userPath, userList);
-    await fs.writeFile(passPath, passList);
-  } catch (err) {
-    res.status(500).json({ error: err.message });
+  if (!users.length || !passwords.length) {
+    res.status(400).json({ error: 'User and password lists must contain demo entries' });
     return;
   }
 
-  try {
-    await execFileAsync('which', ['hydra']);
-  } catch {
-    await Promise.all([
-      fs.unlink(userPath).catch(() => { }),
-      fs.unlink(passPath).catch(() => { }),
-    ]);
-    res.status(500).json({ error: 'Hydra not installed' });
-    return;
-  }
+  const targetLabel = String(target).replace(/[^a-zA-Z0-9 .:_-]/g, '').slice(0, 80) || 'demo-target';
+  const sampleAttempts = users.slice(0, 3).flatMap((user) =>
+    passwords.slice(0, 2).map((password) => `${user}:${mask(password)}`),
+  );
 
-  const args = ['-L', userPath, '-P', passPath, `${service}://${target}`];
+  const output = [
+    'Hydra training simulation only',
+    `Target label: ${targetLabel}`,
+    `Service profile: ${service}`,
+    `Credential combinations modeled: ${users.length * passwords.length}`,
+    'No sockets were opened and no authentication attempts were sent.',
+    '',
+    'Sample modeled attempts:',
+    ...sampleAttempts.map((attempt) => `  - ${attempt}`),
+    '',
+    'Result: demo complete. Use this view to discuss rate limits, lockouts, and defensive monitoring.',
+  ].join('\n');
 
-  try {
-    const { stdout } = await execFileAsync('hydra', args, {
-      cwd: sessionDir,
-      timeout: 1000 * 60,
-    });
-    res.status(200).json({ output: stdout.toString() });
-  } catch (error) {
-    const msg = error.stderr?.toString() || error.message;
-    res.status(500).json({ error: msg });
-  } finally {
-    await Promise.all([
-      fs.unlink(userPath).catch(() => { }),
-      fs.unlink(passPath).catch(() => { }),
-    ]);
-    await fs.copyFile(restoreFile, sessionFile).catch(() => { });
-  }
+  res.status(200).json({ output });
 }

--- a/pages/api/john.js
+++ b/pages/api/john.js
@@ -1,44 +1,37 @@
-import { exec } from 'child_process';
-import { promises as fs } from 'fs';
-import { tmpdir } from 'os';
-import path from 'path';
-import { promisify } from 'util';
-
-const execAsync = promisify(exec);
+const HASH_PATTERNS = [
+  { name: 'MD5-like', regex: /^[a-f0-9]{32}$/i },
+  { name: 'SHA1-like', regex: /^[a-f0-9]{40}$/i },
+  { name: 'SHA256-like', regex: /^[a-f0-9]{64}$/i },
+  { name: 'bcrypt-like', regex: /^\$2[aby]\$\d{2}\$/ },
+];
 
 export default async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });
     return;
   }
-  // John the Ripper is optional; environments without the binary can stub
-  // this handler to return canned responses for demonstration.
+
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }
+
   const { hash } = req.body || {};
-  if (!hash) {
+  if (typeof hash !== 'string' || !hash.trim()) {
     res.status(400).json({ error: 'No hash provided' });
     return;
   }
-  try {
-    await execAsync('which john');
-  } catch {
-    return res.status(500).json({ error: 'John the Ripper not installed' });
-  }
 
-  const file = path.join(tmpdir(), `john-${Date.now()}.txt`);
-  try {
-    await fs.writeFile(file, `${hash}\n`);
-    const { stdout, stderr } = await execAsync(`john ${file}`, {
-      timeout: 1000 * 60,
-    });
-    await fs.unlink(file).catch(() => {});
-    res.status(200).json({ output: stdout || stderr });
-  } catch (e) {
-    await fs.unlink(file).catch(() => {});
-    res.status(500).json({ error: e.stderr || e.message });
-  }
+  const normalized = hash.trim().slice(0, 200);
+  const detected = HASH_PATTERNS.find((pattern) => pattern.regex.test(normalized));
+  const output = [
+    'John the Ripper training simulation only',
+    `Detected format: ${detected?.name || 'unknown demo hash'}`,
+    `Input length: ${normalized.length} characters`,
+    'No cracking process was started and no wordlists were read.',
+    'Result: review hash hygiene, salting, and password policy controls with this canned analysis.',
+  ].join('\n');
+
+  res.status(200).json({ output });
 }

--- a/pages/api/mimikatz.js
+++ b/pages/api/mimikatz.js
@@ -1,26 +1,33 @@
 import modules from '../../components/apps/mimikatz/modules.json';
 
+const summarizeCommand = (value) => String(value || '').trim().replace(/[\r\n]+/g, ' ').slice(0, 120);
+
 export default async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });
     return;
   }
+
   if (req.method === 'GET') {
     const { command } = req.query || {};
     if (command) {
-      return res.status(200).json({ output: `Executed ${command}` });
+      return res.status(200).json({
+        output: `Mimikatz training simulation only. Parsed command: ${summarizeCommand(command)}. No credential access or host inspection occurred.`,
+      });
     }
     return res.status(200).json({ modules });
   }
 
   if (req.method === 'POST') {
     const { script } = req.body || {};
-    if (!script) {
+    if (typeof script !== 'string' || !script.trim()) {
       return res.status(400).json({ error: 'No script provided' });
     }
-    return res.status(200).json({ output: `Executed script: ${script}` });
+    return res.status(200).json({
+      output: `Mimikatz script simulation accepted ${script.split(/\r?\n/).filter(Boolean).length} line(s). No commands were executed.`,
+    });
   }
 
   res.setHeader('Allow', ['GET', 'POST']);
-  return res.status(405).end('Method Not Allowed');
+  return res.status(405).json({ error: 'Method not allowed' });
 }

--- a/pages/api/nse/update.js
+++ b/pages/api/nse/update.js
@@ -1,25 +1,27 @@
 import { readFile } from 'fs/promises';
 import path from 'path';
 
-export default async function handler(_req, res) {
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
   try {
     const versionPath = path.join(process.cwd(), 'public', 'demo-data', 'nmap', 'script-db-version.json');
     const raw = await readFile(versionPath, 'utf8');
-    const { sha: current } = JSON.parse(raw);
+    const { sha: current, updatedAt } = JSON.parse(raw);
 
-    const apiUrl = 'https://api.github.com/repos/nmap/nmap/commits?path=scripts/script.db&per_page=1';
-    const response = await fetch(apiUrl, {
-      headers: { 'User-Agent': 'kali-linux-portfolio' },
+    res.status(200).json({
+      updateAvailable: false,
+      current,
+      latest: current,
+      updatedAt,
+      source: 'bundled-demo-data',
+      note: 'Static demo response; no outbound repository check was performed.',
     });
-    if (!response.ok) {
-      res.status(502).json({ error: 'Failed to query script repository' });
-      return;
-    }
-    const json = await response.json();
-    const latest = json[0]?.sha || '';
-
-    res.status(200).json({ updateAvailable: current !== latest, current, latest });
   } catch (e) {
-    res.status(500).json({ error: 'Unable to check script versions' });
+    res.status(500).json({ error: 'Unable to read bundled script version' });
   }
 }

--- a/pages/api/radare2.js
+++ b/pages/api/radare2.js
@@ -1,18 +1,19 @@
-import { execFile } from 'child_process';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-import { promisify } from 'util';
+const HEX_RE = /^[0-9a-f\s]+$/i;
 
-const execFileAsync = promisify(execFile);
+const disassembleDemo = (hex) => {
+  const bytes = hex.replace(/\s+/g, '').match(/.{1,2}/g) || [];
+  return bytes.slice(0, 16).map((byte, index) => {
+    const addr = `0x${(index).toString(16).padStart(4, '0')}`;
+    return `${addr}  ${byte.padEnd(2, '0')}        demo.byte 0x${byte.padEnd(2, '0')}`;
+  }).join('\n');
+};
 
 export default async function handler(req, res) {
   if (process.env.FEATURE_TOOL_APIS !== 'enabled') {
     res.status(501).json({ error: 'Not implemented' });
     return;
   }
-  // Radare2 utilities are optional; this endpoint may be stubbed when the
-  // binaries are unavailable.
+
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
     return res.status(405).json({ error: 'Method not allowed' });
@@ -20,49 +21,24 @@ export default async function handler(req, res) {
 
   const { action, hex, file } = req.body || {};
 
-  try {
-    if (action === 'disasm' && hex) {
-      try {
-        await execFileAsync('which', ['rasm2']);
-      } catch {
-        return res.status(500).json({ error: 'radare2 not installed' });
-      }
-      try {
-        const { stdout } = await execFileAsync('rasm2', ['-d', hex], {
-          timeout: 1000 * 60,
-        });
-        return res.status(200).json({ result: stdout });
-      } catch (error) {
-        const msg = error.stderr?.toString() || error.message;
-        return res.status(500).json({ error: msg });
-      }
+  if (action === 'disasm') {
+    if (typeof hex !== 'string' || !hex.trim() || !HEX_RE.test(hex) || hex.replace(/\s+/g, '').length > 512) {
+      return res.status(400).json({ error: 'Provide up to 512 hexadecimal characters for the demo disassembler' });
     }
-
-    if (action === 'analyze' && file) {
-      try {
-        await execFileAsync('which', ['rabin2']);
-      } catch {
-        return res.status(500).json({ error: 'radare2 not installed' });
-      }
-      const buffer = Buffer.from(file, 'base64');
-      const tmpPath = path.join(os.tmpdir(), `radare2-${Date.now()}`);
-      fs.writeFileSync(tmpPath, buffer);
-      try {
-        const { stdout } = await execFileAsync('rabin2', ['-I', tmpPath], {
-          timeout: 1000 * 60,
-        });
-        fs.unlink(tmpPath, () => {});
-        return res.status(200).json({ result: stdout });
-      } catch (error) {
-        fs.unlink(tmpPath, () => {});
-        const msg = error.stderr?.toString() || error.message;
-        return res.status(500).json({ error: msg });
-      }
-    }
-
-    return res.status(400).json({ error: 'Invalid request' });
-  } catch (e) {
-    return res.status(500).json({ error: e.message });
+    return res.status(200).json({
+      result: `${disassembleDemo(hex)}\n\nDemo mode: no radare2 binaries were executed.`,
+    });
   }
-}
 
+  if (action === 'analyze') {
+    if (typeof file !== 'string' || file.length > 1024 * 1024) {
+      return res.status(400).json({ error: 'Provide a base64 sample up to 1 MiB for demo analysis' });
+    }
+    const size = Buffer.byteLength(file, 'base64');
+    return res.status(200).json({
+      result: [`Demo binary analysis`, `Decoded size: ${size} bytes`, 'Sections: .text, .data (simulated)', 'Imports: puts, exit (simulated)', 'No files were written and no external tools were executed.'].join('\n'),
+    });
+  }
+
+  return res.status(400).json({ error: 'Invalid request' });
+}


### PR DESCRIPTION
### Motivation

- Prevent any real outbound network calls or local binary execution from the demo/security API endpoints and client-side simulated tools, keeping all security tooling strictly offline and demonstrative.
- Ensure feature-flag gating remains respected while providing safe, deterministic demo outputs that are useful for education and discussion.

### Description

- Replaced execution paths for Hydra, John the Ripper, and radare2 API routes with bounded, deterministic simulation responses that validate inputs and explicitly state no sockets or binaries were used.
- Hardened `pages/api/mimikatz.js` and `pages/api/nse/update.js` to return safe, demonstration-only outputs and to handle HTTP methods and input sanitization consistently.
- Disabled live outbound behavior in client apps by routing Recon-ng to deterministic demo data, converting Nessus to an offline demo session flow, and preventing Wireshark from opening a live WebSocket capture in the UI.
- Updated unit tests that expected legacy execution behavior to assert simulation-only responses and added small accessibility fixes (aria labels) in recon UI controls.

### Testing

- Ran `yarn lint` and fixed warnings; lint completed successfully.
- Ran targeted suites with `yarn test __tests__/hydra.api.test.ts __tests__/hydra-api.test.js __tests__/mimikatz.test.ts --runInBand` and all targeted tests passed after updating expectations to simulation-mode responses.
- Observed an earlier full `yarn test --runInBand` run that surfaced failing legacy expectations and some async warnings before tests were updated; those specific expectations were adjusted and the affected suites re-ran and passed.
- Commands executed during validation: `yarn lint`, `yarn test --runInBand`, and the targeted `yarn test` command listed above; no feature flags were changed beyond test env variables used by the existing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62108031bc8328b7a7ab093fc08804)