### PR TITLE
[config] align CI and test scripts with Yarn

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -10,13 +10,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
           cache: yarn
+      - run: corepack enable
+      - run: corepack prepare yarn@4.9.2 --activate
+      - run: yarn --version
       - run: yarn install --immutable
       - run: yarn dedupe --check
-      - run: npx playwright install --with-deps
+      - run: yarn playwright install --with-deps
       - run: |
           yarn dev &
-          npx wait-on http://localhost:3000
-      - run: npx pa11y-ci --config pa11yci.json
-      - run: npx playwright test playwright/a11y.spec.ts
+          yarn wait-on http://localhost:3000
+      - run: yarn pa11y-ci --config pa11yci.json
+      - run: yarn playwright test playwright/a11y.spec.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - run: yarn --version
       - run: yarn install --immutable
       - run: yarn dedupe --check
-      - run: yarn tsc --noEmit
+      - run: yarn typecheck
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: 'yarn'
+          cache: yarn
       - name: Enable Corepack
         run: corepack enable
       - name: Prepare Yarn
@@ -25,19 +25,17 @@ jobs:
           sudo apt-get install -y libnss3 lsof libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 libxss1 libasound2t64 fonts-liberation libappindicator3-1 xdg-utils
       - name: Installing Packages
         run: yarn install --immutable
-      - name: Deduplicate dependencies
-        run: yarn dedupe
       - name: Verify dependencies are deduped
-        run: yarn dedupe --check
+        run: yarn dedupe:check
 
       - name: Test
-        run: yarn jest -w=1 --forceExit
+        run: yarn test -w=1 --forceExit
 
       - name: Lint
         run: yarn lint
 
       - name: Type Check
-        run: yarn tsc --noEmit
+        run: yarn typecheck
 
       - name: Building
         run: yarn build
@@ -51,8 +49,8 @@ jobs:
         run: yarn export
       - run: touch ./out/.nojekyll
 
-      - name: Deploy to Github-Pages 
+      - name: Deploy to Github-Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          branch: gh-pages 
-          folder: out 
+          branch: gh-pages
+          folder: out

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,6 @@ const customJestConfig = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
     '^@xterm/xterm/css/xterm.css$': '<rootDir>/__mocks__/styleMock.js',
-    '^@/(.*)$': '<rootDir>/$1',
     '^react-ga4$': '<rootDir>/__mocks__/react-ga4.js',
   },
   testPathIgnorePatterns: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     screenshot: 'only-on-failure',
   },
   webServer: {
-    command: 'npm run dev',
+    command: 'yarn dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,


### PR DESCRIPTION
### Motivation
- Ensure CI and local workflows consistently use the repository's Yarn 4/Corepack setup and package scripts instead of ad-hoc `npm`/`npx` calls, remove duplicated config, and avoid mutating steps after an immutable install.

### Description
- Updated `.github/workflows/a11y.yml` to enable Corepack, prepare Yarn 4.9.2, and replace `npx`/hardcoded Node version usage with `yarn`-based commands and `.nvmrc`-driven node selection.
- Changed the CI job to run the repository's `yarn typecheck` script instead of invoking `tsc --noEmit` directly, and standardized Corepack/Yarn preparation steps across workflows.
- Hardened GitHub Pages deploy workflow by using `yarn dedupe:check`, `yarn test`, `yarn typecheck`, consistent `cache: yarn` syntax, and removed a post-install `yarn dedupe` that would mutate an immutable install.
- Aligned `playwright.config.ts` to use `yarn dev` as the webServer command and removed a duplicate module alias entry from `jest.config.js`.

### Testing
- Ran `git diff --check` and fixed whitespace issues, which succeeded.
- Ran `yarn lint` and the lint step completed successfully.
- Ran `yarn typecheck` and TypeScript checks passed.
- Ran `yarn test --runInBand --forceExit` (Jest) which completed successfully: test suites passed (261 suites passed; 4 skipped) and tests passed (923 tests passed; 144 skipped), with non-blocking console warnings about unwrapped state updates and async handles but no failing suites.
- Performed `yarn export` (static export) which completed successfully and emitted the expected Next.js notice that `next export` disables API routes/middleware for static hosts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62103367e08328ba9927c1114bf749)